### PR TITLE
Import ApiProvider & Parser from NelmioApiDocBundle

### DIFF
--- a/DependencyInjection/Compiler/NelmioSupportPass.php
+++ b/DependencyInjection/Compiler/NelmioSupportPass.php
@@ -11,6 +11,7 @@
 
 namespace Dunglas\ApiBundle\DependencyInjection\Compiler;
 
+use Dunglas\ApiBundle\Nelmio\Extractor\ApiDocExtractor;
 use Nelmio\ApiDocBundle\DependencyInjection\RegisterExtractorParsersPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,6 +38,7 @@ class NelmioSupportPass implements CompilerPassInterface
         $container->removeDefinition('nelmio_api_doc.parser.dunglas_api_parser');
 
         $apiDocExtractorDefinition = $container->getDefinition('nelmio_api_doc.extractor.api_doc_extractor');
+        $apiDocExtractorDefinition->setClass(ApiDocExtractor::class);
         /** @var Reference[] $annotationsProviderReferences */
         $annotationsProviderReferences = $apiDocExtractorDefinition->getArgument(6);
 

--- a/DependencyInjection/Compiler/NelmioSupportPass.php
+++ b/DependencyInjection/Compiler/NelmioSupportPass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\DependencyInjection\Compiler;
+
+use Nelmio\ApiDocBundle\DependencyInjection\RegisterExtractorParsersPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * The role of this compiler pass is to unregister any api bundle stuff from the NelmioApiDoc bundle services.
+ * NelmioApiDoc providers and parsers related to the api bundle are now registered by the api bundle itself.
+ * This should be removed once a new major version of NelmioApiDoc is released and api bundle stuff removed from it.
+ *
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class NelmioSupportPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('nelmio_api_doc.annotations_provider.dunglas_api_annotation_provider')) {
+            return;
+        }
+        $container->removeDefinition('nelmio_api_doc.annotations_provider.dunglas_api_annotation_provider');
+        $container->removeDefinition('nelmio_api_doc.parser.dunglas_api_parser');
+
+        $apiDocExtractorDefinition = $container->getDefinition('nelmio_api_doc.extractor.api_doc_extractor');
+        /** @var Reference[] $annotationsProviderReferences */
+        $annotationsProviderReferences = $apiDocExtractorDefinition->getArgument(6);
+
+        if (false !== $key = array_search('nelmio_api_doc.annotations_provider.dunglas_api_annotation_provider', $annotationsProviderReferences)) {
+            unset($annotationsProviderReferences[$key]);
+        }
+        $apiDocExtractorDefinition->replaceArgument(6, $annotationsProviderReferences);
+
+        while ($apiDocExtractorDefinition->hasMethodCall('addParser')) {
+            // Remove all "addParser" method calls
+            $apiDocExtractorDefinition->removeMethodCall('addParser');
+        }
+        // Re-execute the Nelmio extractor parsers pass in order to re-register "addParser" method calls.
+        (new RegisterExtractorParsersPass())->process($container);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('cache')->defaultFalse()->info('The caching service to use. Set to "dunglas_api.mapping.cache.apc" to enable APC metadata caching.')->end()
                 ->booleanNode('enable_fos_user')->defaultValue(false)->info('Enable the FOSUserBundle integration.')->end()
+                ->booleanNode('nelmio_api_doc')->defaultValue(false)->info('Enable the Nelmio Api doc integration.')->end()
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/DunglasApiExtension.php
+++ b/DependencyInjection/DunglasApiExtension.php
@@ -75,6 +75,11 @@ class DunglasApiExtension extends Extension implements PrependExtensionInterface
             $loader->load('fos_user.xml');
         }
 
+        // NelmioApiDoc support
+        if ($config['nelmio_api_doc']) {
+            $loader->load('nelmio_api_doc.xml');
+        }
+
         // Cache
         if (isset($config['cache']) && $config['cache']) {
             $container->setParameter(

--- a/DunglasApiBundle.php
+++ b/DunglasApiBundle.php
@@ -13,7 +13,9 @@ namespace Dunglas\ApiBundle;
 
 use Dunglas\ApiBundle\DependencyInjection\Compiler\DataProviderPass;
 use Dunglas\ApiBundle\DependencyInjection\Compiler\DoctrineQueryExtensionPass;
+use Dunglas\ApiBundle\DependencyInjection\Compiler\NelmioSupportPass;
 use Dunglas\ApiBundle\DependencyInjection\Compiler\ResourcePass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -34,5 +36,6 @@ class DunglasApiBundle extends Bundle
         $container->addCompilerPass(new ResourcePass());
         $container->addCompilerPass(new DataProviderPass());
         $container->addCompilerPass(new DoctrineQueryExtensionPass());
+        $container->addCompilerPass(new NelmioSupportPass(), PassConfig::TYPE_OPTIMIZE);
     }
 }

--- a/Nelmio/Extractor/AnnotationsProvider/ApiProvider.php
+++ b/Nelmio/Extractor/AnnotationsProvider/ApiProvider.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Nelmio\Extractor\AnnotationsProvider;
+
+use Dunglas\ApiBundle\Api\Operation\OperationInterface;
+use Dunglas\ApiBundle\Api\ResourceCollectionInterface;
+use Dunglas\ApiBundle\Api\ResourceInterface;
+use Dunglas\ApiBundle\Hydra\ApiDocumentationBuilderInterface;
+use Dunglas\ApiBundle\Mapping\Factory\ClassMetadataFactoryInterface;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Extractor\AnnotationsProviderInterface;
+use Nelmio\ApiDocBundle\Parser\DunglasApiParser;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Creates Nelmio ApiDoc annotations for the api bundle.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ApiProvider implements AnnotationsProviderInterface
+{
+    /**
+     * @var ResourceCollectionInterface
+     */
+    private $resourceCollection;
+    /**
+     * @var ApiDocumentationBuilderInterface
+     */
+    private $apiDocumentationBuilder;
+    /**
+     * @var ClassMetadataFactoryInterface
+     */
+    private $classMetadataFactory;
+
+    public function __construct(
+        ResourceCollectionInterface $resourceCollection,
+        ApiDocumentationBuilderInterface $apiDocumentationBuilder,
+        ClassMetadataFactoryInterface $classMetadataFactory
+    ) {
+        $this->resourceCollection = $resourceCollection;
+        $this->apiDocumentationBuilder = $apiDocumentationBuilder;
+        $this->classMetadataFactory = $classMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAnnotations()
+    {
+        $annotations = [];
+        $hydraDoc = $this->apiDocumentationBuilder->getApiDocumentation();
+        $entrypointHydraDoc = $this->getResourceHydraDoc($hydraDoc, '#Entrypoint');
+
+        /** @var ResourceInterface $resource */
+        foreach ($this->resourceCollection as $resource) {
+            $classMetadata = $this->classMetadataFactory->getMetadataFor($resource->getEntityClass());
+            $prefixedShortName = ($iri = $classMetadata->getIri()) ? $iri : '#'.$resource->getShortName();
+            $resourceHydraDoc = $this->getResourceHydraDoc($hydraDoc, $prefixedShortName);
+
+            if ($hydraDoc) {
+                foreach ($resource->getCollectionOperations() as $operation) {
+                    $annotations[] = $this->getApiDoc(true, $resource, $operation, $resourceHydraDoc, $entrypointHydraDoc);
+                }
+
+                foreach ($resource->getItemOperations() as $operation) {
+                    $annotations[] = $this->getApiDoc(false, $resource, $operation, $resourceHydraDoc);
+                }
+            }
+        }
+
+        return $annotations;
+    }
+
+    /**
+     * Builds ApiDoc annotation from DunglasApiBundle data.
+     *
+     * @param bool               $collection
+     * @param ResourceInterface  $resource
+     * @param OperationInterface $operation
+     * @param array              $resourceHydraDoc
+     * @param array              $entrypointHydraDoc
+     *
+     * @return ApiDoc
+     */
+    private function getApiDoc(
+        $collection,
+        ResourceInterface $resource,
+        OperationInterface $operation,
+        array $resourceHydraDoc,
+        array $entrypointHydraDoc = []
+    ) {
+        $method = $operation->getRoute()->getMethods()[0];
+
+        if ($collection) {
+            $operationHydraDoc = $this->getCollectionOperationHydraDoc($resource->getShortName(), $method, $entrypointHydraDoc);
+        } else {
+            $operationHydraDoc = $this->getOperationHydraDoc($operation->getRoute()->getMethods()[0], $resourceHydraDoc);
+        }
+
+        $route = $operation->getRoute();
+
+        $data = [
+            'resource' => $route->getPath(),
+            'description' => $operationHydraDoc['hydra:title'],
+            'resourceDescription' => $resourceHydraDoc['hydra:title'],
+            'section' => $resourceHydraDoc['hydra:title'],
+        ];
+
+        $entityClass = $resource->getEntityClass();
+
+        if (isset($operationHydraDoc['expects']) && 'owl:Nothing' !== $operationHydraDoc['expects']) {
+            $data['input'] = sprintf('%s:%s', DunglasApiParser::IN_PREFIX, $entityClass);
+        }
+
+        if (isset($operationHydraDoc['returns']) && 'owl:Nothing' !== $operationHydraDoc['returns']) {
+            $data['output'] = sprintf('%s:%s', DunglasApiParser::OUT_PREFIX, $entityClass);
+        }
+
+        if (Request::METHOD_GET === $method && $collection) {
+            $data['filters'] = [];
+            foreach ($resource->getFilters() as $filter) {
+                foreach ($filter->getDescription($resource) as $name => $definition) {
+                    $data['filters'][] = ['name' => $name] + $definition;
+                }
+            }
+        }
+
+        $apiDoc = new ApiDoc($data);
+        $apiDoc->setRoute($route);
+
+        return $apiDoc;
+    }
+
+    /**
+     * Gets Hydra documentation for the given resource.
+     *
+     * @param array  $hydraApiDoc
+     * @param string $prefixedShortName
+     *
+     * @return array|null
+     */
+    private function getResourceHydraDoc(array $hydraApiDoc, $prefixedShortName)
+    {
+        foreach ($hydraApiDoc['hydra:supportedClass'] as $supportedClass) {
+            if ($supportedClass['@id'] === $prefixedShortName) {
+                return $supportedClass;
+            }
+        }
+    }
+
+    /**
+     * Gets the Hydra documentation of a given operation.
+     *
+     * @param string $method
+     * @param array  $hydraDoc
+     *
+     * @return array|null
+     */
+    private function getOperationHydraDoc($method, array $hydraDoc)
+    {
+        foreach ($hydraDoc['hydra:supportedOperation'] as $supportedOperation) {
+            if ($supportedOperation['hydra:method'] === $method) {
+                return $supportedOperation;
+            }
+        }
+    }
+
+    /**
+     * Gets the Hydra documentation for the collection operation.
+     *
+     * @param string $shortName
+     * @param string $method
+     * @param array  $hydraEntrypointDoc
+     *
+     * @return array|null
+     */
+    private function getCollectionOperationHydraDoc($shortName, $method, array $hydraEntrypointDoc)
+    {
+        $propertyName = '#Entrypoint/'.lcfirst($shortName);
+
+        foreach ($hydraEntrypointDoc['hydra:supportedProperty'] as $supportedProperty) {
+            $hydraProperty = $supportedProperty['hydra:property'];
+            if ($hydraProperty['@id'] === $propertyName) {
+                return $this->getOperationHydraDoc($method, $hydraProperty);
+            }
+        }
+    }
+}

--- a/Nelmio/Extractor/ApiDocExtractor.php
+++ b/Nelmio/Extractor/ApiDocExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Dunglas\ApiBundle\Nelmio\Extractor;
+
+use Doctrine\Common\Util\ClassUtils;
+use Nelmio\ApiDocBundle\Extractor\ApiDocExtractor as BaseApiDocExtractor;
+use Symfony\Component\HttpFoundation\Request;
+
+class ApiDocExtractor extends BaseApiDocExtractor
+{
+    public function getReflectionMethod($controller)
+    {
+        $reflectionMethod = parent::getReflectionMethod($controller);
+        if (null !== $reflectionMethod) {
+            return $reflectionMethod;
+        }
+
+        if ($this->container->has($controller)) {
+            $this->container->enterScope('request');
+            $this->container->set('request', new Request(), 'request');
+            $class = ClassUtils::getRealClass(get_class($this->container->get($controller)));
+            $this->container->leaveScope('request');
+            if (!isset($method) && method_exists($class, '__invoke')) {
+                $method = '__invoke';
+            }
+        }
+
+        if (isset($class) && isset($method)) {
+            try {
+                return new \ReflectionMethod($class, $method);
+            } catch (\ReflectionException $e) {
+            }
+        }
+
+        return;
+    }
+}

--- a/Nelmio/Parser/ApiParser.php
+++ b/Nelmio/Parser/ApiParser.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Nelmio\Parser;
+
+use Dunglas\ApiBundle\Api\ResourceCollectionInterface;
+use Dunglas\ApiBundle\Api\ResourceInterface;
+use Dunglas\ApiBundle\Mapping\AttributeMetadataInterface;
+use Dunglas\ApiBundle\Mapping\Factory\ClassMetadataFactoryInterface;
+use Nelmio\ApiDocBundle\DataTypes;
+use Nelmio\ApiDocBundle\Parser\ParserInterface;
+use PropertyInfo\Type;
+
+/**
+ * Extract input and output information for the NelmioApiDocBundle.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ApiParser implements ParserInterface
+{
+    const IN_PREFIX = 'dunglas_api_in';
+    const OUT_PREFIX = 'dunglas_api_out';
+    const IRI = 'IRI';
+
+    private static $typeMap = array(
+        'int' => DataTypes::INTEGER,
+        'bool' => DataTypes::BOOLEAN,
+        'string' => DataTypes::STRING,
+        'float' => DataTypes::FLOAT,
+    );
+
+    /**
+     * @var ResourceCollectionInterface
+     */
+    private $resourceCollection;
+    /**
+     * @var ClassMetadataFactoryInterface
+     */
+    private $classMetadataFactory;
+
+    public function __construct(
+        ResourceCollectionInterface $resourceCollection,
+        ClassMetadataFactoryInterface $classMetadataFactory
+    ) {
+        $this->resourceCollection = $resourceCollection;
+        $this->classMetadataFactory = $classMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(array $item)
+    {
+        $data = explode(':', $item['class'], 2);
+        if (isset($data[1])) {
+            return null !== $this->resourceCollection->getResourceForEntity($data[1]);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(array $item)
+    {
+        list($io, $entityClass) = explode(':', $item['class'], 2);
+        $resource = $this->resourceCollection->getResourceForEntity($entityClass);
+
+        return $this->parseClass($resource, $entityClass, $io);
+    }
+
+    /**
+     * Parses a class.
+     *
+     * @param ResourceInterface $resource
+     * @param string            $entityClass
+     * @param string            $io
+     *
+     * @return array
+     */
+    private function parseClass(ResourceInterface $resource, $entityClass, $io)
+    {
+        $classMetadata = $this->classMetadataFactory->getMetadataFor(
+            $entityClass,
+            $resource->getNormalizationGroups(),
+            $resource->getDenormalizationGroups(),
+            $resource->getValidationGroups()
+        );
+
+        $data = array();
+        /** @var AttributeMetadataInterface $attributeMetadata */
+        foreach ($classMetadata->getAttributesMetadata() as $name => $attributeMetadata) {
+            if (
+                ($attributeMetadata->isReadable() && self::OUT_PREFIX === $io) ||
+                ($attributeMetadata->isWritable() && self::IN_PREFIX === $io)
+            ) {
+                $data[$name] = $this->parseAttribute($resource, $attributeMetadata, $io);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Parses an attribute.
+     *
+     * @param ResourceInterface          $resource
+     * @param AttributeMetadataInterface $attributeMetadata
+     * @param string                     $io
+     * @param Type|null                  $type
+     *
+     * @return array
+     */
+    private function parseAttribute(ResourceInterface $resource, AttributeMetadataInterface $attributeMetadata, $io, Type $type = null)
+    {
+        $data = array(
+            'dataType' => null,
+            'required' => $attributeMetadata->isRequired(),
+            'description' => $attributeMetadata->getDescription(),
+            'readonly' => !$attributeMetadata->isWritable(),
+        );
+
+        if (null == $type) {
+            if (null === $attributeMetadata->getType()) {
+                // Default to string
+                $data['dataType'] = DataTypes::STRING;
+
+                return $data;
+            }
+
+            $type = $attributeMetadata->getType();
+        }
+
+        if ($type->isCollection()) {
+            $data['actualType'] = DataTypes::COLLECTION;
+
+            if ($collectionType = $type->getCollectionType()) {
+                $subAttribute = $this->parseAttribute($resource, $attributeMetadata, $io, $collectionType);
+                if (self::IRI === $subAttribute['dataType']) {
+                    $data['dataType'] = 'array of IRIs';
+                    $data['subType'] = DataTypes::STRING;
+
+                    return $data;
+                }
+
+                $data['subType'] = $subAttribute['subType'];
+                $data['children'] = $subAttribute['children'];
+            }
+
+            return $data;
+        }
+
+        $phpType = $type->getType();
+        if ('object' === $phpType) {
+            $class = $type->getClass();
+
+            if ('DateTime' === $class) {
+                $data['dataType'] = DataTypes::DATETIME;
+                $data['format'] = sprintf('{DateTime %s}', \DateTime::ATOM);
+
+                return $data;
+            }
+
+            if (
+                (self::OUT_PREFIX === $io && $attributeMetadata->isNormalizationLink()) ||
+                (self::IN_PREFIX === $io && $attributeMetadata->isDenormalizationLink())
+            ) {
+                $data['dataType'] = self::IRI;
+                $data['actualType'] = DataTypes::STRING;
+
+                return $data;
+            }
+
+            $data['actualType'] = DataTypes::MODEL;
+            $data['subType'] = $class;
+            $data['children'] = $this->parseClass($resource, $class, $io);
+
+            return $data;
+        }
+
+        $data['dataType'] = isset(self::$typeMap[$type->getType()]) ? self::$typeMap[$type->getType()] : DataTypes::STRING;
+
+        return $data;
+    }
+}

--- a/Resources/config/nelmio_api_doc.xml
+++ b/Resources/config/nelmio_api_doc.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api.nelmio_api_doc.annotations_provider.api_annotation_provider" class="Dunglas\ApiBundle\Nelmio\Extractor\AnnotationsProvider\ApiProvider">
+            <argument type="service" id="api.resource_collection" />
+            <argument type="service" id="api.hydra.documentation_builder" />
+            <argument type="service" id="api.mapping.class_metadata_factory" />
+
+            <tag name="nelmio_api_doc.extractor.annotations_provider" />
+        </service>
+
+        <service id="api.nelmio_api_doc.parser.api_parser" class="Dunglas\ApiBundle\Nelmio\Parser\ApiParser">
+            <argument type="service" id="api.resource_collection" />
+            <argument type="service" id="api.mapping.class_metadata_factory" />
+
+            <tag name="nelmio_api_doc.extractor.parser" />
+        </service>
+    </services>
+
+</container>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -25,6 +25,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         'supported_formats' => ['jsonld'],
         'cache' => false,
         'enable_fos_user' => false,
+        'nelmio_api_doc' => false,
         'collection' => [
             'filter_name' => [
                 'order' => 'order',

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,12 @@
     "behatch/contexts": "dev-master",
     "symfony/finder": "~2.3",
     "symfony/security": "~2.7.2|~3.0",
-    "phpunit/phpunit": "~4.6"
+    "phpunit/phpunit": "~4.6",
+    "nelmio/api-doc-bundle": "^2.9"
   },
   "suggest": {
-    "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge."
+    "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge.",
+    "nelmio/api-doc-bundle": "To have the api sandbox & documentation."
   },
   "autoload": {
     "psr-4": { "Dunglas\\ApiBundle\\": "" }


### PR DESCRIPTION
and ensure the compatibility with NelmioApiDoc ^2.9 by removing old provider and parser definitions.

This is a draft on how to proceed to migrate the nelmio api doc extension stuff into the Api bundle. 

Note it will not work without https://github.com/nelmio/NelmioApiDocBundle/pull/695 (as currently).

Tests should of course also be ported into the bundle.
Documentation should be updated.

With this PR, the Nelmio API Doc support must be explicitly enabled in the configuration:
```yaml
# config.yml
dunglas_api:
   nelmio_api_doc: true
```

The compiler pass is needed in order to ensure the support of NelmioApiDoc ^2.9, until the old provider and parser are removed from the NelmioApiDocBundle.
When a new NelmioApiDoc version is released with those removals, the compiler pass could be removed. Then we'll have something clean for the first api bundle official release.

What do you think ?

-------
Related to #219 and #156 