### PR TITLE
Bad normalization when a collection contains multiple type

### DIFF
--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -147,7 +147,8 @@ class ItemNormalizer extends AbstractNormalizer
             if (
                 $attributeValue &&
                 $type &&
-                $type->isCollection()
+                $type->isCollection() &&
+                $type->getCollectionType()
             ) {
                 $values = [];
                 foreach ($attributeValue as $index => $obj) {

--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -147,12 +147,11 @@ class ItemNormalizer extends AbstractNormalizer
             if (
                 $attributeValue &&
                 $type &&
-                $type->isCollection() &&
-                ($collectionType = $type->getCollectionType()) &&
-                $subResource = $this->resourceResolver->getResourceFromType($collectionType)
+                $type->isCollection()
             ) {
                 $values = [];
                 foreach ($attributeValue as $index => $obj) {
+                    $subResource = $this->resourceResolver->guessResource($obj);
                     $values[$index] = $this->normalizeRelation($attributeMetadata, $obj, $subResource, $context);
                 }
 


### PR DESCRIPTION
When a collection contains multiple type, the normalizer tries to normalize relation with a bad resource type.

Ex:
A Product class has a collection of Option.
Option class is abstract.
TextOption extends Option.
TimeOption extends Option.
When the product contains TimeOption and TextOption, the normalizer tries to normalize TextOption and TimeOption with the Option resource type.

This change guess resource type on each object in the collection before normalize relation.