### PR TITLE
Fix : normalize collection

### DIFF
--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -152,7 +152,7 @@ class ItemNormalizer extends AbstractNormalizer
                 $subResource = $this->resourceResolver->getResourceFromType($collectionType)
             ) {
                 $values = [];
-                foreach ($attributeValue as $index => $obj) {
+                foreach ($attributeValue->getValues() as $index => $obj) {
                     $values[$index] = $this->normalizeRelation($attributeMetadata, $obj, $subResource, $context);
                 }
 

--- a/Tests/Behat/TestBundle/Entity/DummyWithCollection.php
+++ b/Tests/Behat/TestBundle/Entity/DummyWithCollection.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * DummyWithCollection
+ *
+ * @ORM\Entity
+ */
+class DummyWithCollection
+{
+    /**
+     * @var int The id.
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var ArrayCollection|Dummy[]
+     *
+     * @ORM\ManyToMany(targetEntity="Dummy")
+     */
+    public $elements;
+
+    public function __construct()
+    {
+        $this->elements = new ArrayCollection();
+    }
+
+    /**
+     * @param Dummy $dummy
+     */
+    public function addElement(Dummy $dummy)
+    {
+        $this->elements[] = $dummy;
+    }
+
+    /**
+     * @param Dummy $dummy
+     */
+    public function removeElement(Dummy $dummy)
+    {
+        $this->elements->removeElement($dummy);
+    }
+
+    /**
+     * @return ArrayCollection|Dummy[]
+     */
+    public function getElements()
+    {
+        return $this->elements;
+    }
+}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy;
 use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelatedDummy;
 use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelationEmbedder;
+use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\DummyWithCollection;
 use Sanpi\Behatch\HttpCall\Request;
 
 /**
@@ -203,6 +204,26 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $relationEmbedder = new RelationEmbedder();
 
         $this->manager->persist($relationEmbedder);
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is :nb dummy with collection objects with Dummy
+     */
+    public function thereIsDummyWithCollectionObjectsWithDummy($nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $dummyWithCollection = new DummyWithCollection();
+
+            $dummy = new Dummy();
+            $dummy->setName('Dummy #'.$i);
+            $this->manager->persist($dummy);
+
+            $dummyWithCollection->addElement($dummy);
+
+            $this->manager->persist($dummyWithCollection);
+        }
+
         $this->manager->flush();
     }
 }

--- a/features/dummy_with_collection.feature
+++ b/features/dummy_with_collection.feature
@@ -1,0 +1,18 @@
+Feature: Create-Update an element with a collection
+  In order to use an hypermedia API
+  As a client software developer
+  I need to be able to create, update JSON-LD encoded resources with collection.
+
+  @createSchema
+  @dropSchema
+  Scenario: Update a dummy with collection with another collection values
+    Given there is 3 dummy with collection objects with Dummy
+    When I send a "PUT" request to "/dummy_with_collections/1" with body:
+    """
+    {
+      "elements": ["/dummies/3", "/dummies/2"]
+    }
+    """
+    Then the response status code should be 200
+    And the JSON node "elements[0]" should be equal to "/dummies/3"
+    And the JSON node "elements[1]" should be equal to "/dummies/2"

--- a/features/fixtures/TestApp/config/config.yml
+++ b/features/fixtures/TestApp/config/config.yml
@@ -203,3 +203,8 @@ services:
                                     - method:    "initCollectionOperations"
                                       arguments:
                                             - []
+
+    my_dummy_with_collection_resource:
+        parent:                      "api.resource"
+        arguments:                   [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\DummyWithCollection" ]
+        tags:                        [ { name: "api.resource" } ]

--- a/features/hydra/doc.feature
+++ b/features/hydra/doc.feature
@@ -887,6 +887,81 @@ Feature: Documentation support
               ]
           },
           {
+              "@id": "#DummyWithCollection",
+              "@type": "hydra:Class",
+              "rdfs:label": "DummyWithCollection",
+              "hydra:title": "DummyWithCollection",
+              "hydra:description": "DummyWithCollection",
+              "hydra:supportedProperty": [
+                  {
+                      "@type": "hydra:SupportedProperty",
+                      "hydra:property": {
+                          "@id": "#DummyWithCollection\/element",
+                          "@type": "rdf:Property",
+                          "rdfs:label": "element",
+                          "domain": "#DummyWithCollection"
+                      },
+                      "hydra:title": "element",
+                      "hydra:required": false,
+                      "hydra:readable": false,
+                      "hydra:writable": true
+                  },
+                  {
+                      "@type": "hydra:SupportedProperty",
+                      "hydra:property": {
+                          "@id": "#DummyWithCollection\/elements",
+                          "@type": "Hydra:Link",
+                          "rdfs:label": "elements",
+                          "domain": "#DummyWithCollection",
+                          "range": "#Dummy"
+                      },
+                      "hydra:title": "elements",
+                      "hydra:required": false,
+                      "hydra:readable": true,
+                      "hydra:writable": true
+                  },
+                  {
+                      "@type": "hydra:SupportedProperty",
+                      "hydra:property": {
+                          "@id": "#DummyWithCollection\/id",
+                          "@type": "rdf:Property",
+                          "rdfs:label": "id",
+                          "domain": "#DummyWithCollection",
+                          "range": "xmls:integer"
+                      },
+                      "hydra:title": "id",
+                      "hydra:required": false,
+                      "hydra:readable": false,
+                      "hydra:writable": true,
+                      "hydra:description": "The id."
+                  }
+              ],
+              "hydra:supportedOperation": [
+                  {
+                      "@type": "hydra:Operation",
+                      "hydra:method": "GET",
+                      "hydra:title": "Retrieves DummyWithCollection resource.",
+                      "rdfs:label": "Retrieves DummyWithCollection resource.",
+                      "returns": "#DummyWithCollection"
+                  },
+                  {
+                      "@type": "hydra:ReplaceResourceOperation",
+                      "expects": "#DummyWithCollection",
+                      "hydra:method": "PUT",
+                      "hydra:title": "Replaces the DummyWithCollection resource.",
+                      "rdfs:label": "Replaces the DummyWithCollection resource.",
+                      "returns": "#DummyWithCollection"
+                  },
+                  {
+                      "@type": "hydra:Operation",
+                      "hydra:method": "DELETE",
+                      "hydra:title": "Deletes the DummyWithCollection resource.",
+                      "rdfs:label": "Deletes the DummyWithCollection resource.",
+                      "returns": "owl:Nothing"
+                  }
+              ]
+          },
+          {
               "@id": "#Entrypoint",
               "@type": "hydra:Class",
               "hydra:title": "The API entrypoint",
@@ -1180,6 +1255,36 @@ Feature: Documentation support
                           ]
                       },
                       "hydra:title": "The collection of CustomNormalizedDummy resources",
+                      "hydra:readable": true,
+                      "hydra:writable": false
+                  },
+                  {
+                      "@type": "hydra:SupportedProperty",
+                      "hydra:property": {
+                          "@id": "#Entrypoint\/dummyWithCollection",
+                          "@type": "hydra:Link",
+                          "domain": "#Entrypoint",
+                          "rdfs:label": "The collection of DummyWithCollection resources",
+                          "range": "hydra:PagedCollection",
+                          "hydra:supportedOperation": [
+                              {
+                                  "@type": "hydra:Operation",
+                                  "hydra:method": "GET",
+                                  "hydra:title": "Retrieves the collection of DummyWithCollection resources.",
+                                  "rdfs:label": "Retrieves the collection of DummyWithCollection resources.",
+                                  "returns": "hydra:PagedCollection"
+                              },
+                              {
+                                  "@type": "hydra:CreateResourceOperation",
+                                  "expects": "#DummyWithCollection",
+                                  "hydra:method": "POST",
+                                  "hydra:title": "Creates a DummyWithCollection resource.",
+                                  "rdfs:label": "Creates a DummyWithCollection resource.",
+                                  "returns": "#DummyWithCollection"
+                              }
+                          ]
+                      },
+                      "hydra:title": "The collection of DummyWithCollection resources",
                       "hydra:readable": true,
                       "hydra:writable": false
                   }

--- a/features/json-ld/context.feature
+++ b/features/json-ld/context.feature
@@ -23,7 +23,8 @@ Feature: JSON-LD contexts generation
         "circularReference": "/circular_references",
         "customIdentifierDummy": "/custom_identifier_dummies",
         "customWritableIdentifierDummy": "/custom_writable_identifier_dummies",
-        "customNormalizedDummy": "/custom_normalized_dummies"
+        "customNormalizedDummy": "/custom_normalized_dummies",
+        "dummyWithCollection": "/dummy_with_collections"
     }
     """
 


### PR DESCRIPTION
In certain case collection are normalize into object (json_encode transform array( 1 => 'A' ) into { '1' : 'a' } instead of ['a'].

Here is the bug fix with the corresponding scenario failing on master.
