### PR TITLE
[WIP] Composite identifiers

### DIFF
--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -131,7 +131,12 @@ class ItemNormalizer extends AbstractNormalizer
         $data['@id'] = $this->iriConverter->getIriFromItem($object);
         $data['@type'] = ($iri = $classMetadata->getIri()) ? $iri : $resource->getShortName();
 
-        $identifierName = $classMetadata->getIdentifierName();
+        try {
+            $identifierName = $classMetadata->getIdentifierName();
+        } catch(\RuntimeException $e) {
+            $identifierName = null;
+        }
+
         foreach ($attributesMetadata as $attributeName => $attributeMetadata) {
             if ($identifierName === $attributeName || !$attributeMetadata->isReadable()) {
                 continue;

--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -133,7 +133,7 @@ class ItemNormalizer extends AbstractNormalizer
 
         try {
             $identifierName = $classMetadata->getIdentifierName();
-        } catch(\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $identifierName = null;
         }
 

--- a/Tests/Behat/TestBundle/Entity/CompositeItem.php
+++ b/Tests/Behat/TestBundle/Entity/CompositeItem.php
@@ -11,7 +11,7 @@
 
 namespace Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity;
 
-use Doctrine\ORM\Mapping AS ORM;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
@@ -37,7 +37,7 @@ class CompositeItem
      * @Groups({"default"})
      */
     private $compositeValues;
-    
+
     /**
      * Get id.
      *
@@ -47,7 +47,7 @@ class CompositeItem
     {
         return $this->id;
     }
-    
+
     /**
      * Get field1.
      *
@@ -57,7 +57,7 @@ class CompositeItem
     {
         return $this->field1;
     }
-    
+
     /**
      * Set field1.
      *
@@ -67,7 +67,7 @@ class CompositeItem
     {
         $this->field1 = $field1;
     }
-    
+
     /**
      * Get compositeValues.
      *

--- a/Tests/Behat/TestBundle/Entity/CompositeItem.php
+++ b/Tests/Behat/TestBundle/Entity/CompositeItem.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping AS ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ORM\Entity
+ */
+class CompositeItem
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     * @Groups({"default"})
+     */
+    private $field1;
+
+    /**
+     * @ORM\OneToMany(targetEntity="CompositeRelation", mappedBy="compositeItem", fetch="EAGER")
+     * @Groups({"default"})
+     */
+    private $compositeValues;
+    
+    /**
+     * Get id.
+     *
+     * @return id.
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+    
+    /**
+     * Get field1.
+     *
+     * @return field1.
+     */
+    public function getField1()
+    {
+        return $this->field1;
+    }
+    
+    /**
+     * Set field1.
+     *
+     * @param field1 the value to set.
+     */
+    public function setField1($field1)
+    {
+        $this->field1 = $field1;
+    }
+    
+    /**
+     * Get compositeValues.
+     *
+     * @return compositeValues.
+     */
+    public function getCompositeValues()
+    {
+        return $this->compositeValues;
+    }
+}

--- a/Tests/Behat/TestBundle/Entity/CompositeLabel.php
+++ b/Tests/Behat/TestBundle/Entity/CompositeLabel.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping AS ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ORM\Entity
+ */
+class CompositeLabel
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     * @Groups({"default"})
+     */
+    private $value;
+    
+    /**
+     * Get id.
+     *
+     * @return id.
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+    
+    /**
+     * Get value.
+     *
+     * @return value.
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+    
+    /**
+     * Set value.
+     *
+     * @param value the value to set.
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/Tests/Behat/TestBundle/Entity/CompositeLabel.php
+++ b/Tests/Behat/TestBundle/Entity/CompositeLabel.php
@@ -11,7 +11,7 @@
 
 namespace Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity;
 
-use Doctrine\ORM\Mapping AS ORM;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
@@ -31,7 +31,7 @@ class CompositeLabel
      * @Groups({"default"})
      */
     private $value;
-    
+
     /**
      * Get id.
      *
@@ -41,7 +41,7 @@ class CompositeLabel
     {
         return $this->id;
     }
-    
+
     /**
      * Get value.
      *
@@ -51,7 +51,7 @@ class CompositeLabel
     {
         return $this->value;
     }
-    
+
     /**
      * Set value.
      *

--- a/Tests/Behat/TestBundle/Entity/CompositeRelation.php
+++ b/Tests/Behat/TestBundle/Entity/CompositeRelation.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping AS ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ORM\Entity
+ */
+class CompositeRelation
+{
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     * @Groups({"default"})
+     */
+    private $value;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="CompositeItem", inversedBy="compositeValues")
+     * @ORM\JoinColumn(name="composite_item_id", referencedColumnName="id", nullable=false)
+     * @Groups({"default"})
+     */
+    private $compositeItem;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="CompositeLabel")
+     * @ORM\JoinColumn(name="composite_label_id", referencedColumnName="id", nullable=false)
+     * @Groups({"default"})
+     */
+    private $compositeLabel;
+    
+    /**
+     * Get composite id
+     * @return string
+     */
+    public function getId() {
+        return sprintf('%s-%s', $this->compositeItem->getId(), $this->compositeLabel->getId());
+    }
+
+    /**
+     * Get value.
+     *
+     * @return value.
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+    
+    /**
+     * Set value.
+     *
+     * @param value the value to set.
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+    
+    /**
+     * Get compositeItem.
+     *
+     * @return compositeItem.
+     */
+    public function getCompositeItem()
+    {
+        return $this->compositeItem;
+    }
+    
+    /**
+     * Set compositeItem.
+     *
+     * @param compositeItem the value to set.
+     */
+    public function setCompositeItem($compositeItem)
+    {
+        $this->compositeItem = $compositeItem;
+    }
+    
+    /**
+     * Get compositeLabel.
+     *
+     * @return compositeLabel.
+     */
+    public function getCompositeLabel()
+    {
+        return $this->compositeLabel;
+    }
+    
+    /**
+     * Set compositeLabel.
+     *
+     * @param compositeLabel the value to set.
+     */
+    public function setCompositeLabel($compositeLabel)
+    {
+        $this->compositeLabel = $compositeLabel;
+    }
+}

--- a/Tests/Behat/TestBundle/Entity/CompositeRelation.php
+++ b/Tests/Behat/TestBundle/Entity/CompositeRelation.php
@@ -11,7 +11,7 @@
 
 namespace Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity;
 
-use Doctrine\ORM\Mapping AS ORM;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
@@ -40,12 +40,14 @@ class CompositeRelation
      * @Groups({"default"})
      */
     private $compositeLabel;
-    
+
     /**
-     * Get composite id
+     * Get composite id.
+     *
      * @return string
      */
-    public function getId() {
+    public function getId()
+    {
         return sprintf('%s-%s', $this->compositeItem->getId(), $this->compositeLabel->getId());
     }
 
@@ -58,7 +60,7 @@ class CompositeRelation
     {
         return $this->value;
     }
-    
+
     /**
      * Set value.
      *
@@ -68,7 +70,7 @@ class CompositeRelation
     {
         $this->value = $value;
     }
-    
+
     /**
      * Get compositeItem.
      *
@@ -78,7 +80,7 @@ class CompositeRelation
     {
         return $this->compositeItem;
     }
-    
+
     /**
      * Set compositeItem.
      *
@@ -88,7 +90,7 @@ class CompositeRelation
     {
         $this->compositeItem = $compositeItem;
     }
-    
+
     /**
      * Get compositeLabel.
      *
@@ -98,7 +100,7 @@ class CompositeRelation
     {
         return $this->compositeLabel;
     }
-    
+
     /**
      * Set compositeLabel.
      *

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -18,6 +18,10 @@ use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelatedDummy;
 use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelationEmbedder;
 use Sanpi\Behatch\HttpCall\Request;
 
+use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeItem;
+use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeLabel;
+use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeRelation;
+
 /**
  * Defines application features from the specific context.
  */
@@ -201,6 +205,31 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $relationEmbedder = new RelationEmbedder();
 
         $this->manager->persist($relationEmbedder);
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there are Composite identifier objects
+     */
+    public function thereIsACompositeIdentifierObject()
+    {
+        $item = new CompositeItem();
+        $item->setField1('foobar');
+        $this->manager->persist($item);
+
+        for($i = 0; $i < 4; $i++) {
+            $label = new CompositeLabel();
+            $label->setValue('foo-'.$i);
+
+            $rel = new CompositeRelation();
+            $rel->setCompositeLabel($label);
+            $rel->setCompositeItem($item);
+            $rel->setValue(uniqid());
+
+            $this->manager->persist($label);
+            $this->manager->persist($rel);
+        }
+
         $this->manager->flush();
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -13,14 +13,13 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Tools\SchemaTool;
+use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeItem;
+use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeLabel;
+use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeRelation;
 use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy;
 use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelatedDummy;
 use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelationEmbedder;
 use Sanpi\Behatch\HttpCall\Request;
-
-use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeItem;
-use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeLabel;
-use Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeRelation;
 
 /**
  * Defines application features from the specific context.
@@ -217,7 +216,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $item->setField1('foobar');
         $this->manager->persist($item);
 
-        for($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; ++$i) {
             $label = new CompositeLabel();
             $label->setValue('foo-'.$i);
 

--- a/features/composite.feature
+++ b/features/composite.feature
@@ -1,0 +1,58 @@
+Feature: Retrieve data with Composite identifiers
+  In order to retrieve relations with composite identifiers
+  As a client software developer
+  I need to retrieve all collections 
+
+  @dropSchema
+  @createSchema
+  Scenario: Get collection with composite identifiers
+    Given there are Composite identifier objects
+    When I send a "GET" request to "/composite_items"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/CompositeItem$"},
+        "@id": {"pattern": "^/composite_items$"},
+        "@type": {"pattern": "^hydra:PagedCollection$"},
+        "hydra:totalItems": {"type":"number", "maximum": 2},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {"pattern": "^/composite_items/[0-9]{1,}$"},
+              "@type": {"pattern": "^CompositeItem$"},
+              "field1": {"type": "string", "required": true},
+              "compositeValues": {
+                "type": "array", 
+                "required": true,
+                "maxItems": 4,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "@id": {"pattern": "^/composite_relations/[0-9]{1,}-[0-9]{1,}"},
+                    "@type": {"pattern": "CompositeRelation"},
+                    "value": {"type": "string", "required": true},
+                    "compositeLabel": {
+                      "type": "object",
+                      "properties": {
+                        "@id": {"pattern": "^/composite_labels/[0-9]{1,}"},
+                        "@type": {"pattern": "CompositeLabel"},
+                        "value": {"type": "string"}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "maxItems": 2
+        }
+      }
+    }
+    """

--- a/features/fixtures/TestApp/config/config.yml
+++ b/features/fixtures/TestApp/config/config.yml
@@ -216,3 +216,20 @@ services:
                                     - method:    "initCollectionOperations"
                                       arguments:
                                             - []
+    composite_identifier_item_resource:
+        parent:                     "api.resource"
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeItem' ]
+        tags:                       [ { name: "api.resource" } ]
+        calls:
+                                    - method:    "initNormalizationContext"
+                                      arguments:
+                                          -      { groups: [ "default" ] }
+
+    composite_identifier_relation_resource:
+        parent:                     "api.resource"
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeRelation' ]
+        tags:                       [ { name: "api.resource" } ]
+    composite_identifier_label_resource:
+        parent:                     "api.resource"
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CompositeLabel' ]
+        tags:                       [ { name: "api.resource" } ]

--- a/features/json-ld/context.feature
+++ b/features/json-ld/context.feature
@@ -25,7 +25,10 @@ Feature: JSON-LD contexts generation
         "circularReference": "/circular_references",
         "customIdentifierDummy": "/custom_identifier_dummies",
         "customWritableIdentifierDummy": "/custom_writable_identifier_dummies",
-        "customNormalizedDummy": "/custom_normalized_dummies"
+        "customNormalizedDummy": "/custom_normalized_dummies",
+        "compositeItem": "/composite_items",
+        "compositeRelation": "/composite_relations",
+        "compositeLabel": "/composite_labels"
     }
     """
 


### PR DESCRIPTION
I'm making this pull request:
- to provide a test with composite identifiers
- to demonstrate my issue

This is the use case :

![screenshot from 2016-01-14 16 27 50](https://cloud.githubusercontent.com/assets/1321971/12328463/c7485e1e-badb-11e5-87c3-2591da58cd2e.png)

Basically, it's a ManyToMany relation with one or more fields representing the relation value. It's useful when you want to keep an history of your relations for example (from, thru). 
Now, I want to `GET /composite_item` and see every `CompositeLabel` the `CompositeRelation` has. I'm setting serialization Groups and resources accordingly (see code).

Now, when executing `GET /composite_item` you will get an error:

> The class \"Dunglas\\ApiBundle\\Tests\\Behat\\TestBundle\\Entity\\CompositeRelation\" has no identifier. Maybe you forgot to define the Entity Identifier, or using composite identifiers (which are not supported)?

This is thrown by the ItemNormalizer, because the identifier will not be set (I assume it's because [this condition](https://github.com/dunglas/DunglasApiBundle/blob/master/Mapping/Loader/DoctrineIdentifierLoader.php#L63) gets hit). 
The thing is, results can be loaded, and composite identifiers are supported for this use case (note that I'm using a fetch EAGER). In a second commit I silently catched the `RuntimeException` and the test does pass.
I know that composite identifiers will fail when using `DoctrinePagination` (for example), but if there are defining a relation they should be accepted.

What are your thoughts about this? Has anyone hit the same issue? 