### PR TITLE
Custom naming for for resource endpoint

### DIFF
--- a/Api/Operation/OperationFactory.php
+++ b/Api/Operation/OperationFactory.php
@@ -108,7 +108,7 @@ class OperationFactory
         $pluralizedName = $resource->getPluralizedName();
 
         if (null !== $pluralizedName) {
-            Inflector::rules('plural', array('irregular' => array(Inflector::tableize($shortName) => $pluralizedName)));
+            Inflector::rules('plural', ['irregular' => [Inflector::tableize($shortName) => $pluralizedName]]);
         }
 
         if (!isset(self::$inflectorCache[$shortName])) {

--- a/Api/Operation/OperationFactory.php
+++ b/Api/Operation/OperationFactory.php
@@ -105,10 +105,10 @@ class OperationFactory
         $requirements = []
     ) {
         $shortName = $resource->getShortName();
-        $pluralizedName = $resource->getPluralizedName();
+        $basePath = $resource->getBasePath();
 
-        if (null !== $pluralizedName) {
-            Inflector::rules('plural', ['irregular' => [Inflector::tableize($shortName) => $pluralizedName]]);
+        if (null !== $basePath) {
+            Inflector::rules('plural', ['irregular' => [Inflector::tableize($shortName) => $basePath]]);
         }
 
         if (!isset(self::$inflectorCache[$shortName])) {

--- a/Api/Operation/OperationFactory.php
+++ b/Api/Operation/OperationFactory.php
@@ -105,6 +105,11 @@ class OperationFactory
         $requirements = []
     ) {
         $shortName = $resource->getShortName();
+        $pluralizedName = $resource->getPluralizedName();
+
+        if (null !== $pluralizedName) {
+            Inflector::rules('plural', array('irregular' => array(Inflector::tableize($shortName) => $pluralizedName)));
+        }
 
         if (!isset(self::$inflectorCache[$shortName])) {
             self::$inflectorCache[$shortName] = Inflector::pluralize(Inflector::tableize($shortName));

--- a/Api/Resource.php
+++ b/Api/Resource.php
@@ -57,6 +57,10 @@ class Resource implements RoutedResourceInterface
     /**
      * @var string|null
      */
+    private $pluralizedName;
+    /**
+     * @var string|null
+     */
     private $itemRouteName;
     /**
      * @var string|null
@@ -234,6 +238,24 @@ class Resource implements RoutedResourceInterface
     public function getShortName()
     {
         return $this->shortName;
+    }
+
+    /**
+     * Initializes pluralized name.
+     *
+     * @param string $pluralizedName
+     */
+    public function initPluralizedName($pluralizedName)
+    {
+        $this->pluralizedName = $pluralizedName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPluralizedName()
+    {
+        return $this->pluralizedName;
     }
 
     /**

--- a/Api/Resource.php
+++ b/Api/Resource.php
@@ -57,7 +57,7 @@ class Resource implements RoutedResourceInterface
     /**
      * @var string|null
      */
-    private $pluralizedName;
+    private $basePath;
     /**
      * @var string|null
      */
@@ -241,21 +241,21 @@ class Resource implements RoutedResourceInterface
     }
 
     /**
-     * Initializes pluralized name.
+     * Initializes base path.
      *
-     * @param string $pluralizedName
+     * @param string $basePath
      */
-    public function initPluralizedName($pluralizedName)
+    public function initBasePath($basePath)
     {
-        $this->pluralizedName = $pluralizedName;
+        $this->basePath = $basePath;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getPluralizedName()
+    public function getBasePath()
     {
-        return $this->pluralizedName;
+        return $this->basePath;
     }
 
     /**

--- a/Api/ResourceInterface.php
+++ b/Api/ResourceInterface.php
@@ -90,4 +90,11 @@ interface ResourceInterface
      * @return string
      */
     public function getShortName();
+
+    /**
+     * Gets the custom pluralized name of the resource.
+     *
+     * @return string
+     */
+    public function getPluralizedName();
 }

--- a/Api/ResourceInterface.php
+++ b/Api/ResourceInterface.php
@@ -90,11 +90,4 @@ interface ResourceInterface
      * @return string
      */
     public function getShortName();
-
-    /**
-     * Gets the custom pluralized name of the resource.
-     *
-     * @return string
-     */
-    public function getPluralizedName();
 }

--- a/Api/RoutedResourceInterface.php
+++ b/Api/RoutedResourceInterface.php
@@ -31,4 +31,11 @@ interface RoutedResourceInterface extends ResourceInterface
      * @return string|null
      */
     public function getCollectionRouteName();
+
+    /**
+     * Gets the custom base path of the resource.
+     *
+     * @return string
+     */
+    public function getBasePath();
 }

--- a/Tests/Api/Operation/OperationFactoryTest.php
+++ b/Tests/Api/Operation/OperationFactoryTest.php
@@ -30,10 +30,10 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
         $prophecy->getShortName()->willReturn('Foo');
         $this->resource = $prophecy->reveal();
 
-        $prophecy = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
-        $prophecy->getShortName()->willReturn('Bar');
-        $prophecy->getPluralizedName()->willReturn('Barz');
-        $this->resource2 = $prophecy->reveal();
+        $prophecy2 = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
+        $prophecy2->getShortName()->willReturn('Bar');
+        $prophecy2->getPluralizedName()->willReturn('Barz');
+        $this->resource2 = $prophecy2->reveal();
     }
 
     public function testCreateCollectionOperationWithDefaultValues()

--- a/Tests/Api/Operation/OperationFactoryTest.php
+++ b/Tests/Api/Operation/OperationFactoryTest.php
@@ -26,14 +26,14 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->operationFactory = new OperationFactory();
 
-        $prophecy = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
+        $prophecy = $this->prophesize('Dunglas\ApiBundle\Api\RoutedResourceInterface');
         $prophecy->getShortName()->willReturn('Foo');
-        $prophecy->getPluralizedName()->willReturn(null);
+        $prophecy->getBasePath()->willReturn(null);
         $this->resource = $prophecy->reveal();
 
-        $prophecy2 = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
+        $prophecy2 = $this->prophesize('Dunglas\ApiBundle\Api\RoutedResourceInterface');
         $prophecy2->getShortName()->willReturn('Bar');
-        $prophecy2->getPluralizedName()->willReturn('Barz');
+        $prophecy2->getBasePath()->willReturn('Barz');
         $this->resource2 = $prophecy2->reveal();
     }
 
@@ -115,7 +115,7 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['kevin' => 'dunglas'], $operation->getContext());
     }
 
-    public function testCreateCollectionOperationWithCustomPluralizedName()
+    public function testCreateCollectionOperationWithCustomBasePath()
     {
         $operation = $this->operationFactory->createCollectionOperation($this->resource2, ['GET', 'DELETE']);
 

--- a/Tests/Api/Operation/OperationFactoryTest.php
+++ b/Tests/Api/Operation/OperationFactoryTest.php
@@ -28,6 +28,7 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
 
         $prophecy = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
         $prophecy->getShortName()->willReturn('Foo');
+        $prophecy->getPluralizedName()->willReturn(null);
         $this->resource = $prophecy->reveal();
 
         $prophecy2 = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');

--- a/Tests/Api/Operation/OperationFactoryTest.php
+++ b/Tests/Api/Operation/OperationFactoryTest.php
@@ -20,6 +20,7 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
 {
     private $operationFactory;
     private $resource;
+    private $resource2;
 
     public function setUp()
     {
@@ -28,6 +29,11 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
         $prophecy = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
         $prophecy->getShortName()->willReturn('Foo');
         $this->resource = $prophecy->reveal();
+
+        $prophecy = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
+        $prophecy->getShortName()->willReturn('Bar');
+        $prophecy->getPluralizedName()->willReturn('Barz');
+        $this->resource2 = $prophecy->reveal();
     }
 
     public function testCreateCollectionOperationWithDefaultValues()
@@ -48,7 +54,13 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateCollectionOperationWithAllParameters()
     {
         $operation = $this->operationFactory->createCollectionOperation(
-            $this->resource, ['GET', 'HEAD'], '/bar/{baz}', 'AppBundle:Test:cget', 'qux', ['kevin' => 'dunglas'], ['baz' => '\d']
+            $this->resource,
+            ['GET', 'HEAD'],
+            '/bar/{baz}',
+            'AppBundle:Test:cget',
+            'qux',
+            ['kevin' => 'dunglas'],
+            ['baz' => '\d']
         );
 
         $this->assertEquals('/bar/{baz}', $operation->getRoute()->getPath());
@@ -81,7 +93,13 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateItemOperationWithAllParameters()
     {
         $operation = $this->operationFactory->createItemOperation(
-            $this->resource, ['GET', 'HEAD'], '/bar/{id}', 'AppBundle:Test:cget', 'baz', ['kevin' => 'dunglas'], ['id' => '\d']
+            $this->resource,
+            ['GET', 'HEAD'],
+            '/bar/{id}',
+            'AppBundle:Test:cget',
+            'baz',
+            ['kevin' => 'dunglas'],
+            ['id' => '\d']
         );
 
         $this->assertEquals('/bar/{id}', $operation->getRoute()->getPath());
@@ -94,5 +112,20 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('baz', $operation->getRouteName());
         $this->assertEquals(['kevin' => 'dunglas'], $operation->getContext());
+    }
+
+    public function testCreateCollectionOperationWithCustomPluralizedName()
+    {
+        $operation = $this->operationFactory->createCollectionOperation($this->resource2, ['GET', 'DELETE']);
+
+        $this->assertEquals('/barz', $operation->getRoute()->getPath());
+        $this->assertEquals(['GET', 'DELETE'], $operation->getRoute()->getMethods());
+
+        $defaults = $operation->getRoute()->getDefaults();
+        $this->assertEquals('DunglasApiBundle:Resource:cget', $defaults['_controller']);
+        $this->assertEquals('Bar', $defaults['_resource']);
+
+        $this->assertEquals('api_barz_cget', $operation->getRouteName());
+        $this->assertEquals([], $operation->getContext());
     }
 }

--- a/Tests/Api/ResourceTest.php
+++ b/Tests/Api/ResourceTest.php
@@ -119,12 +119,12 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test', $resource->getShortName());
     }
 
-    public function testPluralizedName()
+    public function testBasePath()
     {
         $resource = new Resource('Dunglas\ApiBundle\Tests\Fixtures\DummyEntity');
-        $resource->initPluralizedName('Tests');
+        $resource->initBasePath('Tests');
 
-        $this->assertEquals('Tests', $resource->getPluralizedName());
+        $this->assertEquals('Tests', $resource->getBasePath());
     }
 
     /**

--- a/Tests/Api/ResourceTest.php
+++ b/Tests/Api/ResourceTest.php
@@ -119,6 +119,14 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test', $resource->getShortName());
     }
 
+    public function testPluralizedName()
+    {
+        $resource = new Resource('Dunglas\ApiBundle\Tests\Fixtures\DummyEntity');
+        $resource->initPluralizedName('Tests');
+
+        $this->assertEquals('Test', $resource->getPluralizedName());
+    }
+
     /**
      * @expectedException \Dunglas\ApiBundle\Exception\InvalidArgumentException
      * @expectedExceptionMessage The class "Foo\Bar" does not exist.

--- a/Tests/Api/ResourceTest.php
+++ b/Tests/Api/ResourceTest.php
@@ -124,7 +124,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
         $resource = new Resource('Dunglas\ApiBundle\Tests\Fixtures\DummyEntity');
         $resource->initPluralizedName('Tests');
 
-        $this->assertEquals('Test', $resource->getPluralizedName());
+        $this->assertEquals('Tests', $resource->getPluralizedName());
     }
 
     /**

--- a/Tests/Behat/TestBundle/Api/CustomResource.php
+++ b/Tests/Behat/TestBundle/Api/CustomResource.php
@@ -69,4 +69,9 @@ class CustomResource implements ResourceInterface
     {
         return 'Custom';
     }
+
+    public function getPluralizedName()
+    {
+        return;
+    }
 }

--- a/Tests/Behat/TestBundle/Api/CustomResource.php
+++ b/Tests/Behat/TestBundle/Api/CustomResource.php
@@ -70,7 +70,7 @@ class CustomResource implements ResourceInterface
         return 'Custom';
     }
 
-    public function getPluralizedName()
+    public function getBasePath()
     {
         return;
     }


### PR DESCRIPTION
Hi there,

I'm making this pull request in order to be able to customize pluralisation of some resource endpoint.

I have a resource called ITRF (acronym for International Terrestrial Reference Frame). For the moment Inflector pluralize it like this : itrves. And we would rather it to be : itrfs
Here is how to do it : 
```yaml
# In services.yml
services:
    resource.itrf:
        parent:     "api.resource"
        arguments:  [ "ItrfAppBundle\\Entity\\Itrf"]
        calls:
            - method: "initPluralizedName"
              arguments: [ 'Itrfs' ]
        tags:       [ { name: "api.resource" } ]
```

It's my first ever contribution to a project, so I'm not sure to do it good.

PS: Sorry for my bad french english...