### PR TITLE
Correct attempt to instanciate isAbstract Class and look for sub@Type

### DIFF
--- a/Api/ResourceResolverTrait.php
+++ b/Api/ResourceResolverTrait.php
@@ -54,7 +54,9 @@ trait ResourceResolverTrait
             $type = gettype($type);
         }
 
-        if (isset($context['resource'])) {
+        if (is_array($object) && isset($object['@type'])) {
+            $resource = $this->resourceCollection->getResourceForShortName($object['@type']);
+        } elseif (isset($context['resource'])) {
             $resource = $context['resource'];
         } else {
             $resource = $this->resourceCollection->getResourceForEntity($type);

--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -212,6 +212,14 @@ class ItemNormalizer extends AbstractNormalizer
             if (is_subclass_of($resource->getEntityClass(), $instanceClass)) {
                 $instanceClass = $resource->getEntityClass();
                 $reflectionClass = new \ReflectionClass($instanceClass);
+                if ($reflectionClass->isAbstract()) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            'Cannot create an instance of %s from serialized data because it is an abstract resource',
+                            $instanceClass
+                        )
+                    );
+                }
             } else {
                 throw new InvalidArgumentException(
                     sprintf(

--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -209,12 +209,19 @@ class ItemNormalizer extends AbstractNormalizer
         $instanceClass = $overrideClass ? get_class($context['object_to_populate']) : $class;
         $reflectionClass = new \ReflectionClass($instanceClass);
         if ($reflectionClass->isAbstract()) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Cannot create an instance of %s from serialized data because it is an abstract resource',
-                    $instanceClass
-                )
-            );
+            $isAbstract = true;
+            if (is_subclass_of($resource->getEntityClass(), $instanceClass)) {
+                $instanceClass = $resource->getEntityClass();
+                $reflectionClass = new \ReflectionClass($instanceClass);
+                $isAbstract = $reflectionClass->isAbstract();
+            } else {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Cannot create an instance of %s from serialized data because it is an abstract resource',
+                        $instanceClass
+                    )
+                );
+            }
         }
 
         $object = $this->instantiateObject(

--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -209,11 +209,9 @@ class ItemNormalizer extends AbstractNormalizer
         $instanceClass = $overrideClass ? get_class($context['object_to_populate']) : $class;
         $reflectionClass = new \ReflectionClass($instanceClass);
         if ($reflectionClass->isAbstract()) {
-            $isAbstract = true;
             if (is_subclass_of($resource->getEntityClass(), $instanceClass)) {
                 $instanceClass = $resource->getEntityClass();
                 $reflectionClass = new \ReflectionClass($instanceClass);
-                $isAbstract = $reflectionClass->isAbstract();
             } else {
                 throw new InvalidArgumentException(
                     sprintf(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #403 
| License       | MIT
| Doc PR        | N/A

All credits remains to @jderusse 

While denormalization, we use metadata defined in entity to generate instance and we mask the "@type" part.

It works but we can have some side effects both on normalizer or on ResourceResolver.

Behat test's coming.

Resolves #403 



