### PR TITLE
Speed up Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache:
 matrix:
     fast_finish: true
     include:
-        - php: 7.0
-        - php: 7.0
+        - php: '7.0'
+        - php: '7.0'
           env: SYMFONY_VERSION=3.0.*
         - php: hhvm
 
@@ -19,7 +19,9 @@ matrix:
         - php: hhvm
 
 before_install:
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi;
     - composer self-update
+    - if [ "$GITHUB_OAUTH_TOKEN" ]; then composer config --global github-oauth.github.com ${GITHUB_OAUTH_TOKEN}; fi;
     - phpunit --self-update
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

xdebug is enabled by default on Travis CI

It slows down Composer - https://getcomposer.org/xdebug
and also just slows everything down...

Since we're not doing coverage report (as far as I can tell), we might as well disable it for now for a nice speed boost.