### PR TITLE
Rename services in test app

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -57,6 +57,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             }
         }
 
+        if ($config['name_converter']) {
+            $container->setAlias('api_platform.name_converter', $config['name_converter']);
+        }
+
         $container->setParameter('api_platform.title', $config['title']);
         $container->setParameter('api_platform.description', $config['description']);
         $container->setParameter('api_platform.supported_formats', $supportedFormats);
@@ -77,8 +81,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->enableJsonLd($loader);
         $this->registerAnnotationLoaders($container);
 
+        $bundles = $container->getParameter('kernel.bundles');
+
         // Doctrine ORM support
-        if (class_exists('Doctrine\ORM\Version')) {
+        if (isset($bundles['DoctrineBundle']) && class_exists('Doctrine\ORM\Version')) {
             $loader->load('doctrine_orm.xml');
         }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->scalarNode('name_converter')->defaultNull()->info('Specify a name converter to use.')->end()
                 ->booleanNode('enable_fos_user')->defaultValue(false)->info('Enable the FOSUserBundle integration.')->end()
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -118,13 +118,24 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load(self::DEFAULT_CONFIG, $containerBuilder);
     }
 
+    public function testSetNameConverter()
+    {
+        $nameConverterId = 'test.name_converter';
+
+        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy->setAlias('api_platform.name_converter', $nameConverterId)->shouldBeCalled();
+        $containerBuilder = $containerBuilderProphecy->reveal();
+
+        $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['name_converter' => $nameConverterId]]), $containerBuilder);
+    }
+
     public function testEnableFosUser()
     {
         $containerBuilderProphecy = $this->getContainerBuilderProphecy();
         $containerBuilderProphecy->setDefinition('api_platform.fos_user.event_listener', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
-        $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_builder' => ['enable_fos_user' => true]]), $containerBuilder);
+        $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['enable_fos_user' => true]]), $containerBuilder);
     }
 
     private function getContainerBuilderProphecy()
@@ -134,7 +145,9 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         });
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([])->shouldBeCalled();
+        $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
+            'DoctrineBundle' => 'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+        ])->shouldBeCalled();
 
         $parameters = [
             'api_platform.title' => 'title',

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -34,6 +34,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'title' => 'title',
             'description' => 'description',
             'supported_formats' => ['jsonld' => ['mime_types' => ['application/ld+json']]],
+            'name_converter' => null,
             'enable_fos_user' => false,
             'collection' => [
                 'order' => null,

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -32,6 +32,7 @@ api_platform:
     supported_formats:
         jsonld:                        ['application/ld+json']
         xml:                           ['application/xml', 'text/xml']
+    name_converter:                    'app.name_converter'
     enable_fos_user:                   true
     collection:
         order_parameter_name:          'order'
@@ -45,11 +46,11 @@ fos_user:
     db_driver:        'orm'
     firewall_name:    'api'
     service:
-        user_manager: 'api_platform.user_manager'
+        user_manager: 'app.user_manager'
     user_class:       'ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\User'
 
 services:
-    api_platform.user_manager:
+    app.user_manager:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Manager\UserManager'
         arguments:
             -  '@security.encoder_factory'
@@ -61,10 +62,10 @@ services:
     fos_user.mailer.default:
         class: 'ApiPlatform\Core\Bridge\Symfony\Bundle\Tests\Mock\MailerMock'
 
-    api_platform.name_converter:
+    app.name_converter:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\NameConverter\CustomConverter'
 
-    xml_responder_view_listener:
+    app.xml_responder_view_listener:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\EventListener\XmlResponderViewListener'
         arguments:
             - '@api_platform.serializer'
@@ -73,22 +74,22 @@ services:
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.view', method: 'onKernelView' }
 
-    my_dummy_resource.search_filter:
+    app.my_dummy_resource.search_filter:
         parent:    'api_platform.doctrine.orm.search_filter'
         arguments: [ { 'id': 'exact', 'name': 'partial', 'alias': 'start', 'description': 'word_start', 'relatedDummy.name': 'exact', 'relatedDummies': 'exact'  } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.search' } ]
 
-    my_dummy_resource.order_filter:
+    app.my_dummy_resource.order_filter:
         parent:    'api_platform.doctrine.orm.order_filter'
         arguments: [ { 'id': ~, 'name': 'desc', 'relatedDummy.symfony': ~ } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.order' } ]
 
-    my_dummy_resource.date_filter:
+    app.my_dummy_resource.date_filter:
         parent:    'api_platform.doctrine.orm.date_filter'
         arguments: [ { 'dummyDate': ~, 'relatedDummy.dummyDate': ~ } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.date' } ]
 
-    my_dummy_resource.range_filter:
+    app.my_dummy_resource.range_filter:
         parent:    'api_platform.doctrine.orm.range_filter'
         arguments: [ { 'dummyPrice': ~ } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.range' } ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

See http://symfony.com/doc/current/best_practices/business-logic.html#services-naming-and-format

Also added `name_converter` in config, instead of using magic hard-coded `api_platform.name_converter` service id (same method as how `DoctrineBundle` handles `naming_strategy`).

Check for `DoctrineBundle` before loading `doctrine_orm.xml`, because the existence of `doctrine/orm` doesn't mean such services are available.