### PR TITLE
Allow ItemDataProvider to throw more exceptions

### DIFF
--- a/src/Api/CollectionDataProviderInterface.php
+++ b/src/Api/CollectionDataProviderInterface.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Api;
 
-use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\ExceptionInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
@@ -28,7 +28,7 @@ interface CollectionDataProviderInterface
      * @param string|null $operationName
      *
      * @throws ResourceClassNotSupportedException
-     * @throws InvalidArgumentException
+     * @throws ExceptionInterface
      *
      * @return array|PaginatorInterface|\Traversable
      */

--- a/src/Api/ItemDataProviderInterface.php
+++ b/src/Api/ItemDataProviderInterface.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Api;
 
-use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\ExceptionInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
@@ -30,7 +30,7 @@ interface ItemDataProviderInterface
      * @param bool        $fetchData
      *
      * @throws ResourceClassNotSupportedException
-     * @throws InvalidArgumentException
+     * @throws ExceptionInterface
      *
      * @return object|null
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

I find the current very restrictive: it only allows an item provider to throw exceptions when it does not support the class or received an incorrect value. As the responsibility of an item provider is to retrieve an item from the persistent layer, it looks to me that there could be all kind of other problems: could not establish a connection with the persistence layer, the item could not be retrieve, etc.

If someone wants to add a custom provider implementing this interface and have to face one of the situation above, he will have little choice but to return `null`. IMO, this is not helpful as the `null` value should be used here for when no item was found. If there was an error while trying to retrieve this item, an exception should be fired. Hence my change in the interface.
