### PR TITLE
Use installed PHPUnit binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,11 @@ matrix:
 before_install:
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi;
     - composer self-update
-    - phpunit --self-update
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install:
     - composer update --no-interaction --prefer-dist
 
 script:
-    - phpunit
+    - vendor/bin/phpunit
     - vendor/bin/behat


### PR DESCRIPTION
Using Travis one is useful when supporting different versions of PHP, as for example PHPUnit 5.2 is not supported on PHP 5.3 or 5.4. But in our case we don't really care and we are installing PHPUnit anyway, so we might as well use it directly instead of having to update Travis one.