### PR TITLE
Fix typo in ContextTrait::createRelationContext

### DIFF
--- a/src/JsonLd/Serializer/ContextTrait.php
+++ b/src/JsonLd/Serializer/ContextTrait.php
@@ -59,8 +59,8 @@ trait ContextTrait
     private function createRelationContext(string $resourceClass, array $context) : array
     {
         $context['resource_class'] = $resourceClass;
-        unset($context['item_operation']);
-        unset($context['collection_operation']);
+        unset($context['item_operation_name']);
+        unset($context['collection_operation_name']);
 
         return $context;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

No such keys as `item_operation` and `collection_operation` in the `$context`.

I assume the intended keys to be unset are `item_operation_name` and `collection_operation_name`?