### PR TITLE
Disable PHPDoc property metadata factory if…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
   "suggest": {
     "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge.",
     "nelmio/api-doc-bundle": "To have the api sandbox & documentation.",
+    "phpdocumentor/reflection-docblock": "To support extracting metadata from PHPDoc.",
     "psr/cache-implementation": "To use metadata caching.",
     "symfony/cache": "To have metadata caching when using Symfony integration."
   },

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -82,6 +82,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerAnnotationLoaders($container);
         $this->setUpMetadataCaching($container, $config);
 
+        if (!interface_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
+            $container->removeDefinition('api_platform.metadata.resource.metadata_factory.php_doc');
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         // Doctrine ORM support


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #460
| License       | MIT
| Doc PR        | N/A

...`phpdocumentor/reflection-docblock` is not available

Replaces #462