### PR TITLE
Add metadata caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   ],
   "require": {
     "php": ">=7.0",
+    "psr/cache": "^1.0.0",
     "symfony/http-foundation": "~2.3|~3.0|~3.1@dev",
     "symfony/serializer": "~3.1@dev",
     "doctrine/inflector": "~1.0",
@@ -33,6 +34,7 @@
     "behat/mink-extension": "~2.2",
     "behat/mink-browserkit-driver": "^1.3.1",
     "behatch/contexts": "~2.5",
+    "symfony/cache": "^3.1.0@dev",
     "symfony/framework-bundle": "~3.1@dev",
     "symfony/finder": "~2.3",
     "symfony/security": "~2.7|~3.0",
@@ -47,7 +49,9 @@
   },
   "suggest": {
     "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge.",
-    "nelmio/api-doc-bundle": "To have the api sandbox & documentation."
+    "nelmio/api-doc-bundle": "To have the api sandbox & documentation.",
+    "psr/cache-implementation": "To use metadata caching.",
+    "symfony/cache": "To have metadata caching when using Symfony integration."
   },
   "autoload": {
     "psr-4": { "ApiPlatform\\Core\\": "src/" }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -81,6 +81,23 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('metadata')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('resource')
+                        ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('cache')->defaultValue('api_platform.metadata.resource.cache.array')->cannotBeEmpty()->info('Cache service for resource metadata.')->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('property')
+                        ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('cache')->defaultValue('api_platform.metadata.property.cache.array')->cannotBeEmpty()->info('Cache service for property metadata.')->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -54,9 +54,9 @@
 
         <!-- Metadata loader -->
 
-        <service id="api_platform.doctrine.orm.metadata.property.factory.item" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Metadata\Property\DoctrineOrmPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" public="false">
+        <service id="api_platform.doctrine.orm.metadata.property.metadata_factory" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Metadata\Property\DoctrineOrmPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" public="false">
             <argument type="service" id="doctrine" />
-            <argument type="service" id="api_platform.doctrine.orm.metadata.property.factory.item.inner" />
+            <argument type="service" id="api_platform.doctrine.orm.metadata.property.metadata_factory.inner" />
         </service>
 
         <!-- Event listener -->

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <!-- Resource collection -->
+        <!-- Resource name collection -->
 
         <service id="api_platform.metadata.resource.name_collection_factory" alias="api_platform.metadata.resource.name_collection_factory.annotation" />
 
@@ -13,7 +13,12 @@
             <argument type="service" id="annotation_reader" />
         </service>
 
-        <!-- Resource item -->
+        <service id="api_platform.metadata.resource.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceNameCollectionFactory" decorates="api_platform.metadata.resource.name_collection_factory" decoration-priority="-1" public="false">
+            <argument type="service" id="api_platform.metadata.resource.cache" />
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory.cached.inner" />
+        </service>
+
+        <!-- Resource metadata -->
 
         <service id="api_platform.metadata.resource.metadata_factory" alias="api_platform.metadata.resource.metadata_factory.annotation" />
 
@@ -33,7 +38,12 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory.operation.inner" />
         </service>
 
-        <!-- Property collection -->
+        <service id="api_platform.metadata.resource.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="-1" public="false">
+            <argument type="service" id="api_platform.metadata.resource.cache" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory.cached.inner" />
+        </service>
+
+        <!-- Property name collection -->
 
         <service id="api_platform.metadata.property.name_collection_factory" alias="api_platform.metadata.property.name_collection_factory.property_info" />
 
@@ -49,7 +59,12 @@
             <argument type="service" id="api_platform.property_info" />
         </service>
 
-        <!-- Property item -->
+        <service id="api_platform.metadata.property.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" decoration-priority="-1" public="false">
+            <argument type="service" id="api_platform.metadata.property.cache" />
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory.cached.inner" />
+        </service>
+
+        <!-- Property metadata -->
 
         <service id="api_platform.metadata.property.metadata_factory" alias="api_platform.metadata.property.metadata_factory.annotation" />
 
@@ -72,6 +87,33 @@
         <service id="api_platform.metadata.property.metadata_factory.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\ValidatorPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" public="false">
             <argument type="service" id="validator" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.validator.inner" />
+        </service>
+
+        <service id="api_platform.metadata.property.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="-1" public="false">
+            <argument type="service" id="api_platform.metadata.property.cache" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory.cached.inner" />
+        </service>
+
+        <!-- Cache -->
+
+        <service id="api_platform.metadata.resource.cache.array" class="Symfony\Component\Cache\Adapter\ArrayAdapter" public="false">
+            <argument>0</argument>
+            <argument>false</argument>
+        </service>
+
+        <service id="api_platform.metadata.resource.cache.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" public="false">
+            <argument>api_platform_metadata_resource</argument>
+            <argument>0</argument>
+        </service>
+
+        <service id="api_platform.metadata.property.cache.array" class="Symfony\Component\Cache\Adapter\ArrayAdapter" public="false">
+            <argument>0</argument>
+            <argument>false</argument>
+        </service>
+
+        <service id="api_platform.metadata.property.cache.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" public="false">
+            <argument>api_platform_metadata_property</argument>
+            <argument>0</argument>
         </service>
 
     </services>

--- a/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Metadata\Property\Factory;
+
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use Psr\Cache\CacheException;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Caches property metadata.
+ *
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInterface
+{
+    const CACHE_KEY_PREFIX = 'property_metadata_';
+
+    private $cacheItemPool;
+    private $decorated;
+
+    public function __construct(CacheItemPoolInterface $cacheItemPool, PropertyMetadataFactoryInterface $decorated)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass, string $property, array $options = []) : PropertyMetadata
+    {
+        $cacheKey = self::CACHE_KEY_PREFIX.sha1(serialize([$resourceClass, $property, $options]));
+
+        try {
+            $cacheItem = $this->cacheItemPool->getItem($cacheKey);
+
+            if ($cacheItem->isHit()) {
+                return $cacheItem->get();
+            }
+        } catch (CacheException $e) {
+            // do nothing
+        }
+
+        $propertyMetadata = $this->decorated->create($resourceClass, $property, $options);
+
+        if (isset($cacheItem)) {
+            try {
+                $cacheItem->set($propertyMetadata);
+                $this->cacheItemPool->save($cacheItem);
+            } catch (CacheException $e) {
+                // do nothing
+            }
+        }
+
+        return $propertyMetadata;
+    }
+}

--- a/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Metadata\Property\Factory;
+
+use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use Psr\Cache\CacheException;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Caches property name collection.
+ *
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+final class CachedPropertyNameCollectionFactory implements PropertyNameCollectionFactoryInterface
+{
+    const CACHE_KEY_PREFIX = 'property_name_collection_';
+
+    private $cacheItemPool;
+    private $decorated;
+
+    public function __construct(CacheItemPoolInterface $cacheItemPool, PropertyNameCollectionFactoryInterface $decorated)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass, array $options = []) : PropertyNameCollection
+    {
+        $cacheKey = self::CACHE_KEY_PREFIX.sha1(serialize([$resourceClass, $options]));
+
+        try {
+            $cacheItem = $this->cacheItemPool->getItem($cacheKey);
+
+            if ($cacheItem->isHit()) {
+                return $cacheItem->get();
+            }
+        } catch (CacheException $e) {
+            // do nothing
+        }
+
+        $propertyNameCollection = $this->decorated->create($resourceClass, $options);
+
+        if (isset($cacheItem)) {
+            try {
+                $cacheItem->set($propertyNameCollection);
+                $this->cacheItemPool->save($cacheItem);
+            } catch (CacheException $e) {
+                // do nothing
+            }
+        }
+
+        return $propertyNameCollection;
+    }
+}

--- a/src/Metadata/Resource/Factory/CachedResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/CachedResourceMetadataFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use Psr\Cache\CacheException;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Caches resource metadata.
+ *
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+final class CachedResourceMetadataFactory implements ResourceMetadataFactoryInterface
+{
+    const CACHE_KEY_PREFIX = 'resource_metadata_';
+
+    private $cacheItemPool;
+    private $decorated;
+
+    public function __construct(CacheItemPoolInterface $cacheItemPool, ResourceMetadataFactoryInterface $decorated)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass) : ResourceMetadata
+    {
+        $cacheKey = self::CACHE_KEY_PREFIX.sha1(serialize([$resourceClass]));
+
+        try {
+            $cacheItem = $this->cacheItemPool->getItem($cacheKey);
+
+            if ($cacheItem->isHit()) {
+                return $cacheItem->get();
+            }
+        } catch (CacheException $e) {
+            // do nothing
+        }
+
+        $resourceMetadata = $this->decorated->create($resourceClass);
+
+        if (isset($cacheItem)) {
+            try {
+                $cacheItem->set($resourceMetadata);
+                $this->cacheItemPool->save($cacheItem);
+            } catch (CacheException $e) {
+                // do nothing
+            }
+        }
+
+        return $resourceMetadata;
+    }
+}

--- a/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
+use Psr\Cache\CacheException;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Caches resource name collection.
+ *
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+final class CachedResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
+{
+    const CACHE_KEY = 'resource_name_collection';
+
+    private $cacheItemPool;
+    private $decorated;
+
+    public function __construct(CacheItemPoolInterface $cacheItemPool, ResourceNameCollectionFactoryInterface $decorated)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create() : ResourceNameCollection
+    {
+        try {
+            $cacheItem = $this->cacheItemPool->getItem(self::CACHE_KEY);
+
+            if ($cacheItem->isHit()) {
+                return $cacheItem->get();
+            }
+        } catch (CacheException $e) {
+            // do nothing
+        }
+
+        $resourceNameCollection = $this->decorated->create();
+
+        if (isset($cacheItem)) {
+            try {
+                $cacheItem->set($resourceNameCollection);
+                $this->cacheItemPool->save($cacheItem);
+            } catch (CacheException $e) {
+                // do nothing
+            }
+        }
+
+        return $resourceNameCollection;
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -152,6 +152,25 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['enable_nelmio_api_doc' => true]]), $containerBuilder);
     }
 
+    public function testSetApcuMetadataCache()
+    {
+        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy->setAlias('api_platform.metadata.resource.cache', 'api_platform.metadata.resource.cache.apcu')->shouldBeCalled();
+        $containerBuilderProphecy->setAlias('api_platform.metadata.resource.cache', 'api_platform.metadata.resource.cache.array')->shouldNotBeCalled();
+        $containerBuilderProphecy->setAlias('api_platform.metadata.property.cache', 'api_platform.metadata.property.cache.apcu')->shouldBeCalled();
+        $containerBuilderProphecy->setAlias('api_platform.metadata.property.cache', 'api_platform.metadata.property.cache.array')->shouldNotBeCalled();
+        $containerBuilderProphecy->has('api_platform.metadata.resource.cache.apcu')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->has('api_platform.metadata.resource.cache.array')->shouldNotBeCalled();
+        $containerBuilderProphecy->has('api_platform.metadata.property.cache.apcu')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->has('api_platform.metadata.property.cache.array')->shouldNotBeCalled();
+        $containerBuilder = $containerBuilderProphecy->reveal();
+
+        $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['metadata' => [
+            'resource' => ['cache' => 'api_platform.metadata.resource.cache.apcu'],
+            'property' => ['cache' => 'api_platform.metadata.property.cache.apcu'],
+        ]]]), $containerBuilder);
+    }
+
     private function getContainerBuilderProphecy()
     {
         $definitionArgument = Argument::that(function ($argument) {
@@ -210,16 +229,23 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.resource_class_resolver',
             'api_platform.operation_method_resolver',
             'api_platform.metadata.resource.name_collection_factory.annotation',
+            'api_platform.metadata.resource.name_collection_factory.cached',
             'api_platform.metadata.resource.metadata_factory.annotation',
             'api_platform.metadata.resource.metadata_factory.php_doc',
             'api_platform.metadata.resource.metadata_factory.short_name',
             'api_platform.metadata.resource.metadata_factory.operation',
+            'api_platform.metadata.resource.metadata_factory.cached',
+            'api_platform.metadata.resource.cache.array',
+            'api_platform.metadata.resource.cache.apcu',
             'api_platform.metadata.property.name_collection_factory.property_info',
+            'api_platform.metadata.property.name_collection_factory.cached',
             'api_platform.metadata.property.metadata_factory.annotation',
             'api_platform.metadata.property.metadata_factory.property_info',
             'api_platform.metadata.property.metadata_factory.serializer',
             'api_platform.metadata.property.metadata_factory.validator',
-            'api_platform.metadata.resource.name_collection_factory.annotation',
+            'api_platform.metadata.property.metadata_factory.cached',
+            'api_platform.metadata.property.cache.array',
+            'api_platform.metadata.property.cache.apcu',
             'api_platform.negotiator',
             'api_platform.route_loader',
             'api_platform.router',
@@ -241,7 +267,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.doctrine.orm.range_filter',
             'api_platform.doctrine.orm.default.collection_data_provider',
             'api_platform.doctrine.orm.default.item_data_provider',
-            'api_platform.doctrine.orm.metadata.property.factory.item',
+            'api_platform.doctrine.orm.metadata.property.metadata_factory',
             'api_platform.doctrine.orm.query_extension.eager_loading',
             'api_platform.doctrine.orm.query_extension.filter',
             'api_platform.doctrine.orm.query_extension.pagination',
@@ -273,11 +299,16 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
         $aliases = [
             'api_platform.metadata.resource.name_collection_factory' => 'api_platform.metadata.resource.name_collection_factory.annotation',
+            'api_platform.metadata.resource.cache' => 'api_platform.metadata.resource.cache.array',
+            'api_platform.metadata.property.cache' => 'api_platform.metadata.property.cache.array',
         ];
 
         foreach ($aliases as $alias => $service) {
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
+
+        $containerBuilderProphecy->has('api_platform.metadata.resource.cache.array')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->has('api_platform.metadata.property.cache.array')->willReturn(true)->shouldBeCalled();
 
         return $containerBuilderProphecy;
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -50,6 +50,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'items_per_page_parameter_name' => 'itemsPerPage',
                 ],
             ],
+            'metadata' => [
+                'resource' => [
+                    'cache' => 'api_platform.metadata.resource.cache.array',
+                ],
+                'property' => [
+                    'cache' => 'api_platform.metadata.property.cache.array',
+                ],
+            ],
         ], $config);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #468
| License       | MIT
| Doc PR        | N/A

Add PSR6 cached decorators for all metadata factories.

Also provide `symfony/cache` integration in the Symfony bundle.