### PR TITLE
Show hydra:totalItems even filter is applied

### DIFF
--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -67,11 +67,6 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Seri
             return $data;
         }
 
-        if ([] !== $appliedFilters) {
-            // Don't display a false result, and don't retrieve the size of the whole collection for performance
-            unset($data['hydra:totalItems']);
-        }
-
         $data['hydra:view'] = [
             '@id' => $this->getId($parts, $parameters, $paginated ? $currentPage : null),
             '@type' => 'hydra:PartialCollectionView',

--- a/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
+++ b/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
@@ -43,25 +43,6 @@ class PartialCollectionViewNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], $normalizer->normalize(new \stdClass(), null, ['request_uri' => '/?page=1&pagination=1']));
     }
 
-    public function testNormalizeDoesNotTotalItemsWhenFilterApplied()
-    {
-        $decoratedNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
-        $decoratedNormalizerProphecy->normalize(Argument::any(), null, Argument::type('array'))->willReturn(['hydra:totalItems' => 40, 'foo' => 'bar'])->shouldBeCalled();
-        $decoratedNormalizer = $decoratedNormalizerProphecy->reveal();
-
-        $normalizer = new PartialCollectionViewNormalizer($decoratedNormalizer);
-        $this->assertEquals(
-            [
-                'foo' => 'bar',
-                'hydra:view' => [
-                    '@id' => '/?baz=22',
-                    '@type' => 'hydra:PartialCollectionView',
-                ],
-            ],
-            $normalizer->normalize(new \stdClass(), null, ['request_uri' => '/?baz=22'])
-        );
-    }
-
     public function testNormalizePaginator()
     {
         $paginatorProphecy = $this->prophesize(PaginatorInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

Please look at the comment [here](https://github.com/api-platform/core/pull/419#issuecomment-199690736) as I think it makes sense to show `hydra:totalItems` even when filter is applied.
