### PR TITLE
Routes should be GET only

### DIFF
--- a/Resources/config/routing/hydra.xml
+++ b/Resources/config/routing/hydra.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_hydra_vocab" path="/apidoc">
+    <route id="api_hydra_vocab" path="/apidoc" methods="GET">
         <default key="_controller">DunglasApiBundle:Hydra:doc</default>
     </route>
 </routes>

--- a/Resources/config/routing/json_ld.xml
+++ b/Resources/config/routing/json_ld.xml
@@ -5,15 +5,15 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_json_ld_entrypoint" path="/">
+    <route id="api_json_ld_entrypoint" path="/" methods="GET">
         <default key="_controller">DunglasApiBundle:JsonLd:entrypoint</default>
     </route>
 
-    <route id="api_json_ld_entrypoint_context" path="/contexts/Entrypoint">
+    <route id="api_json_ld_entrypoint_context" path="/contexts/Entrypoint" methods="GET">
         <default key="_controller">DunglasApiBundle:JsonLd:entrypointContext</default>
     </route>
 
-    <route id="api_json_ld_context" path="/contexts/{shortName}">
+    <route id="api_json_ld_context" path="/contexts/{shortName}" methods="GET">
         <default key="_controller">DunglasApiBundle:JsonLd:context</default>
         <requirement key="shortName">.+</requirement>
     </route>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Minor semantic fix. I suppose these are meant to be GET routes rather than to match ANY.


