### PR TITLE
Fix wrong renaming introduced in #452

### DIFF
--- a/src/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactory.php
@@ -22,7 +22,7 @@ use Doctrine\Common\Annotations\Reader;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class AnnotationPropertyCollectionMetadataFactory implements PropertyNameCollectionFactoryInterface
+final class AnnotationPropertyNameCollectionFactory implements PropertyNameCollectionFactoryInterface
 {
     private $reader;
     private $decorated;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

#452 erroneously renamed `AnnotationPropertyNameCollectionFactory` to `AnnotationPropertyCollectionMetadataFactory`. The actual problem was the file not being renamed to match the class name change (introduced by #436)