### PR TITLE
Fix an issue in RequestParser when the query string is null

### DIFF
--- a/src/Util/RequestParser.php
+++ b/src/Util/RequestParser.php
@@ -32,7 +32,7 @@ abstract class RequestParser
      */
     public static function parseAndDuplicateRequest(Request $request) : Request
     {
-        $query = self::parseRequestParams($request->getQueryString());
+        $query = self::parseRequestParams($request->getQueryString() ?? '');
         $body = self::parseRequestParams($request->getContent());
 
         return $request->duplicate($query, $body);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

`Request::getQueryString` may return `null`.