### PR TITLE
Fix entity not found exception

### DIFF
--- a/features/crud.feature
+++ b/features/crud.feature
@@ -74,6 +74,10 @@ Feature: Create-Retrieve-Update-Delete
     }
     """
 
+  Scenario: Get a resource that does not exist
+    When I send a "GET" request to "/dummies/9999"
+    Then the response status code should be 404
+
   Scenario: Get a collection
     When I send a "GET" request to "/dummies"
     Then the response status code should be 200

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -88,7 +88,7 @@ class ItemDataProvider implements ItemDataProviderInterface
             ++$i;
         }
 
-        if (!$fetchData || $manager instanceof EntityManagerInterface) {
+        if (!$fetchData && $manager instanceof EntityManagerInterface) {
             return $manager->getReference($resourceClass, $identifiers);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

`ApiPlatform\Core\Bridge\Doctrine\Orm\ItemDataProvider::getItem` was wrongly calling `Doctrine\ORM\EntityManagerInterface::getReference`, even when `$fetchData` is `true`. This caused non-existent IDs to fall through and led to `Doctrine\ORM\EntityNotFoundException` being thrown later on.

Added a Behat scenario to prevent regression.