### PR TITLE
Fix data type for NelmioApiDoc

### DIFF
--- a/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
+++ b/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
@@ -169,7 +169,9 @@ final class ApiPlatformParser implements ParserInterface
                 }
 
                 $data['subType'] = $subProperty['subType'];
-                $data['children'] = $subProperty['children'];
+                if (isset($subProperty['children'])) {
+                    $data['children'] = $subProperty['children'];
+                }
             }
 
             return $data;
@@ -186,9 +188,18 @@ final class ApiPlatformParser implements ParserInterface
                 return $data;
             }
 
+            try {
+                $this->resourceMetadataFactory->create($className);
+            } catch (ResourceClassNotFoundException $e) {
+                $data['actualType'] = DataTypes::MODEL;
+                $data['subType'] = $className;
+
+                return $data;
+            }
+
             if (
-                (self::OUT_PREFIX === $io && $propertyMetadata->isReadableLink()) ||
-                (self::IN_PREFIX === $io && $propertyMetadata->isWritableLink())
+                (self::OUT_PREFIX === $io && !$propertyMetadata->isReadableLink()) ||
+                (self::IN_PREFIX === $io && !$propertyMetadata->isWritableLink())
             ) {
                 $data['dataType'] = self::TYPE_IRI;
                 $data['actualType'] = DataTypes::STRING;

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -214,6 +214,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
+        $resourceMetadataFactoryProphecy->create(RelatedDummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -266,11 +267,18 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([
             'relatedDummy' => [
-                'dataType' => null,
+                'dataType' => 'IRI',
                 'required' => false,
                 'description' => 'A related dummy.',
                 'readonly' => false,
-                'actualType' => DataTypes::MODEL,
+                'actualType' => DataTypes::STRING,
+            ],
+            'relatedDummies' => [
+                'dataType' => null,
+                'required' => false,
+                'description' => 'Several dummies.',
+                'readonly' => false,
+                'actualType' => DataTypes::COLLECTION,
                 'subType' => RelatedDummy::class,
                 'children' => [
                     'id' => [
@@ -286,14 +294,6 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
                         'readonly' => false,
                     ],
                 ],
-            ],
-            'relatedDummies' => [
-                'dataType' => 'array of IRIs',
-                'required' => false,
-                'description' => 'Several dummies.',
-                'readonly' => false,
-                'actualType' => DataTypes::COLLECTION,
-                'subType' => DataTypes::STRING,
             ],
         ], $actual);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Bugs from #410 when porting the parser

- Correct identification of embedded / non-embedded resources
- Handle non-resource objects