### PR TITLE
Prevent extra break line at the end of violations list normalization

### DIFF
--- a/Hydra/Serializer/ConstraintViolationListNormalizer.php
+++ b/Hydra/Serializer/ConstraintViolationListNormalizer.php
@@ -39,7 +39,7 @@ class ConstraintViolationListNormalizer implements NormalizerInterface
     {
         $violations = [];
         if ($object instanceof ConstraintViolationListInterface) {
-            $message = '';
+            $messages = [];
 
             foreach ($object as $violation) {
                 $violations[] = [
@@ -47,7 +47,7 @@ class ConstraintViolationListNormalizer implements NormalizerInterface
                     'message' => $violation->getMessage(),
                 ];
 
-                $message .= ($violation->getPropertyPath() ? $violation->getPropertyPath().': ' : '').$violation->getMessage()."\n";
+                $messages [] = ($violation->getPropertyPath() ? $violation->getPropertyPath().': ' : '').$violation->getMessage();
             }
         }
 
@@ -55,7 +55,7 @@ class ConstraintViolationListNormalizer implements NormalizerInterface
             '@context' => $this->router->generate('api_json_ld_context', ['shortName' => 'ConstraintViolationList']),
             '@type' => 'ConstraintViolationList',
             'hydra:title' => isset($context['title']) ? $context['title'] : 'An error occurred',
-            'hydra:description' => isset($message) ? $message : (string) $object,
+            'hydra:description' => isset($messages) ? implode("\n", $messages) : (string) $object,
             'violations' => $violations,
         ];
     }

--- a/features/hydra/error.feature
+++ b/features/hydra/error.feature
@@ -17,7 +17,7 @@ Feature: Error handling
       "@context": "/contexts/ConstraintViolationList",
       "@type": "ConstraintViolationList",
       "hydra:title": "An error occurred",
-      "hydra:description": "name: This value should not be blank.\n",
+      "hydra:description": "name: This value should not be blank.",
       "violations": [
         {
           "propertyPath": "name",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

For example, with 1 constraint violation, actual output is:
```json
{
    "@context": "/contexts/ConstraintViolationList",
    "@type": "ConstraintViolationList",
    "hydra:description": "underNameCustomer Company must be the same than meal.restaurant Company.\n"
}
```

With this fix:
```json
{
    "@context": "/contexts/ConstraintViolationList",
    "@type": "ConstraintViolationList",
    "hydra:description": "underNameCustomer Company must be the same than meal.restaurant Company."
}
```