### PR TITLE
Prevent extra break line at the end of violations list normalization

### DIFF
--- a/features/hydra/error.feature
+++ b/features/hydra/error.feature
@@ -17,7 +17,7 @@ Feature: Error handling
       "@context": "/contexts/ConstraintViolationList",
       "@type": "ConstraintViolationList",
       "hydra:title": "An error occurred",
-      "hydra:description": "name: This value should not be blank.\n",
+      "hydra:description": "name: This value should not be blank.",
       "violations": [
         {
           "propertyPath": "name",

--- a/src/Bridge/Symfony/Validator/Hydra/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Bridge/Symfony/Validator/Hydra/Serializer/ConstraintViolationListNormalizer.php
@@ -40,7 +40,7 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
     public function normalize($object, $format = null, array $context = [])
     {
         $violations = [];
-        $message = '';
+        $messages = [];
 
         foreach ($object as $violation) {
             $violations[] = [
@@ -51,14 +51,14 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
             $propertyPath = $violation->getPropertyPath();
             $prefix = $propertyPath ? sprintf('%s: ', $propertyPath) : '';
 
-            $message .= $prefix.$violation->getMessage()."\n";
+            $messages [] = $prefix.$violation->getMessage();
         }
 
         return [
             '@context' => $this->urlGenerator->generate('api_jsonld_context', ['shortName' => 'ConstraintViolationList']),
             '@type' => 'ConstraintViolationList',
             'hydra:title' => $context['title'] ?? 'An error occurred',
-            'hydra:description' => $message ?? (string) $object,
+            'hydra:description' => $messages ? implode("\n", $messages) : (string) $object,
             'violations' => $violations,
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

For example, with 1 constraint violation, actual output is:
```json
{
    "@context": "/contexts/ConstraintViolationList",
    "@type": "ConstraintViolationList",
    "hydra:description": "underNameCustomer Company must be the same than meal.restaurant Company.\n"
}
```

With this fix:
```json
{
    "@context": "/contexts/ConstraintViolationList",
    "@type": "ConstraintViolationList",
    "hydra:description": "underNameCustomer Company must be the same than meal.restaurant Company."
}
```