### PR TITLE
[V2.x] fix #509 - php's parse str does not allow dots

### DIFF
--- a/features/doctrine/date-filter.feature
+++ b/features/doctrine/date-filter.feature
@@ -246,3 +246,172 @@ Feature: Date filter on collections
       }
     }
     """
+
+  @dropSchema
+  @createSchema
+  Scenario: Get collection filtered by association date
+    Given there is "2" dummy objects with dummyDate and relatedDummy
+    When I send a "GET" request to "/dummies?relatedDummy.dummyDate[after]=2015-04-28"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+          "@context": "\/contexts\/Dummy",
+          "@id": "\/dummies",
+          "@type": "hydra:Collection",
+          "hydra:member": [],
+          "hydra:totalItems": 0,
+          "hydra:view": {
+              "@id": "\/dummies?relatedDummy.dummyDate%5Bafter%5D=2015-04-28",
+              "@type": "hydra:PartialCollectionView"
+          },
+          "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "\/dummies{?id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],order[id],order[name],order[relatedDummy.symfony],dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],dummyBoolean,dummyPrice}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id[]",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "alias",
+                      "property": "alias",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "description",
+                      "property": "description",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy.name",
+                      "property": "relatedDummy.name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy.name[]",
+                      "property": "relatedDummy.name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies[]",
+                      "property": "relatedDummies",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[id]",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[name]",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[relatedDummy.symfony]",
+                      "property": "relatedDummy.symfony",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyDate[before]",
+                      "property": "dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyDate[after]",
+                      "property": "dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy.dummyDate[before]",
+                      "property": "relatedDummy.dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy.dummyDate[after]",
+                      "property": "relatedDummy.dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyPrice[between]",
+                      "property": "dummyPrice",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyPrice[gt]",
+                      "property": "dummyPrice",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyPrice[gte]",
+                      "property": "dummyPrice",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyPrice[lt]",
+                      "property": "dummyPrice",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyPrice[lte]",
+                      "property": "dummyPrice",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyBoolean",
+                      "property": "dummyBoolean",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyPrice",
+                      "property": "dummyPrice",
+                      "required": false
+                  }
+              ]
+          }
+      }
+    """
+    

--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -14,6 +14,7 @@ namespace ApiPlatform\Core\Hydra\Serializer;
 use ApiPlatform\Core\Api\PaginatorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\JsonLd\Serializer\ContextTrait;
+use ApiPlatform\Core\Util\RequestParser;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -100,7 +101,7 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Seri
 
         $parameters = [];
         if (isset($parts['query'])) {
-            parse_str($parts['query'], $parameters);
+            $parameters = RequestParser::parseRequestParams($parts['query']);
 
             // Remove existing page parameter
             unset($parameters[$this->pageParameterName]);

--- a/src/Util/RequestParser.php
+++ b/src/Util/RequestParser.php
@@ -49,7 +49,7 @@ abstract class RequestParser
      *
      * @return array
      */
-    private static function parseRequestParams(string $source) : array
+    public static function parseRequestParams(string $source) : array
     {
         $source = urldecode($source);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #509 
| License       | MIT
| Doc PR        |

Does not use php's parse_str wich does not allow dots, based on what is using guzzle to parse http query.


