### PR TITLE
[V1] fix #509 - php's parse str does not allow dots

### DIFF
--- a/Hydra/Serializer/CollectionNormalizer.php
+++ b/Hydra/Serializer/CollectionNormalizer.php
@@ -18,6 +18,7 @@ use Dunglas\ApiBundle\Api\ResourceResolverTrait;
 use Dunglas\ApiBundle\JsonLd\ContextBuilder;
 use Dunglas\ApiBundle\JsonLd\Serializer\ContextTrait;
 use Dunglas\ApiBundle\Model\PaginatorInterface;
+use Dunglas\ApiBundle\Util\RequestParser;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
 
@@ -147,7 +148,7 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
 
         $parameters = [];
         if (isset($parts['query'])) {
-            parse_str($parts['query'], $parameters);
+            $parameters = RequestParser::parseRequestParams($parts['query']);
 
             // Remove existing page parameter
             if (isset($parameters[$this->pageParameterName])) {

--- a/Util/RequestParser.php
+++ b/Util/RequestParser.php
@@ -47,7 +47,7 @@ abstract class RequestParser
      *
      * @return array
      */
-    private static function parseRequestParams($source)
+    public static function parseRequestParams($source)
     {
         $source = urldecode($source);
 

--- a/features/doctrine/date-filter.feature
+++ b/features/doctrine/date-filter.feature
@@ -294,3 +294,146 @@ Feature: Order filter on collections
       }
     }
     """
+
+  @dropSchema
+  @createSchema
+  Scenario: Get collection filtered by association date
+    Given there is "2" dummy objects with dummyDate and relatedDummy
+    When I send a "GET" request to "/dummies?relatedDummy.dummyDate[after]=2015-04-28"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/Dummy",
+        "@id": "/dummies?relatedDummy.dummyDate[after]=2015-04-28",
+        "@type": "hydra:PagedCollection",
+        "hydra:totalItems": 0,
+        "hydra:itemsPerPage": 3,
+        "hydra:firstPage": "/dummies?relatedDummy.dummyDate%5Bafter%5D=2015-04-28",
+        "hydra:lastPage": "/dummies?relatedDummy.dummyDate%5Bafter%5D=2015-04-28",
+        "hydra:member": [],
+        "hydra:search": {
+            "@type": "hydra:IriTemplate",
+            "hydra:template": "/dummies{?id,name,alias,description,relatedDummy.name,relatedDummies[],dummy,order[id],order[name],order[relatedDummy.symfony],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after]}",
+            "hydra:variableRepresentation": "BasicRepresentation",
+            "hydra:mapping": [
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "id",
+                    "property": "id",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "name",
+                    "property": "name",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "alias",
+                    "property": "alias",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "description",
+                    "property": "description",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "relatedDummy.name",
+                    "property": "relatedDummy.name",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "relatedDummies[]",
+                    "property": "relatedDummies",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummy",
+                    "property": "dummy",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "order[id]",
+                    "property": "id",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "order[name]",
+                    "property": "name",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "order[relatedDummy.symfony]",
+                    "property": "relatedDummy.symfony",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummyPrice[between]",
+                    "property": "dummyPrice",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummyPrice[gt]",
+                    "property": "dummyPrice",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummyPrice[gte]",
+                    "property": "dummyPrice",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummyPrice[lt]",
+                    "property": "dummyPrice",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummyPrice[lte]",
+                    "property": "dummyPrice",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummyDate[before]",
+                    "property": "dummyDate",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "dummyDate[after]",
+                    "property": "dummyDate",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "relatedDummy.dummyDate[before]",
+                    "property": "relatedDummy.dummyDate",
+                    "required": false
+                },
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "relatedDummy.dummyDate[after]",
+                    "property": "relatedDummy.dummyDate",
+                    "required": false
+                }
+            ]
+        }
+    }
+    """


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #509
| License       | MIT
| Doc PR        |

Fix the dots to underscore


