### PR TITLE
Add a workaround for #454 in context.feature

### DIFF
--- a/features/json-ld/context.feature
+++ b/features/json-ld/context.feature
@@ -8,28 +8,23 @@ Feature: JSON-LD contexts generation
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/Entrypoint",
-      "@id": "/",
-      "@type": "Entrypoint",
-      "abstractDummy": "/abstract_dummies",
-      "circularReference": "/circular_references",
-      "compositeItem": "/composite_items",
-      "compositeLabel": "/composite_labels",
-      "compositeRelation": "/composite_relations",
-      "concreteDummy": "/concrete_dummies",
-      "customIdentifierDummy": "/custom_identifier_dummies",
-      "customNormalizedDummy": "/custom_normalized_dummies",
-      "customWritableIdentifierDummy": "/custom_writable_identifier_dummies",
-      "dummy": "/dummies",
-      "relatedDummy": "/related_dummies",
-      "relationEmbedder": "/relation_embedders",
-      "thirdLevel": "/third_levels",
-      "user": "/users"
-    }
-    """
+    And the JSON node "@context" should be equal to "/contexts/Entrypoint"
+    And the JSON node "@id" should be equal to "/"
+    And the JSON node "@type" should be equal to "Entrypoint"
+    And the JSON node "abstractDummy" should be equal to "/abstract_dummies"
+    And the JSON node "circularReference" should be equal to "/circular_references"
+    And the JSON node "compositeItem" should be equal to "/composite_items"
+    And the JSON node "compositeLabel" should be equal to "/composite_labels"
+    And the JSON node "compositeRelation" should be equal to "/composite_relations"
+    And the JSON node "concreteDummy" should be equal to "/concrete_dummies"
+    And the JSON node "customIdentifierDummy" should be equal to "/custom_identifier_dummies"
+    And the JSON node "customNormalizedDummy" should be equal to "/custom_normalized_dummies"
+    And the JSON node "customWritableIdentifierDummy" should be equal to "/custom_writable_identifier_dummies"
+    And the JSON node "dummy" should be equal to "/dummies"
+    And the JSON node "relatedDummy" should be equal to "/related_dummies"
+    And the JSON node "relationEmbedder" should be equal to "/relation_embedders"
+    And the JSON node "thirdLevel" should be equal to "/third_levels"
+    And the JSON node "user" should be equal to "/users"
 
   Scenario: Retrieve Dummy context
     When I send a "GET" request to "/contexts/Dummy"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This adds a workaround for #454 in `context.feature` (which usually fails in some people's local dev environments...)