### PR TITLE
Doctrine query extensions priority

### DIFF
--- a/features/doctrine/order-filter.feature
+++ b/features/doctrine/order-filter.feature
@@ -20,18 +20,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/2$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/3$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[id\\]=asc$"},
@@ -56,18 +76,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/30$"},
-                  {"pattern": "^/dummies/29$"},
-                  {"pattern": "^/dummies/28$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/30$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/29$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/28$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[id\\]=desc"},
@@ -92,18 +132,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/10$"},
-                  {"pattern": "^/dummies/11$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/10$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/11$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[name\\]=asc$"},
@@ -128,18 +188,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/9$"},
-                  {"pattern": "^/dummies/8$"},
-                  {"pattern": "^/dummies/7$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/9$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/8$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/7$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[name\\]=desc$"},
@@ -164,18 +244,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/9$"},
-                  {"pattern": "^/dummies/8$"},
-                  {"pattern": "^/dummies/7$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/9$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/8$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/7$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[name\\]$"},
@@ -201,18 +301,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/2$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/3$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[relatedDummy\\]=asc$"},
@@ -238,18 +358,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/2$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/3$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[alias\\]=asc$"},
@@ -273,18 +413,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/2$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/3$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[alias\\]=desc$"},
@@ -308,18 +468,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/2$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/3$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[unknown\\]=asc$"},
@@ -343,18 +523,38 @@ Feature: Order filter on collections
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
-                ]
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/2$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/3$"
+                }
               }
             }
-          }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
         },
         "hydra:view": {
           "@id": {"pattern": "^/dummies\\?order\\[unknown\\]=desc$"},

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -80,15 +80,15 @@
         <!-- Doctrine Query extensions -->
 
         <service id="api_platform.doctrine.orm.query_extension.eager_loading" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\EagerLoadingExtension" public="false">
-            <tag name="api_platform.doctrine.orm.query_extension.item" />
-            <tag name="api_platform.doctrine.orm.query_extension.collection" />
+            <tag name="api_platform.doctrine.orm.query_extension.item" priority="20" />
+            <tag name="api_platform.doctrine.orm.query_extension.collection" priority="20" />
         </service>
 
         <service id="api_platform.doctrine.orm.query_extension.filter" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\FilterExtension" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.filters" />
 
-            <tag name="api_platform.doctrine.orm.query_extension.collection" />
+            <tag name="api_platform.doctrine.orm.query_extension.collection" priority="10" />
         </service>
 
         <service id="api_platform.doctrine.orm.query_extension.pagination" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\PaginationExtension" public="false">
@@ -103,13 +103,13 @@
             <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
             <argument>%api_platform.collection.pagination.items_per_page_parameter_name%</argument>
 
-            <tag name="api_platform.doctrine.orm.query_extension.collection" />
+            <tag name="api_platform.doctrine.orm.query_extension.collection" priority="-20" />
         </service>
 
         <service id="api_platform.doctrine.orm.query_extension.order" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\OrderExtension" public="false">
             <argument>%api_platform.collection.order%</argument>
 
-            <tag name="api_platform.doctrine.orm.query_extension.collection" />
+            <tag name="api_platform.doctrine.orm.query_extension.collection" priority="-10" />
         </service>
     </services>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Fix the priority of Doctrine query extensions (`OrderExtension` must go before `PaginationExtension`, or it will never be run). Also fixed Behat tests for `OrderFilter` (the JSON schema was not testing the right things - *gosh, I really hate JSON Schema*).