### PR TITLE
Set priority of metadata factories

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -64,7 +64,7 @@
 
         <!-- Metadata loader -->
 
-        <service id="api_platform.doctrine.orm.metadata.property.metadata_factory" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Metadata\Property\DoctrineOrmPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" public="false">
+        <service id="api_platform.doctrine.orm.metadata.property.metadata_factory" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Metadata\Property\DoctrineOrmPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="10" public="false">
             <argument type="service" id="doctrine" />
             <argument type="service" id="api_platform.doctrine.orm.metadata.property.metadata_factory.inner" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata.xml
@@ -13,7 +13,7 @@
             <argument type="service" id="annotation_reader" />
         </service>
 
-        <service id="api_platform.metadata.resource.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceNameCollectionFactory" decorates="api_platform.metadata.resource.name_collection_factory" decoration-priority="-1" public="false">
+        <service id="api_platform.metadata.resource.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceNameCollectionFactory" decorates="api_platform.metadata.resource.name_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.metadata.resource.cache" />
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory.cached.inner" />
         </service>
@@ -26,19 +26,19 @@
             <argument type="service" id="annotation_reader" />
         </service>
 
-        <service id="api_platform.metadata.resource.metadata_factory.php_doc" class="ApiPlatform\Core\Metadata\Resource\Factory\PhpDocResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" public="false">
+        <service id="api_platform.metadata.resource.metadata_factory.php_doc" class="ApiPlatform\Core\Metadata\Resource\Factory\PhpDocResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="30" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory.php_doc.inner" />
         </service>
 
-        <service id="api_platform.metadata.resource.metadata_factory.short_name" class="ApiPlatform\Core\Metadata\Resource\Factory\ShortNameResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" public="false">
+        <service id="api_platform.metadata.resource.metadata_factory.short_name" class="ApiPlatform\Core\Metadata\Resource\Factory\ShortNameResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="20" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory.short_name.inner" />
         </service>
 
-        <service id="api_platform.metadata.resource.metadata_factory.operation" class="ApiPlatform\Core\Metadata\Resource\Factory\OperationResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" public="false">
+        <service id="api_platform.metadata.resource.metadata_factory.operation" class="ApiPlatform\Core\Metadata\Resource\Factory\OperationResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="10" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory.operation.inner" />
         </service>
 
-        <service id="api_platform.metadata.resource.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="-1" public="false">
+        <service id="api_platform.metadata.resource.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.metadata.resource.cache" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory.cached.inner" />
         </service>
@@ -59,7 +59,7 @@
             <argument type="service" id="api_platform.property_info" />
         </service>
 
-        <service id="api_platform.metadata.property.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" decoration-priority="-1" public="false">
+        <service id="api_platform.metadata.property.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.metadata.property.cache" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory.cached.inner" />
         </service>
@@ -73,23 +73,23 @@
         </service>
 
         <!-- The PropertyInfo decorator must always be the first decorator, it will create the metadata if it doesn't exist -->
-        <service id="api_platform.metadata.property.metadata_factory.property_info" class="ApiPlatform\Core\Bridge\Symfony\PropertyInfo\Metadata\Property\PropertyInfoPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" public="false">
+        <service id="api_platform.metadata.property.metadata_factory.property_info" class="ApiPlatform\Core\Bridge\Symfony\PropertyInfo\Metadata\Property\PropertyInfoPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="40" public="false">
             <argument type="service" id="api_platform.property_info" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.property_info.inner" />
         </service>
 
-        <service id="api_platform.metadata.property.metadata_factory.serializer" class="ApiPlatform\Core\Metadata\Property\Factory\SerializerPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" public="false">
+        <service id="api_platform.metadata.property.metadata_factory.serializer" class="ApiPlatform\Core\Metadata\Property\Factory\SerializerPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="30" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.serializer.inner" />
         </service>
 
-        <service id="api_platform.metadata.property.metadata_factory.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\ValidatorPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" public="false">
+        <service id="api_platform.metadata.property.metadata_factory.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\ValidatorPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="20" public="false">
             <argument type="service" id="validator" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.validator.inner" />
         </service>
 
-        <service id="api_platform.metadata.property.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="-1" public="false">
+        <service id="api_platform.metadata.property.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.metadata.property.cache" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.cached.inner" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This allows better control (ordering) of custom decorators, e.g. a custom decorator with the default priority of 0 would fall right after all the built-in decorators but before the `cached` decorator... So that's the expected behaviour out of the box.