### PR TITLE
fix #518 - Add an exception to show that the value is not readable. 

### DIFF
--- a/features/invalid_data.feature
+++ b/features/invalid_data.feature
@@ -35,6 +35,23 @@ Feature: Handle properly invalid data submitted to the API
     }
     """
 
+  Scenario: Create a resource with wrong value type for relation
+    When I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": "Foo",
+      "relatedDummy": "1"
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON node "@context" should be equal to "/contexts/Error"
+    And the JSON node "@type" should be equal to "Error"
+    And the JSON node "hydra:title" should be equal to "An error occurred"
+    And the JSON node "hydra:description" should be equal to 'Expected IRI or nested object for attribute "relatedDummy" of "ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy", "string" given.'
+    And the JSON node "trace" should exist
+
   Scenario: Ignore invalid dates
     When I send a "POST" request to "/dummies" with body:
     """

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -306,6 +306,14 @@ final class ItemNormalizer extends AbstractObjectNormalizer
             return $this->serializer->denormalize($value, $className, self::FORMAT, $this->createRelationContext($className, $context));
         }
 
+        if (!is_array($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected IRI or nested object for attribute "%s" of "%s", "%s" given.',
+                $attributeName,
+                $resourceClass,
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
         throw new InvalidArgumentException(sprintf(
             'Nested objects for attribute "%s" of "%s" are not enabled. Use serialization groups to change that behavior.',
             $attributeName,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #518
| License       | MIT
| Doc PR        | 0

According to the normalizer, we could not pass  a string to one relation.

@teohhanhui is it ok like this ? not sure about the message