### PR TITLE
Fix Dupplication code on Filters

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
@@ -72,17 +72,7 @@ class BooleanFilter extends AbstractFilter
             $field = $property;
 
             if ($this->isPropertyNested($property)) {
-                $propertyParts = $this->splitPropertyParts($property);
-
-                $parentAlias = $alias;
-
-                foreach ($propertyParts['associations'] as $association) {
-                    $alias = QueryNameGenerator::generateJoinAlias($association);
-                    $queryBuilder->leftJoin(sprintf('%s.%s', $parentAlias, $association), $alias);
-                    $parentAlias = $alias;
-                }
-
-                $field = $propertyParts['field'];
+                list($alias, $field) = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder);
             }
             $valueParameter = QueryNameGenerator::generateParameterName($field);
 

--- a/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
@@ -81,17 +81,7 @@ class NumericFilter extends AbstractFilter
             $field = $property;
 
             if ($this->isPropertyNested($property)) {
-                $propertyParts = $this->splitPropertyParts($property);
-
-                $parentAlias = $alias;
-
-                foreach ($propertyParts['associations'] as $association) {
-                    $alias = QueryNameGenerator::generateJoinAlias($association);
-                    $queryBuilder->leftJoin(sprintf('%s.%s', $parentAlias, $association), $alias);
-                    $parentAlias = $alias;
-                }
-
-                $field = $propertyParts['field'];
+                list($alias, $field) = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder);
             }
             $valueParameter = QueryNameGenerator::generateParameterName($field);
 

--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter;
 
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\HttpFoundation\Request;
@@ -78,17 +77,7 @@ class OrderFilter extends AbstractFilter
             $field = $property;
 
             if ($this->isPropertyNested($property)) {
-                $propertyParts = $this->splitPropertyParts($property);
-
-                $parentAlias = $alias;
-
-                foreach ($propertyParts['associations'] as $association) {
-                    $alias = QueryNameGenerator::generateJoinAlias($association);
-                    $queryBuilder->leftJoin(sprintf('%s.%s', $parentAlias, $association), $alias);
-                    $parentAlias = $alias;
-                }
-
-                $field = $propertyParts['field'];
+                list($alias, $field) = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder);
             }
 
             $queryBuilder->addOrderBy(sprintf('%s.%s', $alias, $field), $order);

--- a/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
@@ -67,17 +67,7 @@ class RangeFilter extends AbstractFilter
             $field = $property;
 
             if ($this->isPropertyNested($property)) {
-                $propertyParts = $this->splitPropertyParts($property);
-
-                $parentAlias = $alias;
-
-                foreach ($propertyParts['associations'] as $association) {
-                    $alias = QueryNameGenerator::generateJoinAlias($association);
-                    $queryBuilder->join(sprintf('%s.%s', $parentAlias, $association), $alias);
-                    $parentAlias = $alias;
-                }
-
-                $field = $propertyParts['field'];
+                list($alias, $field) = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder);
             }
 
             foreach ($values as $operator => $value) {

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -113,13 +113,7 @@ class SearchFilter extends AbstractFilter
             }
 
             if ($metadata->hasField($field)) {
-                $values = (array) $value;
-                foreach ($values as $k => $v) {
-                    if (!is_int($k) || !is_string($v)) {
-                        unset($values[$k]);
-                    }
-                }
-                $values = array_values($values);
+                $values = $this->normalizeValues((array) $value);
 
                 if (empty($values)) {
                     continue;
@@ -145,13 +139,7 @@ class SearchFilter extends AbstractFilter
                         ->setParameter($valueParameter, $values);
                 }
             } elseif ($metadata->hasAssociation($field)) {
-                $values = (array) $value;
-                foreach ($values as $k => $v) {
-                    if (!is_int($k) || !is_string($v)) {
-                        unset($values[$k]);
-                    }
-                }
-                $values = array_values($values);
+                $values = $this->normalizeValues((array) $value);
 
                 if (empty($values)) {
                     continue;
@@ -318,4 +306,22 @@ class SearchFilter extends AbstractFilter
 
         return $value;
     }
+
+   /**
+    * Normalize the values array.
+    *
+    * @param array $values
+    *
+    * @return array
+    */
+   private function normalizeValues(array $values) : array
+   {
+       foreach ($values as $key => $value) {
+           if (!is_int($key) || !is_string($value)) {
+               unset($values[$key]);
+           }
+       }
+
+       return array_values($values);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

Since the last commit with both boolean and numeric filters, scrutinizer does not like duplicated code.

And a foreach that scrutinizer does not like.

