### PR TITLE
Fix warning test ResourceMetadata with null values

### DIFF
--- a/tests/Metadata/Resource/Factory/FileConfigurationMetadataTest.php
+++ b/tests/Metadata/Resource/Factory/FileConfigurationMetadataTest.php
@@ -67,23 +67,9 @@ class FileConfigurationMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $resourceMetadata = new ResourceMetadata();
 
-        $metadata = [
-            'shortName' => null,
-            'description' => null,
-            'itemOperations' => [
-                'my_op_name' => ['method' => 'GET'],
-                'my_other_op_name' => ['method' => 'POST'],
-            ],
-            'collectionOperations' => null,
-            'iri' => null,
-            'attributes' => [
-            ],
-        ];
-
-        foreach (['shortName', 'description', 'itemOperations', 'collectionOperations', 'iri', 'attributes'] as $property) {
-            $wither = 'with'.ucfirst($property);
-            $resourceMetadata = $resourceMetadata->$wither($metadata[$property]);
-        }
+        $resourceMetadata = $resourceMetadata->withItemOperations([
+            'my_op_name' => ['method' => 'POST'],
+        ]);
 
         return [[$resourceMetadata]];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Just saw that travis emits a warning `$resourceMetadata->withShortname(null);` weird that I didn't see it on my local environment.

