### PR TITLE
hotfix #537: Change @Resource annotation to @ApiResource

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -12,14 +12,14 @@
 namespace ApiPlatform\Core\Annotation;
 
 /**
- * Resource annotation.
+ * ApiResource annotation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
  * @Annotation
  * @Target({"CLASS"})
  */
-final class Resource
+final class ApiResource
 {
     /**
      * @var string

--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Metadata\Resource\Factory;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Resource\Operation;
 use ApiPlatform\Core\Metadata\Resource\PaginationMetadata;
@@ -19,7 +19,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Doctrine\Common\Annotations\Reader;
 
 /**
- * Creates a resource metadata from {@see Resource} annotations.
+ * Creates a resource metadata from {@see ApiResource} annotations.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -54,7 +54,7 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
             return $this->handleNotFound($parentResourceMetadata, $resourceClass);
         }
 
-        $resourceAnnotation = $this->reader->getClassAnnotation($reflectionClass, Resource::class);
+        $resourceAnnotation = $this->reader->getClassAnnotation($reflectionClass, ApiResource::class);
         if (null === $resourceAnnotation) {
             return $this->handleNotFound($parentResourceMetadata, $resourceClass);
         }
@@ -81,7 +81,7 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
         throw new ResourceClassNotFoundException(sprintf('Resource "%s" not found.', $resourceClass));
     }
 
-    private function createMetadata(Resource $annotation, ResourceMetadata $parentResourceMetadata = null) : ResourceMetadata
+    private function createMetadata(ApiResource $annotation, ResourceMetadata $parentResourceMetadata = null) : ResourceMetadata
     {
         if (!$parentResourceMetadata) {
             return new ResourceMetadata(

--- a/src/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactory.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Metadata\Resource\Factory;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use Doctrine\Common\Annotations\Reader;
 
@@ -79,7 +79,7 @@ final class AnnotationResourceNameCollectionFactory implements ResourceNameColle
         foreach ($declared as $className) {
             $reflectionClass = new \ReflectionClass($className);
             $sourceFile = $reflectionClass->getFileName();
-            if (isset($includedFiles[$sourceFile]) && $this->reader->getClassAnnotation($reflectionClass, Resource::class)) {
+            if (isset($includedFiles[$sourceFile]) && $this->reader->getClassAnnotation($reflectionClass, ApiResource::class)) {
                 $classes[$className] = true;
             }
         }

--- a/src/Metadata/Resource/Factory/XmlResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/XmlResourceMetadataFactory.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\Metadata\Resource\Factory;
 
-use ApiPlatform\Core\Annotation\Resource;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 

--- a/src/Metadata/Resource/Factory/XmlResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/XmlResourceNameCollectionFactory.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\Metadata\Resource\Factory;
 
-use ApiPlatform\Core\Annotation\Resource;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 
 /**

--- a/src/Metadata/Resource/Factory/YamlResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/YamlResourceMetadataFactory.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\Metadata\Resource\Factory;
 
-use ApiPlatform\Core\Annotation\Resource;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Symfony\Component\Yaml\Parser as YamlParser;

--- a/src/Metadata/Resource/Factory/YamlResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/YamlResourceNameCollectionFactory.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\Metadata\Resource\Factory;
 
-use ApiPlatform\Core\Annotation\Resource;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use Symfony\Component\Yaml\Parser as YamlParser;
 

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -11,16 +11,16 @@
 
 namespace ApiPlatform\Core\Tests\Annotation;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class ResourceTest extends \PHPUnit_Framework_TestCase
+class ApiResourceTest extends \PHPUnit_Framework_TestCase
 {
     public function testAssignation()
     {
-        $resource = new Resource();
+        $resource = new ApiResource();
         $resource->shortName = 'shortName';
         $resource->description = 'description';
         $resource->iri = 'http://example.com/res';

--- a/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
@@ -11,9 +11,9 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
+use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\Iri;
 use ApiPlatform\Core\Annotation\Property;
-use ApiPlatform\Core\Annotation\Resource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
- * @Resource(attributes={"filters": {"my_dummy.search", "my_dummy.order", "my_dummy.date"}})
+ * @ApiResource(attributes={"filters": {"my_dummy.search", "my_dummy.order", "my_dummy.date"}})
  * @ORM\Entity
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="discr", type="string", length=16)

--- a/tests/Fixtures/TestBundle/Entity/CircularReference.php
+++ b/tests/Fixtures/TestBundle/Entity/CircularReference.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @Resource(attributes={"normalization_context"={"groups": {"circular"}}})
+ * @ApiResource(attributes={"normalization_context"={"groups": {"circular"}}})
  * @ORM\Entity
  */
 class CircularReference

--- a/tests/Fixtures/TestBundle/Entity/CompositeItem.php
+++ b/tests/Fixtures/TestBundle/Entity/CompositeItem.php
@@ -11,12 +11,12 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
- * @Resource
+ * @ApiResource
  * @ORM\Entity
  */
 class CompositeItem

--- a/tests/Fixtures/TestBundle/Entity/CompositeLabel.php
+++ b/tests/Fixtures/TestBundle/Entity/CompositeLabel.php
@@ -11,13 +11,13 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity
- * @Resource
+ * @ApiResource
  */
 class CompositeLabel
 {

--- a/tests/Fixtures/TestBundle/Entity/CompositeRelation.php
+++ b/tests/Fixtures/TestBundle/Entity/CompositeRelation.php
@@ -11,13 +11,13 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity
- * @Resource
+ * @ApiResource
  */
 class CompositeRelation
 {

--- a/tests/Fixtures/TestBundle/Entity/ConcreteDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/ConcreteDummy.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Jérémy Derusse <jeremy@derusse.com>
  *
- * @Resource
+ * @ApiResource
  * @ORM\Entity
  */
 class ConcreteDummy extends AbstractDummy

--- a/tests/Fixtures/TestBundle/Entity/CustomIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomIdentifierDummy.php
@@ -11,13 +11,13 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Custom identifier dummy.
  *
- * @Resource
+ * @ApiResource
  * @ORM\Entity
  */
 class CustomIdentifierDummy

--- a/tests/Fixtures/TestBundle/Entity/CustomNormalizedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomNormalizedDummy.php
@@ -11,8 +11,8 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
+use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\Property;
-use ApiPlatform\Core\Annotation\Resource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Mikaël Labrut <labrut@gmail.com>
  *
- * @Resource(attributes={
+ * @ApiResource(attributes={
  *     "normalization_context"={"groups"={"output"}},
  *     "denormalization_context"={"groups"={"input"}}
  * })

--- a/tests/Fixtures/TestBundle/Entity/CustomWritableIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomWritableIdentifierDummy.php
@@ -11,13 +11,13 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Custom writable identifier dummy.
  *
- * @Resource
+ * @ApiResource
  * @ORM\Entity
  */
 class CustomWritableIdentifierDummy

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -11,8 +11,8 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
+use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\Property;
-use ApiPlatform\Core\Annotation\Resource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @Resource(attributes={"filters"={"my_dummy.search", "my_dummy.order", "my_dummy.date", "my_dummy.range", "my_dummy.boolean", "my_dummy.numeric"}})
+ * @ApiResource(attributes={"filters"={"my_dummy.search", "my_dummy.order", "my_dummy.date", "my_dummy.range", "my_dummy.boolean", "my_dummy.numeric"}})
  * @ORM\Entity
  */
 class Dummy

--- a/tests/Fixtures/TestBundle/Entity/NoCollectionDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/NoCollectionDummy.php
@@ -11,13 +11,13 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * No collection dummy.
  *
- * @Resource(collectionOperations={})
+ * @ApiResource(collectionOperations={})
  * @ORM\Entity
  */
 class NoCollectionDummy

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @Resource(iri="https://schema.org/Product")
+ * @ApiResource(iri="https://schema.org/Product")
  * @ORM\Entity
  */
 class RelatedDummy extends ParentDummy

--- a/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
+++ b/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @Resource(attributes={
+ * @ApiResource(attributes={
  *     "normalization_context"={"groups"={"barcelona"}},
  *     "denormalization_context"={"groups"={"chicago"}},
  *     "hydra_context"={"@type"="hydra:Operation", "hydra:title"="A custom operation", "returns"="xmls:string"}

--- a/tests/Fixtures/TestBundle/Entity/ThirdLevel.php
+++ b/tests/Fixtures/TestBundle/Entity/ThirdLevel.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @Resource
+ * @ApiResource
  * @ORM\Entity
  */
 class ThirdLevel

--- a/tests/Fixtures/TestBundle/Entity/User.php
+++ b/tests/Fixtures/TestBundle/Entity/User.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use FOS\UserBundle\Model\User as BaseUser;
 use FOS\UserBundle\Model\UserInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity
- * @Resource(attributes={
+ * @ApiResource(attributes={
  *     "normalization_context"={"groups"={"user", "user-read"}},
  *     "denormalization_context"={"groups"={"user", "user-write"}}
  * })

--- a/tests/Fixtures/TestBundle/Entity/UuidIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/UuidIdentifierDummy.php
@@ -11,13 +11,13 @@
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\Resource;
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Custom identifier dummy.
  *
- * @Resource
+ * @ApiResource
  * @ORM\Entity
  */
 class UuidIdentifierDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #537
| License       | MIT

This is resolving the problem of resource being a soft reserved word in php7

