### PR TITLE
(WIP) Bug OneToMany  => ManyToOne composite identifiers

### DIFF
--- a/features/relation.feature
+++ b/features/relation.feature
@@ -23,6 +23,24 @@ Feature: Relations support
     }
     """
 
+  Scenario: Create a dummy friend
+    When I send a "POST" request to "/dummy_friends" with body:
+    """
+    {"name": "Zoidberg"}
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/DummyFriend",
+      "@id": "/dummy_friends/1",
+      "@type": "DummyFriend",
+      "name": "Zoidberg"
+    }
+    """
+
   Scenario: Create a related dummy
     When I send a "POST" request to "/related_dummies" with body:
     """
@@ -42,11 +60,50 @@ Feature: Relations support
       "name": null,
       "dummyDate": null,
       "thirdLevel": "/third_levels/1",
+      "relatedToDummyFriend": null,
       "dummyBoolean": null,
       "symfony": "symfony",
       "age": null
     }
     """
+
+  Scenario: Create a friend relationship
+    When I send a "POST" request to "/related_to_dummy_friends" with body:
+    """
+    {
+        "name": "Friends relation",
+        "dummyFriend": "/dummy_friends/1",
+        "relatedDummy": "/related_dummies/1"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedToDummyFriend",
+      "@id": "/related_to_dummy_friends/dummyFriend=1;relatedDummy=1",
+      "@type": "RelatedToDummyFriend",
+      "name": "Friends relation"
+    }
+    """
+  
+  Scenario: Get the relationship
+    When I send a "GET" request to "/related_to_dummy_friends/dummyFriend=1;relatedDummy=1"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedToDummyFriend",
+      "@id": "/related_to_dummy_friends/dummyFriend=1;relatedDummy=1",
+      "@type": "RelatedToDummyFriend",
+      "name": "Friends relation"
+    }
+    """
+
 
   Scenario: Create a dummy with relations
     When I send a "POST" request to "/dummies" with body:

--- a/tests/Fixtures/TestBundle/Entity/DummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyFriend.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * DummyFriend.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @ApiResource()
+ * @ORM\Entity
+ */
+class DummyFriend
+{
+    /**
+     * @var int The id.
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @Groups({"fakemanytomany"})
+     */
+    private $id;
+
+    /**
+     * @var string The dummy name.
+     *
+     * @ORM\Column
+     * @Assert\NotBlank
+     * @ApiProperty(iri="http://schema.org/name")
+     * @Groups({"fakemanytomany"})
+     */
+    private $name;
+
+    /**
+     * Get id.
+     *
+     * @return id.
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set id.
+     *
+     * @param id the value to set.
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * Get name.
+     *
+     * @return name.
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set name.
+     *
+     * @param name the value to set.
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -61,6 +61,12 @@ class RelatedDummy extends ParentDummy
     public $thirdLevel;
 
     /**
+     * @ORM\OneToMany(targetEntity="RelatedToDummyFriend", cascade={"persist"}, fetch="EAGER", mappedBy="relatedDummy")
+     * @Groups({"fakemanytomany"})
+     */
+    public $relatedToDummyFriend;
+
+    /**
      * @var bool A dummy bool.
      *
      * @ORM\Column(type="boolean", nullable=true)
@@ -116,5 +122,25 @@ class RelatedDummy extends ParentDummy
     public function setDummyBoolean($dummyBoolean)
     {
         $this->dummyBoolean = $dummyBoolean;
+    }
+
+    /**
+     * Get relatedToDummyFriend.
+     *
+     * @return relatedToDummyFriend.
+     */
+    public function getRelatedToDummyFriend()
+    {
+        return $this->relatedToDummyFriend;
+    }
+
+    /**
+     * Set relatedToDummyFriend.
+     *
+     * @param relatedToDummyFriend the value to set.
+     */
+    public function setRelatedToDummyFriend(RelatedToDummyFriend $relatedToDummyFriend)
+    {
+        $this->relatedToDummyFriend = $relatedToDummyFriend;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Related To Dummy Friend represent an association table for a manytomany relation.
+ *
+ * @ApiResource()
+ * @ORM\Entity
+ */
+class RelatedToDummyFriend
+{
+    /**
+     * @var string The dummy name.
+     *
+     * @ORM\Column
+     * @Assert\NotBlank
+     * @ApiProperty(iri="http://schema.org/name")
+     */
+    private $name;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="DummyFriend", fetch="EAGER")
+     * @ORM\JoinColumn(name="dummyfriend_id", referencedColumnName="id", nullable=false)
+     * @Groups({"fakemanytomany"})
+     */
+    private $dummyFriend;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="RelatedDummy", inversedBy="relatedToDummyFriend")
+     * @ORM\JoinColumn(name="relateddummy_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * @Groups({"fakemanytomany"})
+     */
+    private $relatedDummy;
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get dummyFriend.
+     *
+     * @return dummyFriend.
+     */
+    public function getDummyFriend()
+    {
+        return $this->dummyFriend;
+    }
+
+    /**
+     * Set dummyFriend.
+     *
+     * @param dummyFriend the value to set.
+     */
+    public function setDummyFriend($dummyFriend)
+    {
+        $this->dummyFriend = $dummyFriend;
+    }
+
+    /**
+     * Get relatedDummy.
+     *
+     * @return relatedDummy.
+     */
+    public function getRelatedDummy()
+    {
+        return $this->relatedDummy;
+    }
+
+    /**
+     * Set relatedDummy.
+     *
+     * @param relatedDummy the value to set.
+     */
+    public function setRelatedDummy($relatedDummy)
+    {
+        $this->relatedDummy = $relatedDummy;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | nope
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | ∅
| License       | MIT
| Doc PR        | 	∅

I added a behat test to reproduce an issue, for easy debugging use `./vendor/bin/behat -vv --stop-on-failure --name 'Relations support'` and `rm -rf tests/Fixtures/app/cache/*` to clear the database before a second call.

I set up a handmade ManyToMany relation, where the association table is entity-represented so that additional fields could be added to the relation (`RelatedToDummyFriend`).
`RelatedDummy` has a new OneToMany relation to this association entity (`RelatedToDummyFriend`). `RelatedToDummyFriend` references `DummyFriend` on a ManyToOne basis.

Here's the error:

```
Warning: rawurlencode() expects parameter 1 to be string, object given in ~/forks/api-platform/src/Bridge/Symfony/Routing/IriConverter.php line 94
```
Ref: https://github.com/api-platform/core/blob/master/src/Bridge/Symfony/Routing/IriConverter.php#L94 gets the full object instead of the `id`.

This was working before #533, and this test will avoid future regression.

@Simperfit: as you worked on this, do you see where it could come from/any idea of a fix? Thanks!