### PR TITLE
[WIP] Allow the latest version of phpdocumentor/reflection

### DIFF
--- a/Mapping/Loader/PhpDocLoader.php
+++ b/Mapping/Loader/PhpDocLoader.php
@@ -13,6 +13,7 @@ namespace Dunglas\ApiBundle\Mapping\Loader;
 
 use Dunglas\ApiBundle\Mapping\ClassMetadata;
 use Dunglas\ApiBundle\Util\ReflectionTrait;
+use phpDocumentor\Reflection\ClassReflector;
 use phpDocumentor\Reflection\FileReflector;
 use PropertyInfo\PropertyInfoInterface;
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "ocramius/proxy-manager": "~1.0|~2.0",
     "doctrine/inflector": "~1.0",
     "dunglas/php-property-info": "~0.2",
-    "phpdocumentor/reflection": "^1.0.7"
+    "phpdocumentor/reflection": "^1.0.7|~3.0"
   },
   "require-dev": {
     "friendsofsymfony/user-bundle": "~1.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #555
| License       | MIT
| Doc PR        | 

We can't use api-platform 1.1 with symfony 3. here is a fix to allow both version of phpdocumentator/reflection
