### PR TITLE
Allow random composite identifier order

### DIFF
--- a/features/composite.feature
+++ b/features/composite.feature
@@ -1,7 +1,7 @@
 Feature: Retrieve data with Composite identifiers
   In order to retrieve relations with composite identifiers
   As a client software developer
-  I need to retrieve all collections 
+  I need to retrieve all collections
 
   @createSchema
   @dropSchema
@@ -77,15 +77,38 @@ Feature: Retrieve data with Composite identifiers
     """
 
   @createSchema
-  @dropSchema
   Scenario: Get the first composite relation
     Given there are Composite identifier objects
     When I send a "GET" request to "/composite_relations/compositeItem=1;compositeLabel=1"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+        "@context": "\/contexts\/CompositeRelation",
+        "@id": "\/composite_relations\/compositeItem=1;compositeLabel=1",
+        "@type": "CompositeRelation",
+        "value": "somefoobardummy"
+    }
+    """
 
-  @createSchema
+  Scenario: Get the first composite relation with a reverse identifiers order
+    Given there are Composite identifier objects
+    When I send a "GET" request to "/composite_relations/compositeLabel=1;compositeItem=1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+        "@context": "\/contexts\/CompositeRelation",
+        "@id": "\/composite_relations\/compositeItem=1;compositeLabel=1",
+        "@type": "CompositeRelation",
+        "value": "somefoobardummy"
+    }
+    """
+
   @dropSchema
   Scenario: Get first composite item
     Given there are Composite identifier objects

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -125,16 +125,24 @@ class ItemDataProvider implements ItemDataProviderInterface
     {
         $doctrineMetadataIdentifier = $manager->getClassMetadata($resourceClass)->getIdentifier();
         $identifierValues = [$id];
-        $identifierValuesArray = [];
 
         if (count($doctrineMetadataIdentifier) >= 2) {
-            $identifierValues = explode(';', $id);
-            foreach ($identifierValues as $key => $value) {
-                $identifierValueArray = explode('=', $value);
-                if ($doctrineMetadataIdentifier[$key] === $identifierValueArray[0]) {
-                    $identifierValuesArray[] = $identifierValueArray[1];
-                }
+            $identifiers = explode(';', $id);
+            $identifiersMap = [];
+
+            // first transform identifiers to a proper key/value array
+            foreach ($identifiers as $identifier) {
+                $keyValue = explode('=', $identifier);
+                $identifiersMap[$keyValue[0]] = $keyValue[1];
             }
+
+            $identifierValuesArray = [];
+
+            // then, loop through doctrine metadata identifiers to keep the same identifiers order
+            foreach ($doctrineMetadataIdentifier as $metadataIdentifierKey) {
+                $identifierValuesArray[] = $identifiersMap[$metadataIdentifierKey];
+            }
+
             $identifierValues = $identifierValuesArray;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ∅
| License       | MIT
| Doc PR        | 	∅

Thought this was effective but in fact it isn't. Now it is.

Enough philosophical sentences, this allows any parameter order when it comes to composite identifiers. We just make sure that the resulting identifiers matches the doctrine index order.