### PR TITLE
Fix XML/YAML config loading

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -149,23 +149,23 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      */
     private function registerFileLoaders(ContainerBuilder $container)
     {
-        $prefix = DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR;
         $yamlResources = [];
         $xmlResources = [];
 
         foreach ($container->getParameter('kernel.bundles') as $bundle) {
             $reflectionClass = new \ReflectionClass($bundle);
-            $configDirectory = dirname($reflectionClass->getFileName()).$prefix;
-            $yamlResources = array_merge($yamlResources, glob($configDirectory.'api_resources.{yml,yaml}'));
+            $configDirectory = dirname($reflectionClass->getFileName()).'/Resources/config/';
 
-            foreach (Finder::create()->files()->in($configDirectory)->path('api_resources')->name('*.{yml,yaml}') as $file) {
-                $yamlResources[] = $file->getRealPath();
-            }
-
-            $xmlResources = array_merge($xmlResources, glob($configDirectory.'api_resources.xml'));
-
-            foreach (Finder::create()->files()->in($configDirectory)->path('api_resources')->name('*.xml') as $file) {
-                $xmlResources[] = $file->getRealPath();
+            try {
+                foreach (Finder::create()->files()->in($configDirectory)->path('api_resources')->name('*.{yml,yaml,xml}') as $file) {
+                    if ('xml' === $file->getExtension()) {
+                        $xmlResources[] = $file->getRealPath();
+                    } else {
+                        $yamlResources[] = $file->getRealPath();
+                    }
+                }
+            } catch (\InvalidArgumentException $e) {
+                // Ignore invalid paths
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/A
| License       | MIT
| Doc PR        | n/a

Fix an error when the `Resources/config` directory doesn't exist in the bundle (`[InvalidArgumentException] The "/api-platform/src/AppBundle/Resources/config/" directory does not exist.`).

Improve the code to load XML and YAML files.
                          
ping @soyuka 
