### PR TITLE
Switch to the new Symfony cache infrastructure

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -85,7 +85,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->enableJsonLd($loader);
         $this->registerAnnotationLoaders($container);
         $this->registerFileLoaders($container);
-        $this->setUpMetadataCaching($container, $config);
 
         if (!interface_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
             $container->removeDefinition('api_platform.metadata.resource.metadata_factory.php_doc');
@@ -174,36 +173,5 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $container->getDefinition('api_platform.metadata.resource.name_collection_factory.xml')->replaceArgument(0, $xmlResources);
         $container->getDefinition('api_platform.metadata.resource.metadata_factory.xml')->replaceArgument(0, $xmlResources);
-    }
-
-    /**
-     * Sets up metadata caching.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $config
-     */
-    private function setUpMetadataCaching(ContainerBuilder $container, array $config)
-    {
-        $container->setAlias('api_platform.metadata.resource.cache', $config['metadata']['resource']['cache']);
-        $container->setAlias('api_platform.metadata.property.cache', $config['metadata']['property']['cache']);
-
-        if (!class_exists('Symfony\Component\Cache\Adapter\ArrayAdapter')) {
-            $container->removeDefinition('api_platform.metadata.resource.cache.array');
-            $container->removeDefinition('api_platform.metadata.resource.cache.apcu');
-            $container->removeDefinition('api_platform.metadata.property.cache.array');
-            $container->removeDefinition('api_platform.metadata.property.cache.apcu');
-        }
-
-        if (!$container->has($config['metadata']['resource']['cache'])) {
-            $container->removeAlias('api_platform.metadata.resource.cache');
-            $container->removeDefinition('api_platform.metadata.resource.name_collection_factory.cached');
-            $container->removeDefinition('api_platform.metadata.resource.metadata_factory.cached');
-        }
-
-        if (!$container->has($config['metadata']['property']['cache'])) {
-            $container->removeAlias('api_platform.metadata.property.cache');
-            $container->removeDefinition('api_platform.metadata.property.name_collection_factory.cached');
-            $container->removeDefinition('api_platform.metadata.property.metadata_factory.cached');
-        }
     }
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -87,23 +87,6 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-                ->arrayNode('metadata')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->arrayNode('resource')
-                        ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('cache')->defaultValue('api_platform.metadata.resource.cache.array')->cannotBeEmpty()->info('Cache service for resource metadata.')->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('property')
-                        ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('cache')->defaultValue('api_platform.metadata.property.cache.array')->cannotBeEmpty()->info('Cache service for property metadata.')->end()
-                            ->end()
-                        ->end()
-                    ->end()
-                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata.xml
@@ -116,24 +116,12 @@
 
         <!-- Cache -->
 
-        <service id="api_platform.metadata.resource.cache.array" class="Symfony\Component\Cache\Adapter\ArrayAdapter" public="false">
-            <argument>0</argument>
-            <argument>false</argument>
+        <service id="api_platform.metadata.resource.cache" parent="cache.system" public="false">
+            <tag name="cache.pool" />
         </service>
 
-        <service id="api_platform.metadata.resource.cache.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" public="false">
-            <argument>api_platform_metadata_resource</argument>
-            <argument>0</argument>
-        </service>
-
-        <service id="api_platform.metadata.property.cache.array" class="Symfony\Component\Cache\Adapter\ArrayAdapter" public="false">
-            <argument>0</argument>
-            <argument>false</argument>
-        </service>
-
-        <service id="api_platform.metadata.property.cache.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" public="false">
-            <argument>api_platform_metadata_property</argument>
-            <argument>0</argument>
+        <service id="api_platform.metadata.property.cache" parent="cache.system" public="false">
+            <tag name="cache.pool" />
         </service>
 
     </services>

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -12,6 +12,7 @@
 namespace ApiPlatform\Core\Tests\Symfony\Bridge\Bundle\DependencyInjection;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension;
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Prophecy\Argument;
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\DependencyInjection\Alias;
@@ -33,9 +34,10 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'description' => 'description',
         ],
     ];
+
     private $extension;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->extension = new ApiPlatformExtension();
     }
@@ -152,25 +154,6 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['enable_nelmio_api_doc' => true]]), $containerBuilder);
     }
 
-    public function testSetApcuMetadataCache()
-    {
-        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
-        $containerBuilderProphecy->setAlias('api_platform.metadata.resource.cache', 'api_platform.metadata.resource.cache.apcu')->shouldBeCalled();
-        $containerBuilderProphecy->setAlias('api_platform.metadata.resource.cache', 'api_platform.metadata.resource.cache.array')->shouldNotBeCalled();
-        $containerBuilderProphecy->setAlias('api_platform.metadata.property.cache', 'api_platform.metadata.property.cache.apcu')->shouldBeCalled();
-        $containerBuilderProphecy->setAlias('api_platform.metadata.property.cache', 'api_platform.metadata.property.cache.array')->shouldNotBeCalled();
-        $containerBuilderProphecy->has('api_platform.metadata.resource.cache.apcu')->willReturn(true)->shouldBeCalled();
-        $containerBuilderProphecy->has('api_platform.metadata.resource.cache.array')->shouldNotBeCalled();
-        $containerBuilderProphecy->has('api_platform.metadata.property.cache.apcu')->willReturn(true)->shouldBeCalled();
-        $containerBuilderProphecy->has('api_platform.metadata.property.cache.array')->shouldNotBeCalled();
-        $containerBuilder = $containerBuilderProphecy->reveal();
-
-        $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['metadata' => [
-            'resource' => ['cache' => 'api_platform.metadata.resource.cache.apcu'],
-            'property' => ['cache' => 'api_platform.metadata.property.cache.apcu'],
-        ]]]), $containerBuilder);
-    }
-
     private function getContainerBuilderProphecy()
     {
         $definitionArgument = Argument::that(function ($argument) {
@@ -179,7 +162,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
-            'DoctrineBundle' => 'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'DoctrineBundle' => DoctrineBundle::class,
         ])->shouldBeCalled();
 
         $parameters = [
@@ -259,8 +242,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.metadata.resource.metadata_factory.short_name',
             'api_platform.metadata.resource.metadata_factory.operation',
             'api_platform.metadata.resource.metadata_factory.cached',
-            'api_platform.metadata.resource.cache.array',
-            'api_platform.metadata.resource.cache.apcu',
+            'api_platform.metadata.resource.cache',
             'api_platform.metadata.property.name_collection_factory.property_info',
             'api_platform.metadata.property.name_collection_factory.cached',
             'api_platform.metadata.property.metadata_factory.annotation',
@@ -268,8 +250,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.metadata.property.metadata_factory.serializer',
             'api_platform.metadata.property.metadata_factory.validator',
             'api_platform.metadata.property.metadata_factory.cached',
-            'api_platform.metadata.property.cache.array',
-            'api_platform.metadata.property.cache.apcu',
+            'api_platform.metadata.property.cache',
             'api_platform.negotiator',
             'api_platform.route_loader',
             'api_platform.router',
@@ -328,16 +309,11 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $aliases = [
             'api_platform.routing.resource_path_generator' => 'api_platform.routing.resource_path_generator.underscore',
             'api_platform.metadata.resource.name_collection_factory' => 'api_platform.metadata.resource.name_collection_factory.annotation',
-            'api_platform.metadata.resource.cache' => 'api_platform.metadata.resource.cache.array',
-            'api_platform.metadata.property.cache' => 'api_platform.metadata.property.cache.array',
         ];
 
         foreach ($aliases as $alias => $service) {
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
-
-        $containerBuilderProphecy->has('api_platform.metadata.resource.cache.array')->willReturn(true)->shouldBeCalled();
-        $containerBuilderProphecy->has('api_platform.metadata.property.cache.array')->willReturn(true)->shouldBeCalled();
 
         return $containerBuilderProphecy;
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -53,14 +53,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'items_per_page_parameter_name' => 'itemsPerPage',
                 ],
             ],
-            'metadata' => [
-                'resource' => [
-                    'cache' => 'api_platform.metadata.resource.cache.array',
-                ],
-                'property' => [
-                    'cache' => 'api_platform.metadata.property.cache.array',
-                ],
-            ],
         ], $config);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Use the new builtin cache factory provided by Symfony. It will always create the faster cache adapter available, handle cache invalidation (during deployment) and warm the APCu cache using a file cache when possible.

ping @teohhanhui 
