### PR TITLE
Use a chain pattern for data providers

### DIFF
--- a/src/Action/ActionUtilTrait.php
+++ b/src/Action/ActionUtilTrait.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Action;
 
-use ApiPlatform\Core\Api\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Action/GetCollectionAction.php
+++ b/src/Action/GetCollectionAction.php
@@ -11,8 +11,8 @@
 
 namespace ApiPlatform\Core\Action;
 
-use ApiPlatform\Core\Api\CollectionDataProviderInterface;
-use ApiPlatform\Core\Api\PaginatorInterface;
+use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Action/GetItemAction.php
+++ b/src/Action/GetItemAction.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Action;
 
-use ApiPlatform\Core\Api\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Action/PutItemAction.php
+++ b/src/Action/PutItemAction.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Action;
 
-use ApiPlatform\Core\Api\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -11,6 +11,7 @@
 
 namespace ApiPlatform\Core\Api;
 
+use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Util\ClassInfoTrait;

--- a/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm;
 
-use ApiPlatform\Core\Api\CollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryResultExtensionInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
@@ -27,18 +27,15 @@ class CollectionDataProvider implements CollectionDataProviderInterface
 {
     private $managerRegistry;
     private $collectionExtensions;
-    private $decorated;
 
     /**
      * @param ManagerRegistry                      $managerRegistry
      * @param QueryCollectionExtensionInterface[]  $collectionExtensions
-     * @param CollectionDataProviderInterface|null $decorated
      */
-    public function __construct(ManagerRegistry $managerRegistry, array $collectionExtensions = [], CollectionDataProviderInterface $decorated = null)
+    public function __construct(ManagerRegistry $managerRegistry, array $collectionExtensions = [])
     {
         $this->managerRegistry = $managerRegistry;
         $this->collectionExtensions = $collectionExtensions;
-        $this->decorated = $decorated;
     }
 
     /**
@@ -46,14 +43,6 @@ class CollectionDataProvider implements CollectionDataProviderInterface
      */
     public function getCollection(string $resourceClass, string $operationName = null)
     {
-        if ($this->decorated) {
-            try {
-                return $this->decorated->getCollection($resourceClass, $operationName);
-            } catch (ResourceClassNotSupportedException $resourceClassNotSupportedException) {
-                // Ignore it
-            }
-        }
-
         $manager = $this->managerRegistry->getManagerForClass($resourceClass);
         if (null === $manager) {
             throw new ResourceClassNotSupportedException();

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm;
 
-use ApiPlatform\Core\Api\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
@@ -33,22 +33,19 @@ class ItemDataProvider implements ItemDataProviderInterface
     private $propertyNameCollectionFactory;
     private $propertyMetadataFactory;
     private $itemExtensions;
-    private $decorated;
 
     /**
      * @param ManagerRegistry                        $managerRegistry
      * @param PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory
      * @param PropertyMetadataFactoryInterface       $propertyMetadataFactory
      * @param QueryItemExtensionInterface[]          $itemExtensions
-     * @param ItemDataProviderInterface|null         $decorated
      */
-    public function __construct(ManagerRegistry $managerRegistry, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, array $itemExtensions = [], ItemDataProviderInterface $decorated = null)
+    public function __construct(ManagerRegistry $managerRegistry, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, array $itemExtensions = [])
     {
         $this->managerRegistry = $managerRegistry;
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->itemExtensions = $itemExtensions;
-        $this->decorated = $decorated;
     }
 
     /**
@@ -56,14 +53,6 @@ class ItemDataProvider implements ItemDataProviderInterface
      */
     public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false)
     {
-        if ($this->decorated) {
-            try {
-                return $this->decorated->getItem($resourceClass, $id, $operationName, $fetchData);
-            } catch (ResourceClassNotSupportedException $resourceClassNotSupportedException) {
-                // Ignore it
-            }
-        }
-
         $manager = $this->managerRegistry->getManagerForClass($resourceClass);
         if (null === $manager) {
             throw new ResourceClassNotSupportedException();

--- a/src/Bridge/Doctrine/Orm/Paginator.php
+++ b/src/Bridge/Doctrine/Orm/Paginator.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm;
 
-use ApiPlatform\Core\Api\PaginatorInterface;
+use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator as DoctrineOrmPaginator;
 

--- a/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
@@ -11,6 +11,7 @@
 
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle;
 
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineQueryExtensionPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,6 +31,7 @@ final class ApiPlatformBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new DataProviderPass());
         $container->addCompilerPass(new FilterPass());
         $container->addCompilerPass(new DoctrineQueryExtensionPass());
     }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -81,6 +81,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('api.xml');
         $loader->load('metadata.xml');
+        $loader->load('data_provider.xml');
 
         $this->enableJsonLd($loader);
         $this->registerAnnotationLoaders($container);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -149,23 +149,23 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      */
     private function registerFileLoaders(ContainerBuilder $container)
     {
-        $prefix = DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR;
         $yamlResources = [];
         $xmlResources = [];
 
         foreach ($container->getParameter('kernel.bundles') as $bundle) {
             $reflectionClass = new \ReflectionClass($bundle);
-            $configDirectory = dirname($reflectionClass->getFileName()).$prefix;
-            $yamlResources = array_merge($yamlResources, glob($configDirectory.'api_resources.{yml,yaml}'));
+            $configDirectory = dirname($reflectionClass->getFileName()).'/Resources/config/';
 
-            foreach (Finder::create()->files()->in($configDirectory)->path('api_resources')->name('*.{yml,yaml}') as $file) {
-                $yamlResources[] = $file->getRealPath();
-            }
-
-            $xmlResources = array_merge($xmlResources, glob($configDirectory.'api_resources.xml'));
-
-            foreach (Finder::create()->files()->in($configDirectory)->path('api_resources')->name('*.xml') as $file) {
-                $xmlResources[] = $file->getRealPath();
+            try {
+                foreach (Finder::create()->files()->in($configDirectory)->path('api_resources')->name('*.{yml,yaml,xml}') as $file) {
+                    if ('xml' === $file->getExtension()) {
+                        $xmlResources[] = $file->getRealPath();
+                    } else {
+                        $yamlResources[] = $file->getRealPath();
+                    }
+                }
+            } catch (\InvalidArgumentException $e) {
+                // Ignore invalid paths
             }
         }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Registers data providers.
+ *
+ * @internal
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class DataProviderPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->registerDataProviders($container, 'collection');
+        $this->registerDataProviders($container, 'item');
+    }
+
+    /**
+     * The priority sorting algorithm has been backported from Symfony 3.2.
+     *
+     * @see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+     *
+     * @param ContainerBuilder $container
+     * @param string           $type
+     */
+    private function registerDataProviders(ContainerBuilder $container, string $type) {
+        $services = $container->findTaggedServiceIds('api_platform.'.$type.'_data_provider');
+
+        $queue = new \SplPriorityQueue();
+
+        foreach ($services as $serviceId => $tags) {
+            foreach ($tags as $attributes) {
+                $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;
+                $queue->insert(new Reference($serviceId), $priority);
+            }
+        }
+
+        $container->getDefinition('api_platform.'.$type.'_data_provider')->addArgument(iterator_to_array($queue, false));
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -11,8 +11,6 @@
 
         <service id="api_platform.property_info" alias="property_info" public="false" />
 
-        <service id="api_platform.filters" class="ApiPlatform\Core\Api\FilterCollection" public="false" />
-
         <service id="api_platform.resource_class_resolver" class="ApiPlatform\Core\Api\ResourceClassResolver" public="false">
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api_platform.item_data_provider" class="ApiPlatform\Core\DataProvider\ChainItemDataProvider" />
+
+        <service id="api_platform.collection_data_provider" class="ApiPlatform\Core\DataProvider\ChainCollectionDataProvider" />
+
+        <service id="api_platform.filters" class="ApiPlatform\Core\Api\FilterCollection" public="false" />
+    </services>
+
+</container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -5,9 +5,6 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="api_platform.item_data_provider" alias="api_platform.doctrine.orm.default.item_data_provider" />
-        <service id="api_platform.collection_data_provider" alias="api_platform.doctrine.orm.default.collection_data_provider" />
-
         <service id="api_platform.doctrine.metadata_factory" class="Doctrine\Common\Persistence\Mapping\ClassMetadataFactory" public="false">
             <factory service="doctrine.orm.default_entity_manager" method="getMetadataFactory" />
         </service>
@@ -24,8 +21,13 @@
             <argument type="collection"></argument> <!-- extensions -->
         </service>
 
-        <service id="api_platform.doctrine.orm.default.collection_data_provider" parent="api_platform.doctrine.orm.collection_data_provider" class="ApiPlatform\Core\Bridge\Doctrine\Orm\CollectionDataProvider" />
-        <service id="api_platform.doctrine.orm.default.item_data_provider" parent="api_platform.doctrine.orm.item_data_provider" class="ApiPlatform\Core\Bridge\Doctrine\Orm\ItemDataProvider" />
+        <service id="api_platform.doctrine.orm.default.collection_data_provider" parent="api_platform.doctrine.orm.collection_data_provider" class="ApiPlatform\Core\Bridge\Doctrine\Orm\CollectionDataProvider">
+            <tag name="api_platform.collection_data_provider" />
+        </service>
+
+        <service id="api_platform.doctrine.orm.default.item_data_provider" parent="api_platform.doctrine.orm.item_data_provider" class="ApiPlatform\Core\Bridge\Doctrine\Orm\ItemDataProvider">
+            <tag name="api_platform.item_data_provider" />
+        </service>
 
         <!-- Filter -->
 

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -12,7 +12,7 @@
 namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
-use ApiPlatform\Core\Api\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;

--- a/src/DataProvider/ChainCollectionDataProvider.php
+++ b/src/DataProvider/ChainCollectionDataProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\DataProvider;
+
+use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
+
+/**
+ * Tries each configured data provider and returns the result of the first able to handle the resource class.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class ChainCollectionDataProvider implements CollectionDataProviderInterface
+{
+    private $dataProviders;
+
+    /**
+     * @param CollectionDataProviderInterface[] $dataProviders
+     */
+    public function __construct(array $dataProviders)
+    {
+        $this->dataProviders = $dataProviders;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCollection(string $resourceClass, string $operationName = null)
+    {
+        foreach ($this->dataProviders as $dataProvider) {
+            try {
+                return $dataProvider->getCollection($resourceClass, $operationName);
+            } catch (ResourceClassNotSupportedException $e) {
+                continue;
+            }
+        }
+    }
+}

--- a/src/DataProvider/ChainItemDataProvider.php
+++ b/src/DataProvider/ChainItemDataProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\DataProvider;
+
+use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
+
+/**
+ * Tries each configured data provider and returns the result of the first able to handle the resource class.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class ChainItemDataProvider implements ItemDataProviderInterface
+{
+    private $dataProviders;
+
+    /**
+     * @param ItemDataProviderInterface[] $dataProviders
+     */
+    public function __construct(array $dataProviders)
+    {
+        $this->dataProviders = $dataProviders;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false)
+    {
+        foreach ($this->dataProviders as $dataProviders) {
+            try {
+                return $dataProviders->getItem($resourceClass, $id, $operationName, $fetchData);
+            } catch (ResourceClassNotSupportedException $e) {
+                continue;
+            }
+        }
+    }
+}

--- a/src/DataProvider/CollectionDataProviderInterface.php
+++ b/src/DataProvider/CollectionDataProviderInterface.php
@@ -9,9 +9,8 @@
  * file that was distributed with this source code.
  */
 
-namespace ApiPlatform\Core\Api;
+namespace ApiPlatform\Core\DataProvider;
 
-use ApiPlatform\Core\Exception\ExceptionInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
@@ -19,20 +18,17 @@ use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface ItemDataProviderInterface
+interface CollectionDataProviderInterface
 {
     /**
-     * Retrieves an item.
+     * Retrieves a collection.
      *
      * @param string      $resourceClass
      * @param string|null $operationName
-     * @param int|string  $id
-     * @param bool        $fetchData
      *
      * @throws ResourceClassNotSupportedException
-     * @throws ExceptionInterface
      *
-     * @return object|null
+     * @return array|PaginatorInterface|\Traversable
      */
-    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false);
+    public function getCollection(string $resourceClass, string $operationName = null);
 }

--- a/src/DataProvider/ItemDataProviderInterface.php
+++ b/src/DataProvider/ItemDataProviderInterface.php
@@ -9,9 +9,8 @@
  * file that was distributed with this source code.
  */
 
-namespace ApiPlatform\Core\Api;
+namespace ApiPlatform\Core\DataProvider;
 
-use ApiPlatform\Core\Exception\ExceptionInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
@@ -19,18 +18,19 @@ use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface CollectionDataProviderInterface
+interface ItemDataProviderInterface
 {
     /**
-     * Retrieves a collection.
+     * Retrieves an item.
      *
      * @param string      $resourceClass
      * @param string|null $operationName
+     * @param int|string  $id
+     * @param bool        $fetchData
      *
      * @throws ResourceClassNotSupportedException
-     * @throws ExceptionInterface
      *
-     * @return array|PaginatorInterface|\Traversable
+     * @return object|null
      */
-    public function getCollection(string $resourceClass, string $operationName = null);
+    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false);
 }

--- a/src/DataProvider/PaginatorInterface.php
+++ b/src/DataProvider/PaginatorInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ApiPlatform\Core\Api;
+namespace ApiPlatform\Core\DataProvider;
 
 /**
  * Paginator Interface.

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -12,7 +12,7 @@
 namespace ApiPlatform\Core\Hydra\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
-use ApiPlatform\Core\Api\PaginatorInterface;
+use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;

--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Hydra\Serializer;
 
-use ApiPlatform\Core\Api\PaginatorInterface;
+use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\JsonLd\Serializer\ContextTrait;
 use ApiPlatform\Core\Util\RequestParser;

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -211,8 +211,6 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.metadata.resource.metadata_factory',
             'api_platform.metadata.property.name_collection_factory',
             'api_platform.metadata.property.metadata_factory',
-            'api_platform.item_data_provider',
-            'api_platform.collection_data_provider',
             'api_platform.action.delete_item',
         ];
         foreach ($aliases as $alias) {
@@ -245,6 +243,8 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $containerBuilderProphecy->getDefinition('api_platform.metadata.resource.metadata_factory.xml')->willReturn($definition);
 
         $definitions = [
+            'api_platform.item_data_provider',
+            'api_platform.collection_data_provider',
             'api_platform.filters',
             'api_platform.resource_class_resolver',
             'api_platform.operation_method_resolver',

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Symfony\Bridge\Bundle\DependencyInjection;
 
-use ApiPlatform\Core\Api\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Bridge\Symfony\Routing\IriConverter;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;

--- a/tests/Fixtures/TestBundle/Controller/ConfigCustomController.php
+++ b/tests/Fixtures/TestBundle/Controller/ConfigCustomController.php
@@ -12,7 +12,7 @@
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Controller;
 
 use ApiPlatform\Core\Action\ActionUtilTrait;
-use ApiPlatform\Core\Api\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
+++ b/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
@@ -11,7 +11,7 @@
 
 namespace ApiPlatform\Core\Tests\Hydra\Serializer;
 
-use ApiPlatform\Core\Api\PaginatorInterface;
+use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Hydra\Serializer\PartialCollectionViewNormalizer;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #506
| License       | MIT
| Doc PR        | todo

Use a chain instead of a decorator for data providers. It allows to register custom data providers in a more intuitive fashion: just add a tag to your service.

ping @soyuka 