### PR TITLE
hotfix: add exception when the action is not a builtin action

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -25,6 +25,8 @@
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.routing.resource_path_generator" />
+            <argument type="service" id="service_container" />
+
 
             <tag name="routing.loader" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -26,8 +26,6 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.routing.resource_path_generator" />
             <argument type="service" id="service_container" />
-
-
             <tag name="routing.loader" />
         </service>
 

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -19,6 +19,7 @@ use ApiPlatform\Core\Routing\ResourcePathGeneratorInterface;
 use Doctrine\Common\Inflector\Inflector;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\Route;
@@ -39,10 +40,11 @@ final class ApiLoader extends Loader
     private $resourceNameCollectionFactory;
     private $resourceMetadataFactory;
     private $resourcePathGenerator;
+    private $container;
 
-    public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, ResourcePathGeneratorInterface $resourcePathGenerator)
+    public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, ResourcePathGeneratorInterface $resourcePathGenerator, ContainerInterface $container)
     {
-        $this->kernel = $kernel;
+        $this->container = $container;
         $this->fileLoader = new XmlFileLoader(new FileLocator($kernel->locateResource('@ApiPlatformBundle/Resources/config/routing')));
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -116,7 +118,7 @@ final class ApiLoader extends Loader
         if (null === $controller) {
             $controller = self::DEFAULT_ACTION_PATTERN.$actionName;
 
-            if (!$this->kernel->getContainer()->has($controller)) {
+            if (!$this->container->has($controller)) {
                 throw new RuntimeException(sprintf('There is no builtin action for the %s %s operation. You need to define the controller yourself.', $collectionType, $operation['method']));
             }
         }

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -34,6 +34,7 @@ final class ApiLoader extends Loader
     const ROUTE_NAME_PREFIX = 'api_';
     const DEFAULT_ACTION_PATTERN = 'api_platform.action.';
 
+    private $kernel;
     private $fileLoader;
     private $resourceNameCollectionFactory;
     private $resourceMetadataFactory;
@@ -41,6 +42,7 @@ final class ApiLoader extends Loader
 
     public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, ResourcePathGeneratorInterface $resourcePathGenerator)
     {
+        $this->kernel = $kernel;
         $this->fileLoader = new XmlFileLoader(new FileLocator($kernel->locateResource('@ApiPlatformBundle/Resources/config/routing')));
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -108,10 +110,15 @@ final class ApiLoader extends Loader
         }
 
         $controller = $operation['controller'] ?? null;
-        $actionName = sprintf('%s_%s', strtolower($operation['method']), $collection ? 'collection' : 'item');
+        $collectionType = $collection ? 'collection' : 'item';
+        $actionName = sprintf('%s_%s', strtolower($operation['method']), $collectionType);
 
         if (null === $controller) {
             $controller = self::DEFAULT_ACTION_PATTERN.$actionName;
+
+            if (!$this->kernel->getContainer()->has($controller)) {
+                throw new RuntimeException(sprintf('There is no builtin action for the %s %s operation. You need to define the controller yourself.', $collectionType, $operation['method']));
+            }
         }
 
         if ($operationName !== strtolower($operation['method'])) {

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -141,17 +141,13 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
             'api_platform.action.put_item',
             'api_platform.action.delete_item',
         ];
-
-        $containerInterfaceProphecy = $this->prophesize(ContainerInterface::class);
-        $containerInterfaceProphecy->reveal();
-
-        $kernelProphecy->getContainer()->willReturn($containerInterfaceProphecy);
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
 
         foreach ($possibleArguments as $possibleArgument) {
-            $containerInterfaceProphecy->has($possibleArgument)->willReturn(true);
+            $containerProphecy->has($possibleArgument)->willReturn(true);
         }
 
-        $containerInterfaceProphecy->has(Argument::type('string'))->willReturn(false);
+        $containerProphecy->has(Argument::type('string'))->willReturn(false);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyEntity::class)->willReturn($resourceMetadata);
@@ -162,7 +158,7 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
         $resourcePathGeneratorProphecy = $this->prophesize(ResourcePathGeneratorInterface::class);
         $resourcePathGeneratorProphecy->generateResourceBasePath('dummy')->willReturn('dummies');
 
-        $apiLoader = new ApiLoader($kernelProphecy->reveal(), $resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), $resourcePathGeneratorProphecy->reveal());
+        $apiLoader = new ApiLoader($kernelProphecy->reveal(), $resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), $resourcePathGeneratorProphecy->reveal(), $containerProphecy->reveal());
 
         return $apiLoader;
     }

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -19,11 +19,13 @@ use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Core\Routing\ResourcePathGeneratorInterface;
 use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
 use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Route;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
+ * @author Amrouche Hamza <hamza.simperfit@gmail.com>s
  */
 class ApiLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -113,6 +115,10 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
 
         $kernelProphecy = $this->prophesize(KernelInterface::class);
         $kernelProphecy->locateResource(Argument::any())->willReturn($routingConfig);
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+
+        $kernelProphecy->getContainer()->willReturn($containerBuilderProphecy);
+        $containerBuilderProphecy->has(Argument::any())->willReturn(true);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyEntity::class)->willReturn($resourceMetadata);

--- a/tests/Fixtures/TestBundle/Entity/CustomAttributeDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomAttributeDummy.php
@@ -31,10 +31,6 @@ use Symfony\Component\Validator\Constraints as Assert;
  *     "normalization_context"={"groups"={"custom_attr_dummy_get"}},
  *     "denormalization_context"={"groups"={"custom_attr_dummy_get"}}
  *     },
- *          "post"={"method"="POST",
- *      "normalization_context"={"groups"={"custom_attr_dummy_post"}},
- *      "denormalization_context"={"groups"={"custom_attr_dummy_post"}}
- *     },
  *          "put"={"method"="PUT",
  *      "normalization_context"={"groups"={"custom_attr_dummy_put"}},
  *      "denormalization_context"={"groups"={"custom_attr_dummy_put"}}
@@ -60,7 +56,7 @@ class CustomAttributeDummy
      *
      * @ORM\Column
      * @Assert\NotBlank
-     * @Groups({"custom_attr_dummy_read", "custom_attr_dummy_write", "custom_attr_dummy_post", "custom_attr_dummy_get"})
+     * @Groups({"custom_attr_dummy_read", "custom_attr_dummy_write", "custom_attr_dummy_get"})
      * @ApiProperty(iri="http://schema.org/name")
      */
     private $name;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none


We should not use POST in itemOperation (it is not supported) and each unsupported actionName should not be able to be used since it break NelmioApiDoc.


Thanks to @dunglas for the help.