### PR TITLE
fix #582 itemOperation Normalization/Denormalization in doc 

### DIFF
--- a/src/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProvider.php
+++ b/src/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProvider.php
@@ -106,11 +106,11 @@ final class ApiPlatformProvider implements AnnotationsProviderInterface
         ];
 
         if (isset($operationHydraDoc['expects']) && 'owl:Nothing' !== $operationHydraDoc['expects']) {
-            $data['input'] = sprintf('%s:%s', ApiPlatformParser::IN_PREFIX, $resourceClass);
+            $data['input'] = sprintf('%s:%s:%s', ApiPlatformParser::IN_PREFIX, $resourceClass, $operationName);
         }
 
         if (isset($operationHydraDoc['returns']) && 'owl:Nothing' !== $operationHydraDoc['returns']) {
-            $data['output'] = sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, $resourceClass);
+            $data['output'] = sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, $resourceClass, $operationName);
         }
 
         if ($collection && Request::METHOD_GET === $method) {

--- a/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
+++ b/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
@@ -105,16 +105,15 @@ final class ApiPlatformParser implements ParserInterface
         $visited[] = $resourceClass;
 
         $options = [];
+        $attributes = $resourceMetadata->getAttributes();
 
-        $options['serializer_groups'] = $resourceMetadata->getAttribute(
-                'normalization_context',
-                ['groups' => []]
-            )['groups'];
+        if (isset($attributes['normalization_context']['groups'])) {
+            $options['serializer_groups'] = $attributes['normalization_context']['groups'];
+        }
 
-        $options['serializer_groups'] = array_merge(
-                $options['serializer_groups'],
-                $resourceMetadata->getAttribute('denormalization_context', ['groups' => []])
-            )['groups'];
+        if (isset($attributes['denormalization_context']['groups'])) {
+            $options['serializer_groups'] = isset($options['serializer_groups']) ? array_merge($options['serializer_groups'], $attributes['denormalization_context']['groups']) : $options['serializer_groups'];
+        }
 
         return $this->getPropertyMetadata($resourceMetadata, $resourceClass, $io, $visited, $options);
     }

--- a/tests/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProviderTest.php
+++ b/tests/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProviderTest.php
@@ -132,7 +132,7 @@ class ApiPlatformProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Retrieves the collection of Dummy resources.', $actual[0]->getDescription());
         $this->assertEquals('Dummy', $actual[0]->getResourceDescription());
         $this->assertEquals('Dummy', $actual[0]->getSection());
-        $this->assertEquals(sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class), $actual[0]->getOutput());
+        $this->assertEquals(sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class, 'get'), $actual[0]->getOutput());
         $this->assertEquals([
             'name' => [
                 'property' => 'name',
@@ -150,8 +150,8 @@ class ApiPlatformProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Creates a Dummy resource.', $actual[1]->getDescription());
         $this->assertEquals('Dummy', $actual[1]->getResourceDescription());
         $this->assertEquals('Dummy', $actual[1]->getSection());
-        $this->assertEquals(sprintf('%s:%s', ApiPlatformParser::IN_PREFIX, Dummy::class), $actual[1]->getInput());
-        $this->assertEquals(sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class), $actual[1]->getOutput());
+        $this->assertEquals(sprintf('%s:%s:%s', ApiPlatformParser::IN_PREFIX, Dummy::class, 'post'), $actual[1]->getInput());
+        $this->assertEquals(sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class, 'post'), $actual[1]->getOutput());
         $this->assertInstanceOf(Route::class, $actual[1]->getRoute());
         $this->assertEquals('/dummies', $actual[1]->getRoute()->getPath());
         $this->assertEquals(['POST'], $actual[1]->getRoute()->getMethods());
@@ -161,7 +161,7 @@ class ApiPlatformProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Retrieves Dummy resource.', $actual[2]->getDescription());
         $this->assertEquals('Dummy', $actual[2]->getResourceDescription());
         $this->assertEquals('Dummy', $actual[2]->getSection());
-        $this->assertEquals(sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class), $actual[2]->getOutput());
+        $this->assertEquals(sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class, 'get'), $actual[2]->getOutput());
         $this->assertInstanceOf(Route::class, $actual[2]->getRoute());
         $this->assertEquals('/dummies/{id}', $actual[2]->getRoute()->getPath());
         $this->assertEquals(['GET'], $actual[2]->getRoute()->getMethods());
@@ -171,8 +171,8 @@ class ApiPlatformProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Replaces the Dummy resource.', $actual[3]->getDescription());
         $this->assertEquals('Dummy', $actual[3]->getResourceDescription());
         $this->assertEquals('Dummy', $actual[3]->getSection());
-        $this->assertEquals(sprintf('%s:%s', ApiPlatformParser::IN_PREFIX, Dummy::class), $actual[3]->getInput());
-        $this->assertEquals(sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class), $actual[3]->getOutput());
+        $this->assertEquals(sprintf('%s:%s:%s', ApiPlatformParser::IN_PREFIX, Dummy::class, 'put'), $actual[3]->getInput());
+        $this->assertEquals(sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class, 'put'), $actual[3]->getOutput());
         $this->assertInstanceOf(Route::class, $actual[3]->getRoute());
         $this->assertEquals('/dummies/{id}', $actual[3]->getRoute()->getPath());
         $this->assertEquals(['PUT'], $actual[3]->getRoute()->getMethods());

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -70,13 +70,11 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
     public function testSupportsAttributeNormalization()
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadata = new ResourceMetadata();
-        $resourceMetadata->withItemOperations([
-            'get' => ['method' => 'GET', 'normalization_context' => ['groups' => 'custom_attr_dummy_get']],
-            'put' => ['method' => 'PUT', 'denormalization_context' => ['groups' => 'custom_attr_dummy_put']],
+        $resourceMetadataFactoryProphecy->create(CustomAttributeDummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [
+            'get' => ['method' => 'GET', 'normalization_context' => ['groups' => ['custom_attr_dummy_get']]],
+            'put' => ['method' => 'PUT', 'denormalization_context' => ['groups' => ['custom_attr_dummy_put']]],
             'delete' => ['method' => 'DELETE'],
-        ]);
-        $resourceMetadataFactoryProphecy->create(CustomAttributeDummy::class)->willReturn($resourceMetadata)->shouldBeCalled();
+        ], []))->shouldBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -167,7 +165,11 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
     public function testParse()
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [
+            'get' => ['method' => 'GET', 'normalization_context' => ['groups' => ['custom_attr_dummy_get']]],
+            'put' => ['method' => 'PUT', 'denormalization_context' => ['groups' => ['custom_attr_dummy_put']]],
+            'delete' => ['method' => 'DELETE'],
+        ], []))->shouldBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -233,7 +235,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
     public function testParseDateTime()
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [], []))->shouldBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -272,7 +274,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
     public function testParseRelation()
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [], []))->shouldBeCalled();
         $resourceMetadataFactoryProphecy->create(RelatedDummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -105,7 +105,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
         $apiPlatformParser = new ApiPlatformParser($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory);
 
         $actual = $apiPlatformParser->parse([
-            'class' => sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, CustomAttributeDummy::class),
+            'class' => sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, CustomAttributeDummy::class, 'get'),
         ]);
 
         $this->assertEquals([
@@ -123,7 +123,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
             ],
         ], $actual);
     }
-
+  
     public function testSupportsUnknownResource()
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
@@ -168,6 +168,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [
             'get' => ['method' => 'GET', 'normalization_context' => ['groups' => ['custom_attr_dummy_get']]],
             'put' => ['method' => 'PUT', 'denormalization_context' => ['groups' => ['custom_attr_dummy_put']]],
+            'gerard' => ['method' => 'get', 'path' => '/gerard', 'denormalization_context' => ['groups' => ['custom_attr_dummy_put']]],
             'delete' => ['method' => 'DELETE'],
         ], []))->shouldBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
@@ -207,7 +208,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
         $apiPlatformParser = new ApiPlatformParser($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory);
 
         $actual = $apiPlatformParser->parse([
-            'class' => sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class),
+            'class' => sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class, 'gerard'),
         ]);
 
         $this->assertEquals([
@@ -257,7 +258,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
         $apiPlatformParser = new ApiPlatformParser($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory);
 
         $actual = $apiPlatformParser->parse([
-            'class' => sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class),
+            'class' => sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class, 'get'),
         ]);
 
         $this->assertEquals([
@@ -323,7 +324,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
         $apiPlatformParser = new ApiPlatformParser($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory);
 
         $actual = $apiPlatformParser->parse([
-            'class' => sprintf('%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class),
+            'class' => sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, Dummy::class, 'get'),
         ]);
 
         $this->assertEquals([

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -123,7 +123,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
             ],
         ], $actual);
     }
-  
+
     public function testSupportsUnknownResource()
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #582 
| License       | MIT
| Doc PR        | 


I think i'm not bad on this but there is a part of this I don't know how to handle :
Since we are overriding on method, how do I tell the property-info / nelmio that we want this only for the PUT part ?

```php
/**
 * @see http://schema.org/Thing
 *
 * 
 * @ApiResource(iri="http://schema.org/Thing", attributes={
 *     "normalization_context"={"groups"={"thing_default_output"}},
 *     "denormalization_context"={"groups"={"thing_default_input"}}
 * }, itemOperations={
 *     "get"={"method"="GET", "normalization_context"={"groups"={"thing_default_out_get"}}, "denormalization_context"={"groups"={"thing_default_in_get"}}},
 *     "put"={"method"="PUT", "normalization_context"={"groups"={"thing_default_out_put"}}, "denormalization_context"={"groups"={"thing_default_in_put"}}},
 *     }
 * )
 */
```

Right now I only get the overrided part in the doc. It is the intended behaviour ?

Which means I lost the ones in the attributes.

@dunglas What do I miss ?