### PR TITLE
Reset operations for each resource class and remove api prefix to mak…

### DIFF
--- a/features/swagger/doc.feature
+++ b/features/swagger/doc.feature
@@ -13,7 +13,6 @@ Feature: Documentation support
     # Root properties
     And the JSON node "info.title" should be equal to "My Dummy API"
     And the JSON node "info.description" should be equal to "This is a test API."
-    And the JSON node "basePath" should be equal to "/"
     # Supported classes
     And the Swagger class "CircularReference" exist
     And the Swagger class "CustomIdentifierDummy" exist

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -14,7 +14,6 @@
             <argument type="service" id="api_platform.jsonld.context_builder" />
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.operation_method_resolver" />
-            <argument type="service" id="api_platform.router" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument>%api_platform.formats%</argument>
             <argument>%api_platform.title%</argument>

--- a/tests/Swagger/ApiDocumentationBuilderTest.php
+++ b/tests/Swagger/ApiDocumentationBuilderTest.php
@@ -14,7 +14,6 @@ namespace ApiPlatform\Core\tests\Swagger;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\OperationMethodResolverInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
-use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -63,12 +62,10 @@ class ApiDocumentationBuilderTest extends \PHPUnit_Framework_TestCase /**/
         $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'post')->shouldBeCalled()->willReturn('POST');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-
         $iriConverter = $this->prophesize(IriConverterInterface::class);
         $iriConverter->getIriFromResourceClass('dummy')->shouldBeCalled()->willReturn('/dummies');
 
-        $apiDocumentationBuilder = new ApiDocumentationBuilder($resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $contextBuilderProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $operationMethodResolverProphecy->reveal(), $urlGeneratorProphecy->reveal(), $iriConverter->reveal(), $formats, $title, $desc);
+        $apiDocumentationBuilder = new ApiDocumentationBuilder($resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $contextBuilderProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $operationMethodResolverProphecy->reveal(), $iriConverter->reveal(), $formats, $title, $desc);
 
         $expected = [
             'swagger' => '2.0',
@@ -77,7 +74,6 @@ class ApiDocumentationBuilderTest extends \PHPUnit_Framework_TestCase /**/
                 'description' => 'test ApiGerard',
                 'version' => '0.0.0',
             ],
-            'basePath' => null,
             'definitions' => [
                 'dummy' => [
                     'type' => 'object',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR fixes a problem where the generated swagger output was wrong because some resources got tagged incorrectly.

Example:

$operation['item'] and $operation['collection'] are not empty and the next resource has no collection operations defined in it's annotation. Only $operation['item'] will be overriden and thus the swagger documentation would contain output from the previous resource in its collection array.

When prefixing the annotation platform resources like this:

```xml
<import resource="." type="api_platform" prefix="/api"/>
```

Generated paths in swagger will look like /api/foo and the basepath will be /api for the hydra doc route.
Swagger javascript will construct the url to call like this: /api/api/foo which is invalid.

