### PR TITLE
Fix dead link to get started tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ high performance API-first projects.
 The documentation of API Platform Core is available online and can be edited in
 [its dedicated repository](https://github.com/api-platform/doc/tree/master/core).
 
-* [Get started with API Platform](https://github.com/api-platform/doc/tree/master/getting-started/)
+* [Get started with API Platform](https://github.com/api-platform/docs/blob/master/tutorial/index.md)
 * [A documentation](https://github.com/api-platform/doc/tree/master/core/)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

The current link leads to a 404,  this makes it point to the "get started" chapter, on the website.