### PR TITLE
Skip the DoctrineQueryExtensionPass if doctrine is not loaded

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPass.php
@@ -30,6 +30,11 @@ final class DoctrineQueryExtensionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        // if doctrine not loaded
+        if (!$container->hasDefinition('api_platform.doctrine.metadata_factory')) {
+            return;
+        }
+
         $collectionDataProviderDefinition = $container->getDefinition('api_platform.doctrine.orm.collection_data_provider');
         $itemDataProviderDefinition = $container->getDefinition('api_platform.doctrine.orm.item_data_provider');
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPassTest.php
@@ -37,6 +37,7 @@ class DoctrineQueryExtensionPassTest extends \PHPUnit_Framework_TestCase
         $itemDataProviderDefinition = $itemDataProviderDefinitionProphecy->reveal();
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->hasDefinition('api_platform.doctrine.metadata_factory')->willReturn(true)->shouldBeCalled();
         $containerBuilderProphecy->findTaggedServiceIds('api_platform.doctrine.orm.query_extension.collection')->willReturn(['foo' => [], 'bar' => ['priority' => 1]])->shouldBeCalled();
         $containerBuilderProphecy->findTaggedServiceIds('api_platform.doctrine.orm.query_extension.item')->willReturn(['foo' => [], 'bar' => ['priority' => 1]])->shouldBeCalled();
         $containerBuilderProphecy->getDefinition('api_platform.doctrine.orm.collection_data_provider')->willReturn($collectionDataProviderDefinition)->shouldBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

The services related to doctrine [aren't loaded in case doctrine is not available](https://github.com/api-platform/core/blob/master/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php#L112-L115) but the `DoctrineQueryExtensionPass` is executed anyway leading to exceptions such as:
```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "api_platform.doctrine.orm.collection_data_provider".

/home/guilhem/github/ApiDocBundle/vendor/symfony/dependency-injection/ContainerBuilder.php:787
/home/guilhem/github/ApiDocBundle/vendor/api-platform/core/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPass.php:33
```

This PR adds a check to skip the pass if ``doctrine_orm.xml`` is not loaded.
