### PR TITLE
Refactor the management of operations by the swagger DocumentationNormalizer

### DIFF
--- a/features/bootstrap/SwaggerContext.php
+++ b/features/bootstrap/SwaggerContext.php
@@ -39,7 +39,7 @@ final class SwaggerContext implements Context
     }
 
     /**
-     * @Then the Swagger class ":class" exist
+     * @Then the Swagger class ":class" exists
      */
     public function assertTheSwaggerClassExist($className)
     {
@@ -47,7 +47,7 @@ final class SwaggerContext implements Context
     }
 
     /**
-     * @Then the Swagger class ":class" not exist
+     * @Then the Swagger class ":class" doesn't exist
      */
     public function assertTheSwaggerClassNotExist($className)
     {
@@ -61,17 +61,12 @@ final class SwaggerContext implements Context
     }
 
     /**
-     * @Then the Swagger path ":arg1" exist
+     * @Then the Swagger path ":arg1" exists
      */
     public function assertThePathExist($path)
     {
-        try {
-            \PHPUnit_Framework_Assert::assertTrue($this->assertSwaggerPath($path));
-
-            throw new \PHPUnit_Framework_ExpectationFailedException(sprintf('The path "%s" exist.', $path));
-        } catch (\Exception $exception) {
-            // an exception must be catched
-        }
+        $json = $this->getLastJsonResponse();
+        \PHPUnit_Framework_Assert::assertTrue(isset($json->paths) && isset($json->paths->{$path}));
     }
 
     /**
@@ -203,21 +198,6 @@ final class SwaggerContext implements Context
         $classInfos = $this->getClassInfos($className);
 
         return empty($classInfos->{'properties'}) ? $classInfos->{'properties'} : new stdClass();
-    }
-
-    private function assertSwaggerPath(string $expectedPath, bool $getOperation = false): bool
-    {
-        $json = $this->getLastJsonResponse();
-        $validPath = false;
-        if (isset($json->{'paths'}) && $getOperation) {
-            foreach ($json->{'paths'} as $classTitle => $classPath) {
-                if ($expectedPath === $classPath) {
-                    return true;
-                }
-            }
-        }
-
-        return $validPath;
     }
 
     private function getClassInfos(string $className, bool $getOperation = false) : stdClass

--- a/features/swagger/doc.feature
+++ b/features/swagger/doc.feature
@@ -25,13 +25,13 @@ Feature: Documentation support
     And the Swagger class "ParentDummy" doesn't exist
     And the Swagger class "UnknownDummy" doesn't exist
     And the Swagger path "/override/swagger" exists
-    And the Swagger path "/api/custom-call" exists
-    And the JSON node "paths./api/custom-call.get" should exist
-    And the JSON node "paths./api/custom-call.put" should exist
+    And the Swagger path "/api/custom-call/{id}" exists
+    And the JSON node "paths./api/custom-call/{id}.get" should exist
+    And the JSON node "paths./api/custom-call/{id}.put" should exist
 
     # Must be fixed (custom operations with routes)
     # And the Swagger path "/relation_embedders/{id}/custom" exists
 
     # Properties
-    And "id" property doesn't exist for the Swagger class "Dummy"
+    And "id" property exists for the Swagger class "Dummy"
     And "name" property is required for Swagger class "Dummy"

--- a/features/swagger/doc.feature
+++ b/features/swagger/doc.feature
@@ -14,17 +14,24 @@ Feature: Documentation support
     And the JSON node "info.title" should be equal to "My Dummy API"
     And the JSON node "info.description" should be equal to "This is a test API."
     # Supported classes
-    And the Swagger class "CircularReference" exist
-    And the Swagger class "CustomIdentifierDummy" exist
-    And the Swagger class "CustomNormalizedDummy" exist
-    And the Swagger class "CustomWritableIdentifierDummy" exist
-    And the Swagger class "Dummy" exist
-    And the Swagger class "RelatedDummy" exist
-    And the Swagger class "RelationEmbedder" exist
-    And the Swagger class "ThirdLevel" exist
-    And the Swagger class "ParentDummy" not exist
-    And the Swagger class "UnknownDummy" not exist
-    And the Swagger path "/override/swagger" exist
+    And the Swagger class "CircularReference" exists
+    And the Swagger class "CustomIdentifierDummy" exists
+    And the Swagger class "CustomNormalizedDummy" exists
+    And the Swagger class "CustomWritableIdentifierDummy" exists
+    And the Swagger class "Dummy" exists
+    And the Swagger class "RelatedDummy" exists
+    And the Swagger class "RelationEmbedder" exists
+    And the Swagger class "ThirdLevel" exists
+    And the Swagger class "ParentDummy" doesn't exist
+    And the Swagger class "UnknownDummy" doesn't exist
+    And the Swagger path "/override/swagger" exists
+    And the Swagger path "/api/custom-call" exists
+    And the JSON node "paths./api/custom-call.get" should exist
+    And the JSON node "paths./api/custom-call.put" should exist
+
+    # Must be fixed (custom operations with routes)
+    # And the Swagger path "/relation_embedders/{id}/custom" exists
+
     # Properties
     And "id" property doesn't exist for the Swagger class "Dummy"
     And "name" property is required for Swagger class "Dummy"

--- a/src/Swagger/DocumentationNormalizer.php
+++ b/src/Swagger/DocumentationNormalizer.php
@@ -44,7 +44,7 @@ final class DocumentationNormalizer implements NormalizerInterface
     private $operationMethodResolver;
     private $iriConverter;
 
-    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, OperationMethodResolverInterface $operationMethodResolver, IriConverterInterface $iriConverter)
+    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, OperationMethodResolverInterface $operationMethodResolver, IriConverterInterface $iriConverter = null)
     {
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -132,27 +132,26 @@ final class DocumentationNormalizer implements NormalizerInterface
                 }
             }
 
-            try {
-                $resourceClassIri = $this->iriConverter->getIriFromResourceClass($resourceClass);
-            } catch (InvalidArgumentException $e) {
-                continue;
-            }
-
-            $operations = $resourceMetadata->getCollectionOperations() ?? null;
+            $operations = $resourceMetadata->getCollectionOperations() ?? [];
             foreach ($operations as $operationName => $collectionOperation) {
                 $method = $this->operationMethodResolver->getCollectionOperationMethod($resourceClass, $operationName);
-                $path = $resourceMetadata->getCollectionOperationAttribute($operationName, 'path', $resourceClassIri);
+                $path = $this->getPath($resourceClass, $resourceMetadata, $operationName, true);
+                if (null === $path) {
+                    continue;
+                }
 
                 $swaggerOperation = $this->getSwaggerOperation($resourceClass, $resourceMetadata, $operationName, $collectionOperation, $prefixedShortName, true, $definitions, $method, $object->getMimeTypes());
                 $itemOperationsDocs[$path] = array_merge($itemOperationsDocs[$path] ?? [], $swaggerOperation);
             }
 
-            $resourceClassIri .= '/{id}';
             $operations = $resourceMetadata->getItemOperations() ?? [];
             foreach ($operations as $operationName => $itemOperation) {
                 $method = $this->operationMethodResolver->getItemOperationMethod($resourceClass, $operationName);
 
-                $path = $resourceMetadata->getItemOperationAttribute($operationName, 'path', $resourceClassIri);
+                $path = $this->getPath($resourceClass, $resourceMetadata, $operationName, false);
+                if (null === $path) {
+                    continue;
+                }
                 $swaggerOperation = $this->getSwaggerOperation($resourceClass, $resourceMetadata, $operationName, $itemOperation, $prefixedShortName, false, $definitions, $method, $object->getMimeTypes());
                 $itemOperationsDocs[$path] = array_merge($itemOperationsDocs[$path] ?? [], $swaggerOperation);
             }
@@ -175,6 +174,33 @@ final class DocumentationNormalizer implements NormalizerInterface
         $doc['paths'] = $itemOperationsDocs;
 
         return $doc;
+    }
+
+    private function getPath(string $resourceClass, ResourceMetadata $resourceMetadata, string $operationName, bool $collection)
+    {
+        // Check if the operation has a custom path
+        $method = $collection ? 'getCollectionOperationAttribute' : 'getItemOperationAttribute';
+        $path = $resourceMetadata->{$method}($operationName, 'path');
+        if (null !== $path) {
+            return $path;
+        }
+
+        if (null === $this->iriConverter) {
+            throw new InvalidArgumentException(sprintf('%s can\'t manage the %s %s operation of the resource "%s" because it needs an instance of %s to manage standard operations (path not defined manually).', __CLASS__, $collection ? 'collection' : 'item', $resourceClass, IriConverterInterface::class));
+        }
+
+        // @todo Fix the limitation of the IriConverter when a resource
+        // has no collection operations
+        try {
+            $resourceClassIri = $this->iriConverter->getIriFromResourceClass($resourceClass);
+            if (!$collection) {
+                $resourceClassIri .= '/{id}';
+            }
+        } catch (InvalidArgumentException $e) {
+            return;
+        }
+
+        return $resourceClassIri;
     }
 
     /**

--- a/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
+++ b/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
@@ -28,8 +28,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *     "get"={"method"="GET"},
  *     "put"={"method"="PUT"},
  *     "custom_get"={"route_name"="relation_embedded.custom_get"},
- *     "custom1"={"path"="/api/custom-call", "method"="GET"},
- *     "custom2"={"path"="/api/custom-call", "method"="PUT"},
+ *     "custom1"={"path"="/api/custom-call/{id}", "method"="GET"},
+ *     "custom2"={"path"="/api/custom-call/{id}", "method"="PUT"},
  * })
  * @ORM\Entity
  */

--- a/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
+++ b/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
@@ -27,7 +27,9 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * }, itemOperations={
  *     "get"={"method"="GET"},
  *     "put"={"method"="PUT"},
- *     "custom_get"={"route_name"="relation_embedded.custom_get"}
+ *     "custom_get"={"route_name"="relation_embedded.custom_get"},
+ *     "custom1"={"path"="/api/custom-call", "method"="GET"},
+ *     "custom2"={"path"="/api/custom-call", "method"="PUT"},
  * })
  * @ORM\Entity
  */

--- a/tests/Swagger/DocumentationNormalizerTest.php
+++ b/tests/Swagger/DocumentationNormalizerTest.php
@@ -45,7 +45,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase /**/
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create('dummy', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['name']));
 
-        $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']], []);
+        $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST'], 'custom' => ['method' => 'GET', 'path' => '/foo'], 'custom2' => ['method' => 'POST', 'path' => '/foo']], []);
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn($dummyMetadata);
 
@@ -60,6 +60,8 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase /**/
         $operationMethodResolverProphecy->getItemOperationMethod('dummy', 'put')->shouldBeCalled()->willReturn('PUT');
         $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'post')->shouldBeCalled()->willReturn('POST');
+        $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'custom')->shouldBeCalled()->willReturn('GET');
+        $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'custom2')->shouldBeCalled()->willReturn('POST');
 
         $iriConverter = $this->prophesize(IriConverterInterface::class);
         $iriConverter->getIriFromResourceClass('dummy')->shouldBeCalled()->willReturn('/dummies');
@@ -174,6 +176,44 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase /**/
                         ],
                         'responses' => [
                             200 => [
+                                'description' => 'Successful operation',
+                                'schema' => ['$ref' => '#/definitions/dummy'],
+                            ],
+                            400 => ['description' => 'Invalid input'],
+                            404 => ['description' => 'Resource not found'],
+                        ],
+                    ],
+                ],
+                '/foo' => [
+                    'get' => [
+                        'tags' => ['dummy'],
+                        'produces' => ['application/ld+json'],
+                        'summary' => 'Retrieves the collection of dummy resources.',
+                        'responses' => [
+                            200 => [
+                                'description' => 'Successful operation',
+                                'schema' => [
+                                    'type' => 'array',
+                                    'items' => ['$ref' => '#/definitions/dummy'],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'post' => [
+                        'tags' => ['dummy'],
+                        'produces' => ['application/ld+json'],
+                        'consumes' => ['application/ld+json'],
+                        'summary' => 'Creates a dummy resource.',
+                        'parameters' => [
+                            [
+                                'in' => 'body',
+                                'name' => 'body',
+                                'description' => 'dummy resource to be added',
+                                'schema' => ['$ref' => '#/definitions/dummy'],
+                            ],
+                        ],
+                        'responses' => [
+                            201 => [
                                 'description' => 'Successful operation',
                                 'schema' => ['$ref' => '#/definitions/dummy'],
                             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Initial post:

> I found two issues in the swagger ``DocumentationNormalizer``.
> The first one, custom operations always made the normalizer creates a standard operation even if it didn't exist.
> The second one, if two or more custom operations had the same path, they conflicted and only the last one was added to the doc.

In fact I do not even understand why some operations are treated as ``custom`` so this PR simplify the `DocumentationNormalizer` by removing this notion and threat all operations at once.