### PR TITLE
Disable the cache in development

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -123,6 +123,14 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         if (isset($bundles['NelmioApiDocBundle']) && $config['enable_nelmio_api_doc']) {
             $loader->load('nelmio_api_doc.xml');
         }
+
+        // Disable the cache when in dev mode
+        if ($container->getParameter('kernel.debug')) {
+            $container->removeDefinition('api_platform.metadata.resource.name_collection_factory.cached');
+            $container->removeDefinition('api_platform.metadata.resource.metadata_factory.cached');
+            $container->removeDefinition('api_platform.metadata.property.name_collection_factory.cached');
+            $container->removeDefinition('api_platform.metadata.property.metadata_factory.cached');
+        }
     }
 
     /**

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -338,6 +338,8 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
 
+        $containerBuilderProphecy->getParameter('kernel.debug')->willReturn(false)->shouldBeCalled();
+
         return $containerBuilderProphecy;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

It's a bit annoying to have to remove the cache each time you change something in development so I propose to remove or limit to the current process the cache.


