### PR TITLE
Rename getFilterValueFromUrl to getIdFromValue

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -123,7 +123,7 @@ class SearchFilter extends AbstractFilter
 
             if ($metadata->hasField($field)) {
                 if ('id' === $field) {
-                    $values = array_map([$this, 'getFilterValueFromUrl'], $values);
+                    $values = array_map([$this, 'getIdFromValue'], $values);
                 }
 
                 $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
@@ -156,7 +156,7 @@ class SearchFilter extends AbstractFilter
                 continue;
             }
 
-            $values = array_map([$this, 'getFilterValueFromUrl'], $values);
+            $values = array_map([$this, 'getIdFromValue'], $values);
 
             $association = $field;
             $associationAlias = QueryNameGenerator::generateJoinAlias($association);
@@ -318,9 +318,9 @@ class SearchFilter extends AbstractFilter
      *
      * @param string $value
      *
-     * @return string
+     * @return mixed
      */
-    private function getFilterValueFromUrl(string $value) : string
+    private function getIdFromValue(string $value)
     {
         if (null === $this->iriConverter) {
             return $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Rename private function SearchFilter::getFilterValueFromUrl to getIdFromValue