### PR TITLE
Fixed bug with double urldecoding of query string

### DIFF
--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -29,13 +29,16 @@ Feature: Date filter on collections
                   {"pattern": "^/dummies/29$"}
                 ]
               }
-            },
-            "hydra:view": {
-              "@id": {"pattern": "^/dummies\\?dummyDate\\[after\\]=2015-04-28$"},
-              "@type": {"pattern": "^hydra:PartialCollectionView$"}
             }
           },
           "maxItems": 2
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bafter%5D=2015-04-28$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -65,13 +68,93 @@ Feature: Date filter on collections
                   {"pattern": "^/dummies/3$"}
                 ]
               }
-            },
-            "hydra:view": {
-              "@id": {"pattern": "^/dummies\\?dummyDate\\[before\\]=2015-04-05$"},
-              "@type": {"pattern": "^hydra:PartialCollectionView$"}
             }
           },
           "maxItems": 3
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05\\&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+    When I send a "GET" request to "/dummies?dummyDate[after]=2015-04-28T00:00:00%2B00:00"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/28$"},
+                  {"pattern": "^/dummies/29$"}
+                ]
+              }
+            }
+          },
+          "maxItems": 2
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bafter%5D=2015-04-28T00%3A00%3A00%2B00%3A00$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+    When I send a "GET" request to "/dummies?dummyDate[before]=2015-04-05Z"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/1$"},
+                  {"pattern": "^/dummies/2$"},
+                  {"pattern": "^/dummies/3$"}
+                ]
+              }
+            }
+          },
+          "maxItems": 3
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05Z\\&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -101,13 +184,16 @@ Feature: Date filter on collections
                   {"pattern": "^/dummies/5$"}
                 ]
               }
-            },
-            "hydra:view": {
-              "@id": {"pattern": "^/dummies\\?dummyDate\\[before\\]=2015-04-05\\&dummyDate\\[after\\]=2015-04-05$"},
-              "@type": {"pattern": "^hydra:PartialCollectionView$"}
             }
           },
           "maxItems": 1
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05\\&dummyDate%5Bafter%5D=2015-04-05$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -135,13 +221,16 @@ Feature: Date filter on collections
                   {"pattern": "^/dummies/5$"}
                 ]
               }
-            },
-            "hydra:view": {
-              "@id": {"pattern": "^/dummies\\?dummyDate\\[after\\]=2015-04-05\\&dummyDate\\[before\\]=2015-04-05$"},
-              "@type": {"pattern": "^hydra:PartialCollectionView$"}
             }
           },
           "maxItems": 1
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bafter%5D=2015-04-05&dummyDate%5Bbefore%5D=2015-04-05$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -165,8 +254,11 @@ Feature: Date filter on collections
           "maxItems": 0
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyDate\\[after\\]=2015-04-06\\&dummyDate\\[before\\]=2015-04-04$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bafter%5D=2015-04-06\\&dummyDate%5Bbefore%5D=2015-04-04$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -199,13 +291,13 @@ Feature: Date filter on collections
                   {"pattern": "^/dummies/60$"}
                 ]
               }
-            },
-            "hydra:view": {
-              "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate\\[after\\]=2015-04-28$"},
-              "@type": {"pattern": "^hydra:PartialCollectionView$"}
             }
           },
           "maxItems": 3
+        },
+        "hydra:view": {
+          "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28$"},
+          "@type": {"pattern": "^hydra:PartialCollectionView$"}
         }
       }
     }
@@ -235,13 +327,52 @@ Feature: Date filter on collections
                   {"pattern": "^/dummies/60$"}
                 ]
               }
-            },
-            "hydra:view": {
-              "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate\\[after\\]=2015-04-28\\&relatedDummy_dummyDate\\[after\\]=2015-04-28$"},
-              "@type": {"pattern": "^hydra:PartialCollectionView$"}
             }
           },
           "maxItems": 3
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28\\&relatedDummy_dummyDate%5Bafter%5D=2015-04-28$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+    When I send a "GET" request to "/dummies?relatedDummy.dummyDate[after]=2015-04-28T00:00:00%2B00:00"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/58$"},
+                  {"pattern": "^/dummies/59$"},
+                  {"pattern": "^/dummies/60$"}
+                ]
+              }
+            }
+          },
+          "maxItems": 3
+        },
+        "hydra:view": {
+          "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28T00%3A00%3A00%2B00%3A00$"},
+          "@type": {"pattern": "^hydra:PartialCollectionView$"}
         }
       }
     }
@@ -420,4 +551,3 @@ Feature: Date filter on collections
           }
       }
     """
-    

--- a/src/Util/RequestParser.php
+++ b/src/Util/RequestParser.php
@@ -51,7 +51,9 @@ abstract class RequestParser
      */
     public static function parseRequestParams(string $source) : array
     {
-        $source = urldecode($source);
+        // '[' is urlencoded in the input, but we must urldecode it in order
+        // to find it when replacing names with the regexp below.
+        $source = str_replace(urlencode('['), '[', $source);
 
         $source = preg_replace_callback(
             '/(^|(?<=&))[^=[&]+/',
@@ -61,6 +63,7 @@ abstract class RequestParser
             $source
         );
 
+        // parse_str urldecodes both keys and values in resulting array.
         parse_str($source, $params);
 
         return array_combine(array_map('hex2bin', array_keys($params)), $params);

--- a/tests/Util/RequestParserTest.php
+++ b/tests/Util/RequestParserTest.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-
 namespace ApiPlatform\Core\Tests\Util;
 
 use ApiPlatform\Core\Util\RequestParser;
@@ -27,9 +26,28 @@ class RequestParserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($value);
     }
 
-    public function testParseRequestParams()
+    /**
+     * @dataProvider parseRequestParamsProvider
+     */
+    public function testParseRequestParams($source, $expected)
     {
-        $value = RequestParser::parseRequestParams('gerard.name=dargent');
-        $this->assertEquals($value, ['gerard.name' => 'dargent']);
+        $actual = RequestParser::parseRequestParams($source);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function parseRequestParamsProvider()
+    {
+        return [
+            ['gerard.name=dargent', ['gerard.name' => 'dargent']],
+
+            // urlencoded + (plus) in query string.
+            ['date=2000-01-01T00%3A00%3A00%2B00%3A00', ['date' => '2000-01-01T00:00:00+00:00']],
+
+            // urlencoded % (percent sign) in query string.
+            ['%2525=%2525', ['%25' => '%25']],
+
+            // urlencoded [] (square brackets) in query string.
+            ['a%5B1%5D=%2525', ['a' => ['1' => '%25']]],
+        ];
     }
 }


### PR DESCRIPTION
This fixes an issue with query strings being urldecoded twice.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #596
| License       | MIT
| Doc PR        | N/A



