### PR TITLE
hotfix: scrutinizer issue on last PR

### DIFF
--- a/src/Bridge/Doctrine/Orm/Util/QueryNameGeneratorInterface.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryNameGeneratorInterface.php
@@ -23,7 +23,7 @@ interface QueryNameGeneratorInterface
      *
      * @return string
      */
-    public function generateJoinAlias(string $association) : string;
+    public function generateJoinAlias(string $association = '') : string;
 
     /**
      * Generates a cacheable parameter name for DQL query.
@@ -32,5 +32,5 @@ interface QueryNameGeneratorInterface
      *
      * @return string
      */
-    public function generateParameterName(string $name) : string;
+    public function generateParameterName(string $name = '') : string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

This PR is about fixing the bug that has been created on [Scrutinizer](https://scrutinizer-ci.com/g/api-platform/core/issues/master?selectedLabels%5B0%5D=9&orderField=path&order=asc&honorSelectedPaths=0).

I was not respecting the interface directly. Since we don't use the parameter at all. I think it should be empty string by default in the interface too.