### PR TITLE
feature: fix #696 - add an maximum configurable number for client pagination

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -42,7 +42,7 @@ class PaginationExtension implements QueryResultExtensionInterface
     private $itemsPerPageParameterName;
     private $maximumItemPerPage;
 
-    public function __construct(ManagerRegistry $managerRegistry, RequestStack $requestStack, ResourceMetadataFactoryInterface $resourceMetadataFactory, bool $enabled = true, bool $clientEnabled = false, bool $clientItemsPerPage = false, int $itemsPerPage = 30, string $pageParameterName = 'page', string $enabledParameterName = 'pagination', string $itemsPerPageParameterName = 'itemsPerPage', int $maximumItemPerPage = 300)
+    public function __construct(ManagerRegistry $managerRegistry, RequestStack $requestStack, ResourceMetadataFactoryInterface $resourceMetadataFactory, bool $enabled = true, bool $clientEnabled = false, bool $clientItemsPerPage = false, int $itemsPerPage = 30, string $pageParameterName = 'page', string $enabledParameterName = 'pagination', string $itemsPerPageParameterName = 'itemsPerPage', int $maximumItemPerPage = null)
     {
         $this->managerRegistry = $managerRegistry;
         $this->requestStack = $requestStack;
@@ -75,7 +75,7 @@ class PaginationExtension implements QueryResultExtensionInterface
         $itemsPerPage = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_items_per_page', $this->itemsPerPage, true);
         if ($resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_client_items_per_page', $this->clientItemsPerPage, true)) {
             $itemsPerPage = (int) $request->query->get($this->itemsPerPageParameterName, $itemsPerPage);
-            $itemsPerPage = ($itemsPerPage <= $this->maximumItemPerPage ? $itemsPerPage : $this->maximumItemPerPage);
+            $itemsPerPage = ($this->maximumItemPerPage && $itemsPerPage >= $this->maximumItemPerPage ? $this->maximumItemPerPage : $itemsPerPage);
         }
 
         $queryBuilder

--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -40,8 +40,9 @@ class PaginationExtension implements QueryResultExtensionInterface
     private $pageParameterName;
     private $enabledParameterName;
     private $itemsPerPageParameterName;
+    private $maximumItemPerPage;
 
-    public function __construct(ManagerRegistry $managerRegistry, RequestStack $requestStack, ResourceMetadataFactoryInterface $resourceMetadataFactory, bool $enabled = true, bool $clientEnabled = false, bool $clientItemsPerPage = false, int $itemsPerPage = 30, string $pageParameterName = 'page', string $enabledParameterName = 'pagination', string $itemsPerPageParameterName = 'itemsPerPage')
+    public function __construct(ManagerRegistry $managerRegistry, RequestStack $requestStack, ResourceMetadataFactoryInterface $resourceMetadataFactory, bool $enabled = true, bool $clientEnabled = false, bool $clientItemsPerPage = false, int $itemsPerPage = 30, string $pageParameterName = 'page', string $enabledParameterName = 'pagination', string $itemsPerPageParameterName = 'itemsPerPage', int $maximumItemPerPage = 300)
     {
         $this->managerRegistry = $managerRegistry;
         $this->requestStack = $requestStack;
@@ -53,6 +54,7 @@ class PaginationExtension implements QueryResultExtensionInterface
         $this->pageParameterName = $pageParameterName;
         $this->enabledParameterName = $enabledParameterName;
         $this->itemsPerPageParameterName = $itemsPerPageParameterName;
+        $this->maximumItemPerPage = $maximumItemPerPage;
     }
 
     /**
@@ -73,6 +75,7 @@ class PaginationExtension implements QueryResultExtensionInterface
         $itemsPerPage = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_items_per_page', $this->itemsPerPage, true);
         if ($resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_client_items_per_page', $this->clientItemsPerPage, true)) {
             $itemsPerPage = (int) $request->query->get($this->itemsPerPageParameterName, $itemsPerPage);
+            $itemsPerPage = ($itemsPerPage <= $this->maximumItemPerPage ? $itemsPerPage : $this->maximumItemPerPage);
         }
 
         $queryBuilder

--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -75,7 +75,7 @@ class PaginationExtension implements QueryResultExtensionInterface
         $itemsPerPage = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_items_per_page', $this->itemsPerPage, true);
         if ($resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_client_items_per_page', $this->clientItemsPerPage, true)) {
             $itemsPerPage = (int) $request->query->get($this->itemsPerPageParameterName, $itemsPerPage);
-            $itemsPerPage = ($this->maximumItemPerPage && $itemsPerPage >= $this->maximumItemPerPage ? $this->maximumItemPerPage : $itemsPerPage);
+            $itemsPerPage = (null !== $this->maximumItemPerPage && $itemsPerPage >= $this->maximumItemPerPage ? $this->maximumItemPerPage : $itemsPerPage);
         }
 
         $queryBuilder

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -74,6 +74,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.collection.pagination.client_enabled', $config['collection']['pagination']['client_enabled']);
         $container->setParameter('api_platform.collection.pagination.client_items_per_page', $config['collection']['pagination']['client_items_per_page']);
         $container->setParameter('api_platform.collection.pagination.items_per_page', $config['collection']['pagination']['items_per_page']);
+        $container->setParameter('api_platform.collection.pagination.maximum_items_per_page', $config['collection']['pagination']['maximum_items_per_page']);
         $container->setParameter('api_platform.collection.pagination.page_parameter_name', $config['collection']['pagination']['page_parameter_name']);
         $container->setParameter('api_platform.collection.pagination.enabled_parameter_name', $config['collection']['pagination']['enabled_parameter_name']);
         $container->setParameter('api_platform.collection.pagination.items_per_page_parameter_name', $config['collection']['pagination']['items_per_page_parameter_name']);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -54,6 +54,7 @@ final class Configuration implements ConfigurationInterface
                                 ->booleanNode('client_enabled')->defaultFalse()->info('To allow the client to enable or disable the pagination.')->end()
                                 ->booleanNode('client_items_per_page')->defaultFalse()->info('To allow the client to set the number of items per page.')->end()
                                 ->integerNode('items_per_page')->defaultValue(30)->info('The default number of items per page.')->end()
+                                ->integerNode('maximum_items_per_page')->defaultValue(300)->info('The maximum number of items per page.')->end()
                                 ->scalarNode('page_parameter_name')->defaultValue('page')->cannotBeEmpty()->info('The default name of the parameter handling the page number.')->end()
                                 ->scalarNode('enabled_parameter_name')->defaultValue('pagination')->cannotBeEmpty()->info('The name of the query parameter to enable or disable pagination.')->end()
                                 ->scalarNode('items_per_page_parameter_name')->defaultValue('itemsPerPage')->cannotBeEmpty()->info('The name of the query parameter to set the number of items per page.')->end()

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ final class Configuration implements ConfigurationInterface
                                 ->booleanNode('client_enabled')->defaultFalse()->info('To allow the client to enable or disable the pagination.')->end()
                                 ->booleanNode('client_items_per_page')->defaultFalse()->info('To allow the client to set the number of items per page.')->end()
                                 ->integerNode('items_per_page')->defaultValue(30)->info('The default number of items per page.')->end()
-                                ->integerNode('maximum_items_per_page')->defaultValue(300)->info('The maximum number of items per page.')->end()
+                                ->integerNode('maximum_items_per_page')->defaultNull()->info('The maximum number of items per page.')->end()
                                 ->scalarNode('page_parameter_name')->defaultValue('page')->cannotBeEmpty()->info('The default name of the parameter handling the page number.')->end()
                                 ->scalarNode('enabled_parameter_name')->defaultValue('pagination')->cannotBeEmpty()->info('The name of the query parameter to enable or disable pagination.')->end()
                                 ->scalarNode('items_per_page_parameter_name')->defaultValue('itemsPerPage')->cannotBeEmpty()->info('The name of the query parameter to set the number of items per page.')->end()

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -104,6 +104,7 @@
             <argument>%api_platform.collection.pagination.page_parameter_name%</argument>
             <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
             <argument>%api_platform.collection.pagination.items_per_page_parameter_name%</argument>
+            <argument>%api_platform.collection.pagination.maximum_items_per_page%</argument>
 
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="8" />
         </service>

--- a/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -86,7 +86,10 @@ class PaginationExtensionTest extends \PHPUnit_Framework_TestCase
             false,
             false,
             30,
-            '_page'
+            '_page',
+            'pagination',
+            'itemsPerPage',
+            300
         );
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -187,6 +187,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.collection.pagination.page_parameter_name' => 'page',
             'api_platform.collection.pagination.enabled_parameter_name' => 'pagination',
             'api_platform.collection.pagination.items_per_page_parameter_name' => 'itemsPerPage',
+            'api_platform.collection.pagination.maximum_items_per_page' => 300,
         ];
         foreach ($parameters as $key => $value) {
             $containerBuilderProphecy->setParameter($key, $value)->shouldBeCalled();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -187,7 +187,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.collection.pagination.page_parameter_name' => 'page',
             'api_platform.collection.pagination.enabled_parameter_name' => 'pagination',
             'api_platform.collection.pagination.items_per_page_parameter_name' => 'itemsPerPage',
-            'api_platform.collection.pagination.maximum_items_per_page' => 300,
+            'api_platform.collection.pagination.maximum_items_per_page' => null,
         ];
         foreach ($parameters as $key => $value) {
             $containerBuilderProphecy->setParameter($key, $value)->shouldBeCalled();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -58,6 +58,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'page_parameter_name' => 'page',
                     'enabled_parameter_name' => 'pagination',
                     'items_per_page_parameter_name' => 'itemsPerPage',
+                    'maximum_items_per_page' => 300,
                 ],
             ],
         ], $config);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -58,7 +58,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'page_parameter_name' => 'page',
                     'enabled_parameter_name' => 'pagination',
                     'items_per_page_parameter_name' => 'itemsPerPage',
-                    'maximum_items_per_page' => 300,
+                    'maximum_items_per_page' => null,
                 ],
             ],
         ], $config);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #696 
| License       | MIT
| Doc PR        | O


This PR give the possibility to limit the number of items that the client can see on the same page.