### PR TITLE
Allow integers instead of floats for JSON. Fix #37.

### DIFF
--- a/features/security/strong_typing.feature
+++ b/features/security/strong_typing.feature
@@ -102,7 +102,6 @@ Feature: Handle properly invalid data submitted to the API
     And the JSON node "hydra:title" should be equal to "An error occurred"
     And the JSON node "hydra:description" should be equal to 'The type of the key "a" must be "int", "string" given.'
 
-  @dropSchema
   Scenario: Send a scalar having the bad type
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummies" with body:
@@ -118,3 +117,17 @@ Feature: Handle properly invalid data submitted to the API
     And the JSON node "@type" should be equal to "Error"
     And the JSON node "hydra:title" should be equal to "An error occurred"
     And the JSON node "hydra:description" should be equal to 'The type of the "name" attribute must be "string", "integer" given.'
+
+  @dropSchema
+  Scenario: According to the JSON spec, allow numbers without explicit floating point for JSON formats
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": "foo",
+      "dummyPrice": 42
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -183,14 +183,33 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return;
         }
 
+        $this->validateType($attribute, $type, $value, $format);
+        $this->setValue($object, $attribute, $value);
+    }
+
+    /**
+     * Validates the type of the value. Allows using integers as floats for JSON formats.
+     *
+     * @param string      $attribute
+     * @param Type        $type
+     * @param string|null $format
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validateType(string $attribute, Type $type, $value, string $format = null)
+    {
         $builtinType = $type->getBuiltinType();
-        if (!call_user_func('is_'.$builtinType, $value)) {
+        if (false !== strpos($format, 'json') && Type::BUILTIN_TYPE_FLOAT === $builtinType) {
+            $isValid = is_float($value) || is_int($value);
+        } else {
+            $isValid = call_user_func('is_'.$builtinType, $value);
+        }
+
+        if (!$isValid) {
             throw new InvalidArgumentException(sprintf(
                 'The type of the "%s" attribute must be "%s", "%s" given.', $attribute, $builtinType, gettype($value)
             ));
         }
-
-        $this->setValue($object, $attribute, $value);
     }
 
     /**

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -438,18 +438,18 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The type of the "name" attribute must be "string", "integer" given.
+     * @expectedExceptionMessage The type of the "foo" attribute must be "float", "integer" given.
      */
     public function testBadType()
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
-            new PropertyNameCollection(['name'])
+            new PropertyNameCollection(['foo'])
         )->shouldBeCalled();
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn(
-            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', false, true, false, false)
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'foo', [])->willReturn(
+            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT), '', false, true, false, false)
         )->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
@@ -468,7 +468,39 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
-        $normalizer->denormalize(['name' => 42], Dummy::class);
+        $normalizer->denormalize(['foo' => 42], Dummy::class);
+    }
+
+    public function testJsonAllowIntAsFloat()
+    {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
+            new PropertyNameCollection(['foo'])
+        )->shouldBeCalled();
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'foo', [])->willReturn(
+            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT), '', false, true, false, false)
+        )->shouldBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'foo', 42)->shouldBeCalled();
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(DenormalizerInterface::class);
+
+        $normalizer = $this->getMockForAbstractClass(AbstractItemNormalizer::class, [
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $iriConverterProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $propertyAccessorProphecy->reveal(),
+        ]);
+        $normalizer->setSerializer($serializerProphecy->reveal());
+
+        $normalizer->denormalize(['foo' => 42], Dummy::class, 'jsonfoo');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #37
| License       | MIT
| Doc PR        | n/a