### PR TITLE
Updates regarding doctrine performances with associations

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -82,6 +82,9 @@
         <!-- Doctrine Query extensions -->
 
         <service id="api_platform.doctrine.orm.query_extension.eager_loading" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\EagerLoadingExtension" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+
             <tag name="api_platform.doctrine.orm.query_extension.item" priority="64" />
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="64" />
         </service>

--- a/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -13,7 +13,12 @@ namespace ApiPlatform\Core\Tests\Doctrine\Orm\Extension;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\EagerLoadingExtension;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyRelated;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder;
@@ -25,39 +30,131 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testApplyToCollection()
     {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+
+        $relatedNameCollection = new PropertyNameCollection(['id', 'name', 'notindatabase', 'notreadable']);
+
+        $propertyNameCollectionFactoryProphecy->create(DummyRelated::class)->willReturn($relatedNameCollection)->shouldBeCalled();
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $relationPropertyMetadata = new PropertyMetadata();
+        $relationPropertyMetadata = $relationPropertyMetadata->withReadableLink(true);
+
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy')->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy2')->willReturn($relationPropertyMetadata)->shouldBeCalled();
+
+        $idPropertyMetadata = new PropertyMetadata();
+        $idPropertyMetadata = $idPropertyMetadata->withIdentifier(true);
+        $namePropertyMetadata = new PropertyMetadata();
+        $namePropertyMetadata = $namePropertyMetadata->withReadable(true);
+        $notInDatabasePropertyMetadata = new PropertyMetadata();
+        $notInDatabasePropertyMetadata = $notInDatabasePropertyMetadata->withReadable(true);
+        $notReadablePropertyMetadata = new PropertyMetadata();
+        $notReadablePropertyMetadata = $notReadablePropertyMetadata->withReadable(false);
+
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'id')->willReturn($idPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'name')->willReturn($namePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'notindatabase')->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'notreadable')->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
+
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
-        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([0 => 'dummyRelation']);
-        $classMetadataProphecy->associationMappings = ['dummyRelation' => ['fetch' => 3]];
+        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([0 => 'relatedDummy', 'relatedDummy2']);
+        $classMetadataProphecy->associationMappings = [
+            'relatedDummy' => ['fetch' => 3, 'joinColumns' => [['nullable' => true]], 'targetEntity' => DummyRelated::class],
+            'relatedDummy2' => ['fetch' => 3, 'joinColumns' => [['nullable' => false]], 'targetEntity' => DummyRelated::class],
+        ];
+
+        $relatedClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
+
+        foreach ($relatedNameCollection as $property) {
+            if ($property !== 'id') {
+                $relatedClassMetadataProphecy->hasField($property)->willReturn($property !== 'notindatabase')->shouldBeCalled();
+            }
+        }
+
+        $relatedClassMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([]);
+
         $emProphecy = $this->prophesize(EntityManager::class);
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
-        $queryBuilderProphecy->leftJoin('o.dummyRelation', 'a0')->shouldBeCalled(1);
-        $queryBuilderProphecy->addSelect('a0')->shouldBeCalled(1);
+        $emProphecy->getClassMetadata(DummyRelated::class)->shouldBeCalled()->willReturn($relatedClassMetadataProphecy->reveal());
 
-        $em = $queryBuilderProphecy->getEntityManager()->shouldBeCalled(1)->willReturn($emProphecy->reveal());
+        $queryBuilderProphecy->leftJoin('o.relatedDummy', 'a0')->shouldBeCalled(1);
+        $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'a11')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a0.{id,name}')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a11.{id,name}')->shouldBeCalled(1);
+
+        $em = $queryBuilderProphecy->getEntityManager()->shouldBeCalled(2)->willReturn($emProphecy->reveal());
 
         $queryBuilder = $queryBuilderProphecy->reveal();
-        $orderExtensionTest = new EagerLoadingExtension();
+        $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal());
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
     public function testApplyToItem()
     {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+
+        $relatedNameCollection = new PropertyNameCollection(['id', 'name', 'notindatabase', 'notreadable']);
+
+        $propertyNameCollectionFactoryProphecy->create(DummyRelated::class)->willReturn($relatedNameCollection)->shouldBeCalled();
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $relationPropertyMetadata = new PropertyMetadata();
+        $relationPropertyMetadata = $relationPropertyMetadata->withReadableLink(true);
+
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy')->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy2')->willReturn($relationPropertyMetadata)->shouldBeCalled();
+
+        $idPropertyMetadata = new PropertyMetadata();
+        $idPropertyMetadata = $idPropertyMetadata->withIdentifier(true);
+        $namePropertyMetadata = new PropertyMetadata();
+        $namePropertyMetadata = $namePropertyMetadata->withReadable(true);
+        $notInDatabasePropertyMetadata = new PropertyMetadata();
+        $notInDatabasePropertyMetadata = $notInDatabasePropertyMetadata->withReadable(true);
+        $notReadablePropertyMetadata = new PropertyMetadata();
+        $notReadablePropertyMetadata = $notReadablePropertyMetadata->withReadable(false);
+
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'id')->willReturn($idPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'name')->willReturn($namePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'notindatabase')->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(DummyRelated::class, 'notreadable')->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
+
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
-        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([0 => 'dummyRelation']);
-        $classMetadataProphecy->associationMappings = ['dummyRelation' => ['fetch' => 3]];
+        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([0 => 'relatedDummy', 'relatedDummy2']);
+        $classMetadataProphecy->associationMappings = [
+            'relatedDummy' => ['fetch' => 3, 'joinColumns' => [['nullable' => true]], 'targetEntity' => DummyRelated::class],
+            'relatedDummy2' => ['fetch' => 3, 'joinColumns' => [['nullable' => false]], 'targetEntity' => DummyRelated::class],
+        ];
+
+        $relatedClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
+
+        foreach ($relatedNameCollection as $property) {
+            if ($property !== 'id') {
+                $relatedClassMetadataProphecy->hasField($property)->willReturn($property !== 'notindatabase')->shouldBeCalled();
+            }
+        }
+
+        $relatedClassMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([]);
+
         $emProphecy = $this->prophesize(EntityManager::class);
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
-        $queryBuilderProphecy->leftJoin('o.dummyRelation', 'a0')->shouldBeCalled(1);
-        $queryBuilderProphecy->addSelect('a0')->shouldBeCalled(1);
+        $emProphecy->getClassMetadata(DummyRelated::class)->shouldBeCalled()->willReturn($relatedClassMetadataProphecy->reveal());
 
-        $em = $queryBuilderProphecy->getEntityManager()->shouldBeCalled(1)->willReturn($emProphecy->reveal());
+        $queryBuilderProphecy->leftJoin('o.relatedDummy', 'a0')->shouldBeCalled(1);
+        $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'a11')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a0.{id,name}')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a11.{id,name}')->shouldBeCalled(1);
+
+        $em = $queryBuilderProphecy->getEntityManager()->shouldBeCalled(2)->willReturn($emProphecy->reveal());
 
         $queryBuilder = $queryBuilderProphecy->reveal();
-        $orderExtensionTest = new EagerLoadingExtension();
+        $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal());
+        $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
+
         $orderExtensionTest->applyToItem($queryBuilder, new QueryNameGenerator(), Dummy::class, []);
     }
 }

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterExtensionTest.php
@@ -41,4 +41,21 @@ class FilterExtensionTest extends \PHPUnit_Framework_TestCase
         $orderExtensionTest = new FilterExtension($resourceMetadataFactoryProphecy->reveal(), new FilterCollection(['dummyFilter' => $filterProphecy->reveal()]));
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get');
     }
+
+    public function testApplyToCollectionWithoutFilters()
+    {
+        $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
+
+        $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST'], 'custom' => ['method' => 'GET', 'path' => '/foo'], 'custom2' => ['method' => 'POST', 'path' => '/foo']]);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn($dummyMetadata);
+
+        $queryBuilder = $queryBuilderProphecy->reveal();
+
+        $filterProphecy = $this->prophesize(FilterInterface::class);
+        $filterProphecy->apply($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get')->shouldNotBeCalled();
+
+        $orderExtensionTest = new FilterExtension($resourceMetadataFactoryProphecy->reveal(), new FilterCollection(['dummyFilter' => $filterProphecy->reveal()]));
+        $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get');
+    }
 }

--- a/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
@@ -184,7 +184,7 @@ class BooleanFilterTest extends KernelTestCase
                 [
                     'relatedDummy.dummyBoolean' => '1',
                 ],
-                sprintf('SELECT o FROM %s o left join o.relateddummy relateddummy_a1 where relateddummy_a1.dummyboolean = :dummyboolean_p1', Dummy::class),
+                sprintf('SELECT o FROM %s o inner join o.relateddummy relateddummy_a1 where relateddummy_a1.dummyboolean = :dummyboolean_p1', Dummy::class),
             ],
             // test with multiple 1 value
             [

--- a/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
@@ -179,7 +179,7 @@ class NumericFilterTest extends KernelTestCase
                 [
                     'relatedDummy.id' => 0,
                 ],
-                sprintf('SELECT o FROM %s o left join o.relateddummy relateddummy_a1 where relateddummy_a1.id = :id_p1', Dummy::class),
+                sprintf('SELECT o FROM %s o inner join o.relateddummy relateddummy_a1 where relateddummy_a1.id = :id_p1', Dummy::class),
             ],
             // test with one correct and one wrong value
             [

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -299,7 +299,7 @@ class OrderFilterTest extends KernelTestCase
                         'relatedDummy.symfony' => 'desc',
                     ],
                 ],
-                sprintf('SELECT o FROM %s o LEFT JOIN o.relatedDummy relatedDummy_a1 ORDER BY o.id ASC, o.name DESC, relatedDummy_a1.symfony DESC', Dummy::class),
+                sprintf('SELECT o FROM %s o INNER JOIN o.relatedDummy relatedDummy_a1 ORDER BY o.id ASC, o.name DESC, relatedDummy_a1.symfony DESC', Dummy::class),
             ],
             // Properties enabled with empty request (default values)
             [

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -624,4 +624,26 @@ class SearchFilterTest extends KernelTestCase
             ],
         ];
     }
+
+    public function testDoubleJoin()
+    {
+        $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'exact']);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $queryBuilder = $this->repository->createQueryBuilder('o');
+        $filter = new SearchFilter(
+            $this->managerRegistry,
+            $requestStack,
+            $this->iriConverter,
+            $this->propertyAccessor,
+            ['relatedDummy.symfony' => null]
+        );
+
+        $queryBuilder->innerJoin('o.relatedDummy', 'relateddummy_a1');
+
+        $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, 'op');
+        $actual = strtolower($queryBuilder->getQuery()->getDQL());
+        $expected = strtolower(sprintf('SELECT o FROM %s o inner join o.relatedDummy relateddummy_a1 WHERE relateddummy_a1.symfony = :symfony_p1', Dummy::class));
+        $this->assertEquals($actual, $expected);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ∅
| License       | MIT
| Doc PR        | ∅

- [x] Do not join twice when filtering on an association (`EagerLoadingExtension` + `SearchFilter`) (tested)
- [x] Inner join instead of left join relations when those aren't nullable `EagerLoadingExtension` (tested)
- [x] Do not to fetch properties that are not serializable! (tested)
- [x] Discuss `Query::HINT_FORCE_PARTIAL_LOAD` to avoid fetching OneToOne relations when we don't need them 

