### PR TITLE
Add "Vary: Accept" response header

### DIFF
--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -36,7 +36,7 @@ final class AddFormatListener
     /**
      * Sets the applicable format to the HttpFoundation Request.
      *
-     * @param $event GetResponseEvent
+     * @param GetResponseEvent $event
      */
     public function onKernelRequest(GetResponseEvent $event)
     {

--- a/src/EventListener/RespondListener.php
+++ b/src/EventListener/RespondListener.php
@@ -46,6 +46,7 @@ final class RespondListener
             self::METHOD_TO_CODE[$request->getMethod()] ?? Response::HTTP_OK,
             [
                 'Content-Type' => sprintf('%s; charset=utf-8', $request->getMimeType($request->getRequestFormat())),
+                'Vary' => 'Accept',
                 'X-Content-Type-Options' => 'nosniff',
                 'X-Frame-Options' => 'deny',
             ]

--- a/tests/EventListener/RespondListenerTest.php
+++ b/tests/EventListener/RespondListenerTest.php
@@ -55,6 +55,7 @@ class RespondListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $response->getContent());
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('text/xml; charset=utf-8', $response->headers->get('Content-Type'));
+        $this->assertEquals('Accept', $response->headers->get('Vary'));
         $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
     }
@@ -81,6 +82,7 @@ class RespondListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $response->getContent());
         $this->assertEquals(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertEquals('text/xml; charset=utf-8', $response->headers->get('Content-Type'));
+        $this->assertEquals('Accept', $response->headers->get('Vary'));
         $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
     }
@@ -107,6 +109,7 @@ class RespondListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $response->getContent());
         $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertEquals('text/xml; charset=utf-8', $response->headers->get('Content-Type'));
+        $this->assertEquals('Accept', $response->headers->get('Vary'));
         $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

We must add the "Vary: Accept" response header, since we're varying the response by "Accept" request header. Otherwise, it messes up HTTP caching (Varnish etc.).