### PR TITLE
Remove keyword final from ItemNormalizers in order to make them exten…

### DIFF
--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -26,7 +26,7 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+class ItemNormalizer extends AbstractItemNormalizer
 {
     use ContextTrait;
 

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -27,7 +27,7 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+class ItemNormalizer extends AbstractItemNormalizer
 {
     use ContextTrait;
     use JsonLdContextTrait;

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -16,7 +16,7 @@ namespace ApiPlatform\Core\Serializer;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+class ItemNormalizer extends AbstractItemNormalizer
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

We are trying to exclude null values from the response. I posted the question on gitter and it was suggested to use a custom SerializeListener. But actually the SerializeListener from the api-platform does already all the magic of converting an object to json-ld or any other response format.  Because we support also rdfxml and other serialization formats that would mean we would have to parse the response format, remove the null values and encode it back to the serialized format.
So I figured out that the right place to exclude null values from the response would be in the ItemNormalizer classes. If we could extend your normalizers and simply overwrite the normalize function that would be an easy way to exclude null values.

Is there a particular reason for making the normalizers final?