### PR TITLE
Requesting an invalid format should throw a 406 instead of a 500

### DIFF
--- a/features/content_negotiation.feature
+++ b/features/content_negotiation.feature
@@ -107,6 +107,17 @@ Feature: Content Negotiation support
     Then the response status code should be 406
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
 
+  Scenario: Requesting an invalid format in the URL should throw an error
+    And I send a "GET" request to "/dummies/1.invalid"
+    Then the response status code should be 406
+    And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
+
+  Scenario: Requesting an invalid format in the Accept header and in the URL should throw an error
+    When I add "Accept" header equal to "text/invalid"
+    And I send a "GET" request to "/dummies/1.invalid"
+    Then the response status code should be 406
+    And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
+
   @dropSchema
   Scenario: If the request format is HTML, the error should be in HTML
     When I add "Accept" header equal to "text/html"

--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -50,7 +50,15 @@ final class AddFormatListener
 
         // Empty strings must be converted to null because the Symfony router doesn't support parameter typing before 3.2 (_format)
         $routeFormat = $request->attributes->get('_format') ?: null;
-        $mimeTypes = $routeFormat ? $request->getMimeTypes($routeFormat) : array_keys($this->mimeTypes);
+        if ($routeFormat) {
+            $mimeTypes = $request->getMimeTypes($routeFormat);
+
+            if (0 === count($mimeTypes)) {
+                throw $this->getNotAcceptableHttpException($routeFormat, array_keys($this->mimeTypes));
+            }
+        } else {
+            $mimeTypes = array_keys($this->mimeTypes);
+        }
 
         // First, try to guess the format from the Accept header
         $accept = $request->headers->get('Accept');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When requesting a resource with a unknown format that Request::getMimeTypes can't resolve it throw a 500 instead of a 406.