### PR TITLE
Handle invalid formats in the URL. Fix #733.

### DIFF
--- a/features/security/validate_response_types.feature
+++ b/features/security/validate_response_types.feature
@@ -26,13 +26,13 @@ Feature: Validate response types
 
   Scenario: Requesting an invalid format in the URL should throw an error
     And I send a "GET" request to "/dummies/1.invalid"
-    Then the response status code should be 406
+    Then the response status code should be 404
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
-    And the JSON node "detail" should be equal to 'Requested format "" is not supported. Supported MIME types are "application/ld+json", "application/hal+json", "application/xml", "text/xml", "application/json", "text/html".'
+    And the JSON node "detail" should be equal to "Not Found"
 
   Scenario: Requesting an invalid format in the Accept header and in the URL should throw an error
     When I add "Accept" header equal to "text/invalid"
     And I send a "GET" request to "/dummies/1.invalid"
-    Then the response status code should be 406
+    Then the response status code should be 404
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
-    And the JSON node "detail" should be equal to 'Requested format "text/invalid" is not supported. Supported MIME types are "".'
+    And the JSON node "detail" should be equal to "Not Found"

--- a/features/security/validate_response_types.feature
+++ b/features/security/validate_response_types.feature
@@ -23,3 +23,16 @@ Feature: Validate response types
     Then the response status code should be 406
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
     And the JSON node "detail" should be equal to 'Requested format "invalid" is not supported. Supported MIME types are "application/ld+json", "application/hal+json", "application/xml", "text/xml", "application/json", "text/html".'
+
+  Scenario: Requesting an invalid format in the URL should throw an error
+    And I send a "GET" request to "/dummies/1.invalid"
+    Then the response status code should be 406
+    And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
+    And the JSON node "detail" should be equal to 'Requested format "" is not supported. Supported MIME types are "application/ld+json", "application/hal+json", "application/xml", "text/xml", "application/json", "text/html".'
+
+  Scenario: Requesting an invalid format in the Accept header and in the URL should throw an error
+    When I add "Accept" header equal to "text/invalid"
+    And I send a "GET" request to "/dummies/1.invalid"
+    Then the response status code should be 406
+    And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
+    And the JSON node "detail" should be equal to 'Requested format "text/invalid" is not supported. Supported MIME types are "".'

--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -55,7 +55,7 @@ final class AddFormatListener
         // First, try to guess the format from the Accept header
         $accept = $request->headers->get('Accept');
         if (null !== $accept) {
-            if (null === $acceptHeader = $this->negotiator->getBest($accept, $mimeTypes)) {
+            if (empty($mimeTypes) || null === $acceptHeader = $this->negotiator->getBest($accept, $mimeTypes)) {
                 throw $this->getNotAcceptableHttpException($accept, $mimeTypes);
             }
 
@@ -73,7 +73,7 @@ final class AddFormatListener
                 return;
             }
 
-            throw $this->getNotAcceptableHttpException($mimeType);
+            throw $this->getNotAcceptableHttpException($mimeType ?: '');
         }
 
         // Finally, if no Accept header nor Symfony request format is set, return the default format

--- a/tests/EventListener/AddFormatListenerTest.php
+++ b/tests/EventListener/AddFormatListenerTest.php
@@ -37,8 +37,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportedRequestFormat()
     {
-        $request = new Request();
-        $request->attributes->set('_api_resource_class', 'Foo');
+        $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->setRequestFormat('xml');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -54,8 +53,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testRespondFlag()
     {
-        $request = new Request();
-        $request->attributes->set('_api_respond', true);
+        $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('xml');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -75,8 +73,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnsupportedRequestFormat()
     {
-        $request = new Request();
-        $request->attributes->set('_api_resource_class', 'Foo');
+        $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->setRequestFormat('xml');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -91,8 +88,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportedAcceptHeader()
     {
-        $request = new Request();
-        $request->attributes->set('_api_resource_class', 'Foo');
+        $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml, application/json;q=0.9, */*;q=0.8');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -107,8 +103,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testAcceptAllHeader()
     {
-        $request = new Request();
-        $request->attributes->set('_api_resource_class', 'Foo');
+        $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -128,8 +123,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnsupportedAcceptHeader()
     {
-        $request = new Request();
-        $request->attributes->set('_api_resource_class', 'Foo');
+        $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml;q=0.9');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -146,8 +140,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidAcceptHeader()
     {
-        $request = new Request();
-        $request->attributes->set('_api_resource_class', 'Foo');
+        $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'invalid');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -160,8 +153,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testAcceptHeaderTakePrecedenceOverRequestFormat()
     {
-        $request = new Request();
-        $request->attributes->set('_api_resource_class', 'Foo');
+        $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'application/json');
         $request->setRequestFormat('xml');
 
@@ -173,5 +165,21 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest($event);
 
         $this->assertSame('json', $request->getRequestFormat());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Not Found
+     */
+    public function testInvalidRouteFormat()
+    {
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_format' => 'invalid']);
+
+        $eventProphecy = $this->prophesize(GetResponseEvent::class);
+        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
+        $event = $eventProphecy->reveal();
+
+        $listener = new AddFormatListener(new Negotiator(), ['json' => ['application/json']]);
+        $listener->onKernelRequest($event);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #733
| License       | MIT
| Doc PR        | n/a

This is an alternative fix to #733 but I'm not sure that it's the good way to fix the underlying problem. I think that trying to access an URL with an unsupported extension in the URL should throw a 404 (and not a 406).

WDYT @polc @api-platform/core-team?