### PR TITLE
(WIP) Fix Custom action "_api_item_operation_name" not respected when generating @id route

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -21,6 +21,7 @@
 
         <service id="api_platform.route_name_resolver" class="ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolver" public="false">
             <argument type="service" id="api_platform.router" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
         </service>
 
         <service id="api_platform.route_name_resolver.cached" class="ApiPlatform\Core\Bridge\Symfony\Routing\CachedRouteNameResolver" decorates="api_platform.route_name_resolver" decoration-priority="-10" public="false">

--- a/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
@@ -14,6 +14,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Symfony\Routing;
 use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolver;
 use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolverInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\User;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
@@ -110,5 +111,26 @@ class RouteNameResolverTest extends \PHPUnit_Framework_TestCase
         $actual = $routeNameResolver->getRouteName('AppBundle\Entity\User', true);
 
         $this->assertSame('some_collection_route', $actual);
+    }
+
+    public function testGetCorrectRouteNameForItemRoute()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('custom_user_item_route', new Route('/auth/me', [
+            '_api_resource_class' => User::class,
+            '_api_item_operation_name' => 'user_custom_item_operation',
+        ]));
+        $routeCollection->add('user_item_route', new Route('/user/{id}', [
+            '_api_resource_class' => User::class,
+            '_api_item_operation_name' => 'user_item_operation',
+        ]));
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->getRouteCollection()->willReturn($routeCollection);
+
+        $routeNameResolver = new RouteNameResolver($routerProphecy->reveal());
+        $actual = $routeNameResolver->getRouteName(User::class, false);
+
+        $this->assertSame('user_item_operation', $actual);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #689 
| License       | MIT
| Doc PR        | ∅

I thought this was an easy fix but in fact it is not.

We need to move [things that generates operation names](https://github.com/api-platform/core/blob/master/src/Bridge/Symfony/Routing/ApiLoader.php#L35) (prefix, inflector etc.) to a new class so that it can be used in the `RouteNameResolver` to find the correct operation. 

@teohhanhui @Simperfit maybe you've more ideas on how to fix this? I can work on this if you think it's the correct way to do this.