### PR TITLE
Fixes parameter referenceType not being respected

### DIFF
--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -122,6 +122,6 @@ final class ContextBuilder implements ContextBuilderInterface
     {
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
 
-        return $this->urlGenerator->generate('api_jsonld_context', ['shortName' => $resourceMetadata->getShortName()]);
+        return $this->urlGenerator->generate('api_jsonld_context', ['shortName' => $resourceMetadata->getShortName()], $referenceType);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | api-platform/doc#1234

The parameter referencType is not always respected in the context builder.

In the method getBaseContext the parameter is also not respected but hard coded. When I changed it, I broke your build, so I removed it again.