### PR TITLE
Adds jsonld context, Adds support for jsonld typed values

### DIFF
--- a/features/jsonld/context.feature
+++ b/features/jsonld/context.feature
@@ -64,3 +64,23 @@ Feature: JSON-LD contexts generation
         }
       }
       """
+
+    Scenario: Retrieve Dummy with extended jsonld context
+      When I send a "GET" request to "/contexts/JsonldContextDummy"
+      Then the response status code should be 200
+      And the response should be in JSON
+      And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+      And the JSON should be equal to:
+      """
+      {
+          "@context": {
+              "@vocab": "http:\/\/example.com\/doc.jsonld#",
+              "hydra": "http:\/\/www.w3.org\/ns\/hydra\/core#",
+              "person": {
+                  "@id": "http:\/\/example.com\/id",
+                  "@type": "@id",
+                  "foo": "bar"
+              }
+          }
+      }
+      """

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -281,6 +281,12 @@ final class DocumentationNormalizer implements NormalizerInterface
      */
     private function getRange(PropertyMetadata $propertyMetadata)
     {
+        $jsonldContext = $propertyMetadata->getAttributes()['jsonld_context'] ?? [];
+
+        if (isset($jsonldContext['@type'])) {
+            return $jsonldContext['@type'];
+        }
+
         if (null === $type = $propertyMetadata->getType()) {
             return;
         }

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -97,18 +97,25 @@ final class ContextBuilder implements ContextBuilderInterface
             }
 
             $convertedName = $this->nameConverter ? $this->nameConverter->normalize($propertyName) : $propertyName;
+            $jsonldContext = $propertyMetadata->getAttributes()['jsonld_context'] ?? [];
 
             if (!$id = $propertyMetadata->getIri()) {
                 $id = sprintf('%s/%s', $prefixedShortName, $convertedName);
             }
 
             if (true !== $propertyMetadata->isReadableLink()) {
-                $context[$convertedName] = [
+                $jsonldContext = $jsonldContext + [
                     '@id' => $id,
                     '@type' => '@id',
                 ];
-            } else {
+            }
+
+            if (empty($jsonldContext)) {
                 $context[$convertedName] = $id;
+            } else {
+                $context[$convertedName] = $jsonldContext + [
+                    '@id' => $id,
+                ];
             }
         }
 

--- a/tests/Fixtures/TestBundle/Entity/JsonldContextDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/JsonldContextDummy.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Jsonld Context Dummy.
+ *
+ *
+ * @ApiResource
+ * @ORM\Entity
+ */
+class JsonldContextDummy
+{
+    /**
+     * @var int The id.
+     *
+     * @ApiProperty(identifier=true)
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string The dummy person.
+     *
+     * @ApiProperty(
+     *     attributes={
+     *         "jsonld_context"= {
+     *             "@id"="http://example.com/id",
+     *             "@type"="@id",
+     *             "foo"="bar"
+     *         }
+     *     },
+     * )
+     */
+    private $person;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setPerson($person)
+    {
+        $this->person = $person;
+    }
+
+    public function getPerson()
+    {
+        return $this->person;
+    }
+}

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -39,7 +39,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $documentation = new Documentation(new ResourceNameCollection(['dummy' => 'dummy']), $title, $desc, $version, []);
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create('dummy', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['name']));
+        $propertyNameCollectionFactoryProphecy->create('dummy', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['name', 'description']));
 
         $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']], []);
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
@@ -47,6 +47,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create('dummy', 'name')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'name', true, true, true, true, false, false, null, null, []));
+        $propertyMetadataFactoryProphecy->create('dummy', 'description')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'description', true, true, true, true, false, false, null, null, ['jsonld_context' => ['@type' => '@id']]));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(Argument::type('string'))->willReturn(true);
@@ -125,6 +126,21 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                             'hydra:readable' => true,
                             'hydra:writable' => true,
                             'hydra:description' => 'name',
+                        ],
+                        1 => [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#dummy/description',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'description',
+                                'domain' => '#dummy',
+                                'range' => '@id',
+                            ],
+                            'hydra:title' => 'description',
+                            'hydra:required' => false,
+                            'hydra:readable' => true,
+                            'hydra:writable' => true,
+                            'hydra:description' => 'description',
                         ],
                     ],
                     'hydra:supportedOperation' => [

--- a/tests/JsonLd/ContextBuilderTest.php
+++ b/tests/JsonLd/ContextBuilderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\JsonLd;
+
+use ApiPlatform\Core\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\JsonLd\ContextBuilder;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Markus Mächler <markus.maechler@bithost.ch>
+ */
+class ContextBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    private $entityClass;
+    private $resourceNameCollectionFactoryProphecy;
+    private $resourceMetadataFactoryProphecy;
+    private $propertyNameCollectionFactoryProphecy;
+    private $propertyMetadataFactoryProphecy;
+    private $urlGeneratorProphecy;
+
+    public function setUp()
+    {
+        $this->entityClass = '\Dummy\DummyEntity';
+        $this->resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $this->propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $this->propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $this->urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+    }
+
+    public function testResourceContext()
+    {
+        $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity'));
+        $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
+        $this->propertyMetadataFactoryProphecy->create($this->entityClass, 'dummyPropertyA')->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'Dummy property A', true, true, true, true, false, false, null, null, []));
+
+        $contextBuilder = new ContextBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), $this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->urlGeneratorProphecy->reveal());
+
+        $expected = [
+            '@vocab' => '#',
+            'hydra' => 'http://www.w3.org/ns/hydra/core#',
+            'dummyPropertyA' => '#DummyEntity/dummyPropertyA',
+        ];
+
+        $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
+    }
+
+    public function testResourceContextWithJsonldContext()
+    {
+        $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity'));
+        $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
+        $this->propertyMetadataFactoryProphecy->create($this->entityClass, 'dummyPropertyA')->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'Dummy property A', true, true, true, true, false, false, null, null, ['jsonld_context' => ['@type' => '@id', '@id' => 'customId', 'foo' => 'bar']]));
+
+        $contextBuilder = new ContextBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), $this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->urlGeneratorProphecy->reveal());
+
+        $expected = [
+            '@vocab' => '#',
+            'hydra' => 'http://www.w3.org/ns/hydra/core#',
+            'dummyPropertyA' => [
+                '@type' => '@id',
+                '@id' => 'customId',
+                'foo' => 'bar',
+            ],
+        ];
+
+        $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
+    }
+
+    public function testResourceContextWithReverse()
+    {
+        $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity'));
+        $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
+        $this->propertyMetadataFactoryProphecy->create($this->entityClass, 'dummyPropertyA')->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'Dummy property A', true, true, true, true, false, false, null, null, ['jsonld_context' => ['@reverse' => 'parent']]));
+
+        $contextBuilder = new ContextBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), $this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->urlGeneratorProphecy->reveal());
+
+        $expected = [
+            '@vocab' => '#',
+            'hydra' => 'http://www.w3.org/ns/hydra/core#',
+            'dummyPropertyA' => [
+                '@id' => '#DummyEntity/dummyPropertyA',
+                '@reverse' => 'parent'
+            ],
+        ];
+
+        $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This pull request is just an implementation proposal, it is not yet ready to be merged. I have not put any effort into fixing the tests.

This pull request wants to add json-ld typed values: https://www.w3.org/TR/json-ld/#typed-values
e.g.

**entity** 
```php
    /**
     * @var string | array
     *
     * @ApiProperty(iri="http://xmlns.com/foaf/0.1/firstName");
     *
     */
    private $firstName;

    /**
     * @var string | array
     *
     * @ApiProperty(iri="http://xmlns.com/foaf/0.1/lastName", valueType="literal");
     *
     */
    private $lastName;
```


**context**
```json
{
    "@context": {
        "@vocab": "http://swissbib-hydra.lo/apidoc.jsonld#",
        "hydra": "http://www.w3.org/ns/hydra/core#",
        "firstName": "http://xmlns.com/foaf/0.1/firstName",
        "lastName": {
            "@id": "http://xmlns.com/foaf/0.1/lastName",
            "@type": "literal"
        }
    }
}
```

What do you think?