### PR TITLE
Fix Swagger UI integration

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -47,7 +47,7 @@
                         }
                     });
 
-                    {% if operationId is defined %}
+                    {% if operationId is not null %}
                         {% set domId = '#' ~ shortName ~ '_' ~ operationId %}
                         {% set id = app.request.attributes.get('id') %}
 
@@ -72,7 +72,7 @@
                 onFailure: function() {
                     log('Unable to Load SwaggerUI');
                 },
-                docExpansion: {% if operationId is defined %}'none'{% else %}'list'{% endif %},
+                docExpansion: 'list',
                 jsonEditor: false,
                 defaultModelRendering: 'schema',
                 showRequestHeaders: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Avoid the unwanted `#//` at the end of the homepage URL when displaying Swagger UI.