### PR TITLE
[FEATURE] Pass controllerResult to SerializerContextBuilder

### DIFF
--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -58,7 +58,7 @@ final class SerializeListener
             return;
         }
 
-        $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
+        $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes, $controllerResult);
         $request->attributes->set('_api_respond', true);
 
         $event->setControllerResult($this->serializer->serialize($controllerResult, $request->getRequestFormat(), $context));

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -32,7 +32,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
     /**
      * {@inheritdoc}
      */
-    public function createFromRequest(Request $request, bool $normalization, array $attributes = null) : array
+    public function createFromRequest(Request $request, bool $normalization, array $attributes = null, $controllerResult = null) : array
     {
         if (null === $attributes) {
             $attributes = RequestAttributesExtractor::extractAttributes($request);

--- a/src/Serializer/SerializerContextBuilderInterface.php
+++ b/src/Serializer/SerializerContextBuilderInterface.php
@@ -27,10 +27,11 @@ interface SerializerContextBuilderInterface
      * @param Request    $request
      * @param bool       $normalization
      * @param array|null $extractedAttributes
+	 * @param mixed      $controllerResult
      *
      * @throws RuntimeException
      *
      * @return array
      */
-    public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null) : array;
+    public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null, $controllerResult = null) : array;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

Solves the problem described here:
http://stackoverflow.com/questions/39720409/api-platform-conditionally-adding-group-to-serialization-context-based-on-reque

By passing the controllerResult to the SerializerContextBuilder we allow to control serializaton groups much more fine-grained.

This way we are able to control serialization groups not only based on corrently logged in user fx but rather also in combination with the actual controller result.

For example: When the current User is the author of some Product, add group „product_owner“