### PR TITLE
Fix #673: name converter for Swagger and NelmioApiDocBundle

### DIFF
--- a/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
+++ b/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Nelmio\ApiDocBundle\DataTypes;
 use Nelmio\ApiDocBundle\Parser\ParserInterface;
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Extract input and output information for the NelmioApiDocBundle.
@@ -42,12 +43,14 @@ final class ApiPlatformParser implements ParserInterface
     private $resourceMetadataFactory;
     private $propertyNameCollectionFactory;
     private $propertyMetadataFactory;
+    private $nameConverter;
 
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory)
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, NameConverterInterface $nameConverter = null)
     {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
+        $this->nameConverter = $nameConverter;
     }
 
     /**
@@ -171,7 +174,8 @@ final class ApiPlatformParser implements ParserInterface
                 ($propertyMetadata->isReadable() && self::OUT_PREFIX === $io) ||
                 ($propertyMetadata->isWritable() && self::IN_PREFIX === $io)
             ) {
-                $data[$propertyName] = $this->parseProperty($resourceMetadata, $propertyMetadata, $io, null, $visited);
+                $normalizedPropertyName = $this->nameConverter ? $this->nameConverter->normalize($propertyName) : $propertyName;
+                $data[$normalizedPropertyName] = $this->parseProperty($resourceMetadata, $propertyMetadata, $io, null, $visited);
             }
         }
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/nelmio_api_doc.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/nelmio_api_doc.xml
@@ -19,6 +19,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="nelmio_api_doc.extractor.parser" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -15,6 +15,7 @@
             <argument type="service" id="api_platform.operation_path_resolver" />
             <argument type="service" id="api_platform.router" />
             <argument type="service" id="api_platform.filters" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="serializer.normalizer" priority="16" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #673 
| License       | MIT
| Doc PR        | N/A

This PR fixes #673 by adding the support of [the name converter system](https://github.com/api-platform/docs/blob/master/core/serialization-groups-and-relations.md#name-conversion) to Swagger and NelmioApiDocBundle.

