### PR TITLE
Swagger UI template - use minimalist escaping for XSS prevention

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -31,7 +31,7 @@
         $(function () {
             window.swaggerUi = new SwaggerUi({
                 url: '{{ path('api_doc', {'_format': 'json'} ) }}',
-                spec: JSON.parse('{{ spec|escape('js') }}'),
+                spec: {{ spec|replace({'<': '\u003c'})|raw }},
                 dom_id: 'swagger-ui-container',
                 supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
                 onComplete: function() {
@@ -48,11 +48,11 @@
                     });
 
                     {% if operationId is not null %}
-                        {% set domId = '#' ~ shortName ~ '_' ~ operationId %}
+                        {% set domId = shortName ~ '_' ~ operationId %}
                         {% set id = app.request.attributes.get('id') %}
 
-                        var queryParameters = JSON.parse('{{ app.request.query.all()|json_encode|escape('js') }}');
-                        $('{{ domId|escape('js') }} form.sandbox input.parameter').each(function (i, e) {
+                        var queryParameters = {{ app.request.query.all()|json_encode|replace({'<': '\u003c'})|raw }};
+                        $('#{{ domId|escape('js') }} form.sandbox input.parameter').each(function (i, e) {
                             var $e = $(e);
                             var name = $e.attr('name');
 
@@ -62,10 +62,10 @@
                         });
 
                         {% if id %}
-                            $('{{ domId|escape('js') }} form.sandbox input[name="id"]').val('{{ id|escape('js') }}');
+                            $('#{{ domId|escape('js') }} form.sandbox input[name="id"]').val('{{ id|escape('js') }}');
                         {% endif %}
 
-                        $('{{ domId|escape('js') }} form.sandbox').submit();
+                        $('#{{ domId|escape('js') }} form.sandbox').submit();
                         document.location.hash = '#!/{{ shortName|escape('js') }}/{{ operationId|escape('js') }}';
                     {% endif %}
                 },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

At the bottom of https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#HTML_entity_encoding

> An alternative to escaping and unescaping JSON directly in JavaScript, is to normalize JSON server-side by converting '<' to '\u003c' before delivering it to the browser.

`{{ ...|escape('js') }}` was unnecessary in the first place because we know we're dealing with well-formed JSON, which has no possibility of causing any harm in a JS context.