### PR TITLE
(wip) Posting a number when property type is string doesn't trigger an error

### DIFF
--- a/features/crud.feature
+++ b/features/crud.feature
@@ -16,7 +16,9 @@ Feature: Create-Retrieve-Update-Delete
           "value1",
           "value2"
         ]
-      }
+      },
+      "dummyFloat": 1.2,
+      "dummyPrice": 1.2
     }
     """
     Then the response status code should be 201
@@ -32,8 +34,8 @@ Feature: Create-Retrieve-Update-Delete
       "dummy": null,
       "dummyBoolean": null,
       "dummyDate": "2015-03-01T10:00:00+00:00",
-      "dummyFloat": null,
-      "dummyPrice": null,
+      "dummyFloat": 1.2,
+      "dummyPrice": "1.2",
       "relatedDummy": null,
       "relatedDummies": [],
       "jsonData": {
@@ -63,8 +65,8 @@ Feature: Create-Retrieve-Update-Delete
       "dummy": null,
       "dummyBoolean": null,
       "dummyDate": "2015-03-01T10:00:00+00:00",
-      "dummyFloat": null,
-      "dummyPrice": null,
+      "dummyFloat": 1.2,
+      "dummyPrice": "1.2",
       "relatedDummy": null,
       "relatedDummies": [],
       "jsonData": {
@@ -102,8 +104,8 @@ Feature: Create-Retrieve-Update-Delete
           "dummy": null,
           "dummyBoolean": null,
           "dummyDate": "2015-03-01T10:00:00+00:00",
-          "dummyFloat": null,
-          "dummyPrice": null,
+          "dummyFloat": 1.2,
+          "dummyPrice": "1.2",
           "relatedDummy": null,
           "relatedDummies": [],
           "jsonData": {
@@ -337,8 +339,8 @@ Feature: Create-Retrieve-Update-Delete
       "dummy": null,
       "dummyBoolean": null,
       "dummyDate": "2015-03-01T10:00:00+00:00",
-      "dummyFloat": null,
-      "dummyPrice": null,
+      "dummyFloat": 1.2,
+      "dummyPrice": "1.2",
       "relatedDummy": null,
       "relatedDummies": [],
       "jsonData": [
@@ -360,3 +362,4 @@ Feature: Create-Retrieve-Update-Delete
     When I send a "DELETE" request to "/dummies/1"
     Then the response status code should be 204
     And the response should be empty
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | not yet
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | should not
| Fixed tickets | #777
| License       | MIT
| Doc PR        | ∅

See PR comment.

Can someone tell me how we know it's a number, even though the `@var` is typed `string` [here](https://github.com/api-platform/core/blob/master/tests/Fixtures/TestBundle/Entity/Dummy.php#L92)?
~~There might be a bug in the docs specifically with the `@ORM(type=decimal)` opposed to `float` (not proofed yet).~~