### PR TITLE
Remove a unused service definition

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
@@ -69,12 +69,6 @@
             <argument type="service" id="api_platform.filters" />
         </service>
 
-        <!-- Action -->
-
-        <service id="api_platform.hydra.action.exception" class="ApiPlatform\Core\Hydra\Action\ExceptionAction">
-            <argument type="service" id="api_platform.hydra.normalizer.error" />
-       </service>
-
     </services>
 
 </container>

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -268,7 +268,6 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.hal.normalizer.collection',
             'api_platform.hal.normalizer.entrypoint',
             'api_platform.hal.normalizer.item',
-            'api_platform.hydra.action.exception',
             'api_platform.hydra.listener.response.add_link_header',
             'api_platform.hydra.normalizer.collection',
             'api_platform.hydra.normalizer.collection_filters',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The `api_platform.hydra.action.exception` definition should be removed because it is not used and its `ApiPlatform\Core\Hydra\Action\ExceptionAction` class no longer exists.
