### PR TITLE
fix eager, left join if previous was a left join

### DIFF
--- a/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\UnknownDummy;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder;
@@ -96,9 +97,10 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
 
-        $relatedNameCollection = new PropertyNameCollection(['id', 'name', 'notindatabase', 'notreadable']);
+        $relatedNameCollection = new PropertyNameCollection(['id', 'name', 'notindatabase', 'notreadable', 'relation']);
 
         $propertyNameCollectionFactoryProphecy->create(RelatedDummy::class)->willReturn($relatedNameCollection)->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(UnknownDummy::class)->willReturn(new PropertyNameCollection(['id']))->shouldBeCalled();
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $relationPropertyMetadata = new PropertyMetadata();
@@ -122,16 +124,19 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
         $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'name')->willReturn($namePropertyMetadata)->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notindatabase')->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notreadable')->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'relation')->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(UnknownDummy::class, 'id')->willReturn($idPropertyMetadata)->shouldBeCalled();
 
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
-        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([0 => 'relatedDummy', 'relatedDummy2', 'relatedDummy3', 'relatedDummy4']);
+        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn(['relatedDummy', 'relatedDummy2', 'relatedDummy3', 'relatedDummy4']);
         $classMetadataProphecy->associationMappings = [
             'relatedDummy' => ['fetch' => 3, 'joinColumns' => [['nullable' => true]], 'targetEntity' => RelatedDummy::class],
-            'relatedDummy2' => ['fetch' => 3, 'joinColumns' => [['nullable' => false]], 'targetEntity' => RelatedDummy::class],
-            'relatedDummy3' => ['fetch' => 3, 'joinTable' => ['joinColumns' => [['nullable' => false]]], 'targetEntity' => RelatedDummy::class],
-            'relatedDummy4' => ['fetch' => 3, 'targetEntity' => RelatedDummy::class],
+            'relatedDummy2' => ['fetch' => 3, 'joinColumns' => [['nullable' => false]], 'targetEntity' => UnknownDummy::class],
+            'relatedDummy3' => ['fetch' => 3, 'joinTable' => ['joinColumns' => [['nullable' => false]]], 'targetEntity' => UnknownDummy::class],
+            'relatedDummy4' => ['fetch' => 3, 'targetEntity' => UnknownDummy::class],
+            'relatedDummy5' => ['fetch' => 2, 'targetEntity' => UnknownDummy::class],
         ];
 
         $relatedClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
@@ -142,26 +147,35 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $relatedClassMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([]);
+        $relatedClassMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn(['relation']);
+
+        $relatedClassMetadataProphecy->associationMappings = [
+            'relation' => ['fetch' => 3, 'joinColumns' => [['nullable' => false]], 'targetEntity' => UnknownDummy::class],
+        ];
+
+        $unknownClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
+        $unknownClassMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn([]);
 
         $emProphecy = $this->prophesize(EntityManager::class);
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
         $emProphecy->getClassMetadata(RelatedDummy::class)->shouldBeCalled()->willReturn($relatedClassMetadataProphecy->reveal());
+        $emProphecy->getClassMetadata(UnknownDummy::class)->shouldBeCalled()->willReturn($unknownClassMetadataProphecy->reveal());
 
         $queryBuilderProphecy->leftJoin('o.relatedDummy', 'a0')->shouldBeCalled(1);
-        $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'a11')->shouldBeCalled(1);
-        $queryBuilderProphecy->innerJoin('o.relatedDummy3', 'a122')->shouldBeCalled(1);
-        $queryBuilderProphecy->leftJoin('o.relatedDummy4', 'a1233')->shouldBeCalled(1);
+        $queryBuilderProphecy->leftJoin('a0.relation', 'a10')->shouldBeCalled(1);
+        $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'a111')->shouldBeCalled(1);
+        $queryBuilderProphecy->innerJoin('o.relatedDummy3', 'a1122')->shouldBeCalled(1);
+        $queryBuilderProphecy->leftJoin('o.relatedDummy4', 'a11233')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('partial a0.{id,name}')->shouldBeCalled(1);
-        $queryBuilderProphecy->addSelect('partial a11.{id,name}')->shouldBeCalled(1);
-        $queryBuilderProphecy->addSelect('partial a122.{id,name}')->shouldBeCalled(1);
-        $queryBuilderProphecy->addSelect('partial a1233.{id,name}')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a10.{id}')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a111.{id}')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a1122.{id}')->shouldBeCalled(1);
+        $queryBuilderProphecy->addSelect('partial a11233.{id}')->shouldBeCalled(1);
 
         $queryBuilderProphecy->getEntityManager()->shouldBeCalled(2)->willReturn($emProphecy->reveal());
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal());
-        $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
 
         $orderExtensionTest->applyToItem($queryBuilder, new QueryNameGenerator(), Dummy::class, []);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ∅
| License       | MIT
| Doc PR        | ∅

When doing a `LEFT` join, the next association that should be fetched in `EAGER` mode was doing an `INNER` join. As a result, there were things missing from the end results.
