### PR TITLE
Pass ResourceMetadata instead of $resourceShortName in OperationPathR…

### DIFF
--- a/src/Bridge/Symfony/Routing/RouterOperationPathResolver.php
+++ b/src/Bridge/Symfony/Routing/RouterOperationPathResolver.php
@@ -12,6 +12,7 @@
 namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -19,6 +20,7 @@ use Symfony\Component\Routing\RouterInterface;
  * Resolves the operations path using a Symfony route.
  *
  * @author Guilhem N. <egetick@gmail.com>
+ * @author Jérémy Leherpeur <jeremy@leherpeur.net>
  */
 final class RouterOperationPathResolver implements OperationPathResolverInterface
 {
@@ -34,10 +36,10 @@ final class RouterOperationPathResolver implements OperationPathResolverInterfac
     /**
      * {@inheritdoc}
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, bool $collection) : string
+    public function resolveOperationPath(ResourceMetadata $resourceMetadata, array $operation, bool $collection) : string
     {
         if (!isset($operation['route_name'])) {
-            return $this->deferred->resolveOperationPath($resourceShortName, $operation, $collection);
+            return $this->deferred->resolveOperationPath($resourceMetadata, $operation, $collection);
         }
 
         $route = $this->router->getRouteCollection()->get($operation['route_name']);

--- a/src/PathResolver/CustomOperationPathResolver.php
+++ b/src/PathResolver/CustomOperationPathResolver.php
@@ -11,10 +11,13 @@
 
 namespace ApiPlatform\Core\PathResolver;
 
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+
 /**
  * Resolves the custom operations path.
  *
  * @author Guilhem N. <egetick@gmail.com>
+ * @author Jérémy Leherpeur <jeremy@leherpeur.net>
  */
 final class CustomOperationPathResolver implements OperationPathResolverInterface
 {
@@ -28,12 +31,12 @@ final class CustomOperationPathResolver implements OperationPathResolverInterfac
     /**
      * {@inheritdoc}
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, bool $collection) : string
+    public function resolveOperationPath(ResourceMetadata $resourceMetadata, array $operation, bool $collection) : string
     {
         if (isset($operation['path'])) {
             return $operation['path'];
         }
 
-        return $this->deferred->resolveOperationPath($resourceShortName, $operation, $collection);
+        return $this->deferred->resolveOperationPath($resourceMetadata, $operation, $collection);
     }
 }

--- a/src/PathResolver/DashOperationPathResolver.php
+++ b/src/PathResolver/DashOperationPathResolver.php
@@ -11,21 +11,23 @@
 
 namespace ApiPlatform\Core\PathResolver;
 
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generates a path with words separated by dashes.
  *
  * @author Paul Le Corre <paul@lecorre.me>
+ * @author Jérémy Leherpeur <jeremy@leherpeur.net>
  */
 final class DashOperationPathResolver implements OperationPathResolverInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, bool $collection) : string
+    public function resolveOperationPath(ResourceMetadata $resourceMetadata, array $operation, bool $collection) : string
     {
-        $path = '/'.Inflector::pluralize(strtolower(preg_replace('~(?<=\\w)([A-Z])~', '-$1', $resourceShortName)));
+        $path = '/'.Inflector::pluralize(strtolower(preg_replace('~(?<=\\w)([A-Z])~', '-$1', $resourceMetadata->getShortName())));
 
         if (!$collection) {
             $path .= '/{id}';

--- a/src/PathResolver/OperationPathResolverInterface.php
+++ b/src/PathResolver/OperationPathResolverInterface.php
@@ -11,21 +11,24 @@
 
 namespace ApiPlatform\Core\PathResolver;
 
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+
 /**
  * Resolves the path of a resource operation.
  *
  * @author Paul Le Corre <paul@lecorre.me>
+ * @author Jérémy Leherpeur <jeremy@leherpeur.net>
  */
 interface OperationPathResolverInterface
 {
     /**
      * Resolves the operation path.
      *
-     * @param string $resourceShortName
-     * @param array  $operation         The operation metadata
-     * @param bool   $collection
+     * @param ResourceMetadata $resourceMetadata
+     * @param array            $operation        The operation metadata
+     * @param bool             $collection
      *
      * @return string
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, bool $collection) : string;
+    public function resolveOperationPath(ResourceMetadata $resourceMetadata, array $operation, bool $collection) : string;
 }

--- a/src/PathResolver/UnderscoreOperationPathResolver.php
+++ b/src/PathResolver/UnderscoreOperationPathResolver.php
@@ -11,21 +11,23 @@
 
 namespace ApiPlatform\Core\PathResolver;
 
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generates a path with words separated by underscores.
  *
  * @author Paul Le Corre <paul@lecorre.me>
+ * @author Jérémy Leherpeur <jeremy@leherpeur.net>
  */
 final class UnderscoreOperationPathResolver implements OperationPathResolverInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, bool $collection) : string
+    public function resolveOperationPath(ResourceMetadata $resourceMetadata, array $operation, bool $collection) : string
     {
-        $path = '/'.Inflector::pluralize(Inflector::tableize($resourceShortName));
+        $path = '/'.Inflector::pluralize(Inflector::tableize($resourceMetadata->getShortName()));
 
         if (!$collection) {
             $path .= '/{id}';

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -73,10 +73,9 @@ final class DocumentationNormalizer implements NormalizerInterface
 
         foreach ($object->getResourceNameCollection() as $resourceClass) {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-            $resourceShortName = $resourceMetadata->getShortName();
 
-            $this->addPaths($paths, $definitions, $resourceClass, $resourceShortName, $resourceMetadata, $mimeTypes, true);
-            $this->addPaths($paths, $definitions, $resourceClass, $resourceShortName, $resourceMetadata, $mimeTypes, false);
+            $this->addPaths($paths, $definitions, $resourceClass, $resourceMetadata, $mimeTypes, true);
+            $this->addPaths($paths, $definitions, $resourceClass, $resourceMetadata, $mimeTypes, false);
         }
 
         $definitions->ksort();
@@ -91,19 +90,18 @@ final class DocumentationNormalizer implements NormalizerInterface
      * @param \ArrayObject     $paths
      * @param \ArrayObject     $definitions
      * @param string           $resourceClass
-     * @param string           $resourceShortName
      * @param ResourceMetadata $resourceMetadata
      * @param array            $mimeTypes
      * @param bool             $collection
      */
-    private function addPaths(\ArrayObject $paths, \ArrayObject $definitions, string $resourceClass, string $resourceShortName, ResourceMetadata $resourceMetadata, array $mimeTypes, bool $collection)
+    private function addPaths(\ArrayObject $paths, \ArrayObject $definitions, string $resourceClass, ResourceMetadata $resourceMetadata, array $mimeTypes, bool $collection)
     {
         if (null === $operations = $collection ? $resourceMetadata->getCollectionOperations() : $resourceMetadata->getItemOperations()) {
             return;
         }
 
         foreach ($operations as $operationName => $operation) {
-            $path = $this->getPath($resourceShortName, $operation, $collection);
+            $path = $this->getPath($resourceMetadata, $operation, $collection);
             $method = $collection ? $this->operationMethodResolver->getCollectionOperationMethod($resourceClass, $operationName) : $this->operationMethodResolver->getItemOperationMethod($resourceClass, $operationName);
 
             $paths[$path][strtolower($method)] = $this->getPathOperation($operationName, $operation, $method, $collection, $resourceClass, $resourceMetadata, $mimeTypes, $definitions);
@@ -118,15 +116,15 @@ final class DocumentationNormalizer implements NormalizerInterface
      *
      * @see https://github.com/OAI/OpenAPI-Specification/issues/93
      *
-     * @param string $resourceShortName
-     * @param array  $operation
-     * @param bool   $collection
+     * @param ResourceMetadata $resourceMetadata
+     * @param array            $operation
+     * @param bool             $collection
      *
      * @return string
      */
-    private function getPath(string $resourceShortName, array $operation, bool $collection) : string
+    private function getPath(ResourceMetadata $resourceMetadata, array $operation, bool $collection) : string
     {
-        $path = $this->operationPathResolver->resolveOperationPath($resourceShortName, $operation, $collection);
+        $path = $this->operationPathResolver->resolveOperationPath($resourceMetadata, $operation, $collection);
         if ('.{_format}' === substr($path, -10)) {
             $path = substr($path, 0, -10);
         }

--- a/tests/PathResolver/DashOperationPathResolverTest.php
+++ b/tests/PathResolver/DashOperationPathResolverTest.php
@@ -11,21 +11,26 @@
 
 namespace ApiPlatform\Core\Tests\PathResolver;
 
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\PathResolver\DashOperationPathResolver;
 
 class DashOperationPathResolverTest extends \PHPUnit_Framework_TestCase
 {
     public function testResolveCollectionOperationPath()
     {
+        $resourceMetadata = new ResourceMetadata('ShortName');
+
         $dashOperationPathResolver = new DashOperationPathResolver();
 
-        $this->assertSame('/short-names.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], true));
+        $this->assertSame('/short-names.{_format}', $dashOperationPathResolver->resolveOperationPath($resourceMetadata, [], true));
     }
 
     public function testResolveItemOperationPath()
     {
+        $resourceMetadata = new ResourceMetadata('ShortName');
+
         $dashOperationPathResolver = new DashOperationPathResolver();
 
-        $this->assertSame('/short-names/{id}.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], false));
+        $this->assertSame('/short-names/{id}.{_format}', $dashOperationPathResolver->resolveOperationPath($resourceMetadata, [], false));
     }
 }

--- a/tests/PathResolver/UnderscoreOperationPathResolverTest.php
+++ b/tests/PathResolver/UnderscoreOperationPathResolverTest.php
@@ -11,14 +11,17 @@
 
 namespace ApiPlatform\Core\Tests\PathResolver;
 
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver;
 
 class UnderscoreOperationPathResolverTest extends \PHPUnit_Framework_TestCase
 {
     public function testResolveCollectionOperationPath()
     {
+        $resourceMetadata = new ResourceMetadata('ShortName');
+
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
 
-        $this->assertSame('/short_names.{_format}', $underscoreOperationPathResolver->resolveOperationPath('ShortName', [], true));
+        $this->assertSame('/short_names.{_format}', $underscoreOperationPathResolver->resolveOperationPath($resourceMetadata, [], true));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | https://github.com/api-platform/docs/pull/121 |

Pass ResourceMetadata instead of $resourceShortName in OperationPathResolvers
