### PR TITLE
Tweak tests for RFC 7807 compliance

### DIFF
--- a/features/problem.feature
+++ b/features/problem.feature
@@ -16,8 +16,7 @@ Feature: Error handling valid according to RFC 7807 (application/problem+json)
     And the JSON should be equal to:
     """
     {
-      "type": "https://tools.ietf.org/html/rfc2616#section-10",
-      "title": "An error occurred",
+      "title": "Bad Request",
       "detail": "name: This value should not be blank.",
       "violations": [
         {
@@ -43,7 +42,6 @@ Feature: Error handling valid according to RFC 7807 (application/problem+json)
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
-    And the JSON node "type" should be equal to "https://tools.ietf.org/html/rfc2616#section-10"
-    And the JSON node "title" should be equal to "An error occurred"
+    And the JSON node "title" should be equal to "Bad Request"
     And the JSON node "detail" should be equal to 'Nested documents for attribute "relatedDummy" are not allowed. Use IRIs instead.'
     And the JSON node "trace" should exist


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

The current implementation is not RFC 7807 compliant:

> Consumers MUST use the "type" string as the primary identifier for the problem type
> (https://tools.ietf.org/html/rfc7807#section-3.1)
> 
> A problem's type URI SHOULD resolve to HTML documentation that explains how to resolve the problem.
> (https://tools.ietf.org/html/rfc7807#section-4)

But instead we're using a link to the "Status Code Definitions" section of RFC 2616 (deprecated and replaced by RFC 7231).

So I propose we should omit the "type" altogether, which is allowed:

> When this member is not present, its value is assumed to be "about:blank".
> (https://tools.ietf.org/html/rfc7807#section-3.1)

In which case the spec further states:

> When "about:blank" is used, the title SHOULD be the same as the recommended HTTP status phrase for that code (e.g., "Not Found" for 404, and so on)
> (https://tools.ietf.org/html/rfc7807#section-4.2)
