### PR TITLE
fix #795 add context for correct metadata on serialization groups

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -39,7 +39,11 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
      */
     public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
-        $this->joinRelations($queryBuilder, $resourceClass);
+        if (null !== $operationName) {
+            $context = ['collection_operation_name' => $operationName];
+        }
+
+        $this->joinRelations($queryBuilder, $resourceClass, $context ?? []);
     }
 
     /**
@@ -47,15 +51,27 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
      */
     public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null)
     {
-        $this->joinRelations($queryBuilder, $resourceClass);
+        if (null !== $operationName) {
+            $context = ['item_operation_name' => $operationName];
+        }
+
+        $this->joinRelations($queryBuilder, $resourceClass, $context ?? []);
     }
 
-    public function getMetadataProperties(string $resourceClass) : array
+    /**
+     * Get metadata properties for a given resource class.
+     *
+     * @param string $resourceClass
+     * @param array  $context       the serialization context
+     *
+     * @return array
+     */
+    private function getMetadataProperties(string $resourceClass, array $context = []) : array
     {
         $properties = [];
 
         foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
-            $properties[$property] = $this->propertyMetadataFactory->create($resourceClass, $property);
+            $properties[$property] = $this->propertyMetadataFactory->create($resourceClass, $property, $context);
         }
 
         return $properties;
@@ -66,18 +82,20 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
      *
      * @param QueryBuilder $queryBuilder
      * @param string       $resourceClass
+     * @param array        $context       the serialization context
      * @param string       $originAlias   the current entity alias (first o, then a1, a2 etc.)
      * @param string       $relationAlias the previous relation alias to keep it unique
      * @param bool         $wasLeftJoin   if the relation containing the new one had a left join, we have to force the new one to left join too
      */
-    private function joinRelations(QueryBuilder $queryBuilder, string $resourceClass, string $originAlias = 'o', string &$relationAlias = 'a', bool $wasLeftJoin = false)
+    private function joinRelations(QueryBuilder $queryBuilder, string $resourceClass, array $context = [], string $originAlias = 'o', string &$relationAlias = 'a', bool $wasLeftJoin = false)
     {
-        $classMetadata = $queryBuilder->getEntityManager()->getClassMetadata($resourceClass);
+        $entityManager = $queryBuilder->getEntityManager();
+        $classMetadata = $entityManager->getClassMetadata($resourceClass);
         $j = 0;
 
         foreach ($classMetadata->getAssociationNames() as $i => $association) {
             $mapping = $classMetadata->associationMappings[$association];
-            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $association);
+            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $association, $context);
 
             if (ClassMetadataInfo::FETCH_EAGER !== $mapping['fetch'] || false === $propertyMetadata->isReadableLink()) {
                 continue;
@@ -98,7 +116,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
             $associationAlias = $relationAlias.$i;
             $queryBuilder->{$method}($originAlias.'.'.$association, $associationAlias);
             $select = [];
-            $targetClassMetadata = $queryBuilder->getEntityManager()->getClassMetadata($mapping['targetEntity']);
+            $targetClassMetadata = $entityManager->getClassMetadata($mapping['targetEntity']);
 
             foreach ($this->getMetadataProperties($mapping['targetEntity']) as $property => $propertyMetadata) {
                 if (true === $propertyMetadata->isIdentifier()) {
@@ -116,7 +134,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
 
             $relationAlias = $relationAlias.++$j;
 
-            $this->joinRelations($queryBuilder, $mapping['targetEntity'], $associationAlias, $relationAlias, $method === 'leftJoin');
+            $this->joinRelations($queryBuilder, $mapping['targetEntity'], $context, $associationAlias, $relationAlias, $method === 'leftJoin');
         }
     }
 }

--- a/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -41,8 +41,8 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
         $relationPropertyMetadata = new PropertyMetadata();
         $relationPropertyMetadata = $relationPropertyMetadata->withReadableLink(true);
 
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy')->willReturn($relationPropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy2')->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy2', [])->willReturn($relationPropertyMetadata)->shouldBeCalled();
 
         $idPropertyMetadata = new PropertyMetadata();
         $idPropertyMetadata = $idPropertyMetadata->withIdentifier(true);
@@ -53,10 +53,10 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
         $notReadablePropertyMetadata = new PropertyMetadata();
         $notReadablePropertyMetadata = $notReadablePropertyMetadata->withReadable(false);
 
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'id')->willReturn($idPropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'name')->willReturn($namePropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notindatabase')->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notreadable')->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'id', [])->willReturn($idPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'name', [])->willReturn($namePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notindatabase', [])->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notreadable', [])->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
 
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
@@ -106,10 +106,10 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
         $relationPropertyMetadata = new PropertyMetadata();
         $relationPropertyMetadata = $relationPropertyMetadata->withReadableLink(true);
 
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy')->willReturn($relationPropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy2')->willReturn($relationPropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy3')->willReturn($relationPropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy4')->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy2', [])->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy3', [])->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy4', [])->willReturn($relationPropertyMetadata)->shouldBeCalled();
 
         $idPropertyMetadata = new PropertyMetadata();
         $idPropertyMetadata = $idPropertyMetadata->withIdentifier(true);
@@ -120,12 +120,12 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
         $notReadablePropertyMetadata = new PropertyMetadata();
         $notReadablePropertyMetadata = $notReadablePropertyMetadata->withReadable(false);
 
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'id')->willReturn($idPropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'name')->willReturn($namePropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notindatabase')->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notreadable')->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'relation')->willReturn($relationPropertyMetadata)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(UnknownDummy::class, 'id')->willReturn($idPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'id', [])->willReturn($idPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'name', [])->willReturn($namePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notindatabase', [])->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notreadable', [])->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'relation', [])->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(UnknownDummy::class, 'id', [])->willReturn($idPropertyMetadata)->shouldBeCalled();
 
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
@@ -178,5 +178,47 @@ class EagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal());
 
         $orderExtensionTest->applyToItem($queryBuilder, new QueryNameGenerator(), Dummy::class, []);
+    }
+
+    public function testCreateItemWithOperationName()
+    {
+        $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'foo', ['item_operation_name' => 'item_operation'])->shouldBeCalled()->willReturn(new PropertyMetadata());
+
+        $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
+        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn(['foo']);
+        $classMetadataProphecy->associationMappings = [
+            'foo' => ['fetch' => 1],
+        ];
+
+        $emProphecy = $this->prophesize(EntityManager::class);
+        $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
+        $queryBuilderProphecy->getEntityManager()->shouldBeCalled()->willReturn($emProphecy);
+
+        $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal());
+        $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, [], 'item_operation');
+    }
+
+    public function testCreateCollectionWithOperationName()
+    {
+        $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'foo', ['collection_operation_name' => 'collection_operation'])->shouldBeCalled()->willReturn(new PropertyMetadata());
+
+        $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
+        $classMetadataProphecy->getAssociationNames()->shouldBeCalled()->willReturn(['foo']);
+        $classMetadataProphecy->associationMappings = [
+            'foo' => ['fetch' => 1],
+        ];
+
+        $emProphecy = $this->prophesize(EntityManager::class);
+        $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
+        $queryBuilderProphecy->getEntityManager()->shouldBeCalled()->willReturn($emProphecy);
+
+        $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal());
+        $orderExtensionTest->applyToCollection($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, 'collection_operation');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #795 
| License       | MIT
| Doc PR        | 

This fixes a bug where we could not rely on `isReadableLink` because the serializer metadata factory was not getting the correct groups. It was missing the `x_operation_name` [here](https://github.com/api-platform/core/blob/master/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php#L157). 