### PR TITLE
Add the ability to configure and match exceptions with an HTTP status code

### DIFF
--- a/src/Action/ExceptionAction.php
+++ b/src/Action/ExceptionAction.php
@@ -11,36 +11,48 @@
 
 namespace ApiPlatform\Core\Action;
 
-use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Util\ErrorFormatGuesser;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Renders a normalized exception for a given {@see \Symfony\Component\Debug\Exception\FlattenException}.
+ *
+ * Usage:
+ *
+ *     $exceptionAction = new ExceptionAction(
+ *         new Serializer(),
+ *         [
+ *             'jsonproblem' => ['application/problem+json'],
+ *             'jsonld' => ['application/ld+json'],
+ *         ],
+ *         [
+ *             ExceptionInterface::class => Response::HTTP_BAD_REQUEST,
+ *             InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
+ *         ]
+ *     );
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 final class ExceptionAction
 {
-    const DEFAULT_EXCEPTION_TO_STATUS = [
-        ExceptionInterface::class => Response::HTTP_BAD_REQUEST,
-        InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
-    ];
-
     private $serializer;
     private $errorFormats;
     private $exceptionToStatus;
 
-    public function __construct(SerializerInterface $serializer, array $errorFormats, $exceptionToStatus = [])
+    /**
+     * @param SerializerInterface $serializer
+     * @param array               $errorFormats      A list of enabled formats, the first one will be the default
+     * @param array               $exceptionToStatus A list of exceptions mapped to their HTTP status code
+     */
+    public function __construct(SerializerInterface $serializer, array $errorFormats, array $exceptionToStatus = [])
     {
         $this->serializer = $serializer;
         $this->errorFormats = $errorFormats;
-        $this->exceptionToStatus = self::DEFAULT_EXCEPTION_TO_STATUS + $exceptionToStatus;
+        $this->exceptionToStatus = $exceptionToStatus;
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -87,6 +87,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.title', $config['title']);
         $container->setParameter('api_platform.description', $config['description']);
         $container->setParameter('api_platform.version', $config['version']);
+        $container->setParameter('api_platform.exception_to_status', $config['exception_to_status']);
         $container->setParameter('api_platform.formats', $formats);
         $container->setParameter('api_platform.error_formats', $errorFormats);
         $container->setParameter('api_platform.collection.order', $config['collection']['order']);

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -168,6 +168,7 @@
         <service id="api_platform.action.exception" class="ApiPlatform\Core\Action\ExceptionAction">
             <argument type="service" id="api_platform.serializer" />
             <argument>%api_platform.error_formats%</argument>
+            <argument>%api_platform.exception_to_status%</argument>
         </service>
 
         <!-- Cache -->

--- a/tests/Action/ExceptionActionTest.php
+++ b/tests/Action/ExceptionActionTest.php
@@ -16,32 +16,60 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 class ExceptionActionTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGetException()
+    public function testActionWithCatchableException()
     {
-        $flattenException = $this->prophesize(FlattenException::class);
-        $flattenException->getClass()->willReturn(InvalidArgumentException::class);
-        $flattenException->setStatusCode(Response::HTTP_BAD_REQUEST)->willReturn();
-        $flattenException->getHeaders()->willReturn(['Content-Type' => 'application/problem+json']);
+        $serializerException = $this->prophesize(ExceptionInterface::class);
+        $serializerException->willExtend(\Exception::class);
 
-        $flattenException->getStatusCode()->willReturn(Response::HTTP_BAD_REQUEST);
+        $flattenException = FlattenException::create($serializerException->reveal());
+
         $serializer = $this->prophesize(SerializerInterface::class);
-        $exceptionAction = new ExceptionAction($serializer->reveal(), ['jsonproblem' => ['application/problem+json'], 'jsonld' => ['application/ld+json']]);
+        $serializer->serialize($flattenException, 'jsonproblem')->willReturn();
+
+        $exceptionAction = new ExceptionAction($serializer->reveal(), ['jsonproblem' => ['application/problem+json'], 'jsonld' => ['application/ld+json']], [ExceptionInterface::class => Response::HTTP_BAD_REQUEST, InvalidArgumentException::class => Response::HTTP_BAD_REQUEST]);
+
         $request = new Request();
         $request->setFormat('jsonproblem', 'application/problem+json');
-        $serializer->serialize($flattenException, 'jsonproblem')->willReturn();
+
         $expected = new Response('', Response::HTTP_BAD_REQUEST, [
             'Content-Type' => 'application/problem+json; charset=utf-8',
             'X-Content-Type-Options' => 'nosniff',
             'X-Frame-Options' => 'deny',
         ]);
 
-        $this->assertEquals($expected, $exceptionAction($flattenException->reveal(), $request));
+        $this->assertEquals($expected, $exceptionAction($flattenException, $request));
+    }
+
+    public function testActionWithUncatchableException()
+    {
+        $serializerException = $this->prophesize(ExceptionInterface::class);
+        $serializerException->willExtend(\Exception::class);
+
+        $flattenException = FlattenException::create($serializerException->reveal());
+
+        $serializer = $this->prophesize(SerializerInterface::class);
+        $serializer->serialize($flattenException, 'jsonproblem')->willReturn();
+
+        $exceptionAction = new ExceptionAction($serializer->reveal(), ['jsonproblem' => ['application/problem+json'], 'jsonld' => ['application/ld+json']]);
+
+        $request = new Request();
+        $request->setFormat('jsonproblem', 'application/problem+json');
+
+        $expected = new Response('', Response::HTTP_INTERNAL_SERVER_ERROR, [
+            'Content-Type' => 'application/problem+json; charset=utf-8',
+            'X-Content-Type-Options' => 'nosniff',
+            'X-Frame-Options' => 'deny',
+        ]);
+
+        $this->assertEquals($expected, $exceptionAction($flattenException, $request));
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -12,6 +12,7 @@
 namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\DependencyInjection;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use FOS\UserBundle\FOSUserBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
@@ -23,6 +24,8 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -190,6 +193,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.description' => 'description',
             'api_platform.error_formats' => ['jsonproblem' => ['application/problem+json'], 'jsonld' => ['application/ld+json']],
             'api_platform.formats' => ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']],
+            'api_platform.exception_to_status' => [ExceptionInterface::class => Response::HTTP_BAD_REQUEST, InvalidArgumentException::class => Response::HTTP_BAD_REQUEST],
             'api_platform.title' => 'title',
             'api_platform.version' => 'version',
         ];

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -12,23 +12,41 @@
 namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\DependencyInjection;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Configuration;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var Processor
+     */
+    private $processor;
+
+    public function setUp()
+    {
+        $this->configuration = new Configuration();
+        $this->processor = new Processor();
+    }
+
     public function testDefaultConfig()
     {
-        $configuration = new Configuration();
-        $treeBuilder = $configuration->getConfigTreeBuilder();
-        $processor = new Processor();
-        $config = $processor->processConfiguration($configuration, ['api_platform' => ['title' => 'title', 'description' => 'description', 'version' => '1.0.0']]);
+        $treeBuilder = $this->configuration->getConfigTreeBuilder();
+        $config = $this->processor->processConfiguration($this->configuration, ['api_platform' => ['title' => 'title', 'description' => 'description', 'version' => '1.0.0']]);
 
-        $this->assertInstanceOf(ConfigurationInterface::class, $configuration);
+        $this->assertInstanceOf(ConfigurationInterface::class, $this->configuration);
         $this->assertInstanceOf(TreeBuilder::class, $treeBuilder);
         $this->assertEquals([
             'title' => 'title',
@@ -42,6 +60,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'error_formats' => [
                 'jsonproblem' => ['mime_types' => ['application/problem+json']],
                 'jsonld' => ['mime_types' => ['application/ld+json']],
+            ],
+            'exception_to_status' => [
+                ExceptionInterface::class => Response::HTTP_BAD_REQUEST,
+                InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
             ],
             'default_operation_path_resolver' => 'api_platform.operation_path_resolver.underscore',
             'name_converter' => null,
@@ -63,5 +85,77 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ], $config);
+    }
+
+    public function testExceptionToStatusConfig()
+    {
+        $config = $this->processor->processConfiguration($this->configuration, [
+            'api_platform' => [
+                'exception_to_status' => [
+                    \InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
+                    \RuntimeException::class => 'HTTP_INTERNAL_SERVER_ERROR',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue(isset($config['exception_to_status']));
+        $this->assertSame([
+            \InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
+            \RuntimeException::class => Response::HTTP_INTERNAL_SERVER_ERROR,
+        ], $config['exception_to_status']);
+    }
+
+    public function invalidHttpStatusCodeProvider()
+    {
+        return [
+            [0],
+            [99],
+            [700],
+            [1000],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidHttpStatusCodeProvider
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessageRegExp /The HTTP status code ".+" is not valid\./
+     */
+    public function testExceptionToStatusConfigWithInvalidHttpStatusCode($invalidHttpStatusCode)
+    {
+        $this->processor->processConfiguration($this->configuration, [
+            'api_platform' => [
+                'exception_to_status' => [
+                    \Exception::class => $invalidHttpStatusCode,
+                ],
+            ],
+        ]);
+    }
+
+    public function invalidHttpStatusCodeValueProvider()
+    {
+        return [
+            [true],
+            [null],
+            [-INF],
+            [40.4],
+            ['foo'],
+            ['HTTP_FOO_BAR'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidHttpStatusCodeValueProvider
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
+     * @expectedExceptionMessageRegExp /Invalid type for path "api_platform\.exception_to_status\.Exception". Expected int, but got .+\./
+     */
+    public function testExceptionToStatusConfigWithInvalidHttpStatusCodeValue($invalidHttpStatusCodeValue)
+    {
+        $this->processor->processConfiguration($this->configuration, [
+            'api_platform' => [
+                'exception_to_status' => [
+                    \Exception::class => $invalidHttpStatusCodeValue,
+                ],
+            ],
+        ]);
     }
 }

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -47,6 +47,9 @@ api_platform:
             client_items_per_page:     true
             items_per_page:            3
     enable_nelmio_api_doc: true
+    exception_to_status:
+        Symfony\Component\Serializer\Exception\ExceptionInterface: 400
+        ApiPlatform\Core\Exception\InvalidArgumentException: 'HTTP_BAD_REQUEST'
 
 fos_user:
     db_driver:        'orm'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #405 
| License       | MIT
| Doc PR        | N/A

This PR adds the ability to configure and match exceptions with an HTTP status code and to override default exceptions (i.e., `Symfony\Component\Serializer\Exception\UnexpectedValueException` and `Symfony\Component\Serializer\Exception\ExceptionInterface` to 400 HTTP error).

Example of configuration:
```yaml
api_platform:
  exception_to_status:
    Foo\Bar\BazException: 400
    Baz\Bar\FooException: "HTTP_BAD_REQUEST" # or use a constant defined in the 'Symfony\Component\HttpFoundation\Response' class
```

