### PR TITLE
Mask required when writable false in PropertyMetadata

### DIFF
--- a/src/Metadata/Property/PropertyMetadata.php
+++ b/src/Metadata/Property/PropertyMetadata.php
@@ -154,6 +154,10 @@ final class PropertyMetadata
      */
     public function isRequired()
     {
+        if (true === $this->required && false === $this->writable) {
+            return false;
+        }
+
         return $this->required;
     }
 

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -387,10 +387,6 @@ final class DocumentationNormalizer implements NormalizerInterface
             $normalizedPropertyName = $this->nameConverter ? $this->nameConverter->normalize($propertyName) : $propertyName;
 
             if ($propertyMetadata->isRequired()) {
-                if (false === $propertyMetadata->isWritable()) {
-                    throw new RuntimeException(sprintf('The property "%s" of the resource "%s" can not be required and read-only at the same time.', $propertyName, $resourceClass));
-                }
-
                 $definitionSchema['required'][] = $normalizedPropertyName;
             }
 

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -112,7 +112,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'id' => [
                 'dataType' => DataTypes::INTEGER,
-                'required' => true,
+                'required' => false,
                 'description' => 'The id.',
                 'readonly' => true,
             ],
@@ -215,7 +215,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'id' => [
                 'dataType' => DataTypes::INTEGER,
-                'required' => true,
+                'required' => false,
                 'description' => 'The id.',
                 'readonly' => true,
             ],
@@ -346,7 +346,7 @@ class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
                 'children' => [
                     'id' => [
                         'dataType' => DataTypes::INTEGER,
-                        'required' => true,
+                        'required' => false,
                         'description' => null,
                         'readonly' => true,
                     ],

--- a/tests/Metadata/Property/PropertyMetadataTest.php
+++ b/tests/Metadata/Property/PropertyMetadataTest.php
@@ -75,4 +75,25 @@ class PropertyMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($newMetadata === $metadata);
         $this->assertEquals(['a' => 'b'], $newMetadata->getAttributes());
     }
+
+    public function testShouldReturnRequiredFalseWhenRequiredTrueIsSetButMaskedByWritableFalse()
+    {
+        $metadata = new PropertyMetadata();
+
+        $metadata = $metadata->withRequired(true);
+        $metadata = $metadata->withWritable(false);
+
+        $this->assertFalse($metadata->isRequired());
+    }
+
+    public function testShouldReturnPreviouslySetRequiredTrueWhenWritableFalseUnmasked()
+    {
+        $metadata = new PropertyMetadata();
+
+        $metadata = $metadata->withRequired(true);
+        $metadata = $metadata->withWritable(false);
+        $metadata = $metadata->withWritable(true);
+
+        $this->assertTrue($metadata->isRequired());
+    }
 }

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -242,47 +242,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    /**
-     * @expectedException \ApiPlatform\Core\Exception\RuntimeException
-     * @expectedExceptionMessage The property "id" of the resource "ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy" can not be required and read-only at the same time.
-     */
-    public function testNormalizeThrowsExceptionWithAReadOnlyAndRequiredProperty()
-    {
-        $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Dummy API', 'This is a dummy API', '1.2.3', ['jsonld' => ['application/ld+json']]);
-
-        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['id']));
-
-        $dummyMetadata = new ResourceMetadata('Dummy', 'This is a dummy.', null, ['post' => ['method' => 'POST']], [], []);
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn($dummyMetadata);
-
-        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'id')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'This is an id.', true, false, null, null, true));
-
-        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
-
-        $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
-        $operationMethodResolverProphecy->getItemOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
-
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
-
-        $normalizer = new DocumentationNormalizer(
-            $resourceMetadataFactoryProphecy->reveal(),
-            $propertyNameCollectionFactoryProphecy->reveal(),
-            $propertyMetadataFactoryProphecy->reveal(),
-            $resourceClassResolverProphecy->reveal(),
-            $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
-        );
-
-        $normalizer->normalize($documentation);
-    }
-
     public function testNormalizeWithNameConverter()
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Dummy API', 'This is a dummy API', '1.2.3', ['jsonld' => ['application/ld+json']]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Follow up from https://github.com/api-platform/core/pull/764#discussion_r81112046

/cc @dunglas