### PR TITLE
eager associations joins are on the same alias in dql

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
@@ -256,11 +256,11 @@ abstract class AbstractFilter implements FilterInterface
     {
         $parts = $queryBuilder->getDQLPart('join');
 
-        if (!isset($parts[$alias])) {
+        if (!isset($parts['o'])) {
             return;
         }
 
-        foreach ($parts[$alias] as $join) {
+        foreach ($parts['o'] as $join) {
             if (sprintf('%s.%s', $alias, $association) === $join->getJoin()) {
                 return $join;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Though doctrine would create a new join part for each new joined entities, in fact they are under the same branch of dql parts. This fixes a second join by the filter, when an eager association has already been joined.
