### PR TITLE
getItemFromIri now takes an optional context as third argument

### DIFF
--- a/src/Api/IriConverterInterface.php
+++ b/src/Api/IriConverterInterface.php
@@ -26,12 +26,13 @@ interface IriConverterInterface
      *
      * @param string $iri
      * @param bool   $fetchData
+     * @param array  $context
      *
      * @throws InvalidArgumentException
      *
      * @return object
      */
-    public function getItemFromIri(string $iri, bool $fetchData = false);
+    public function getItemFromIri(string $iri, bool $fetchData = false, array $context = []);
 
     /**
      * Gets the IRI associated with the given item.

--- a/src/Bridge/Doctrine/Orm/Extension/QueryItemExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/QueryItemExtensionInterface.php
@@ -28,6 +28,7 @@ interface QueryItemExtensionInterface
      * @param string                      $resourceClass
      * @param array                       $identifiers
      * @param string|null                 $operationName
+     * @param array                       $context
      */
-    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null);
+    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null, array $context = []);
 }

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -54,7 +54,7 @@ class ItemDataProvider implements ItemDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false)
+    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false, array $context = [])
     {
         $manager = $this->managerRegistry->getManagerForClass($resourceClass);
         if (null === $manager) {
@@ -74,7 +74,7 @@ class ItemDataProvider implements ItemDataProviderInterface
         $this->addWhereForIdentifiers($identifiers, $queryBuilder);
 
         foreach ($this->itemExtensions as $extension) {
-            $extension->applyToItem($queryBuilder, $queryNameGenerator, $resourceClass, $identifiers, $operationName);
+            $extension->applyToItem($queryBuilder, $queryNameGenerator, $resourceClass, $identifiers, $operationName, $context);
 
             if ($extension instanceof QueryResultItemExtensionInterface && $extension->supportsResult($resourceClass, $operationName)) {
                 return $extension->getResult($queryBuilder);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -90,6 +90,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.exception_to_status', $config['exception_to_status']);
         $container->setParameter('api_platform.formats', $formats);
         $container->setParameter('api_platform.error_formats', $errorFormats);
+        $container->setParameter('api_platform.eager_loading_max_joins', $config['eager_loading_max_joins']);
         $container->setParameter('api_platform.collection.order', $config['collection']['order']);
         $container->setParameter('api_platform.collection.order_parameter_name', $config['collection']['order_parameter_name']);
         $container->setParameter('api_platform.collection.pagination.enabled', $config['collection']['pagination']['enabled']);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('version')->defaultValue('0.0.0')->info('The version of the API.')->end()
                 ->scalarNode('default_operation_path_resolver')->defaultValue('api_platform.operation_path_resolver.underscore')->info('Specify the default operation path resolver to use for generating resources operations path.')->end()
                 ->scalarNode('name_converter')->defaultNull()->info('Specify a name converter to use.')->end()
+                ->scalarNode('eager_loading_max_joins')->defaultValue(100)->info('Max number of joined relations before EagerLoading throws a RuntimeException')->end()
                 ->booleanNode('enable_fos_user')->defaultValue(false)->info('Enable the FOSUserBundle integration.')->end()
                 ->booleanNode('enable_nelmio_api_doc')->defaultValue(false)->info('Enable the Nelmio Api doc integration.')->end()
                 ->booleanNode('enable_swagger')->defaultValue(true)->info('Enable the Swagger documentation and export.')->end()

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -90,6 +90,8 @@
         <service id="api_platform.doctrine.orm.query_extension.eager_loading" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\EagerLoadingExtension" public="false">
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument>%api_platform.eager_loading_max_joins%</argument>
 
             <tag name="api_platform.doctrine.orm.query_extension.item" priority="64" />
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="64" />

--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <title>{% if title %}{{ title }} - {% endif %}API Platform</title>
 
-    <link rel="icon" type="image/png" href="{{ asset('bundles/apiplatform/swagger-ui/images/favicon-32x32.png') }}" sizes="32x32">
-    <link rel="icon" type="image/png" href="{{ asset('bundles/apiplatform/swagger-ui/images/favicon-16x16.png') }}" sizes="16x16">
-
     <link href="{{ asset('bundles/apiplatform/swagger-ui/css/typography.css') }}" media="screen" rel="stylesheet">
     <link href="{{ asset('bundles/apiplatform/swagger-ui/css/reset.css') }}" media="screen" rel="stylesheet">
     <link href="{{ asset('bundles/apiplatform/swagger-ui/css/screen.css') }}" media="screen" rel="stylesheet">

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -53,7 +53,7 @@ final class IriConverter implements IriConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function getItemFromIri(string $iri, bool $fetchData = false)
+    public function getItemFromIri(string $iri, bool $fetchData = false, array $context = [])
     {
         try {
             $parameters = $this->router->match($iri);
@@ -65,7 +65,7 @@ final class IriConverter implements IriConverterInterface
             throw new InvalidArgumentException(sprintf('No resource associated to "%s".', $iri));
         }
 
-        if ($item = $this->itemDataProvider->getItem($parameters['_api_resource_class'], $parameters['id'], null, $fetchData)) {
+        if ($item = $this->itemDataProvider->getItem($parameters['_api_resource_class'], $parameters['id'], null, $fetchData, $context)) {
             return $item;
         }
 

--- a/src/DataProvider/ChainItemDataProvider.php
+++ b/src/DataProvider/ChainItemDataProvider.php
@@ -33,11 +33,11 @@ final class ChainItemDataProvider implements ItemDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false)
+    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false, array $context = [])
     {
         foreach ($this->dataProviders as $dataProviders) {
             try {
-                return $dataProviders->getItem($resourceClass, $id, $operationName, $fetchData);
+                return $dataProviders->getItem($resourceClass, $id, $operationName, $fetchData, $context);
             } catch (ResourceClassNotSupportedException $e) {
                 continue;
             }

--- a/src/DataProvider/ItemDataProviderInterface.php
+++ b/src/DataProvider/ItemDataProviderInterface.php
@@ -27,10 +27,11 @@ interface ItemDataProviderInterface
      * @param string|null $operationName
      * @param int|string  $id
      * @param bool        $fetchData
+     * @param array       $context
      *
      * @throws ResourceClassNotSupportedException
      *
      * @return object|null
      */
-    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false);
+    public function getItem(string $resourceClass, $id, string $operationName = null, bool $fetchData = false, array $context = []);
 }

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -95,7 +95,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 throw new InvalidArgumentException('Update is not allowed for this operation.');
             }
 
-            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['@id'], true);
+            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['@id'], true, $context);
         }
 
         return parent::denormalize($data, $class, $format, $context);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -270,7 +270,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     {
         if (is_string($value)) {
             try {
-                return $this->iriConverter->getItemFromIri($value, true);
+                return $this->iriConverter->getItemFromIri($value, true, $context);
             } catch (InvalidArgumentException $e) {
                 // Give a chance to other normalizers (e.g.: DateTimeNormalizer)
             }

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -33,7 +33,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 throw new InvalidArgumentException('Update is not allowed for this operation.');
             }
 
-            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['id'], true);
+            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['id'], true, $context);
         }
 
         return parent::denormalize($data, $class, $format, $context);

--- a/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
@@ -37,6 +37,7 @@ class ItemDataProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetItemSingleIdentifier()
     {
+        $context = ['foo' => 'bar'];
         $queryProphecy = $this->prophesize(AbstractQuery::class);
         $queryProphecy->getOneOrNullResult()->willReturn([])->shouldBeCalled();
 
@@ -67,7 +68,7 @@ class ItemDataProviderTest extends \PHPUnit_Framework_TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
 
         $extensionProphecy = $this->prophesize(QueryItemExtensionInterface::class);
-        $extensionProphecy->applyToItem($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, ['id' => 1], 'foo')->shouldBeCalled();
+        $extensionProphecy->applyToItem($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, ['id' => 1], 'foo', $context)->shouldBeCalled();
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class)->willReturn(new PropertyNameCollection(['id']))->shouldBeCalled();
@@ -78,7 +79,7 @@ class ItemDataProviderTest extends \PHPUnit_Framework_TestCase
 
         $dataProvider = new ItemDataProvider($managerRegistryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), [$extensionProphecy->reveal()]);
 
-        $this->assertEquals([], $dataProvider->getItem(Dummy::class, 1, 'foo'));
+        $this->assertEquals([], $dataProvider->getItem(Dummy::class, 1, 'foo', true, $context));
     }
 
     public function testGetItemDoubleIdentifier()
@@ -116,7 +117,7 @@ class ItemDataProviderTest extends \PHPUnit_Framework_TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
 
         $extensionProphecy = $this->prophesize(QueryItemExtensionInterface::class);
-        $extensionProphecy->applyToItem($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, ['ida' => 1, 'idb' => 2], 'foo')->shouldBeCalled();
+        $extensionProphecy->applyToItem($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, ['ida' => 1, 'idb' => 2], 'foo', [])->shouldBeCalled();
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class)->willReturn(new PropertyNameCollection(['nonid', 'ida', 'idb']))->shouldBeCalled();
@@ -186,7 +187,7 @@ class ItemDataProviderTest extends \PHPUnit_Framework_TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
 
         $extensionProphecy = $this->prophesize(QueryResultItemExtensionInterface::class);
-        $extensionProphecy->applyToItem($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, ['id' => 1], 'foo')->shouldBeCalled();
+        $extensionProphecy->applyToItem($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, ['id' => 1], 'foo', [])->shouldBeCalled();
         $extensionProphecy->supportsResult(Dummy::class, 'foo')->willReturn(true)->shouldBeCalled();
         $extensionProphecy->getResult($queryBuilder)->willReturn([])->shouldBeCalled();
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -196,6 +196,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.exception_to_status' => [ExceptionInterface::class => Response::HTTP_BAD_REQUEST, InvalidArgumentException::class => Response::HTTP_BAD_REQUEST],
             'api_platform.title' => 'title',
             'api_platform.version' => 'version',
+            'api_platform.eager_loading_max_joins' => 100,
         ];
         foreach ($parameters as $key => $value) {
             $containerBuilderProphecy->setParameter($key, $value)->shouldBeCalled();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -70,6 +70,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'enable_fos_user' => false,
             'enable_nelmio_api_doc' => false,
             'enable_swagger' => true,
+            'eager_loading_max_joins' => 100,
             'collection' => [
                 'order' => null,
                 'order_parameter_name' => 'order',

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -90,7 +90,7 @@ class IriConverterTest extends \PHPUnit_Framework_TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
 
         $itemDataProviderProphecy = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProviderProphecy->getItem('AppBundle\Entity\User', 3, null, false)->shouldBeCalledTimes(1);
+        $itemDataProviderProphecy->getItem('AppBundle\Entity\User', 3, null, false, [])->shouldBeCalledTimes(1);
 
         $routeNameResolverProphecy = $this->prophesize(RouteNameResolverInterface::class);
 
@@ -117,7 +117,7 @@ class IriConverterTest extends \PHPUnit_Framework_TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
 
         $itemDataProviderProphecy = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProviderProphecy->getItem('AppBundle\Entity\User', 3, null, true)
+        $itemDataProviderProphecy->getItem('AppBundle\Entity\User', 3, null, true, [])
             ->willReturn('foo')
             ->shouldBeCalledTimes(1);
 

--- a/tests/DataProvider/ChainItemDataProviderTest.php
+++ b/tests/DataProvider/ChainItemDataProviderTest.php
@@ -29,13 +29,13 @@ class ChainItemDataProviderTest extends \PHPUnit_Framework_TestCase
         $dummy->setName('Lucie');
 
         $firstDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $firstDataProvider->getItem(Dummy::class, 1, null, false)->willThrow(ResourceClassNotSupportedException::class);
+        $firstDataProvider->getItem(Dummy::class, 1, null, false, [])->willThrow(ResourceClassNotSupportedException::class);
 
         $secondDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $secondDataProvider->getItem(Dummy::class, 1, null, false)->willReturn($dummy);
+        $secondDataProvider->getItem(Dummy::class, 1, null, false, [])->willReturn($dummy);
 
         $thirdDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $thirdDataProvider->getItem(Dummy::class, 1, null, false)->willReturn(new \stdClass());
+        $thirdDataProvider->getItem(Dummy::class, 1, null, false, [])->willReturn(new \stdClass());
 
         $chainItemDataProvider = new ChainItemDataProvider([$firstDataProvider->reveal(), $secondDataProvider->reveal(), $thirdDataProvider->reveal()]);
 
@@ -45,7 +45,7 @@ class ChainItemDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetItemExeptions()
     {
         $firstDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $firstDataProvider->getItem('notfound', 1, null, false)->willThrow(ResourceClassNotSupportedException::class);
+        $firstDataProvider->getItem('notfound', 1, null, false, [])->willThrow(ResourceClassNotSupportedException::class);
 
         $chainItemDataProvider = new ChainItemDataProvider([$firstDataProvider->reveal()]);
 

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -72,9 +72,8 @@ services:
     app.user_manager:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Manager\UserManager'
         arguments:
-            -  '@security.encoder_factory'
-            -  '@fos_user.util.username_canonicalizer'
-            -  '@fos_user.util.email_canonicalizer'
+            -  '@fos_user.util.password_updater'
+            -  '@fos_user.util.canonical_fields_updater'
             -  '@fos_user.object_manager'
             -  '%fos_user.model.user.class%'
 

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -247,8 +247,8 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
         )->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getItemFromIri('/dummies/1', true)->willReturn($relatedDummy1)->shouldBeCalled();
-        $iriConverterProphecy->getItemFromIri('/dummies/2', true)->willReturn($relatedDummy2)->shouldBeCalled();
+        $iriConverterProphecy->getItemFromIri('/dummies/1', true, Argument::type('array'))->willReturn($relatedDummy1)->shouldBeCalled();
+        $iriConverterProphecy->getItemFromIri('/dummies/2', true, Argument::type('array'))->willReturn($relatedDummy2)->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'name', 'foo')->shouldBeCalled();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #810 |
| License | MIT |
| Doc PR | n/a |

Not sure that this will be accepted but IMO it can be a great queries performance boost.

At the moment, on denormalization, relations that should be updated are fetched through the `getItemFromIri`. Now, when doing this, their groups in the denormalization process are just fine and are using the ones from the requested operation.
For example (pseudo-code):

```
PUT /dummies
{ "relatedDummy": "/related_dummies/2" }

denormalizeRelation(RelatedDummy::class, ['groups' => 'dummies_group'])
```

Now, if you have more than one relation to update, it's very interesting to directly fetch what you know will be updated using joins instead of letting doctrine do lazy loadings. The thing is, when using `getItemFromIri`, the `ItemDataProvider` is not aware of the initially requested `resourceClass`. Therefore, it will assume that the serialization groups are the one of the given class (for example `RelatedDummy`).

This PR gives the ability to use a `context` inside the data provider (and its extensions) and allows a fine-grained control over queries, where we want to fetch data based on the initial `resourceClass` groups. 

Note that I'm using a modified `EagerLoadingExtension` where I do not use `FETCH_EAGER`. Using this, I've never more than 1 query for `get_collection | get_item` and only 1 per `getItemFromIri` on `POST` and `PUT` requests (instead of many many more before). So, knowing that joins are based on groups, here are the results with/without this PR:

This takes the  `RelatedDummy` `denormalization_groups` where we might want to save more than when we save `Dummy`:
![pr-without](https://cloud.githubusercontent.com/assets/1321971/19594381/1dafef16-9785-11e6-9339-156024a4559a.png)

This takes the `Dummy` `denormalization_groups`, therefore only what we want to save is retrieved:
![pr-with](https://cloud.githubusercontent.com/assets/1321971/19594387/2025e7f0-9785-11e6-9446-718bf7d4adfb.png)

Let me know what you think about this! Thanks!
