### PR TITLE
Add constants for event's priorities

### DIFF
--- a/src/EventListener/EventPriorities.php
+++ b/src/EventListener/EventPriorities.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\EventListener;
+
+/**
+ * Constants for common priorities.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class EventPriorities
+{
+    const PRE_READ = 5;
+    const POST_READ = 3;
+    const PRE_DESERIALIZE = 3;
+    const POST_DESERIALIZE = 1;
+    const PRE_VALIDATE = 65;
+    const POST_VALIDATE = 63;
+    const PRE_WRITE = 33;
+    const POST_WRITE = 31;
+    const PRE_RESPOND = 9;
+    const POST_RESPOND = 7;
+}

--- a/tests/EventListener/EventPrioritiesTest.php
+++ b/tests/EventListener/EventPrioritiesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\EventListener;
+
+use ApiPlatform\Core\EventListener\EventPriorities;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class EventPrioritiesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstants()
+    {
+        $this->assertEquals(5, EventPriorities::PRE_READ);
+        $this->assertEquals(3, EventPriorities::POST_READ);
+        $this->assertEquals(3, EventPriorities::PRE_DESERIALIZE);
+        $this->assertEquals(1, EventPriorities::POST_DESERIALIZE);
+        $this->assertEquals(65, EventPriorities::PRE_VALIDATE);
+        $this->assertEquals(63, EventPriorities::POST_VALIDATE);
+        $this->assertEquals(33, EventPriorities::PRE_WRITE);
+        $this->assertEquals(31, EventPriorities::POST_WRITE);
+        $this->assertEquals(9, EventPriorities::PRE_RESPOND);
+        $this->assertEquals(7, EventPriorities::POST_RESPOND);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Makes it easier for newcomers to use the event system. Example:

```php
<?php

// src/AppBundle/EventSubscriber/BookMailSubscriber.php

namespace AppBundle\EventSubscriber;

use ApiPlatform\Core\EventListener\EventPriorities;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;
use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
use Symfony\Component\HttpKernel\KernelEvents;

final class BookMailSubscriber implements EventSubscriberInterface
{
    private $mailer;

    public function __construct(\Swift_Mailer $mailer)
    {
        $this->mailer = $mailer;
    }

    public static function getSubscribedEvents()
    {
        return [
            KernelEvents::VIEW => [['sendMail', EventPriorities::POST_WRITE /* instead of 31 */]],
        ];
    }

    public function sendMail(GetResponseForControllerResultEvent $event)
    {
        // ...
    }
}
```

ping @salahm