### PR TITLE
No need to explicilty fetch data in normalizers

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -342,7 +342,7 @@ class SearchFilter extends AbstractFilter
     protected function getIdFromValue(string $value)
     {
         try {
-            if ($item = $this->iriConverter->getItemFromIri($value)) {
+            if ($item = $this->iriConverter->getItemFromIri($value, ['fetch_data' => false])) {
                 return $this->propertyAccessor->getValue($item, 'id');
             }
         } catch (InvalidArgumentException $e) {

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -68,7 +68,7 @@ class ItemDataProvider implements ItemDataProviderInterface
 
         $identifiers = $this->normalizeIdentifiers($id, $manager, $resourceClass);
 
-        $fetchData = $context['fetch_data'] ?? false;
+        $fetchData = $context['fetch_data'] ?? true;
         if (!$fetchData && $manager instanceof EntityManagerInterface) {
             return $manager->getReference($resourceClass, $identifiers);
         }

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -91,7 +91,7 @@ final class ReadListener
     private function getItemData(Request $request, array $attributes)
     {
         $id = $request->attributes->get('id');
-        $data = $this->itemDataProvider->getItem($attributes['resource_class'], $id, $attributes['item_operation_name'], ['fetch_data' => true]);
+        $data = $this->itemDataProvider->getItem($attributes['resource_class'], $id, $attributes['item_operation_name']);
 
         if (null === $data) {
             throw new NotFoundHttpException('Not Found');

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -95,7 +95,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 throw new InvalidArgumentException('Update is not allowed for this operation.');
             }
 
-            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['@id'], ['fetch_data' => true] + $context);
+            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['@id'], ['fetch_data' => false] + $context);
         }
 
         return parent::denormalize($data, $class, $format, $context);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -272,7 +272,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     {
         if (is_string($value)) {
             try {
-                return $this->iriConverter->getItemFromIri($value, ['fetch_data' => true] + $context);
+                return $this->iriConverter->getItemFromIri($value, ['fetch_data' => false] + $context);
             } catch (InvalidArgumentException $e) {
                 // Give a chance to other normalizers (e.g.: DateTimeNormalizer)
             }

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -33,7 +33,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 throw new InvalidArgumentException('Update is not allowed for this operation.');
             }
 
-            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['id'], ['fetch_data' => true] + $context);
+            $context['object_to_populate'] = $this->iriConverter->getItemFromIri($data['id'], ['fetch_data' => false] + $context);
         }
 
         return parent::denormalize($data, $class, $format, $context);

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -87,7 +87,7 @@ class ReadListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = new \stdClass();
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProvider->getItem('Foo', 1, 'get', ['fetch_data' => true])->willReturn($data)->shouldBeCalled();
+        $itemDataProvider->getItem('Foo', 1, 'get')->willReturn($data)->shouldBeCalled();
 
         $request = new Request([], [], ['id' => 1, '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json']);
         $request->setMethod(Request::METHOD_GET);
@@ -109,7 +109,7 @@ class ReadListenerTest extends \PHPUnit_Framework_TestCase
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
 
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProvider->getItem('Foo', 22, 'get', ['fetch_data' => true])->willReturn(null)->shouldBeCalled();
+        $itemDataProvider->getItem('Foo', 22, 'get')->willReturn(null)->shouldBeCalled();
 
         $request = new Request([], [], ['id' => 22, '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json']);
         $request->setMethod(Request::METHOD_GET);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

Correct me if I'm wrong, but I think we don't need to explicitly fetch data in the denormalizeRelation. I'm not sure about normalization contexts, but if we have the ID, going through the reference should be enough. Is there a reason I don't see that we need to keep those? If there is one, it's not in the behat tests and I'd like to add it, thanks!
