### PR TITLE
Make EagerLoadingExtension robuster and less complex

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -111,7 +111,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
     }
 
     /**
-     * Left joins relations to eager load.
+     * Joins relations to eager load.
      *
      * @param QueryBuilder $queryBuilder
      * @param string       $resourceClass
@@ -131,8 +131,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
 
         $entityManager = $queryBuilder->getEntityManager();
         $classMetadata = $entityManager->getClassMetadata($resourceClass);
-        $j = 0;
-        $i = 0;
+        $i = $j = 0;
 
         foreach ($classMetadata->associationMappings as $association => $mapping) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $association, $propertyMetadataOptions);
@@ -145,16 +144,11 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 continue;
             }
 
-            if (false === $wasLeftJoin) {
-                $joinColumns = $mapping['joinColumns'] ?? $mapping['joinTable']['joinColumns'] ?? null;
-
-                if (null === $joinColumns) {
-                    $method = 'leftJoin';
-                } else {
-                    $method = false === $joinColumns[0]['nullable'] ? 'innerJoin' : 'leftJoin';
-                }
-            } else {
+            $joinColumns = $mapping['joinColumns'] ?? $mapping['joinTable']['joinColumns'] ?? null;
+            if (false !== $wasLeftJoin || !isset($joinColumns[0]['nullable']) || false !== $joinColumns[0]['nullable']) {
                 $method = 'leftJoin';
+            } else {
+                $method = 'innerJoin';
             }
 
             $associationAlias = $relationAlias.$i++;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Sometime the `nullable` key may not exist.

Btw @soyuka, I've some question regarding the `eager_only`:

* Can't we enable it by default to improve the performance for everybody?
* What do you think about making this feature configurable per resource using attributes?
