### PR TITLE
Fix consider empty resource declaration as an actual resource

### DIFF
--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -52,9 +52,7 @@ final class YamlExtractor extends AbstractExtractor
     {
         foreach ($resourcesYaml as $resourceName => $resourceYaml) {
             if (null === $resourceYaml) {
-                $this->resources[$resourceName] = null;
-
-                continue;
+                $resourceYaml = [];
             }
 
             if (!is_array($resourceYaml)) {

--- a/tests/Fixtures/FileConfigurations/bad_declaration.yml
+++ b/tests/Fixtures/FileConfigurations/bad_declaration.yml
@@ -1,0 +1,2 @@
+resources:
+    'ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy': ''

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceMetadataFactory;
 use ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy;
 
 /**
@@ -35,6 +36,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
 
         $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new XmlExtractor([$configPath]));
         $resourceMetadata = $resourceMetadataFactory->create(FileConfigDummy::class);
+        $resourceMetadataDummy = $resourceMetadataFactory->create(Dummy::class);
 
         $this->assertInstanceOf(ResourceMetadata::class, $resourceMetadata);
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
@@ -125,6 +127,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
 
         $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new YamlExtractor([$configPath]));
         $resourceMetadata = $resourceMetadataFactory->create(FileConfigDummy::class);
+        $resourceMetadataDummy = $resourceMetadataFactory->create(Dummy::class);
 
         $this->assertInstanceOf(ResourceMetadata::class, $resourceMetadata);
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
@@ -214,6 +217,17 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     public function testCreateWithMalformedYaml()
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/parse_exception.yml';
+
+        (new ExtractorResourceMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class);
+    }
+
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /"ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy" setting is expected to be null or an array, string given in ".+\/Fixtures\/FileConfigurations\/bad_declaration\.yml"\./
+     */
+    public function testCreateWithBadDeclaration()
+    {
+        $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/bad_declaration.yml';
 
         (new ExtractorResourceMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This was not working:
```yaml
resources:
  App\AppBundle\Entity\Foo: ~
```

Should we recommend using single quotes around class declarations in yaml? 