### PR TITLE
Fix attributes values for the XML extractor

### DIFF
--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -66,7 +66,7 @@ final class XmlExtractor extends AbstractExtractor
             if (isset($attribute->attribute[0])) {
                 $value = $this->getAttributes($attribute, 'attribute');
             } else {
-                $value = (string) $attribute;
+                $value = XmlUtils::phpize($attribute);
             }
 
             if (isset($attribute['name'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

IMO attributes values for the XML extractor should be _phpized_ because some values need to be parsed to boolean, integer, etc.

Ex:
* `force_eager`: currently a string (`"false"` or `"true"`) instead of a boolean
* `pagination_items_per_page`: currently a string instead of an integer

