### PR TITLE
Proposal to avoid join recursivity in eager loading

### DIFF
--- a/features/main/circular_reference.feature
+++ b/features/main/circular_reference.feature
@@ -4,7 +4,6 @@ Feature: Circular references handling
   I should be able to catch circular references.
 
   @createSchema
-  @dropSchema
   Scenario: Create a circular reference
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/circular_references" with body:
@@ -31,5 +30,41 @@ Feature: Circular references handling
       "children": [
         "/circular_references/1"
       ]
+    }
+    """
+
+  @dropSchema
+  Scenario: Fetch circular reference
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/circular_references" with body:
+    """
+    {}
+    """
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/circular_references/2" with body:
+    """
+    {
+      "parent": "/circular_references/1"
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/CircularReference",
+      "@id": "/circular_references/2",
+      "@type": "CircularReference",
+      "parent": {
+          "@id": "/circular_references/1",
+          "@type": "CircularReference",
+          "parent": "/circular_references/1",
+          "children": [
+              "/circular_references/1",
+              "/circular_references/2"
+          ]
+      },
+      "children": []
     }
     """

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -151,6 +151,11 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 continue;
             }
 
+            if ($mapping['targetEntity'] === $resourceClass) {
+                $queryBuilder->addSelect($associationAlias);
+                continue;
+            }
+
             $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $associationAlias, $propertyMetadataOptions, $method === 'leftJoin', $joinCount);
         }
     }

--- a/tests/Fixtures/TestBundle/Entity/CircularReference.php
+++ b/tests/Fixtures/TestBundle/Entity/CircularReference.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(attributes={"normalization_context"={"groups": {"circular"}}, "force_eager"=false})
+ * @ApiResource(attributes={"normalization_context"={"groups": {"circular"}}})
  * @ORM\Entity
  */
 class CircularReference


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/api-platform/issues/187
| License       | MIT
| Doc PR        | n/a

In the case of recursive entities, we should only join once those attributes. Indeed, this fix doesn't break joins where you could join the same entity in two different associations but only if the class references itself. So, the `maxJoins` is still valid.

WDYT @teohhanhui ?