### PR TITLE
Make filters's ids defaulting to the service name

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPass.php
@@ -36,7 +36,7 @@ final class FilterPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('api_platform.filter') as $serviceId => $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['id'])) {
-                    throw new RuntimeException('Filter tags must have an "id" property.');
+                    $tag['id'] = $serviceId;
                 }
 
                 $filters[$tag['id']] = new Reference($serviceId);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPassTest.php
@@ -16,6 +16,7 @@ use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -29,29 +30,34 @@ class FilterPassTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(CompilerPassInterface::class, $dataProviderPass);
 
         $definitionProphecy = $this->prophesize(Definition::class);
-        $definitionProphecy->addArgument(Argument::type('array'))->shouldBeCalled();
+        $definitionProphecy->addArgument(Argument::that(function (array $arg) {
+            return !isset($arg['foo']) && isset($arg['my_id']) && $arg['my_id'] instanceof Reference;
+        }))->shouldBeCalled();
         $definition = $definitionProphecy->reveal();
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->findTaggedServiceIds('api_platform.filter')->willReturn(['foo' => [], 'bar' => [0 => ['id' => 'my_id']]])->shouldBeCalled();
+        $containerBuilderProphecy->findTaggedServiceIds('api_platform.filter')->willReturn(['foo' => [], 'bar' => [['id' => 'my_id']]])->shouldBeCalled();
         $containerBuilderProphecy->getDefinition('api_platform.filters')->willReturn($definition)->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $dataProviderPass->process($containerBuilder);
     }
 
-    /**
-     * @expectedException        \ApiPlatform\Core\Exception\RuntimeException
-     * @expectedExceptionMessage Filter tags must have an "id" property.
-     */
     public function testIdNotExist()
     {
         $dataProviderPass = new FilterPass();
 
         $this->assertInstanceOf(CompilerPassInterface::class, $dataProviderPass);
 
+        $definitionProphecy = $this->prophesize(Definition::class);
+        $definitionProphecy->addArgument(Argument::that(function (array $arg) {
+            return !isset($arg['foo']) && isset($arg['bar']) && $arg['bar'] instanceof Reference;
+        }))->shouldBeCalled();
+        $definition = $definitionProphecy->reveal();
+
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->findTaggedServiceIds('api_platform.filter')->willReturn(['foo' => [], 'bar' => [0 => ['hi' => 'hello']]])->shouldBeCalled();
+        $containerBuilderProphecy->findTaggedServiceIds('api_platform.filter')->willReturn(['foo' => [], 'bar' => [['hi' => 'hello']]])->shouldBeCalled();
+        $containerBuilderProphecy->getDefinition('api_platform.filters')->willReturn($definition)->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $dataProviderPass->process($containerBuilder);

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -88,10 +88,11 @@ services:
         arguments: [ { 'id': 'exact', 'name': 'partial', 'alias': 'start', 'description': 'word_start', 'relatedDummy.name': 'exact', 'relatedDummies': 'exact', 'dummy': 'ipartial' } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.search' } ]
 
-    app.my_dummy_resource.order_filter:
+    # Tests if the id default to the service name, do not add id attributes here
+    my_dummy.order:
         parent:    'api_platform.doctrine.orm.order_filter'
         arguments: [ { 'id': ~, 'name': 'desc', 'relatedDummy.symfony': ~ } ]
-        tags:      [ { name: 'api_platform.filter', id: 'my_dummy.order' } ]
+        tags:      [ { name: 'api_platform.filter' } ]
 
     app.my_dummy_resource.date_filter:
         parent:    'api_platform.doctrine.orm.date_filter'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Tiny DX improvement.