### PR TITLE
Add configuration option to define custom loader paths

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -69,7 +69,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerJsonLdConfiguration($formats, $loader);
         $this->registerJsonHalConfiguration($formats, $loader);
         $this->registerJsonProblemConfiguration($errorFormats, $loader);
-        $this->registerLoaders($container, $bundles);
+        $this->registerLoaders($container, $bundles, $config['loader_paths']);
         $this->registerBundlesConfiguration($bundles, $config, $loader);
         $this->registerCacheConfiguration($container);
         $this->registerDoctrineExtensionConfiguration($container, $config);
@@ -244,11 +244,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param ContainerBuilder $container
      * @param string[]         $bundles
      */
-    private function registerLoaders(ContainerBuilder $container, array $bundles)
+    private function registerLoaders(ContainerBuilder $container, array $bundles, array $loaderPaths)
     {
-        $annotationPaths = [];
-        $yamlResources = [];
-        $xmlResources = [];
+        $annotationPaths = $loaderPaths['annotation'];
+        $yamlResources = $loaderPaths['yaml'];
+        $xmlResources = $loaderPaths['xml'];
 
         foreach ($bundles as $bundle) {
             $bundleDirectory = dirname((new \ReflectionClass($bundle))->getFileName());

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -77,6 +77,21 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+
+                ->arrayNode('loader_paths')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('annotation')
+                            ->prototype('scalar')->end()
+                        ->end()
+                        ->arrayNode('yaml')
+                            ->prototype('scalar')->end()
+                        ->end()
+                        ->arrayNode('xml')
+                            ->prototype('scalar')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         $this->addExceptionToStatusSection($rootNode);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -90,6 +90,11 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'maximum_items_per_page' => null,
                 ],
             ],
+            'loader_paths' => [
+                'annotation' => [],
+                'yaml' => [],
+                'xml' => [],
+            ],
         ], $config);
     }
 


### PR DESCRIPTION
This PR introduces an option to define custom paths for the mapping loaders (see. #868). As you can see, it is really simple to implement that feature. What we need to discuss now, how the configuration should look like.

Currently, I added a loader_paths namespace where you can define custom paths for annotation, yaml and xml based mappings. (In the other issue I asked only for annotation based mappings, but I think its better to add customizations for all loaders.) However, this might not be the best structure. Maybe we should introduce some general mapping related namespace for other options at in the future (if there are any).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #868 
| License       | MIT
| Doc PR        | 