### PR TITLE
Added an example of failure with an entity containing a collection of discriminated entities

### DIFF
--- a/features/main/discr.feature
+++ b/features/main/discr.feature
@@ -1,0 +1,48 @@
+@createSchema
+@dropSchema
+Feature: Dealing with collection of discriminated entities
+
+  Scenario: Create an entity having a collection of this type
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/discr_container_dummies" with body:
+    """
+    {
+      "collection": [
+        {
+          "@type": "DiscrFirstDummy",
+          "common": "1",
+          "prop1": "foo"
+        },
+        {
+          "@type": "DiscrSecondDummy",
+          "common": "2",
+          "prop2": "bar"
+        }
+      ]
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/DiscrContainerDummy",
+      "@id": "/discr_container_dummies/1",
+      "@type": "DiscrContainerDummy",
+      "collection": [
+        {
+          "@id": "\/discr_first_dummies\/1",
+          "@type": "DiscrFirstDummy",
+          "common": "1",
+          "prop1": "foo"
+        },
+        {
+          "@id": "\/discr_second_dummies\/2",
+          "@type": "DiscrSecondDummy",
+          "common": "2",
+          "prop2": "bar"
+        }
+      ]
+    }
+    """

--- a/tests/Fixtures/TestBundle/Entity/DiscrAbstractDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/DiscrAbstractDummy.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"discr_abstract_dummy"}},
+ *         "denormalization_context"={"groups"={"discr_abstract_dummy"}}
+ *     }
+ * )
+ * @ORM\Entity
+ *
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *     "first" = "DiscrFirstDummy",
+ *     "second" = "DiscrSecondDummy"
+ * })
+ */
+abstract class DiscrAbstractDummy
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var DiscrContainerDummy
+     *
+     * @ORM\ManyToOne(targetEntity="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DiscrContainerDummy", inversedBy="collection")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     *
+     * @Groups({"discr_abstract_dummy"})
+     */
+    protected $parent;
+
+    /**
+     * @var string A common prop amonsgt all other subclasses
+     *
+     * @ORM\Column(type="string")
+     * @Groups({"discr_abstract_dummy", "discr_container_dummy"})
+     */
+    protected $common;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return static
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return DiscrContainerDummy
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @param DiscrContainerDummy $parent
+     * @return static
+     */
+    public function setParent(DiscrContainerDummy $parent)
+    {
+        $this->parent = $parent;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommon()
+    {
+        return $this->common;
+    }
+
+    /**
+     * @param string $common
+     * @return static
+     */
+    public function setCommon($common)
+    {
+        $this->common = $common;
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DiscrContainerDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/DiscrContainerDummy.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"discr_container_dummy"}},
+ *         "denormalization_context"={"groups"={"discr_container_dummy"}}
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class DiscrContainerDummy
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var ArrayCollection|Collection|DiscrAbstractDummy[] The collection containing discriminated entities
+     *
+     * @ORM\OneToMany(
+     *     targetEntity="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DiscrAbstractDummy",
+     *     mappedBy="parent",
+     *     cascade={"persist","remove"}
+     * )
+     *
+     * @Groups({"discr_container_dummy"})
+     */
+    private $collection;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return static
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return DiscrAbstractDummy[]|ArrayCollection|Collection
+     */
+    public function getCollection()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * @param DiscrAbstractDummy[]|ArrayCollection|Collection $collection
+     * @return static
+     */
+    public function setCollection($collection)
+    {
+        $this->collection = new ArrayCollection(
+            $collection instanceof Collection
+                ? $collection->toArray()
+                : $collection
+        );
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DiscrFirstDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/DiscrFirstDummy.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"discr_first_dummy"}},
+ *         "denormalization_context"={"groups"={"discr_first_dummy"}}
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class DiscrFirstDummy extends DiscrAbstractDummy
+{
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     * @Groups({"discr_first_dummy", "discr_container_dummy"})
+     */
+    private $prop1;
+
+    /**
+     * @return string
+     */
+    public function getProp1()
+    {
+        return $this->prop1;
+    }
+
+    /**
+     * @param string $prop1
+     * @return static
+     */
+    public function setProp1($prop1)
+    {
+        $this->prop1 = $prop1;
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DiscrSecondDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/DiscrSecondDummy.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"discr_second_dummy"}},
+ *         "denormalization_context"={"groups"={"discr_second_dummy"}}
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class DiscrSecondDummy extends DiscrAbstractDummy
+{
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     * @Groups({"discr_second_dummy", "discr_container_dummy"})
+     */
+    private $prop2;
+
+    /**
+     * @return string
+     */
+    public function getProp2()
+    {
+        return $this->prop2;
+    }
+
+    /**
+     * @param string $prop2
+     * @return static
+     */
+    public function setProp2($prop2)
+    {
+        $this->prop2 = $prop2;
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/DiscrAbstractDummyDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/DiscrAbstractDummyDenormalizer.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Denormalizer;
+
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DiscrAbstractDummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DiscrFirstDummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DiscrSecondDummy;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class DiscrAbstractDummyDenormalizer implements DenormalizerInterface
+{
+    /** @var DenormalizerInterface */
+    protected $denormalizer;
+
+    /**
+     * @param DenormalizerInterface $denormalizer
+     *
+     * @return static
+     */
+    public function setDenormalizer(DenormalizerInterface $denormalizer)
+    {
+        $this->denormalizer = $denormalizer;
+
+        return $this;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if ($data['@type'] == 'DiscrFirstDummy') {
+            $dataType = DiscrFirstDummy::class;
+        } elseif ($data['@type'] == 'DiscrSecondDummy') {
+            $dataType = DiscrSecondDummy::class;
+        } else {
+            throw new \Exception('Not implemented');
+        }
+
+        unset($data['@type']);
+
+        $denormalized = $this->denormalizer->denormalize(
+            $data,
+            $dataType,
+            $format,
+            [
+                'resource_class' => $dataType,
+            ] + $context);
+
+        return $denormalized;
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return ($type === DiscrAbstractDummy::class)
+            && is_array($data)
+            && isset($data['@type']);
+    }
+
+}

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/DiscrContainerDummyDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/DiscrContainerDummyDenormalizer.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Denormalizer;
+
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DiscrContainerDummy;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class DiscrContainerDummyDenormalizer implements DenormalizerInterface
+{
+    /**
+     * Ugly way to have a context in the supportsDenormalization method
+     *
+     * @var bool
+     */
+    static protected $youShallNotPass = false;
+
+    /** @var DenormalizerInterface */
+    protected $denormalizer;
+
+    /**
+     * @param DenormalizerInterface $denormalizer
+     *
+     * @return static
+     */
+    public function setDenormalizer(DenormalizerInterface $denormalizer)
+    {
+        $this->denormalizer = $denormalizer;
+
+        return $this;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        static::$youShallNotPass = true;
+        /** @var DiscrContainerDummy $denormalized */
+        $denormalized = $this->denormalizer->denormalize($data, $class, $format, $context);
+        static::$youShallNotPass = false;
+
+        if ($denormalized instanceof DiscrContainerDummy) {
+            $this->populate($denormalized);
+        }
+
+        return $denormalized;
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return ($type === DiscrContainerDummy::class) && !static::$youShallNotPass;
+    }
+
+    /**
+     * @param DiscrContainerDummy $dummy
+     */
+    private function populate(DiscrContainerDummy $dummy)
+    {
+        foreach ($dummy->getCollection() as $elm) {
+            $elm->setParent($dummy);
+        }
+    }
+
+}

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -120,3 +120,20 @@ services:
 
     logger:
         class: Psr\Log\NullLogger
+
+    app.serializer.normalizer.discr_container_dummy:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Denormalizer\DiscrContainerDummyDenormalizer'
+        public: false
+        tags:
+            - { name: 'serializer.normalizer', priority: 128 }
+        calls:
+            - [ 'setDenormalizer', ['@serializer'] ]
+
+
+    app.serializer.normalizer.discr_abstract_dummy:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Denormalizer\DiscrAbstractDummyDenormalizer'
+        public: false
+        tags:
+            - { name: 'serializer.normalizer', priority: 128 }
+        calls:
+            - [ 'setDenormalizer', ['@serializer'] ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hi there,

I've got 2 problems here, both of them regarding a collection of discriminated entities. I've tried to keep the example as simple as possible

* first, running the new behat test provided (behat features/main/discr.feature -v), we can see that api platform assumes that a collection contains only a certain type of elements, but that's not 100% correct in the case of a collection of discriminated entities. It results that the entire collection's elements inherit a single PropertyMetadata in the AbstractItemNormalizer

* second, if we remove the serializer group "discr_container_dummy" from the DiscrAbstractDummy entity, we can see that the test throws an exception because the parent denormalization group could not be found (again AbstractItemNormalizer)

Any idea ?

Regards,
Yohann