### PR TITLE
Allow use of pagination_maximum_items_per_page per resource

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -75,7 +75,10 @@ final class PaginationExtension implements QueryResultCollectionExtensionInterfa
         $itemsPerPage = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_items_per_page', $this->itemsPerPage, true);
         if ($resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_client_items_per_page', $this->clientItemsPerPage, true)) {
             $itemsPerPage = (int) $request->query->get($this->itemsPerPageParameterName, $itemsPerPage);
-            $itemsPerPage = (null !== $this->maximumItemPerPage && $itemsPerPage >= $this->maximumItemPerPage ? $this->maximumItemPerPage : $itemsPerPage);
+            $maximumItemsPerPage = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_maximum_items_per_page', $this->maximumItemPerPage, true);
+            if (null !== $maximumItemsPerPage) {
+                $itemsPerPage = min($itemsPerPage, (int) $maximumItemsPerPage);
+            }
         }
 
         $queryBuilder


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | pending approbation of this PR to create it

Now it's only possible to indicate the maximum number of results in a collection for all resources.
Depends on complexity of one resource, we want to limit the maximum number of results in a collection to avoid leak of system resources.

This PR adds the attribute "pagination_maximum_items_per_page" to allow this customization.
If it's ok, I can create the doc PR.