### PR TITLE
fix #857 - fix on put when both @id and id are present

### DIFF
--- a/features/main/custom_normalized.feature
+++ b/features/main/custom_normalized.feature
@@ -22,12 +22,67 @@ Feature: Using custom normalized entity
       "@context": "/contexts/CustomNormalizedDummy",
       "@id": "/custom_normalized_dummies/1",
       "@type": "CustomNormalizedDummy",
+      "id": 1,
       "name": "My Dummy",
       "alias": "My alias"
     }
     """
 
-  Scenario: Get a resource
+  Scenario: Create a resource with a custom normalized dummy
+    When I add "Content-Type" header equal to "application/json"
+    When I add "Accept" header equal to "application/json"
+    And I send a "POST" request to "/related_normalized_dummies" with body:
+    """
+    {
+      "name": "My Dummy"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+        "id": 1,
+        "name": "My Dummy",
+        "customNormalizedDummy": []
+    }
+    """
+
+  Scenario: Create a resource with a custom normalized dummy and an id
+    When I add "Content-Type" header equal to "application/json"
+    When I add "Accept" header equal to "application/json"
+    And I send a "PUT" request to "/related_normalized_dummies/1" with body:
+    """
+    {
+      "name": "My Dummy",
+      "customNormalizedDummy":[{
+        "@context": "/contexts/CustomNormalizedDummy",
+        "@id": "/custom_normalized_dummies/1",
+        "@type": "CustomNormalizedDummy",
+        "id": 1,
+        "name": "My Dummy"
+    }]
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "id": 1,
+      "name": "My Dummy",
+      "customNormalizedDummy":[{
+        "id": 1,
+        "name": "My Dummy",
+        "alias": "My alias"
+         }]
+    }
+    """
+
+
+  Scenario: Get a custom normalized dummy resource
     When I send a "GET" request to "/custom_normalized_dummies/1"
     Then the response status code should be 200
     And the response should be in JSON
@@ -38,6 +93,7 @@ Feature: Using custom normalized entity
       "@context": "/contexts/CustomNormalizedDummy",
       "@id": "/custom_normalized_dummies/1",
       "@type": "CustomNormalizedDummy",
+      "id": 1,
       "name": "My Dummy",
       "alias": "My alias"
     }
@@ -58,6 +114,7 @@ Feature: Using custom normalized entity
         {
           "@id": "/custom_normalized_dummies/1",
           "@type": "CustomNormalizedDummy",
+           "id": 1,
           "name": "My Dummy",
           "alias": "My alias"
         }
@@ -83,6 +140,7 @@ Feature: Using custom normalized entity
       "@context": "/contexts/CustomNormalizedDummy",
       "@id": "/custom_normalized_dummies/1",
       "@type": "CustomNormalizedDummy",
+      "id": 1,
       "name": "My Dummy modified",
       "alias": "My alias"
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyFriend.php
@@ -49,7 +49,7 @@ class DummyFriend
     /**
      * Get id.
      *
-     * @return id
+     * @return int
      */
     public function getId()
     {
@@ -69,7 +69,7 @@ class DummyFriend
     /**
      * Get name.
      *
-     * @return name
+     * @return string
      */
     public function getName()
     {
@@ -79,7 +79,7 @@ class DummyFriend
     /**
      * Set name.
      *
-     * @param name the value to set
+     * @param string the value to set
      */
     public function setName($name)
     {

--- a/tests/Fixtures/TestBundle/Entity/RelatedNormalizedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedNormalizedDummy.php
@@ -13,22 +13,23 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Custom Normalized Dummy.
+ * Related to Normalized Dummy.
  *
- * @author Mikaël Labrut <labrut@gmail.com>
+ * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  *
  * @ApiResource(attributes={
- *     "normalization_context"={"groups"={"output"}},
- *     "denormalization_context"={"groups"={"input"}}
+ *     "normalization_context"={"groups"={"related_output", "output"}},
+ *     "denormalization_context"={"groups"={"related_input", "input"}}
  * })
  * @ORM\Entity
  */
-class CustomNormalizedDummy
+class RelatedNormalizedDummy
 {
     /**
      * @var int The id
@@ -36,7 +37,7 @@ class CustomNormalizedDummy
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
-     * @Groups({"input", "output"})
+     * @Groups({"related_output", "related_input"})
      */
     private $id;
 
@@ -46,23 +47,24 @@ class CustomNormalizedDummy
      * @ORM\Column
      * @Assert\NotBlank
      * @ApiProperty(iri="http://schema.org/name")
-     * @Groups({"input", "output"})
+     * @Groups({"related_output", "related_input"})
      */
     private $name;
 
     /**
-     * @var string The dummy name alias
+     * @var ArrayCollection Several Normalized dummies
      *
-     * @ORM\Column(nullable=true)
-     * @ApiProperty(iri="https://schema.org/alternateName")
-     * @Groups({"input", "output"})
+     * @ORM\ManyToMany(targetEntity="CustomNormalizedDummy")
+     * @Groups({"related_output", "related_input"})
      */
-    private $alias;
+    public $customNormalizedDummy;
 
-    /**
-     * @return int
-     */
-    public function getId()
+    public function __construct()
+    {
+        $this->customNormalizedDummy = new ArrayCollection();
+    }
+
+    public function getId(): int
     {
         return $this->id;
     }
@@ -75,43 +77,24 @@ class CustomNormalizedDummy
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
-     * @return string
+     * @return ArrayCollection
      */
-    public function getAlias()
+    public function getCustomNormalizedDummy()
     {
-        return $this->alias;
+        return $this->customNormalizedDummy;
     }
 
     /**
-     * @param string $alias
+     * @param ArrayCollection $customNormalizedDummy
      */
-    public function setAlias($alias)
+    public function setCustomNormalizedDummy($customNormalizedDummy)
     {
-        $this->alias = $alias;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPersonalizedAlias()
-    {
-        return $this->alias;
-    }
-
-    /**
-     * @param string $value
-     */
-    public function setPersonalizedAlias($value)
-    {
-        $this->alias = $value;
+        $this->customNormalizedDummy = $customNormalizedDummy;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #857 
| License       | MIT
| Doc PR        | 


Add an non-regression test and modify the comportement of itemNormalizer
