### PR TITLE
Fix an error when decorating the Swagger normalizer

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -13,10 +13,10 @@ namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Command;
 
 use ApiPlatform\Core\Documentation\Documentation;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
-use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * Console command to dump Swagger API documentations.
@@ -32,7 +32,7 @@ final class SwaggerCommand extends Command
     private $apiVersion;
     private $apiFormats;
 
-    public function __construct(DocumentationNormalizer $documentationNormalizer, ResourceNameCollectionFactoryInterface $resourceNameCollection, string $apiTitle, string $apiDescription, string $apiVersion, array $apiFormats)
+    public function __construct(NormalizerInterface $documentationNormalizer, ResourceNameCollectionFactoryInterface $resourceNameCollection, string $apiTitle, string $apiDescription, string $apiVersion, array $apiFormats)
     {
         parent::__construct();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Fix this error when decorating the Swagger normalizer:

```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to ApiPlatform\Core\Bridge\Symfony\Bundl
e\Command\SwaggerCommand::__construct() must be an instance of ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer, instance of AppBundle\Swagge
r\SwaggerDecorator given, called in demo/var/cache/dev/appDevDebugProjectContainer.php on line 879 in demo/vendor/api-platform/core/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php:35
```