### PR TITLE
Add a flag to disable all request listeners

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "phpdocumentor/type-resolver": "^0.2",
         "phpunit/phpunit": "^5.6.8",
         "psr/log": "^1.0",
+        "sensio/framework-extra-bundle": "^3.0",
         "symfony/asset": "^2.7 || ^3.0",
         "symfony/cache": "^3.1",
         "symfony/config": "^3.2",

--- a/features/main/custom_operation.feature
+++ b/features/main/custom_operation.feature
@@ -1,0 +1,29 @@
+Feature: Custom operation
+  As a client software developer
+  I need to be able to create custom operations
+
+  @createSchema
+  Scenario: Custom normalization operation
+    When I send a "POST" request to "/custom/denormalization"
+    And I add "Content-Type" header equal to "application/ld+json"
+    Then the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/CustomActionDummy",
+        "@id": "/custom_action_dummies/1",
+        "@type": "CustomActionDummy",
+        "id": 1,
+        "foo": "custom!"
+    }
+    """
+
+  @dropSchema
+  Scenario: Custom normalization operation
+    When I send a "GET" request to "/custom/1/normalization"
+    Then the JSON should be equal to:
+    """
+    {
+        "id": 1,
+        "foo": "foo"
+    }
+    """

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -45,13 +45,17 @@ final class ValidateListener
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
         $request = $event->getRequest();
+        if ($request->isMethodSafe(false) || $request->isMethod(Request::METHOD_DELETE)) {
+            return;
+        }
+
         try {
             $attributes = RequestAttributesExtractor::extractAttributes($request);
         } catch (RuntimeException $e) {
             return;
         }
 
-        if ($request->isMethodSafe(false) || $request->isMethod(Request::METHOD_DELETE)) {
+        if (!$attributes['request']) {
             return;
         }
 

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -55,7 +55,7 @@ final class ValidateListener
             return;
         }
 
-        if (!$attributes['request']) {
+        if (!$attributes['receive']) {
             return;
         }
 

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -55,6 +55,10 @@ final class DeserializeListener
             return;
         }
 
+        if (!$attributes['request']) {
+            return;
+        }
+
         $format = $this->getFormat($request);
         $context = $this->serializerContextBuilder->createFromRequest($request, false, $attributes);
 

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -55,7 +55,7 @@ final class DeserializeListener
             return;
         }
 
-        if (!$attributes['request']) {
+        if (!$attributes['receive']) {
             return;
         }
 

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -52,7 +52,7 @@ final class ReadListener
             return;
         }
 
-        if (!$attributes['request']) {
+        if (!$attributes['receive']) {
             return;
         }
 

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -52,6 +52,10 @@ final class ReadListener
             return;
         }
 
+        if (!$attributes['request']) {
+            return;
+        }
+
         if (isset($attributes['collection_operation_name'])) {
             $data = $this->getCollectionData($request, $attributes);
         } else {

--- a/src/Util/RequestAttributesExtractor.php
+++ b/src/Util/RequestAttributesExtractor.php
@@ -56,6 +56,12 @@ final class RequestAttributesExtractor
             throw new RuntimeException('One of the request attribute "_api_collection_operation_name" or "_api_item_operation_name" must be defined.');
         }
 
+        if (null === $apiRequest = $request->attributes->get('_api_request')) {
+            $result['request'] = true;
+        } else {
+            $result['request'] = (bool) $apiRequest;
+        }
+
         return $result;
     }
 }

--- a/src/Util/RequestAttributesExtractor.php
+++ b/src/Util/RequestAttributesExtractor.php
@@ -56,10 +56,10 @@ final class RequestAttributesExtractor
             throw new RuntimeException('One of the request attribute "_api_collection_operation_name" or "_api_item_operation_name" must be defined.');
         }
 
-        if (null === $apiRequest = $request->attributes->get('_api_request')) {
-            $result['request'] = true;
+        if (null === $apiRequest = $request->attributes->get('_api_receive')) {
+            $result['receive'] = true;
         } else {
-            $result['request'] = (bool) $apiRequest;
+            $result['receive'] = (bool) $apiRequest;
         }
 
         return $result;

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
@@ -36,8 +36,11 @@ class ValidateListenerTest extends \PHPUnit_Framework_TestCase
         $resourceMetadataFactoryProphecy->create()->shouldNotBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
+        $request = new Request();
+        $request->setMethod('POST');
+
         $event = $this->prophesize(GetResponseForControllerResultEvent::class);
-        $event->getRequest()->willReturn(new Request())->shouldBeCalled();
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
 
         $listener = new ValidateListener($validator, $resourceMetadataFactory);
         $listener->onKernelView($event->reveal());

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
@@ -16,7 +16,6 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -61,11 +61,11 @@ class DeserializeListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testDoNotCallWhenRequestRequestIsFalse()
+    public function testDoNotCallWhenReceiveFlagIsFalse()
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
-        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_request' => false]);
+        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_receive' => false]);
         $request->setMethod(Request::METHOD_POST);
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -61,6 +61,24 @@ class DeserializeListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
+    public function testDoNotCallWhenRequestRequestIsFalse()
+    {
+        $eventProphecy = $this->prophesize(GetResponseEvent::class);
+
+        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_request' => false]);
+        $request->setMethod(Request::METHOD_POST);
+        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->deserialize()->shouldNotBeCalled();
+
+        $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
+        $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->shouldNotBeCalled();
+
+        $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), self::FORMATS);
+        $listener->onKernelRequest($eventProphecy->reveal());
+    }
+
     /**
      * @dataProvider methodProvider
      */

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -30,16 +30,14 @@ class ReadListenerTest extends \PHPUnit_Framework_TestCase
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $itemDataProvider->getItem()->shouldNotBeCalled();
 
-        $request = new Request();
-
         $event = $this->prophesize(GetResponseEvent::class);
-        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getRequest()->willReturn(new Request())->shouldBeCalled();
 
         $listener = new ReadListener($collectionDataProvider->reveal(), $itemDataProvider->reveal());
         $listener->onKernelRequest($event->reveal());
     }
 
-    public function testRequestIsFalse()
+    public function testDoNotCallWhenReceiveFlagIsFalse()
     {
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $collectionDataProvider->getCollection()->shouldNotBeCalled();
@@ -47,7 +45,7 @@ class ReadListenerTest extends \PHPUnit_Framework_TestCase
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $itemDataProvider->getItem()->shouldNotBeCalled();
 
-        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_request' => false]);
+        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_receive' => false]);
         $request->setMethod('PUT');
 
         $event = $this->prophesize(GetResponseEvent::class);

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -39,6 +39,24 @@ class ReadListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest($event->reveal());
     }
 
+    public function testRequestIsFalse()
+    {
+        $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
+        $collectionDataProvider->getCollection()->shouldNotBeCalled();
+
+        $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
+        $itemDataProvider->getItem()->shouldNotBeCalled();
+
+        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_request' => false]);
+        $request->setMethod('PUT');
+
+        $event = $this->prophesize(GetResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $listener = new ReadListener($collectionDataProvider->reveal(), $itemDataProvider->reveal());
+        $listener->onKernelRequest($event->reveal());
+    }
+
     public function testRetrieveCollectionPost()
     {
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);

--- a/tests/Fixtures/TestBundle/Controller/CustomActionController.php
+++ b/tests/Fixtures/TestBundle/Controller/CustomActionController.php
@@ -12,10 +12,10 @@
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Controller;
 
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CustomActionDummy;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>

--- a/tests/Fixtures/TestBundle/Controller/CustomActionController.php
+++ b/tests/Fixtures/TestBundle/Controller/CustomActionController.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Controller;
+
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CustomActionDummy;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class CustomActionController extends Controller
+{
+    /**
+     * @Route(
+     *     name="custom_normalization",
+     *     path="/custom/{id}/normalization",
+     *     defaults={"_api_resource_class"=CustomActionDummy::class, "_api_item_operation_name"="custom_normalization"}
+     * )
+     * @Method("GET")
+     */
+    public function customNormalizationAction(CustomActionDummy $_data)
+    {
+        $_data->setFoo('foo');
+
+        return $this->json($_data);
+    }
+
+    /**
+     * @Route(
+     *     name="custom_denormalization",
+     *     path="/custom/denormalization",
+     *     defaults={
+     *         "_api_resource_class"=CustomActionDummy::class,
+     *         "_api_collection_operation_name"="custom_denormalization",
+     *         "_api_receive"=false
+     *     }
+     * )
+     * @Method("POST")
+     */
+    public function customDenormalizationAction(Request $request)
+    {
+        if ($request->attributes->has('data')) {
+            throw new \RuntimeException('The "data" attribute must not be set.');
+        }
+
+        $object = new CustomActionDummy();
+        $object->setFoo('custom!');
+
+        return $object;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ApiResource(itemOperations={
+ *     "get"={"method"="GET"},
+ *     "custom_normalization"={"route_name"="custom_normalization"}
+ * }, collectionOperations={
+ *     "get"={"method"="GET"},
+ *     "custom_denormalization"={"route_name"="custom_denormalization"}
+ * })
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class CustomActionDummy
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     */
+    private $foo = '';
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function setFoo(string $foo)
+    {
+        $this->foo = $foo;
+    }
+}

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -14,6 +14,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\TestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use FOS\UserBundle\FOSUserBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
+use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -33,6 +34,7 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new TwigBundle(),
             new DoctrineBundle(),
+            new SensioFrameworkExtraBundle(),
             new ApiPlatformBundle(),
             new SecurityBundle(),
             new FOSUserBundle(),

--- a/tests/Fixtures/app/config/routing.yml
+++ b/tests/Fixtures/app/config/routing.yml
@@ -11,3 +11,7 @@ relation_embedded.custom_get:
     methods:  ['GET', 'HEAD']
     defaults:
         _controller:     'TestBundle:Custom:custom'
+
+controller:
+    resource: "@TestBundle/Controller"
+    type:     annotation

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -24,7 +24,7 @@ class RequestAttributesExtractorTest extends \PHPUnit_Framework_TestCase
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'collection_operation_name' => 'post', 'request' => true],
+            ['resource_class' => 'Foo', 'collection_operation_name' => 'post', 'receive' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
     }
@@ -34,31 +34,31 @@ class RequestAttributesExtractorTest extends \PHPUnit_Framework_TestCase
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => true],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
     }
 
-    public function testExtractRequest()
+    public function testExtractReceive()
     {
-        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_request' => '0']);
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_receive' => '0']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => false],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => false],
             RequestAttributesExtractor::extractAttributes($request)
         );
 
-        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_request' => '1']);
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_receive' => '1']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => true],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => true],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
     }

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -61,7 +61,6 @@ class RequestAttributesExtractorTest extends \PHPUnit_Framework_TestCase
             ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
-
     }
 
     /**

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -24,7 +24,7 @@ class RequestAttributesExtractorTest extends \PHPUnit_Framework_TestCase
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'collection_operation_name' => 'post'],
+            ['resource_class' => 'Foo', 'collection_operation_name' => 'post', 'request' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
     }
@@ -34,9 +34,34 @@ class RequestAttributesExtractorTest extends \PHPUnit_Framework_TestCase
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get'],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
+    }
+
+    public function testExtractRequest()
+    {
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_request' => '0']);
+
+        $this->assertEquals(
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => false],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_request' => '1']);
+
+        $this->assertEquals(
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => true],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
+
+        $this->assertEquals(
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'request' => true],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #880, #781, #782, #805
| License       | MIT
| Doc PR        | todo

To disable all API Platform request listeners (read, deserialize and validate), you have to create a new request attribute (for instance by setting the `defaults` key in a route definition) called `api_request` to false.

ping @lyrixx, @kbsali, @gpenverne.
