### PR TITLE
Make missed classes final and remove some unused code

### DIFF
--- a/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
@@ -25,7 +25,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-class CollectionDataProvider implements CollectionDataProviderInterface
+final class CollectionDataProvider implements CollectionDataProviderInterface
 {
     private $managerRegistry;
     private $collectionExtensions;

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -31,11 +31,10 @@ use Doctrine\ORM\QueryBuilder;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-class ItemDataProvider implements ItemDataProviderInterface
+final class ItemDataProvider implements ItemDataProviderInterface
 {
     private $managerRegistry;
     private $propertyNameCollectionFactory;
-    private $propertyMetadataFactory;
     private $itemExtensions;
 
     /**
@@ -48,7 +47,6 @@ class ItemDataProvider implements ItemDataProviderInterface
     {
         $this->managerRegistry = $managerRegistry;
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
-        $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->itemExtensions = $itemExtensions;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | n/a

The data providers have been missed but they must be final as they aren't designed to be extended. It's a BC break but IMO it's necessary.

I've also removed some unused code (the parameter is unused too but removing it will be a bigger BC break).

WDYT @api-platform/core-team 