### PR TITLE
Fix the FOSUser config

### DIFF
--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -57,6 +57,9 @@ fos_user:
     service:
         user_manager: 'app.user_manager'
     user_class:       'ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\User'
+    from_email:
+        address:      'no-reply@les-tilleuls.coop'
+        sender_name:  'Kévin Dunglas'
 
 nelmio_api_doc:
     sandbox:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Sync with last changes in FOSUser. Should make tests green again.