### PR TITLE
Remove deprecated calls to each()

### DIFF
--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -86,8 +86,11 @@ final class AddFormatListener
         }
 
         // Finally, if no Accept header nor Symfony request format is set, return the default format
-        reset($this->formats);
-        $request->setRequestFormat(each($this->formats)['key']);
+        foreach ($this->formats as $format => $mimeType) {
+            $request->setRequestFormat($format);
+
+            return;
+        }
     }
 
     /**

--- a/src/Util/ErrorFormatGuesser.php
+++ b/src/Util/ErrorFormatGuesser.php
@@ -39,8 +39,10 @@ final class ErrorFormatGuesser
             return ['key' => $requestFormat, 'value' => $errorFormats[$requestFormat]];
         }
 
-        reset($errorFormats);
+        foreach ($errorFormats as $key => $value) {
+            return ['key' => $key, 'value' => $value];
+        }
 
-        return each($errorFormats);
+        return [];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

`each()` is deprecated in PHP 7.2. This PR removes calls to this function. 