### PR TITLE
Refactor RequestAttributesExtractor to not throw on the hot path

### DIFF
--- a/src/Bridge/FosUser/EventListener.php
+++ b/src/Bridge/FosUser/EventListener.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\Bridge\FosUser;
 
-use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
@@ -41,9 +40,7 @@ final class EventListener
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
         $request = $event->getRequest();
-        try {
-            RequestAttributesExtractor::extractAttributes($request);
-        } catch (RuntimeException $e) {
+        if (!RequestAttributesExtractor::extractAttributes($request)) {
             return;
         }
 

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -12,7 +12,6 @@
 namespace ApiPlatform\Core\Bridge\Symfony\Validator\EventListener;
 
 use ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException;
-use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -45,17 +44,12 @@ final class ValidateListener
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
         $request = $event->getRequest();
-        if ($request->isMethodSafe(false) || $request->isMethod(Request::METHOD_DELETE)) {
-            return;
-        }
-
-        try {
-            $attributes = RequestAttributesExtractor::extractAttributes($request);
-        } catch (RuntimeException $e) {
-            return;
-        }
-
-        if (!$attributes['receive']) {
+        if (
+            $request->isMethodSafe(false)
+            || $request->isMethod(Request::METHOD_DELETE)
+            || !($attributes = RequestAttributesExtractor::extractAttributes($request))
+            || !$attributes['receive']
+        ) {
             return;
         }
 

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\EventListener;
 
-use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -45,17 +44,12 @@ final class DeserializeListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        if ($request->isMethodSafe(false) || $request->isMethod(Request::METHOD_DELETE)) {
-            return;
-        }
-
-        try {
-            $attributes = RequestAttributesExtractor::extractAttributes($request);
-        } catch (RuntimeException $e) {
-            return;
-        }
-
-        if (!$attributes['receive']) {
+        if (
+            $request->isMethodSafe(false)
+            || $request->isMethod(Request::METHOD_DELETE)
+            || !($attributes = RequestAttributesExtractor::extractAttributes($request))
+            || !$attributes['receive']
+        ) {
             return;
         }
 

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -14,7 +14,6 @@ namespace ApiPlatform\Core\EventListener;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
-use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -46,13 +45,10 @@ final class ReadListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        try {
-            $attributes = RequestAttributesExtractor::extractAttributes($request);
-        } catch (RuntimeException $e) {
-            return;
-        }
-
-        if (!$attributes['receive']) {
+        if (
+            !($attributes = RequestAttributesExtractor::extractAttributes($request))
+            || !$attributes['receive']
+        ) {
             return;
         }
 

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -50,9 +50,7 @@ final class SerializeListener
             return;
         }
 
-        try {
-            $attributes = RequestAttributesExtractor::extractAttributes($request);
-        } catch (RuntimeException $e) {
+        if (!$attributes = RequestAttributesExtractor::extractAttributes($request)) {
             $this->serializeRawData($event, $request, $controllerResult);
 
             return;

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace ApiPlatform\Core\Serializer;
 
+use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,8 +35,8 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
      */
     public function createFromRequest(Request $request, bool $normalization, array $attributes = null): array
     {
-        if (null === $attributes) {
-            $attributes = RequestAttributesExtractor::extractAttributes($request);
+        if (null === $attributes && !$attributes = RequestAttributesExtractor::extractAttributes($request)) {
+            throw new RuntimeException('Request attributes are not valid.');
         }
 
         $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);

--- a/src/Util/RequestAttributesExtractor.php
+++ b/src/Util/RequestAttributesExtractor.php
@@ -11,7 +11,6 @@
 
 namespace ApiPlatform\Core\Util;
 
-use ApiPlatform\Core\Exception\RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -28,12 +27,10 @@ final class RequestAttributesExtractor
     }
 
     /**
-     * Extracts resource class, operation name and format request attributes. Throws an exception if the request does not
-     * contain required attributes.
+     * Extracts resource class, operation name and format request attributes. Returns an empty array if the request does
+     * not contain required attributes.
      *
      * @param Request $request
-     *
-     * @throws RuntimeException
      *
      * @return array
      */
@@ -42,7 +39,7 @@ final class RequestAttributesExtractor
         $result = ['resource_class' => $request->attributes->get('_api_resource_class')];
 
         if (null === $result['resource_class']) {
-            throw new RuntimeException('The request attribute "_api_resource_class" must be defined.');
+            return [];
         }
 
         $collectionOperationName = $request->attributes->get('_api_collection_operation_name');
@@ -53,7 +50,7 @@ final class RequestAttributesExtractor
         } elseif ($itemOperationName) {
             $result['item_operation_name'] = $itemOperationName;
         } else {
-            throw new RuntimeException('One of the request attribute "_api_collection_operation_name" or "_api_item_operation_name" must be defined.');
+            return [];
         }
 
         if (null === $apiRequest = $request->attributes->get('_api_receive')) {

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -63,21 +63,13 @@ class RequestAttributesExtractorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \ApiPlatform\Core\Exception\RuntimeException
-     * @expectedExceptionMessage The request attribute "_api_resource_class" must be defined.
-     */
     public function testResourceClassNotSet()
     {
-        RequestAttributesExtractor::extractAttributes(new Request([], [], ['_api_item_operation_name' => 'get']));
+        $this->assertEmpty(RequestAttributesExtractor::extractAttributes(new Request([], [], ['_api_item_operation_name' => 'get'])));
     }
 
-    /**
-     * @expectedException \ApiPlatform\Core\Exception\RuntimeException
-     * @expectedExceptionMessage One of the request attribute "_api_collection_operation_name" or "_api_item_operation_name" must be defined.
-     */
     public function testOperationNotSet()
     {
-        RequestAttributesExtractor::extractAttributes(new Request([], [], ['_api_resource_class' => 'Foo']));
+        $this->assertEmpty(RequestAttributesExtractor::extractAttributes(new Request([], [], ['_api_resource_class' => 'Foo'])));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

As suggested by @lyrixx [on Twitter](https://twitter.com/lyrixx/status/831900318539640833), throwing an exception on the hot execution path is bad for performance. This PR improves the situation.