### PR TITLE
Fix #944 - allows to filter by relation by keeping EagerLoading enabled

### DIFF
--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -395,18 +395,18 @@ Feature: Date filter on collections
     And the JSON should be equal to:
     """
     {
-          "@context": "\/contexts\/Dummy",
-          "@id": "\/dummies",
+          "@context": "/contexts/Dummy",
+          "@id": "/dummies",
           "@type": "hydra:Collection",
           "hydra:member": [],
           "hydra:totalItems": 0,
           "hydra:view": {
-              "@id": "\/dummies?relatedDummy.dummyDate%5Bafter%5D=2015-04-28",
+              "@id": "/dummies?relatedDummy.dummyDate%5Bafter%5D=2015-04-28",
               "@type": "hydra:PartialCollectionView"
           },
           "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,order[id],order[name],order[relatedDummy.symfony],dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],dummyBoolean,dummyFloat,dummyPrice}",
+              "hydra:template": "/dummies{?id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,order[id],order[name],order[relatedDummy.symfony],dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],dummyBoolean,dummyFloat,dummyPrice}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -467,6 +467,12 @@ Feature: Date filter on collections
                       "@type": "IriTemplateMapping",
                       "variable": "dummy",
                       "property": "dummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies.name",
+                      "property": "relatedDummies.name",
                       "required": false
                   },
                   {

--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -123,7 +123,7 @@ Feature: Create-Retrieve-Update-Delete
       "hydra:totalItems": 1,
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "/dummies{?id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,order[id],order[name],order[relatedDummy.symfony],dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],dummyBoolean,dummyFloat,dummyPrice}",
+        "hydra:template": "/dummies{?id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,order[id],order[name],order[relatedDummy.symfony],dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],dummyBoolean,dummyFloat,dummyPrice}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -184,6 +184,12 @@ Feature: Create-Retrieve-Update-Delete
             "@type": "IriTemplateMapping",
             "variable": "dummy",
             "property": "dummy",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedDummies.name",
+            "property": "relatedDummies.name",
             "required": false
           },
           {

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -60,13 +60,13 @@ Feature: Relations support
       "@context": "/contexts/RelatedDummy",
       "@id": "/related_dummies/1",
       "@type": "https://schema.org/Product",
+      "id": 1,
       "name": null,
+      "symfony": "symfony",
       "dummyDate": null,
       "thirdLevel": "/third_levels/1",
-      "relatedToDummyFriend": null,
+      "relatedToDummyFriend": [],
       "dummyBoolean": null,
-      "id": 1,
-      "symfony": "symfony",
       "age": null
     }
     """

--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Fixes filters on OneToMany associations
+ * https://github.com/api-platform/core/issues/944.
+ */
+final class FilterEagerLoadingExtension implements QueryCollectionExtensionInterface
+{
+    private $resourceMetadataFactory;
+    private $forceEager;
+
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, $forceEager = true)
+    {
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->forceEager = $forceEager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+        if (false === $this->forceEager || false === $this->isForceEager($resourceClass, ['collection_operation_name' => $operationName])) {
+            return;
+        }
+
+        //If no where part, nothing to do
+        $wherePart = $queryBuilder->getDQLPart('where');
+
+        if (!$wherePart) {
+            return;
+        }
+
+        $joinParts = $queryBuilder->getDQLPart('join');
+
+        if (!$joinParts || !isset($joinParts['o'])) {
+            return;
+        }
+
+        $queryBuilderClone = clone $queryBuilder;
+        $queryBuilderClone->resetDQLPart('where');
+        $queryBuilderClone->andWhere($queryBuilderClone->expr()->in('o', $this->getQueryBuilderWithNewAliases($queryBuilder, $queryNameGenerator)->getDQL()));
+
+        $queryBuilder->resetDQLPart('where');
+        foreach ($queryBuilderClone->getDQLPart('where')->getParts() as $wherePart) {
+            $queryBuilder->add('where', $wherePart);
+        }
+    }
+
+    /**
+     * Returns a clone of the given query builder where everything gets re-aliased.
+     *
+     * @param QueryBuilder                $queryBuilder
+     * @param QueryNameGeneratorInterface $queryBuilder
+     * @param string                      $originAlias  - the base alias
+     * @param string                      $replacement  - the replacement for the base alias, will change the from alias
+     */
+    private function getQueryBuilderWithNewAliases(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $originAlias = 'o', string $replacement = 'o_2')
+    {
+        $queryBuilderClone = clone $queryBuilder;
+        $queryBuilderClone->select($replacement);
+
+        $joinParts = $queryBuilder->getDQLPart('join');
+        $wherePart = $queryBuilder->getDQLPart('where');
+
+        //reset parts
+        $queryBuilderClone->resetDQLPart('join');
+        $queryBuilderClone->resetDQLPart('where');
+
+        //Change from alias
+        $from = $queryBuilderClone->getDQLPart('from')[0];
+        $queryBuilderClone->resetDQLPart('from');
+        $queryBuilderClone->from($from->getFrom(), $replacement);
+
+        $aliases = ["$originAlias."];
+        $replacements = ["$replacement."];
+
+        //Change join aliases
+        foreach ($joinParts[$originAlias] as $joinPart) {
+            $aliases[] = "{$joinPart->getAlias()}.";
+            $alias = $queryNameGenerator->generateJoinAlias($joinPart->getAlias());
+            $replacements[] = "$alias.";
+            $join = new Join($joinPart->getJoinType(), str_replace($aliases, $replacements, $joinPart->getJoin()), $alias, $joinPart->getConditionType(), $joinPart->getCondition(), $joinPart->getIndexBy());
+
+            $queryBuilderClone->add('join', [$join], true);
+        }
+
+        //Change where aliases
+        foreach ($wherePart->getParts() as $where) {
+            $queryBuilderClone->add('where', str_replace($aliases, $replacements, $where));
+        }
+
+        return $queryBuilderClone;
+    }
+
+    /**
+     * Does an operation force eager?
+     *
+     * @param string $resourceClass
+     * @param array  $options
+     *
+     * @return bool
+     */
+    private function isForceEager(string $resourceClass, array $options): bool
+    {
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+
+        if (isset($options['collection_operation_name'])) {
+            $forceEager = $resourceMetadata->getCollectionOperationAttribute($options['collection_operation_name'], 'force_eager', null, true);
+        } else {
+            $forceEager = $resourceMetadata->getAttribute('force_eager');
+        }
+
+        return is_bool($forceEager) ? $forceEager : $this->forceEager;
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -105,6 +105,15 @@
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="32" />
         </service>
 
+        <!-- This needs to be executed right after the filter extension -->
+
+        <service id="api_platform.doctrine.orm.query_extension.filter_eager_loading" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\FilterEagerLoadingExtension" public="false">
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument>%api_platform.eager_loading.force_eager%</argument>
+
+            <tag name="api_platform.doctrine.orm.query_extension.collection" priority="31" />
+        </service>
+
         <service id="api_platform.doctrine.orm.query_extension.pagination" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\PaginationExtension" public="false">
             <argument type="service" id="doctrine" />
             <argument type="service" id="request_stack" />

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Doctrine\Orm\Extension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\FilterEagerLoadingExtension;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class FilterEagerLoadingExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsNoForceEagerCollectionAttributes()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class, null, null, null, [
+            'get' => [
+                'force_eager' => false,
+            ],
+        ], null));
+
+        $qb = $this->prophesize(QueryBuilder::class);
+        $qb->getDQLPart('where')->shouldNotBeCalled();
+
+        $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
+
+        $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), true);
+        $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
+    }
+
+    public function testIsNoForceEagerResource()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class, null, null, null, [
+            'get' => [],
+        ], ['force_eager' => false]));
+
+        $qb = $this->prophesize(QueryBuilder::class);
+        $qb->getDQLPart('where')->shouldNotBeCalled();
+
+        $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
+
+        $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), true);
+        $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, null);
+    }
+
+    public function testIsForceEagerConfig()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class, null, null, null, [
+            'get' => [],
+        ]));
+
+        $qb = $this->prophesize(QueryBuilder::class);
+        $qb->getDQLPart('where')->shouldNotBeCalled();
+
+        $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
+
+        $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), false);
+        $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
+    }
+
+    public function testHasNoWherePart()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class));
+
+        $qb = $this->prophesize(QueryBuilder::class);
+        $qb->getDQLPart('where')->shouldBeCalled()->willReturn(null);
+
+        $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
+
+        $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), true);
+        $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
+    }
+
+    public function testHasNoJoinPart()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class));
+
+        $qb = $this->prophesize(QueryBuilder::class);
+        $qb->getDQLPart('where')->shouldBeCalled()->willReturn(new Expr\Andx());
+        $qb->getDQLPart('join')->shouldBeCalled()->willReturn(null);
+
+        $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
+
+        $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), true);
+        $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
+    }
+
+    public function testApplyCollection()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class));
+
+        $em = $this->prophesize(EntityManager::class);
+        $em->getExpressionBuilder()->shouldBeCalled()->willReturn(new Expr());
+
+        $qb = new QueryBuilder($em->reveal());
+
+        $qb->select('o')
+            ->from(DummyCar::class, 'o')
+            ->leftJoin('o.colors', 'colors')
+            ->where('o.colors = :foo')
+            ->setParameter('foo', 1);
+
+        $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
+        $queryNameGenerator->generateJoinAlias('colors')->shouldBeCalled()->willReturn('colors_2');
+
+        $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), true);
+        $filterEagerLoadingExtension->applyToCollection($qb, $queryNameGenerator->reveal(), DummyCar::class, 'get');
+
+        $this->assertEquals('SELECT o FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar o LEFT JOIN o.colors colors WHERE o IN(SELECT o_2 FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar o_2 LEFT JOIN o_2.colors colors_2 WHERE o_2.colors = :foo)', $qb->getDQL());
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -249,6 +249,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.doctrine.orm.order_filter',
             'api_platform.doctrine.orm.query_extension.eager_loading',
             'api_platform.doctrine.orm.query_extension.filter',
+            'api_platform.doctrine.orm.query_extension.filter_eager_loading',
             'api_platform.doctrine.orm.query_extension.order',
             'api_platform.doctrine.orm.query_extension.pagination',
             'api_platform.doctrine.orm.range_filter',

--- a/tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation as Serializer;
+
+/**
+ * @ApiResource(
+ *     attributes={
+ *          "normalization_context"={"groups"={"colors"}},
+ *          "filters"={"dummy_car_colors.search_filter"}
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class DummyCar
+{
+    /**
+     * @var int The entity Id
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @var string Something else
+     *
+     * @ORM\OneToMany(targetEntity="DummyCarColor", mappedBy="car")
+     *
+     * @Serializer\Groups({"colors"})
+     */
+    private $colors;
+
+    public function __construct()
+    {
+        $this->colors = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getColors()
+    {
+        return $this->colors;
+    }
+
+    /**
+     * @param string $colors
+     *
+     * @return static
+     */
+    public function setColors($colors)
+    {
+        $this->colors = $colors;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyCarColor.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCarColor.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation as Serializer;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class DummyCarColor
+{
+    /**
+     * @var int The entity Id
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @var DummyCar
+     *
+     * @ORM\ManyToOne(targetEntity="DummyCar", inversedBy="colors")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     * @Assert\NotBlank
+     */
+    private $car;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(nullable=false)
+     * @Assert\NotBlank
+     *
+     * @Serializer\Groups({"colors"})
+     */
+    private $prop = '';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return DummyCar|null
+     */
+    public function getCar()
+    {
+        return $this->car;
+    }
+
+    /**
+     * @param DummyCar $car
+     *
+     * @return static
+     */
+    public function setCar(DummyCar $car)
+    {
+        $this->car = $car;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProp()
+    {
+        return $this->prop;
+    }
+
+    /**
+     * @param string $prop
+     *
+     * @return static
+     */
+    public function setProp($prop)
+    {
+        $this->prop = $prop;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyFriend.php
@@ -42,7 +42,7 @@ class DummyFriend
      * @ORM\Column
      * @Assert\NotBlank
      * @ApiProperty(iri="http://schema.org/name")
-     * @Groups({"fakemanytomany"})
+     * @Groups({"fakemanytomany", "friends"})
      */
     private $name;
 

--- a/tests/Fixtures/TestBundle/Entity/ParentDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/ParentDummy.php
@@ -12,6 +12,7 @@
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * Parent Dummy.
@@ -26,6 +27,7 @@ class ParentDummy
      * @var int The age
      *
      * @ORM\Column(type="integer", nullable=true)
+     * @Groups({"friends"})
      */
     private $age;
 

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -12,6 +12,7 @@
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -21,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(iri="https://schema.org/Product")
+ * @ApiResource(iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends"}})
  * @ORM\Entity
  */
 class RelatedDummy extends ParentDummy
@@ -30,6 +31,7 @@ class RelatedDummy extends ParentDummy
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
+     * @Groups({"friends"})
      */
     private $id;
 
@@ -37,12 +39,13 @@ class RelatedDummy extends ParentDummy
      * @var string A name
      *
      * @ORM\Column(nullable=true)
+     * @Groups({"friends"})
      */
     public $name;
 
     /**
      * @ORM\Column
-     * @Groups({"barcelona", "chicago"})
+     * @Groups({"barcelona", "chicago", "friends"})
      */
     protected $symfony = 'symfony';
 
@@ -51,25 +54,32 @@ class RelatedDummy extends ParentDummy
      *
      * @ORM\Column(type="datetime", nullable=true)
      * @Assert\DateTime
+     * @Groups({"friends"})
      */
     public $dummyDate;
 
     /**
      * @ORM\ManyToOne(targetEntity="ThirdLevel", cascade={"persist"})
-     * @Groups({"barcelona", "chicago"})
+     * @Groups({"barcelona", "chicago", "friends"})
      */
     public $thirdLevel;
 
     /**
-     * @ORM\OneToMany(targetEntity="RelatedToDummyFriend", cascade={"persist"}, fetch="EAGER", mappedBy="relatedDummy")
-     * @Groups({"fakemanytomany"})
+     * @ORM\OneToMany(targetEntity="RelatedToDummyFriend", cascade={"persist"}, mappedBy="relatedDummy")
+     * @Groups({"fakemanytomany", "friends"})
      */
     public $relatedToDummyFriend;
+
+    public function __construct()
+    {
+        $this->relatedToDummyFriend = new ArrayCollection();
+    }
 
     /**
      * @var bool A dummy bool
      *
      * @ORM\Column(type="boolean", nullable=true)
+     * @Groups({"friends"})
      */
     public $dummyBoolean;
 
@@ -139,8 +149,8 @@ class RelatedDummy extends ParentDummy
      *
      * @param relatedToDummyFriend the value to set
      */
-    public function setRelatedToDummyFriend(RelatedToDummyFriend $relatedToDummyFriend)
+    public function addRelatedToDummyFriend(RelatedToDummyFriend $relatedToDummyFriend)
     {
-        $this->relatedToDummyFriend = $relatedToDummyFriend;
+        $this->relatedToDummyFriend->add($relatedToDummyFriend);
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
@@ -31,15 +31,15 @@ class RelatedToDummyFriend
      * @ORM\Column
      * @Assert\NotBlank
      * @ApiProperty(iri="http://schema.org/name")
-     * @Groups({"fakemanytomany"})
+     * @Groups({"fakemanytomany", "friends"})
      */
     private $name;
 
     /**
      * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="DummyFriend", fetch="EAGER")
+     * @ORM\ManyToOne(targetEntity="DummyFriend")
      * @ORM\JoinColumn(name="dummyfriend_id", referencedColumnName="id", nullable=false)
-     * @Groups({"fakemanytomany"})
+     * @Groups({"fakemanytomany", "friends"})
      */
     private $dummyFriend;
 

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -94,7 +94,7 @@ services:
 
     app.my_dummy_resource.search_filter:
         parent:    'api_platform.doctrine.orm.search_filter'
-        arguments: [ { 'id': 'exact', 'name': 'partial', 'alias': 'start', 'description': 'word_start', 'relatedDummy.name': 'exact', 'relatedDummies': 'exact', 'dummy': 'ipartial' } ]
+        arguments: [ { 'id': 'exact', 'name': 'partial', 'alias': 'start', 'description': 'word_start', 'relatedDummy.name': 'exact', 'relatedDummies': 'exact', 'dummy': 'ipartial', 'relatedDummies.name': 'start' } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.search' } ]
 
     app.my_dummy_resource.order_filter:
@@ -126,5 +126,17 @@ services:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Action\ConfigCustom'
         arguments: ['@api_platform.item_data_provider']
 
+    app.entity.filter.dummy_car:
+        parent:    'api_platform.doctrine.orm.search_filter'
+        arguments: [ { 'colors.prop': 'ipartial' } ]
+        tags:      [ { name: 'api_platform.filter', id: 'dummy_car_colors.search_filter' } ]
+
+    app.related_dummy_resource.search_filter:
+        parent:    'api_platform.doctrine.orm.search_filter'
+        arguments: [ { 'relatedToDummyFriend.dummyFriend': 'exact' } ]
+        tags:      [ { name: 'api_platform.filter', id: 'related_dummy.friends' } ]
+
+
     logger:
         class: Psr\Log\NullLogger
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #944
| License       | MIT
| Doc PR        | na

/!\ This is probably the worse code I've ever produced here and I hope we can find how to improve it together.

To fix #944 I needed to alter the query generated by the filters and the eager loading extension. To do so, I've added a `FilterEagerLoadingExtension` that patches the Query generated by the `FilterExtension`. 

It runs directly after the `FilterExtension` and transforms the query so that it ends up doing something like:

```
SELECT o, partial bars_a1_p.{id,prop} 
FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo o 
LEFT JOIN o.bars bars_a1_p 
WHERE o IN(
  SELECT p 
  FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo p 
  LEFT JOIN p.bars bars_a1 
  WHERE LOWER(bars_a1.prop) LIKE LOWER(CONCAT('%', :prop_p1, '%'))
)
```

TODO:

- [x] Rename test class Foo/Bar too generic
- [x] Unit tests
- [x] Allow the user to skip this extension so that we can get the relation items filtered (previous behavior that is considered as a bug)
- [x] Prevent the extension from running when `forceEager` is not set
- [x] Performances might be improved slightly by selecting the wanted id with the were clause (removes the JOIN inside the IN and select from that entity directly, but it's complex)
- [x] Test OneToMany
- [x] Test ManyToMany

~~Apologizes to Scrutinizer, that complexity index will be very high -_-.~~