### PR TITLE
Builtin cache invalidation system aka make API Platform fast as hell

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,6 +5,7 @@ default:
         - 'FeatureContext': { doctrine: '@doctrine' }
         - 'HydraContext'
         - 'SwaggerContext'
+        - 'HttpCacheContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
         - 'Behatch\Context\JsonContext'
@@ -26,10 +27,10 @@ coverage:
   suites:
     default:
       contexts:
-      contexts:
         - 'FeatureContext': { doctrine: '@doctrine' }
         - 'HydraContext'
         - 'SwaggerContext'
+        - 'HttpCacheContext'
         - 'CoverageContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "doctrine/orm": "^2.5",
         "doctrine/annotations": "^1.2",
         "friendsofsymfony/user-bundle": "^2.0",
+        "guzzlehttp/guzzle": "^6.0",
         "nelmio/api-doc-bundle": "^2.11.2",
         "php-mock/php-mock-phpunit": "^1.1",
         "phpdocumentor/reflection-docblock": "^3.0",
@@ -63,6 +64,7 @@
     },
     "suggest": {
         "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge.",
+        "guzzlehttp/guzzle": "To use the HTTP cache invalidation system.",
         "phpdocumentor/reflection-docblock": "To support extracting metadata from PHPDoc.",
         "psr/cache-implementation": "To use metadata caching.",
         "symfony/cache": "To have metadata caching when using Symfony integration.",

--- a/features/bootstrap/HttpCacheContext.php
+++ b/features/bootstrap/HttpCacheContext.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Behat\Symfony2Extension\Context\KernelAwareContext;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class HttpCacheContext implements KernelAwareContext
+{
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+
+    public function setKernel(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @Then ":iris" IRIs should be purged
+     */
+    public function irisShouldBePurged(string $iris)
+    {
+        $purger = $this->kernel->getContainer()->get('api_platform.http_cache.purger');
+
+        $purgedIris = implode(',', $purger->getIris());
+        $purger->clear();
+
+        if ($iris !== $purgedIris) {
+            throw new \PHPUnit_Framework_ExpectationFailedException(
+                sprintf('IRIs "%s" does not match expected "%s".', $purgedIris, $iris)
+            );
+        }
+    }
+}

--- a/features/http_cache/headers.feature
+++ b/features/http_cache/headers.feature
@@ -1,0 +1,13 @@
+Feature: Default values of HTTP cache headers
+  In order to make API responses caheable
+  As an API software developer
+  I need to be able to set default cache headers values
+
+  @createSchema
+  @dropSchema
+  Scenario: Cache headers default value
+    When I send a "GET" request to "/relation_embedders"
+    Then the response status code should be 200
+    And the header "Etag" should be equal to '"21248afbca1f242fd3009ac7cdf13293"'
+    And the header "Cache-Control" should be equal to "max-age=60, public, s-maxage=3600"
+    And the header "Vary" should be equal to "Content-Type, Cookie"

--- a/features/http_cache/tags.feature
+++ b/features/http_cache/tags.feature
@@ -1,0 +1,104 @@
+Feature: Cache invalidation through HTTP Cache tags
+  In order to have a fast API
+  As an API software developer
+  I need to store API responses in a cache
+
+  @createSchema
+  Scenario: Create some embedded resources
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/relation_embedders" with body:
+    """
+    {
+      "anotherRelated": {
+        "name": "Related",
+        "thirdLevel": {}
+      }
+    }
+    """
+    Then the response status code should be 201
+    And the header "Cache-Tags" should not exist
+    And "/relation_embedders,/related_dummies,/third_levels" IRIs should be purged
+
+  Scenario: Tags must be set for items
+    When I send a "GET" request to "/relation_embedders/1"
+    Then the response status code should be 200
+    And the header "Cache-Tags" should be equal to "/relation_embedders/1,/related_dummies/1,/third_levels/1"
+
+  Scenario: Create some more resources
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/relation_embedders" with body:
+    """
+    {
+      "anotherRelated": {
+        "name": "Another Related",
+        "thirdLevel": {}
+      }
+    }
+    """
+    Then the response status code should be 201
+    And the header "Cache-Tags" should not exist
+
+  Scenario: Tags must be set for collections
+    When I send a "GET" request to "/relation_embedders"
+    Then the response status code should be 200
+    And the header "Cache-Tags" should be equal to "/relation_embedders/1,/related_dummies/1,/third_levels/1,/relation_embedders/2,/related_dummies/2,/third_levels/2,/relation_embedders"
+
+  Scenario: Purge item on update
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/relation_embedders/1" with body:
+    """
+    {
+      "paris": "France"
+    }
+    """
+    Then the response status code should be 200
+    And the header "Cache-Tags" should not exist
+    And "/relation_embedders,/relation_embedders/1,/related_dummies/1" IRIs should be purged
+
+  Scenario: Purge item and the related collection on update
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "DELETE" request to "/relation_embedders/1"
+    Then the response status code should be 204
+    And the header "Cache-Tags" should not exist
+    And "/relation_embedders,/relation_embedders/1,/related_dummies/1" IRIs should be purged
+
+  Scenario: Create two Relation2
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/relation2s" with body:
+    """
+    {
+    }
+    """
+    And I send a "POST" request to "/relation2s" with body:
+    """
+    {
+    }
+    """
+    Then the response status code should be 201
+
+  Scenario: Embedded collection must be listed in cache tags
+    When I send a "GET" request to "/relation2s/1"
+    Then the header "Cache-Tags" should be equal to "/relation2s/1"
+
+  Scenario: Create a Relation1
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/relation1s" with body:
+    """
+    {
+      "relation2": "/relation2s/1"
+    }
+    """
+    Then the response status code should be 201
+    And "/relation1s,/relation2s/1" IRIs should be purged
+
+  @dropSchema
+  Scenario: Update a Relation1
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/relation1s/1" with body:
+    """
+    {
+      "relation2": "/relation2s/2"
+    }
+    """
+    Then the response status code should be 200
+    And "/relation1s,/relation1s/1,/relation2s/2,/relation2s/1" IRIs should be purged

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -12,12 +12,12 @@ Feature: Subresource support
     And the JSON should be equal to:
     """
     {
-      "@context": "/contexts/Answer",
-      "@id": "/answers/1",
-      "@type": "Answer",
-      "id": 1,
-      "content": "42",
-      "question": "/questions/1"
+        "@context": "\/contexts\/Answer",
+        "@id": "\/answers\/1",
+        "@type": "Answer",
+        "id": 1,
+        "content": "42",
+        "question": "\/questions\/1"
     }
     """
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,10 +4,11 @@ parameters:
     excludes_analyse:
         - tests/Fixtures/app/cache
     ignoreErrors:
-        - '#Call to an undefined method Symfony\\Component\\Routing\\Exception\\ExceptionInterface::getCode()#'
+        - '#Call to an undefined method Symfony\\Component\\Routing\\Exception\\ExceptionInterface::getCode\(\)#'
         - '#Call to an undefined method Prophecy\\Prophecy\\ObjectProphecy::[a-zA-Z0-9_]+\(\)#'
         - '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy::\$[a-zA-Z0-9_]+#'
         - '#Call to an undefined method PHPUnit_Framework_MockObject_MockObject::[a-zA-Z0-9_]+\(\)#'
+        - '#Call to an undefined method Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata::getAssociationMappings\(\)#'
 
         # False positives
         - '#Parameter \#2 \$dqlPart of method Doctrine\\ORM\\QueryBuilder::add\(\) expects Doctrine\\ORM\\Query\\Expr\\Base, Doctrine\\ORM\\Query\\Expr\\Join\[\] given#' # Fixed in Doctrine's master

--- a/src/Api/IdentifiersExtractorInterface.php
+++ b/src/Api/IdentifiersExtractorInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Api;
 
+use ApiPlatform\Core\Exception\RuntimeException;
+
 /**
  * Extracts identifiers for a given Resource according to the retrieved Metadata.
  *

--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Doctrine\EventListener;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\HttpCache\PurgerInterface;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\PersistentCollection;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * Purges responses containing modified entities from the proxy cache.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @experimental
+ */
+final class PurgeHttpCacheListener
+{
+    private $purger;
+    private $iriConverter;
+    private $resourceClassResolver;
+    private $propertyAccessor;
+    private $tags = [];
+
+    public function __construct(PurgerInterface $purger, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->purger = $purger;
+        $this->iriConverter = $iriConverter;
+        $this->resourceClassResolver = $resourceClassResolver;
+        $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
+    }
+
+    /**
+     * Collects tags from the previous and the current version of the updated entities to purge related documents.
+     */
+    public function preUpdate(PreUpdateEventArgs $eventArgs)
+    {
+        $object = $eventArgs->getObject();
+        $this->gatherResourceAndItemTags($object, true);
+
+        $changeSet = $eventArgs->getEntityChangeSet();
+        $associationMappings = $eventArgs->getEntityManager()->getClassMetadata(ClassUtils::getClass($eventArgs->getObject()))->getAssociationMappings();
+
+        foreach ($changeSet as $key => $value) {
+            if (!isset($associationMappings[$key])) {
+                continue;
+            }
+
+            $this->addTagsFor($value[0]);
+            $this->addTagsFor($value[1]);
+        }
+    }
+
+    /**
+     * Collects tags from inserted and deleted entities, including relations.
+     */
+    public function onFlush(OnFlushEventArgs $eventArgs)
+    {
+        $em = $eventArgs->getEntityManager();
+        $uow = $em->getUnitOfWork();
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            $this->gatherResourceAndItemTags($entity, false);
+            $this->gatherRelationTags($em, $entity);
+        }
+
+        foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            $this->gatherResourceAndItemTags($entity, true);
+            $this->gatherRelationTags($em, $entity);
+        }
+
+        foreach ($uow->getScheduledEntityDeletions() as $entity) {
+            $this->gatherResourceAndItemTags($entity, true);
+            $this->gatherRelationTags($em, $entity);
+        }
+    }
+
+    /**
+     * Purges tags collected during this request, and clears the tag list.
+     */
+    public function postFlush()
+    {
+        $this->purger->purge($this->tags);
+        $this->tags = [];
+    }
+
+    private function gatherResourceAndItemTags($entity, bool $purgeItem)
+    {
+        try {
+            $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
+        } catch (InvalidArgumentException $e) {
+            return;
+        }
+
+        $iri = $this->iriConverter->getIriFromResourceClass($resourceClass);
+        $this->tags[$iri] = $iri;
+        if ($purgeItem) {
+            $iri = $this->iriConverter->getIriFromItem($entity);
+            $this->tags[$iri] = $iri;
+        }
+    }
+
+    private function gatherRelationTags(EntityManagerInterface $em, $entity)
+    {
+        $associationMappings = $em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
+        foreach (array_keys($associationMappings) as $property) {
+            $this->addTagsFor($this->propertyAccessor->getValue($entity, $property));
+        }
+    }
+
+    private function addTagsFor($value)
+    {
+        if (!is_array($value) && !$value instanceof \Traversable) {
+            $this->addTagForItem($value);
+
+            return;
+        }
+
+        if ($value instanceof PersistentCollection) {
+            $value = clone $value;
+        }
+
+        foreach ($value as $v) {
+            $this->addTagForItem($v);
+        }
+    }
+
+    private function addTagForItem($value)
+    {
+        try {
+            $iri = $this->iriConverter->getIriFromItem($value);
+            $this->tags[$iri] = $iri;
+        } catch (InvalidArgumentException $e) {
+        } catch (RuntimeException $e) {
+        }
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -19,9 +19,11 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -87,15 +89,18 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $loader->load('security.xml');
         }
 
+        $useDoctrine = isset($bundles['DoctrineBundle']) && class_exists(Version::class);
+
         $this->registerMetadataConfiguration($container, $loader, $bundles, $config['loader_paths']);
         $this->registerOAuthConfiguration($container, $config, $loader);
         $this->registerSwaggerConfiguration($container, $config, $loader);
         $this->registerJsonLdConfiguration($formats, $loader);
         $this->registerJsonHalConfiguration($formats, $loader);
         $this->registerJsonProblemConfiguration($errorFormats, $loader);
-        $this->registerBundlesConfiguration($bundles, $config, $loader);
+        $this->registerBundlesConfiguration($bundles, $config, $loader, $useDoctrine);
         $this->registerCacheConfiguration($container);
-        $this->registerDoctrineExtensionConfiguration($container, $config);
+        $this->registerDoctrineExtensionConfiguration($container, $config, $useDoctrine);
+        $this->registerHttpCache($container, $config, $loader, $useDoctrine);
     }
 
     /**
@@ -129,6 +134,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.collection.pagination.page_parameter_name', $config['collection']['pagination']['page_parameter_name']);
         $container->setParameter('api_platform.collection.pagination.enabled_parameter_name', $config['collection']['pagination']['enabled_parameter_name']);
         $container->setParameter('api_platform.collection.pagination.items_per_page_parameter_name', $config['collection']['pagination']['items_per_page_parameter_name']);
+        $container->setParameter('api_platform.http_cache.etag', $config['http_cache']['etag']);
+        $container->setParameter('api_platform.http_cache.max_age', $config['http_cache']['max_age']);
+        $container->setParameter('api_platform.http_cache.shared_max_age', $config['http_cache']['shared_max_age']);
+        $container->setParameter('api_platform.http_cache.vary', $config['http_cache']['vary']);
+        $container->setParameter('api_platform.http_cache.public', $config['http_cache']['public']);
 
         $container->setAlias('api_platform.operation_path_resolver.default', $config['default_operation_path_resolver']);
 
@@ -308,11 +318,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param string[]      $bundles
      * @param array         $config
      * @param XmlFileLoader $loader
+     * @param bool          $useDoctrine
      */
-    private function registerBundlesConfiguration(array $bundles, array $config, XmlFileLoader $loader)
+    private function registerBundlesConfiguration(array $bundles, array $config, XmlFileLoader $loader, bool $useDoctrine)
     {
         // Doctrine ORM support
-        if (isset($bundles['DoctrineBundle']) && class_exists(Version::class)) {
+        if ($useDoctrine) {
             $loader->load('doctrine_orm.xml');
         }
 
@@ -349,13 +360,48 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      *
      * @param ContainerBuilder $container
      * @param array            $config
+     * @param bool             $useDoctrine
      */
-    private function registerDoctrineExtensionConfiguration(ContainerBuilder $container, array $config)
+    private function registerDoctrineExtensionConfiguration(ContainerBuilder $container, array $config, bool $useDoctrine)
     {
-        if (false === $config['eager_loading']['enabled']) {
-            $container->removeDefinition('api_platform.doctrine.orm.query_extension.eager_loading');
-            $container->removeDefinition('api_platform.doctrine.orm.query_extension.filter_eager_loading');
+        if (!$useDoctrine || $config['eager_loading']['enabled']) {
+            return;
         }
+
+        $container->removeDefinition('api_platform.doctrine.orm.query_extension.eager_loading');
+        $container->removeDefinition('api_platform.doctrine.orm.query_extension.filter_eager_loading');
+    }
+
+    private function registerHttpCache(ContainerBuilder $container, array $config, XmlFileLoader $loader, bool $useDoctrine)
+    {
+        $loader->load('http_cache.xml');
+
+        if (!$config['http_cache']['invalidation']['enabled']) {
+            return;
+        }
+
+        if ($useDoctrine) {
+            $loader->load('doctrine_orm_http_cache_purger.xml');
+        }
+
+        $loader->load('http_cache_tags.xml');
+
+        if (!$config['http_cache']['invalidation']['varnish_urls']) {
+            return;
+        }
+
+        $references = [];
+        foreach ($config['http_cache']['invalidation']['varnish_urls'] as $url) {
+            $id = sprintf('api_platform.http_cache.purger.varnish_client.%s', $url);
+            $references[] = new Reference($id);
+
+            $definition = new ChildDefinition('api_platform.http_cache.purger.varnish_client');
+            $definition->addArgument(['base_uri' => $url]);
+            $container->setDefinition($id, $definition);
+        }
+
+        $container->getDefinition('api_platform.http_cache.purger.varnish')->addArgument($references);
+        $container->setAlias('api_platform.http_cache.purger', 'api_platform.http_cache.purger.varnish');
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -114,6 +114,33 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+
+                ->arrayNode('http_cache')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('etag')->defaultTrue()->info('Automatically generate etags for API responses.')->end()
+                        ->integerNode('max_age')->defaultNull()->info('Default value for the response max age.')->end()
+                        ->integerNode('shared_max_age')->defaultNull()->info('Default value for the response shared (proxy) max age.')->end()
+                        ->arrayNode('vary')
+                            ->defaultValue(['Content-Type'])
+                            ->prototype('scalar')->end()
+                            ->info('Default values of the "Vary" HTTP header.')
+                        ->end()
+                        ->booleanNode('public')->defaultNull()->info('To make all responses public by default.')->end()
+                        ->arrayNode('invalidation')
+                            ->info('Enable the tags-based cache invalidation system.')
+                            ->canBeEnabled()
+                            ->children()
+                                ->arrayNode('varnish_urls')
+                                    ->defaultValue([])
+                                    ->prototype('scalar')->end()
+                                    ->info('URLs of the Varnish servers to purge using cache tags when a resource is updated.')
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+
             ->end();
 
         $this->addExceptionToStatusSection($rootNode);

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_http_cache_purger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_http_cache_purger.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <!-- Event listener -->
+
+        <service id="api_platform.doctrine.listener.http_cache.purge" class="ApiPlatform\Core\Bridge\Doctrine\EventListener\PurgeHttpCacheListener">
+            <argument type="service" id="api_platform.http_cache.purger" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+
+            <tag name="doctrine.event_listener" event="preUpdate" />
+            <tag name="doctrine.event_listener" event="onFlush" />
+            <tag name="doctrine.event_listener" event="postFlush" />
+        </service>
+
+    </services>
+
+</container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/http_cache.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/http_cache.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api_platform.http_cache.listener.response.configure" class="ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener">
+            <argument>%api_platform.http_cache.etag%</argument>
+            <argument>%api_platform.http_cache.max_age%</argument>
+            <argument>%api_platform.http_cache.shared_max_age%</argument>
+            <argument>%api_platform.http_cache.vary%</argument>
+            <argument>%api_platform.http_cache.public%</argument>
+
+            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-1" />
+        </service>
+    </services>
+</container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/http_cache_tags.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/http_cache_tags.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api_platform.http_cache.purger.varnish_client" class="GuzzleHttp\Client" abstract="true" public="false" />
+        <service id="api_platform.http_cache.purger.varnish" class="ApiPlatform\Core\HttpCache\VarnishPurger" public="false" />
+
+        <service id="api_platform.http_cache.listener.response.add_tags" class="ApiPlatform\Core\HttpCache\EventListener\AddTagsListener">
+            <argument type="service" id="api_platform.iri_converter" />
+
+            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-2" />
+        </service>
+    </services>
+</container>

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Util\ClassInfoTrait;
@@ -93,9 +94,15 @@ final class IriConverter implements IriConverterInterface
         $resourceClass = $this->getObjectClass($item);
         $routeName = $this->routeNameResolver->getRouteName($resourceClass, false);
 
-        $identifiers = $this->generateIdentifiersUrl($this->identifiersExtractor->getIdentifiersFromItem($item));
+        try {
+            $identifiers = $this->generateIdentifiersUrl($this->identifiersExtractor->getIdentifiersFromItem($item));
 
-        return $this->router->generate($routeName, ['id' => implode(';', $identifiers)], $referenceType);
+            return $this->router->generate($routeName, ['id' => implode(';', $identifiers)], $referenceType);
+        } catch (RuntimeException $e) {
+            throw new InvalidArgumentException(sprintf('Unable to generate an IRI for the item of type "%s"', $resourceClass));
+        } catch (RoutingExceptionInterface $e) {
+            throw new InvalidArgumentException(sprintf('Unable to generate an IRI for the item of type "%s"', $resourceClass));
+        }
     }
 
     /**

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -59,9 +59,13 @@ final class SerializeListener
         }
 
         $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
-        $request->attributes->set('_api_respond', true);
+        $resources = [];
+        $context['resources'] = &$resources;
 
         $event->setControllerResult($this->serializer->serialize($controllerResult, $request->getRequestFormat(), $context));
+
+        $request->attributes->set('_api_respond', true);
+        $request->attributes->set('_resources', $request->attributes->get('_resources', []) + $resources);
     }
 
     /**

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -46,13 +46,15 @@ final class ItemNormalizer extends AbstractItemNormalizer
         $context['cache_key'] = $this->getHalCacheKey($format, $context);
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
         $context = $this->initContext($resourceClass, $context);
+        $context['iri'] = $this->iriConverter->getIriFromItem($object);
+        $context['api_normalize'] = true;
 
         $rawData = parent::normalize($object, $format, $context);
         if (!is_array($rawData)) {
             return $rawData;
         }
 
-        $data = ['_links' => ['self' => ['href' => $this->iriConverter->getIriFromItem($object)]]];
+        $data = ['_links' => ['self' => ['href' => $context['iri']]]];
         $components = $this->getComponents($object, $format, $context);
         $data = $this->populateRelation($data, $object, $format, $context, $components, 'links');
         $data = $this->populateRelation($data, $object, $format, $context, $components, 'embedded');

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\HttpCache\EventListener;
+
+use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Configures cache HTTP headers for the current response.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @experimental
+ */
+final class AddHeadersListener
+{
+    private $etag;
+    private $maxAge;
+    private $sharedMaxage;
+    private $vary;
+    private $public;
+
+    public function __construct(bool $etag = false, int $maxAge = null, int $sharedMaxAge = null, array $vary = null, bool $public = null)
+    {
+        $this->etag = $etag;
+        $this->maxAge = $maxAge;
+        $this->sharedMaxage = $sharedMaxAge;
+        $this->vary = $vary;
+        $this->public = $public;
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        if (!$request->isMethodCacheable() || !RequestAttributesExtractor::extractAttributes($request)) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        if ($this->etag) {
+            $response->setEtag(md5($response->getContent()));
+        }
+
+        if (null !== $this->maxAge) {
+            $response->setMaxAge($this->maxAge);
+        }
+
+        if (null !== $this->vary) {
+            $response->setVary($this->vary);
+        }
+
+        if (null !== $this->sharedMaxage) {
+            $response->setSharedMaxAge($this->sharedMaxage);
+        }
+
+        if (null !== $this->public) {
+            $this->public ? $response->setPublic() : $response->setPrivate();
+        }
+    }
+}

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\HttpCache\EventListener;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Sets the list of resources' IRIs included in this response in the "Cache-Tags" HTTP header.
+ *
+ * The "Cache-Tags" is used because it is supported by CloudFlare.
+ *
+ * @see https://support.cloudflare.com/hc/en-us/articles/206596608-How-to-Purge-Cache-Using-Cache-Tags-Enterprise-only-
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @experimental
+ */
+final class AddTagsListener
+{
+    private $iriConverter;
+
+    public function __construct(IriConverterInterface $iriConverter)
+    {
+        $this->iriConverter = $iriConverter;
+    }
+
+    /**
+     * Adds the "Cache-Tags" header.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+
+        if (
+            !$request->isMethodCacheable()
+            || !$response->isCacheable()
+            || (!$attributes = RequestAttributesExtractor::extractAttributes($request))
+            || !$resources = $request->attributes->get('_resources')
+        ) {
+            return;
+        }
+
+        if (isset($attributes['collection_operation_name'])) {
+            // Allows to purge collections
+            $iri = $this->iriConverter->getIriFromResourceClass($attributes['resource_class']);
+            $resources[$iri] = $iri;
+        }
+
+        if (!$resources) {
+            return;
+        }
+
+        $event->getResponse()->headers->set('Cache-Tags', implode(',', $resources));
+    }
+}

--- a/src/HttpCache/PurgerInterface.php
+++ b/src/HttpCache/PurgerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\HttpCache;
+
+/**
+ * Purges resources from the cache.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @experimental
+ */
+interface PurgerInterface
+{
+    /**
+     * Purges all responses containing the given resources from the cache.
+     *
+     * @param string[] $iris
+     */
+    public function purge(array $iris);
+}

--- a/src/HttpCache/VarnishPurger.php
+++ b/src/HttpCache/VarnishPurger.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\HttpCache;
+
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Purges Varnish.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @experimental
+ */
+final class VarnishPurger implements PurgerInterface
+{
+    private $clients;
+
+    /**
+     * @param ClientInterface[] $clients
+     */
+    public function __construct(array $clients)
+    {
+        $this->clients = $clients;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purge(array $iris)
+    {
+        if (!$iris) {
+            return;
+        }
+
+        // Create the regex to purge all tags in just one request
+        $parts = array_map(function ($iri) {
+            return sprintf('(^|\,)%s($|\,)', preg_quote($iri));
+        }, $iris);
+
+        $regex = isset($parts[1]) ? sprintf('(%s)', implode(')|(', $parts)) : $parts[0];
+
+        foreach ($this->clients as $client) {
+            $client->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => $regex]]);
+        }
+    }
+}

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -68,13 +68,14 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
         // Use resolved resource class instead of given resource class to support multiple inheritance child types
         $context['resource_class'] = $resourceClass;
+        $context['iri'] = $this->iriConverter->getIriFromItem($object);
 
         $rawData = parent::normalize($object, $format, $context);
         if (!is_array($rawData)) {
             return $rawData;
         }
 
-        $data['@id'] = $this->iriConverter->getIriFromItem($object);
+        $data['@id'] = $context['iri'];
         $data['@type'] = $resourceMetadata->getIri() ?: $resourceMetadata->getShortName();
 
         return $data + $rawData;

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -86,6 +86,11 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $context = $this->initContext($resourceClass, $context);
         $context['api_normalize'] = true;
 
+        if (isset($context['resources'])) {
+            $resource = $context['iri'] ?? $this->iriConverter->getIriFromItem($object);
+            $context['resources'][$resource] = $resource;
+        }
+
         return parent::normalize($object, $format, $context);
     }
 
@@ -432,6 +437,11 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $this->serializer->normalize($relatedObject, $format, $this->createRelationSerializationContext($resourceClass, $context));
         }
 
-        return $this->iriConverter->getIriFromItem($relatedObject);
+        $iri = $this->iriConverter->getIriFromItem($relatedObject);
+        if (isset($context['resources'])) {
+            $context['resources'][$iri] = $iri;
+        }
+
+        return $iri;
     }
 }

--- a/src/Util/RequestAttributesExtractor.php
+++ b/src/Util/RequestAttributesExtractor.php
@@ -39,9 +39,7 @@ final class RequestAttributesExtractor
      */
     public static function extractAttributes(Request $request)
     {
-        $result = [
-            'resource_class' => $request->attributes->get('_api_resource_class'),
-        ];
+        $result = ['resource_class' => $request->attributes->get('_api_resource_class')];
 
         if ($subresourceContext = $request->attributes->get('_api_subresource_context')) {
             $result['subresource_context'] = $subresourceContext;

--- a/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Doctrine\EventListener;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Bridge\Doctrine\EventListener\PurgeHttpCacheListener;
+use ApiPlatform\Core\HttpCache\PurgerInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use Prophecy\Argument;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class PurgeHttpCacheListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOnFlush()
+    {
+        $toInsert1 = new Dummy();
+        $toInsert2 = new Dummy();
+
+        $toUpdate1 = new Dummy();
+        $toUpdate1->setId(1);
+        $toUpdate2 = new Dummy();
+        $toUpdate2->setId(2);
+
+        $toDelete1 = new Dummy();
+        $toDelete1->setId(3);
+        $toDelete2 = new Dummy();
+        $toDelete2->setId(4);
+
+        $purgerProphecy = $this->prophesize(PurgerInterface::class);
+        $purgerProphecy->purge(['/dummies' => '/dummies', '/dummies/1' => '/dummies/1', '/dummies/2' => '/dummies/2', '/dummies/3' => '/dummies/3', '/dummies/4' => '/dummies/4'])->shouldBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($toUpdate1)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($toUpdate2)->willReturn('/dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($toDelete1)->willReturn('/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($toDelete2)->willReturn('/dummies/4')->shouldBeCalled();
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class)->shouldBeCalled();
+
+        $uowProphecy = $this->prophesize(UnitOfWork::class);
+        $uowProphecy->getScheduledEntityInsertions()->willReturn([$toInsert1, $toInsert2])->shouldBeCalled();
+        $uowProphecy->getScheduledEntityUpdates()->willReturn([$toUpdate1, $toUpdate2])->shouldBeCalled();
+        $uowProphecy->getScheduledEntityDeletions()->willReturn([$toDelete1, $toDelete2])->shouldBeCalled();
+
+        $emProphecy = $this->prophesize(EntityManagerInterface::class);
+        $emProphecy->getUnitOfWork()->willReturn($uowProphecy->reveal())->shouldBeCalled();
+        $emProphecy->getClassMetadata(Dummy::class)->willReturn(new ClassMetadata(Dummy::class))->shouldBeCalled();
+        $eventArgs = new OnFlushEventArgs($emProphecy->reveal());
+
+        $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal());
+        $listener->onFlush($eventArgs);
+        $listener->postFlush();
+    }
+
+    public function testPreUpdate()
+    {
+        $oldRelatedDummy = new RelatedDummy();
+        $oldRelatedDummy->setId(1);
+
+        $newRelatedDummy = new RelatedDummy();
+        $newRelatedDummy->setId(2);
+
+        $dummy = new Dummy();
+        $dummy->setId(1);
+
+        $purgerProphecy = $this->prophesize(PurgerInterface::class);
+        $purgerProphecy->purge(['/dummies' => '/dummies', '/dummies/1' => '/dummies/1', '/related_dummies/old' => '/related_dummies/old', '/related_dummies/new' => '/related_dummies/new'])->shouldBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($oldRelatedDummy)->willReturn('/related_dummies/old')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($newRelatedDummy)->willReturn('/related_dummies/new')->shouldBeCalled();
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class)->shouldBeCalled();
+
+        $emProphecy = $this->prophesize(EntityManagerInterface::class);
+
+        $classMetadata = new ClassMetadata(Dummy::class);
+        $classMetadata->mapManyToOne(['fieldName' => 'relatedDummy', 'targetEntity' => RelatedDummy::class]);
+        $emProphecy->getClassMetadata(Dummy::class)->willReturn($classMetadata)->shouldBeCalled();
+
+        $changeSet = ['relatedDummy' => [$oldRelatedDummy, $newRelatedDummy]];
+        $eventArgs = new PreUpdateEventArgs($dummy, $emProphecy->reveal(), $changeSet);
+
+        $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal());
+        $listener->preUpdate($eventArgs);
+        $listener->postFlush();
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -45,6 +45,10 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'jsonld' => ['mime_types' => ['application/ld+json']],
             'jsonhal' => ['mime_types' => ['application/hal+json']],
         ],
+        'http_cache' => ['invalidation' => [
+            'enabled' => true,
+            'varnish_urls' => ['test'],
+        ]],
     ]];
 
     private $extension;
@@ -189,7 +193,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['enable_nelmio_api_doc' => true]]), $containerBuilder);
     }
 
-    public function testEnablSecurity()
+    public function testEnableSecurity()
     {
         $containerBuilderProphecy = $this->getContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
@@ -256,6 +260,11 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.eager_loading.force_eager' => true,
             'api_platform.eager_loading.fetch_partial' => false,
             'api_platform.resource_class_directories' => [],
+            'api_platform.http_cache.etag' => true,
+            'api_platform.http_cache.max_age' => null,
+            'api_platform.http_cache.shared_max_age' => null,
+            'api_platform.http_cache.vary' => ['Content-Type'],
+            'api_platform.http_cache.public' => null,
         ];
         foreach ($parameters as $key => $value) {
             $containerBuilderProphecy->setParameter($key, $value)->shouldBeCalled();
@@ -304,6 +313,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.doctrine.orm.subresource_data_provider',
             'api_platform.filter_locator',
             'api_platform.filter_collection_factory',
+            'api_platform.doctrine.listener.http_cache.purge',
             'api_platform.filters',
             'api_platform.doctrine.listener.view.write',
             'api_platform.jsonld.normalizer.item',
@@ -393,6 +403,11 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.swagger.action.ui',
             'api_platform.swagger.command.swagger_command',
             'api_platform.swagger.normalizer.documentation',
+            'api_platform.http_cache.listener.response.configure',
+            'api_platform.http_cache.purger.varnish',
+            'api_platform.http_cache.purger.varnish_client',
+            'api_platform.http_cache.listener.response.add_tags',
+            'api_platform.http_cache.purger.varnish_client.test',
         ];
 
         foreach ($definitions as $definition) {
@@ -415,6 +430,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.property_accessor' => 'property_accessor',
             'api_platform.property_info' => 'property_info',
             'api_platform.serializer' => 'serializer',
+            'api_platform.http_cache.purger' => 'api_platform.http_cache.purger.varnish',
         ];
 
         foreach ($aliases as $alias => $service) {
@@ -423,6 +439,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
         $containerBuilderProphecy->getParameter('kernel.debug')->willReturn(false);
         $containerBuilderProphecy->getParameter('api_platform.api_resources_directory')->willReturn('Entity');
+        $containerBuilderProphecy->getDefinition('api_platform.http_cache.purger.varnish')->willReturn(new Definition());
 
         return $containerBuilderProphecy;
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -109,6 +109,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'xml' => [],
             ],
             'api_resources_directory' => 'Entity',
+            'http_cache' => [
+                'invalidation' => ['enabled' => false, 'varnish_urls' => []],
+                'etag' => true,
+                'max_age' => null,
+                'shared_max_age' => null,
+                'vary' => ['Content-Type'],
+                'public' => null,
+            ],
         ], $config);
     }
 

--- a/tests/EventListener/SerializeListenerTest.php
+++ b/tests/EventListener/SerializeListenerTest.php
@@ -102,7 +102,7 @@ class SerializeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializeCollectionOperation()
     {
-        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'collection_operation_name' => 'get'];
+        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'collection_operation_name' => 'get', 'resources' => []];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->serialize(Argument::any(), 'xml', $expectedContext)->willReturn('bar')->shouldBeCalled();
 
@@ -123,7 +123,7 @@ class SerializeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializeItemOperation()
     {
-        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'item_operation_name' => 'get'];
+        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'item_operation_name' => 'get', 'resources' => []];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->serialize(Argument::any(), 'xml', $expectedContext)->willReturn('bar')->shouldBeCalled();
 

--- a/tests/Fixtures/NullPurger.php
+++ b/tests/Fixtures/NullPurger.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use ApiPlatform\Core\HttpCache\PurgerInterface;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class NullPurger implements PurgerInterface
+{
+    private $iris = [];
+
+    public function purge(array $iris)
+    {
+        $this->iris = $iris;
+    }
+
+    public function getIris(): array
+    {
+        return $this->iris;
+    }
+
+    public function clear()
+    {
+        $this->iris = [];
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyAggregateOffer.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyAggregateOffer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -58,61 +59,31 @@ class DummyAggregateOffer
         $this->offers = new ArrayCollection();
     }
 
-    /**
-     * Get offers.
-     *
-     * @return offers
-     */
-    public function getOffers(): ArrayCollection
+    public function getOffers(): Collection
     {
         return $this->offers;
     }
 
-    /**
-     * Set offers.
-     *
-     * @param offers the value to set
-     */
     public function setOffers($offers)
     {
         $this->offers = $offers;
     }
 
-    /**
-     * Add offer.
-     *
-     * @param offer the value to add
-     */
     public function addOffer(DummyOffer $offer)
     {
         $this->offers->add($offer);
     }
 
-    /**
-     * Get id.
-     *
-     * @return id
-     */
-    public function getId(): int
+    public function getId()
     {
         return $this->id;
     }
 
-    /**
-     * Get value.
-     *
-     * @return value
-     */
     public function getValue(): int
     {
         return $this->value;
     }
 
-    /**
-     * Set value.
-     *
-     * @param value the value to set
-     */
     public function setValue(int $value)
     {
         $this->value = $value;

--- a/tests/Fixtures/TestBundle/Entity/DummyOffer.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyOffer.php
@@ -43,31 +43,16 @@ class DummyOffer
      */
     private $value;
 
-    /**
-     * Get id.
-     *
-     * @return id
-     */
-    public function getId(): int
+    public function getId()
     {
         return $this->id;
     }
 
-    /**
-     * Get value.
-     *
-     * @return value
-     */
     public function getValue(): int
     {
         return $this->value;
     }
 
-    /**
-     * Set value.
-     *
-     * @param value the value to set
-     */
     public function setValue(int $value)
     {
         $this->value = $value;

--- a/tests/Fixtures/TestBundle/Entity/DummyProduct.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyProduct.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -39,7 +40,7 @@ class DummyProduct
     private $id;
 
     /**
-     * @var ArrayCollection
+     * @var Collection
      *
      * @ApiProperty(subresource=true)
      * @ORM\OneToMany(targetEntity="DummyAggregateOffer", mappedBy="id", cascade={"persist"})
@@ -58,61 +59,31 @@ class DummyProduct
         $this->offers = new ArrayCollection();
     }
 
-    /**
-     * Get offers.
-     *
-     * @return offers
-     */
-    public function getOffers(): ArrayCollection
+    public function getOffers(): Collection
     {
         return $this->offers;
     }
 
-    /**
-     * Set offers.
-     *
-     * @param offers the value to set
-     */
     public function setOffers($offers)
     {
         $this->offers = $offers;
     }
 
-    /**
-     * Add offer.
-     *
-     * @param offer the value to add
-     */
     public function addOffer(DummyAggregateOffer $offer)
     {
         $this->offers->add($offer);
     }
 
-    /**
-     * Get id.
-     *
-     * @return id
-     */
-    public function getId(): int
+    public function getId()
     {
         return $this->id;
     }
 
-    /**
-     * Get name.
-     *
-     * @return name
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set name.
-     *
-     * @param name the value to set
-     */
     public function setName($name)
     {
         $this->name = $name;

--- a/tests/Fixtures/TestBundle/Entity/Relation1.php
+++ b/tests/Fixtures/TestBundle/Entity/Relation1.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Relation1
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Relation2", inversedBy="relation1s")
+     */
+    public $relation2;
+}

--- a/tests/Fixtures/TestBundle/Entity/Relation2.php
+++ b/tests/Fixtures/TestBundle/Entity/Relation2.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Relation2
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Relation1", mappedBy="relation2")
+     */
+    public $relation1s;
+
+    public function __construct()
+    {
+        $this->relation1s = new ArrayCollection();
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
+++ b/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
@@ -29,6 +29,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * }, itemOperations={
  *     "get"={"method"="GET"},
  *     "put"={"method"="PUT"},
+ *     "delete"={"method"="DELETE"},
  *     "custom_get"={"route_name"="relation_embedded.custom_get"},
  *     "custom1"={"path"="/api/custom-call/{id}", "method"="GET"},
  *     "custom2"={"path"="/api/custom-call/{id}", "method"="PUT"},

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -15,7 +15,7 @@ framework:
         storage_id:                    'session.storage.mock_file'
     form:                              ~ # For FOSUser
     templating:
-        engines:                       ['twig'] # For Swagger YU
+        engines:                       ['twig'] # For Swagger UI
 
 doctrine:
     dbal:
@@ -49,6 +49,13 @@ api_platform:
     exception_to_status:
         Symfony\Component\Serializer\Exception\ExceptionInterface: 400
         ApiPlatform\Core\Exception\InvalidArgumentException: 'HTTP_BAD_REQUEST'
+    http_cache:
+        invalidation:
+            enabled: true
+        max_age:        60
+        shared_max_age: 3600
+        vary:           ['Content-Type', 'Cookie']
+        public:         true
 
 fos_user:
     db_driver:        'orm'
@@ -157,3 +164,5 @@ services:
     logger:
         class: Psr\Log\NullLogger
 
+    api_platform.http_cache.purger:
+        class: ApiPlatform\Core\Tests\Fixtures\NullPurger

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\HttpCache\EventListener;
+
+use ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class AddHeadersListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDoNotSetHeaderWhenMethodNotCacheable()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $request->setMethod('PUT');
+
+        $response = new Response();
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldNotBeCalled();
+
+        $listener = new AddHeadersListener(true);
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertNull($response->getEtag());
+    }
+
+    public function testDoNotSetHeaderWhenNotAnApiOperation()
+    {
+        $request = new Request();
+        $response = new Response();
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldNotBeCalled();
+
+        $listener = new AddHeadersListener(true);
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertNull($response->getEtag());
+    }
+
+    public function testAddHeaders()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $response = new Response();
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddHeadersListener(true, 100, 200, ['Content-Type'], true);
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('"d41d8cd98f00b204e9800998ecf8427e"', $response->getEtag());
+        $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
+        $this->assertSame(['Content-Type'], $response->getVary());
+    }
+}

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\HttpCache\EventListener;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\HttpCache\EventListener\AddTagsListener;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class AddTagsListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDoNotSetHeaderWhenMethodNotCacheable()
+    {
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $request->setMethod('PUT');
+
+        $response = new Response();
+        $response->setPublic();
+        $response->setEtag('foo');
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertFalse($response->headers->has('Cache-Tags'));
+    }
+
+    public function testDoNotSetHeaderWhenResponseNotCacheable()
+    {
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+
+        $response = new Response();
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertFalse($response->headers->has('Cache-Tags'));
+    }
+
+    public function testDoNotSetHeaderWhenNotAnApiOperation()
+    {
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $request = new Request([], [], ['_resources' => ['/foo', '/bar']]);
+
+        $response = new Response();
+        $response->setPublic();
+        $response->setEtag('foo');
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertFalse($response->headers->has('Cache-Tags'));
+    }
+
+    public function testDoNotSetHeaderWhenEmptyTagList()
+    {
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $request = new Request([], [], ['_resources' => [], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+
+        $response = new Response();
+        $response->setPublic();
+        $response->setEtag('foo');
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertFalse($response->headers->has('Cache-Tags'));
+    }
+
+    public function testAddTags()
+    {
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+
+        $response = new Response();
+        $response->setPublic();
+        $response->setEtag('foo');
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('/foo,/bar', $response->headers->get('Cache-Tags'));
+    }
+
+    public function testAddCollectionIri()
+    {
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+
+        $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get']);
+
+        $response = new Response();
+        $response->setPublic();
+        $response->setEtag('foo');
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('/foo,/bar,/dummies', $response->headers->get('Cache-Tags'));
+    }
+}

--- a/tests/HttpCache/VarnishPurgerTest.php
+++ b/tests/HttpCache/VarnishPurgerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\HttpCache;
+
+use ApiPlatform\Core\HttpCache\VarnishPurger;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class VarnishPurgerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPurge()
+    {
+        $clientProphecy1 = $this->prophesize(ClientInterface::class);
+        $clientProphecy1->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '(^|\,)/foo($|\,)']])->willReturn(new Response())->shouldBeCalled();
+        $clientProphecy1->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))']])->willReturn(new Response())->shouldBeCalled();
+
+        $clientProphecy2 = $this->prophesize(ClientInterface::class);
+        $clientProphecy2->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '(^|\,)/foo($|\,)']])->willReturn(new Response())->shouldBeCalled();
+        $clientProphecy2->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))']])->willReturn(new Response())->shouldBeCalled();
+
+        $purger = new VarnishPurger([$clientProphecy1->reveal(), $clientProphecy2->reveal()]);
+        $purger->purge(['/foo']);
+        $purger->purge(['/foo', '/bar']);
+    }
+
+    public function testEmptyTags()
+    {
+        $clientProphecy1 = $this->prophesize(ClientInterface::class);
+        $clientProphecy1->requestAsync()->shouldNotBeCalled();
+
+        $purger = new VarnishPurger([$clientProphecy1->reveal()]);
+        $purger->purge([]);
+    }
+}

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -112,12 +112,13 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
         )->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/dummies/2')->shouldBeCalled();
 
-        $propertyAccesorProphecy = $this->prophesize(PropertyAccessorInterface::class);
-        $propertyAccesorProphecy->getValue($dummy, 'name')->willReturn('foo')->shouldBeCalled();
-        $propertyAccesorProphecy->getValue($dummy, 'relatedDummy')->willReturn($relatedDummy)->shouldBeCalled();
-        $propertyAccesorProphecy->getValue($dummy, 'relatedDummies')->willReturn(
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $propertyAccessorProphecy->getValue($dummy, 'name')->willReturn('foo')->shouldBeCalled();
+        $propertyAccessorProphecy->getValue($dummy, 'relatedDummy')->willReturn($relatedDummy)->shouldBeCalled();
+        $propertyAccessorProphecy->getValue($dummy, 'relatedDummies')->willReturn(
             new ArrayCollection([$relatedDummy])
         )->shouldBeCalled();
 
@@ -135,7 +136,7 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $iriConverterProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
-            $propertyAccesorProphecy->reveal(),
+            $propertyAccessorProphecy->reveal(),
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
         $normalizer->setIgnoredAttributes(['alias']);
@@ -144,7 +145,7 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
             'name' => 'foo',
             'relatedDummy' => '/dummies/2',
             'relatedDummies' => ['/dummies/2'],
-        ], $normalizer->normalize($dummy));
+        ], $normalizer->normalize($dummy, null, ['resources' => []]));
     }
 
     public function testNormalizeReadableLinks()
@@ -182,6 +183,7 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
         )->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->getValue($dummy, 'relatedDummy')->willReturn($relatedDummy)->shouldBeCalled();
@@ -209,7 +211,7 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'relatedDummy' => ['foo' => 'hello'],
             'relatedDummies' => [['foo' => 'hello']],
-        ], $normalizer->normalize($dummy));
+        ], $normalizer->normalize($dummy, null, ['resources' => []]));
     }
 
     public function testDenormalize()
@@ -614,10 +616,11 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
         )->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
 
-        $propertyAccesorProphecy = $this->prophesize(PropertyAccessorInterface::class);
-        $propertyAccesorProphecy->getValue($dummy, 'name')->willReturn('foo')->shouldBeCalled();
-        $propertyAccesorProphecy->getValue($dummy, 'nickname')->willThrow(new NoSuchPropertyException())->shouldBeCalled();
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $propertyAccessorProphecy->getValue($dummy, 'name')->willReturn('foo')->shouldBeCalled();
+        $propertyAccessorProphecy->getValue($dummy, 'nickname')->willThrow(new NoSuchPropertyException())->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, DummyTableInheritance::class, true)->willReturn(DummyTableInheritance::class)->shouldBeCalled();
@@ -632,13 +635,13 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $iriConverterProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
-            $propertyAccesorProphecy->reveal(),
+            $propertyAccessorProphecy->reveal(),
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
         $this->assertEquals([
             'name' => 'foo',
             'nickname' => null,
-        ], $normalizer->normalize($dummy, null, ['resource_class' => DummyTableInheritance::class]));
+        ], $normalizer->normalize($dummy, null, ['resource_class' => DummyTableInheritance::class, 'resources' => []]));
     }
 }

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -78,6 +78,7 @@ class ItemNormalizerTest extends \PHPUnit_Framework_TestCase
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
@@ -94,7 +95,7 @@ class ItemNormalizerTest extends \PHPUnit_Framework_TestCase
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
-        $this->assertEquals(['name' => 'hello'], $normalizer->normalize($dummy));
+        $this->assertEquals(['name' => 'hello'], $normalizer->normalize($dummy, null, ['resources' => []]));
     }
 
     public function testDenormalize()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

The usual quote:

> There are only two hard things in Computer Science: cache invalidation and naming things.
>
> -- Phil Karlton

Well, API Platform is an awesome name, so this PR try to solve the other hard thing: caching to make your API as fast as possible.

It introduces a builtin mechanism to always serve API responses from a cache (Varnish and CloudFlare are targeted), and invalid stale data in real time when a resource is updated, deleted or created.
With this mechanism, on my computer and using Docker, large and complex responses are served in **~15ms instead of ~700ms** without cache.

The API Platform serializer has been tweaked to store the list of all resources included in a given response (the root document, but also embedded documents and documents appearing in lists).

The response is marked with all resources it contains in the `Cache-Tags` HTTP header. A md5 hash of all included IRIs is generated to prevent collisions and reduce the header size.
Then, all API's responses are stored with a high expiration time in the proxy cache. On all subsequent (read) requests from a client, the response is served from the proxy, the PHP application is not touched.

When a resource is modified (only changes made to Doctrine entities are supported for now), all responses containing or referencing it are purged from the cache.
A class to purge Varnish is provided in this PR, and a class to purge CloudFlare (enterprise plans only) will be provided later. An interface allows to add support for other cache providers.

Paged collections are also handled: if a resource is added or removed, all collection pages are purged. If a resource is edited, pages (and all other API responses, including those embedding it as a nested document) are purged.

Enabling this new feature **doesn't require to change existing code**. The following config enable the mechanism and mades your API instantly blazing fast:

```yaml
api_platform:
    http_cache:
        enable_tags: true
        varnish_url: 'http://my-varnish-proxy'
        shared_max_age: 3600
```

I've also opened a PR to add Varnish with a compatible setup to the API Platform Docker setup: api-platform/api-platform#238.
Last but not least, this PR introduces some config options to set global cache settings. Example:

```yaml
api_platform:
    http_cache:
        max_age: 60
        shared_max_age: 3600
        vary: ['Content-Type', 'Cookie']
```

Note: for advanced needs, prefer the awesome [FosHttpCache library](foshttpcache.readthedocs.io).

As stated in the quote, cache invalidation **is** a hard thing and this PR probably contains bugs and edge cases. Please test it and report any problem.

TODO:
* [x] Add unit tests