### PR TITLE
Added PaginationHelper class

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -52,7 +52,7 @@ final class PaginationExtension implements QueryResultCollectionExtensionInterfa
             return;
         }
 
-        $this->paginationHelper->setResourceAndOperation( $resourceClass, $operationName );
+        $this->paginationHelper->setResourceAndOperation($resourceClass, $operationName);
         if (!$this->paginationHelper->isPaginationEnabled()) {
             return;
         }
@@ -75,7 +75,7 @@ final class PaginationExtension implements QueryResultCollectionExtensionInterfa
             return false;
         }
 
-        $this->paginationHelper->setResourceAndOperation( $resourceClass, $operationName );
+        $this->paginationHelper->setResourceAndOperation($resourceClass, $operationName);
 
         return $this->paginationHelper->isPaginationEnabled();
     }

--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -15,7 +15,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryChecker;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use ApiPlatform\Core\Util\PaginationHelperFactory;
+use ApiPlatform\Core\Util\Factory\PaginationHelperFactory;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator as DoctrineOrmPaginator;

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -188,19 +188,17 @@
 
         <!-- Util -->
 
-        <service id="api_platform.util.pagination_helper" class="ApiPlatform\Core\Util\PaginationHelper">
+        <service id="api_platform.util.pagination_helper_factory" class="ApiPlatform\Core\Util\PaginationHelperFactory">
             <argument type="service" id="request_stack" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
-            <call method="setConfig">
-                <argument>%api_platform.collection.pagination.enabled%</argument>
-                <argument>%api_platform.collection.pagination.client_enabled%</argument>
-                <argument>%api_platform.collection.pagination.client_items_per_page%</argument>
-                <argument>%api_platform.collection.pagination.items_per_page%</argument>
-                <argument>%api_platform.collection.pagination.page_parameter_name%</argument>
-                <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
-                <argument>%api_platform.collection.pagination.items_per_page_parameter_name%</argument>
-                <argument>%api_platform.collection.pagination.maximum_items_per_page%</argument>
-            </call>
+            <argument>%api_platform.collection.pagination.enabled%</argument>
+            <argument>%api_platform.collection.pagination.client_enabled%</argument>
+            <argument>%api_platform.collection.pagination.client_items_per_page%</argument>
+            <argument>%api_platform.collection.pagination.items_per_page%</argument>
+            <argument>%api_platform.collection.pagination.page_parameter_name%</argument>
+            <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
+            <argument>%api_platform.collection.pagination.items_per_page_parameter_name%</argument>
+            <argument>%api_platform.collection.pagination.maximum_items_per_page%</argument>
         </service>
     </services>
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -188,7 +188,7 @@
 
         <!-- Util -->
 
-        <service id="api_platform.util.pagination_helper_factory" class="ApiPlatform\Core\Util\PaginationHelperFactory">
+        <service id="api_platform.util.pagination_helper_factory" class="ApiPlatform\Core\Util\Factory\PaginationHelperFactory">
             <argument type="service" id="request_stack" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument>%api_platform.collection.pagination.enabled%</argument>

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -177,6 +177,23 @@
         <service id="api_platform.cache.route_name_resolver" parent="cache.system" public="false">
             <tag name="cache.pool" />
         </service>
+
+        <!-- Util -->
+
+        <service id="api_platform.util.pagination_helper" class="ApiPlatform\Core\Util\PaginationHelper">
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <call method="setConfig">
+                <argument>%api_platform.collection.pagination.enabled%</argument>
+                <argument>%api_platform.collection.pagination.client_enabled%</argument>
+                <argument>%api_platform.collection.pagination.client_items_per_page%</argument>
+                <argument>%api_platform.collection.pagination.items_per_page%</argument>
+                <argument>%api_platform.collection.pagination.page_parameter_name%</argument>
+                <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
+                <argument>%api_platform.collection.pagination.items_per_page_parameter_name%</argument>
+                <argument>%api_platform.collection.pagination.maximum_items_per_page%</argument>
+            </call>
+        </service>
     </services>
 
 </container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -109,7 +109,15 @@
             <argument type="service" id="doctrine" />
             <argument type="service" id="request_stack" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
-            <argument type="service" id="api_platform.util.pagination_helper" />
+            <argument>%api_platform.collection.pagination.enabled%</argument>
+            <argument>%api_platform.collection.pagination.client_enabled%</argument>
+            <argument>%api_platform.collection.pagination.client_items_per_page%</argument>
+            <argument>%api_platform.collection.pagination.items_per_page%</argument>
+            <argument>%api_platform.collection.pagination.page_parameter_name%</argument>
+            <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
+            <argument>%api_platform.collection.pagination.items_per_page_parameter_name%</argument>
+            <argument>%api_platform.collection.pagination.maximum_items_per_page%</argument>
+            <argument type="service" id="api_platform.util.pagination_helper_factory" />
 
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="8" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -109,14 +109,7 @@
             <argument type="service" id="doctrine" />
             <argument type="service" id="request_stack" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
-            <argument>%api_platform.collection.pagination.enabled%</argument>
-            <argument>%api_platform.collection.pagination.client_enabled%</argument>
-            <argument>%api_platform.collection.pagination.client_items_per_page%</argument>
-            <argument>%api_platform.collection.pagination.items_per_page%</argument>
-            <argument>%api_platform.collection.pagination.page_parameter_name%</argument>
-            <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
-            <argument>%api_platform.collection.pagination.items_per_page_parameter_name%</argument>
-            <argument>%api_platform.collection.pagination.maximum_items_per_page%</argument>
+            <argument type="service" id="api_platform.util.pagination_helper" />
 
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="8" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -16,7 +16,7 @@
             <argument type="service" id="api_platform.router" />
             <argument type="service" id="api_platform.filters" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
-            <argument type="service" id="api_platform.util.pagination_helper" />
+            <argument type="service" id="api_platform.util.pagination_helper_factory" />
 
             <tag name="serializer.normalizer" priority="16" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="api_platform.router" />
             <argument type="service" id="api_platform.filters" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="api_platform.util.pagination_helper" />
 
             <tag name="serializer.normalizer" priority="16" />
         </service>

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -237,12 +237,6 @@ final class DocumentationNormalizer implements NormalizerInterface
         return $pathOperation;
     }
 
-    /**
-     * @param string $resourceClass
-     * @param string $operationName
-     *
-     * @return array
-     */
     private function getPaginationParameters(string $resourceClass, string $operationName): array
     {
         if (!$this->paginationHelperFactory) {

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -240,6 +240,7 @@ final class DocumentationNormalizer implements NormalizerInterface
     /**
      * @param string $resourceClass
      * @param string $operationName
+     *
      * @return array
      */
     protected function getPaginationParameters(string $resourceClass, string $operationName)
@@ -252,34 +253,34 @@ final class DocumentationNormalizer implements NormalizerInterface
 
         $paginationParameters = [];
 
-        if ($this->paginationHelper->getConfig('clientEnabled')) {
+        if ($this->paginationHelper->isClientPaginationEnabledByDefault()) {
             $paginationParameters[] = [
-                "name" => $this->paginationHelper->getConfig('parameterNameEnabled'),
-                "in" => "query",
-                "type" => "boolean",
-                "description" => "Enable pagination",
-                "default" => $this->paginationHelper->isPaginationEnabled(),
+                'name' => $this->paginationHelper->getParameterNameEnabled(),
+                'in' => 'query',
+                'type' => 'boolean',
+                'description' => 'Enable pagination',
+                'default' => $this->paginationHelper->isPaginationEnabled(),
             ];
         }
 
         $paginationParameters[] = [
-            "name" => $this->paginationHelper->getConfig('parameterNamePage'),
-            "in" => "query",
-            "type" => "integer",
-            "description" => "Page number",
-            "default" => 1,
-            "minimum" => 1
+            'name' => $this->paginationHelper->getParameterNamePage(),
+            'in' => 'query',
+            'type' => 'integer',
+            'description' => 'Page number',
+            'default' => 1,
+            'minimum' => 1,
         ];
 
-        if ($this->paginationHelper->getConfig('clientItemsPerPage')) {
+        if ($this->paginationHelper->isClientItemsPerPageEnabledByDefault()) {
             $paginationParameters[] = [
-                "name" => $this->paginationHelper->getConfig('parameterNameItemsPerPage'),
-                "in" => "query",
-                "type" => "integer",
-                "description" => "Items per page",
-                "default" => $this->paginationHelper->getItemsPerPage(),
-                "minimum" => 1,
-                "maximum" => $this->paginationHelper->getConfig('maximumItemsPerPage')
+                'name' => $this->paginationHelper->getParameterNameItemsPerPage(),
+                'in' => 'query',
+                'type' => 'integer',
+                'description' => 'Items per page',
+                'default' => $this->paginationHelper->getItemsPerPage(),
+                'minimum' => 1,
+                'maximum' => $this->paginationHelper->getDefaultMaximumItemsPerPage(),
             ];
         }
 

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
-use ApiPlatform\Core\Util\PaginationHelperFactory;
+use ApiPlatform\Core\Util\Factory\PaginationHelperFactory;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

--- a/src/Util/Factory/PaginationHelperFactory.php
+++ b/src/Util/Factory/PaginationHelperFactory.php
@@ -9,11 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace ApiPlatform\Core\Util;
+namespace ApiPlatform\Core\Util\Factory;
 
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\PaginationHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+/**
+ * @author Jonathan Doelfs <jd@sodatech.com>
+ */
 class PaginationHelperFactory
 {
     private $requestStack;

--- a/src/Util/PaginationHelper.php
+++ b/src/Util/PaginationHelper.php
@@ -1,0 +1,197 @@
+<?php
+namespace ApiPlatform\Core\Util;
+
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use Exception;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+
+class PaginationHelper
+{
+    private $requestStack;
+    private $resourceMetadataFactory;
+    private $resourceMetadata;
+
+    private $enabled = true;
+    private $clientEnabled = false;
+    private $clientItemsPerPage = false;
+    private $itemsPerPage = 30;
+    private $maximumItemsPerPage = null;
+
+    private $parameterNamePage = 'page';
+    private $parameterNameEnabled = 'pagination';
+    private $parameterNameItemsPerPage = 'itemsPerPage';
+
+    private $resourceClass;
+    private $operationName;
+
+
+    /**
+     * PaginationHelper constructor.
+     * @param RequestStack $requestStack
+     * @param ResourceMetadataFactoryInterface $resourceMetadataFactory
+     */
+    public function __construct(RequestStack $requestStack, ResourceMetadataFactoryInterface $resourceMetadataFactory)
+    {
+        $this->requestStack = $requestStack;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+    }
+
+
+    /**
+     * @param bool $enabled
+     * @param bool $clientEnabled
+     * @param bool $clientItemsPerPage
+     * @param int $itemsPerPage
+     * @param string $parameterNamePage
+     * @param string $parameterNameEnabled
+     * @param string $parameterNameItemsPerPage
+     * @param int|null $maximumItemsPerPage
+     */
+    public function setConfig(bool $enabled = true, bool $clientEnabled = false, bool $clientItemsPerPage = false, int $itemsPerPage = 30, string $parameterNamePage = 'page', string $parameterNameEnabled = 'pagination', string $parameterNameItemsPerPage = 'itemsPerPage', int $maximumItemsPerPage = null)
+    {
+        $this->enabled = $enabled;
+        $this->clientEnabled = $clientEnabled;
+        $this->clientItemsPerPage = $clientItemsPerPage;
+        $this->itemsPerPage = $itemsPerPage;
+        $this->maximumItemsPerPage = $maximumItemsPerPage;
+
+        $this->parameterNamePage = $parameterNamePage;
+        $this->parameterNameEnabled = $parameterNameEnabled;
+        $this->parameterNameItemsPerPage = $parameterNameItemsPerPage;
+    }
+
+
+    /**
+     * @param $name
+     * @return null
+     */
+    public function getConfig($name)
+    {
+        if (!in_array($name, ['enabled', 'clientEnabled', 'clientItemsPerPage', 'itemsPerPage', 'maximumItemsPerPage', 'parameterNamePage', 'parameterNameEnabled', 'parameterNameItemsPerPage'])) {
+            return null;
+        }
+
+        return $this->$name;
+    }
+
+
+    /**
+     * @param string $resourceClass
+     * @param string|null $operationName
+     */
+    public function setResourceAndOperation(string $resourceClass, string $operationName = null)
+    {
+        $this->resourceClass = $resourceClass;
+        $this->operationName = $operationName;
+    }
+
+
+    /**
+     * @return null|\Symfony\Component\HttpFoundation\Request
+     * @throws Exception
+     */
+    protected function getRequest()
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            throw new Exception('No valid request available');
+        }
+
+        return $request;
+    }
+
+
+    /**
+     * @return ResourceMetadata
+     * @throws Exception
+     */
+    protected function getResourceMetadata(): ResourceMetadata
+    {
+        if (!$this->resourceMetadata) {
+            if (!$this->resourceClass) {
+                throw new Exception('resourceClass and operation not set');
+            }
+
+            $this->resourceMetadata = $this->resourceMetadataFactory->create($this->resourceClass);
+        }
+
+        return $this->resourceMetadata;
+    }
+
+
+    /**
+     * @param string $key
+     * @param null $defaultValue
+     * @param bool $resourceFallback
+     * @return mixed
+     */
+    protected function getResourceMetadataAttribute(string $key, $defaultValue = null, bool $resourceFallback = false)
+    {
+        return $this->getResourceMetadata()->getCollectionOperationAttribute($this->operationName, $key, $defaultValue, $resourceFallback);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isResourcePaginationEnabled(): bool
+    {
+        $enabled = $this->getResourceMetadataAttribute('pagination_enabled', $this->enabled, true);
+        $clientEnabled = $this->getResourceMetadataAttribute('pagination_client_enabled', $this->clientEnabled, true);
+
+        return $enabled || $clientEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaginationEnabled(): bool
+    {
+        $enabled = $this->getResourceMetadataAttribute('pagination_enabled', $this->enabled, true);
+        $clientEnabled = $this->getResourceMetadataAttribute('pagination_client_enabled', $this->clientEnabled, true);
+
+        if ($clientEnabled) {
+            $enabled = filter_var($this->getRequest()->query->get($this->parameterNameEnabled, $enabled), FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $enabled;
+    }
+
+
+    /**
+     * @return float
+     */
+    public function getItemsPerPage(): float
+    {
+        $itemsPerPage = $this->getResourceMetadataAttribute('pagination_items_per_page', $this->itemsPerPage, true);
+        $clientItemsPerPage = $this->getResourceMetadataAttribute('pagination_client_items_per_page', $this->clientItemsPerPage, true);
+        $maximumItemsPerPage = $this->getResourceMetadataAttribute('maximum_items_per_page', $this->maximumItemsPerPage, true);
+
+        if ($clientItemsPerPage) {
+            $itemsPerPage = (float)$this->getRequest()->query->get($this->parameterNameItemsPerPage, $itemsPerPage);
+
+            if (null !== $this->maximumItemsPerPage && $itemsPerPage >= $maximumItemsPerPage) {
+                $itemsPerPage = $maximumItemsPerPage;
+            }
+        }
+
+        return (float)$itemsPerPage;
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getPage(): int
+    {
+        $page = (int)$this->getRequest()->query->get($this->parameterNamePage, 1);
+
+        if ($page < 1) {
+            $page = 1;
+        }
+
+        return $page;
+    }
+
+}

--- a/src/Util/PaginationHelper.php
+++ b/src/Util/PaginationHelper.php
@@ -1,4 +1,12 @@
 <?php
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace ApiPlatform\Core\Util;
 
@@ -70,9 +78,9 @@ class PaginationHelper
     }
 
     /**
-     * @return null|\Symfony\Component\HttpFoundation\Request
-     *
      * @throws Exception
+     *
+     * @return null|\Symfony\Component\HttpFoundation\Request
      */
     protected function getRequest()
     {
@@ -85,9 +93,9 @@ class PaginationHelper
     }
 
     /**
-     * @return ResourceMetadata
-     *
      * @throws Exception
+     *
+     * @return ResourceMetadata
      */
     protected function getResourceMetadata(): ResourceMetadata
     {

--- a/src/Util/PaginationHelper.php
+++ b/src/Util/PaginationHelper.php
@@ -14,6 +14,9 @@ namespace ApiPlatform\Core\Util;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+/**
+ * @author Jonathan Doelfs <jd@sodatech.com>
+ */
 class PaginationHelper
 {
     private $requestStack;
@@ -84,7 +87,7 @@ class PaginationHelper
 
         if ($itemsPerPage < 1) {
             $itemsPerPage = 1;
-        } elseif (null !== $this->maximumItemsPerPage && $itemsPerPage >= $maximumItemsPerPage) {
+        } elseif ($maximumItemsPerPage > 0 && $itemsPerPage >= $maximumItemsPerPage) {
             $itemsPerPage = $maximumItemsPerPage;
         }
 

--- a/src/Util/PaginationHelper.php
+++ b/src/Util/PaginationHelper.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace ApiPlatform\Core\Util;
 
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Exception;
 use Symfony\Component\HttpFoundation\RequestStack;
-
 
 class PaginationHelper
 {
@@ -26,10 +26,8 @@ class PaginationHelper
     private $resourceClass;
     private $operationName;
 
-
     /**
-     * PaginationHelper constructor.
-     * @param RequestStack $requestStack
+     * @param RequestStack                     $requestStack
      * @param ResourceMetadataFactoryInterface $resourceMetadataFactory
      */
     public function __construct(RequestStack $requestStack, ResourceMetadataFactoryInterface $resourceMetadataFactory)
@@ -38,15 +36,14 @@ class PaginationHelper
         $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
 
-
     /**
-     * @param bool $enabled
-     * @param bool $clientEnabled
-     * @param bool $clientItemsPerPage
-     * @param int $itemsPerPage
-     * @param string $parameterNamePage
-     * @param string $parameterNameEnabled
-     * @param string $parameterNameItemsPerPage
+     * @param bool     $enabled
+     * @param bool     $clientEnabled
+     * @param bool     $clientItemsPerPage
+     * @param int      $itemsPerPage
+     * @param string   $parameterNamePage
+     * @param string   $parameterNameEnabled
+     * @param string   $parameterNameItemsPerPage
      * @param int|null $maximumItemsPerPage
      */
     public function setConfig(bool $enabled = true, bool $clientEnabled = false, bool $clientItemsPerPage = false, int $itemsPerPage = 30, string $parameterNamePage = 'page', string $parameterNameEnabled = 'pagination', string $parameterNameItemsPerPage = 'itemsPerPage', int $maximumItemsPerPage = null)
@@ -62,23 +59,8 @@ class PaginationHelper
         $this->parameterNameItemsPerPage = $parameterNameItemsPerPage;
     }
 
-
     /**
-     * @param $name
-     * @return null
-     */
-    public function getConfig($name)
-    {
-        if (!in_array($name, ['enabled', 'clientEnabled', 'clientItemsPerPage', 'itemsPerPage', 'maximumItemsPerPage', 'parameterNamePage', 'parameterNameEnabled', 'parameterNameItemsPerPage'])) {
-            return null;
-        }
-
-        return $this->$name;
-    }
-
-
-    /**
-     * @param string $resourceClass
+     * @param string      $resourceClass
      * @param string|null $operationName
      */
     public function setResourceAndOperation(string $resourceClass, string $operationName = null)
@@ -87,9 +69,9 @@ class PaginationHelper
         $this->operationName = $operationName;
     }
 
-
     /**
      * @return null|\Symfony\Component\HttpFoundation\Request
+     *
      * @throws Exception
      */
     protected function getRequest()
@@ -102,9 +84,9 @@ class PaginationHelper
         return $request;
     }
 
-
     /**
      * @return ResourceMetadata
+     *
      * @throws Exception
      */
     protected function getResourceMetadata(): ResourceMetadata
@@ -120,11 +102,11 @@ class PaginationHelper
         return $this->resourceMetadata;
     }
 
-
     /**
      * @param string $key
-     * @param null $defaultValue
-     * @param bool $resourceFallback
+     * @param null   $defaultValue
+     * @param bool   $resourceFallback
+     *
      * @return mixed
      */
     protected function getResourceMetadataAttribute(string $key, $defaultValue = null, bool $resourceFallback = false)
@@ -158,7 +140,6 @@ class PaginationHelper
         return $enabled;
     }
 
-
     /**
      * @return float
      */
@@ -169,23 +150,22 @@ class PaginationHelper
         $maximumItemsPerPage = $this->getResourceMetadataAttribute('maximum_items_per_page', $this->maximumItemsPerPage, true);
 
         if ($clientItemsPerPage) {
-            $itemsPerPage = (float)$this->getRequest()->query->get($this->parameterNameItemsPerPage, $itemsPerPage);
+            $itemsPerPage = (float) $this->getRequest()->query->get($this->parameterNameItemsPerPage, $itemsPerPage);
 
             if (null !== $this->maximumItemsPerPage && $itemsPerPage >= $maximumItemsPerPage) {
                 $itemsPerPage = $maximumItemsPerPage;
             }
         }
 
-        return (float)$itemsPerPage;
+        return (float) $itemsPerPage;
     }
-
 
     /**
      * @return int
      */
     public function getPage(): int
     {
-        $page = (int)$this->getRequest()->query->get($this->parameterNamePage, 1);
+        $page = (int) $this->getRequest()->query->get($this->parameterNamePage, 1);
 
         if ($page < 1) {
             $page = 1;
@@ -194,4 +174,56 @@ class PaginationHelper
         return $page;
     }
 
+    /**
+     * @return bool
+     */
+    public function isPaginationEnabledByDefault(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isClientPaginationEnabledByDefault(): bool
+    {
+        return $this->clientEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isClientItemsPerPageEnabledByDefault(): bool
+    {
+        return $this->clientItemsPerPage;
+    }
+
+    public function getDefaultMaximumItemsPerPage()
+    {
+        return $this->maximumItemsPerPage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParameterNamePage(): string
+    {
+        return $this->parameterNamePage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParameterNameEnabled(): string
+    {
+        return $this->parameterNameEnabled;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParameterNameItemsPerPage(): string
+    {
+        return $this->parameterNameItemsPerPage;
+    }
 }

--- a/src/Util/PaginationHelper.php
+++ b/src/Util/PaginationHelper.php
@@ -52,9 +52,6 @@ class PaginationHelper
         $this->operationName = $operationName;
     }
 
-    /**
-     * @return bool
-     */
     public function isResourcePaginationEnabled(): bool
     {
         $enabled = $this->getResourceMetadataAttribute('pagination_enabled', $this->enabled, true);
@@ -63,9 +60,6 @@ class PaginationHelper
         return $enabled || $clientEnabled;
     }
 
-    /**
-     * @return bool
-     */
     public function isPaginationEnabled(): bool
     {
         $enabled = $this->getResourceMetadataAttribute('pagination_enabled', $this->enabled, true);
@@ -78,29 +72,25 @@ class PaginationHelper
         return (bool) $enabled;
     }
 
-    /**
-     * @return float
-     */
-    public function getItemsPerPage(): float
+    public function getItemsPerPage(): int
     {
         $itemsPerPage = $this->getResourceMetadataAttribute('pagination_items_per_page', $this->itemsPerPage, true);
         $clientItemsPerPage = $this->getResourceMetadataAttribute('pagination_client_items_per_page', $this->clientItemsPerPage, true);
         $maximumItemsPerPage = $this->getResourceMetadataAttribute('maximum_items_per_page', $this->maximumItemsPerPage, true);
 
         if ($clientItemsPerPage) {
-            $itemsPerPage = (float) $this->getRequestParameter($this->parameterNameItemsPerPage, $itemsPerPage);
-
-            if (null !== $this->maximumItemsPerPage && $itemsPerPage >= $maximumItemsPerPage) {
-                $itemsPerPage = $maximumItemsPerPage;
-            }
+            $itemsPerPage = (int) $this->getRequestParameter($this->parameterNameItemsPerPage, $itemsPerPage);
         }
 
-        return (float) $itemsPerPage;
+        if ($itemsPerPage < 1) {
+            $itemsPerPage = 1;
+        } elseif (null !== $this->maximumItemsPerPage && $itemsPerPage >= $maximumItemsPerPage) {
+            $itemsPerPage = $maximumItemsPerPage;
+        }
+
+        return (int) $itemsPerPage;
     }
 
-    /**
-     * @return int
-     */
     public function getPage(): int
     {
         $page = (int) $this->getRequestParameter($this->parameterNamePage, 1);
@@ -112,68 +102,44 @@ class PaginationHelper
         return $page;
     }
 
-    /**
-     * @return bool
-     */
     public function isClientPaginationEnabled(): bool
     {
         return (bool) $this->getResourceMetadataAttribute('client_pagination_enabled', $this->clientEnabled, true);
     }
 
-    /**
-     * @return bool
-     */
     public function isClientItemsPerPageEnabled(): bool
     {
         return (bool) $this->getResourceMetadataAttribute('pagination_client_items_per_page', $this->clientItemsPerPage, true);
     }
 
-    /**
-     * @return int
-     */
     public function getMaximumItemsPerPage(): int
     {
         return (int) $this->getResourceMetadataAttribute('maximum_items_per_page', $this->maximumItemsPerPage, true);
     }
 
-    /**
-     * @return string
-     */
     public function getParameterNamePage(): string
     {
         return $this->parameterNamePage;
     }
 
-    /**
-     * @return string
-     */
     public function getParameterNameEnabled(): string
     {
         return $this->parameterNameEnabled;
     }
 
-    /**
-     * @return string
-     */
     public function getParameterNameItemsPerPage(): string
     {
         return $this->parameterNameItemsPerPage;
     }
 
-    /**
-     * @param string $key
-     * @param null   $default
-     *
-     * @return string
-     */
-    private function getRequestParameter(string $key, $default = null)
+    private function getRequestParameter(string $key, $default = null): string
     {
         $request = $this->requestStack->getCurrentRequest();
         if (null === $request) {
             return $default;
         }
 
-        return $request->query->get($key, $default);
+        return (string) $request->query->get($key, $default);
     }
 
     /**

--- a/src/Util/PaginationHelper.php
+++ b/src/Util/PaginationHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the API Platform project.
  *

--- a/src/Util/PaginationHelperFactory.php
+++ b/src/Util/PaginationHelperFactory.php
@@ -45,12 +45,6 @@ class PaginationHelperFactory
         $this->parameterNameItemsPerPage = $parameterNameItemsPerPage;
     }
 
-    /**
-     * @param string      $resourceClass
-     * @param string|null $operationName
-     *
-     * @return PaginationHelper
-     */
     public function create(string $resourceClass, string $operationName = null): PaginationHelper
     {
         return new PaginationHelper($this->requestStack, $this->resourceMetadataFactory, $resourceClass, $operationName, $this->enabled, $this->clientEnabled, $this->clientItemsPerPage, $this->itemsPerPage, $this->parameterNamePage, $this->parameterNameEnabled, $this->parameterNameItemsPerPage, $this->maximumItemsPerPage);

--- a/src/Util/PaginationHelperFactory.php
+++ b/src/Util/PaginationHelperFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Util;
+
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class PaginationHelperFactory
+{
+    private $requestStack;
+    private $resourceMetadataFactory;
+
+    private $enabled = true;
+    private $clientEnabled = false;
+    private $clientItemsPerPage = false;
+    private $itemsPerPage = 30;
+    private $maximumItemsPerPage = null;
+
+    private $parameterNamePage = 'page';
+    private $parameterNameEnabled = 'pagination';
+    private $parameterNameItemsPerPage = 'itemsPerPage';
+
+    public function __construct(RequestStack $requestStack, ResourceMetadataFactoryInterface $resourceMetadataFactory, bool $enabled = true, bool $clientEnabled = false, bool $clientItemsPerPage = false, int $itemsPerPage = 30, string $parameterNamePage = 'page', string $parameterNameEnabled = 'pagination', string $parameterNameItemsPerPage = 'itemsPerPage', int $maximumItemsPerPage = null)
+    {
+        $this->requestStack = $requestStack;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+
+        $this->enabled = $enabled;
+        $this->clientEnabled = $clientEnabled;
+        $this->clientItemsPerPage = $clientItemsPerPage;
+        $this->itemsPerPage = $itemsPerPage;
+        $this->maximumItemsPerPage = $maximumItemsPerPage;
+
+        $this->parameterNamePage = $parameterNamePage;
+        $this->parameterNameEnabled = $parameterNameEnabled;
+        $this->parameterNameItemsPerPage = $parameterNameItemsPerPage;
+    }
+
+    /**
+     * @param string      $resourceClass
+     * @param string|null $operationName
+     *
+     * @return PaginationHelper
+     */
+    public function create(string $resourceClass, string $operationName = null): PaginationHelper
+    {
+        return new PaginationHelper($this->requestStack, $this->resourceMetadataFactory, $resourceClass, $operationName, $this->enabled, $this->clientEnabled, $this->clientItemsPerPage, $this->itemsPerPage, $this->parameterNamePage, $this->parameterNameEnabled, $this->parameterNameItemsPerPage, $this->maximumItemsPerPage);
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -336,6 +336,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.swagger.action.ui',
             'api_platform.swagger.command.swagger_command',
             'api_platform.swagger.normalizer.documentation',
+            'api_platform.util.pagination_helper_factory',
         ];
 
         foreach ($definitions as $definition) {

--- a/tests/Util/Factory/PaginationHelperFactoryTest.php
+++ b/tests/Util/Factory/PaginationHelperFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\tests\Util\Factory;
+
+use ApiPlatform\Core\Util\Factory\PaginationHelperFactory;
+use ApiPlatform\Core\Util\PaginationHelper;
+use Symfony\Component\HttpFoundation\RequestStack;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+
+/**
+ * @author Jonathan Doelfs <jd@sodatech.com>
+ */
+class PaginationHelperFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClassIsCorrect()
+    {
+        $requestStackProphecy = $this->prophesize(RequestStack::class);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+
+        $factory = new PaginationHelperFactory($requestStackProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal());
+        $this->assertInstanceOf(PaginationHelper::class, $factory->create('someResourceClass', 'someOperationName'));
+    }
+}

--- a/tests/Util/Factory/PaginationHelperFactoryTest.php
+++ b/tests/Util/Factory/PaginationHelperFactoryTest.php
@@ -11,10 +11,10 @@
 
 namespace ApiPlatform\Core\tests\Util\Factory;
 
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\Factory\PaginationHelperFactory;
 use ApiPlatform\Core\Util\PaginationHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
-use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 
 /**
  * @author Jonathan Doelfs <jd@sodatech.com>

--- a/tests/Util/PaginationHelperTest.php
+++ b/tests/Util/PaginationHelperTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\tests\Util;
+
+use ApiPlatform\Core\Util\PaginationHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+
+/**
+ * @author Jonathan Doelfs <jd@sodatech.com>
+ */
+class PaginationHelperTest extends \PHPUnit_Framework_TestCase
+{
+    private $resourceClass = 'someResourceClass';
+    private $operationName = 'someOperationName';
+
+    private $enabled = true;
+    private $clientEnabled = false;
+    private $clientItemsPerPage = false;
+    private $itemsPerPage = 30;
+    private $parameterNamePage = 'page';
+    private $parameterNameEnabled = 'pagination';
+    private $parameterNameItemsPerPage = 'itemsPerPage';
+    private $maximumItemsPerPage = null;
+
+    public function getPaginationHelper(array $collectionOperationData = null, array $requestQuery = null): PaginationHelper
+    {
+        $requestStack = new RequestStack();
+        if (!is_null($requestQuery)) {
+            $requestStack->push(new Request($requestQuery));
+        }
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create($this->resourceClass)->willReturn(
+            new ResourceMetadata('foo', '', null, [], [
+                $this->operationName => $collectionOperationData,
+            ])
+        );
+
+        return new PaginationHelper($requestStack, $resourceMetadataFactoryProphecy->reveal(), $this->resourceClass, $this->operationName, $this->enabled, $this->clientEnabled, $this->clientItemsPerPage, $this->itemsPerPage, $this->parameterNamePage, $this->parameterNameEnabled, $this->parameterNameItemsPerPage, $this->maximumItemsPerPage);
+    }
+
+    public function testIsResourcePaginationEnabled()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->enabled || $this->clientEnabled, $paginationHelper->isResourcePaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => false, 'pagination_client_enabled' => false]);
+        $this->assertFalse($paginationHelper->isResourcePaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => true, 'pagination_client_enabled' => false]);
+        $this->assertTrue($paginationHelper->isResourcePaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => false, 'pagination_client_enabled' => true]);
+        $this->assertTrue($paginationHelper->isResourcePaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => true, 'pagination_client_enabled' => true]);
+        $this->assertTrue($paginationHelper->isResourcePaginationEnabled());
+    }
+
+    public function testIsPaginationEnabled()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->enabled || $this->clientEnabled, $paginationHelper->isPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => false, 'pagination_client_enabled' => false]);
+        $this->assertFalse($paginationHelper->isPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => true, 'pagination_client_enabled' => false]);
+        $this->assertTrue($paginationHelper->isPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => false, 'pagination_client_enabled' => true]);
+        $this->assertFalse($paginationHelper->isPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => false, 'pagination_client_enabled' => true], [$this->parameterNameEnabled => '1']);
+        $this->assertTrue($paginationHelper->isPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => false, 'pagination_client_enabled' => true], [$this->parameterNameEnabled => '0']);
+        $this->assertFalse($paginationHelper->isPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_enabled' => true, 'pagination_client_enabled' => true], [$this->parameterNameEnabled => '0']);
+        $this->assertFalse($paginationHelper->isPaginationEnabled());
+    }
+
+    public function testGetItemsPerPage()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->itemsPerPage, $paginationHelper->getItemsPerPage());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_items_per_page' => 10, 'pagination_client_items_per_page' => false, 'maximum_items_per_page' => 20]);
+        $this->assertEquals(10, $paginationHelper->getItemsPerPage());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_items_per_page' => 20, 'pagination_client_items_per_page' => false, 'maximum_items_per_page' => 10]);
+        $this->assertEquals(10, $paginationHelper->getItemsPerPage());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_items_per_page' => 10, 'pagination_client_items_per_page' => true, 'maximum_items_per_page' => 40], [$this->parameterNameItemsPerPage => 30]);
+        $this->assertEquals(30, $paginationHelper->getItemsPerPage());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_items_per_page' => 10, 'pagination_client_items_per_page' => true, 'maximum_items_per_page' => 20], [$this->parameterNameItemsPerPage => 30]);
+        $this->assertEquals(20, $paginationHelper->getItemsPerPage());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_items_per_page' => 10, 'pagination_client_items_per_page' => true, 'maximum_items_per_page' => 20], [$this->parameterNameItemsPerPage => -2]);
+        $this->assertEquals(1, $paginationHelper->getItemsPerPage());
+    }
+
+    public function testGetPage()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals(1, $paginationHelper->getPage());
+
+        $paginationHelper = $this->getPaginationHelper(null, [$this->parameterNamePage => 4]);
+        $this->assertEquals(4, $paginationHelper->getPage());
+
+        $paginationHelper = $this->getPaginationHelper(null, [$this->parameterNamePage => -2]);
+        $this->assertEquals(1, $paginationHelper->getPage());
+    }
+
+    public function testIsClientPaginationEnabled()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->clientEnabled, $paginationHelper->isClientPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['client_pagination_enabled' => true]);
+        $this->assertTrue($paginationHelper->isClientPaginationEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['client_pagination_enabled' => false]);
+        $this->assertFalse($paginationHelper->isClientPaginationEnabled());
+    }
+
+    public function testIsClientItemsPerPageEnabled()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->clientItemsPerPage, $paginationHelper->isClientItemsPerPageEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_client_items_per_page' => true]);
+        $this->assertTrue($paginationHelper->isClientItemsPerPageEnabled());
+
+        $paginationHelper = $this->getPaginationHelper(['pagination_client_items_per_page' => false]);
+        $this->assertFalse($paginationHelper->isClientItemsPerPageEnabled());
+    }
+
+    public function testGetMaximumItemsPerPage()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->maximumItemsPerPage, $paginationHelper->getMaximumItemsPerPage());
+
+        $paginationHelper = $this->getPaginationHelper(['maximum_items_per_page' => 5]);
+        $this->assertEquals(5, $paginationHelper->getMaximumItemsPerPage());
+    }
+
+    public function testGetParameterNamePage()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->parameterNamePage, $paginationHelper->getParameterNamePage());
+    }
+
+    public function testGetParameterNameEnabled()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->parameterNameEnabled, $paginationHelper->getParameterNameEnabled());
+    }
+
+    public function testGetParameterNameItemsPerPage()
+    {
+        $paginationHelper = $this->getPaginationHelper();
+        $this->assertEquals($this->parameterNameItemsPerPage, $paginationHelper->getParameterNameItemsPerPage());
+    }
+}

--- a/tests/Util/PaginationHelperTest.php
+++ b/tests/Util/PaginationHelperTest.php
@@ -11,11 +11,11 @@
 
 namespace ApiPlatform\Core\tests\Util;
 
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Util\PaginationHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 
 /**
  * @author Jonathan Doelfs <jd@sodatech.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #875 
| License       | MIT
| Doc PR        | none yet

The main intention for this PR is to make it easier to implement pagination for custom data providers and to make it more independent from the ORM. 
This is my first contribution to a public project, so please be patient if some things are not perfect yet. I will add tests and doc pr if you think the code changes are ok. 
I'm not sure if the name and namespace of the ApiPlatform\Core\Util\PaginationHelper class really fits.

Changes in this PR:
- Added PaginationHelper class to make it easier to implement pagination for custom data providers
- Added pagination fields to swagger api doc
- Changed PaginationExtension to use PaginationHelper class
- Fixed bug in PaginationExtension->isPaginationEnabled (code is now in PaginationHelper class. Use $enabled instead of $this->enabled as default when getting clientEnabled var) (is clientEnabled really useful? I think it should be dropped)
- Allow use of pagination_maximum_items_per_page per resource (Issue #875)