### PR TITLE
Fix normalizing 3rd level objects

### DIFF
--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -50,7 +50,7 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
         }
 
         if (($strict && isset($type) && $resourceClass !== $type) || !$this->isResourceClass($typeToFind)) {
-            if (is_subclass_of($type, $resourceClass) && $this->isResourceClass($resourceClass)) {
+            if ($this->isResourceClass($resourceClass)) {
                 return $type;
             }
 

--- a/src/Serializer/ContextTrait.php
+++ b/src/Serializer/ContextTrait.php
@@ -28,10 +28,6 @@ trait ContextTrait
      */
     private function initContext(string $resourceClass, array $context): array
     {
-        if (isset($context['api_sub_level'])) {
-            return $context;
-        }
-
         return array_merge($context, [
             'api_sub_level' => true,
             'resource_class' => $resourceClass,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I experience an exception `No resource class found for object of type ...` when trying to normalize some object on 3rd level from initial resource. 
For example:
Object1 Resource has collection of Object2 and Object2 has relation to Object3.
All of them are ApiResources and api-platform fails to normalize Object3

Changes proposed solve the problem and tests still pass.
I did not write new test case though, not sure where to put test for this thing.
Please advice.
