### PR TITLE
Boolean filter integration tests improvements

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -235,6 +235,14 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function thereIsDummyObjectsWithDummyBoolean($nb, $bool)
     {
+        if (in_array($bool, ['true', '1', 1], true)) {
+            $bool = true;
+        } elseif (in_array($bool, ['false', '0', 0], true)) {
+            $bool = false;
+        } else {
+            $expected = ['true', 'false', '1', '0'];
+            throw new InvalidArgumentException(sprintf('Invalid boolean value for "%s" property, expected one of ( "%s" )', $bool, implode('" | "', $expected)));
+        }
         $descriptions = ['Smart dummy.', 'Not so smart dummy.'];
 
         for ($i = 1; $i <= $nb; ++$i) {
@@ -242,7 +250,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
             $dummy->setName('Dummy #'.$i);
             $dummy->setAlias('Alias #'.($nb - $i));
             $dummy->setDescription($descriptions[($i - 1) % 2]);
-            $dummy->setDummyBoolean((bool) $bool);
+            $dummy->setDummyBoolean($bool);
 
             $this->manager->persist($dummy);
         }

--- a/features/doctrine/boolean_filter.feature
+++ b/features/doctrine/boolean_filter.feature
@@ -4,7 +4,7 @@ Feature: Boolean filter on collections
   I need to retrieve collections with boolean value
 
   @createSchema
-  Scenario: Get collection by dummyBoolean false
+  Scenario: Get collection by dummyBoolean true
     Given there is "15" dummy objects with dummyBoolean true
     When I send a "GET" request to "/dummies?dummyBoolean=true"
     Then the response status code should be 200
@@ -34,8 +34,11 @@ Feature: Boolean filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyBoolean=0"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyBoolean=true"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -70,8 +73,11 @@ Feature: Boolean filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyBoolean=1"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyBoolean=1"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -106,8 +112,11 @@ Feature: Boolean filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyBoolean=false"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyBoolean=false"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+           }
         }
       }
     }
@@ -144,8 +153,11 @@ Feature: Boolean filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?unknown=0"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?unknown=0"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+           }
         }
       }
     }
@@ -179,8 +191,11 @@ Feature: Boolean filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?unknown=1$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?unknown=1"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+           }
         }
       }
     }

--- a/features/doctrine/boolean_filter.feature
+++ b/features/doctrine/boolean_filter.feature
@@ -6,6 +6,7 @@ Feature: Boolean filter on collections
   @createSchema
   Scenario: Get collection by dummyBoolean true
     Given there is "15" dummy objects with dummyBoolean true
+    And there is "10" dummy objects with dummyBoolean false
     When I send a "GET" request to "/dummies?dummyBoolean=true"
     Then the response status code should be 200
     And the response should be in JSON
@@ -43,6 +44,7 @@ Feature: Boolean filter on collections
       }
     }
     """
+    And the JSON node "hydra:totalItems" should be equal to 15
 
   Scenario: Get collection by dummyBoolean true
     When I send a "GET" request to "/dummies?dummyBoolean=1"
@@ -82,8 +84,9 @@ Feature: Boolean filter on collections
       }
     }
     """
+    And the JSON node "hydra:totalItems" should be equal to 15
+
   Scenario: Get collection by dummyBoolean false
-    Given there is "15" dummy objects with dummyBoolean false
     When I send a "GET" request to "/dummies?dummyBoolean=false"
     Then the response status code should be 200
     And the response should be in JSON
@@ -103,9 +106,9 @@ Feature: Boolean filter on collections
             "properties": {
               "@id": {
                 "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
+                  {"pattern": "^/dummies/16$"},
+                  {"pattern": "^/dummies/17$"},
+                  {"pattern": "^/dummies/18$"}
                 ]
               }
             }
@@ -116,12 +119,52 @@ Feature: Boolean filter on collections
           "properties": {
             "@id": {"pattern": "^/dummies\\?dummyBoolean=false"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
-           }
+          }
         }
       }
     }
     """
+    And the JSON node "hydra:totalItems" should be equal to 10
 
+  Scenario: Get collection by dummyBoolean false
+    When I send a "GET" request to "/dummies?dummyBoolean=0"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/16$"},
+                  {"pattern": "^/dummies/17$"},
+                  {"pattern": "^/dummies/18$"}
+                ]
+              }
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyBoolean=0"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+    And the JSON node "hydra:totalItems" should be equal to 10
 
   @dropSchema
   Scenario: Get collection ordered by a non valid properties
@@ -157,11 +200,12 @@ Feature: Boolean filter on collections
           "properties": {
             "@id": {"pattern": "^/dummies\\?unknown=0"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
-           }
+          }
         }
       }
     }
     """
+    And the JSON node "hydra:totalItems" should be equal to 25
 
     When I send a "GET" request to "/dummies?unknown=1"
     Then the response status code should be 200
@@ -195,8 +239,9 @@ Feature: Boolean filter on collections
           "properties": {
             "@id": {"pattern": "^/dummies\\?unknown=1"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
-           }
+          }
         }
       }
     }
     """
+    And the JSON node "hydra:totalItems" should be equal to 25


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

I've been reading the [boolean filter documentation](https://api-platform.com/docs/core/filters#boolean-filter) and found that using `on|off` as documented was not working. So I've been searching in the code and saw that only `true|false|1|0` was implemented and tested and also figured out that most of integration tests were not working properly.

It seems that it was working at some point and has been removed [here](https://github.com/api-platform/core/commit/e4eca423d32720bc0cba3fd9a0e47675c1fa21c1#diff-31a7356474220b422a684ad542968342) on purpose ?

Should I open a PR to the doc to remove it or should I re-add this possibility into the core ?