### PR TITLE
hydra:view schema validation 

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -6,8 +6,8 @@ default:
         - 'HydraContext'
         - 'SwaggerContext'
         - 'Behat\MinkExtension\Context\MinkContext'
-        - 'Sanpi\Behatch\Context\RestContext'
-        - 'Sanpi\Behatch\Context\JsonContext'
+        - 'Behatch\Context\RestContext'
+        - 'Behatch\Context\JsonContext'
   extensions:
     'Behat\Symfony2Extension':
       kernel:
@@ -32,5 +32,5 @@ coverage:
         - 'SwaggerContext'
         - 'CoverageContext'
         - 'Behat\MinkExtension\Context\MinkContext'
-        - 'Sanpi\Behatch\Context\RestContext'
-        - 'Sanpi\Behatch\Context\JsonContext'
+        - 'Behatch\Context\RestContext'
+        - 'Behatch\Context\JsonContext'

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "behat/mink-browserkit-driver": "^1.3.1",
         "behat/mink-extension": "^2.2",
         "behat/symfony2-extension": "^2.1",
-        "behatch/contexts": "^2.5",
+        "behatch/contexts": "^2.6",
         "doctrine/doctrine-bundle": "^1.6.3",
         "doctrine/orm": "^2.5",
         "doctrine/annotations": "^1.2",

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -21,7 +21,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Tools\SchemaTool;
-use Sanpi\Behatch\HttpCall\Request;
+use Behatch\HttpCall\Request;
 
 /**
  * Defines application features from the specific context.

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -19,9 +19,9 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelationEmbedder;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\UuidIdentifierDummy;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behatch\HttpCall\Request;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Tools\SchemaTool;
-use Behatch\HttpCall\Request;
 
 /**
  * Defines application features from the specific context.

--- a/features/bootstrap/HydraContext.php
+++ b/features/bootstrap/HydraContext.php
@@ -37,7 +37,7 @@ class HydraContext implements Context
     {
         /** @var InitializedContextEnvironment $environment */
         $environment = $scope->getEnvironment();
-        $this->restContext = $environment->getContext('Sanpi\Behatch\Context\RestContext');
+        $this->restContext = $environment->getContext('Behatch\Context\RestContext');
     }
 
     /**

--- a/features/bootstrap/SwaggerContext.php
+++ b/features/bootstrap/SwaggerContext.php
@@ -12,7 +12,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Environment\InitializedContextEnvironment;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Sanpi\Behatch\Context\RestContext;
+use Behatch\Context\RestContext;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class SwaggerContext implements Context

--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -75,7 +75,7 @@ Feature: Date filter on collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05\\&page=1$"},
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05&page=1$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }
@@ -152,7 +152,7 @@ Feature: Date filter on collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05Z\\&page=1$"},
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05Z&page=1$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }
@@ -191,7 +191,7 @@ Feature: Date filter on collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05\\&dummyDate%5Bafter%5D=2015-04-05$"},
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bbefore%5D=2015-04-05&dummyDate%5Bafter%5D=2015-04-05$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }
@@ -256,7 +256,7 @@ Feature: Date filter on collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?dummyDate%5Bafter%5D=2015-04-06\\&dummyDate%5Bbefore%5D=2015-04-04$"},
+            "@id": {"pattern": "^/dummies\\?dummyDate%5Bafter%5D=2015-04-06&dummyDate%5Bbefore%5D=2015-04-04$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }
@@ -296,8 +296,11 @@ Feature: Date filter on collections
           "maxItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -334,7 +337,7 @@ Feature: Date filter on collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28\\&relatedDummy_dummyDate%5Bafter%5D=2015-04-28$"},
+            "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28&relatedDummy_dummyDate%5Bafter%5D=2015-04-28$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }
@@ -371,8 +374,11 @@ Feature: Date filter on collections
           "maxItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28T00%3A00%3A00%2B00%3A00$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?relatedDummy\\.dummyDate%5Bafter%5D=2015-04-28T00%3A00%3A00%2B00%3A00$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }

--- a/features/doctrine/numeric_filter.feature
+++ b/features/doctrine/numeric_filter.feature
@@ -23,8 +23,11 @@ Feature: Numeric filter on collections
           "maxItems": 0
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?id=9.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?id=9.99$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -57,8 +60,11 @@ Feature: Numeric filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?id=10"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?id=10"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -95,8 +101,11 @@ Feature: Numeric filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?unknown=0"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?unknown=0"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -130,8 +139,11 @@ Feature: Numeric filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?unknown=1$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?unknown=1"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }

--- a/features/doctrine/order_filter.feature
+++ b/features/doctrine/order_filter.feature
@@ -54,8 +54,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[id\\]=asc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Bid%5D=asc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -110,8 +113,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[id\\]=desc"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Bid%5D=desc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -166,8 +172,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[name\\]=asc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Bname%5D=asc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -222,8 +231,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[name\\]=desc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Bname%5D=desc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -278,8 +290,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[name\\]$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Bname%5D="},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -335,8 +350,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[relatedDummy\\]=asc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5BrelatedDummy%5D=asc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -392,8 +410,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[alias\\]=asc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Balias%5D=asc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -447,8 +468,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[alias\\]=desc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Balias%5D=desc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -502,8 +526,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[unknown\\]=asc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Bunknown%5D=asc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -557,8 +584,11 @@ Feature: Order filter on collections
           "minItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?order\\[unknown\\]=desc$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5Bunknown%5D=desc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }

--- a/features/doctrine/range_filter.feature
+++ b/features/doctrine/range_filter.feature
@@ -49,8 +49,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^15$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[between\\]=12.99..15.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Bbetween%5D=12.99..15.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -84,8 +87,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^30$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[between\\]=9.99..12.99..15.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Bbetween%5D=9.99..12.99..15.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -128,8 +134,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^8$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[lt\\]=12.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Blt%5D=12.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -180,8 +189,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^16$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[lte\\]=12.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Blte%5D=12.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -223,8 +235,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^7$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[gt\\]=15.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Bgt%5D=15.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -273,8 +288,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^14$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[gte\\]=15.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Bgte%5D=15.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -316,8 +334,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^7$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[gt\\]=12.99\\&dummyPrice\\[lt\\]=19.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Bgt%5D=12.99&dummyPrice%5Blt%5D=19.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -343,8 +364,11 @@ Feature: Range filter on collections
         },
         "hydra:totalItems": {"pattern": "^0$"},
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?dummyPrice\\[gt\\]=19.99$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Bgt%5D=19.99$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }

--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -34,8 +34,11 @@ Feature: Search filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?name=my$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?name=my"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -99,8 +102,11 @@ Feature: Search filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?alias=Ali$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?alias=Ali"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -135,8 +141,11 @@ Feature: Search filter on collections
           }
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?description=smart$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?description=smart"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -161,8 +170,11 @@ Feature: Search filter on collections
           "maxItems": 0
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?name=MuYm$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?name=MuYm$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }

--- a/features/hydra/collection.feature
+++ b/features/hydra/collection.feature
@@ -63,11 +63,14 @@ Feature: Collections support
           "maxItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?page=1$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"},
-          "hydra:first": {"pattern": "^/dummies\\?page=1$"},
-          "hydra:last": {"pattern": "^/dummies\\?page=10$"},
-          "hydra:next": {"pattern": "^/dummies\\?page=2$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"},
+            "hydra:first": {"pattern": "^/dummies\\?page=1$"},
+            "hydra:last": {"pattern": "^/dummies\\?page=10$"},
+            "hydra:next": {"pattern": "^/dummies\\?page=2$"}
+          }
         }
       }
     }
@@ -104,12 +107,15 @@ Feature: Collections support
           "maxItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?page=1$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"},
-          "hydra:first": {"pattern": "^/dummies$"},
-          "hydra:last": {"pattern": "^/dummies\\?page=10$"},
-          "hydra:next": {"pattern": "^/dummies\\?page=8$"},
-          "hydra:previous": {"pattern": "^/dummies\\?page=6$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?page=7$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"},
+            "hydra:first": {"pattern": "^/dummies\\?page=1$"},
+            "hydra:last": {"pattern": "^/dummies\\?page=10$"},
+            "hydra:next": {"pattern": "^/dummies\\?page=8$"},
+            "hydra:previous": {"pattern": "^/dummies\\?page=6$"}
+          }
         }
       }
     }
@@ -146,11 +152,14 @@ Feature: Collections support
           "maxItems": 3
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?page=10$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"},
-          "hydra:first": {"pattern": "^/dummies$"},
-          "hydra:last": {"pattern": "^/dummies\\?page=10$"},
-          "hydra:previous": {"pattern": "^/dummies\\?page=9$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?page=10$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"},
+            "hydra:first": {"pattern": "^/dummies\\?page=1$"},
+            "hydra:last": {"pattern": "^/dummies\\?page=10$"},
+            "hydra:previous": {"pattern": "^/dummies\\?page=9$"}
+          }
         },
         "hydra:search": {}
       },
@@ -202,12 +211,15 @@ Feature: Collections support
           "maxItems": 10
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?page=2\\&itemsPerPage=10$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"},
-          "hydra:first": {"pattern": "^/dummies\\?itemsPerPage=10$"},
-          "hydra:last": {"pattern": "^/dummies\\?itemsPerPage=10\\&page=3$"},
-          "hydra:previous": {"pattern": "^/dummies\\?itemsPerPage=10$"},
-          "hydra:next": {"pattern": "^/dummies\\?itemsPerPage=10\\&page=3$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?itemsPerPage=10&page=2$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"},
+            "hydra:first": {"pattern": "^/dummies\\?itemsPerPage=10&page=1$"},
+            "hydra:last": {"pattern": "^/dummies\\?itemsPerPage=10&page=3$"},
+            "hydra:previous": {"pattern": "^/dummies\\?itemsPerPage=10&page=1$"},
+            "hydra:next": {"pattern": "^/dummies\\?itemsPerPage=10&page=3$"}
+          }
         },
         "hydra:search": {}
       },
@@ -256,8 +268,11 @@ Feature: Collections support
           "maxItems": 1
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?id=8$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?id=8$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         },
         "hydra:search": {}
       },
@@ -290,8 +305,11 @@ Feature: Collections support
           "maxItems": 1
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?id=%2fdummies%2f8$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?id=%2Fdummies%2F8$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         },
         "hydra:search": {}
       },
@@ -325,8 +343,11 @@ Feature: Collections support
           "maxItems": 1
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?name=Dummy%20%238$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?name=Dummy%20%238$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         },
         "hydra:search": {}
       },

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -185,8 +185,11 @@ Feature: Relations support
           "maxItems": 1
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?relatedDummy=%2Frelated_dummies%2F1$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?relatedDummy=%2Frelated_dummies%2F1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }
@@ -218,8 +221,11 @@ Feature: Relations support
           "maxItems": 1
         },
         "hydra:view": {
-          "@id": {"pattern": "^/dummies\\?relatedDummies\\[\\]=%2Frelated_dummies%2F1$"},
-          "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?relatedDummies%5B%5D=%2Frelated_dummies%2F1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
         }
       }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I found that the hydra:view schema validation pattern were not correctly checked in the testsuite. Any value would let the tests passing as the schema is malformed.

I've also updated the Behatch namespace as they changed it in 2.6 (call it deprecated) without providing a decent BC version.