### PR TITLE
Add default order in API Platform Configuration

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -59,7 +59,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('order')->defaultNull()->info('The default order of results.')->end()
+                        ->scalarNode('order')->defaultValue('ASC')->info('The default order of results.')->end() // Default ORDER is required for postgresql and mysql >= 5.7 when using LIMIT/OFFSET request
                         ->scalarNode('order_parameter_name')->defaultValue('order')->cannotBeEmpty()->info('The name of the query parameter to order results.')->end()
                         ->arrayNode('pagination')
                             ->canBeDisabled()

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -186,7 +186,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         ])->shouldBeCalled();
 
         $parameters = [
-            'api_platform.collection.order' => null,
+            'api_platform.collection.order' => 'ASC',
             'api_platform.collection.order_parameter_name' => 'order',
             'api_platform.collection.pagination.client_enabled' => false,
             'api_platform.collection.pagination.client_items_per_page' => false,

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -77,7 +77,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'force_eager' => true,
             ],
             'collection' => [
-                'order' => null,
+                'order' => 'ASC',
                 'order_parameter_name' => 'order',
                 'pagination' => [
                     'enabled' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #965 
| License       | MIT
| Doc PR        | N/A

Add default Order to make it work for users who have postgresql and Mysql 5.7 and who has not defined api_platform_collection_order by default
