### PR TITLE
Deprecate xml operations configuration and provide new way to make it…

### DIFF
--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -43,12 +43,40 @@ final class XmlExtractor extends AbstractExtractor
                 'shortName' => $this->phpize($resource, 'shortName', 'string'),
                 'description' => $this->phpize($resource, 'description', 'string'),
                 'iri' => $this->phpize($resource, 'iri', 'string'),
-                'itemOperations' => $this->getAttributes($resource, 'itemOperation') ?: null,
-                'collectionOperations' => $this->getAttributes($resource, 'collectionOperation') ?: null,
+                'itemOperations' => $this->getOperations($resource, 'itemOperation'),
+                'collectionOperations' => $this->getOperations($resource, 'collectionOperation'),
                 'attributes' => $this->getAttributes($resource, 'attribute') ?: null,
                 'properties' => $this->getProperties($resource) ?: null,
             ];
         }
+    }
+
+    /**
+     * Return the array containing configured operations. Returns NULL if there is no operation configuration.
+     *
+     * @param \SimpleXMLElement $resource
+     * @param string            $operationType
+     *
+     * @return array|null
+     */
+    private function getOperations(\SimpleXMLElement $resource, string $operationType)
+    {
+        if ($legacyOperations = $this->getAttributes($resource, $operationType)) {
+            @trigger_error(
+                sprintf('Configuring "%1$s" tags without using a parent "%1$ss" tag is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3', $operationType),
+                E_USER_DEPRECATED
+            );
+
+            return $legacyOperations;
+        }
+
+        $operationsParent = $operationType.'s';
+
+        if (!isset($resource->$operationsParent)) {
+            return;
+        }
+
+        return $this->getAttributes($resource->$operationsParent, $operationType);
     }
 
     /**

--- a/src/Metadata/schema/metadata.xsd
+++ b/src/Metadata/schema/metadata.xsd
@@ -14,15 +14,44 @@
 
     <xsd:complexType name="resource">
             <xsd:sequence minOccurs="0" maxOccurs="unbounded">
-                <xsd:element name="itemOperation" minOccurs="0" maxOccurs="unbounded" type="attribute"/>
-                <xsd:element name="collectionOperation" minOccurs="0" maxOccurs="unbounded" type="attribute"/>
+                <xsd:element name="itemOperation" minOccurs="0" maxOccurs="unbounded" type="itemOperation"/>
+                <xsd:element name="collectionOperation" minOccurs="0" maxOccurs="unbounded" type="collectionOperation"/>
                 <xsd:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="attribute"/>
                 <xsd:element name="property" minOccurs="0" maxOccurs="unbounded" type="property"/>
+                <xsd:element name="itemOperations" minOccurs="0" maxOccurs="unbounded" type="itemOperations"/>
+                <xsd:element name="collectionOperations" minOccurs="0" maxOccurs="unbounded" type="collectionOperations"/>
             </xsd:sequence>
+
             <xsd:attribute type="xsd:string" name="class" use="required"/>
             <xsd:attribute type="xsd:string" name="shortName"/>
             <xsd:attribute type="xsd:string" name="description"/>
             <xsd:attribute type="xsd:string" name="iri"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="itemOperations">
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="itemOperation" minOccurs="0" maxOccurs="unbounded" type="itemOperation"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="itemOperation">
+        <xsd:sequence minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="attribute" minOccurs="1" maxOccurs="unbounded" type="attribute"/>
+        </xsd:sequence>
+        <xsd:attribute type="xsd:string" name="name"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="collectionOperations">
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="collectionOperation" minOccurs="0" maxOccurs="unbounded" type="collectionOperation"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="collectionOperation">
+        <xsd:sequence minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="attribute" minOccurs="1" maxOccurs="unbounded" type="attribute"/>
+        </xsd:sequence>
+        <xsd:attribute type="xsd:string" name="name"/>
     </xsd:complexType>
 
     <xsd:complexType name="attribute" mixed="true">

--- a/tests/Fixtures/FileConfigurations/legacyoperations.xml
+++ b/tests/Fixtures/FileConfigurations/legacyoperations.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<resources>
+        <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
+            <itemOperation name="my_op_name">
+                <attribute name="method">POST</attribute>
+            </itemOperation>
+            <itemOperation name="my_other_op_name">
+                <attribute name="method">GET</attribute>
+            </itemOperation>
+            <collectionOperation name="my_op_name">
+                <attribute name="method">POST</attribute>
+            </collectionOperation>
+        </resource>
+</resources>

--- a/tests/Fixtures/FileConfigurations/nocollectionoperations.xml
+++ b/tests/Fixtures/FileConfigurations/nocollectionoperations.xml
@@ -2,10 +2,12 @@
 
 <resources>
         <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
-          <itemOperations>
+            <itemOperations>
                 <itemOperation name="my_op_name">
-                        <attribute name="method">POST</attribute>
+                    <attribute name="method">POST</attribute>
                 </itemOperation>
-          </itemOperations>
+            </itemOperations>
+
+            <collectionOperations />
         </resource>
 </resources>

--- a/tests/Fixtures/FileConfigurations/noitemoperations.xml
+++ b/tests/Fixtures/FileConfigurations/noitemoperations.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<resources>
+        <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
+            <itemOperations />
+            <collectionOperations>
+                <collectionOperation name="my_op_name">
+                    <attribute name="method">POST</attribute>
+                </collectionOperation>
+            </collectionOperations>
+        </resource>
+</resources>

--- a/tests/Fixtures/FileConfigurations/resources.xml
+++ b/tests/Fixtures/FileConfigurations/resources.xml
@@ -8,18 +8,20 @@
             description="Dummy resource"
             iri="someirischema"
     >
-        <itemOperation name="my_op_name">
-            <attribute name="method">GET</attribute>
-        </itemOperation>
-        <itemOperation name="my_other_op_name">
-            <attribute name="method">POST</attribute>
-        </itemOperation>
-
-        <collectionOperation name="my_collection_op">
-            <attribute name="method">POST</attribute>
-            <attribute name="path">the/collection/path</attribute>
-        </collectionOperation>
-
+        <itemOperations>
+            <itemOperation name="my_op_name">
+                <attribute name="method">GET</attribute>
+            </itemOperation>
+            <itemOperation name="my_other_op_name">
+                <attribute name="method">POST</attribute>
+            </itemOperation>
+        </itemOperations>
+        <collectionOperations>
+            <collectionOperation name="my_collection_op">
+                <attribute name="method">POST</attribute>
+                <attribute name="path">the/collection/path</attribute>
+            </collectionOperation>
+        </collectionOperations>
         <attribute name="normalization_context">
             <attribute name="groups">
                 <attribute>default</attribute>

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -73,6 +73,53 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     }
 
     /**
+     * @expectedDeprecation Configuring "%s" tags without using a parent "%ss" tag is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @group legacy
+     * @dataProvider legacyOperationsResourceMetadataProvider
+     */
+    public function testLegacyOperationsResourceMetadata($expectedResourceMetadata)
+    {
+        $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/legacyoperations.xml';
+
+        $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new XmlExtractor([$configPath]));
+        $resourceMetadata = $resourceMetadataFactory->create(FileConfigDummy::class);
+
+        $this->assertInstanceOf(ResourceMetadata::class, $resourceMetadata);
+
+        $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
+    }
+
+    /**
+     * @dataProvider noCollectionOperationsResourceMetadataProvider
+     */
+    public function testXmlNoCollectionOperationsResourceMetadata($expectedResourceMetadata)
+    {
+        $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/nocollectionoperations.xml';
+
+        $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new XmlExtractor([$configPath]));
+        $resourceMetadata = $resourceMetadataFactory->create(FileConfigDummy::class);
+
+        $this->assertInstanceOf(ResourceMetadata::class, $resourceMetadata);
+
+        $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
+    }
+
+    /**
+     * @dataProvider noItemOperationsResourceMetadataProvider
+     */
+    public function testXmlNoItemOperationsResourceMetadata($expectedResourceMetadata)
+    {
+        $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/noitemoperations.xml';
+
+        $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new XmlExtractor([$configPath]));
+        $resourceMetadata = $resourceMetadataFactory->create(FileConfigDummy::class);
+
+        $this->assertInstanceOf(ResourceMetadata::class, $resourceMetadata);
+
+        $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
+    }
+
+    /**
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
      */
     public function testInvalidXmlResourceMetadataFactory()
@@ -102,6 +149,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     }
 
     /**
+     * @expectedDeprecation Configuring "%s" tags without using a parent "%ss" tag is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
      * @dataProvider resourceMetadataProvider
      */
     public function testXmlExistingParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata)

--- a/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -64,4 +64,36 @@ abstract class FileConfigurationMetadataFactoryProvider extends \PHPUnit_Framewo
 
         return [[$resourceMetadata]];
     }
+
+    public function noCollectionOperationsResourceMetadataProvider()
+    {
+        $resourceMetadata = new ResourceMetadata();
+        $resourceMetadata = $resourceMetadata->withItemOperations(['my_op_name' => ['method' => 'POST']]);
+        $resourceMetadata = $resourceMetadata->withCollectionOperations([]);
+
+        return [[$resourceMetadata]];
+    }
+
+    public function noItemOperationsResourceMetadataProvider()
+    {
+        $resourceMetadata = new ResourceMetadata();
+        $resourceMetadata = $resourceMetadata->withCollectionOperations(['my_op_name' => ['method' => 'POST']]);
+        $resourceMetadata = $resourceMetadata->withItemOperations([]);
+
+        return [[$resourceMetadata]];
+    }
+
+    public function legacyOperationsResourceMetadataProvider()
+    {
+        $resourceMetadata = new ResourceMetadata();
+        $resourceMetadata = $resourceMetadata->withItemOperations([
+          'my_op_name' => ['method' => 'POST'],
+          'my_other_op_name' => ['method' => 'GET'],
+        ]);
+        $resourceMetadata = $resourceMetadata->withCollectionOperations([
+            'my_op_name' => ['method' => 'POST'],
+        ]);
+
+        return [[$resourceMetadata]];
+    }
 }


### PR DESCRIPTION
… possible to disable all operations

----

<details>
<summary>Git things</summary>
 
Cleaning #993 @sawmurai 

To do so, I did:

`git rebase -i [commit sha preceding your first commit]`, I then changed your multiple commits to `fixup` (you can also move the commits there to the latest):

![rebase](https://cloud.githubusercontent.com/assets/1321971/24150590/65f6e60c-0e46-11e7-951d-3b5c20a629f1.png)

Then every time it has a conflict, edit + fix conflict. Then `git add conflicting files` + `git rebase --continue`.

You end up with 1 commit and no weird things in github usually mean it's clean :).
</details>