### PR TITLE
Avoid to truncate WHERE clauses when clonning the querybuilder

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -13,6 +13,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 
@@ -102,8 +103,17 @@ final class FilterEagerLoadingExtension implements QueryCollectionExtensionInter
         }
 
         //Change where aliases
-        foreach ($wherePart->getParts() as $where) {
-            $queryBuilderClone->add('where', str_replace($aliases, $replacements, $where));
+        switch (true) {
+            case $wherePart instanceof Expr\Orx:
+                foreach ($wherePart->getParts() as $where) {
+                    $queryBuilderClone->orWhere(str_replace($aliases, $replacements, $where));
+                }
+                break;
+            case $wherePart instanceof Expr\Andx:
+                foreach ($wherePart->getParts() as $where) {
+                    $queryBuilderClone->andWhere(str_replace($aliases, $replacements, $where));
+                }
+                break;
         }
 
         return $queryBuilderClone;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR aims to fix a bug introduced by #950 
Actually when the querybuilder is cloned, some where parts are stripped.

The issue comes from 

```php
    // Change where aliases
    foreach ($wherePart->getParts() as $where) {
        $queryBuilderClone->add('where', str_replace($aliases, $replacements, $where));
    }
```
because the `add()` function doesn't append.

There's probably a cleaner way of fixing this, please let me know and i'll update
