### PR TITLE
Fix the generated XML Schema type for float

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -303,7 +303,7 @@ final class DocumentationNormalizer implements NormalizerInterface
                 return 'xmls:integer';
 
             case Type::BUILTIN_TYPE_FLOAT:
-                return 'xmls:number';
+                return 'xmls:decimal';
 
             case Type::BUILTIN_TYPE_BOOL:
                 return 'xmls:boolean';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

`xmls:number` doesn't even exist...