### PR TITLE
Normalize identifiers to the correct type

### DIFF
--- a/tests/Bridge/Doctrine/Util/IdentifierManagerTraitTest.php
+++ b/tests/Bridge/Doctrine/Util/IdentifierManagerTraitTest.php
@@ -17,12 +17,18 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInte
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\ORM\EntityManagerInterface;
 
 class IdentifierManagerTraitImpl
 {
-    use IdentifierManagerTrait;
+    use IdentifierManagerTrait {
+        IdentifierManagerTrait::normalizeIdentifiers as public;
+    }
 
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory)
     {
@@ -33,7 +39,75 @@ class IdentifierManagerTraitImpl
 
 class IdentifierManagerTraitTest extends \PHPUnit_Framework_TestCase
 {
-    private function getMetadataProphecies(array $identifiers, string $resourceClass)
+    public function testSingleIdentifier()
+    {
+        list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataFactories(Dummy::class, [
+            'id',
+        ]);
+        $objectManager = $this->getObjectManager(Dummy::class, [
+            'id' => [
+                'type' => DBALType::INTEGER,
+            ],
+        ]);
+
+        $identifierManager = new IdentifierManagerTraitImpl($propertyNameCollectionFactory, $propertyMetadataFactory);
+
+        $this->assertEquals($identifierManager->normalizeIdentifiers(1, $objectManager, Dummy::class), ['id' => 1]);
+    }
+
+    public function testCompositeIdentifier()
+    {
+        list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataFactories(Dummy::class, [
+            'ida',
+            'idb',
+        ]);
+        $objectManager = $this->getObjectManager(Dummy::class, [
+            'ida' => [
+                'type' => DBALType::INTEGER,
+            ],
+            'idb' => [
+                'type' => DBALType::INTEGER,
+            ],
+        ]);
+
+        $identifierManager = new IdentifierManagerTraitImpl($propertyNameCollectionFactory, $propertyMetadataFactory);
+
+        $this->assertEquals($identifierManager->normalizeIdentifiers('ida=1;idb=2', $objectManager, Dummy::class), ['ida' => 1, 'idb' => 2]);
+    }
+
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\PropertyNotFoundException
+     * @expectedExceptionMessage Invalid identifier "idbad=1;idb=2", "ida" has not been found.
+     */
+    public function testInvalidIdentifier()
+    {
+        list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataFactories(Dummy::class, [
+            'ida',
+            'idb',
+        ]);
+        $objectManager = $this->getObjectManager(Dummy::class, [
+            'ida' => [
+                'type' => DBALType::INTEGER,
+            ],
+            'idb' => [
+                'type' => DBALType::INTEGER,
+            ],
+        ]);
+
+        $identifierManager = new IdentifierManagerTraitImpl($propertyNameCollectionFactory, $propertyMetadataFactory);
+
+        $identifierManager->normalizeIdentifiers('idbad=1;idb=2', $objectManager, Dummy::class);
+    }
+
+    /**
+     * Gets mocked metadata factories.
+     *
+     * @param string $resourceClass
+     * @param array  $identifiers
+     *
+     * @return array
+     */
+    private function getMetadataFactories(string $resourceClass, array $identifiers): array
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
@@ -51,55 +125,37 @@ class IdentifierManagerTraitTest extends \PHPUnit_Framework_TestCase
         //random property to prevent the use of non-identifiers metadata while looping
         $propertyMetadataFactoryProphecy->create($resourceClass, 'foobar')->willReturn(new PropertyMetadata());
 
-        $propertyNameCollectionFactoryProphecy->create($resourceClass)->willReturn(new PropertyNameCollection($nameCollection))->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create($resourceClass)->willReturn(new PropertyNameCollection($nameCollection));
 
         return [$propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal()];
     }
 
-    private function getObjectManagerProphecy(array $output, string $resourceClass)
+    /**
+     * Gets a mocked object manager.
+     *
+     * @param string $resourceClass
+     * @param array  $identifierFields
+     *
+     * @return ObjectManager
+     */
+    private function getObjectManager(string $resourceClass, array $identifierFields): ObjectManager
     {
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
-        $classMetadataProphecy->getIdentifier()->willReturn($output)->shouldBeCalled();
-        $managerProphecy = $this->prophesize(ObjectManager::class);
-        $managerProphecy->getClassMetadata($resourceClass)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
+        $classMetadataProphecy->getIdentifier()->willReturn(array_keys($identifierFields));
+
+        foreach ($identifierFields as $name => $field) {
+            $classMetadataProphecy->getTypeOfField($name)->willReturn($field['type']);
+        }
+
+        $platformProphecy = $this->prophesize(AbstractPlatform::class);
+
+        $connectionProphecy = $this->prophesize(Connection::class);
+        $connectionProphecy->getDatabasePlatform()->willReturn($platformProphecy);
+
+        $managerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $managerProphecy->getClassMetadata($resourceClass)->willReturn($classMetadataProphecy->reveal());
+        $managerProphecy->getConnection()->willReturn($connectionProphecy);
 
         return $managerProphecy->reveal();
-    }
-
-    public function testSingleIdentifier()
-    {
-        $identifiers = ['id'];
-        list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataProphecies($identifiers, Dummy::class);
-        $objectManager = $this->getObjectManagerProphecy($identifiers, Dummy::class);
-
-        $identifierManager = new IdentifierManagerTraitImpl($propertyNameCollectionFactory, $propertyMetadataFactory);
-
-        $this->assertEquals($identifierManager->normalizeIdentifiers(1, $objectManager, Dummy::class), ['id' => 1]);
-    }
-
-    public function testCompositeIdentifier()
-    {
-        $identifiers = ['ida', 'idb'];
-        list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataProphecies($identifiers, Dummy::class);
-        $objectManager = $this->getObjectManagerProphecy($identifiers, Dummy::class);
-
-        $identifierManager = new IdentifierManagerTraitImpl($propertyNameCollectionFactory, $propertyMetadataFactory);
-
-        $this->assertEquals($identifierManager->normalizeIdentifiers('ida=1;idb=2', $objectManager, Dummy::class), ['ida' => 1, 'idb' => 2]);
-    }
-
-    /**
-     * @expectedException \ApiPlatform\Core\Exception\PropertyNotFoundException
-     * @expectedExceptionMessage Invalid identifier "idbad=1;idb=2", "ida" has not been found.
-     */
-    public function testInvalidIdentifier()
-    {
-        $identifiers = ['ida', 'idb'];
-        list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataProphecies($identifiers, Dummy::class);
-        $objectManager = $this->getObjectManagerProphecy($identifiers, Dummy::class);
-
-        $identifierManager = new IdentifierManagerTraitImpl($propertyNameCollectionFactory, $propertyMetadataFactory);
-
-        $identifierManager->normalizeIdentifiers('idbad=1;idb=2', $objectManager, Dummy::class);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Improve compatibility with `declare(strict_types=1);`

Should be backported to `2.0`