### PR TITLE
Allow Upper Case property names

### DIFF
--- a/src/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactory.php
@@ -74,7 +74,7 @@ final class AnnotationPropertyNameCollectionFactory implements PropertyNameColle
             }
 
             $propertyName = $this->reflection->getProperty($reflectionMethod->name);
-            if (!preg_match('/^[A-Z]{2,}/', $propertyName)) {
+            if (!$reflectionClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName)) {
                 $propertyName = lcfirst($propertyName);
             }
 


### PR DESCRIPTION
ReflectionExtractor::getProperties() returns $id instead of $Id. It is bad naming convention, but is possible

```
class Entity {
    protected $Id;

    public function getId()
    {
        return $this->Id;
    }
}
```

https://github.com/symfony/symfony/pull/22265

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1026
| License       | MIT
