### PR TITLE
[Validator] [Exception] returns 409 when unique violation is catched

### DIFF
--- a/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -49,7 +49,7 @@ final class ValidationExceptionListener
 
         $event->setResponse(new Response(
                 $this->serializer->serialize($exception->getConstraintViolationList(), $format['key']),
-                Response::HTTP_BAD_REQUEST,
+                $exception->hasOnlyConstraintUniqueViolation() ? Response::HTTP_CONFLICT : Response::HTTP_BAD_REQUEST,
                 [
                     'Content-Type' => sprintf('%s; charset=utf-8', $format['value'][0]),
                     'X-Content-Type-Options' => 'nosniff',

--- a/src/Bridge/Symfony/Validator/Exception/ValidationException.php
+++ b/src/Bridge/Symfony/Validator/Exception/ValidationException.php
@@ -11,6 +11,7 @@
 
 namespace ApiPlatform\Core\Bridge\Symfony\Validator\Exception;
 
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
@@ -37,5 +38,25 @@ final class ValidationException extends \RuntimeException
     public function getConstraintViolationList()
     {
         return $this->constraintViolationList;
+    }
+
+    /**
+     * Check if the list violation only contains Unique Violation.
+     *
+     * @return bool
+     */
+    public function hasOnlyConstraintUniqueViolation()
+    {
+        if (count($this->constraintViolationList) > 0) {
+            foreach ($this->constraintViolationList as $constraintViolation) {
+                if (UniqueEntity::NOT_UNIQUE_ERROR !== $constraintViolation->getCode()) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidationExceptionListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidationExceptionListenerTest.php
@@ -13,10 +13,13 @@ namespace ApiPlatform\Core\Tests\Bridge\Symfony\Validator\EventListener;
 
 use ApiPlatform\Core\Bridge\Symfony\Validator\EventListener\ValidationExceptionListener;
 use ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
@@ -39,6 +42,79 @@ class ValidationExceptionListenerTest extends \PHPUnit_Framework_TestCase
     public function testValidationException()
     {
         $list = new ConstraintViolationList([]);
+
+        $eventProphecy = $this->prophesize(GetResponseForExceptionEvent::class);
+        $eventProphecy->getException()->willReturn(new ValidationException($list))->shouldBeCalled();
+        $eventProphecy->getRequest()->willReturn(new Request())->shouldBeCalled();
+        $eventProphecy->setResponse(new Response('{"foo": "bar"}', Response::HTTP_BAD_REQUEST, [
+            'Content-Type' => 'application/ld+json; charset=utf-8',
+            'X-Content-Type-Options' => 'nosniff',
+            'X-Frame-Options' => 'deny',
+        ]))->shouldBeCalled();
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->serialize($list, 'hydra')->willReturn('{"foo": "bar"}')->shouldBeCalled();
+
+        $listener = new ValidationExceptionListener($serializerProphecy->reveal(), ['hydra' => ['application/ld+json']]);
+        $listener->onKernelException($eventProphecy->reveal());
+    }
+
+    public function testValidationUniqueViolationException()
+    {
+        $violation = new ConstraintViolation(
+            'jordan already exists',
+            'this is the message template',
+            [],
+            ['jordan' => 42],
+            'jordan',
+            null,
+            null,
+            UniqueEntity::NOT_UNIQUE_ERROR
+        );
+
+        $list = new ConstraintViolationList([$violation]);
+
+        $eventProphecy = $this->prophesize(GetResponseForExceptionEvent::class);
+        $eventProphecy->getException()->willReturn(new ValidationException($list))->shouldBeCalled();
+        $eventProphecy->getRequest()->willReturn(new Request())->shouldBeCalled();
+        $eventProphecy->setResponse(new Response('{"foo": "bar"}', Response::HTTP_CONFLICT, [
+            'Content-Type' => 'application/ld+json; charset=utf-8',
+            'X-Content-Type-Options' => 'nosniff',
+            'X-Frame-Options' => 'deny',
+        ]))->shouldBeCalled();
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->serialize($list, 'hydra')->willReturn('{"foo": "bar"}')->shouldBeCalled();
+
+        $listener = new ValidationExceptionListener($serializerProphecy->reveal(), ['hydra' => ['application/ld+json']]);
+        $listener->onKernelException($eventProphecy->reveal());
+    }
+
+    public function testValidationMultipleViolationException()
+    {
+        $violation1 = new ConstraintViolation(
+            'jordan already exists',
+            'this is the message template',
+            [],
+            ['jordan' => 42],
+            'jordan',
+            null,
+            null,
+            UniqueEntity::NOT_UNIQUE_ERROR
+        );
+
+        $violation2 = new ConstraintViolation(
+            'montreal already exists',
+            'this is the message template',
+            [],
+            ['montreal' => 42],
+            'montreal',
+            null,
+            null,
+            NotBlank::IS_BLANK_ERROR
+        );
+
+        $list = new ConstraintViolationList([$violation1, $violation2]);
 
         $eventProphecy = $this->prophesize(GetResponseForExceptionEvent::class);
         $eventProphecy->getException()->willReturn(new ValidationException($list))->shouldBeCalled();


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes ? 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1016 
| License       | MIT
| Doc PR        | N/A

A PR proposal to return 409 Status code when unique violation is catched.
