### PR TITLE
Allow Upper Case property names

### DIFF
--- a/src/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactory.php
@@ -74,7 +74,7 @@ final class AnnotationPropertyNameCollectionFactory implements PropertyNameColle
             }
 
             $propertyName = $this->reflection->getProperty($reflectionMethod->name);
-            if (!preg_match('/^[A-Z]{2,}/', $propertyName)) {
+            if (!$reflectionClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName)) {
                 $propertyName = lcfirst($propertyName);
             }
 

--- a/tests/Fixtures/TestBundle/Entity/UpperCaseIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/UpperCaseIdentifierDummy.php
@@ -15,14 +15,12 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Custom identifier dummy.
- *
- * @author Exploit.cz <insekticid@exploit.cz>
+ * UpperCaseIdentifier dummy.
  *
  * @ApiResource
  * @ORM\Entity
  */
-class UuidIdentifierDummy
+class UpperCaseIdentifierDummy
 {
     /**
      * @var string The custom identifier
@@ -30,7 +28,7 @@ class UuidIdentifierDummy
      * @ORM\Column(type="guid")
      * @ORM\Id
      */
-    private $uuid;
+    private $Uuid;
 
     /**
      * @var string The dummy name
@@ -41,12 +39,12 @@ class UuidIdentifierDummy
 
     public function getUuid(): string
     {
-        return $this->uuid;
+        return $this->Uuid;
     }
 
-    public function setUuid(string $uuid)
+    public function setUuid(string $Uuid)
     {
-        $this->uuid = $uuid;
+        $this->Uuid = $Uuid;
     }
 
     public function getName(): string

--- a/tests/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactoryTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\AnnotationPropertyNameCollectionF
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\UpperCaseIdentifierDummy;
 use Doctrine\Common\Annotations\Reader;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ProphecyInterface;
@@ -57,6 +58,36 @@ class AnnotationPropertyNameCollectionFactoryTest extends \PHPUnit_Framework_Tes
             [null, ['name', 'alias']],
             [$decoratedThrowsNotFound, ['name', 'alias']],
             [$decoratedReturnParent, ['name', 'alias', 'foo']],
+        ];
+    }
+
+    /**
+     * @dataProvider getUpperCaseDependencies
+     */
+    public function testUpperCaseCreate(ProphecyInterface $decorated = null, array $results)
+    {
+        $reader = $this->prophesize(Reader::class);
+        $reader->getPropertyAnnotation(new \ReflectionProperty(UpperCaseIdentifierDummy::class, 'name'), ApiProperty::class)->willReturn(new ApiProperty())->shouldBeCalled();
+        $reader->getPropertyAnnotation(new \ReflectionProperty(UpperCaseIdentifierDummy::class, 'Uuid'), ApiProperty::class)->willReturn(new ApiProperty())->shouldBeCalled();
+        $reader->getPropertyAnnotation(Argument::type(\ReflectionProperty::class), ApiProperty::class)->willReturn(null)->shouldBeCalled();
+        $reader->getMethodAnnotation(new \ReflectionMethod(UpperCaseIdentifierDummy::class, 'getName'), ApiProperty::class)->willReturn(new ApiProperty())->shouldBeCalled();
+        $reader->getMethodAnnotation(new \ReflectionMethod(UpperCaseIdentifierDummy::class, 'getUuid'), ApiProperty::class)->willReturn(new ApiProperty())->shouldBeCalled();
+        $reader->getMethodAnnotation(Argument::type(\ReflectionMethod::class), ApiProperty::class)->willReturn(null)->shouldBeCalled();
+
+        $factory = new AnnotationPropertyNameCollectionFactory($reader->reveal(), $decorated ? $decorated->reveal() : null);
+        $metadata = $factory->create(UpperCaseIdentifierDummy::class, []);
+
+        $this->assertEquals($results, iterator_to_array($metadata));
+    }
+
+    public function getUpperCaseDependencies()
+    {
+        $decoratedThrowsNotFound = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $decoratedThrowsNotFound->create(UpperCaseIdentifierDummy::class, [])->willThrow(new ResourceClassNotFoundException())->shouldBeCalled();
+
+        return [
+            [null, ['Uuid', 'name']],
+            [$decoratedThrowsNotFound, ['Uuid', 'name']],
         ];
     }
 


### PR DESCRIPTION
ReflectionExtractor::getProperties() returns $id instead of $Id. It is bad naming convention, but is possible

```
use ApiPlatform\Core\Annotation\ApiProperty;
use Doctrine\ORM\Mapping as ORM;

class Entity {
    /**
     * @var string The dummy Guid
     *
     * @ORM\Column(nullable=true)
     * @ApiProperty()
     */
    protected $Id;

    public function getId()
    {
        return $this->Id;
    }
}
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1026
| License       | MIT

