### PR TITLE
Fix not available subType to dataType of subProperty

### DIFF
--- a/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
+++ b/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
@@ -236,7 +236,7 @@ final class ApiPlatformParser implements ParserInterface
                     return $data;
                 }
 
-                $data['subType'] = $subProperty['subType'];
+                $data['subType'] = $subProperty['dataType'];
                 if (isset($subProperty['children'])) {
                     $data['children'] = $subProperty['children'];
                 }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The subProperty does not contain a further subType key, but a dataType key.

Had this error:

`Notice: Undefined index: subType`

 for instance when using a simple_array Doctrine type.

Tests are running but i was not sure howto add a test to api-platform/core/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
