### PR TITLE
Allow the operation name to be null in ResourceMetadata

### DIFF
--- a/src/Metadata/Resource/ResourceMetadata.php
+++ b/src/Metadata/Resource/ResourceMetadata.php
@@ -165,14 +165,14 @@ final class ResourceMetadata
     /**
      * Gets a collection operation attribute, optionally fallback to a resource attribute.
      *
-     * @param string $operationName
-     * @param string $key
-     * @param mixed  $defaultValue
-     * @param bool   $resourceFallback
+     * @param string|null $operationName
+     * @param string      $key
+     * @param mixed       $defaultValue
+     * @param bool        $resourceFallback
      *
      * @return mixed
      */
-    public function getCollectionOperationAttribute(string $operationName, string $key, $defaultValue = null, bool $resourceFallback = false)
+    public function getCollectionOperationAttribute(string $operationName = null, string $key, $defaultValue = null, bool $resourceFallback = false)
     {
         return $this->getOperationAttribute($this->collectionOperations, $operationName, $key, $defaultValue, $resourceFallback);
     }
@@ -180,14 +180,14 @@ final class ResourceMetadata
     /**
      * Gets an item operation attribute, optionally fallback to a resource attribute.
      *
-     * @param string $operationName
-     * @param string $key
-     * @param mixed  $defaultValue
-     * @param bool   $resourceFallback
+     * @param string|null $operationName
+     * @param string      $key
+     * @param mixed       $defaultValue
+     * @param bool        $resourceFallback
      *
      * @return mixed
      */
-    public function getItemOperationAttribute(string $operationName, string $key, $defaultValue = null, bool $resourceFallback = false)
+    public function getItemOperationAttribute(string $operationName = null, string $key, $defaultValue = null, bool $resourceFallback = false)
     {
         return $this->getOperationAttribute($this->itemOperations, $operationName, $key, $defaultValue, $resourceFallback);
     }
@@ -195,17 +195,17 @@ final class ResourceMetadata
     /**
      * Gets an operation attribute, optionally fallback to a resource attribute.
      *
-     * @param array|null $operations
-     * @param string     $operationName
-     * @param string     $key
-     * @param mixed      $defaultValue
-     * @param bool       $resourceFallback
+     * @param array|null  $operations
+     * @param string|null $operationName
+     * @param string      $key
+     * @param mixed       $defaultValue
+     * @param bool        $resourceFallback
      *
      * @return mixed
      */
-    private function getOperationAttribute(array $operations = null, string $operationName, string $key, $defaultValue = null, bool $resourceFallback = false)
+    private function getOperationAttribute(array $operations = null, string $operationName = null, string $key, $defaultValue = null, bool $resourceFallback = false)
     {
-        if (isset($operations[$operationName][$key])) {
+        if (null !== $operationName && isset($operations[$operationName][$key])) {
             return $operations[$operationName][$key];
         }
 

--- a/tests/Metadata/Resource/ResourceMetadataTest.php
+++ b/tests/Metadata/Resource/ResourceMetadataTest.php
@@ -29,11 +29,13 @@ class ResourceMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], $metadata->getItemOperations());
         $this->assertEquals('a', $metadata->getItemOperationAttribute('iop1', 'foo', 'z', false));
         $this->assertEquals('bar', $metadata->getItemOperationAttribute('iop1', 'baz', 'z', true));
+        $this->assertEquals('bar', $metadata->getItemOperationAttribute(null, 'baz', 'z', true));
         $this->assertEquals('z', $metadata->getItemOperationAttribute('iop1', 'notExist', 'z', true));
         $this->assertEquals('z', $metadata->getItemOperationAttribute('notExist', 'notExist', 'z', true));
         $this->assertEquals(['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], $metadata->getCollectionOperations());
         $this->assertEquals('c', $metadata->getCollectionOperationAttribute('cop1', 'foo', 'z', false));
         $this->assertEquals('bar', $metadata->getCollectionOperationAttribute('cop1', 'baz', 'z', true));
+        $this->assertEquals('bar', $metadata->getCollectionOperationAttribute(null, 'baz', 'z', true));
         $this->assertEquals('z', $metadata->getCollectionOperationAttribute('cop1', 'notExist', 'z', true));
         $this->assertEquals('z', $metadata->getCollectionOperationAttribute('notExist', 'notExist', 'z', true));
         $this->assertEquals(['baz' => 'bar'], $metadata->getAttributes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1047
| License       | MIT
| Doc PR        | n/a