### PR TITLE
Get rid of the dependency to the templating component

### DIFF
--- a/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -53,7 +53,7 @@ final class SwaggerUiAction
         $documentation = new Documentation($this->resourceNameCollectionFactory->create(), $this->title, $this->description, $this->version, $this->formats);
 
         return new Response($this->twig->render(
-            'ApiPlatformBundle:SwaggerUi:index.html.twig',
+            '@ApiPlatform/SwaggerUi/index.html.twig',
             $this->getContext($request) + ['spec' => $this->serializer->serialize($documentation, 'json')])
         );
     }

--- a/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
+++ b/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
@@ -58,7 +58,7 @@ class SwaggerUiActionTest extends \PHPUnit_Framework_TestCase
         $postRequest->setMethod('POST');
 
         $twigCollectionProphecy = $this->prophesize(\Twig_Environment::class);
-        $twigCollectionProphecy->render('ApiPlatformBundle:SwaggerUi:index.html.twig', [
+        $twigCollectionProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [
             'spec' => 'hello',
             'shortName' => 'F',
             'operationId' => 'getFCollection',
@@ -68,7 +68,7 @@ class SwaggerUiActionTest extends \PHPUnit_Framework_TestCase
         ])->shouldBeCalled();
 
         $twigItemProphecy = $this->prophesize(\Twig_Environment::class);
-        $twigItemProphecy->render('ApiPlatformBundle:SwaggerUi:index.html.twig', [
+        $twigItemProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [
             'spec' => 'hello',
             'shortName' => 'F',
             'operationId' => 'getFItem',
@@ -96,7 +96,7 @@ class SwaggerUiActionTest extends \PHPUnit_Framework_TestCase
         $serializerProphecy->serialize(Argument::type(Documentation::class), 'json')->willReturn('hello')->shouldBeCalled();
 
         $twigProphecy = $this->prophesize(\Twig_Environment::class);
-        $twigProphecy->render('ApiPlatformBundle:SwaggerUi:index.html.twig', [
+        $twigProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [
             'spec' => 'hello',
             'shortName' => null,
             'operationId' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Allow API Platform to work without the `symfony/templating` component.