### PR TITLE
Update priority of FosUser\EventListener

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -22,6 +22,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedToDummyFriend;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelationEmbedder;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\User;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\UuidIdentifierDummy;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
@@ -419,5 +420,18 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $this->manager->persist($relatedDummy2);
 
         $this->manager->flush();
+    }
+
+    /**
+     * @Then the password :password for user :user should be hashed
+     */
+    public function thePasswordForUserShouldBeHashed($password, $user)
+    {
+        $repository = $this->doctrine->getRepository(User::class);
+        $user = $repository->find($user);
+
+        if (!password_verify($password, $user->getPassword())) {
+            throw new \Exception('User password mismatch');
+        }
     }
 }

--- a/features/integration/fos_user.feature
+++ b/features/integration/fos_user.feature
@@ -29,6 +29,7 @@ Feature: FOSUser integration
       "username": "dummy.user"
     }
     """
+    And the password "azerty" for user "1" should be hashed
 
   @dropSchema
   Scenario: Delete a user

--- a/src/Bridge/Symfony/Bundle/Resources/config/fos_user.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/fos_user.xml
@@ -8,7 +8,7 @@
         <service id="api_platform.fos_user.event_listener" class="ApiPlatform\Core\Bridge\FosUser\EventListener">
             <argument type="service" id="fos_user.user_manager" />
 
-            <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="11" />
+            <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="24" />
         </service>
     </services>
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -170,7 +170,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThan(
             $viewListener->getTag('kernel.event_listener')[0]['priority'],
             $fosListener->getTag('kernel.event_listener')[0]['priority'],
-            "api_platform.fos_user.event_listener priority needs to be greater than that of api_platform.listener.view.serialize"
+            'api_platform.fos_user.event_listener priority needs to be greater than that of api_platform.listener.view.serialize'
         );
     }
 

--- a/tests/Fixtures/app/config/security.yml
+++ b/tests/Fixtures/app/config/security.yml
@@ -1,5 +1,6 @@
 security:
     encoders:
+        ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\User: bcrypt
         FOS\UserBundle\Model\UserInterface: plaintext
 
     providers:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1064
| License       | MIT
| Doc PR        | N/A

Since #597, the `ApiPlatform\Core\EventListener\SerializerListener` (formerly `SerializerViewListener`) class changed priorty from 10 to 16.
The `ApiPlatform\Core\Bridge\FosUser\EventListener` class has a priority of 11, which means it now runs after the `SerializerListener`. This causes the controller result to be already serialized, which fails the checks in the FOSUser listener.

This PR updates the priority of `ApiPlatform\Core\Bridge\FosUser\EventListener` to 24, so that it can run before the `SerializerListener` class.