### PR TITLE
Fix the resource class resolver (and collection normalizers) with Traversable values

### DIFF
--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Api;
 
-use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Util\ClassInfoTrait;
@@ -40,7 +39,7 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
      */
     public function getResourceClass($value, string $resourceClass = null, bool $strict = false): string
     {
-        if (is_object($value) && !$value instanceof PaginatorInterface) {
+        if (is_object($value) && !$value instanceof \Traversable) {
             $typeToFind = $type = $this->getObjectClass($value);
             if (null === $resourceClass) {
                 $resourceClass = $typeToFind;
@@ -56,7 +55,7 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
                 return $type;
             }
 
-            throw new InvalidArgumentException(sprintf('No resource class found for object of type "%s"', $typeToFind));
+            throw new InvalidArgumentException(sprintf('No resource class found for object of type "%s".', $typeToFind));
         }
 
         return $resourceClass;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This PR allows the `ResourceClassResolver::getResourceClass()` method to return the given resource class when value is a `\Traversable`.
So, `CollectionNormalizer` classes no longer throw an `InvalidArgumentException` exception with `\Traversable` objects during the normalization.
