### PR TITLE
Add support for customizable api resources folder's name.

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -113,6 +113,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.exception_to_status', $config['exception_to_status']);
         $container->setParameter('api_platform.formats', $formats);
         $container->setParameter('api_platform.error_formats', $errorFormats);
+        $container->setParameter('api_platform.api_resources_directory', $config['api_resources_directory']);
         $container->setParameter('api_platform.eager_loading.enabled', $config['eager_loading']['enabled']);
         $container->setParameter('api_platform.eager_loading.max_joins', $config['eager_loading']['max_joins']);
         $container->setParameter('api_platform.eager_loading.force_eager', $config['eager_loading']['force_eager']);
@@ -168,6 +169,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $resourceClassDirectories = $loaderPaths['annotation'];
         $xmlResources = $loaderPaths['xml'];
         $yamlResources = $loaderPaths['yaml'];
+        $resourcesDirectory = $container->getParameter('api_platform.api_resources_directory');
 
         foreach ($bundles as $bundle) {
             $bundleDirectory = dirname((new \ReflectionClass($bundle))->getFileName());
@@ -176,7 +178,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $xmlResources = array_merge($xmlResources, $newXmlResources);
             $yamlResources = array_merge($yamlResources, $newYamlResources);
 
-            if (file_exists($entityDirectory = $bundleDirectory.'/Entity')) {
+            if (file_exists($entityDirectory = $bundleDirectory.'/'.$resourcesDirectory)) {
                 $resourceClassDirectories[] = $entityDirectory;
                 $container->addResource(new DirectoryResource($entityDirectory, '/\.php$/'));
             }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -45,6 +45,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('version')->defaultValue('0.0.0')->info('The version of the API.')->end()
                 ->scalarNode('default_operation_path_resolver')->defaultValue('api_platform.operation_path_resolver.underscore')->info('Specify the default operation path resolver to use for generating resources operations path.')->end()
                 ->scalarNode('name_converter')->defaultNull()->info('Specify a name converter to use.')->end()
+                ->scalarNode('api_resources_directory')->defaultValue('Entity')->info('The name of the directory within the bundles that contains the api resources.')->end()
                 ->arrayNode('eager_loading')
                     ->canBeDisabled()
                     ->addDefaultsIfNotSet()

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -40,6 +40,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
     const DEFAULT_CONFIG = ['api_platform' => [
         'title' => 'title',
         'description' => 'description',
+        'api_resources_directory' => 'Entity',
         'version' => 'version',
         'formats' => [
             'jsonld' => ['mime_types' => ['application/ld+json']],
@@ -234,6 +235,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.collection.pagination.items_per_page_parameter_name' => 'itemsPerPage',
             'api_platform.collection.pagination.maximum_items_per_page' => null,
             'api_platform.collection.pagination.page_parameter_name' => 'page',
+            'api_platform.api_resources_directory' => 'Entity',
             'api_platform.description' => 'description',
             'api_platform.error_formats' => ['jsonproblem' => ['application/problem+json'], 'jsonld' => ['application/ld+json']],
             'api_platform.oauth.enabled' => false,
@@ -415,6 +417,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         }
 
         $containerBuilderProphecy->getParameter('kernel.debug')->willReturn(false);
+        $containerBuilderProphecy->getParameter('api_platform.api_resources_directory')->willReturn('Entity');
 
         return $containerBuilderProphecy;
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -107,6 +107,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'yaml' => [],
                 'xml' => [],
             ],
+            'api_resources_directory' => 'Entity',
         ], $config);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/195


This PR adds the possibility to customise the name of the folder in which the api resources (as in the classes tagged using the `@ApiResource` annotation) are stored, rather than the hardcoded "Entity" folder.
Such change allows for easier separation between the entities used for persisting the data and the classes used for describing the api resources.