### PR TITLE
Add attributes to metadata XSD file

### DIFF
--- a/src/Metadata/schema/metadata.xsd
+++ b/src/Metadata/schema/metadata.xsd
@@ -1,7 +1,9 @@
 <?xml version="1.0" ?>
 
 <xsd:schema
+        xmlns="https://api-platform.com/schema/metadata"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="https://api-platform.com/schema/metadata"
         elementFormDefault="qualified">
 
     <xsd:element name="resources" type="resources"/>

--- a/tests/Fixtures/FileConfigurations/propertyinvalid.xml
+++ b/tests/Fixtures/FileConfigurations/propertyinvalid.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 
-<resources>
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
     <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
         <property name="foo">
             <foo>Foo</foo>

--- a/tests/Fixtures/FileConfigurations/resourcenotfound.xml
+++ b/tests/Fixtures/FileConfigurations/resourcenotfound.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<resources>
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
     <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ThisDoesNotExist">
     </resource>
 </resources>

--- a/tests/Fixtures/FileConfigurations/resources.xml
+++ b/tests/Fixtures/FileConfigurations/resources.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 
-<resources>
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
     <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy"/>
     <resource
             class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy"
@@ -56,6 +59,6 @@
             <attribute name="baz">Baz</attribute>
         </property>
 
-        <property name="name" description="The dummy name" />
+        <property name="name" description="The dummy name"/>
     </resource>
 </resources>

--- a/tests/Fixtures/FileConfigurations/resourcesinvalid.xml
+++ b/tests/Fixtures/FileConfigurations/resourcesinvalid.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<resources>
-        <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
-                <foo name="my_op_name" />
-        </resource>
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
+    <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
+        <foo name="my_op_name"/>
+    </resource>
 </resources>

--- a/tests/Fixtures/FileConfigurations/resourcesoptional.xml
+++ b/tests/Fixtures/FileConfigurations/resourcesoptional.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<resources>
-        <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
-                <itemOperation name="my_op_name">
-                        <attribute name="method">POST</attribute>
-                </itemOperation>
-        </resource>
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
+    <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy">
+        <itemOperation name="my_op_name">
+            <attribute name="method">POST</attribute>
+        </itemOperation>
+    </resource>
 </resources>

--- a/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
@@ -83,7 +83,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
 
     /**
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /.+Element 'foo': This element is not expected\..+/
+     * @expectedExceptionMessageRegExp #.+Element '\{https://api-platform.com/schema/metadata\}foo': This element is not expected\..+#
      */
     public function testCreateWithInvalidXml()
     {

--- a/tests/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactoryTest.php
@@ -64,7 +64,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends \PHPUnit_Framework_Test
 
     /**
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /.+Element 'foo': This element is not expected\..+/
+     * @expectedExceptionMessageRegExp #.+Element '\{https://api-platform.com/schema/metadata\}foo': This element is not expected\..+#
      */
     public function testCreateWithInvalidXml()
     {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | TBD

Not a critical thing, but as I tend to prefer XML for configuration files I'm sure other will enjoy the change :
Added attributes allow to validate resources.xml files as developers can do with other Symfony config files (ex: routing, services, ...)
This would ease auto-completion by editors supporting XML structure hints from the XSD (like PHPStorm) by defining the namespace in the XML header, as other XML config files do in Symfony : 
```xml
<!-- src/AppBundle/Resources/config/api_resources/resources.xml -->

<?xml version="1.0" encoding="UTF-8" ?>
<resources xmlns="https://api-platform.com/schema/metadata"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="https://api-platform.com/schema/metadata
           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
   [...]
</resources>
```
The proposed URI for the schema (`https://api-platform.com/schema/metadata/metadata-2.0.xsd`) is subject of discussion as it implies that the last stable version of the XSD file for the choosen branch is publicly available.

I'll make the PR to the Getting-Started page of the documentation once those details will be sorted out.
WHat do you think about this ?