### PR TITLE
Add dynamic serialization groups filter

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -113,6 +113,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.exception_to_status', $config['exception_to_status']);
         $container->setParameter('api_platform.formats', $formats);
         $container->setParameter('api_platform.error_formats', $errorFormats);
+        $container->setParameter('api_platform.group_parameter_name', $config['group_parameter_name']);
         $container->setParameter('api_platform.eager_loading.enabled', $config['eager_loading']['enabled']);
         $container->setParameter('api_platform.eager_loading.max_joins', $config['eager_loading']['max_joins']);
         $container->setParameter('api_platform.eager_loading.force_eager', $config['eager_loading']['force_eager']);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -45,6 +45,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('version')->defaultValue('0.0.0')->info('The version of the API.')->end()
                 ->scalarNode('default_operation_path_resolver')->defaultValue('api_platform.operation_path_resolver.underscore')->info('Specify the default operation path resolver to use for generating resources operations path.')->end()
                 ->scalarNode('name_converter')->defaultNull()->info('Specify a name converter to use.')->end()
+                ->scalarNode('group_parameter_name')->defaultValue('groups')->info('The default name of the parameter handling the groups.')->end()
                 ->arrayNode('eager_loading')
                     ->canBeDisabled()
                     ->addDefaultsIfNotSet()

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -74,6 +74,14 @@
             <tag name="serializer.normalizer" />
         </service>
 
+        <!-- Group filter -->
+
+        <service id="api_platform.serializer.group_filter" class="ApiPlatform\Core\Serializer\GroupFilter" public="false" decorates="api_platform.serializer.context_builder">
+            <argument type="service" id="api_platform.serializer.group_filter.inner" />
+            <argument>%api_platform.group_parameter_name%</argument>
+            <tag name="api_platform.filter" id="api_platform.group_filter" />
+        </service>
+
         <!-- Resources Operations path resolver -->
 
         <service id="api_platform.operation_path_resolver" alias="api_platform.operation_path_resolver.router" public="false" />

--- a/src/Serializer/GroupFilter.php
+++ b/src/Serializer/GroupFilter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Serializer;
+
+use ApiPlatform\Core\Api\FilterInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Group filter allows to add dynamic filters via query parameters.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class GroupFilter implements FilterInterface, SerializerContextBuilderInterface
+{
+    private $decorated;
+    private $parameterName;
+
+    public function __construct(SerializerContextBuilderInterface $decorated, $parameterName = 'groups')
+    {
+        $this->decorated = $decorated;
+        $this->parameterName = $parameterName;
+    }
+
+    public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null): array
+    {
+        $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);
+
+        $groups = $request->query->get($this->parameterName);
+
+        if (!$groups) {
+            return $context;
+        }
+
+        if (!is_array($groups)) {
+            $groups = [$groups];
+        }
+
+        $context['groups'] = array_merge($groups, $context['groups'] ?? []);
+
+        return $context;
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        return [$this->parameterName => [
+            'property' => $this->parameterName,
+            'type' => 'array',
+            'required' => false,
+        ]];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | NO
| Fixed tickets | #1082
| License       | MIT
| Doc PR        | n/a

Should this filter be enabled per resource or will act on a global scope?
Should we add a way to disable it globally?

If we want it to show up on swagger it needs to be enabled in the resource filters (`src/Swagger/Serializer/DocumentationNormalizer.php+:588`). Do we want this in swagger?