### PR TITLE
Remove redundant type declaration of PaginatorInterface

### DIFF
--- a/src/DataProvider/CollectionDataProviderInterface.php
+++ b/src/DataProvider/CollectionDataProviderInterface.php
@@ -30,7 +30,7 @@ interface CollectionDataProviderInterface
      *
      * @throws ResourceClassNotSupportedException
      *
-     * @return array|PaginatorInterface|\Traversable
+     * @return array|\Traversable
      */
     public function getCollection(string $resourceClass, string $operationName = null);
 }

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\EventListener;
 
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
-use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -69,7 +68,7 @@ final class ReadListener
      * @param Request $request
      * @param array   $attributes
      *
-     * @return array|\Traversable|PaginatorInterface|null
+     * @return array|\Traversable|null
      */
     private function getCollectionData(Request $request, array $attributes)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

```php
PaginatorInterface instanceof \Traversable
```