### PR TITLE
Add JsonSerializable on identifier generator test

### DIFF
--- a/tests/Fixtures/TestBundle/Doctrine/Generator/Uuid.php
+++ b/tests/Fixtures/TestBundle/Doctrine/Generator/Uuid.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Doctrine\Generator;
 
-class Uuid
+class Uuid implements \JsonSerializable
 {
     private $id;
 
@@ -25,5 +25,10 @@ class Uuid
     public function __toString()
     {
         return $this->id;
+    }
+
+    public function jsonSerialize()
+    {
+        return (string) $this->id;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/CustomGeneratedIdentifier.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomGeneratedIdentifier.php
@@ -37,6 +37,6 @@ class CustomGeneratedIdentifier
 
     public function getId()
     {
-        return (string) $this->id;
+        return $this->id;
     }
 }


### PR DESCRIPTION
Better like this. If you don' t implement JsonSerializable, the `id` normalized value will not be what you expect.
