### PR TITLE
Move the metadata from validator factory to the validator.xml file

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
@@ -64,11 +64,6 @@
             <argument type="service" id="api_platform.metadata.property.metadata_factory.serializer.inner" />
         </service>
 
-        <service id="api_platform.metadata.property.metadata_factory.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\ValidatorPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="20" public="false">
-            <argument type="service" id="validator" />
-            <argument type="service" id="api_platform.metadata.property.metadata_factory.validator.inner" />
-        </service>
-
         <service id="api_platform.metadata.property.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.property" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.cached.inner" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -5,6 +5,11 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="api_platform.metadata.property.metadata_factory.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\ValidatorPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="20" public="false">
+            <argument type="service" id="validator" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory.validator.inner" />
+        </service>
+
         <service id="api_platform.listener.view.validate" class="ApiPlatform\Core\Bridge\Symfony\Validator\EventListener\ValidateListener">
             <argument type="service" id="validator" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

As the validator as a dev dependency, it won't necessary be installed when using ApiPlatform's "pack" and Symfony Flex. Still, the validator is a dependency to get the metadata from its component: moving this definition to the `validator.xml` file that is only included when the validator component exists fixes the problem.