### PR TITLE
Add the header_comment rule to the PHP-CS-Fixer's configuration

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,14 @@
 <?php
 
+$header = <<<'HEADER'
+This file is part of the API Platform project.
+
+(c) Kévin Dunglas <dunglas@gmail.com>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+HEADER;
+
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude('tests/Fixtures/app/cache')
@@ -17,6 +26,10 @@ return PhpCsFixer\Config::create()
             'allow_single_line_closure' => true,
         ],
         'declare_strict_types' => true,
+        'header_comment' => [
+            'header' => $header,
+            'location' => 'after_open',
+        ],
         'modernize_types_casting' => true,
         // 'native_function_invocation' => true,
         'no_extra_consecutive_blank_lines' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A