### PR TITLE
Fix ignoring attributes for the abstract item normalizer

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -132,8 +132,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $propertyMetadata = $this->propertyMetadataFactory->create($context['resource_class'], $propertyName, $options);
 
             if (
-                (isset($context['api_normalize']) && $propertyMetadata->isReadable()) ||
-                (isset($context['api_denormalize']) && $propertyMetadata->isWritable())
+                $this->isAllowedAttribute($classOrObject, $propertyName, null, $context) &&
+                ((isset($context['api_normalize']) && $propertyMetadata->isReadable()) ||
+                (isset($context['api_denormalize']) && $propertyMetadata->isWritable()))
             ) {
                 $allowedAttributes[] = $propertyName;
             }

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -76,16 +76,20 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
 
         $dummy = new Dummy();
         $dummy->setName('foo');
+        $dummy->setAlias('ignored');
         $dummy->setRelatedDummy($relatedDummy);
         $dummy->relatedDummies->add(new RelatedDummy());
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
-            new PropertyNameCollection(['name', 'relatedDummy', 'relatedDummies'])
+            new PropertyNameCollection(['name', 'alias', 'relatedDummy', 'relatedDummies'])
         )->shouldBeCalled();
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn(
+            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', true)
+        )->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'alias', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', true)
         )->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn(
@@ -134,6 +138,7 @@ class AbstractItemNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyAccesorProphecy->reveal(),
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
+        $normalizer->setIgnoredAttributes(['alias']);
 
         $this->assertEquals([
             'name' => 'foo',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1120
| License       | MIT
| Doc PR        | N/A

This PR add the ability to [ignore attributes](http://symfony.com/doc/current/components/serializer.html#ignoring-attributes) for our abstract item normalizer.

This fix originally comes from #1123 but #1120 made me realize that this is a bug and this one has to be fixed in our `2.0` branch.