### PR TITLE
Fix the Varnish purger

### DIFF
--- a/src/HttpCache/VarnishPurger.php
+++ b/src/HttpCache/VarnishPurger.php
@@ -48,10 +48,10 @@ final class VarnishPurger implements PurgerInterface
             return sprintf('(^|\,)%s($|\,)', preg_quote($iri));
         }, $iris);
 
-        $regex = isset($parts[1]) ? sprintf('(%s)', implode(')|(', $parts)) : $parts[0];
+        $regex = count($parts) > 1 ? sprintf('(%s)', implode(')|(', $parts)) : array_shift($parts);
 
         foreach ($this->clients as $client) {
-            $client->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => $regex]]);
+            $client->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => $regex]]);
         }
     }
 }

--- a/tests/HttpCache/VarnishPurgerTest.php
+++ b/tests/HttpCache/VarnishPurgerTest.php
@@ -25,22 +25,22 @@ class VarnishPurgerTest extends \PHPUnit_Framework_TestCase
     public function testPurge()
     {
         $clientProphecy1 = $this->prophesize(ClientInterface::class);
-        $clientProphecy1->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '(^|\,)/foo($|\,)']])->willReturn(new Response())->shouldBeCalled();
-        $clientProphecy1->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))']])->willReturn(new Response())->shouldBeCalled();
+        $clientProphecy1->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '(^|\,)/foo($|\,)']])->willReturn(new Response())->shouldBeCalled();
+        $clientProphecy1->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))']])->willReturn(new Response())->shouldBeCalled();
 
         $clientProphecy2 = $this->prophesize(ClientInterface::class);
-        $clientProphecy2->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '(^|\,)/foo($|\,)']])->willReturn(new Response())->shouldBeCalled();
-        $clientProphecy2->requestAsync('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))']])->willReturn(new Response())->shouldBeCalled();
+        $clientProphecy2->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '(^|\,)/foo($|\,)']])->willReturn(new Response())->shouldBeCalled();
+        $clientProphecy2->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))']])->willReturn(new Response())->shouldBeCalled();
 
         $purger = new VarnishPurger([$clientProphecy1->reveal(), $clientProphecy2->reveal()]);
         $purger->purge(['/foo']);
-        $purger->purge(['/foo', '/bar']);
+        $purger->purge(['/foo' => '/foo', '/bar' => '/bar']);
     }
 
     public function testEmptyTags()
     {
         $clientProphecy1 = $this->prophesize(ClientInterface::class);
-        $clientProphecy1->requestAsync()->shouldNotBeCalled();
+        $clientProphecy1->request()->shouldNotBeCalled();
 
         $purger = new VarnishPurger([$clientProphecy1->reveal()]);
         $purger->purge([]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

* Allows non indexed arrays
* Use `request` instead of `requestAsync` to throw an error in the purge doesn't work
