### PR TITLE
fix #1161 #1144 followup

### DIFF
--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -152,11 +152,13 @@ final class ApiLoader extends Loader
                 'collection' => $isCollection,
             ];
 
-            $visiting = "$resourceClass$subresource";
+            $visiting = "$rootResourceClass $resourceClass $propertyName $subresource";
 
             if (in_array($visiting, $visited, true)) {
                 continue;
             }
+
+            $visited[] = $visiting;
 
             if (null === $parentOperation) {
                 $rootResourceMetadata = $this->resourceMetadataFactory->create($rootResourceClass);
@@ -172,8 +174,6 @@ final class ApiLoader extends Loader
                 $operation['route_name'] = str_replace(self::SUBRESOURCE_SUFFIX, "_$propertyName".self::SUBRESOURCE_SUFFIX, $parentOperation['route_name']);
                 $operation['path'] = $this->operationPathResolver->resolveOperationPath($parentOperation['path'], $operation, OperationType::SUBRESOURCE);
             }
-
-            $visited[] = $visiting;
 
             $route = new Route(
                 $operation['path'],

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -175,6 +175,16 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
             $this->getSubresourceRoute('/dummies/{id}/subresources/{subresource}/recursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_dummies_subresources_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => [['id', DummyEntity::class], ['subresource', RelatedDummyEntity::class]], 'collection' => false]),
             $routeCollection->get('api_dummies_subresources_recursivesubresource_get_subresource')
         );
+
+        $this->assertEquals(
+            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource/{secondrecursivesubresource}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', RelatedDummyEntity::class], ['secondrecursivesubresource', DummyEntity::class]], 'collection' => true]),
+            $routeCollection->get('api_related_dummies_secondrecursivesubresource_subresources_get_subresource')
+        );
+
+        $this->assertEquals(
+            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_related_dummies_secondrecursivesubresource_get_subresource', ['property' => 'secondrecursivesubresource', 'identifiers' => [['id', RelatedDummyEntity::class]], 'collection' => false]),
+            $routeCollection->get('api_related_dummies_secondrecursivesubresource_get_subresource')
+        );
     }
 
     private function getApiLoaderWithResourceMetadata(ResourceMetadata $resourceMetadata, $recursiveSubresource = false): ApiLoader
@@ -208,7 +218,7 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(DummyEntity::class)->willReturn(new PropertyNameCollection(['id', 'subresource']));
-        $propertyNameCollectionFactoryProphecy->create(RelatedDummyEntity::class)->willReturn(new PropertyNameCollection(['id', 'recursivesubresource']));
+        $propertyNameCollectionFactoryProphecy->create(RelatedDummyEntity::class)->willReturn(new PropertyNameCollection(['id', 'recursivesubresource', 'secondrecursivesubresource']));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'id')->willReturn(new PropertyMetadata());
@@ -222,9 +232,11 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
 
         if (false === $recursiveSubresource) {
             $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource')->willReturn(new PropertyMetadata());
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource')->willReturn(new PropertyMetadata());
         } else {
             $dummyType = new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyEntity::class);
             $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource')->willReturn((new PropertyMetadata())->withSubresource(true)->withType($dummyType));
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource')->willReturn((new PropertyMetadata())->withSubresource(true)->withType($dummyType));
         }
 
         $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->willReturn($subResourcePropertyMetadata);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1161 
| License       | MIT
| Doc PR        | na

@teohhanhui I don't see the point of setting up a complex `visited` array for this task. I mean, I could populate an array like in your example, but if I then want to use it to compute the RouteCollection, won't I do the job twice?