### PR TITLE
fix deprecation notice from in IriConvertor::getIriFromItem

### DIFF
--- a/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
+++ b/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
@@ -55,7 +55,6 @@ final class CachedRouteNameResolver implements RouteNameResolverInterface
             $context = func_get_arg(2);
         } else {
             $context = [];
-            @trigger_error(sprintf('Method %s() will have a third `$context = []` argument in version 3.0. Not defining it is deprecated since 2.1.', __METHOD__), E_USER_DEPRECATED);
         }
 
         $routeName = $this->decorated->getRouteName($resourceClass, $operationType, $context);

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -92,7 +92,7 @@ final class IriConverter implements IriConverterInterface
     public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
         $resourceClass = $this->getObjectClass($item);
-        $routeName = $this->routeNameResolver->getRouteName($resourceClass, false);
+        $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM, []);
 
         try {
             $identifiers = $this->generateIdentifiersUrl($this->identifiersExtractor->getIdentifiersFromItem($item));

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -92,7 +92,7 @@ final class IriConverter implements IriConverterInterface
     public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
         $resourceClass = $this->getObjectClass($item);
-        $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM, []);
+        $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
 
         try {
             $identifiers = $this->generateIdentifiersUrl($this->identifiersExtractor->getIdentifiersFromItem($item));

--- a/src/Bridge/Symfony/Routing/RouteNameResolver.php
+++ b/src/Bridge/Symfony/Routing/RouteNameResolver.php
@@ -41,7 +41,6 @@ final class RouteNameResolver implements RouteNameResolverInterface
             $context = func_get_arg(2);
         } else {
             $context = [];
-            @trigger_error(sprintf('Method %s() will have a third `$context = []` argument in version 3.0. Not defining it is deprecated since 2.1.', __METHOD__), E_USER_DEPRECATED);
         }
 
         $operationType = OperationTypeDeprecationHelper::getOperationType($operationType);


### PR DESCRIPTION
Per [OperationTypeDeprecationHelper.php](https://github.com/api-platform/core/blob/42940e3f48c3450d6c193f6bca6b8c5041821ffa/src/Api/OperationTypeDeprecationHelper.php#L18) comment: `false` should be replaced with `OperationType::ITEM`. 

Per deprecation notice in [RouteNameResolver](https://github.com/api-platform/core/blob/e66ed60aa0ea4065f75cbd8c24ef07d8f2b14abb/src/Bridge/Symfony/Routing/RouteNameResolver.php#L44) third argument also becomes mandatory and is empty array when not in use. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes - fix deprecation notice
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I've tried, but I cannot figure out how to write a test to cover this change. The deprecation comes out of RouteNameResolver::getRouteName which has coverage, but the deprecated call is made from IriConverter::GetIriFromItem which doesn't appear to have coverage at the moment.

I ended up in a situation where I was attempting to mock/prophesize Router returning a mocked RouteCollection returning a mocked Route and began to suspect that I was following the wrong path. If anyone can provide pointers I'll be eternally grateful. 
