### PR TITLE
Check if operation_type exists in AbstractItemNormalizer

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -410,7 +410,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
              * On a subresource, we know the value of the identifiers.
              * If attributeValue is null, meaning that it hasn't been returned by the DataProvider, get the item Iri
              */
-            if (null === $attributeValue && $context['operation_type'] === OperationType::SUBRESOURCE && isset($context['subresource_resources'][$className])) {
+            if (null === $attributeValue && isset($context['operation_type']) && $context['operation_type'] === OperationType::SUBRESOURCE && isset($context['subresource_resources'][$className])) {
                 return $this->iriConverter->getItemIriFromResourceClass($className, $context['subresource_resources'][$className]);
             } elseif ($attributeValue) {
                 return $this->normalizeRelation($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

When I directly serialize an entity which is ApiPlatform resource, `$context['operation_type']` isn't set (usually it's set by SerializerContextBuilder::createFromRequest) and it throws and error
```
Undefined index: operation_type in AbstractItemNormalizer
```
For consistency, CollectionNormalizer [has `isset($context['operation_type'])` check](https://github.com/survos/core/blob/e66ed60aa0ea4065f75cbd8c24ef07d8f2b14abb/src/Hydra/Serializer/CollectionNormalizer.php#L78-L78).
