### PR TITLE
[2.1] Fix Eager Loading of Embedded Entities in Relations

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -195,8 +195,18 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 }
 
                 //the field test allows to add methods to a Resource which do not reflect real database fields
-                if (true === $targetClassMetadata->hasField($property) && (true === $propertyMetadata->getAttribute('fetchable') || true === $propertyMetadata->isReadable())) {
+                if ($targetClassMetadata->hasField($property) && (true === $propertyMetadata->getAttribute('fetchable') || $propertyMetadata->isReadable())) {
                     $select[] = $property;
+                }
+
+                if (array_key_exists($property, $targetClassMetadata->embeddedClasses)) {
+                    foreach ($this->propertyNameCollectionFactory->create($targetClassMetadata->embeddedClasses[$property]['class']) as $embeddedProperty) {
+                        $propertyMetadata = $this->propertyMetadataFactory->create($entity, $property, $propertyMetadataOptions);
+                        $propertyName = "$property.$embeddedProperty";
+                        if ($targetClassMetadata->hasField($propertyName) && (true === $propertyMetadata->getAttribute('fetchable') || $propertyMetadata->isReadable())) {
+                            $select[] = $propertyName;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Doctrine Embeddables are correctly fetched for item and collection and support was added recently for filters which is awesome but I found that embedded entities in relations where forgotten by the EagerLoadingExtension.

This PR aims to fix that.
