### PR TITLE
Fix a problem when a composite identifier is missing

### DIFF
--- a/features/main/composite.feature
+++ b/features/main/composite.feature
@@ -120,6 +120,11 @@ Feature: Retrieve data with Composite identifiers
     }
     """
 
+  Scenario: Get the first composite relation with a missing identifier
+    Given there are Composite identifier objects
+    When I send a "GET" request to "/composite_relations/compositeLabel=1;"
+    Then the response status code should be 400
+
   @dropSchema
   Scenario: Get first composite item
     Given there are Composite identifier objects

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -18,6 +18,8 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryResultItemExtensionInter
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\IdentifierManagerTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\PropertyNotFoundException;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -67,7 +69,11 @@ class ItemDataProvider implements ItemDataProviderInterface
             throw new ResourceClassNotSupportedException();
         }
 
-        $identifiers = $this->normalizeIdentifiers($id, $manager, $resourceClass);
+        try {
+            $identifiers = $this->normalizeIdentifiers($id, $manager, $resourceClass);
+        } catch (PropertyNotFoundException $e) {
+            throw new InvalidArgumentException($e->getMessage());
+        }
 
         $fetchData = $context['fetch_data'] ?? true;
         if (!$fetchData && $manager instanceof EntityManagerInterface) {

--- a/src/Bridge/Doctrine/Orm/Util/IdentifierManagerTrait.php
+++ b/src/Bridge/Doctrine/Orm/Util/IdentifierManagerTrait.php
@@ -50,6 +50,10 @@ trait IdentifierManagerTrait
 
             // first transform identifiers to a proper key/value array
             foreach (explode(';', $id) as $identifier) {
+                if (!$identifier) {
+                    continue;
+                }
+
                 $identifierPair = explode('=', $identifier);
                 $identifiersMap[$identifierPair[0]] = $identifierPair[1];
             }

--- a/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
@@ -121,6 +121,28 @@ class ItemDataProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $dataProvider->getItem(Dummy::class, 'ida=1;idb=2', 'foo'));
     }
 
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
+     */
+    public function testGetItemWrongCompositeIdentifier()
+    {
+        list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataFactories(Dummy::class, [
+            'ida',
+            'idb',
+        ]);
+        $managerRegistry = $this->getManagerRegistry(Dummy::class, [
+            'ida' => [
+                'type' => DBALType::INTEGER,
+            ],
+            'idb' => [
+                'type' => DBALType::INTEGER,
+            ],
+        ], $this->prophesize(QueryBuilder::class)->reveal());
+
+        $dataProvider = new ItemDataProvider($managerRegistry, $propertyNameCollectionFactory, $propertyMetadataFactory);
+        $dataProvider->getItem(Dummy::class, 'ida=1;', 'foo');
+    }
+
     public function testQueryResultExtension()
     {
         $comparisonProphecy = $this->prophesize(Comparison::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR fixes a bug when a resource is requested with a wrong composite identifier, like 'ida=1;' instead of 'ida=1;idb=2'.