### PR TITLE
[RFR] Add SerializerAwareInterface supports on ItemDataProvider

### DIFF
--- a/features/main/serializable_item_data_provider.feature
+++ b/features/main/serializable_item_data_provider.feature
@@ -1,0 +1,18 @@
+Feature: Serializable item data provider
+  In order to call any external API
+  As a developer
+  I should be able to serialize the response directly from the ItemDataProvider.
+
+  Scenario: Get a resource containing a raw object
+    When  I send a "GET" request to "/serializable_resources/1"
+    Then the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/SerializableResource",
+        "@id": "/serializable_resources/1",
+        "@type": "SerializableResource",
+        "id": 1,
+        "foo": "Lorem",
+        "bar": "Ipsum"
+    }
+    """

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -53,14 +53,14 @@ final class DataProviderPass implements CompilerPassInterface
         $queue = new \SplPriorityQueue();
 
         foreach ($services as $serviceId => $tags) {
+            $definition = $container->getDefinition($serviceId);
+            if (is_subclass_of($definition->getClass(), SerializerAwareDataProviderInterface::class)) {
+                $definition->addMethodCall('setSerializerLocator', [$container->getDefinition('api_platform.serializer_locator')]);
+            }
+
             foreach ($tags as $attributes) {
                 $priority = $attributes['priority'] ?? 0;
                 $queue->insert(new Reference($serviceId), $priority);
-
-                $definition = $container->getDefinition($serviceId);
-                if (is_subclass_of($definition->getClass(), SerializerAwareDataProviderInterface::class)) {
-                    $definition->addMethodCall('setSerializerLocator', [$container->getDefinition('api_platform.serializer_locator')]);
-                }
             }
         }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
 
 use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\DataProvider\SerializerAwareDataProviderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -55,6 +56,11 @@ final class DataProviderPass implements CompilerPassInterface
             foreach ($tags as $attributes) {
                 $priority = $attributes['priority'] ?? 0;
                 $queue->insert(new Reference($serviceId), $priority);
+
+                $definition = $container->getDefinition($serviceId);
+                if (is_subclass_of($definition->getClass(), SerializerAwareDataProviderInterface::class)) {
+                    $definition->addMethodCall('setSerializerLocator', [$container->getDefinition('api_platform.serializer_locator')]);
+                }
             }
         }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\DataProvider\SerializerAwareDataProviderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -25,9 +26,12 @@ use Symfony\Component\DependencyInjection\Reference;
  * @internal
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
 final class DataProviderPass implements CompilerPassInterface
 {
+    use PriorityTaggedServiceTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -48,22 +52,15 @@ final class DataProviderPass implements CompilerPassInterface
      */
     private function registerDataProviders(ContainerBuilder $container, string $type)
     {
-        $services = $container->findTaggedServiceIds("api_platform.{$type}_data_provider", true);
+        $services = $this->findAndSortTaggedServices("api_platform.{$type}_data_provider", $container);
 
-        $queue = new \SplPriorityQueue();
-
-        foreach ($services as $serviceId => $tags) {
-            $definition = $container->getDefinition($serviceId);
+        foreach ($services as $reference) {
+            $definition = $container->getDefinition((string)$reference);
             if (is_a($definition->getClass(), SerializerAwareDataProviderInterface::class, true)) {
-                $definition->addMethodCall('setSerializerLocator', [$container->getDefinition('api_platform.serializer_locator')]);
-            }
-
-            foreach ($tags as $attributes) {
-                $priority = $attributes['priority'] ?? 0;
-                $queue->insert(new Reference($serviceId), $priority);
+                $definition->addMethodCall('setSerializerLocator', [new Reference('api_platform.serializer_locator')]);
             }
         }
 
-        $container->getDefinition("api_platform.{$type}_data_provider")->addArgument(iterator_to_array($queue, false));
+        $container->getDefinition("api_platform.{$type}_data_provider")->addArgument($services);
     }
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -54,7 +54,7 @@ final class DataProviderPass implements CompilerPassInterface
 
         foreach ($services as $serviceId => $tags) {
             $definition = $container->getDefinition($serviceId);
-            if (is_subclass_of($definition->getClass(), SerializerAwareDataProviderInterface::class)) {
+            if (is_a($definition->getClass(), SerializerAwareDataProviderInterface::class, true)) {
                 $definition->addMethodCall('setSerializerLocator', [$container->getDefinition('api_platform.serializer_locator')]);
             }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -55,7 +55,7 @@ final class DataProviderPass implements CompilerPassInterface
         $services = $this->findAndSortTaggedServices("api_platform.{$type}_data_provider", $container);
 
         foreach ($services as $reference) {
-            $definition = $container->getDefinition((string)$reference);
+            $definition = $container->getDefinition((string) $reference);
             if (is_a($definition->getClass(), SerializerAwareDataProviderInterface::class, true)) {
                 $definition->addMethodCall('setSerializerLocator', [new Reference('api_platform.serializer_locator')]);
             }

--- a/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
@@ -5,6 +5,13 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="api_platform.serializer_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
+            <tag name="container.service_locator" />
+            <argument type="collection">
+                <argument key="serializer" type="service" id="api_platform.serializer" />
+            </argument>
+        </service>
+
         <service id="api_platform.item_data_provider" class="ApiPlatform\Core\DataProvider\ChainItemDataProvider" />
 
         <service id="api_platform.collection_data_provider" class="ApiPlatform\Core\DataProvider\ChainCollectionDataProvider" />

--- a/src/DataProvider/SerializerAwareDataProviderInterface.php
+++ b/src/DataProvider/SerializerAwareDataProviderInterface.php
@@ -16,7 +16,7 @@ namespace ApiPlatform\Core\DataProvider;
 use Psr\Container\ContainerInterface;
 
 /**
- * Inject serializer in data providers.
+ * Injects serializer in data providers.
  *
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */

--- a/src/DataProvider/SerializerAwareDataProviderInterface.php
+++ b/src/DataProvider/SerializerAwareDataProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\DataProvider;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Inject serializer in data providers.
+ *
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+interface SerializerAwareDataProviderInterface
+{
+    /**
+     * @param ContainerInterface $serializerLocator
+     */
+    public function setSerializerLocator(ContainerInterface $serializerLocator);
+}

--- a/src/DataProvider/SerializerAwareDataProviderInterface.php
+++ b/src/DataProvider/SerializerAwareDataProviderInterface.php
@@ -18,12 +18,9 @@ use Psr\Container\ContainerInterface;
 /**
  * Inject serializer in data providers.
  *
- * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
 interface SerializerAwareDataProviderInterface
 {
-    /**
-     * @param ContainerInterface $serializerLocator
-     */
     public function setSerializerLocator(ContainerInterface $serializerLocator);
 }

--- a/src/DataProvider/SerializerAwareDataProviderTrait.php
+++ b/src/DataProvider/SerializerAwareDataProviderTrait.php
@@ -19,26 +19,22 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * Inject serializer in data providers.
  *
- * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
 trait SerializerAwareDataProviderTrait
 {
     /**
+     * @internal
+     *
      * @var ContainerInterface
      */
     private $serializerLocator;
 
-    /**
-     * @param ContainerInterface $serializerLocator
-     */
     public function setSerializerLocator(ContainerInterface $serializerLocator)
     {
         $this->serializerLocator = $serializerLocator;
     }
 
-    /**
-     * @return SerializerInterface
-     */
     private function getSerializer(): SerializerInterface
     {
         return $this->serializerLocator->get('serializer');

--- a/src/DataProvider/SerializerAwareDataProviderTrait.php
+++ b/src/DataProvider/SerializerAwareDataProviderTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\DataProvider;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Inject serializer in data providers.
+ *
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+trait SerializerAwareDataProviderTrait
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $serializerLocator;
+
+    /**
+     * @param ContainerInterface $serializerLocator
+     */
+    public function setSerializerLocator(ContainerInterface $serializerLocator)
+    {
+        $this->serializerLocator = $serializerLocator;
+    }
+
+    /**
+     * @return SerializerInterface
+     */
+    private function getSerializer(): SerializerInterface
+    {
+        return $this->serializerLocator->get('serializer');
+    }
+}

--- a/src/DataProvider/SerializerAwareDataProviderTrait.php
+++ b/src/DataProvider/SerializerAwareDataProviderTrait.php
@@ -17,7 +17,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
- * Inject serializer in data providers.
+ * Injects serializer in data providers.
  *
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -454,6 +454,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.subresource_data_provider',
             'api_platform.subresource_operation_factory',
             'api_platform.subresource_operation_factory.cached',
+            'api_platform.serializer_locator',
         ];
 
         foreach ($definitions as $definition) {

--- a/tests/Fixtures/TestBundle/DataProvider/SerializableItemDataProvider.php
+++ b/tests/Fixtures/TestBundle/DataProvider/SerializableItemDataProvider.php
@@ -14,17 +14,17 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\DataProvider;
 
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\SerializerAwareDataProviderInterface;
+use ApiPlatform\Core\DataProvider\SerializerAwareDataProviderTrait;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\SerializableResource;
-use Symfony\Component\Serializer\SerializerAwareInterface;
-use Symfony\Component\Serializer\SerializerAwareTrait;
 
 /**
  * @author Vincent Chalamon <vincent@les-tilleuls.coop>
  */
-class SerializableItemDataProvider implements ItemDataProviderInterface, SerializerAwareInterface
+class SerializableItemDataProvider implements ItemDataProviderInterface, SerializerAwareDataProviderInterface
 {
-    use SerializerAwareTrait;
+    use SerializerAwareDataProviderTrait;
 
     /**
      * {@inheritdoc}
@@ -35,7 +35,7 @@ class SerializableItemDataProvider implements ItemDataProviderInterface, Seriali
             throw new ResourceClassNotSupportedException();
         }
 
-        return $this->serializer->deserialize(<<<'JSON'
+        return $this->getSerializer()->deserialize(<<<'JSON'
 {
     "id": 1,
     "foo": "Lorem",

--- a/tests/Fixtures/TestBundle/DataProvider/SerializableItemDataProvider.php
+++ b/tests/Fixtures/TestBundle/DataProvider/SerializableItemDataProvider.php
@@ -20,7 +20,7 @@ use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\SerializableResource;
 
 /**
- * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
 class SerializableItemDataProvider implements ItemDataProviderInterface, SerializerAwareDataProviderInterface
 {

--- a/tests/Fixtures/TestBundle/DataProvider/SerializableItemDataProvider.php
+++ b/tests/Fixtures/TestBundle/DataProvider/SerializableItemDataProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\SerializableResource;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+
+/**
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+class SerializableItemDataProvider implements ItemDataProviderInterface, SerializerAwareInterface
+{
+    use SerializerAwareTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
+    {
+        if (SerializableResource::class !== $resourceClass) {
+            throw new ResourceClassNotSupportedException();
+        }
+
+        return $this->serializer->deserialize(<<<'JSON'
+{
+    "id": 1,
+    "foo": "Lorem",
+    "bar": "Ipsum"
+}
+JSON
+            , $resourceClass, 'json');
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/SerializableResource.php
+++ b/tests/Fixtures/TestBundle/Entity/SerializableResource.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+
+/**
+ * Resource linked to an external API.
+ *
+ * @ApiResource
+ *
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+class SerializableResource
+{
+    /**
+     * @var int
+     *
+     * @ApiProperty(identifier=true)
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $foo;
+
+    /**
+     * @var string
+     */
+    public $bar;
+}

--- a/tests/Fixtures/TestBundle/Entity/SerializableResource.php
+++ b/tests/Fixtures/TestBundle/Entity/SerializableResource.php
@@ -21,7 +21,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *
  * @ApiResource
  *
- * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
 class SerializableResource
 {

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/SerializableResourceDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/SerializableResourceDenormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Denormalizer;
+
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\SerializableResource;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+class SerializableResourceDenormalizer implements DenormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $resource = new SerializableResource();
+        $resource->bar = $data['bar'];
+        $resource->foo = $data['foo'];
+        $resource->id = $data['id'];
+
+        return $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return 'json' === $format && SerializableResource::class === $type && is_array($data);
+    }
+}

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/SerializableResourceDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/SerializableResourceDenormalizer.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\SerializableResource;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
- * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
 class SerializableResourceDenormalizer implements DenormalizerInterface
 {

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -92,6 +92,18 @@ services:
         tags:
             -  { name: 'api_platform.item_data_provider' }
 
+    serializable.item_data_provider:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\DataProvider\SerializableItemDataProvider'
+        public: false
+        tags:
+            -  { name: 'api_platform.item_data_provider' }
+
+    app.serializer.denormalizer.serializable_resource:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Denormalizer\SerializableResourceDenormalizer'
+        public: false
+        tags:
+            -  { name: 'api_platform.item_data_provider' }
+
     app.user_manager:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Manager\UserManager'
         arguments:

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -102,7 +102,7 @@ services:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Denormalizer\SerializableResourceDenormalizer'
         public: false
         tags:
-            -  { name: 'api_platform.item_data_provider' }
+            -  { name: 'serializer.normalizer' }
 
     app.user_manager:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Manager\UserManager'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1165
| License       | MIT
| Doc PR        | WIP

Calling any external API from a custom ItemDataProvider, it may return a JSON which must be deserialized to my object. To do so, I must inject the `serializer` service in my custom ItemDataProvider, which creates a CircularReferenceException. A solution could be to use [service locators](http://symfony.com/blog/new-in-symfony-3-3-service-locators), but the following solution can manage it more easily for final users.

This PR allows to support `SerializerAwareInterface` on ItemDataProvider to prevent this exception.

- [x] Fix DoctrineBridge min version (bug on detecting non-entity classes)
- [x] Add interface + trait
- [x] Detect interface on data providers (collection/item) to add `api_platform.serializer` dependency through service locator
- [x] Add Behat tests
- [x] Add unit tests