### PR TITLE
Avoid errors when a request has no content

### DIFF
--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -49,6 +49,10 @@ final class AddHeadersListener
 
         $response = $event->getResponse();
 
+        if (!$response->getContent()) {
+            return;
+        }
+
         if ($this->etag) {
             $response->setEtag(md5($response->getContent()));
         }


### PR DESCRIPTION
An example would be returning a BinaryFileResponse

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

