### PR TITLE
[Hydra] add collection flag in documentation properties

### DIFF
--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -175,7 +175,15 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                                 '@type' => 'hydra:Link',
                                 'rdfs:label' => 'The collection of dummy resources',
                                 'domain' => '#Entrypoint',
-                                'range' => 'hydra:PagedCollection',
+                                'rdfs:range' => [
+                                    'hydra:PagedCollection',
+                                    [
+                                        'owl:equivalentClass' => [
+                                            'owl:onProperty' => 'hydra:member',
+                                            'owl:allValuesFrom' => '#dummy',
+                                        ],
+                                    ],
+                                ],
                                 'hydra:supportedOperation' => [
                                     0 => [
                                         '@type' => 'hydra:Operation',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #912
| License       | MIT
| Doc PR        | n/a

Today it's impossible to know if an Hydra property is a collection of * or not.
I implemented the solution provided on https://lists.w3.org/Archives/Public/public-hydra/2017Jun/0010.html.

- [ ] Add tests
- [ ] Update tests
