### PR TITLE
Adds conflict on symfony/dependency-injection < 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
         "symfony/validator": "^3.3 || ^4.0",
         "symfony/yaml": "^3.3 || ^4.0"
     },
+    "conflict": {
+        "symfony/dependency-injection": "<3.3"
+    },
     "suggest": {
         "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge.",
         "guzzlehttp/guzzle": "To use the HTTP cache invalidation system.",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Fixed tickets | #1170 
| License       | MIT

As discussed in #1170, I'm adding composer conflict for symfony/dependency-injection lower than 3.3, since the bundle packed in the repository only works for symfony ^3.3.

There was discussion about adding more conflicts, I'm not sure if this is a good idea. Since api-platform/core is not only a bundle, it could totally be installed with doctrine/orm or any other require-dev package without using the api-platform bundle (in theory).

I would rather add only real conflicts.