### PR TITLE
Fix path for custom operation with Swagger UI

### DIFF
--- a/src/Api/OperationTypeDeprecationHelper.php
+++ b/src/Api/OperationTypeDeprecationHelper.php
@@ -22,7 +22,7 @@ namespace ApiPlatform\Core\Api;
  * Because we introduced a third type in API Platform 2.1, we're using a string with OperationType constants:
  * - OperationType::ITEM
  * - OperationType::COLLECTION
- * - OperationType::SUBCOLLECTION
+ * - OperationType::SUBRESOURCE
  *
  * @internal
  */

--- a/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -92,7 +92,7 @@ final class SwaggerUiAction
 
         $swaggerData = [
             'url' => $this->urlGenerator->generate('api_doc', ['format' => 'json']),
-            'spec' => $this->normalizer->normalize($documentation, 'json'),
+            'spec' => $this->normalizer->normalize($documentation, 'json', ['base_url' => $request->getBaseUrl()]),
         ];
 
         $swaggerData['oauth'] = [

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -13,7 +13,7 @@
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.operation_method_resolver" />
             <argument type="service" id="api_platform.operation_path_resolver" />
-            <argument type="service" id="api_platform.router" />
+            <argument>null</argument>
             <argument type="service" id="api_platform.filter_locator" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
             <argument>%api_platform.oauth.enabled%</argument>

--- a/src/Bridge/Symfony/Routing/RouteNameGenerator.php
+++ b/src/Bridge/Symfony/Routing/RouteNameGenerator.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Routing;
+
+use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Api\OperationTypeDeprecationHelper;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use Doctrine\Common\Util\Inflector;
+
+/**
+ * Generates the Symfony route name associated with an operation name and a resource short name.
+ *
+ * @internal
+ *
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
+ */
+class RouteNameGenerator
+{
+    const ROUTE_NAME_PREFIX = 'api_';
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Generates a Symfony route name.
+     *
+     * @param string      $operationName
+     * @param string      $resourceShortName
+     * @param string|bool $operationType
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return string
+     */
+    public static function generate(string $operationName, string $resourceShortName, $operationType): string
+    {
+        if (OperationType::SUBRESOURCE === $operationType = OperationTypeDeprecationHelper::getOperationType($operationType)) {
+            throw new InvalidArgumentException(sprintf('%s::SUBRESOURCE is not supported as operation type by %s().', OperationType::class, __METHOD__));
+        }
+
+        return sprintf(
+            '%s%s_%s_%s',
+            static::ROUTE_NAME_PREFIX,
+            Inflector::pluralize(Inflector::tableize($resourceShortName)),
+            $operationName,
+            $operationType
+        );
+    }
+}

--- a/src/PathResolver/CustomOperationPathResolver.php
+++ b/src/PathResolver/CustomOperationPathResolver.php
@@ -32,12 +32,20 @@ final class CustomOperationPathResolver implements OperationPathResolverInterfac
     /**
      * {@inheritdoc}
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType): string
+    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType/*, string $operationName = null*/): string
     {
+        if (func_num_args() >= 4) {
+            $operationName = func_get_arg(3);
+        } else {
+            @trigger_error(sprintf('Method %s() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.', __METHOD__), E_USER_DEPRECATED);
+
+            $operationName = null;
+        }
+
         if (isset($operation['path'])) {
             return $operation['path'];
         }
 
-        return $this->deferred->resolveOperationPath($resourceShortName, $operation, OperationTypeDeprecationHelper::getOperationType($operationType));
+        return $this->deferred->resolveOperationPath($resourceShortName, $operation, OperationTypeDeprecationHelper::getOperationType($operationType), $operationName);
     }
 }

--- a/src/PathResolver/DashOperationPathResolver.php
+++ b/src/PathResolver/DashOperationPathResolver.php
@@ -27,8 +27,12 @@ final class DashOperationPathResolver implements OperationPathResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType): string
+    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType/*, string $operationName = null*/): string
     {
+        if (func_num_args() < 4) {
+            @trigger_error(sprintf('Method %s() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $operationType = OperationTypeDeprecationHelper::getOperationType($operationType);
 
         if ($operationType === OperationType::SUBRESOURCE && 1 < count($operation['identifiers'])) {

--- a/src/PathResolver/OperationPathResolverInterface.php
+++ b/src/PathResolver/OperationPathResolverInterface.php
@@ -27,8 +27,9 @@ interface OperationPathResolverInterface
      * @param array       $operation         The operation metadata
      * @param string|bool $operationType     One of the constants defined in ApiPlatform\Core\Api\OperationType
      *                                       If the property is a boolean, true represents OperationType::COLLECTION, false is for OperationType::ITEM
+     * @param string      $operationName     The operation name
      *
      * @return string
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType): string;
+    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType/*, string $operationName = null*/): string;
 }

--- a/src/PathResolver/UnderscoreOperationPathResolver.php
+++ b/src/PathResolver/UnderscoreOperationPathResolver.php
@@ -27,8 +27,12 @@ final class UnderscoreOperationPathResolver implements OperationPathResolverInte
     /**
      * {@inheritdoc}
      */
-    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType): string
+    public function resolveOperationPath(string $resourceShortName, array $operation, $operationType/*, string $operationName = null*/): string
     {
+        if (func_num_args() < 4) {
+            @trigger_error(sprintf('Method %s() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $operationType = OperationTypeDeprecationHelper::getOperationType($operationType);
 
         if ($operationType === OperationType::SUBRESOURCE && 1 < count($operation['identifiers'])) {

--- a/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
+++ b/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
@@ -49,7 +49,7 @@ class SwaggerUiActionTest extends \PHPUnit_Framework_TestCase
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata('F'))->shouldBeCalled();
 
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class);
-        $normalizerProphecy->normalize(Argument::type(Documentation::class), 'json')->willReturn(self::SPEC)->shouldBeCalled();
+        $normalizerProphecy->normalize(Argument::type(Documentation::class), 'json', Argument::type('array'))->willReturn(self::SPEC)->shouldBeCalled();
 
         $urlGeneratorProphecy = $this->prophesize(UrlGenerator::class);
         $urlGeneratorProphecy->generate('api_doc', ['format' => 'json'])->willReturn('/url')->shouldBeCalled();
@@ -138,8 +138,9 @@ class SwaggerUiActionTest extends \PHPUnit_Framework_TestCase
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection(['Foo', 'Bar']))->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class);
-        $normalizerProphecy->normalize(Argument::type(Documentation::class), 'json')->willReturn(self::SPEC)->shouldBeCalled();
+        $normalizerProphecy->normalize(Argument::type(Documentation::class), 'json', Argument::type('array'))->willReturn(self::SPEC)->shouldBeCalled();
 
         $twigProphecy = $this->prophesize(\Twig_Environment::class);
         $twigProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [

--- a/tests/Bridge/Symfony/Routing/RouteNameGeneratorTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameGeneratorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Routing;
+
+use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameGenerator;
+
+/**
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
+ */
+class RouteNameGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGenerate()
+    {
+        $this->assertEquals('api_foos_get_collection', RouteNameGenerator::generate('get', 'Foo', OperationType::COLLECTION));
+        $this->assertEquals('api_bars_custom_operation_item', RouteNameGenerator::generate('custom_operation', 'Bar', OperationType::ITEM));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     */
+    public function testLegacyGenerate()
+    {
+        $this->assertEquals('api_foos_get_collection', RouteNameGenerator::generate('get', 'Foo', true));
+    }
+
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
+     * @expectedExceptionMessage ApiPlatform\Core\Api\OperationType::SUBRESOURCE is not supported as operation type by ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameGenerator::generate().
+     */
+    public function testGenerateWithSubresource()
+    {
+        RouteNameGenerator::generate('api_foos_bars_get_subresource', 'Bar', OperationType::SUBRESOURCE);
+    }
+}

--- a/tests/Bridge/Symfony/Routing/RouterOperationPathResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouterOperationPathResolverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Routing;
+
+use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameGenerator;
+use ApiPlatform\Core\Bridge\Symfony\Routing\RouterOperationPathResolver;
+use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
+use Prophecy\Argument;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
+ */
+class RouterOperationPathResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResolveOperationPath()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('foos', new Route('/foos'));
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->getRouteCollection()->willReturn($routeCollection)->shouldBeCalled();
+
+        $operationPathResolver = new RouterOperationPathResolver($routerProphecy->reveal(), $this->prophesize(OperationPathResolverInterface::class)->reveal());
+
+        $this->assertEquals('/foos', $operationPathResolver->resolveOperationPath('Foo', ['route_name' => 'foos'], OperationType::COLLECTION, 'get'));
+    }
+
+    public function testResolveOperationPathWithSubresource()
+    {
+        $operationPathResolverProphecy = $this->prophesize(OperationPathResolverInterface::class);
+        $operationPathResolverProphecy->resolveOperationPath('Bar', Argument::type('array'), OperationType::SUBRESOURCE, 'api_foos_bars_get_subresource')->willReturn('/foos/{id}/bars.{_format}')->shouldBeCalled();
+
+        $operationPathResolver = new RouterOperationPathResolver($this->prophesize(RouterInterface::class)->reveal(), $operationPathResolverProphecy->reveal());
+
+        $this->assertEquals('/foos/{id}/bars.{_format}', $operationPathResolver->resolveOperationPath('Bar', [], OperationType::SUBRESOURCE, 'api_foos_bars_get_subresource'));
+    }
+
+    public function testResolveOperationPathWithRouteNameGeneration()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add(RouteNameGenerator::generate('get', 'Foo', OperationType::COLLECTION), new Route('/foos'));
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->getRouteCollection()->willReturn($routeCollection)->shouldBeCalled();
+
+        $operationPathResolver = new RouterOperationPathResolver($routerProphecy->reveal(), $this->prophesize(OperationPathResolverInterface::class)->reveal());
+
+        $this->assertEquals('/foos', $operationPathResolver->resolveOperationPath('Foo', [], OperationType::COLLECTION, 'get'));
+    }
+
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The route "api_foos_get_collection" of the resource "Foo" was not found.
+     */
+    public function testResolveOperationPathWithRouteNotFound()
+    {
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->getRouteCollection()->willReturn(new RouteCollection())->shouldBeCalled();
+
+        $operationPathResolver = new RouterOperationPathResolver($routerProphecy->reveal(), $this->prophesize(OperationPathResolverInterface::class)->reveal());
+        $operationPathResolver->resolveOperationPath('Foo', [], OperationType::COLLECTION, 'get');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Method ApiPlatform\Core\Bridge\Symfony\Routing\RouterOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     */
+    public function testLegacyResolveOperationPath()
+    {
+        $operationPathResolverProphecy = $this->prophesize(OperationPathResolverInterface::class);
+        $operationPathResolverProphecy->resolveOperationPath('Foo', [], OperationType::ITEM, null)->willReturn('/foos/{id}.{_format}')->shouldBeCalled();
+
+        $operationPathResolver = new RouterOperationPathResolver($this->prophesize(RouterInterface::class)->reveal(), $operationPathResolverProphecy->reveal());
+
+        $this->assertEquals('/foos/{id}.{_format}', $operationPathResolver->resolveOperationPath('Foo', [], false));
+    }
+}

--- a/tests/PathResolver/CustomOperationPathResolverTest.php
+++ b/tests/PathResolver/CustomOperationPathResolverTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\PathResolver;
+
+use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\PathResolver\CustomOperationPathResolver;
+use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
+
+/**
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
+ */
+class CustomOperationPathResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResolveOperationPath()
+    {
+        $operationPathResolver = new CustomOperationPathResolver($this->prophesize(OperationPathResolverInterface::class)->reveal());
+
+        $this->assertEquals('/foos.{_format}', $operationPathResolver->resolveOperationPath('Foo', ['path' => '/foos.{_format}'], OperationType::COLLECTION, 'get'));
+    }
+
+    public function testResolveOperationPathWithDeferred()
+    {
+        $operationPathResolverProphecy = $this->prophesize(OperationPathResolverInterface::class);
+        $operationPathResolverProphecy->resolveOperationPath('Foo', [], OperationType::ITEM, 'get')->willReturn('/foos/{id}.{_format}')->shouldBeCalled();
+
+        $operationPathResolver = new CustomOperationPathResolver($operationPathResolverProphecy->reveal());
+
+        $this->assertEquals('/foos/{id}.{_format}', $operationPathResolver->resolveOperationPath('Foo', [], OperationType::ITEM, 'get'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Method ApiPlatform\Core\PathResolver\CustomOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     */
+    public function testLegacyResolveOperationPath()
+    {
+        $operationPathResolver = new CustomOperationPathResolver($this->prophesize(OperationPathResolverInterface::class)->reveal());
+
+        $this->assertEquals('/foos.{_format}', $operationPathResolver->resolveOperationPath('Foo', ['path' => '/foos.{_format}'], true));
+    }
+}

--- a/tests/PathResolver/DashOperationPathResolverTest.php
+++ b/tests/PathResolver/DashOperationPathResolverTest.php
@@ -16,32 +16,47 @@ namespace ApiPlatform\Core\Tests\PathResolver;
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\PathResolver\DashOperationPathResolver;
 
+/**
+ * @author Guilhem N. <egetick@gmail.com>
+ */
 class DashOperationPathResolverTest extends \PHPUnit_Framework_TestCase
 {
     public function testResolveCollectionOperationPath()
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
 
-        $this->assertSame('/short-names.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::COLLECTION));
+        $this->assertSame('/short-names.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::COLLECTION, 'get'));
     }
 
     public function testResolveItemOperationPath()
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
 
-        $this->assertSame('/short-names/{id}.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::ITEM));
+        $this->assertSame('/short-names/{id}.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::ITEM, 'get'));
     }
 
     public function testResolveSubresourceOperationPath()
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
 
-        $path = $dashOperationPathResolver->resolveOperationPath('ShortName', ['property' => 'relatedFoo', 'identifiers' => [['id', 'class']], 'collection' => true], OperationType::SUBRESOURCE);
+        $path = $dashOperationPathResolver->resolveOperationPath('ShortName', ['property' => 'relatedFoo', 'identifiers' => [['id', 'class']], 'collection' => true], OperationType::SUBRESOURCE, 'get');
 
         $this->assertSame('/short-names/{id}/related-foos.{_format}', $path);
 
-        $next = $dashOperationPathResolver->resolveOperationPath($path, ['property' => 'bar', 'identifiers' => [['id', 'class'], ['relatedId', 'class']], 'collection' => false], OperationType::SUBRESOURCE);
+        $next = $dashOperationPathResolver->resolveOperationPath($path, ['property' => 'bar', 'identifiers' => [['id', 'class'], ['relatedId', 'class']], 'collection' => false], OperationType::SUBRESOURCE, 'get');
 
         $this->assertSame('/short-names/{id}/related-foos/{relatedId}/bar.{_format}', $next);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Method ApiPlatform\Core\PathResolver\DashOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     */
+    public function testLegacyResolveOperationPath()
+    {
+        $dashOperationPathResolver = new DashOperationPathResolver();
+
+        $this->assertSame('/short-names.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], true));
     }
 }

--- a/tests/PathResolver/UnderscoreOperationPathResolverTest.php
+++ b/tests/PathResolver/UnderscoreOperationPathResolverTest.php
@@ -16,32 +16,47 @@ namespace ApiPlatform\Core\Tests\PathResolver;
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver;
 
+/**
+ * @author Guilhem N. <egetick@gmail.com>
+ */
 class UnderscoreOperationPathResolverTest extends \PHPUnit_Framework_TestCase
 {
     public function testResolveCollectionOperationPath()
     {
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
 
-        $this->assertSame('/short_names.{_format}', $underscoreOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::COLLECTION));
+        $this->assertSame('/short_names.{_format}', $underscoreOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::COLLECTION, 'get'));
     }
 
     public function testResolveItemOperationPath()
     {
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
 
-        $this->assertSame('/short_names/{id}.{_format}', $underscoreOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::ITEM));
+        $this->assertSame('/short_names/{id}.{_format}', $underscoreOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::ITEM, 'get'));
     }
 
     public function testResolveSubresourceOperationPath()
     {
         $dashOperationPathResolver = new UnderscoreOperationPathResolver();
 
-        $path = $dashOperationPathResolver->resolveOperationPath('ShortName', ['property' => 'relatedFoo', 'identifiers' => [['id', 'class']], 'collection' => true], OperationType::SUBRESOURCE);
+        $path = $dashOperationPathResolver->resolveOperationPath('ShortName', ['property' => 'relatedFoo', 'identifiers' => [['id', 'class']], 'collection' => true], OperationType::SUBRESOURCE, 'get');
 
         $this->assertSame('/short_names/{id}/related_foos.{_format}', $path);
 
-        $next = $dashOperationPathResolver->resolveOperationPath($path, ['property' => 'bar', 'identifiers' => [['id', 'class'], ['relatedId', 'class']], 'collection' => false], OperationType::SUBRESOURCE);
+        $next = $dashOperationPathResolver->resolveOperationPath($path, ['property' => 'bar', 'identifiers' => [['id', 'class'], ['relatedId', 'class']], 'collection' => false], OperationType::SUBRESOURCE, 'get');
 
         $this->assertSame('/short_names/{id}/related_foos/{relatedId}/bar.{_format}', $next);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Method ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     */
+    public function testLegacyResolveOperationPath()
+    {
+        $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
+
+        $this->assertSame('/short_names.{_format}', $underscoreOperationPathResolver->resolveOperationPath('ShortName', [], true));
     }
 }

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -42,6 +42,25 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  */
 class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an instance of ApiPlatform\Core\Api\UrlGeneratorInterface to ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer::__construct() is deprecated since version 2.1 and will be removed in 3.0.
+     */
+    public function testLegacyConstruct()
+    {
+        $normalizer = new DocumentationNormalizer(
+            $this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(),
+            $this->prophesize(PropertyNameCollectionFactoryInterface::class)->reveal(),
+            $this->prophesize(PropertyMetadataFactoryInterface::class)->reveal(),
+            $this->prophesize(ResourceClassResolverInterface::class)->reveal(),
+            $this->prophesize(OperationMethodResolverInterface::class)->reveal(),
+            $this->prophesize(OperationPathResolverInterface::class)->reveal(),
+            $this->prophesize(UrlGeneratorInterface::class)->reveal()
+        );
+
+        $this->assertInstanceOf(DocumentationNormalizer::class, $normalizer);
+    }
+
     public function testNormalize()
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
@@ -67,9 +86,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'custom')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'custom2')->shouldBeCalled()->willReturn('POST');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/app_dev.php/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -78,8 +94,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $expected = [
@@ -244,7 +259,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             ]),
         ];
 
-        $this->assertEquals($expected, $normalizer->normalize($documentation));
+        $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
     }
 
     public function testNormalizeWithNameConverter()
@@ -269,9 +284,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getItemOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/app_dev.php/')->shouldBeCalled();
-
         $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
         $nameConverterProphecy->normalize('name')->willReturn('name')->shouldBeCalled();
         $nameConverterProphecy->normalize('nameConverted')->willReturn('name_converted')->shouldBeCalled();
@@ -285,7 +297,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
             $operationPathResolver,
-            $urlGeneratorProphecy->reveal(),
+            null,
             null,
             $nameConverterProphecy->reveal(),
             true,
@@ -298,7 +310,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
 
         $expected = [
             'swagger' => '2.0',
-            'basePath' => '/app_dev.php/',
+            'basePath' => '/',
             'info' => [
                 'title' => 'Dummy API',
                 'description' => 'This is a dummy API',
@@ -406,9 +418,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/app_dev.php/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -417,13 +426,12 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $expected = [
             'swagger' => '2.0',
-            'basePath' => '/app_dev.php/',
+            'basePath' => '/',
             'info' => [
                 'title' => 'Test API',
                 'description' => 'This is a test API.',
@@ -592,9 +600,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/app_dev.php/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -603,13 +608,12 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $expected = [
             'swagger' => '2.0',
-            'basePath' => '/app_dev.php/',
+            'basePath' => '/',
             'info' => [
                 'title' => 'Test API',
                 'description' => 'This is a test API.',
@@ -781,9 +785,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/app_dev.php/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -792,13 +793,12 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $expected = [
             'swagger' => '2.0',
-            'basePath' => '/app_dev.php/',
+            'basePath' => '/',
             'info' => [
                 'title' => 'Test API',
                 'description' => 'This is a test API.',
@@ -1004,7 +1004,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -1012,8 +1011,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
@@ -1050,9 +1048,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldNotBeCalled();
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -1061,8 +1056,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $expected = [
@@ -1103,9 +1097,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('FOO');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -1114,8 +1105,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $expected = [
@@ -1199,9 +1189,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/app_dev.php/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -1210,13 +1197,12 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
-            $operationPathResolver,
-            $urlGeneratorProphecy->reveal()
+            $operationPathResolver
         );
 
         $expected = [
             'swagger' => '2.0',
-            'basePath' => '/app_dev.php/',
+            'basePath' => '/',
             'info' => [
                 'title' => 'Test API',
                 'description' => 'This is a test API.',
@@ -1385,9 +1371,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
 
-        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/')->shouldBeCalled();
-
         $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
 
         $normalizer = new DocumentationNormalizer(
@@ -1397,7 +1380,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $resourceClassResolverProphecy->reveal(),
             $operationMethodResolverProphecy->reveal(),
             $operationPathResolver,
-            $urlGeneratorProphecy->reveal(),
+            null,
             $filterLocator
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/api-platform/issues/254
| License       | MIT
| Doc PR        | N/A

A fix while waiting for Swagger 3 which will permit overriding the base path at the path item level.
See:
* https://github.com/OAI/OpenAPI-Specification/issues/562
* https://github.com/OAI/OpenAPI-Specification/pull/604