### PR TITLE
Allow to use a service for dynamic validation groups

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -13,6 +13,7 @@
         <service id="api_platform.listener.view.validate" class="ApiPlatform\Core\Bridge\Symfony\Validator\EventListener\ValidateListener">
             <argument type="service" id="validator" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="service_container" />
 
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="64" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Usage:

```php
<?php

// src/ValidatorGroupsGenerator.php

class ValidatorGroupsGenerator
{
    private $s;

    public function __construct(AService $s)
    {
        $this->s = $s;
    }

    public function __invoke(): array
    {
        return $this->s->isSomething() ? ['a', 'b'] : ['a'];
    }
}
```

```yaml
services:
    App\ValidatorGroupsGenerator: ['@a_service']
```

```php
<?php

// src/Entity/Book.php

use ApiPlatform\Core\Annotation\ApiResource;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @ApiResource(attributes={"validation_groups"="App\ValidatorGroupsGenerator"})
 */
class Book
{
    /**
     * @Assert\NotBlank(groups={"a"})
     */
    private $name;

    /**
     * @Assert\NotNull(groups={"b"})
     */
    private $author;

    // ...
}
```

TODO:

* [x] Add tests