### PR TITLE
Implement subresource metadata and annotation

### DIFF
--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -67,9 +67,4 @@ final class ApiProperty
      * @var array
      */
     public $attributes = [];
-
-    /**
-     * @var bool
-     */
-    public $subresource;
 }

--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Annotation;
+
+/**
+ * Property annotation.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @Annotation
+ * @Target({"METHOD", "PROPERTY"})
+ */
+final class ApiSubresource
+{
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/annotation.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/annotation.xml
@@ -28,6 +28,11 @@
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.annotation.inner" />
         </service>
+
+        <service id="api_platform.metadata.subresource.metadata_factory.annotation" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="30" class="ApiPlatform\Core\Metadata\Property\Factory\AnnotationSubresourceMetadataFactory" public="false">
+            <argument type="service" id="annotation_reader" />
+            <argument type="service" id="api_platform.metadata.subresource.metadata_factory.annotation.inner" />
+        </service>
     </services>
 
 </container>

--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -130,7 +130,10 @@ final class XmlExtractor extends AbstractExtractor
                 'identifier' => $this->phpize($property, 'identifier', 'bool'),
                 'iri' => $this->phpize($property, 'iri', 'string'),
                 'attributes' => $this->getAttributes($property, 'attribute'),
-                'subresource' => $this->phpize($property, 'subresource', 'bool'),
+                'subresource' => $property->subresource ? [
+                    'collection' => $this->phpize($property->subresource, 'collection', 'bool'),
+                    'resourceClass' => $this->phpize($property->subresource, 'resourceClass', 'string'),
+                ] : null,
             ];
         }
 

--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -107,7 +107,7 @@ final class YamlExtractor extends AbstractExtractor
                 'identifier' => $this->phpize($propertyValues, 'identifier', 'bool'),
                 'iri' => $this->phpize($propertyValues, 'iri', 'string'),
                 'attributes' => $propertyValues['attributes'] ?? null,
-                'subresource' => $this->phpize($propertyValues, 'subresource', 'bool'),
+                'subresource' => $propertyValues['subresource'] ?? null,
             ];
         }
     }

--- a/src/Metadata/Property/Factory/AnnotationPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationPropertyMetadataFactory.php
@@ -117,13 +117,12 @@ final class AnnotationPropertyMetadataFactory implements PropertyMetadataFactory
                 $annotation->identifier,
                 $annotation->iri,
                 null,
-                $annotation->attributes,
-                $annotation->subresource
+                $annotation->attributes
             );
         }
 
         $propertyMetadata = $parentPropertyMetadata;
-        foreach ([['get', 'description'], ['is', 'readable'], ['is', 'writable'], ['is', 'readableLink'], ['is', 'writableLink'], ['is', 'required'], ['get', 'iri'], ['is', 'identifier'], ['get', 'attributes'], ['has', 'subresource']] as $property) {
+        foreach ([['get', 'description'], ['is', 'readable'], ['is', 'writable'], ['is', 'readableLink'], ['is', 'writableLink'], ['is', 'required'], ['get', 'iri'], ['is', 'identifier'], ['get', 'attributes']] as $property) {
             if (null !== $value = $annotation->{$property[1]}) {
                 $propertyMetadata = $this->createWith($propertyMetadata, $property, $value);
             }

--- a/src/Metadata/Property/Factory/AnnotationSubresourceMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationSubresourceMetadataFactory.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\Property\Factory;
+
+use ApiPlatform\Core\Annotation\ApiSubresource;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Property\SubresourceMetadata;
+use ApiPlatform\Core\Util\Reflection;
+use Doctrine\Common\Annotations\Reader;
+
+/**
+ * Adds subresources to the properties metadata from {@see ApiResource} annotations.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class AnnotationSubresourceMetadataFactory implements PropertyMetadataFactoryInterface
+{
+    private $reader;
+    private $decorated;
+
+    public function __construct(Reader $reader, PropertyMetadataFactoryInterface $decorated)
+    {
+        $this->reader = $reader;
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass, string $property, array $options = []): PropertyMetadata
+    {
+        $propertyMetadata = $this->decorated->create($resourceClass, $property, $options);
+
+        try {
+            $reflectionClass = new \ReflectionClass($resourceClass);
+        } catch (\ReflectionException $reflectionException) {
+            return $propertyMetadata;
+        }
+
+        if ($reflectionClass->hasProperty($property)) {
+            $annotation = $this->reader->getPropertyAnnotation($reflectionClass->getProperty($property), ApiSubresource::class);
+
+            if (null !== $annotation) {
+                return $this->updateMetadata($annotation, $propertyMetadata);
+            }
+        }
+
+        foreach (array_merge(Reflection::ACCESSOR_PREFIXES, Reflection::MUTATOR_PREFIXES) as $prefix) {
+            $methodName = $prefix.ucfirst($property);
+            if (!$reflectionClass->hasMethod($methodName)) {
+                continue;
+            }
+
+            $reflectionMethod = $reflectionClass->getMethod($methodName);
+            if (!$reflectionMethod->isPublic()) {
+                continue;
+            }
+
+            $annotation = $this->reader->getMethodAnnotation($reflectionMethod, ApiSubresource::class);
+
+            if (null !== $annotation) {
+                return $this->updateMetadata($annotation, $propertyMetadata);
+            }
+        }
+
+        return $propertyMetadata;
+    }
+
+    private function updateMetadata(ApiSubresource $annotation, PropertyMetadata $propertyMetadata): PropertyMetadata
+    {
+        $type = $propertyMetadata->getType();
+        $isCollection = $type->isCollection();
+        $resourceClass = $isCollection ? $type->getCollectionValueType()->getClassName() : $type->getClassName();
+
+        return $propertyMetadata->withSubresource(new SubresourceMetadata($resourceClass, $isCollection));
+    }
+}

--- a/src/Metadata/Property/PropertyMetadata.php
+++ b/src/Metadata/Property/PropertyMetadata.php
@@ -35,7 +35,7 @@ final class PropertyMetadata
     private $attributes;
     private $subresource;
 
-    public function __construct(Type $type = null, string $description = null, bool $readable = null, bool $writable = null, bool $readableLink = null, bool $writableLink = null, bool $required = null, bool $identifier = null, string $iri = null, $childInherited = null, array $attributes = null, bool $subresource = null)
+    public function __construct(Type $type = null, string $description = null, bool $readable = null, bool $writable = null, bool $readableLink = null, bool $writableLink = null, bool $required = null, bool $identifier = null, string $iri = null, $childInherited = null, array $attributes = null, SubresourceMetadata $subresource = null)
     {
         $this->type = $type;
         $this->description = $description;
@@ -347,12 +347,34 @@ final class PropertyMetadata
         return $metadata;
     }
 
-    public function hasSubresource()
+    /**
+     * Represents whether the property has a subresource.
+     *
+     * @return bool
+     */
+    public function hasSubresource(): bool
+    {
+        return $this->subresource !== null;
+    }
+
+    /**
+     * Gets the subresource metadata.
+     *
+     * @return SubresourceMetadata|null
+     */
+    public function getSubresource()
     {
         return $this->subresource;
     }
 
-    public function withSubresource(bool $subresource = null): self
+    /**
+     * Returns a new instance with the given subresource.
+     *
+     * @param SubresourceMetadata $subresource
+     *
+     * @return self
+     */
+    public function withSubresource(SubresourceMetadata $subresource = null): self
     {
         $metadata = clone $this;
         $metadata->subresource = $subresource;

--- a/src/Metadata/Property/SubresourceMetadata.php
+++ b/src/Metadata/Property/SubresourceMetadata.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\Property;
+
+/**
+ * Subresource metadata.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class SubresourceMetadata
+{
+    private $resourceClass;
+    private $collection;
+
+    public function __construct(string $resourceClass, bool $collection = false)
+    {
+        $this->resourceClass = $resourceClass;
+        $this->collection = $collection;
+    }
+
+    public function getResourceClass(): string
+    {
+        return $this->resourceClass;
+    }
+
+    public function withResourceClass($resourceClass): self
+    {
+        $metadata = clone $this;
+        $metadata->resourceClass = $resourceClass;
+
+        return $metadata;
+    }
+
+    public function isCollection(): bool
+    {
+        return $this->collection;
+    }
+
+    public function withCollection(bool $collection): self
+    {
+        $metadata = clone $this;
+        $metadata->collection = $collection;
+
+        return $metadata;
+    }
+}

--- a/src/Metadata/schema/metadata.xsd
+++ b/src/Metadata/schema/metadata.xsd
@@ -63,9 +63,15 @@
         <xsd:attribute type="xsd:string" name="name"/>
     </xsd:complexType>
 
+    <xsd:complexType name="subresource" mixed="true">
+        <xsd:attribute type="xsd:boolean" name="collection"/>
+        <xsd:attribute type="xsd:string" name="resourceClass"/>
+    </xsd:complexType>
+
     <xsd:complexType name="property">
         <xsd:sequence minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="attribute"/>
+            <xsd:element name="subresource" minOccurs="0" maxOccurs="unbounded" type="subresource"/>
         </xsd:sequence>
         <xsd:attribute type="xsd:string" name="name"/>
         <xsd:attribute type="xsd:string" name="description"/>

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -429,6 +429,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.metadata.resource.name_collection_factory.cached',
             'api_platform.metadata.resource.name_collection_factory.xml',
             'api_platform.metadata.resource.name_collection_factory.yaml',
+            'api_platform.metadata.subresource.metadata_factory.annotation',
             'api_platform.identifiers_extractor',
             'api_platform.identifiers_extractor.cached',
             'api_platform.negotiator',

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Core\Metadata\Property\SubresourceMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
@@ -227,7 +228,7 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
         $relatedType = new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummyEntity::class);
 
         $subResourcePropertyMetadata = (new PropertyMetadata())
-                                        ->withSubresource(true)
+                                        ->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, true))
                                         ->withType(new Type(Type::BUILTIN_TYPE_ARRAY, false, \ArrayObject::class, true, null, $relatedType));
 
         if (false === $recursiveSubresource) {
@@ -235,8 +236,14 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
             $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource')->willReturn(new PropertyMetadata());
         } else {
             $dummyType = new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyEntity::class);
-            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource')->willReturn((new PropertyMetadata())->withSubresource(true)->withType($dummyType));
-            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource')->willReturn((new PropertyMetadata())->withSubresource(true)->withType($dummyType));
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource')
+                ->willReturn((new PropertyMetadata())
+                ->withSubresource(new SubresourceMetadata(DummyEntity::class, false))
+                ->withType($dummyType));
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource')
+                ->willReturn((new PropertyMetadata())
+                ->withSubresource(new SubresourceMetadata(DummyEntity::class, false))
+                ->withType($dummyType));
         }
 
         $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->willReturn($subResourcePropertyMetadata);

--- a/tests/Fixtures/FileConfigurations/resources.xml
+++ b/tests/Fixtures/FileConfigurations/resources.xml
@@ -49,6 +49,7 @@
                 writableLink="false"
                 required="true"
         >
+            <subresource collection="true" resourceClass="Foo" />
             <attribute name="foo">
                 <attribute>Foo</attribute>
             </attribute>

--- a/tests/Fixtures/FileConfigurations/resources.yml
+++ b/tests/Fixtures/FileConfigurations/resources.yml
@@ -23,6 +23,7 @@ resources:
         iri: 'someirischema'
         properties:
             'foo':
+                subresource: {collection: true, resourceClass: 'Foo'}
                 description: 'The dummy foo'
                 readable: true
                 writable: true

--- a/tests/Fixtures/TestBundle/Entity/Container.php
+++ b/tests/Fixtures/TestBundle/Entity/Container.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -33,7 +33,7 @@ class Container
     private $id;
 
     /**
-     * @ApiProperty(subresource=true)
+     * @ApiSubresource
      * @ORM\OneToMany(
      *      targetEntity="Node",
      *      mappedBy="container",

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -125,7 +126,7 @@ class Dummy
      * @var ArrayCollection Several dummies
      *
      * @ORM\ManyToMany(targetEntity="RelatedDummy")
-     * @ApiProperty(subresource=true)
+     * @ApiSubresource
      */
     public $relatedDummies;
 

--- a/tests/Fixtures/TestBundle/Entity/DummyAggregateOffer.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyAggregateOffer.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -42,7 +42,7 @@ class DummyAggregateOffer
     /**
      * @var ArrayCollection
      *
-     * @ApiProperty(subresource=true)
+     * @ApiSubresource
      * @ORM\OneToMany(targetEntity="DummyOffer", mappedBy="id", cascade={"persist"})
      */
     private $offers;

--- a/tests/Fixtures/TestBundle/Entity/DummyProduct.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyProduct.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -42,7 +42,7 @@ class DummyProduct
     /**
      * @var Collection
      *
-     * @ApiProperty(subresource=true)
+     * @ApiSubresource
      * @ORM\OneToMany(targetEntity="DummyAggregateOffer", mappedBy="id", cascade={"persist"})
      */
     private $offers;

--- a/tests/Fixtures/TestBundle/Entity/Question.php
+++ b/tests/Fixtures/TestBundle/Entity/Question.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -38,7 +38,7 @@ class Question
     /**
      * @ORM\OneToOne(targetEntity="Answer", inversedBy="question")
      * @ORM\JoinColumn(name="answer_id", referencedColumnName="id", unique=true)
-     * @ApiProperty(subresource=true)
+     * @ApiSubresource
      */
     private $answer;
 

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -62,14 +62,14 @@ class RelatedDummy extends ParentDummy
     public $dummyDate;
 
     /**
-     * @ApiProperty(subresource=true)
+     * @ApiSubresource
      * @ORM\ManyToOne(targetEntity="ThirdLevel", cascade={"persist"})
      * @Groups({"barcelona", "chicago", "friends"})
      */
     public $thirdLevel;
 
     /**
-     * @ApiProperty(subresource=true)
+     * @ApiSubresource
      * @ORM\OneToMany(targetEntity="RelatedToDummyFriend", cascade={"persist"}, mappedBy="relatedDummy")
      * @Groups({"fakemanytomany", "friends"})
      */

--- a/tests/Metadata/Property/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Property/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Metadata\Property\Factory;
 
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Property\SubresourceMetadata;
 
 /**
  * Property metadata provider for file configured factories tests.
@@ -36,6 +37,7 @@ abstract class FileConfigurationMetadataFactoryProvider extends \PHPUnit_Framewo
                 'bar' => [['Bar'], 'baz' => 'Baz'],
                 'baz' => 'Baz',
             ],
+            'subresource' => new SubresourceMetadata('Foo', true),
         ];
 
         return [[$this->getPropertyMetadata($metadata)]];
@@ -52,6 +54,7 @@ abstract class FileConfigurationMetadataFactoryProvider extends \PHPUnit_Framewo
             'required' => true,
             'identifier' => false,
             'attributes' => ['Foo'],
+            'subresource' => new SubresourceMetadata('Foo', true),
         ];
 
         return [[$this->getPropertyMetadata($metadata)]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

For now the @ApiSubresource only does the same thing as `@ApiProperty(subresource=true)`. It'll be better with metadata and an annotation class if we want to add features to it in the future.

Related to https://github.com/api-platform/core/pull/1188. ping @pierredup 