### PR TITLE
[Proposal] Update Swagger's definition keys (more verbose)

### DIFF
--- a/features/swagger/docs.feature
+++ b/features/swagger/docs.feature
@@ -17,31 +17,31 @@ Feature: Documentation support
     # Supported classes
     And the Swagger class "AbstractDummy" exists
     And the Swagger class "CircularReference" exists
-    And the Swagger class "CircularReference_a0dd2858dcb0d966f739c1ac906afa2e" exists
+    And the Swagger class "CircularReference-circular" exists
     And the Swagger class "CompositeItem" exists
     And the Swagger class "CompositeLabel" exists
     And the Swagger class "ConcreteDummy" exists
     And the Swagger class "CustomIdentifierDummy" exists
-    And the Swagger class "CustomNormalizedDummy_601856395b57c6b15175297eb6c9890e" exists
-    And the Swagger class "CustomNormalizedDummy_db9cba1a967111a02380774784c47722" exists
+    And the Swagger class "CustomNormalizedDummy-input" exists
+    And the Swagger class "CustomNormalizedDummy-output" exists
     And the Swagger class "CustomWritableIdentifierDummy" exists
     And the Swagger class "Dummy" exists
     And the Swagger class "RelatedDummy" exists
     And the Swagger class "DummyTableInheritance" exists
     And the Swagger class "DummyTableInheritanceChild" exists
-    And the Swagger class "OverriddenOperationDummy_441e1f98db3d0250bcb18dca087687c3" exists
-    And the Swagger class "OverriddenOperationDummy_45f46ed6dc6f412229a8c12cd5583586" exists
-    And the Swagger class "OverriddenOperationDummy_868796b9924a520acbb96f8b75dade9f" exists
-    And the Swagger class "OverriddenOperationDummy_ff74003f36aebfe31c696fae1f701ae4" exists
+    And the Swagger class "OverriddenOperationDummy-overridden_operation_dummy_get" exists
+    And the Swagger class "OverriddenOperationDummy-overridden_operation_dummy_put" exists
+    And the Swagger class "OverriddenOperationDummy-overridden_operation_dummy_read" exists
+    And the Swagger class "OverriddenOperationDummy-overridden_operation_dummy_write" exists
     And the Swagger class "RelatedDummy" exists
     And the Swagger class "NoCollectionDummy" exists
     And the Swagger class "RelatedToDummyFriend" exists
-    And the Swagger class "RelatedToDummyFriend_ad38b7a2760884e744c577a92e02b8c4" exists
+    And the Swagger class "RelatedToDummyFriend-fakemanytomany" exists
     And the Swagger class "DummyFriend" exists
-    And the Swagger class "RelationEmbedder_ced9cba177bf3134e609fccf878df9a7" exists
-    And the Swagger class "RelationEmbedder_f02fd88a2291463447338402aee9a220" exists
-    And the Swagger class "User_4320517091b72c69e9f0c72aac0141e8" exists
-    And the Swagger class "User_7ce91261c0e731d95bb24b83b1f637b2" exists
+    And the Swagger class "RelationEmbedder-barcelona" exists
+    And the Swagger class "RelationEmbedder-chicago" exists
+    And the Swagger class "User-user_user-read" exists
+    And the Swagger class "User-user_user-write" exists
     And the Swagger class "UuidIdentifierDummy" exists
     And the Swagger class "ThirdLevel" exists
     And the Swagger class "ParentDummy" doesn't exist

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -371,11 +371,7 @@ final class DocumentationNormalizer implements NormalizerInterface
      */
     private function getDefinition(\ArrayObject $definitions, ResourceMetadata $resourceMetadata, string $resourceClass, array $serializerContext = null): string
     {
-        if (isset($serializerContext['groups'])) {
-            $definitionKey = sprintf('%s_%s', $resourceMetadata->getShortName(), md5(serialize($serializerContext['groups'])));
-        } else {
-            $definitionKey = $resourceMetadata->getShortName();
-        }
+        $definitionKey = $this->getDefinitionKey($resourceMetadata->getShortName(), (array) ($serializerContext['groups'] ?? []));
 
         if (!isset($definitions[$definitionKey])) {
             $definitions[$definitionKey] = [];  // Initialize first to prevent infinite loop
@@ -383,6 +379,11 @@ final class DocumentationNormalizer implements NormalizerInterface
         }
 
         return $definitionKey;
+    }
+
+    private function getDefinitionKey(string $resourceShortName, array $groups): string
+    {
+        return $groups ? sprintf('%s-%s', $resourceShortName, implode('_', $groups)) : $resourceShortName;
     }
 
     /**

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -382,7 +382,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), $title, $description, $version, $formats);
         $groups = ['dummy', 'foo', 'bar'];
 
-        $ref = 'Dummy_'.md5(serialize($groups));
+        $ref = 'Dummy-'.implode('_', $groups);
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, ['serializer_groups' => $groups])->shouldBeCalled(1)->willReturn(new PropertyNameCollection(['gerard']));
@@ -697,7 +697,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                                 'name' => 'dummy',
                                 'in' => 'body',
                                 'description' => 'The updated Dummy resource',
-                                'schema' => ['$ref' => '#/definitions/Dummy_be35824b9d92d1dfc6f78fe086649b8f'],
+                                'schema' => ['$ref' => '#/definitions/Dummy-dummy'],
                             ],
                         ],
                         'responses' => [
@@ -723,7 +723,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         ]),
                     ],
                 ]),
-                'Dummy_be35824b9d92d1dfc6f78fe086649b8f' => new \ArrayObject([
+                'Dummy-dummy' => new \ArrayObject([
                     'type' => 'object',
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
@@ -882,13 +882,13 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                                 'name' => 'dummy',
                                 'in' => 'body',
                                 'description' => 'The updated Dummy resource',
-                                'schema' => ['$ref' => '#/definitions/Dummy_be35824b9d92d1dfc6f78fe086649b8f'],
+                                'schema' => ['$ref' => '#/definitions/Dummy-dummy'],
                             ],
                         ],
                         'responses' => [
                             200 => [
                                 'description' => 'Dummy resource updated',
-                                'schema' => ['$ref' => '#/definitions/Dummy_be35824b9d92d1dfc6f78fe086649b8f'],
+                                'schema' => ['$ref' => '#/definitions/Dummy-dummy'],
                             ],
                             400 => ['description' => 'Invalid input'],
                             404 => ['description' => 'Resource not found'],
@@ -908,7 +908,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         ]),
                     ],
                 ]),
-                'Dummy_be35824b9d92d1dfc6f78fe086649b8f' => new \ArrayObject([
+                'Dummy-dummy' => new \ArrayObject([
                     'type' => 'object',
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
@@ -1136,8 +1136,8 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $version = '1.2.3';
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), $title, $description, $version, $formats);
         $groups = ['dummy', 'foo', 'bar'];
-        $ref = 'Dummy_'.md5(serialize($groups));
-        $relatedDummyRef = 'RelatedDummy_'.md5(serialize($groups));
+        $ref = 'Dummy-'.implode('_', $groups);
+        $relatedDummyRef = 'RelatedDummy-'.implode('_', $groups);
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, ['serializer_groups' => $groups])->shouldBeCalled(1)->willReturn(new PropertyNameCollection(['name', 'relatedDummy']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Since Swagger-UI 3.x, definitions are exposed in the ui. My proposal is to make them more verbose when an operation has defined roles. So instead of a md5 hash, I propose to use a slug.
Slug can be discussed and currently I use `_groups_<group x>_<group y>_<group ...>`.

Before:

<img width="258" alt="capture d ecran 2017-06-27 a 14 57 33" src="https://user-images.githubusercontent.com/4034907/27593963-d973f3e0-5b58-11e7-8c4e-f8cc543a5757.png">

After:

<img width="133" alt="capture d ecran 2017-06-27 a 14 51 53" src="https://user-images.githubusercontent.com/4034907/27593983-e9060e4c-5b58-11e7-9614-89c42a830361.png">

WDYT?