### PR TITLE
Replace AccessDeniedException by AccessDeniedHttpException

### DIFF
--- a/src/EventListener/DenyAccessListener.php
+++ b/src/EventListener/DenyAccessListener.php
@@ -17,8 +17,8 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * Denies access to the current resource if the logged user doesn't have sufficient permissions.
@@ -41,7 +41,7 @@ final class DenyAccessListener
      *
      * @param GetResponseEvent $event
      *
-     * @throws AccessDeniedException
+     * @throws AccessDeniedHttpException
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
@@ -72,7 +72,7 @@ final class DenyAccessListener
         }
 
         if (!$this->authorizationChecker->isGranted(new Expression($isGranted), $request->attributes->get('data'))) {
-            throw new AccessDeniedException();
+            throw new AccessDeniedHttpException();
         }
     }
 }

--- a/tests/EventListener/DenyAccessListenerTest.php
+++ b/tests/EventListener/DenyAccessListenerTest.php
@@ -89,7 +89,7 @@ class DenyAccessListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
     public function testIsNotGranted()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | 

Replace "AccessDeniedException" by "AccessDeniedHttpException" in `DenyAccessListener` to have a status code 403 when using *is_granted* attribute on ApiResource.

Example : 
```
@ApiResource(
      attributes={"is_granted"="has_role('ROLE_ADMIN')"}
}
```