### PR TITLE
Extra try-catch in DenyAccessListener to keep ExpressionVoter from failing if is_granted expression is invalid

### DIFF
--- a/src/EventListener/DenyAccessListener.php
+++ b/src/EventListener/DenyAccessListener.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\EventListener;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -71,7 +72,11 @@ final class DenyAccessListener
             throw new \LogicException(sprintf('The "symfony/expression-language" library must be installed to use the "is_granted" attribute on class "%s".', $attributes['resource_class']));
         }
 
-        if (!$this->authorizationChecker->isGranted(new Expression($isGranted), $request->attributes->get('data'))) {
+        try {
+            if (!$this->authorizationChecker->isGranted(new Expression($isGranted), $request->attributes->get('data'))) {
+                throw new AccessDeniedException();
+            }
+        } catch (SyntaxError $e) {
             throw new AccessDeniedException();
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

The problem I wanted to address:
I have custom Voters  that handle my custom operations(apply, get, delete)  from `is_granted` field. That works, but if I deny access then ExpressionVoter tries to process `is_granted`, which fails, since its not a valid expression according to Expression Language.