### PR TITLE
404 instead of 400 for bad identifiers fix #1191

### DIFF
--- a/features/main/composite.feature
+++ b/features/main/composite.feature
@@ -123,7 +123,7 @@ Feature: Retrieve data with Composite identifiers
   Scenario: Get the first composite relation with a missing identifier
     Given there are Composite identifier objects
     When I send a "GET" request to "/composite_relations/compositeLabel=1;"
-    Then the response status code should be 400
+    Then the response status code should be 404
 
   @dropSchema
   Scenario: Get first composite item

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -18,8 +18,6 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryResultItemExtensionInter
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\IdentifierManagerTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
-use ApiPlatform\Core\Exception\InvalidArgumentException;
-use ApiPlatform\Core\Exception\PropertyNotFoundException;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -69,11 +67,7 @@ class ItemDataProvider implements ItemDataProviderInterface
             throw new ResourceClassNotSupportedException();
         }
 
-        try {
-            $identifiers = $this->normalizeIdentifiers($id, $manager, $resourceClass);
-        } catch (PropertyNotFoundException $e) {
-            throw new InvalidArgumentException($e->getMessage());
-        }
+        $identifiers = $this->normalizeIdentifiers($id, $manager, $resourceClass);
 
         $fetchData = $context['fetch_data'] ?? true;
         if (!$fetchData && $manager instanceof EntityManagerInterface) {

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\EventListener;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
+use ApiPlatform\Core\Exception\PropertyNotFoundException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -100,7 +101,12 @@ final class ReadListener
     private function getItemData(Request $request, array $attributes)
     {
         $id = $request->attributes->get('id');
-        $data = $this->itemDataProvider->getItem($attributes['resource_class'], $id, $attributes['item_operation_name']);
+
+        try {
+            $data = $this->itemDataProvider->getItem($attributes['resource_class'], $id, $attributes['item_operation_name']);
+        } catch (PropertyNotFoundException $e) {
+            throw new NotFoundHttpException('Not Found');
+        }
 
         if (null === $data) {
             throw new NotFoundHttpException('Not Found');

--- a/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
@@ -122,7 +122,7 @@ class ItemDataProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
+     * @expectedException \ApiPlatform\Core\Exception\PropertyNotFoundException
      */
     public function testGetItemWrongCompositeIdentifier()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1191 
| License       | MIT
| Doc PR        | na

Another solution for this would be to catch the Exception in the ReadListener and return null. Lmk wdyt about this.

ping @teohhanhui  @Simperfit 