### PR TITLE
Fix Hydra documentation

### DIFF
--- a/features/bootstrap/HydraContext.php
+++ b/features/bootstrap/HydraContext.php
@@ -95,6 +95,16 @@ class HydraContext implements Context
     }
 
     /**
+     * @Then the value of the node ":node" of the operation ":operation" of the Hydra class ":class" contains ":value"
+     */
+    public function assertOperationNodeValueContains($nodeName, $operationMethod, $className, $value)
+    {
+        $property = $this->getOperation($operationMethod, $className);
+
+        \PHPUnit_Framework_Assert::assertContains($value, $this->propertyAccessor->getValue($property, $nodeName));
+    }
+
+    /**
      * @Then :nb operations are available for Hydra class ":class"
      */
     public function assertNbOperationsExist($nb, $className)

--- a/features/hydra/collection.feature
+++ b/features/hydra/collection.feature
@@ -18,9 +18,6 @@ Feature: Collections support
         "@id": {"pattern": "^/dummies$"},
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:totalItems": {"type":"number", "maximum": 0},
-        "hydra:itemsPerPage": {"type":"number", "maximum": 3},
-        "hydra:firstPage": {"pattern": "^/dummies$"},
-        "hydra:lastPage": {"pattern": "^/dummies$"},
         "hydra:member": {
           "type": "array",
           "maxItems": 0

--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -70,7 +70,8 @@ Feature: Documentation support
     And the value of the node "hydra:title" of the property "name" of the Hydra class "Dummy" is "name"
     And the value of the node "hydra:description" of the property "name" of the Hydra class "Dummy" is "The dummy name"
     # Operations
-    And the value of the node "@type" of the operation "GET" of the Hydra class "Dummy" is "hydra:Operation"
+    And the value of the node "@type" of the operation "GET" of the Hydra class "Dummy" contains "hydra:Operation"
+    And the value of the node "@type" of the operation "GET" of the Hydra class "Dummy" contains "schema:FindAction"
     And the value of the node "hydra:method" of the operation "GET" of the Hydra class "Dummy" is "GET"
     And the value of the node "hydra:title" of the operation "GET" of the Hydra class "Dummy" is "Retrieves Dummy resource."
     And the value of the node "rdfs:label" of the operation "GET" of the Hydra class "Dummy" is "Retrieves Dummy resource."

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -173,7 +173,6 @@ Feature: Relations support
         "@id": {"pattern": "^/dummies$"},
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:totalItems": {"type":"number", "maximum": 1},
-        "hydra:itemsPerPage": {"type":"number", "maximum": 3},
         "hydra:member": {
           "type": "array",
           "items": {
@@ -209,7 +208,6 @@ Feature: Relations support
         "@id": {"pattern": "^/dummies$"},
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:totalItems": {"type":"number", "maximum": 1},
-        "hydra:itemsPerPage": {"type":"number", "maximum": 3},
         "hydra:member": {
           "type": "array",
           "items": {

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -95,7 +95,7 @@ final class DocumentationNormalizer implements NormalizerInterface
                 '@type' => 'hydra:Link',
                 'domain' => '#Entrypoint',
                 'rdfs:label' => "The collection of $shortName resources",
-                'range' => 'hydra:PagedCollection',
+                'range' => 'hydra:Collection',
                 'hydra:supportedOperation' => $hydraCollectionOperations,
             ],
             'hydra:title' => "The collection of $shortName resources",
@@ -233,36 +233,38 @@ final class DocumentationNormalizer implements NormalizerInterface
 
         if ('GET' === $method && $collection) {
             $hydraOperation = [
+                '@type' => ['hydra:Operation', 'schema:FindAction'],
                 'hydra:title' => "Retrieves the collection of $shortName resources.",
-                'returns' => 'hydra:PagedCollection',
+                'returns' => 'hydra:Collection',
             ] + $hydraOperation;
         } elseif ('GET' === $method) {
             $hydraOperation = [
+                '@type' => ['hydra:Operation', 'schema:FindAction'],
                 'hydra:title' => "Retrieves $shortName resource.",
                 'returns' => $prefixedShortName,
             ] + $hydraOperation;
         } elseif ('POST' === $method) {
             $hydraOperation = [
-                '@type' => 'hydra:CreateResourceOperation',
+                '@type' => ['hydra:Operation', 'schema:CreateAction'],
                 'hydra:title' => "Creates a $shortName resource.",
                 'returns' => $prefixedShortName,
                 'expects' => $prefixedShortName,
             ] + $hydraOperation;
         } elseif ('PUT' === $method) {
             $hydraOperation = [
-                '@type' => 'hydra:ReplaceResourceOperation',
+                '@type' => ['hydra:Operation', 'schema:ReplaceAction'],
                 'hydra:title' => "Replaces the $shortName resource.",
                 'returns' => $prefixedShortName,
                 'expects' => $prefixedShortName,
             ] + $hydraOperation;
         } elseif ('DELETE' === $method) {
             $hydraOperation = [
+                '@type' => ['hydra:Operation', 'schema:DeleteAction'],
                 'hydra:title' => "Deletes the $shortName resource.",
                 'returns' => 'owl:Nothing',
             ] + $hydraOperation;
         }
 
-        $hydraOperation['@type'] ?? $hydraOperation['@type'] = 'hydra:Operation';
         $hydraOperation['hydra:method'] ?? $hydraOperation['hydra:method'] = $method;
 
         if (!isset($hydraOperation['rdfs:label']) && isset($hydraOperation['hydra:title'])) {
@@ -458,7 +460,7 @@ final class DocumentationNormalizer implements NormalizerInterface
      */
     private function computeDoc(Documentation $object, array $classes): array
     {
-        $doc = ['@context' => $this->getContext(), '@id' => $this->urlGenerator->generate('api_doc', ['_format' => self::FORMAT])];
+        $doc = ['@context' => $this->getContext(), '@id' => $this->urlGenerator->generate('api_doc', ['_format' => self::FORMAT]), '@type' => 'hydra:ApiDocumentation'];
 
         if ('' !== $object->getTitle()) {
             $doc['hydra:title'] = $object->getTitle();
@@ -488,6 +490,7 @@ final class DocumentationNormalizer implements NormalizerInterface
             'rdfs' => ContextBuilderInterface::RDFS_NS,
             'xmls' => ContextBuilderInterface::XML_NS,
             'owl' => ContextBuilderInterface::OWL_NS,
+            'schema' => ContextBuilderInterface::SCHEMA_ORG_NS,
             'domain' => ['@id' => 'rdfs:domain', '@type' => '@id'],
             'range' => ['@id' => 'rdfs:range', '@type' => '@id'],
             'subClassOf' => ['@id' => 'rdfs:subClassOf', '@type' => '@id'],

--- a/src/JsonLd/ContextBuilderInterface.php
+++ b/src/JsonLd/ContextBuilderInterface.php
@@ -28,6 +28,7 @@ interface ContextBuilderInterface
     const RDFS_NS = 'http://www.w3.org/2000/01/rdf-schema#';
     const XML_NS = 'http://www.w3.org/2001/XMLSchema#';
     const OWL_NS = 'http://www.w3.org/2002/07/owl#';
+    const SCHEMA_ORG_NS = 'http://schema.org/';
 
     /**
      * Gets the base context.

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -82,6 +82,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                 'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
                 'xmls' => 'http://www.w3.org/2001/XMLSchema#',
                 'owl' => 'http://www.w3.org/2002/07/owl#',
+                'schema' => 'http://schema.org/',
                 'domain' => [
                     '@id' => 'rdfs:domain',
                     '@type' => '@id',
@@ -104,6 +105,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
             '@id' => '/doc',
+            '@type' => 'hydra:ApiDocumentation',
             'hydra:title' => 'Test Api',
             'hydra:description' => 'test ApiGerard',
             'hydra:supportedClass' => [
@@ -147,14 +149,14 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                     ],
                     'hydra:supportedOperation' => [
                         0 => [
-                            '@type' => 'hydra:Operation',
+                            '@type' => ['hydra:Operation', 'schema:FindAction'],
                             'hydra:method' => 'GET',
                             'hydra:title' => 'Retrieves dummy resource.',
                             'rdfs:label' => 'Retrieves dummy resource.',
                             'returns' => '#dummy',
                         ],
                         1 => [
-                            '@type' => 'hydra:ReplaceResourceOperation',
+                            '@type' => ['hydra:Operation', 'schema:ReplaceAction'],
                             'expects' => '#dummy',
                             'hydra:method' => 'PUT',
                             'hydra:title' => 'Replaces the dummy resource.',
@@ -175,17 +177,17 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                                 '@type' => 'hydra:Link',
                                 'rdfs:label' => 'The collection of dummy resources',
                                 'domain' => '#Entrypoint',
-                                'range' => 'hydra:PagedCollection',
+                                'range' => 'hydra:Collection',
                                 'hydra:supportedOperation' => [
                                     0 => [
-                                        '@type' => 'hydra:Operation',
+                                        '@type' => ['hydra:Operation', 'schema:FindAction'],
                                         'hydra:method' => 'GET',
                                         'hydra:title' => 'Retrieves the collection of dummy resources.',
                                         'rdfs:label' => 'Retrieves the collection of dummy resources.',
-                                        'returns' => 'hydra:PagedCollection',
+                                        'returns' => 'hydra:Collection',
                                     ],
                                     1 => [
-                                        '@type' => 'hydra:CreateResourceOperation',
+                                        '@type' => ['hydra:Operation', 'schema:CreateAction'],
                                         'expects' => '#dummy',
                                         'hydra:method' => 'POST',
                                         'hydra:title' => 'Creates a dummy resource.',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

* Remove old references to the `PagedCollection` class (see https://github.com/HydraCG/Specifications/issues/42)
* Remove old references to the `*ResourceOperation` classes (see https://github.com/HydraCG/Specifications/issues/11)
* Replace predefined operations with the schema.org actions (see https://github.com/HydraCG/Specifications/pull/125)
* Add `ApiDocumentation` class as type of the generated documentation

