### PR TITLE
Fix BC break in ValidateListener

### DIFF
--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -74,6 +74,7 @@ final class ValidateListener
 
         if (
             $this->container &&
+            is_string($validationGroups) &&
             $this->container->has($validationGroups) &&
             ($service = $this->container->get($validationGroups)) &&
             is_callable($service)
@@ -83,7 +84,7 @@ final class ValidateListener
             $validationGroups = call_user_func_array($validationGroups, [$data]);
         }
 
-        $violations = $this->validator->validate($data, null, $validationGroups);
+        $violations = $this->validator->validate($data, null, (array) $validationGroups);
         if (0 !== count($violations)) {
             throw new ValidationException($violations);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/core/pull/1198#issuecomment-314716934
| License       | MIT
| Doc PR        | N/A

* Fix the bug/BC break introduced by #1198 (see https://github.com/api-platform/core/pull/1198#issuecomment-314716934)
* Allow to use a simple scalar instead of an array as validation group in attributes.
