### PR TITLE
Allow using PHP constants in YAML resources files

### DIFF
--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -32,7 +32,7 @@ final class YamlExtractor extends AbstractExtractor
     protected function extractPath(string $path)
     {
         try {
-            $resourcesYaml = Yaml::parse(file_get_contents($path), Yaml::PARSE_KEYS_AS_STRINGS);
+            $resourcesYaml = Yaml::parse(file_get_contents($path), Yaml::PARSE_KEYS_AS_STRINGS | Yaml::PARSE_CONSTANT);
         } catch (ParseException $e) {
             $e->setParsedFile($path);
 

--- a/tests/Fixtures/FileConfigurations/resources.yml
+++ b/tests/Fixtures/FileConfigurations/resources.yml
@@ -19,7 +19,7 @@ resources:
                 groups: ['default']
             hydra_context:
                 '@type': 'hydra:Operation'
-                '@hydra:title': 'File config Dummy'
+                '@hydra:title': !php/const:ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy::HYDRA_TITLE
         iri: 'someirischema'
         properties:
             'foo':

--- a/tests/Fixtures/TestBundle/Entity/FileConfigDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/FileConfigDummy.php
@@ -22,6 +22,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class FileConfigDummy
 {
+    const HYDRA_TITLE = 'File config Dummy';
+
     /**
      * @var int The id
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A
