### PR TITLE
Improve performance of the metadata system

### DIFF
--- a/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
@@ -28,6 +28,7 @@ final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInte
 
     private $cacheItemPool;
     private $decorated;
+    private $memoryCache = [];
 
     public function __construct(CacheItemPoolInterface $cacheItemPool, PropertyMetadataFactoryInterface $decorated)
     {
@@ -40,13 +41,18 @@ final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInte
      */
     public function create(string $resourceClass, string $property, array $options = []): PropertyMetadata
     {
-        $cacheKey = self::CACHE_KEY_PREFIX.md5(serialize([$resourceClass, $property, $options]));
+        $localKey = serialize([$resourceClass, $property, $options]);
+        if (isset($this->memoryCache[$localKey])) {
+            return $this->memoryCache[$localKey];
+        }
+
+        $cacheKey = self::CACHE_KEY_PREFIX.md5($localKey);
 
         try {
             $cacheItem = $this->cacheItemPool->getItem($cacheKey);
 
             if ($cacheItem->isHit()) {
-                return $cacheItem->get();
+                return $this->memoryCache[$localKey] = $cacheItem->get();
             }
         } catch (CacheException $e) {
             // do nothing
@@ -55,12 +61,12 @@ final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInte
         $propertyMetadata = $this->decorated->create($resourceClass, $property, $options);
 
         if (!isset($cacheItem)) {
-            return $propertyMetadata;
+            return $this->memoryCache[$localKey] = $propertyMetadata;
         }
 
         $cacheItem->set($propertyMetadata);
         $this->cacheItemPool->save($cacheItem);
 
-        return $propertyMetadata;
+        return $this->memoryCache[$localKey] = $propertyMetadata;
     }
 }

--- a/tests/Metadata/Property/Factory/CachedPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/CachedPropertyMetadataFactoryTest.php
@@ -41,7 +41,9 @@ class CachedPropertyMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $resultedPropertyMetadata = $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy');
 
         $this->assertInstanceOf(PropertyMetadata::class, $resultedPropertyMetadata);
-        $this->assertEquals(new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false), $resultedPropertyMetadata);
+        $expectedResult = new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false);
+        $this->assertEquals($expectedResult, $resultedPropertyMetadata);
+        $this->assertEquals($expectedResult, $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy'), 'Trigger the local cache');
     }
 
     public function testCreateWithItemNotHit()
@@ -63,7 +65,9 @@ class CachedPropertyMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $resultedPropertyMetadata = $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy');
 
         $this->assertInstanceOf(PropertyMetadata::class, $resultedPropertyMetadata);
-        $this->assertEquals(new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false), $resultedPropertyMetadata);
+        $expectedResult = new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false);
+        $this->assertEquals($expectedResult, $resultedPropertyMetadata);
+        $this->assertEquals($expectedResult, $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy'), 'Trigger the local cache');
     }
 
     public function testCreateWithGetCacheItemThrowsCacheException()
@@ -81,7 +85,10 @@ class CachedPropertyMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $resultedPropertyMetadata = $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy');
 
         $this->assertInstanceOf(PropertyMetadata::class, $resultedPropertyMetadata);
-        $this->assertEquals(new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false), $resultedPropertyMetadata);
+
+        $expectedResult = new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false);
+        $this->assertEquals($expectedResult, $resultedPropertyMetadata);
+        $this->assertEquals($expectedResult, $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy'), 'Trigger the local cache');
     }
 
     private function generateCacheKey(string $resourceClass = Dummy::class, string $property = 'dummy', array $options = [])

--- a/tests/Metadata/Property/Factory/CachedPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/CachedPropertyNameCollectionFactoryTest.php
@@ -41,7 +41,10 @@ class CachedPropertyNameCollectionFactoryTest extends \PHPUnit_Framework_TestCas
         $resultedPropertyNameCollection = $cachedPropertyNameCollectionFactory->create(Dummy::class);
 
         $this->assertInstanceOf(PropertyNameCollection::class, $resultedPropertyNameCollection);
-        $this->assertEquals(new PropertyNameCollection(['id', 'name', 'description', 'dummy']), $resultedPropertyNameCollection);
+
+        $expectedResult = new PropertyNameCollection(['id', 'name', 'description', 'dummy']);
+        $this->assertEquals($expectedResult, $resultedPropertyNameCollection);
+        $this->assertEquals($expectedResult, $cachedPropertyNameCollectionFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     public function testCreateWithItemNotHit()
@@ -63,7 +66,10 @@ class CachedPropertyNameCollectionFactoryTest extends \PHPUnit_Framework_TestCas
         $resultedPropertyNameCollection = $cachedPropertyNameCollectionFactory->create(Dummy::class);
 
         $this->assertInstanceOf(PropertyNameCollection::class, $resultedPropertyNameCollection);
-        $this->assertEquals(new PropertyNameCollection(['id', 'name', 'description', 'dummy']), $resultedPropertyNameCollection);
+
+        $expectedResult = new PropertyNameCollection(['id', 'name', 'description', 'dummy']);
+        $this->assertEquals($expectedResult, $resultedPropertyNameCollection);
+        $this->assertEquals($expectedResult, $cachedPropertyNameCollectionFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     public function testCreateWithGetCacheItemThrowsCacheException()
@@ -81,7 +87,10 @@ class CachedPropertyNameCollectionFactoryTest extends \PHPUnit_Framework_TestCas
         $resultedPropertyNameCollection = $cachedPropertyNameCollectionFactory->create(Dummy::class);
 
         $this->assertInstanceOf(PropertyNameCollection::class, $resultedPropertyNameCollection);
-        $this->assertEquals(new PropertyNameCollection(['id', 'name', 'description', 'dummy']), $resultedPropertyNameCollection);
+
+        $expectedResult = new PropertyNameCollection(['id', 'name', 'description', 'dummy']);
+        $this->assertEquals($expectedResult, $resultedPropertyNameCollection);
+        $this->assertEquals($expectedResult, $cachedPropertyNameCollectionFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     private function generateCacheKey(string $resourceClass = Dummy::class, array $options = [])

--- a/tests/Metadata/Resource/Factory/CachedResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/CachedResourceMetadataFactoryTest.php
@@ -63,7 +63,10 @@ class CachedResourceMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $resultedResourceMetadata = $cachedResourceMetadataFactory->create(Dummy::class);
 
         $this->assertInstanceOf(ResourceMetadata::class, $resultedResourceMetadata);
-        $this->assertEquals(new ResourceMetadata(null, 'Dummy.'), $resultedResourceMetadata);
+
+        $expectedResult = new ResourceMetadata(null, 'Dummy.');
+        $this->assertEquals($expectedResult, $resultedResourceMetadata);
+        $this->assertEquals($expectedResult, $cachedResourceMetadataFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     public function testCreateWithGetCacheItemThrowsCacheException()
@@ -81,11 +84,14 @@ class CachedResourceMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $resultedResourceMetadata = $cachedResourceMetadataFactory->create(Dummy::class);
 
         $this->assertInstanceOf(ResourceMetadata::class, $resultedResourceMetadata);
-        $this->assertEquals(new ResourceMetadata(null, 'Dummy.'), $resultedResourceMetadata);
+
+        $expectedResult = new ResourceMetadata(null, 'Dummy.');
+        $this->assertEquals($expectedResult, $resultedResourceMetadata);
+        $this->assertEquals($expectedResult, $cachedResourceMetadataFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     private function generateCacheKey(string $resourceClass = Dummy::class)
     {
-        return CachedResourceMetadataFactory::CACHE_KEY_PREFIX.md5(serialize([$resourceClass]));
+        return CachedResourceMetadataFactory::CACHE_KEY_PREFIX.md5($resourceClass);
     }
 }

--- a/tests/Metadata/Resource/Factory/CachedResourceNameCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/CachedResourceNameCollectionFactoryTest.php
@@ -41,7 +41,10 @@ class CachedResourceNameCollectionFactoryTest extends \PHPUnit_Framework_TestCas
         $resultedResourceNameCollection = $cachedResourceNameCollectionFactory->create();
 
         $this->assertInstanceOf(ResourceNameCollection::class, $resultedResourceNameCollection);
-        $this->assertEquals(new ResourceNameCollection([Dummy::class]), $resultedResourceNameCollection);
+
+        $expectedResult = new ResourceNameCollection([Dummy::class]);
+        $this->assertEquals($expectedResult, $resultedResourceNameCollection);
+        $this->assertEquals($expectedResult, $cachedResourceNameCollectionFactory->create(), 'Trigger the local cache');
     }
 
     public function testCreateWithItemNotHit()
@@ -63,7 +66,10 @@ class CachedResourceNameCollectionFactoryTest extends \PHPUnit_Framework_TestCas
         $resultedResourceNameCollection = $cachedResourceNameCollectionFactory->create();
 
         $this->assertInstanceOf(ResourceNameCollection::class, $resultedResourceNameCollection);
-        $this->assertEquals(new ResourceNameCollection([Dummy::class]), $resultedResourceNameCollection);
+
+        $expectedResult = new ResourceNameCollection([Dummy::class]);
+        $this->assertEquals($expectedResult, $resultedResourceNameCollection);
+        $this->assertEquals($expectedResult, $cachedResourceNameCollectionFactory->create(), 'Trigger the local cache');
     }
 
     public function testCreateWithGetCacheItemThrowsCacheException()
@@ -81,6 +87,9 @@ class CachedResourceNameCollectionFactoryTest extends \PHPUnit_Framework_TestCas
         $resultedResourceNameCollection = $cachedResourceNameCollectionFactory->create();
 
         $this->assertInstanceOf(ResourceNameCollection::class, $resultedResourceNameCollection);
-        $this->assertEquals(new ResourceNameCollection([Dummy::class]), $resultedResourceNameCollection);
+
+        $expectedResult = new ResourceNameCollection([Dummy::class]);
+        $this->assertEquals($expectedResult, $resultedResourceNameCollection);
+        $this->assertEquals($expectedResult, $cachedResourceNameCollectionFactory->create(), 'Trigger the local cache');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

By default, the Symfony's `cache.system` setup uses apcu. Our metadata component relies on this cache, however, as we retrieve the cache many time in a single request `apcu_fetch` is called many times and do a lot of IO. This fix introduce a local memory cache to avoid the IO operations.