### PR TITLE
Removed null description @var in ApiResource

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -29,7 +29,7 @@ final class ApiResource
     public $shortName;
 
     /**
-     * @var string|null
+     * @var string
      */
     public $description;
 

--- a/tests/Annotation/AnnotatedClass.php
+++ b/tests/Annotation/AnnotatedClass.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Annotation;
+
 use ApiPlatform\Core\Annotation\ApiResource;
 
 /**
@@ -28,5 +29,4 @@ use ApiPlatform\Core\Annotation\ApiResource;
  */
 class AnnotatedClass
 {
-
 }

--- a/tests/Annotation/AnnotatedClass.php
+++ b/tests/Annotation/AnnotatedClass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Annotation;
+use ApiPlatform\Core\Annotation\ApiResource;
+
+/**
+ * @ApiResource(
+ *     shortName="shortName",
+ *     description="description",
+ *     iri="http://example.com/res",
+ *     itemOperations={"foo":{"bar"}},
+ *     collectionOperations={"bar":{"foo"}},
+ *     attributes={"foo":"bar"}
+ * )
+ *
+ * @author Marcus Speight <marcus@pmconnect.co.uk>
+ */
+class AnnotatedClass
+{
+
+}

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Annotation;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Marcus Speight <marcus@pmconnect.co.uk>
  */
 class ApiResourceTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,6 +31,18 @@ class ApiResourceTest extends \PHPUnit_Framework_TestCase
         $resource->itemOperations = ['foo' => ['bar']];
         $resource->collectionOperations = ['bar' => ['foo']];
         $resource->attributes = ['foo' => 'bar'];
+
+        $this->assertEquals('shortName', $resource->shortName);
+        $this->assertEquals('description', $resource->description);
+        $this->assertEquals('http://example.com/res', $resource->iri);
+        $this->assertEquals(['bar' => ['foo']], $resource->collectionOperations);
+        $this->assertEquals(['foo' => 'bar'], $resource->attributes);
+    }
+
+    public function testApiResourceAnnotation()
+    {
+        $reader = new AnnotationReader();
+        $resource = $reader->getClassAnnotation(new \ReflectionClass(AnnotatedClass::class), ApiResource::class);
 
         $this->assertEquals('shortName', $resource->shortName);
         $this->assertEquals('description', $resource->description);

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -18,7 +18,6 @@ use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
- * @author Marcus Speight <marcus@pmconnect.co.uk>
  */
 class ApiResourceTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Doctrine's DocParser throws an exception if you set a description.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1050
| License       | MIT
| Doc PR        | N/A

