### PR TITLE
Keep propagating the correct context to relations when (de)normalizing

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -292,7 +292,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         if (!$this->resourceClassResolver->isResourceClass($className) || $propertyMetadata->isWritableLink()) {
-            return $this->serializer->denormalize($value, $className, $format, $this->createRelationSerializationContext($className, $context));
+            $context['resource_class'] = $className;
+
+            return $this->serializer->denormalize($value, $className, $format, $context);
         }
 
         if (!is_array($value)) {
@@ -358,8 +360,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     protected function createRelationSerializationContext(string $resourceClass, array $context): array
     {
-        $context['resource_class'] = $resourceClass;
-        unset($context['item_operation_name'], $context['collection_operation_name']);
+        @trigger_error(sprintf('The method %s() is deprecated since 2.1 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
         return $context;
     }
@@ -434,7 +435,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     private function normalizeRelation(PropertyMetadata $propertyMetadata, $relatedObject, string $resourceClass, string $format = null, array $context)
     {
         if ($propertyMetadata->isReadableLink()) {
-            return $this->serializer->normalize($relatedObject, $format, $this->createRelationSerializationContext($resourceClass, $context));
+            $context['resource_class'] = $resourceClass;
+
+            return $this->serializer->normalize($relatedObject, $format, $context);
         }
 
         $iri = $this->iriConverter->getIriFromItem($relatedObject);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1210 
| License       | MIT
| Doc PR        | n/a

And...... Nothing happened :D.

Though, really unsure on how I could test this to avoid regression. There's no point in unit-testing it because it's not impacting the normalization, instead it may impact features that rely on the same context. Also, we can't test if a feature has been executed (like `force_eager=false`) with behat... 