### PR TITLE
Authorize empty content put in custom operations

### DIFF
--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -395,6 +395,41 @@ Feature: Create-Retrieve-Update-Delete
     }
     """
 
+  Scenario: Update a resource with empty body
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/dummies/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
+      "description": null,
+      "dummy": null,
+      "dummyBoolean": null,
+      "dummyDate": "2015-03-01T10:00:00+00:00",
+      "dummyFloat": null,
+      "dummyPrice": null,
+      "relatedDummy": null,
+      "relatedDummies": [],
+      "jsonData": [
+        {
+          "key": "value1"
+        },
+        {
+          "key": "value2"
+        }
+      ],
+      "name_converted": null,
+      "id": 1,
+      "name": "A nice dummy",
+      "alias": null
+    }
+    """
+
   @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/dummies/1"

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -52,7 +52,7 @@ final class DeserializeListener
             || $request->isMethod(Request::METHOD_DELETE)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || ($request->isMethod(Request::METHOD_PUT) &&  '' === $requestContent)
+            || ($request->isMethod(Request::METHOD_PUT) && '' === $requestContent)
         ) {
             return;
         }

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -51,6 +51,7 @@ final class DeserializeListener
             || $request->isMethod(Request::METHOD_DELETE)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
+            || ($request->isMethod(Request::METHOD_PUT) &&$request->getContent() === "")
         ) {
             return;
         }

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -46,13 +46,12 @@ final class DeserializeListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        $requestContent = null;
         if (
             $request->isMethodSafe(false)
             || $request->isMethod(Request::METHOD_DELETE)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || ($request->isMethod(Request::METHOD_PUT) && '' === ($requestContent = $request->getContent()))
+            || ('' === ($requestContent = $request->getContent()) && $request->isMethod(Request::METHOD_PUT))
         ) {
             return;
         }
@@ -68,7 +67,7 @@ final class DeserializeListener
         $request->attributes->set(
             'data',
             $this->serializer->deserialize(
-                $requestContent ?? $request->getContent(), $attributes['resource_class'], $format, $context
+                $requestContent, $attributes['resource_class'], $format, $context
             )
         );
     }

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -46,12 +46,13 @@ final class DeserializeListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
+        $requestContent = $request->getContent();
         if (
             $request->isMethodSafe(false)
             || $request->isMethod(Request::METHOD_DELETE)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || ($request->isMethod(Request::METHOD_PUT) && $request->getContent() === '')
+            || ($request->isMethod(Request::METHOD_PUT) &&  '' === $requestContent)
         ) {
             return;
         }
@@ -67,7 +68,7 @@ final class DeserializeListener
         $request->attributes->set(
             'data',
             $this->serializer->deserialize(
-                $request->getContent(), $attributes['resource_class'], $format, $context
+                $requestContent, $attributes['resource_class'], $format, $context
             )
         );
     }

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -51,7 +51,7 @@ final class DeserializeListener
             || $request->isMethod(Request::METHOD_DELETE)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || ($request->isMethod(Request::METHOD_PUT) &&$request->getContent() === "")
+            || ($request->isMethod(Request::METHOD_PUT) && $request->getContent() === '')
         ) {
             return;
         }

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -46,13 +46,13 @@ final class DeserializeListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        $requestContent = $request->getContent();
+        $requestContent = null;
         if (
             $request->isMethodSafe(false)
             || $request->isMethod(Request::METHOD_DELETE)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || ($request->isMethod(Request::METHOD_PUT) && '' === $requestContent)
+            || ($request->isMethod(Request::METHOD_PUT) && '' === ($requestContent = $request->getContent()))
         ) {
             return;
         }
@@ -68,7 +68,7 @@ final class DeserializeListener
         $request->attributes->set(
             'data',
             $this->serializer->deserialize(
-                $requestContent, $attributes['resource_class'], $format, $context
+                $requestContent ?? $request->getContent(), $attributes['resource_class'], $format, $context
             )
         );
     }

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -45,6 +45,25 @@ class DeserializeListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
+    public function testDoNotCallWhenPutAndEmptyRequestContent()
+    {
+        $eventProphecy = $this->prophesize(GetResponseEvent::class);
+
+        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'put'], [], [], [], '');
+        $request->setMethod(Request::METHOD_PUT);
+        $request->headers->set('Content-Type', 'application/json');
+        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->deserialize()->shouldNotBeCalled();
+
+        $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
+        $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->shouldNotBeCalled();
+
+        $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), self::FORMATS);
+        $listener->onKernelRequest($eventProphecy->reveal());
+    }
+
     public function testDoNotCallWhenRequestNotManaged()
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | NA

This PR allows to send empty request content for PUT in a custom operation.

Use case : 
I have a custom Action (ex : "reset") associated to an ApiResource "Job". 
I don't have any request content to send when I send a PUT request to `/jobs/1234/reset`.
But I've a SerializerError because the request content is required.
