### PR TITLE
Change the is_granted key to access_control

### DIFF
--- a/src/Security/EventListener/DenyAccessListener.php
+++ b/src/Security/EventListener/DenyAccessListener.php
@@ -66,11 +66,11 @@ final class DenyAccessListener
 
         $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
         if (isset($attributes['collection_operation_name'])) {
-            $isGranted = $resourceMetadata->getCollectionOperationAttribute($attributes['collection_operation_name'], 'is_granted', null, true);
+            $isGranted = $resourceMetadata->getCollectionOperationAttribute($attributes['collection_operation_name'], 'access_control', null, true);
         } elseif (isset($attributes['item_operation_name'])) {
-            $isGranted = $resourceMetadata->getItemOperationAttribute($attributes['item_operation_name'], 'is_granted', null, true);
+            $isGranted = $resourceMetadata->getItemOperationAttribute($attributes['item_operation_name'], 'access_control', null, true);
         } else {
-            $isGranted = $resourceMetadata->getCollectionOperationAttribute($attributes['subresource_operation_name'], 'is_granted', null, true);
+            $isGranted = $resourceMetadata->getCollectionOperationAttribute($attributes['subresource_operation_name'], 'access_control', null, true);
         }
 
         if (null === $isGranted) {
@@ -78,13 +78,13 @@ final class DenyAccessListener
         }
 
         if (null === $this->tokenStorage || null === $this->authenticationTrustResolver) {
-            throw new \LogicException(sprintf('The "symfony/security" library must be installed to use the "is_granted" attribute on class "%s".', $attributes['resource_class']));
+            throw new \LogicException(sprintf('The "symfony/security" library must be installed to use the "access_control" attribute on class "%s".', $attributes['resource_class']));
         }
         if (null === $this->tokenStorage->getToken()) {
-            throw new \LogicException(sprintf('The resource must be behind a firewall to use the "is_granted" attribute on class "%s".', $attributes['resource_class']));
+            throw new \LogicException(sprintf('The resource must be behind a firewall to use the "access_control" attribute on class "%s".', $attributes['resource_class']));
         }
         if (null === $this->expressionLanguage) {
-            throw new \LogicException(sprintf('The "symfony/expression-language" library must be installed to use the "is_granted" attribute on class "%s".', $attributes['resource_class']));
+            throw new \LogicException(sprintf('The "symfony/expression-language" library must be installed to use the "access_control" attribute on class "%s".', $attributes['resource_class']));
         }
 
         if (!$this->expressionLanguage->evaluate($isGranted, $this->getVariables($request))) {
@@ -107,7 +107,9 @@ final class DenyAccessListener
             'user' => $token->getUser(),
             'object' => $request->attributes->get('data'),
             'request' => $request,
-            'roles' => array_map(function (Role $role) {return $role->getRole(); }, $roles),
+            'roles' => array_map(function (Role $role) {
+                return $role->getRole();
+            }, $roles),
             'trust_resolver' => $this->authenticationTrustResolver,
             // needed for the is_granted expression function
             'auth_checker' => $this->authorizationChecker,

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -23,13 +23,13 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
  * @ApiResource(
- *     attributes={"is_granted"="has_role('ROLE_USER')"},
+ *     attributes={"access_control"="has_role('ROLE_USER')"},
  *     collectionOperations={
  *         "get"={"method"="GET"},
- *         "post"={"method"="POST", "is_granted"="has_role('ROLE_ADMIN')"}
+ *         "post"={"method"="POST", "access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"method"="GET", "is_granted"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"method"="GET", "access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
  *     }
  * )
  * @ORM\Entity

--- a/tests/Security/EventListener/DenyAccessListenerTest.php
+++ b/tests/Security/EventListener/DenyAccessListenerTest.php
@@ -78,7 +78,7 @@ class DenyAccessListenerTest extends \PHPUnit_Framework_TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['is_granted' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
@@ -104,7 +104,7 @@ class DenyAccessListenerTest extends \PHPUnit_Framework_TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['is_granted' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
@@ -127,7 +127,7 @@ class DenyAccessListenerTest extends \PHPUnit_Framework_TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['is_granted' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
@@ -147,7 +147,7 @@ class DenyAccessListenerTest extends \PHPUnit_Framework_TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['is_granted' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
@@ -171,7 +171,7 @@ class DenyAccessListenerTest extends \PHPUnit_Framework_TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['is_granted' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This expliciter now that we have a `is_granted` function usable in the expression.