### PR TITLE
Refactor cycle breaking (visited tracking) in SubresourceOperationFactory

### DIFF
--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -91,7 +91,7 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', DummyEntity::class, true]], 'collection' => true, 'operationId' => 'ApiPlatform\Core\Tests\Fixtures\DummyEntity-subresource-ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity']),
+            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', DummyEntity::class, true]], 'collection' => true, 'operationId' => 'api_dummies_subresources_get_subresource']),
             $routeCollection->get('api_dummies_subresources_get_subresource')
         );
     }
@@ -160,32 +160,32 @@ class ApiLoaderTest extends \PHPUnit_Framework_TestCase
         $routeCollection = $this->getApiLoaderWithResourceMetadata($resourceMetadata, true)->load(null);
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', DummyEntity::class, true]], 'collection' => true, 'operationId' => 'ApiPlatform\Core\Tests\Fixtures\DummyEntity-subresource-ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity']),
+            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', DummyEntity::class, true]], 'collection' => true, 'operationId' => 'api_dummies_subresources_get_subresource']),
             $routeCollection->get('api_dummies_subresources_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_recursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', RelatedDummyEntity::class, true], ['recursivesubresource', DummyEntity::class, false]], 'collection' => true, 'operationId' => 'ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity-recursivesubresource-ApiPlatform\Core\Tests\Fixtures\DummyEntity-subresource-ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity']),
+            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_recursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', RelatedDummyEntity::class, true], ['recursivesubresource', DummyEntity::class, false]], 'collection' => true, 'operationId' => 'api_related_dummies_recursivesubresource_subresources_get_subresource']),
             $routeCollection->get('api_related_dummies_recursivesubresource_subresources_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_related_dummies_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => [['id', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity-recursivesubresource-ApiPlatform\Core\Tests\Fixtures\DummyEntity']),
+            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_related_dummies_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => [['id', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'api_related_dummies_recursivesubresource_get_subresource']),
             $routeCollection->get('api_related_dummies_recursivesubresource_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/dummies/{id}/subresources/{subresource}/recursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_dummies_subresources_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => [['id', DummyEntity::class, true], ['subresource', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'ApiPlatform\Core\Tests\Fixtures\DummyEntity-subresource-ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity-recursivesubresource-ApiPlatform\Core\Tests\Fixtures\DummyEntity']),
+            $this->getSubresourceRoute('/dummies/{id}/subresources/{subresource}/recursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_dummies_subresources_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => [['id', DummyEntity::class, true], ['subresource', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'api_dummies_subresources_recursivesubresource_get_subresource']),
             $routeCollection->get('api_dummies_subresources_recursivesubresource_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', RelatedDummyEntity::class, true], ['secondrecursivesubresource', DummyEntity::class, false]], 'collection' => true, 'operationId' => 'ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity-secondrecursivesubresource-ApiPlatform\Core\Tests\Fixtures\DummyEntity-subresource-ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity']),
+            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', RelatedDummyEntity::class, true], ['secondrecursivesubresource', DummyEntity::class, false]], 'collection' => true, 'operationId' => 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource']),
             $routeCollection->get('api_related_dummies_secondrecursivesubresource_subresources_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_related_dummies_secondrecursivesubresource_get_subresource', ['property' => 'secondrecursivesubresource', 'identifiers' => [['id', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity-secondrecursivesubresource-ApiPlatform\Core\Tests\Fixtures\DummyEntity']),
+            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_related_dummies_secondrecursivesubresource_get_subresource', ['property' => 'secondrecursivesubresource', 'identifiers' => [['id', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'api_related_dummies_secondrecursivesubresource_get_subresource']),
             $routeCollection->get('api_related_dummies_secondrecursivesubresource_get_subresource')
         );
     }

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -60,7 +60,7 @@ class SubresourceOperationFactoryTest extends \PHPUnit_Framework_TestCase
         $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $pathSegmentNameGeneratorProphecy->reveal());
 
         $this->assertEquals([
-            'ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subresource-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity' => [
+            'api_dummy_entities_subresource_get_subresource' => [
                 'property' => 'subresource',
                 'collection' => false,
                 'resource_class' => RelatedDummyEntity::class,
@@ -71,7 +71,7 @@ class SubresourceOperationFactoryTest extends \PHPUnit_Framework_TestCase
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource.{_format}',
             ],
-            'ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subresource-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity-anotherSubresource-ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity' => [
+            'api_dummy_entities_subresource_another_subresource_get_subresource' => [
                 'property' => 'anotherSubresource',
                 'collection' => false,
                 'resource_class' => DummyEntity::class,
@@ -83,7 +83,7 @@ class SubresourceOperationFactoryTest extends \PHPUnit_Framework_TestCase
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource.{_format}',
             ],
-            'ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subresource-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity-anotherSubresource-ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subcollection-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity' => [
+            'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource' => [
                 'property' => 'subcollection',
                 'collection' => true,
                 'resource_class' => RelatedDummyEntity::class,
@@ -96,7 +96,7 @@ class SubresourceOperationFactoryTest extends \PHPUnit_Framework_TestCase
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource/subcollections.{_format}',
             ],
-            'ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subcollection-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity' => [
+            'api_dummy_entities_subcollections_get_subresource' => [
                 'property' => 'subcollection',
                 'collection' => true,
                 'resource_class' => RelatedDummyEntity::class,
@@ -107,7 +107,7 @@ class SubresourceOperationFactoryTest extends \PHPUnit_Framework_TestCase
                 'route_name' => 'api_dummy_entities_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections.{_format}',
             ],
-            'ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subcollection-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity-anotherSubresource-ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity' => [
+            'api_dummy_entities_subcollections_another_subresource_get_subresource' => [
                 'property' => 'anotherSubresource',
                 'collection' => false,
                 'resource_class' => DummyEntity::class,
@@ -119,7 +119,7 @@ class SubresourceOperationFactoryTest extends \PHPUnit_Framework_TestCase
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections/{subcollection}/another_subresource.{_format}',
             ],
-            'ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subcollection-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity-anotherSubresource-ApiPlatform\\Core\\Tests\\Fixtures\\DummyEntity-subresource-ApiPlatform\\Core\\Tests\\Fixtures\\RelatedDummyEntity' => [
+            'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource' => [
                 'property' => 'subresource',
                 'collection' => false,
                 'resource_class' => RelatedDummyEntity::class,

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -1572,7 +1572,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                 '/api/questions/{id}/answer' => new \ArrayObject([
                     'get' => new \ArrayObject([
                         'tags' => ['Answer', 'Question'],
-                        'operationId' => 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Question-answer-ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Answer',
+                        'operationId' => 'api_questions_answer_get_subresource',
                         'produces' => ['application/ld+json'],
                         'summary' => 'Retrieves a Answer resource.',
                         'responses' => [


### PR DESCRIPTION
…tory

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Refactor with visited tracking logic which is much easier to follow.