### PR TITLE
[RFC] purge on kernel terminate, instead of post flush

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -97,7 +97,7 @@ final class PurgeHttpCacheListener
     /**
      * Purges tags collected during this request, and clears the tag list.
      */
-    public function postFlush()
+    public function onKernelTerminate()
     {
         $this->purger->purge($this->tags);
         $this->tags = [];

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_http_cache_purger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_http_cache_purger.xml
@@ -15,7 +15,7 @@
 
             <tag name="doctrine.event_listener" event="preUpdate" />
             <tag name="doctrine.event_listener" event="onFlush" />
-            <tag name="doctrine.event_listener" event="postFlush" />
+            <tag name="kernel.event_listener" event="kernel.terminate" method="onKernelTerminate" />
         </service>
 
     </services>

--- a/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -71,7 +71,7 @@ class PurgeHttpCacheListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal());
         $listener->onFlush($eventArgs);
-        $listener->postFlush();
+        $listener->onKernelTerminate();
     }
 
     public function testPreUpdate()
@@ -108,6 +108,6 @@ class PurgeHttpCacheListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal());
         $listener->preUpdate($eventArgs);
-        $listener->postFlush();
+        $listener->onKernelTerminate();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes? public signature? But class is `@experimental`
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

It seems wrong to me to do purging in post flush, as this causes wait time for the user.
`kernel.terminate` seems the right place for this, as it was designed for heavy work after the user has their response.

Additionally, currently, if a purge fails, the user will receive a 500, which seems wrong, as their request actually succeeded (writing to the api). 
