### PR TITLE
fix #1294 hydra_context should override operation metadata

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -232,34 +232,34 @@ final class DocumentationNormalizer implements NormalizerInterface
         $shortName = $resourceMetadata->getShortName();
 
         if ('GET' === $method && $collection) {
-            $hydraOperation = [
+            $hydraOperation += [
                 'hydra:title' => "Retrieves the collection of $shortName resources.",
                 'returns' => 'hydra:PagedCollection',
-            ] + $hydraOperation;
+            ];
         } elseif ('GET' === $method) {
-            $hydraOperation = [
+            $hydraOperation += [
                 'hydra:title' => "Retrieves $shortName resource.",
                 'returns' => $prefixedShortName,
-            ] + $hydraOperation;
+            ];
         } elseif ('POST' === $method) {
-            $hydraOperation = [
+            $hydraOperation += [
                 '@type' => 'hydra:CreateResourceOperation',
                 'hydra:title' => "Creates a $shortName resource.",
                 'returns' => $prefixedShortName,
                 'expects' => $prefixedShortName,
-            ] + $hydraOperation;
+            ];
         } elseif ('PUT' === $method) {
-            $hydraOperation = [
+            $hydraOperation += [
                 '@type' => 'hydra:ReplaceResourceOperation',
                 'hydra:title' => "Replaces the $shortName resource.",
                 'returns' => $prefixedShortName,
                 'expects' => $prefixedShortName,
-            ] + $hydraOperation;
+            ];
         } elseif ('DELETE' === $method) {
-            $hydraOperation = [
+            $hydraOperation += [
                 'hydra:title' => "Deletes the $shortName resource.",
                 'returns' => 'owl:Nothing',
-            ] + $hydraOperation;
+            ];
         }
 
         $hydraOperation['@type'] ?? $hydraOperation['@type'] = 'hydra:Operation';

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -43,7 +43,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create('dummy', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['name', 'description']));
 
-        $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']], []);
+        $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET', 'hydra_context' => ['hydra:foo' => 'bar', 'hydra:title' => 'foobar']], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']], []);
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn($dummyMetadata);
 
@@ -149,9 +149,10 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         0 => [
                             '@type' => 'hydra:Operation',
                             'hydra:method' => 'GET',
-                            'hydra:title' => 'Retrieves dummy resource.',
-                            'rdfs:label' => 'Retrieves dummy resource.',
+                            'hydra:title' => 'foobar',
+                            'rdfs:label' => 'foobar',
                             'returns' => '#dummy',
+                            'hydra:foo' => 'bar',
                         ],
                         1 => [
                             '@type' => 'hydra:ReplaceResourceOperation',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1294
| License       | MIT
| Doc PR        | na

Needs to be ported back in master (may be conflicts)