### PR TITLE
Fix #1224 json-ld context should not be prefixed by #

### DIFF
--- a/features/jsonld/context.feature
+++ b/features/jsonld/context.feature
@@ -25,24 +25,24 @@ Feature: JSON-LD contexts generation
             "@vocab": "http://example.com/docs.jsonld#",
             "hydra": "http://www.w3.org/ns/hydra/core#",
             "description": "https://schema.org/description",
-            "dummy": "#Dummy/dummy",
-            "dummyBoolean": "#Dummy/dummyBoolean",
-            "dummyDate": "#Dummy/dummyDate",
-            "dummyFloat": "#Dummy/dummyFloat",
-            "dummyPrice": "#Dummy/dummyPrice",
+            "dummy": "Dummy/dummy",
+            "dummyBoolean": "Dummy/dummyBoolean",
+            "dummyDate": "Dummy/dummyDate",
+            "dummyFloat": "Dummy/dummyFloat",
+            "dummyPrice": "Dummy/dummyPrice",
             "relatedDummy": {
-                "@id": "#Dummy/relatedDummy",
+                "@id": "Dummy/relatedDummy",
                 "@type": "@id"
             },
             "relatedDummies": {
-                "@id": "#Dummy/relatedDummies",
+                "@id": "Dummy/relatedDummies",
                 "@type": "@id"
             },
-            "jsonData": "#Dummy/jsonData",
-            "nameConverted": "#Dummy/nameConverted",
+            "jsonData": "Dummy/jsonData",
+            "nameConverted": "Dummy/nameConverted",
             "name": "http://schema.org/name",
             "alias": "https://schema.org/alternateName",
-            "foo": "#Dummy/foo"
+            "foo": "Dummy/foo"
         }
     }
     """
@@ -58,10 +58,10 @@ Feature: JSON-LD contexts generation
           "@context": {
               "@vocab": "http://example.com/docs.jsonld#",
               "hydra": "http://www.w3.org/ns/hydra/core#",
-              "paris": "#RelationEmbedder/paris",
-              "krondstadt": "#RelationEmbedder/krondstadt",
-              "anotherRelated": "#RelationEmbedder/anotherRelated",
-              "related": "#RelationEmbedder/related"
+              "paris": "RelationEmbedder/paris",
+              "krondstadt": "RelationEmbedder/krondstadt",
+              "anotherRelated": "RelationEmbedder/anotherRelated",
+              "related": "RelationEmbedder/related"
           }
       }
       """

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -89,7 +89,7 @@ final class ContextBuilder implements ContextBuilderInterface
     {
         $context = $this->getBaseContext($referenceType);
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-        $prefixedShortName = sprintf('#%s', $resourceMetadata->getShortName());
+        $shortName = $resourceMetadata->getShortName();
 
         foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $propertyName) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $propertyName);
@@ -102,7 +102,7 @@ final class ContextBuilder implements ContextBuilderInterface
             $jsonldContext = $propertyMetadata->getAttributes()['jsonld_context'] ?? [];
 
             if (!$id = $propertyMetadata->getIri()) {
-                $id = sprintf('%s/%s', $prefixedShortName, $convertedName);
+                $id = sprintf('%s/%s', $shortName, $convertedName);
             }
 
             if (true !== $propertyMetadata->isReadableLink()) {

--- a/tests/JsonLd/ContextBuilderTest.php
+++ b/tests/JsonLd/ContextBuilderTest.php
@@ -57,7 +57,7 @@ class ContextBuilderTest extends \PHPUnit_Framework_TestCase
         $expected = [
             '@vocab' => '#',
             'hydra' => 'http://www.w3.org/ns/hydra/core#',
-            'dummyPropertyA' => '#DummyEntity/dummyPropertyA',
+            'dummyPropertyA' => 'DummyEntity/dummyPropertyA',
         ];
 
         $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
@@ -96,7 +96,7 @@ class ContextBuilderTest extends \PHPUnit_Framework_TestCase
             '@vocab' => '#',
             'hydra' => 'http://www.w3.org/ns/hydra/core#',
             'dummyPropertyA' => [
-                '@id' => '#DummyEntity/dummyPropertyA',
+                '@id' => 'DummyEntity/dummyPropertyA',
                 '@reverse' => 'parent',
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1224
| License       | MIT
| Doc PR        | na

According to the specs I think that the `#` character is there to separate the URL from the given element, for example:

```
    "@context": {
      "name": "http://example.com/organization#name"
    },
```

I'm really no json-ld expert, let me know if removing `#` doesn't seem correct to you.