### PR TITLE
Allow to fetchEager a non-serializable property fix #1290

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -156,7 +156,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 continue;
             }
 
-            if (false === $propertyMetadata->isReadableLink() || false === $propertyMetadata->isReadable()) {
+            if ((false === $propertyMetadata->isReadableLink() || false === $propertyMetadata->isReadable()) && false === $propertyMetadata->getAttribute('fetchEager', false)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1290
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/233

The following will bypass `readable` and `readableLink`:

```
@ApiProperty(attributes={"fetchEager": true})
```

ping @bendavies could you give this a try?
