### PR TITLE
Add hydra items per page

### DIFF
--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -90,6 +90,7 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
 
         if (is_array($object) || $object instanceof \Countable) {
             $data['hydra:totalItems'] = $object instanceof PaginatorInterface ? $object->getTotalItems() : count($object);
+            $data['itemsPerPage'] = $object instanceof PaginatorInterface ? $object->getItemsPerPage() : null;
         }
 
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

I publish this PR to raise (and maybe solve at the same time) a question : 
How can we put the number of items per page in a hydra response? The official spec doesn't say anything but this is a very needed feature for every app developers out there. 

This PR tries to solve this answer by adding an "itemsPerPage" element in the JSON response (same as an HAL answer), next to the `hydra:totalItems` element.

I am clearly not an expert on Hydra, so comments are very welcome. 
