### PR TITLE
	Avoid serializing "resources" in the normalization context

### DIFF
--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -59,13 +59,17 @@ final class SerializeListener
         }
 
         $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
-        $resources = [];
+        $resources = new class() extends \ArrayObject {
+            public function serialize()
+            {
+            }
+        };
         $context['resources'] = &$resources;
 
         $event->setControllerResult($this->serializer->serialize($controllerResult, $request->getRequestFormat(), $context));
 
         $request->attributes->set('_api_respond', true);
-        $request->attributes->set('_resources', $request->attributes->get('_resources', []) + $resources);
+        $request->attributes->set('_resources', $request->attributes->get('_resources', []) + (array) $resources);
     }
 
     /**

--- a/tests/EventListener/SerializeListenerTest.php
+++ b/tests/EventListener/SerializeListenerTest.php
@@ -102,9 +102,13 @@ class SerializeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializeCollectionOperation()
     {
-        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'collection_operation_name' => 'get', 'resources' => []];
+        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'collection_operation_name' => 'get'];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize(Argument::any(), 'xml', $expectedContext)->willReturn('bar')->shouldBeCalled();
+        $serializerProphecy->serialize(Argument::any(), 'xml', Argument::that(function ($context) use ($expectedContext) {
+            unset($context['resources']);
+
+            return $context === $expectedContext;
+        }))->willReturn('bar')->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get']);
         $request->setRequestFormat('xml');
@@ -123,9 +127,13 @@ class SerializeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializeItemOperation()
     {
-        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'item_operation_name' => 'get', 'resources' => []];
+        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'item_operation_name' => 'get'];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize(Argument::any(), 'xml', $expectedContext)->willReturn('bar')->shouldBeCalled();
+        $serializerProphecy->serialize(Argument::any(), 'xml', Argument::that(function ($context) use ($expectedContext) {
+            unset($context['resources']);
+
+            return $context === $expectedContext;
+        }))->willReturn('bar')->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
         $request->setRequestFormat('xml');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1303 
| License       | MIT
| Doc PR        | na

Because [getCacheKey](https://github.com/symfony/serializer/blob/master/Normalizer/AbstractObjectNormalizer.php#L361) serializes the `context`, let's avoid serializing the `$context['resources']` that can get pretty big.

Solves the performance issue.
