### PR TITLE
Update swagger doc with pagination parameter

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -23,6 +23,8 @@
             <argument>%api_platform.oauth.authorizationUrl%</argument>
             <argument>%api_platform.oauth.scopes%</argument>
             <argument type="service" id="api_platform.subresource_operation_factory"></argument>
+            <argument>%api_platform.collection.pagination.enabled%</argument>
+            <argument>%api_platform.collection.pagination.page_parameter_name%</argument>
             <tag name="serializer.normalizer" priority="16" />
         </service>
 

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -60,11 +60,13 @@ final class DocumentationNormalizer implements NormalizerInterface
     private $oauthAuthorizationUrl;
     private $oauthScopes;
     private $subresourceOperationFactory;
+    private $paginationEnabled;
+    private $paginationPageParameterName;
 
     /**
      * @param ContainerInterface|FilterCollection|null $filterLocator The new filter locator or the deprecated filter collection
      */
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, OperationMethodResolverInterface $operationMethodResolver, OperationPathResolverInterface $operationPathResolver, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, $oauthEnabled = false, $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null)
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, OperationMethodResolverInterface $operationMethodResolver, OperationPathResolverInterface $operationPathResolver, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, $oauthEnabled = false, $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, $paginationEnabled = true, $paginationPageParameterName = 'page')
     {
         if ($urlGenerator) {
             @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.1 and will be removed in 3.0.', UrlGeneratorInterface::class, __METHOD__), E_USER_DEPRECATED);
@@ -86,6 +88,8 @@ final class DocumentationNormalizer implements NormalizerInterface
         $this->oauthAuthorizationUrl = $oauthAuthorizationUrl;
         $this->oauthScopes = $oauthScopes;
         $this->subresourceOperationFactory = $subresourceOperationFactory;
+        $this->paginationEnabled = $paginationEnabled;
+        $this->paginationPageParameterName = $paginationPageParameterName;
     }
 
     /**
@@ -103,7 +107,7 @@ final class DocumentationNormalizer implements NormalizerInterface
 
             $this->addPaths($paths, $definitions, $resourceClass, $resourceShortName, $resourceMetadata, $mimeTypes, OperationType::COLLECTION);
             $this->addPaths($paths, $definitions, $resourceClass, $resourceShortName, $resourceMetadata, $mimeTypes, OperationType::ITEM);
-
+            
             if (null === $this->subresourceOperationFactory) {
                 continue;
             }
@@ -279,7 +283,11 @@ final class DocumentationNormalizer implements NormalizerInterface
             if (!isset($pathOperation['parameters']) && $parameters = $this->getFiltersParameters($resourceClass, $operationName, $resourceMetadata, $definitions, $serializerContext)) {
                 $pathOperation['parameters'] = $parameters;
             }
-
+            
+            if ($this->paginationEnabled && $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_enabled', true, true)) {
+                $pathOperation['parameters'][] = $this->getPaginationParameters();
+            }
+            
             return $pathOperation;
         }
 
@@ -664,7 +672,23 @@ final class DocumentationNormalizer implements NormalizerInterface
 
         return $parameters;
     }
-
+    
+    /**
+     * Returns pagination parameters for the "get" collection operation
+     * 
+     * @return array
+     */
+    private function getPaginationParameters(): array
+    {
+        return [
+            'name' => $this->paginationPageParameterName,
+            'in' => 'query',
+            'required' => false,
+            'type' => 'int',
+            'description' => 'The collection page number'
+        ];
+    }
+    
     /**
      * {@inheritdoc}
      */

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -127,6 +127,15 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         'operationId' => 'getDummyCollection',
                         'produces' => ['application/ld+json'],
                         'summary' => 'Retrieves the collection of Dummy resources.',
+                        'parameters' => [
+                            [
+                                'name' => 'page',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'int',
+                                'description' => 'The collection page number'
+                            ]
+                        ],
                         'responses' => [
                             200 => [
                                 'description' => 'Dummy collection response',
@@ -219,6 +228,15 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         'operationId' => 'customDummyCollection',
                         'produces' => ['application/ld+json'],
                         'summary' => 'Retrieves the collection of Dummy resources.',
+                        'parameters' => [
+                            [
+                                'name' => 'page',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'int',
+                                'description' => 'The collection page number'
+                            ]
+                        ],
                         'responses' => [
                             200 => [
                                 'description' => 'Dummy collection response',
@@ -469,6 +487,15 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         'operationId' => 'getDummyCollection',
                         'produces' => ['application/ld+json'],
                         'summary' => 'Retrieves the collection of Dummy resources.',
+                        'parameters' => [
+                            [
+                                'name' => 'page',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'int',
+                                'description' => 'The collection page number'
+                            ]
+                        ],
                         'responses' => [
                             200 => [
                                 'description' => 'Dummy collection response',
@@ -655,6 +682,15 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         'operationId' => 'getDummyCollection',
                         'produces' => ['application/ld+json'],
                         'summary' => 'Retrieves the collection of Dummy resources.',
+                        'parameters' => [
+                            [
+                                'name' => 'page',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'int',
+                                'description' => 'The collection page number'
+                            ]
+                        ],
                         'responses' => [
                             200 => [
                                 'description' => 'Dummy collection response',
@@ -844,6 +880,15 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         'operationId' => 'getDummyCollection',
                         'produces' => ['application/ld+json'],
                         'summary' => 'Retrieves the collection of Dummy resources.',
+                        'parameters' => [
+                            [
+                                'name' => 'page',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'int',
+                                'description' => 'The collection page number'
+                            ]
+                        ],
                         'responses' => [
                             200 => [
                                 'description' => 'Dummy collection response',
@@ -1260,6 +1305,15 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                         'operationId' => 'getDummyCollection',
                         'produces' => ['application/ld+json'],
                         'summary' => 'Retrieves the collection of Dummy resources.',
+                        'parameters' => [
+                            [
+                                'name' => 'page',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'int',
+                                'description' => 'The collection page number'
+                            ]
+                        ],
                         'responses' => [
                             200 => [
                                 'description' => 'Dummy collection response',
@@ -1464,6 +1518,13 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
                                 'required' => false,
                                 'type' => 'integer',
                             ],
+                            [
+                                'name' => 'page',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'int',
+                                'description' => 'The collection page number'
+                            ]
                         ],
                     ]),
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #381 (partially)
| License       | MIT
| Doc PR        | api-platform/doc#1234

Add pagination parameter to the swagger "get" collection operation, partially solving #381
