### PR TITLE
fetch_data -> true when using json

### DIFF
--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -44,7 +44,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
     private function updateObjectToPopulate(array $data, array &$context)
     {
         try {
-            $context['object_to_populate'] = $this->iriConverter->getItemFromIri((string) $data['id'], $context + ['fetch_data' => false]);
+            $context['object_to_populate'] = $this->iriConverter->getItemFromIri((string) $data['id'], $context + ['fetch_data' => true]);
         } catch (InvalidArgumentException $e) {
             $identifier = null;
             foreach ($this->propertyNameCollectionFactory->create($context['resource_class'], $context) as $propertyName) {
@@ -58,7 +58,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 throw $e;
             }
 
-            $context['object_to_populate'] = $this->iriConverter->getItemFromIri(sprintf('%s/%s', $this->iriConverter->getIriFromResourceClass($context['resource_class']), $data[$identifier]), $context + ['fetch_data' => false]);
+            $context['object_to_populate'] = $this->iriConverter->getItemFromIri(sprintf('%s/%s', $this->iriConverter->getIriFromResourceClass($context['resource_class']), $data[$identifier]), $context + ['fetch_data' => true]);
         }
     }
 }


### PR DESCRIPTION
fix https://github.com/api-platform/core/issues/1338#issuecomment-325624277

The JsonLd Normalizer has `fetch_data = true` but not the default one. See : 
https://github.com/api-platform/core/blob/12871f38fdadf79e696526ac492be4ccfd82001c/src/JsonLd/Serializer/ItemNormalizer.php#L105

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #1338
| License       | MIT
