### PR TITLE
Fix #1326 (DateFilter before/after filters on before or equals/after or equals)

### DIFF
--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -406,7 +406,7 @@ Feature: Date filter on collections
       },
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
+        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -429,7 +429,19 @@ Feature: Date filter on collections
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "dummyDate[strictly_before]",
+            "property": "dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "dummyDate[after]",
+            "property": "dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "dummyDate[strictly_after]",
             "property": "dummyDate",
             "required": false
           },
@@ -441,7 +453,19 @@ Feature: Date filter on collections
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "relatedDummy.dummyDate[strictly_before]",
+            "property": "relatedDummy.dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "relatedDummy.dummyDate[after]",
+            "property": "relatedDummy.dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedDummy.dummyDate[strictly_after]",
             "property": "relatedDummy.dummyDate",
             "required": false
           },
@@ -661,7 +685,7 @@ Feature: Date filter on collections
           },
           "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "/dummies{?dummyBoolean,dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
+              "hydra:template": "/dummies{?dummyBoolean,dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -678,7 +702,19 @@ Feature: Date filter on collections
                   },
                   {
                       "@type": "IriTemplateMapping",
+                      "variable": "dummyDate[strictly_before]",
+                      "property": "dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
                       "variable": "dummyDate[after]",
+                      "property": "dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "dummyDate[strictly_after]",
                       "property": "dummyDate",
                       "required": false
                   },
@@ -690,7 +726,19 @@ Feature: Date filter on collections
                   },
                   {
                       "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy.dummyDate[strictly_before]",
+                      "property": "relatedDummy.dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
                       "variable": "relatedDummy.dummyDate[after]",
+                      "property": "relatedDummy.dummyDate",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy.dummyDate[strictly_after]",
                       "property": "relatedDummy.dummyDate",
                       "required": false
                   },

--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -123,7 +123,7 @@ Feature: Create-Retrieve-Update-Delete
       "hydra:totalItems": 1,
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
+        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -146,7 +146,19 @@ Feature: Create-Retrieve-Update-Delete
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "dummyDate[strictly_before]",
+            "property": "dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "dummyDate[after]",
+            "property": "dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "dummyDate[strictly_after]",
             "property": "dummyDate",
             "required": false
           },
@@ -158,7 +170,19 @@ Feature: Create-Retrieve-Update-Delete
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "relatedDummy.dummyDate[strictly_before]",
+            "property": "relatedDummy.dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "relatedDummy.dummyDate[after]",
+            "property": "relatedDummy.dummyDate",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedDummy.dummyDate[strictly_after]",
             "property": "relatedDummy.dummyDate",
             "required": false
           },

--- a/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
@@ -94,7 +94,17 @@ class DateFilterTest extends KernelTestCase
                 'type' => 'DateTimeInterface',
                 'required' => false,
             ],
+            'dummyDate[strictly_before]' => [
+                'property' => 'dummyDate',
+                'type' => 'DateTimeInterface',
+                'required' => false,
+            ],
             'dummyDate[after]' => [
+                'property' => 'dummyDate',
+                'type' => 'DateTimeInterface',
+                'required' => false,
+            ],
+            'dummyDate[strictly_after]' => [
                 'property' => 'dummyDate',
                 'type' => 'DateTimeInterface',
                 'required' => false,
@@ -124,6 +134,15 @@ class DateFilterTest extends KernelTestCase
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyDate >= :dummyDate_p1', Dummy::class),
             ],
+            'after but not equals (all properties enabled)' => [
+                null,
+                [
+                    'dummyDate' => [
+                        'strictly_after' => '2015-04-05',
+                    ],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyDate > :dummyDate_p1', Dummy::class),
+            ],
             'after' => [
                 [
                     'dummyDate' => null,
@@ -135,6 +154,17 @@ class DateFilterTest extends KernelTestCase
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyDate >= :dummyDate_p1', Dummy::class),
             ],
+            'after but not equals' => [
+                [
+                    'dummyDate' => null,
+                ],
+                [
+                    'dummyDate' => [
+                        'strictly_after' => '2015-04-05',
+                    ],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyDate > :dummyDate_p1', Dummy::class),
+            ],
             'before (all properties enabled)' => [
                 null,
                 [
@@ -143,6 +173,15 @@ class DateFilterTest extends KernelTestCase
                     ],
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyDate <= :dummyDate_p1', Dummy::class),
+            ],
+            'before but not equals (all properties enabled)' => [
+                null,
+                [
+                    'dummyDate' => [
+                        'strictly_before' => '2015-04-05',
+                    ],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyDate < :dummyDate_p1', Dummy::class),
             ],
             'before' => [
                 [
@@ -155,6 +194,17 @@ class DateFilterTest extends KernelTestCase
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyDate <= :dummyDate_p1', Dummy::class),
             ],
+            'before but not equals' => [
+                [
+                    'dummyDate' => null,
+                ],
+                [
+                    'dummyDate' => [
+                        'strictly_before' => '2015-04-05',
+                    ],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyDate < :dummyDate_p1', Dummy::class),
+            ],
             'before + after (all properties enabled)' => [
                 null,
                 [
@@ -164,6 +214,16 @@ class DateFilterTest extends KernelTestCase
                     ],
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyDate <= :dummyDate_p1 AND o.dummyDate >= :dummyDate_p2', Dummy::class),
+            ],
+            'before but not equals + after but not equals (all properties enabled)' => [
+                null,
+                [
+                    'dummyDate' => [
+                        'strictly_after' => '2015-04-05',
+                        'strictly_before' => '2015-04-05',
+                    ],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyDate < :dummyDate_p1 AND o.dummyDate > :dummyDate_p2', Dummy::class),
             ],
             'before + after' => [
                 [
@@ -176,6 +236,18 @@ class DateFilterTest extends KernelTestCase
                     ],
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyDate <= :dummyDate_p1 AND o.dummyDate >= :dummyDate_p2', Dummy::class),
+            ],
+            'before but not equals + after but not equals' => [
+                [
+                    'dummyDate' => null,
+                ],
+                [
+                    'dummyDate' => [
+                        'strictly_after' => '2015-04-05',
+                        'strictly_before' => '2015-04-05',
+                    ],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyDate < :dummyDate_p1 AND o.dummyDate > :dummyDate_p2', Dummy::class),
             ],
             'property not enabled' => [
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1326
| License       | MIT
| Doc PR        | api-platform/doc#244

The DateFilter `?property[after]=date` should filter on `>`, not on `>=` to have only the items with date after the value

