### PR TITLE
Correctly retrieve resource class of an object if it exists even when…

### DIFF
--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -54,6 +54,9 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
             if (is_subclass_of($type, $resourceClass) && $this->isResourceClass($resourceClass)) {
                 return $type;
             }
+            if ($this->isResourceClass($typeToFind)) {
+                return $typeToFind;
+            }
 
             throw new InvalidArgumentException(sprintf('No resource class found for object of type "%s".', $typeToFind));
         }

--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -50,11 +50,11 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
             $typeToFind = $type = $resourceClass;
         }
 
-        if (($strict && isset($type) && $resourceClass !== $type) || !$this->isResourceClass($typeToFind)) {
+        if (($strict && isset($type) && $resourceClass !== $type) || false === $isResourceClass = $this->isResourceClass($typeToFind)) {
             if (is_subclass_of($type, $resourceClass) && $this->isResourceClass($resourceClass)) {
                 return $type;
             }
-            if ($this->isResourceClass($typeToFind)) {
+            if ($isResourceClass ?? $this->isResourceClass($typeToFind)) {
                 return $typeToFind;
             }
 

--- a/tests/Api/ResourceClassResolverTest.php
+++ b/tests/Api/ResourceClassResolverTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritance;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceChild;
 
@@ -35,6 +36,18 @@ class ResourceClassResolverTest extends \PHPUnit_Framework_TestCase
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
         $resourceClass = $resourceClassResolver->getResourceClass($dummy, Dummy::class);
+        $this->assertEquals($resourceClass, Dummy::class);
+    }
+
+    public function testGetResourceClassWithOtherClassName()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('Smail');
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
+
+        $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+        $resourceClass = $resourceClassResolver->getResourceClass($dummy, DummyCar::class, true);
         $this->assertEquals($resourceClass, Dummy::class);
     }
 


### PR DESCRIPTION
… it is not the given resource class

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

Correctly retrieve resource class of an object if it exists even when it is not the given resource class



