### PR TITLE
Avoid `count()` error in testsuite for PHP7.2

### DIFF
--- a/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
@@ -34,7 +34,8 @@ class ValidateListenerTest extends \PHPUnit_Framework_TestCase
         $expectedValidationGroups = ['a', 'b', 'c'];
 
         $validatorProphecy = $this->prophesize(ValidatorInterface::class);
-        $validatorProphecy->validate($data, null, $expectedValidationGroups)->shouldBeCalled();
+        $constraintViolationList = $this->prophesize(ConstraintViolationListInterface::class);
+        $validatorProphecy->validate($data, null, $expectedValidationGroups)->willReturn($constraintViolationList)->shouldBeCalled();
         $validator = $validatorProphecy->reveal();
 
         list($resourceMetadataFactory, $event) = $this->createEventObject($expectedValidationGroups, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

Follows #1349 for 2.0 branch