### PR TITLE
Hotfix to handle denormalization_context on hydra documentation

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -150,7 +150,9 @@ final class DocumentationNormalizer implements NormalizerInterface
 
         if (isset($attributes['denormalization_context']['groups'])) {
             if (isset($context['serializer_groups'])) {
-                $context['serializer_groups'] += $attributes['denormalization_context']['groups'];
+                foreach ($attributes['denormalization_context']['groups'] as $groupName) {
+                    $context['serializer_groups'][] = $groupName;
+                }
             } else {
                 $context['serializer_groups'] = $attributes['denormalization_context']['groups'];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Denormalization_context is ignored due to unmerged arrays as expected.

If someone have an elegant way to merge those arrays. I tried with array_merge but it add an other level of array :(

ping @dunglas 
