### PR TITLE
Deprecate NelmioApiDoc 2 support

### DIFF
--- a/src/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProvider.php
+++ b/src/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProvider.php
@@ -53,6 +53,8 @@ final class ApiPlatformProvider implements AnnotationsProviderInterface
         $this->documentationNormalizer = $documentationNormalizer;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->operationMethodResolver = $operationMethodResolver;
+
+        @trigger_error('The '.__NAMESPACE__.'\ApiPlatformProvider class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
+++ b/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
@@ -53,6 +53,8 @@ final class ApiPlatformParser implements ParserInterface
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->nameConverter = $nameConverter;
+
+        @trigger_error('The '.__NAMESPACE__.'\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 2 has native support for API Platform.', E_USER_DEPRECATED);
     }
 
     /**

--- a/tests/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProviderTest.php
+++ b/tests/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProviderTest.php
@@ -32,6 +32,9 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @group legacy
+ * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Extractor\AnnotationsProvider\ApiPlatformProvider class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
  */
 class ApiPlatformProviderTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -32,6 +32,9 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @group legacy
+ * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformProvider class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
  */
 class ApiPlatformParserTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

NelmioApiDocBundle 3 has native support for API Platform. Deprecating our support for v2.