### PR TITLE
Enable the Symfony PHPUnit bridge

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,4 +29,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Api/OperationTypeDeprecationHelper.php
+++ b/src/Api/OperationTypeDeprecationHelper.php
@@ -36,7 +36,7 @@ final class OperationTypeDeprecationHelper
     public static function getOperationType($operationType): string
     {
         if (is_bool($operationType)) {
-            @trigger_error('Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3', E_USER_DEPRECATED);
+            @trigger_error('Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3', E_USER_DEPRECATED);
 
             $operationType = $operationType === true ? OperationType::COLLECTION : OperationType::ITEM;
         }

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -102,11 +102,11 @@
         </service>
 
         <service id="api_platform.operation_path_resolver.underscore" class="ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver" public="false">
-                <deprecated>The "%service_id%" service is deprecated since ApiPlatform 2.1 and will be removed in 3.0. Use "api_platform.path_segment_name_generator.underscore" instead.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since API Platform 2.1 and will be removed in 3.0. Use "api_platform.path_segment_name_generator.underscore" instead.</deprecated>
         </service>
 
         <service id="api_platform.operation_path_resolver.dash" class="ApiPlatform\Core\PathResolver\DashOperationPathResolver" public="false">
-                <deprecated>The "%service_id%" service is deprecated since ApiPlatform 2.1 and will be removed in 3.0. Use "api_platform.path_segment_name_generator.dash" instead.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since API Platform 2.1 and will be removed in 3.0. Use "api_platform.path_segment_name_generator.dash" instead.</deprecated>
         </service>
 
         <!-- Path name generator -->

--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -65,7 +65,7 @@ final class XmlExtractor extends AbstractExtractor
     {
         if ($legacyOperations = $this->getAttributes($resource, $operationType)) {
             @trigger_error(
-                sprintf('Configuring "%1$s" tags without using a parent "%1$ss" tag is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3', $operationType),
+                sprintf('Configuring "%1$s" tags without using a parent "%1$ss" tag is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3', $operationType),
                 E_USER_DEPRECATED
             );
 

--- a/src/PathResolver/DashOperationPathResolver.php
+++ b/src/PathResolver/DashOperationPathResolver.php
@@ -19,16 +19,21 @@ use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator;
  * Generates a path with words separated by underscores.
  *
  * @author Paul Le Corre <paul@lecorre.me>
+ *
+ * @deprecated since version 2.1, to be removed in 3.0. Use {@see \ApiPlatform\Core\Operation\DashPathSegmentNameGenerator} instead.
  */
 final class DashOperationPathResolver implements OperationPathResolverInterface
 {
+    public function __construct()
+    {
+        @trigger_error(sprintf('The use of %s is deprecated since 2.1. Please use %s instead.', __CLASS__, DashPathSegmentNameGenerator::class), E_USER_DEPRECATED);
+    }
+
     /**
      * {@inheritdoc}
      */
     public function resolveOperationPath(string $resourceShortName, array $operation, $operationType/*, string $operationName = null*/): string
     {
-        @trigger_error(sprintf('The use of %s is deprecated since 2.1. Please use PathSegmentNameGenerator instead.', __CLASS__), E_USER_DEPRECATED);
-
         if (func_num_args() >= 4) {
             $operationName = func_get_arg(3);
         } else {

--- a/src/PathResolver/UnderscoreOperationPathResolver.php
+++ b/src/PathResolver/UnderscoreOperationPathResolver.php
@@ -19,16 +19,21 @@ use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator;
  * Generates a path with words separated by underscores.
  *
  * @author Paul Le Corre <paul@lecorre.me>
+ *
+ * @deprecated since version 2.1, to be removed in 3.0. Use {@see \ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator} instead.
  */
 final class UnderscoreOperationPathResolver implements OperationPathResolverInterface
 {
+    public function __construct()
+    {
+        @trigger_error(sprintf('The use of %s is deprecated since 2.1. Please use %s instead.', __CLASS__, UnderscorePathSegmentNameGenerator::class), E_USER_DEPRECATED);
+    }
+
     /**
      * {@inheritdoc}
      */
     public function resolveOperationPath(string $resourceShortName, array $operation, $operationType/*, string $operationName = null*/): string
     {
-        @trigger_error(sprintf('The use of %s is deprecated since 2.1. Please use PathSegmentNameGenerator instead.', __CLASS__), E_USER_DEPRECATED);
-
         if (func_num_args() >= 4) {
             $operationName = func_get_arg(3);
         } else {

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -123,7 +123,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using a string "HTTP_INTERNAL_SERVER_ERROR" as a constant of the "Symfony\Component\HttpFoundation\Response" class is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3. Use the Symfony's custom YAML extension for PHP constants instead (i.e. "!php/const:Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST").
+     * @expectedDeprecation Using a string "HTTP_INTERNAL_SERVER_ERROR" as a constant of the "Symfony\Component\HttpFoundation\Response" class is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3. Use the Symfony's custom YAML extension for PHP constants instead (i.e. "!php/const:Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR").
      */
     public function testLegacyExceptionToStatusConfig()
     {

--- a/tests/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
@@ -59,10 +59,6 @@ class CachedRouteNameResolverTest extends \PHPUnit_Framework_TestCase
         $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
-     */
     public function testGetRouteNameForItemRouteOnCacheMiss()
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
@@ -123,10 +119,6 @@ class CachedRouteNameResolverTest extends \PHPUnit_Framework_TestCase
         $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::COLLECTION);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
-     */
     public function testGetRouteNameForCollectionRouteOnCacheMiss()
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);

--- a/tests/Bridge/Symfony/Routing/RouteNameGeneratorTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameGeneratorTest.php
@@ -29,7 +29,7 @@ class RouteNameGeneratorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
     public function testLegacyGenerate()
     {

--- a/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
@@ -55,7 +55,7 @@ class RouteNameResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
     public function testGetRouteNameForItemRouteLegacy()
     {
@@ -120,7 +120,7 @@ class RouteNameResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
     public function testGetRouteNameForCollectionRouteLegacy()
     {

--- a/tests/Bridge/Symfony/Routing/RouterOperationPathResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouterOperationPathResolverTest.php
@@ -82,7 +82,7 @@ class RouterOperationPathResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @group legacy
      * @expectedDeprecation Method ApiPlatform\Core\Bridge\Symfony\Routing\RouterOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
     public function testLegacyResolveOperationPath()
     {

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -73,7 +73,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     }
 
     /**
-     * @expectedDeprecation Configuring "%s" tags without using a parent "%ss" tag is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation Configuring "%s" tags without using a parent "%ss" tag is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      * @group legacy
      * @dataProvider legacyOperationsResourceMetadataProvider
      */

--- a/tests/PathResolver/CustomOperationPathResolverTest.php
+++ b/tests/PathResolver/CustomOperationPathResolverTest.php
@@ -41,7 +41,7 @@ class CustomOperationPathResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation Method ApiPlatform\Core\PathResolver\CustomOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
      */
     public function testLegacyResolveOperationPath()
     {

--- a/tests/PathResolver/DashOperationPathResolverTest.php
+++ b/tests/PathResolver/DashOperationPathResolverTest.php
@@ -18,10 +18,14 @@ use ApiPlatform\Core\PathResolver\DashOperationPathResolver;
 
 /**
  * @author Guilhem N. <egetick@gmail.com>
+ *
  * @group legacy
  */
 class DashOperationPathResolverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
+     */
     public function testResolveCollectionOperationPath()
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
@@ -29,6 +33,9 @@ class DashOperationPathResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/short-names.{_format}', $dashOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::COLLECTION, 'get'));
     }
 
+    /**
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
+     */
     public function testResolveItemOperationPath()
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
@@ -37,6 +44,8 @@ class DashOperationPathResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
+     *
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
      * @expectedMessage Subresource operations are not supported by the OperationPathResolver.
      */
@@ -48,7 +57,8 @@ class DashOperationPathResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
     public function testLegacyResolveOperationPath()
     {

--- a/tests/PathResolver/UnderscoreOperationPathResolverTest.php
+++ b/tests/PathResolver/UnderscoreOperationPathResolverTest.php
@@ -18,10 +18,14 @@ use ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver;
 
 /**
  * @author Guilhem N. <egetick@gmail.com>
+ *
  * @group legacy
  */
 class UnderscoreOperationPathResolverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
+     */
     public function testResolveCollectionOperationPath()
     {
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
@@ -29,6 +33,9 @@ class UnderscoreOperationPathResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/short_names.{_format}', $underscoreOperationPathResolver->resolveOperationPath('ShortName', [], OperationType::COLLECTION, 'get'));
     }
 
+    /**
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
+     */
     public function testResolveItemOperationPath()
     {
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
@@ -37,6 +44,8 @@ class UnderscoreOperationPathResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
+     *
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
      * @expectedMessage Subresource operations are not supported by the OperationPathResolver.
      */
@@ -48,7 +57,8 @@ class UnderscoreOperationPathResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedDeprecation Using a boolean for the Operation Type is deprecrated since API Platform 2.1 and will not be possible anymore in API Platform 3
+     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
+     * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
     public function testLegacyResolveOperationPath()
     {

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -32,7 +32,6 @@ use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator;
 use ApiPlatform\Core\PathResolver\CustomOperationPathResolver;
 use ApiPlatform\Core\PathResolver\OperationPathResolver;
 use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
-use ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver;
 use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
 use ApiPlatform\Core\Tests\Fixtures\DummyFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Answer;
@@ -72,10 +71,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(DocumentationNormalizer::class, $normalizer);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testNormalize()
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
@@ -101,7 +96,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'custom')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'custom2')->shouldBeCalled()->willReturn('POST');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -309,10 +304,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testNormalizeWithNameConverter()
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Dummy API', 'This is a dummy API', '1.2.3', ['jsonld' => ['application/ld+json']]);
@@ -339,7 +330,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $nameConverterProphecy->normalize('name')->willReturn('name')->shouldBeCalled();
         $nameConverterProphecy->normalize('nameConverted')->willReturn('name_converted')->shouldBeCalled();
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -424,10 +415,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator
-     */
     public function testNormalizeWithApiKeysEnabled()
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
@@ -449,7 +436,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getItemOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $apiKeysConfiguration = [
             'header' => [
@@ -549,10 +536,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testNormalizeWithOnlyNormalizationGroups()
     {
         $title = 'Test API';
@@ -598,7 +581,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -747,10 +730,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testNormalizeWithOnlyDenormalizationGroups()
     {
         $title = 'Test API';
@@ -793,7 +772,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -942,10 +921,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testNormalizeWithNormalizationAndDenormalizationGroups()
     {
         $title = 'Test API';
@@ -991,7 +966,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -1140,10 +1115,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testFilters()
     {
         $filterLocatorProphecy = $this->prophesize(ContainerInterface::class);
@@ -1197,7 +1168,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group legacy
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
      * @expectedExceptionMessage The "$filterLocator" argument is expected to be an implementation of the "Psr\Container\ContainerInterface" interface or null.
      */
@@ -1210,7 +1180,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
             $this->prophesize(ResourceClassResolverInterface::class)->reveal(),
             $this->prophesize(OperationMethodResolverInterface::class)->reveal(),
             $this->prophesize(OperationPathResolverInterface::class)->reveal(),
-            $this->prophesize(UrlGeneratorInterface::class)->reveal(),
+            null,
             new \ArrayObject()
         );
     }
@@ -1222,7 +1192,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -1267,7 +1237,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldNotBeCalled();
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -1291,10 +1261,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testWithCustomMethod()
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), '', '', '0.0.0', ['jsonld' => ['application/ld+json']]);
@@ -1320,7 +1286,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('FOO');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -1351,10 +1317,6 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use PathSegmentNameGenerator instead
-     */
     public function testNormalizeWithNestedNormalizationGroups()
     {
         $title = 'Test API';
@@ -1416,7 +1378,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'post')->shouldBeCalled()->willReturn('POST');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -1607,7 +1569,7 @@ class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
         $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
         $operationMethodResolverProphecy->getCollectionOperationMethod(Dummy::class, 'get')->shouldBeCalled()->willReturn('GET');
 
-        $operationPathResolver = new CustomOperationPathResolver(new UnderscoreOperationPathResolver());
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

PHPUnit works better with deprecations when the Symfony PHPUnit Bridge is enabled...