### PR TITLE
Fix Travis when deps are low

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "symfony/finder": "^3.3 || ^4.0",
         "symfony/form": "^3.3 || ^4.0",
         "symfony/framework-bundle": "^3.3 || ^4.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0 || ^4.0",
+        "symfony/phpunit-bridge": "^3.3 || ^4.0",
         "symfony/routing": "^3.3 || ^4.0",
         "symfony/security": "^3.0 || ^4.0",
         "symfony/security-bundle": "^3.0 || ^4.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
          colors="true"
 >
     <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
         <ini name="error_reporting" value="-1" />
         <ini name="memory_limit" value="-1" />
         <server name="KERNEL_DIR" value="tests/Fixtures/app/" />

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -357,6 +357,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      * @param array  $context
      *
      * @return array
+     *
+     * @deprecated since version 2.1, to be removed in 3.0.
      */
     protected function createRelationSerializationContext(string $resourceClass, array $context): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

> Class "Symfony\Bridge\PhpUnit\SymfonyTestsListener" does not exist

We obtain this message with `deps=low` when we run PHPUnit, but tests are not executed and the command exits with 0.

About the `weak_vendors`, see https://github.com/api-platform/core/pull/1368#issuecomment-329133122.