### PR TITLE
[PropertyFilter] Fix whitelist comparison

### DIFF
--- a/features/serializer/property_filter.feature
+++ b/features/serializer/property_filter.feature
@@ -168,11 +168,74 @@ Feature: Filter with serialization attributes on items and collections
     }
     """
 
-  Scenario: Get a collection of resources by attributes foo, bar, group.baz and group.qux
-    When I send a "GET" request to "/dummy_properties?whitelisted_properties[]=foo&whitelisted_properties[]=bar&whitelisted_properties[group][]=baz"
+  Scenario: Get a collection of resources by attributes foo, bar
+    When I send a "GET" request to "/dummy_properties?whitelisted_properties[]=foo&whitelisted_properties[]=bar"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/DummyProperty$"},
+        "@id": {"pattern": "^/dummy_properties$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {},
+                "@type": {},
+                "foo": {}
+              },
+              "additionalProperties": false,
+              "required": ["@id", "@type", "foo"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {},
+                "@type": {},
+                "foo": {}
+              },
+              "additionalProperties": false,
+              "required": ["@id", "@type", "foo"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {},
+                "@type": {},
+                "foo": {}
+              },
+              "additionalProperties": false,
+              "required": ["@id", "@type", "foo"]
+            }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummy_properties\\?whitelisted_properties%5B%5D=foo&whitelisted_properties%5B%5D=bar&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Get a collection of resources by attributes foo, bar, group.baz and group.qux
+    When I send a "GET" request to "/dummy_properties?whitelisted_nested_properties[]=foo&whitelisted_nested_properties[]=bar&whitelisted_nested_properties[group][]=baz"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And print last JSON response
     And the JSON should be valid according to this schema:
     """
     {
@@ -252,7 +315,7 @@ Feature: Filter with serialization attributes on items and collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummy_properties\\?whitelisted_properties%5B%5D=foo&whitelisted_properties%5B%5D=bar&whitelisted_properties%5Bgroup%5D%5B%5D=baz&page=1$"},
+            "@id": {"pattern": "^/dummy_properties\\?whitelisted_nested_properties%5B%5D=foo&whitelisted_nested_properties%5B%5D=bar&whitelisted_nested_properties%5Bgroup%5D%5B%5D=baz&page=1$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }

--- a/features/serializer/property_filter.feature
+++ b/features/serializer/property_filter.feature
@@ -260,6 +260,65 @@ Feature: Filter with serialization attributes on items and collections
     }
     """
 
+  Scenario: Get a collection of resources by attributes bar not allowed
+    When I send a "GET" request to "/dummy_properties?whitelisted_properties[]=bar"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/DummyProperty$"},
+        "@id": {"pattern": "^/dummy_properties$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {},
+                "@type": {}
+              },
+              "additionalProperties": false,
+              "required": ["@id", "@type"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {},
+                "@type": {}
+              },
+              "additionalProperties": false,
+              "required": ["@id", "@type"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {},
+                "@type": {}
+              },
+              "additionalProperties": false,
+              "required": ["@id", "@type"]
+            }
+          ],
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummy_properties\\?whitelisted_properties%5B%5D=bar&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
   Scenario: Get a collection of resources by attributes empty
     When I send a "GET" request to "/dummy_properties?properties[]=&properties[group][]="
     Then the response status code should be 200

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -30,7 +30,7 @@ final class PropertyFilter implements FilterInterface
     {
         $this->overrideDefaultProperties = $overrideDefaultProperties;
         $this->parameterName = $parameterName;
-        $this->whitelist = $whitelist;
+        $this->whitelist = null === $whitelist ? null : $this->formatWhitelist($whitelist);
     }
 
     /**
@@ -43,7 +43,7 @@ final class PropertyFilter implements FilterInterface
         }
 
         if (null !== $this->whitelist) {
-            $properties = array_intersect_key($this->whitelist, $properties);
+            $properties = $this->intersectArrayRecursive($properties, $this->whitelist);
         }
 
         if (!$this->overrideDefaultProperties && isset($context['attributes'])) {
@@ -65,5 +65,88 @@ final class PropertyFilter implements FilterInterface
                 'required' => false,
             ],
         ];
+    }
+
+    /**
+     * Generate an array of whitelist properties to match the format that properties
+     * will have in the request.
+     *
+     * Will transform ['foo', 'group.bar.'baz', 'fuz']
+     * into ['foo', 'group' => ['bar' => 'baz'], 'fuz']
+     *
+     * @param array $whitelist the whitelist to format
+     *
+     * @return array an array containing the whitelist ready to match request parameters
+     */
+    private function formatWhitelist(array $whitelist): array
+    {
+        $results = [];
+        foreach ($whitelist as $propertyPath) {
+            $segments = explode('.', $propertyPath);
+            $root = array_shift($segments);
+            if ($segments) {
+                $segments = array_reverse($segments);
+                $child = [$segments[0]];
+                array_shift($segments);
+                foreach ($segments as $segment) {
+                    $child = [$segment => $child];
+                }
+                $results[$root] = array_merge_recursive($results[$root] ?? [], $child);
+            } else {
+                $results[] = $root;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Computes the intersection of arrays recursively for arrays with a mix of numeric and associatives keys.
+     *
+     * @param array $array1 the array with master values to check
+     * @param array $array2 An array to compare values against
+     *
+     * @return array an array containing all of the values in array1 recursively whose values exist in array2
+     */
+    private function intersectArrayRecursive(array $array1, array $array2): array
+    {
+        list($numeric1, $assoc1) = $this->partitionAssocAndNumericArrayKeys($array1);
+        list($numeric2, $assoc2) = $this->partitionAssocAndNumericArrayKeys($array2);
+
+        $results = array_values(array_intersect($numeric1, $numeric2));
+        foreach ($assoc1 as $key => $value) {
+            if (!array_key_exists($key, $assoc2)) {
+                continue;
+            }
+            if ($value === $assoc2[$key]) {
+                $results[$key] = $value;
+            } elseif (is_array($value) && is_array($assoc2[$key])) {
+                $results[$key] = $this->intersectArrayRecursive($value, $assoc2[$key]);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Partition an array in two array, the first one containing numeric keys
+     * and the second one for the associative keys.
+     *
+     * @param array $array the array to partition
+     *
+     * @return array an array of two arrays
+     */
+    private function partitionAssocAndNumericArrayKeys(array $array): array
+    {
+        $numeric = $assoc = [];
+        foreach ($array as $key => $value) {
+            if (is_numeric($key)) {
+                $numeric[] = $value;
+            } else {
+                $assoc[$key] = $value;
+            }
+        }
+
+        return [$numeric, $assoc];
     }
 }

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -43,7 +43,7 @@ final class PropertyFilter implements FilterInterface
         }
 
         if (null !== $this->whitelist) {
-            $properties = $this->intersectArrayRecursive($properties, $this->whitelist);
+            $properties = $this->getProperties($properties, $this->whitelist);
         }
 
         if (!$this->overrideDefaultProperties && isset($context['attributes'])) {
@@ -71,82 +71,44 @@ final class PropertyFilter implements FilterInterface
      * Generate an array of whitelist properties to match the format that properties
      * will have in the request.
      *
-     * Will transform ['foo', 'group.bar.'baz', 'fuz']
-     * into ['foo', 'group' => ['bar' => 'baz'], 'fuz']
-     *
      * @param array $whitelist the whitelist to format
      *
-     * @return array an array containing the whitelist ready to match request parameters
+     * @return array An array containing the whitelist ready to match request parameters
      */
     private function formatWhitelist(array $whitelist): array
     {
-        $results = [];
-        foreach ($whitelist as $propertyPath) {
-            $segments = explode('.', $propertyPath);
-            $root = array_shift($segments);
-            if ($segments) {
-                $segments = array_reverse($segments);
-                $child = [$segments[0]];
-                array_shift($segments);
-                foreach ($segments as $segment) {
-                    $child = [$segment => $child];
-                }
-                $results[$root] = array_merge_recursive($results[$root] ?? [], $child);
-            } else {
-                $results[] = $root;
+        if (array_values($whitelist) === $whitelist) {
+            return $whitelist;
+        }
+        foreach ($whitelist as $name => $value) {
+            if (null === $value) {
+                unset($whitelist[$name]);
+                $whitelist[] = $name;
             }
         }
 
-        return $results;
+        return $whitelist;
     }
 
-    /**
-     * Computes the intersection of arrays recursively for arrays with a mix of numeric and associatives keys.
-     *
-     * @param array $array1 the array with master values to check
-     * @param array $array2 An array to compare values against
-     *
-     * @return array an array containing all of the values in array1 recursively whose values exist in array2
-     */
-    private function intersectArrayRecursive(array $array1, array $array2): array
+    private function getProperties(array $properties, array $whitelist = null): array
     {
-        list($numeric1, $assoc1) = $this->partitionAssocAndNumericArrayKeys($array1);
-        list($numeric2, $assoc2) = $this->partitionAssocAndNumericArrayKeys($array2);
+        $whitelist = $whitelist ?? $this->whitelist;
+        $result = [];
 
-        $results = array_values(array_intersect($numeric1, $numeric2));
-        foreach ($assoc1 as $key => $value) {
-            if (!array_key_exists($key, $assoc2)) {
+        foreach ($properties as $key => $value) {
+            if (is_numeric($key)) {
+                if (in_array($value, $whitelist, true)) {
+                    $result[] = $value;
+                }
+
                 continue;
             }
-            if ($value === $assoc2[$key]) {
-                $results[$key] = $value;
-            } elseif (is_array($value) && is_array($assoc2[$key])) {
-                $results[$key] = $this->intersectArrayRecursive($value, $assoc2[$key]);
+
+            if (isset($whitelist[$key]) && is_array($value) && $recursiveResult = $this->getProperties($value, $whitelist[$key])) {
+                $result[$key] = $recursiveResult;
             }
         }
 
-        return $results;
-    }
-
-    /**
-     * Partition an array in two array, the first one containing numeric keys
-     * and the second one for the associative keys.
-     *
-     * @param array $array the array to partition
-     *
-     * @return array an array of two arrays
-     */
-    private function partitionAssocAndNumericArrayKeys(array $array): array
-    {
-        $numeric = $assoc = [];
-        foreach ($array as $key => $value) {
-            if (is_numeric($key)) {
-                $numeric[] = $value;
-            } else {
-                $assoc[$key] = $value;
-            }
-        }
-
-        return [$numeric, $assoc];
+        return $result;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/DummyProperty.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyProperty.php
@@ -29,7 +29,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *     "denormalization_context"={"groups"={"dummy_write"}},
  *     "filters"={
  *         "dummy_property.property",
- *          "dummy_property.whitelist_property"
+ *         "dummy_property.whitelist_property"
  *     }
  * })
  */

--- a/tests/Fixtures/TestBundle/Entity/DummyProperty.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyProperty.php
@@ -29,7 +29,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *     "denormalization_context"={"groups"={"dummy_write"}},
  *     "filters"={
  *         "dummy_property.property",
- *         "dummy_property.whitelist_property"
+ *         "dummy_property.whitelist_property",
+ *         "dummy_property.whitelisted_properties"
  *     }
  * })
  */

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -149,8 +149,13 @@ services:
 
     app.entity.filter.dummy_property.whitelist_property:
         parent:    'api_platform.serializer.property_filter'
-        arguments: [ 'whitelisted_properties', false, ['foo', 'group.baz', 'group.qux'] ]
+        arguments: [ 'whitelisted_properties', false, [foo] ]
         tags:      [ { name: 'api_platform.filter', id: 'dummy_property.whitelist_property' } ]
+
+    app.entity.filter.dummy_property.whitelist_nested_property:
+        parent:    'api_platform.serializer.property_filter'
+        arguments: [ 'whitelisted_nested_properties', false, {foo: ~, group: [baz, qux]} ]
+        tags:      [ { name: 'api_platform.filter', id: 'dummy_property.whitelisted_properties' } ]
 
     app.entity.filter.dummy_group.group:
         parent:    'api_platform.serializer.group_filter'

--- a/tests/Fixtures/app/config/config.yml
+++ b/tests/Fixtures/app/config/config.yml
@@ -149,7 +149,7 @@ services:
 
     app.entity.filter.dummy_property.whitelist_property:
         parent:    'api_platform.serializer.property_filter'
-        arguments: [ 'whitelisted_properties', false, ['foo', {'group': ['baz', 'qux']}] ]
+        arguments: [ 'whitelisted_properties', false, ['foo', 'group.baz', 'group.qux'] ]
         tags:      [ { name: 'api_platform.filter', id: 'dummy_property.whitelist_property' } ]
 
     app.entity.filter.dummy_group.group:

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -56,21 +56,35 @@ class PropertyFilterTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyWithPropertiesWhitelist()
     {
+        $request = new Request(['properties' => ['foo', 'bar', 'baz']]);
+        $context = ['attributes' => ['qux']];
+
+        $propertyFilter = new PropertyFilter('properties', false, ['bar', 'fuz', 'foo']);
+        $propertyFilter->apply($request, true, [], $context);
+
+        $this->assertEquals(['attributes' => ['qux', 'foo', 'bar']], $context);
+    }
+
+    public function testApplyWithPropertiesWhitelistWithNestedProperty()
+    {
         $request = new Request(['properties' => ['foo', 'bar', 'group' => ['baz' => ['baz', 'qux'], 'qux']]]);
         $context = ['attributes' => ['qux']];
 
-        $propertyFilter = new PropertyFilter('properties', false, ['foo', 'group.baz.qux']);
+        $propertyFilter = new PropertyFilter('properties', false, ['foo' => null, 'group' => ['baz' => ['qux']]]);
         $propertyFilter->apply($request, true, [], $context);
 
         $this->assertEquals(['attributes' => ['qux', 'foo', 'group' => ['baz' => ['qux']]]], $context);
+    }
 
-        $request = new Request(['properties' => ['bar', 'group' => ['baz', 'fiz', 'fuz']]]);
-        $context = ['attributes' => ['tuc']];
+    public function testApplyWithPropertiesWhitelistNotMatchingAnyProperty()
+    {
+        $request = new Request(['properties' => ['foo', 'bar', 'group' => ['baz' => ['baz', 'qux'], 'qux']]]);
+        $context = ['attributes' => ['qux']];
 
-        $propertyFilter = new PropertyFilter('properties', false, ['group.baz', 'foo', 'group.fuz']);
+        $propertyFilter = new PropertyFilter('properties', false, ['fuz', 'fiz']);
         $propertyFilter->apply($request, true, [], $context);
 
-        $this->assertEquals(['attributes' => ['tuc', 'group' => ['baz', 'fuz']]], $context);
+        $this->assertEquals(['attributes' => ['qux']], $context);
     }
 
     public function testApplyWithoutPropertiesWhitelistWithOverriding()

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -59,10 +59,18 @@ class PropertyFilterTest extends \PHPUnit_Framework_TestCase
         $request = new Request(['properties' => ['foo', 'bar', 'group' => ['baz' => ['baz', 'qux'], 'qux']]]);
         $context = ['attributes' => ['qux']];
 
-        $propertyFilter = new PropertyFilter('properties', false, ['foo', 'group' => ['baz' => ['qux']]]);
+        $propertyFilter = new PropertyFilter('properties', false, ['foo', 'group.baz.qux']);
         $propertyFilter->apply($request, true, [], $context);
 
-        $this->assertEquals(['attributes' => ['qux', 'foo',  'group' => ['baz' => ['qux']]]], $context);
+        $this->assertEquals(['attributes' => ['qux', 'foo', 'group' => ['baz' => ['qux']]]], $context);
+
+        $request = new Request(['properties' => ['bar', 'group' => ['baz', 'fiz', 'fuz']]]);
+        $context = ['attributes' => ['tuc']];
+
+        $propertyFilter = new PropertyFilter('properties', false, ['group.baz', 'foo', 'group.fuz']);
+        $propertyFilter->apply($request, true, [], $context);
+
+        $this->assertEquals(['attributes' => ['tuc', 'group' => ['baz', 'fuz']]], $context);
     }
 
     public function testApplyWithoutPropertiesWhitelistWithOverriding()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | to come

I'm using the GroupFilter with whitelist since it got merged but never really tried/used the ProprertyFilter whitelist in an application and just relied on the tests I wrote initially. When trying to use it in a real application last week I noticed that the behavior was not the expected one.

An example to reproduce the issue is to whitelist a `foo` property. Then when requesting `/resource?properties[]=bar`, `foo`will be present in the serialized entity.

Another thing I've been trying to fix is the filter declaration and it might be considered as a BC break but given the actual implementation is unusable, I'm pretty sure that we would know if someone would have tried/implemented it already.
The thing is that the array containing properties has numeric and non-numeric keys  like:
```php
[
    'foo',
    'bar',
    'group' => ['baz, 'fuz'],
]
```

I'm no expert but I didn't found a way to generate an array of this kind in yml. The old given example was generating the following:
```php
[
    'foo',
    'bar',
    ['group' => ['baz, 'fuz']],
]
```

So in order to ease the array intersection, I went to a whitelist definition of the following form
```
['foo', 'bar', 'group.baz', 'group.fuz']
```

Even if this is sort of a a BC break, the actual implementation has no chance to work, and using this format will be more inline with the other filter.

