### PR TITLE
operationName parameter should be optional in SubresourceDataProviders

### DIFF
--- a/src/DataProvider/ChainSubresourceDataProvider.php
+++ b/src/DataProvider/ChainSubresourceDataProvider.php
@@ -35,7 +35,7 @@ final class ChainSubresourceDataProvider implements SubresourceDataProviderInter
     /**
      * {@inheritdoc}
      */
-    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName)
+    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null)
     {
         foreach ($this->dataProviders as $dataProviders) {
             try {

--- a/src/DataProvider/SubresourceDataProviderInterface.php
+++ b/src/DataProvider/SubresourceDataProviderInterface.php
@@ -34,5 +34,5 @@ interface SubresourceDataProviderInterface
      *
      * @return object|null
      */
-    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName);
+    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

operationName can be null in SubresourceDataProviders like the other DataProviders.