### PR TITLE
Fix missing service when no Varnish URL is defined

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -426,10 +426,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $loader->load('http_cache_tags.xml');
 
-        if (!$config['http_cache']['invalidation']['varnish_urls']) {
-            return;
-        }
-
         $references = [];
         foreach ($config['http_cache']['invalidation']['varnish_urls'] as $url) {
             $id = sprintf('api_platform.http_cache.purger.varnish_client.%s', $url);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -157,7 +157,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadDefaultConfig()
     {
-        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $this->extension->load(self::DEFAULT_CONFIG, $containerBuilder);
@@ -167,7 +167,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $nameConverterId = 'test.name_converter';
 
-        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
         $containerBuilderProphecy->setAlias('api_platform.name_converter', $nameConverterId)->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
@@ -176,7 +176,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableFosUser()
     {
-        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
             'DoctrineBundle' => DoctrineBundle::class,
             'FOSUserBundle' => FOSUserBundle::class,
@@ -208,7 +208,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableNelmioApiDoc()
     {
-        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
             'DoctrineBundle' => DoctrineBundle::class,
             'NelmioApiDocBundle' => NelmioApiDocBundle::class,
@@ -222,7 +222,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableSecurity()
     {
-        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
             'DoctrineBundle' => DoctrineBundle::class,
             'SecurityBundle' => SecurityBundle::class,
@@ -260,12 +260,23 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testDisableEagerLoadingExtension()
     {
-        $containerBuilderProphecy = $this->getContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
         $containerBuilderProphecy->setParameter('api_platform.eager_loading.enabled', false)->shouldBeCalled();
         $containerBuilderProphecy->removeDefinition('api_platform.doctrine.orm.query_extension.eager_loading')->shouldBeCalled();
         $containerBuilderProphecy->removeDefinition('api_platform.doctrine.orm.query_extension.filter_eager_loading')->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['eager_loading' => ['enabled' => false]]]), $containerBuilder);
+    }
+
+    public function testNotRegisterHttpCacheWhenEnabledWithNoVarnishServer()
+    {
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
+        $containerBuilder = $containerBuilderProphecy->reveal();
+
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['http_cache']['invalidation']['varnish_urls'] = [];
+
+        $this->extension->load($config, $containerBuilder);
     }
 
     private function getPartialContainerBuilderProphecy()
@@ -452,13 +463,11 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         return $containerBuilderProphecy;
     }
 
-    private function getContainerBuilderProphecy()
+    private function getBaseContainerBuilderProphecy()
     {
         $containerBuilderProphecy = $this->getPartialContainerBuilderProphecy();
 
-        $definitionArgument = Argument::that(function ($argument) {
-            return $argument instanceof Definition || $argument instanceof DefinitionDecorator;
-        });
+        $definitionArgument = $this->getDefinitionArgumentToken();
 
         $containerBuilderProphecy->addResource(Argument::type(DirectoryResource::class))->shouldBeCalled();
 
@@ -559,7 +568,6 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.http_cache.purger.varnish',
             'api_platform.http_cache.purger.varnish_client',
             'api_platform.http_cache.listener.response.add_tags',
-            'api_platform.http_cache.purger.varnish_client.test',
         ];
 
         foreach ($definitions as $definition) {
@@ -569,5 +577,24 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
         $containerBuilderProphecy->setAlias('api_platform.http_cache.purger', 'api_platform.http_cache.purger.varnish')->shouldBeCalled();
 
         return $containerBuilderProphecy;
+    }
+
+    private function getDefaultContainerBuilderProphecy()
+    {
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
+
+        $containerBuilderProphecy
+            ->setDefinition('api_platform.http_cache.purger.varnish_client.test', $this->getDefinitionArgumentToken())
+            ->shouldBeCalled()
+        ;
+
+        return $containerBuilderProphecy;
+    }
+
+    private function getDefinitionArgumentToken()
+    {
+        return Argument::that(function ($argument) {
+            return $argument instanceof Definition || $argument instanceof DefinitionDecorator;
+        });
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1394
| License       | MIT
| Doc PR        | -

When HTTP Cache invalidation is enabled, the `api_platform.doctrine.listener.http_cache.purge` service is created. This service depends on `api_platform.http_cache.purger` which is an alias that is only defined when at least one Varnish URL is defined.

With this PR, the alias is defined even if no Varnish URL is defined, which fixes the dependency issue.