### PR TITLE
Better exception message

### DIFF
--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -58,7 +58,10 @@ final class AddFormatListener
         if (null === $routeFormat = $request->attributes->get('_format') ?: null) {
             $mimeTypes = array_keys($this->mimeTypes);
         } elseif (!isset($this->formats[$routeFormat])) {
-            throw new NotFoundHttpException('Not Found');
+            throw new NotFoundHttpException(sprintf(
+                'Format "%s" is not supported',
+                $routeFormat
+            ));
         } else {
             $mimeTypes = Request::getMimeTypes($routeFormat);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | api-platform/doc#1234


Getting "Not Found" on a GET route can get really confusing when the object is found but the format is not.