### PR TITLE
Provide a better exception message

### DIFF
--- a/features/security/validate_response_types.feature
+++ b/features/security/validate_response_types.feature
@@ -28,11 +28,11 @@ Feature: Validate response types
     And I send a "GET" request to "/dummies/1.invalid"
     Then the response status code should be 404
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
-    And the JSON node "detail" should be equal to "Not Found"
+    And the JSON node "detail" should be equal to 'Format "invalid" is not supported'
 
   Scenario: Requesting an invalid format in the Accept header and in the URL should throw an error
     When I add "Accept" header equal to "text/invalid"
     And I send a "GET" request to "/dummies/1.invalid"
     Then the response status code should be 404
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
-    And the JSON node "detail" should be equal to "Not Found"
+    And the JSON node "detail" should be equal to 'Format "invalid" is not supported'

--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -58,7 +58,7 @@ final class AddFormatListener
         if (null === $routeFormat = $request->attributes->get('_format') ?: null) {
             $mimeTypes = array_keys($this->mimeTypes);
         } elseif (!isset($this->formats[$routeFormat])) {
-            throw new NotFoundHttpException('Not Found');
+            throw new NotFoundHttpException(sprintf('Format "%s" is not supported', $routeFormat));
         } else {
             $mimeTypes = Request::getMimeTypes($routeFormat);
         }

--- a/tests/EventListener/AddFormatListenerTest.php
+++ b/tests/EventListener/AddFormatListenerTest.php
@@ -171,7 +171,7 @@ class AddFormatListenerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @expectedExceptionMessage Not Found
+     * @expectedExceptionMessage Format "invalid" is not supported
      */
     public function testInvalidRouteFormat()
     {


### PR DESCRIPTION
Getting "Not found" on a route where you are getting an object can get
real confusing.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

