### PR TITLE
Bump branch alias to 2.2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1.x-dev"
+            "dev-master": "2.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
2.1.x-dev is already taken by the 2.1 branch, and this should represent
the next minor version anyway.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

The branch alias was still pointing to the old 2.1 version.
