### PR TITLE
Improve payload support and remove duplicate code in ConstraintViolationListNormalizer

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -59,7 +59,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('validator')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->variableNode('serialize_payload_fields')->defaultFalse()->info('Enable the serialization of payload fields when a validation error is thrown.')->end()
+                        ->variableNode('serialize_payload_fields')->defaultValue([])->info('Enable the serialization of payload fields when a validation error is thrown.')->end()
                     ->end()
                 ->end()
                 ->arrayNode('eager_loading')

--- a/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
@@ -39,7 +39,7 @@ final class ConstraintViolationListNormalizer extends AbstractConstraintViolatio
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        [$messages, $violations] = $this->getMessagesAndViolations($object);
+        list($messages, $violations) = $this->getMessagesAndViolations($object);
 
         return [
             '@context' => $this->urlGenerator->generate('api_jsonld_context', ['shortName' => 'ConstraintViolationList']),

--- a/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
@@ -14,32 +14,24 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Hydra\Serializer;
 
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
+use ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer;
 
 /**
  * Converts {@see \Symfony\Component\Validator\ConstraintViolationListInterface} to a Hydra error representation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ConstraintViolationListNormalizer implements NormalizerInterface
+final class ConstraintViolationListNormalizer extends AbstractConstraintViolationListNormalizer
 {
     const FORMAT = 'jsonld';
 
-    /**
-     * @var UrlGeneratorInterface
-     */
     private $urlGenerator;
 
-    /**
-     * @var bool|array
-     */
-    private $serializePayloadFields;
-
-    public function __construct(UrlGeneratorInterface $urlGenerator, $serializePayloadFields = false)
+    public function __construct(UrlGeneratorInterface $urlGenerator, array $serializePayloadFields = null)
     {
+        parent::__construct($serializePayloadFields);
+
         $this->urlGenerator = $urlGenerator;
-        $this->serializePayloadFields = $serializePayloadFields;
     }
 
     /**
@@ -47,33 +39,7 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        $violations = [];
-        $messages = [];
-
-        foreach ($object as $violation) {
-            $violationData = [
-                'propertyPath' => $violation->getPropertyPath(),
-                'message' => $violation->getMessage(),
-            ];
-            $constraint = $violation->getConstraint();
-            if ($this->serializePayloadFields && $constraint && $constraint->payload) {
-                if (true === $this->serializePayloadFields) {
-                    $violationData['payload'] = $constraint->payload;
-                } elseif (is_array($this->serializePayloadFields)) {
-                    // We add only fields defined in the config
-                    $payloadFields = array_intersect_key($constraint->payload, array_flip($this->serializePayloadFields));
-                    if (!empty($payloadFields)) {    // prevent the case where in the config there are fields which are not in the payload
-                        $violationData['payload'] = $payloadFields;
-                    }
-                }
-            }
-            $violations[] = $violationData;
-
-            $propertyPath = $violation->getPropertyPath();
-            $prefix = $propertyPath ? sprintf('%s: ', $propertyPath) : '';
-
-            $messages[] = $prefix.$violation->getMessage();
-        }
+        [$messages, $violations] = $this->getMessagesAndViolations($object);
 
         return [
             '@context' => $this->urlGenerator->generate('api_jsonld_context', ['shortName' => 'ConstraintViolationList']),
@@ -82,13 +48,5 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
             'hydra:description' => $messages ? implode("\n", $messages) : (string) $object,
             'violations' => $violations,
         ];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsNormalization($data, $format = null)
-    {
-        return self::FORMAT === $format && $data instanceof ConstraintViolationListInterface;
     }
 }

--- a/src/Problem/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Problem/Serializer/ConstraintViolationListNormalizer.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Problem\Serializer;
 
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
+use ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer;
 
 /**
  * Converts {@see \Symfony\Component\Validator\ConstraintViolationListInterface} the API Problem spec (RFC 7807).
@@ -23,52 +22,16 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ConstraintViolationListNormalizer implements NormalizerInterface
+final class ConstraintViolationListNormalizer extends AbstractConstraintViolationListNormalizer
 {
     const FORMAT = 'jsonproblem';
-
-    /**
-     * @var bool|array
-     */
-    private $serializePayloadFields;
-
-    public function __construct($serializePayloadFields = false)
-    {
-        $this->serializePayloadFields = $serializePayloadFields;
-    }
 
     /**
      * {@inheritdoc}
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        $violations = [];
-        $messages = [];
-
-        foreach ($object as $violation) {
-            $violationData = [
-                'propertyPath' => $violation->getPropertyPath(),
-                'message' => $violation->getMessage(),
-            ];
-            $constraint = $violation->getConstraint();
-            if ($this->serializePayloadFields && $constraint && $constraint->payload) {
-                if (true === $this->serializePayloadFields) {
-                    $violationData['payload'] = $constraint->payload;
-                } elseif (is_array($this->serializePayloadFields)) {
-                    // We add only fields defined in the config
-                    $payloadFields = array_intersect_key($constraint->payload, array_flip($this->serializePayloadFields));
-                    if (!empty($payloadFields)) {    // prevent the case where in the config there are fields which are not in the payload
-                        $violationData['payload'] = $payloadFields;
-                    }
-                }
-            }
-            $violations[] = $violationData;
-
-            $propertyPath = $violation->getPropertyPath();
-            $prefix = $propertyPath ? sprintf('%s: ', $propertyPath) : '';
-
-            $messages[] = $prefix.$violation->getMessage();
-        }
+        [$messages, $violations] = $this->getMessagesAndViolations($object);
 
         return [
             'type' => $context['type'] ?? 'https://tools.ietf.org/html/rfc2616#section-10',
@@ -76,13 +39,5 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
             'detail' => $messages ? implode("\n", $messages) : (string) $object,
             'violations' => $violations,
         ];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsNormalization($data, $format = null)
-    {
-        return self::FORMAT === $format && $data instanceof ConstraintViolationListInterface;
     }
 }

--- a/src/Problem/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Problem/Serializer/ConstraintViolationListNormalizer.php
@@ -31,7 +31,7 @@ final class ConstraintViolationListNormalizer extends AbstractConstraintViolatio
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        [$messages, $violations] = $this->getMessagesAndViolations($object);
+        list($messages, $violations) = $this->getMessagesAndViolations($object);
 
         return [
             'type' => $context['type'] ?? 'https://tools.ietf.org/html/rfc2616#section-10',

--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Serializer;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Common features regarding Constraint Violation normalization.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @internal
+ */
+abstract class AbstractConstraintViolationListNormalizer implements NormalizerInterface
+{
+    private $serializePayloadFields;
+
+    public function __construct(array $serializePayloadFields = null)
+    {
+        $this->serializePayloadFields = $serializePayloadFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return static::FORMAT === $format && $data instanceof ConstraintViolationListInterface;
+    }
+
+    protected function getMessagesAndViolations(ConstraintViolationListInterface $constraintViolationList): array
+    {
+        $violations = $messages = [];
+
+        foreach ($constraintViolationList as $violation) {
+            $violationData = ['propertyPath' => $violation->getPropertyPath(), 'message' => $violation->getMessage()];
+
+            $constraint = $violation->getConstraint();
+            if ($this->serializePayloadFields && $constraint && $constraint->payload) {
+                // If some fields are whitelisted, only them are added
+                $payloadFields = null === $this->serializePayloadFields ? $constraint->payload : array_intersect_key($constraint->payload, array_flip($this->serializePayloadFields));
+                $payloadFields && $violationData['payload'] = $payloadFields;
+            }
+
+            $violations[] = $violationData;
+
+            $propertyPath = $violation->getPropertyPath();
+            $prefix = $propertyPath ? sprintf('%s: ', $propertyPath) : '';
+            $messages[] = "$prefix{$violation->getMessage()}";
+        }
+
+        return [$messages, $violations];
+    }
+}

--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -25,6 +25,8 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  */
 abstract class AbstractConstraintViolationListNormalizer implements NormalizerInterface
 {
+    const FORMAT = null; // Must be overrode
+
     private $serializePayloadFields;
 
     public function __construct(array $serializePayloadFields = null)

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -508,7 +508,7 @@ class ApiPlatformExtensionTest extends \PHPUnit_Framework_TestCase
             'api_platform.graphql.enabled' => true,
             'api_platform.graphql.graphiql.enabled' => true,
             'api_platform.resource_class_directories' => Argument::type('array'),
-            'api_platform.validator.serialize_payload_fields' => false,
+            'api_platform.validator.serialize_payload_fields' => [],
         ];
 
         foreach ($parameters as $key => $value) {

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -70,7 +70,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'default_operation_path_resolver' => 'api_platform.operation_path_resolver.underscore',
             'path_segment_name_generator' => 'api_platform.path_segment_name_generator.underscore',
             'validator' => [
-                'serialize_payload_fields' => false,
+                'serialize_payload_fields' => [],
             ],
             'name_converter' => null,
             'enable_fos_user' => true,

--- a/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
@@ -28,7 +28,7 @@ class ConstraintViolationNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
 
-        $normalizer = new ConstraintViolationListNormalizer($urlGeneratorProphecy->reveal(), false);
+        $normalizer = new ConstraintViolationListNormalizer($urlGeneratorProphecy->reveal(), []);
 
         $this->assertTrue($normalizer->supportsNormalization(new ConstraintViolationList(), ConstraintViolationListNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new ConstraintViolationList(), 'xml'));

--- a/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
@@ -25,7 +25,7 @@ class ConstraintViolationNormalizerTest extends \PHPUnit_Framework_TestCase
 {
     public function testSupportNormalization()
     {
-        $normalizer = new ConstraintViolationListNormalizer(false);
+        $normalizer = new ConstraintViolationListNormalizer([]);
 
         $this->assertTrue($normalizer->supportsNormalization(new ConstraintViolationList(), ConstraintViolationListNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new ConstraintViolationList(), 'xml'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Follows #1364.

* Remove code duplication (https://insight.sensiolabs.com/projects/92d78899-946c-4282-89a3-ac92344f9a93/analyses/2123)
* Enforce type safety (now the type is `?array`, if null is passed, it means the whole payload will be serialized)

ping @pierre-H
