### PR TITLE
Add doctrine/common to "require" block.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=7.0",
 
+        "doctrine/common": "~2.8.1",
         "doctrine/inflector": "^1.0",
         "psr/cache": "^1.0",
         "psr/container": "^1.0",


### PR DESCRIPTION
Since ApiPlatform\Core\Metadata\Resource\Factory\AnnotationResourceMetadataFactory depend on Doctrine\Common.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

*Please update this template with something that matches your PR*
