### PR TITLE
Add job to test upstream libs deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
       env: coverage=1 lint=1
     - php: '7.1'
       env: deps='low'
+    - php: '7.1'
+      env: SYMFONY_DEPRECATIONS_HELPER=0
+  allow_failures:
+      env: SYMFONY_DEPRECATIONS_HELPER=0
 
 before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | hopefully
| Fixed tickets | none
| License       | MIT
| Doc PR        | n / a

If api-platform uses upstream libs in a deprecated way, we should be aware
of it.
