### PR TITLE
Fix missing cache tag on empty collections

### DIFF
--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -51,11 +51,11 @@ final class AddTagsListener
             !$request->isMethodCacheable()
             || !$response->isCacheable()
             || (!$attributes = RequestAttributesExtractor::extractAttributes($request))
-            || !$resources = $request->attributes->get('_resources')
         ) {
             return;
         }
 
+        $resources = $request->attributes->get('_resources');
         if (isset($attributes['collection_operation_name'])) {
             // Allows to purge collections
             $iri = $this->iriConverter->getIriFromResourceClass($attributes['resource_class']);

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -144,4 +144,25 @@ class AddTagsListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('/foo,/bar,/dummies', $response->headers->get('Cache-Tags'));
     }
+
+    public function testAddCollectionIriWhenCollectionIsEmpty()
+    {
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+
+        $request = new Request([], [], ['_resources' => [], '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get']);
+
+        $response = new Response();
+        $response->setPublic();
+        $response->setEtag('foo');
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('/dummies', $response->headers->get('Cache-Tags'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a collection is empty, the cache tag of the collection itself is missing from the response, which cannot be invalidated later when the collection changes.