### PR TITLE
Fix tags addition with an empty value

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -129,6 +129,10 @@ final class PurgeHttpCacheListener
 
     private function addTagsFor($value)
     {
+        if (!$value) {
+            return;
+        }
+
         if (!is_array($value) && !$value instanceof \Traversable) {
             $this->addTagForItem($value);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Fix compatibility with PHP7.2: `Warning: get_class() expects parameter 1 to be object, null given`

