### PR TITLE
Don't use dynamic values in service keys

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -28,7 +28,6 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -426,17 +425,15 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $loader->load('http_cache_tags.xml');
 
-        $references = [];
-        foreach ($config['http_cache']['invalidation']['varnish_urls'] as $url) {
-            $id = sprintf('api_platform.http_cache.purger.varnish_client.%s', $url);
-            $references[] = new Reference($id);
-
+        $definitions = [];
+        foreach ($config['http_cache']['invalidation']['varnish_urls'] as $key => $url) {
             $definition = new ChildDefinition('api_platform.http_cache.purger.varnish_client');
             $definition->addArgument(['base_uri' => $url]);
-            $container->setDefinition($id, $definition);
+
+            $definitions[] = $definition;
         }
 
-        $container->getDefinition('api_platform.http_cache.purger.varnish')->addArgument($references);
+        $container->getDefinition('api_platform.http_cache.purger.varnish')->addArgument($definitions);
         $container->setAlias('api_platform.http_cache.purger', 'api_platform.http_cache.purger.varnish');
     }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -157,7 +157,7 @@ class ApiPlatformExtensionTest extends TestCase
 
     public function testLoadDefaultConfig()
     {
-        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $this->extension->load(self::DEFAULT_CONFIG, $containerBuilder);
@@ -167,7 +167,7 @@ class ApiPlatformExtensionTest extends TestCase
     {
         $nameConverterId = 'test.name_converter';
 
-        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setAlias('api_platform.name_converter', $nameConverterId)->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
@@ -176,7 +176,7 @@ class ApiPlatformExtensionTest extends TestCase
 
     public function testEnableFosUser()
     {
-        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
             'DoctrineBundle' => DoctrineBundle::class,
             'FOSUserBundle' => FOSUserBundle::class,
@@ -208,7 +208,7 @@ class ApiPlatformExtensionTest extends TestCase
 
     public function testEnableNelmioApiDoc()
     {
-        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
             'DoctrineBundle' => DoctrineBundle::class,
             'NelmioApiDocBundle' => NelmioApiDocBundle::class,
@@ -222,7 +222,7 @@ class ApiPlatformExtensionTest extends TestCase
 
     public function testEnableSecurity()
     {
-        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
             'DoctrineBundle' => DoctrineBundle::class,
             'SecurityBundle' => SecurityBundle::class,
@@ -260,7 +260,7 @@ class ApiPlatformExtensionTest extends TestCase
 
     public function testDisableEagerLoadingExtension()
     {
-        $containerBuilderProphecy = $this->getDefaultContainerBuilderProphecy();
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setParameter('api_platform.eager_loading.enabled', false)->shouldBeCalled();
         $containerBuilderProphecy->removeDefinition('api_platform.doctrine.orm.query_extension.eager_loading')->shouldBeCalled();
         $containerBuilderProphecy->removeDefinition('api_platform.doctrine.orm.query_extension.filter_eager_loading')->shouldBeCalled();
@@ -569,18 +569,6 @@ class ApiPlatformExtensionTest extends TestCase
         }
 
         $containerBuilderProphecy->setAlias('api_platform.http_cache.purger', 'api_platform.http_cache.purger.varnish')->shouldBeCalled();
-
-        return $containerBuilderProphecy;
-    }
-
-    private function getDefaultContainerBuilderProphecy()
-    {
-        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
-
-        $containerBuilderProphecy
-            ->setDefinition('api_platform.http_cache.purger.varnish_client.test', Argument::type(Definition::class))
-            ->shouldBeCalled()
-        ;
 
         return $containerBuilderProphecy;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Related to symfony/symfony#24673. It may be a small BC break, but it's mandatory to support Symfony Flex and it was a bad idea (mine) from the very beginning.