### PR TITLE
Document what count() is supposed to return

### DIFF
--- a/src/DataProvider/PaginatorInterface.php
+++ b/src/DataProvider/PaginatorInterface.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\DataProvider;
 
 /**
+ * The \Countable implementation should return the number of items on the
+ * current page, as an integer.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */

--- a/src/DataProvider/PaginatorInterface.php
+++ b/src/DataProvider/PaginatorInterface.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\DataProvider;
 
 /**
- * Paginator Interface.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

`count()` could return the number of pages, or the total number of items, or the number of items on the current page. Looking at the doctrine ORM implementation, it looks like it should be the number of items on the current page, so let's document that, maybe it is relied on somewhere?

I'm contributing this on 2.1, but on master the implementation was moved in an abstract class. Here is how it looks: https://github.com/api-platform/core/blob/c7e2cda19a906d9d13d145312fe9ec231a78d45e/src/Bridge/Doctrine/Orm/AbstractPaginator.php#L71-L74
