### PR TITLE
Make it easier to configure operations

### DIFF
--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -175,7 +175,7 @@ final class ApiLoader extends Loader
         }
 
         if (!isset($operation['method'])) {
-            throw new RuntimeException('Either a "route_name" or a "method" operation attribute must exist.');
+            throw new RuntimeException(sprintf('Either a "route_name" or a "method" operation attribute must exist for the operation "%s" of the resource "%s".', $operationName, $resourceClass));
         }
 
         if (null === $controller = $operation['controller'] ?? null) {

--- a/src/Bridge/Symfony/Routing/OperationMethodResolver.php
+++ b/src/Bridge/Symfony/Routing/OperationMethodResolver.php
@@ -96,14 +96,7 @@ final class OperationMethodResolver implements OperationMethodResolverInterface
             throw new RuntimeException(sprintf('Either a "route_name" or a "method" operation attribute must exist for the operation "%s" of the resource "%s".', $operationName, $resourceClass));
         }
 
-        $route = $this->getRoute($routeName);
-        $methods = $route->getMethods();
-
-        if (empty($methods)) {
-            return 'GET';
-        }
-
-        return $methods[0];
+        return $this->getRoute($routeName)->getMethods()[0] ?? 'GET';
     }
 
     /**

--- a/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
@@ -19,10 +19,10 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  * @ApiResource(itemOperations={
- *     "get"={"method"="GET"},
+ *     "get",
  *     "custom_normalization"={"route_name"="custom_normalization"}
  * }, collectionOperations={
- *     "get"={"method"="GET"},
+ *     "get",
  *     "custom_denormalization"={"route_name"="custom_denormalization"}
  * })
  *

--- a/tests/Fixtures/TestBundle/Entity/OverriddenOperationDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/OverriddenOperationDummy.php
@@ -30,18 +30,17 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "denormalization_context"={"groups"={"overridden_operation_dummy_write"}}
  *     },
  *     collectionOperations={
- *
  *       "get"={"method"="GET"},
  *       "post"={"method"="POST"},
  *       "swagger"= {
  *          "path"="/override/swagger",
  *          "method"="GET",
- *          }
+ *       }
  *     },
  *     itemOperations={
  *         "swagger"= {
- *          "method"="GET",
- *          },
+ *             "method"="GET",
+ *         },
  *         "get"={
  *             "method"="GET",
  *             "normalization_context"={"groups"={"overridden_operation_dummy_get"}},

--- a/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
+++ b/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
@@ -29,9 +29,9 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *        "hydra_context"={"@type"="hydra:Operation", "hydra:title"="A custom operation", "returns"="xmls:string"}
  *     },
  *     itemOperations={
- *         "get"={"method"="GET"},
- *         "put"={"method"="PUT"},
- *         "delete"={"method"="DELETE"},
+ *         "get",
+ *         "put"={},
+ *         "delete",
  *         "custom_get"={"route_name"="relation_embedded.custom_get"},
  *         "custom1"={"path"="/api/custom-call/{id}", "method"="GET"},
  *         "custom2"={"path"="/api/custom-call/{id}", "method"="PUT"},

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -25,11 +25,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ApiResource(
  *     attributes={"access_control"="has_role('ROLE_USER')"},
  *     collectionOperations={
- *         "get"={"method"="GET"},
- *         "post"={"method"="POST", "access_control"="has_role('ROLE_ADMIN')"}
+ *         "get",
+ *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"method"="GET", "access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
  *     }
  * )
  * @ORM\Entity

--- a/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\Resource\Factory\OperationResourceMetadataFactory;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class OperationResourceMetadataFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider getMetadata
+     */
+    public function testCreateOperation(ResourceMetadata $before, ResourceMetadata $after, array $formats = [])
+    {
+        $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decoratedProphecy->create(Dummy::class)->shouldBeCalled()->willReturn($before);
+
+        $this->assertEquals($after, (new OperationResourceMetadataFactory($decoratedProphecy->reveal(), $formats))->create(Dummy::class));
+    }
+
+    public function getMetadata()
+    {
+        $jsonapi = ['jsonapi' => ['application/vnd.api+json']];
+
+        return [
+            // Item operations
+            [new ResourceMetadata(null, null, null, null, []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT'], 'delete' => ['method' => 'DELETE']], [])],
+            [new ResourceMetadata(null, null, null, null, []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT'], 'patch' => ['method' => 'PATCH'], 'delete' => ['method' => 'DELETE']], []), $jsonapi],
+            [new ResourceMetadata(null, null, null, ['get'], []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET']], [])],
+            [new ResourceMetadata(null, null, null, ['put'], []), new ResourceMetadata(null, null, null, ['put' => ['method' => 'PUT']], [])],
+            [new ResourceMetadata(null, null, null, ['delete'], []), new ResourceMetadata(null, null, null, ['delete' => ['method' => 'DELETE']], [])],
+            [new ResourceMetadata(null, null, null, ['patch'], []), new ResourceMetadata(null, null, null, ['patch' => []], [])],
+            [new ResourceMetadata(null, null, null, ['patch'], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH']], []), $jsonapi],
+
+            // Collection operations
+            [new ResourceMetadata(null, null, null, []), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']])],
+            [new ResourceMetadata(null, null, null, [], ['get']), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET']])],
+            [new ResourceMetadata(null, null, null, [], ['post']), new ResourceMetadata(null, null, null, [], ['post' => ['method' => 'POST']])],
+            [new ResourceMetadata(null, null, null, [], ['options']), new ResourceMetadata(null, null, null, [], ['options' => []])],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Before:

```php
/**
 * @ApiResource(
 *     collectionOperations={
 *         "get"={"method"="GET"},
 *         "post"={"method"="POST"}
 *     },
 *     itemOperations={
 *         "get"={"method"="GET"}
 *     }
 */
```

Now:

```php
/**
 * @ApiResource(
 *     collectionOperations={"get", "post"},
 *     itemOperations={"get"}
 */
```

Before:

```php
/**
 * @ApiResource(
 *     attributes={"access_control"="has_role('ROLE_USER')"},
 *     collectionOperations={
 *         "get"={"method"="GET"},
 *         "post"={"method"="POST", "access_control"="has_role('ROLE_ADMIN')"}
 *     },
 *     itemOperations={
 *         "get"={"method"="GET", "access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
 *     }
 */
```

Now:

```php
/**
 * @ApiResource(
 *     attributes={"access_control"="has_role('ROLE_USER')"},
 *     collectionOperations={
 *         "get",
 *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
 *     },
 *     itemOperations={
 *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
 *     }
 */
```

Also includes unit tests for existing features of `OperationResourceMetadataFactory`, support for YAML and XML and various minor improvements.