### PR TITLE
Fix filter eager loading & merge #1449 + test

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -69,7 +69,11 @@ final class FilterEagerLoadingExtension implements QueryCollectionExtensionInter
             $queryBuilderClone->andWhere($queryBuilderClone->expr()->in($originAlias, $in->getDQL()));
         } else {
             // Because Doctrine doesn't support WHERE ( foo, bar ) IN () (https://github.com/doctrine/doctrine2/issues/5238), we are building as many subqueries as they are identifiers
-            foreach ($classMetadata->identifier as $identifier) {
+            foreach ($classMetadata->getIdentifier() as $identifier) {
+                if (!$classMetadata->hasAssociation($identifier)) {
+                    continue;
+                }
+
                 $replacementAlias = $queryNameGenerator->generateJoinAlias($originAlias);
                 $in = $this->getQueryBuilderWithNewAliases($queryBuilder, $queryNameGenerator, $originAlias, $replacementAlias);
                 $in->select("IDENTITY($replacementAlias.$identifier)");

--- a/src/Bridge/Doctrine/Orm/Util/EagerLoadingTrait.php
+++ b/src/Bridge/Doctrine/Orm/Util/EagerLoadingTrait.php
@@ -91,7 +91,7 @@ trait EagerLoadingTrait
     {
         $checked[] = $classMetadata->name;
 
-        foreach ($classMetadata->associationMappings as $mapping) {
+        foreach ($classMetadata->getAssociationMappings() as $mapping) {
             if (ClassMetadataInfo::FETCH_EAGER === $mapping['fetch']) {
                 return true;
             }

--- a/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
@@ -146,17 +146,15 @@ final class QueryChecker
                 if (!isset($orderByAliases[$alias])) {
                     continue;
                 }
-
                 $relationship = QueryJoinParser::getJoinRelationship($join);
 
                 if (false !== strpos($relationship, '.')) {
                     /*
-                     * (Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers)
-                     *
+                     * We select the parent alias because it may differ from the origin alias given above
                      * @see https://github.com/api-platform/core/issues/1313
                      */
-                    list($parentAlias, $association) = explode('.', $relationship);
-                    $metadata = QueryJoinParser::getClassMetadataFromJoinAlias($parentAlias, $queryBuilder, $managerRegistry);
+                    list($relationAlias, $association) = explode('.', $relationship);
+                    $metadata = QueryJoinParser::getClassMetadataFromJoinAlias($relationAlias, $queryBuilder, $managerRegistry);
                     if ($metadata->isCollectionValuedAssociation($association)) {
                         return true;
                     }

--- a/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
@@ -150,8 +150,14 @@ final class QueryChecker
                 $relationship = QueryJoinParser::getJoinRelationship($join);
 
                 if (false !== strpos($relationship, '.')) {
-                    $metadata = QueryJoinParser::getClassMetadataFromJoinAlias($alias, $queryBuilder, $managerRegistry);
-                    if ($metadata->isCollectionValuedAssociation($relationship)) {
+                    /*
+                     * (Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers)
+                     *
+                     * @see https://github.com/api-platform/core/issues/1313
+                     */
+                    list($parentAlias, $association) = explode('.', $relationship);
+                    $metadata = QueryJoinParser::getClassMetadataFromJoinAlias($parentAlias, $queryBuilder, $managerRegistry);
+                    if ($metadata->isCollectionValuedAssociation($association)) {
                         return true;
                     }
                 } else {

--- a/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
@@ -33,7 +33,7 @@ class QueryJoinParserTest extends TestCase
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
         $queryBuilder->getRootAliases()->willReturn(['d']);
-        $queryBuilder->getDQLPart('join')->willReturn(['a_1' => new Join('INNER_JOIN', 'relatedDummy', 'a_1', null, 'a_1.name = r.name')]);
+        $queryBuilder->getDQLPart('join')->willReturn(['a_1' => [new Join('INNER_JOIN', 'relatedDummy', 'a_1', null, 'a_1.name = r.name')]]);
         $classMetadata = $this->prophesize(ClassMetadata::class);
         $objectManager = $this->prophesize(ObjectManager::class);
         $objectManager->getClassMetadata('Dummy')->willReturn($classMetadata->reveal());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1313 + no ticket see below
| License       | MIT
| Doc PR        | n/a

1. First commit is a fix on `FilterEagerLoadingExtension` with composite identifiers when one of the composite identifier is not an association. I also improved the testability of `EagerLoadingTrait` by using `ClassMetadataInfo` methods instead of public properties (easier to prophesize).

2. Merges #1449  + add a test + improve comment