### PR TITLE
Use database type conversion in Filters (test postgres+mysql)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 env:
   global:
     - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
+    - APP_ENV=test
 
 matrix:
   include:
@@ -18,11 +19,23 @@ matrix:
     - php: '7.2'
       env: lint=1
     - php: '7.2'
-      env: deps='low'
+      env: deps=low
     - php: '7.2'
-      env: deps='beta'
+      env: deps=beta
     - php: '7.2'
       env: SYMFONY_DEPRECATIONS_HELPER=0
+    - php: '7.2'
+      services:
+          - postgresql
+      before_script:
+          - psql -c 'create database api_platform_test;' -U postgres
+      env: APP_ENV=postgres
+    - php: '7.2'
+      services:
+          - mysql
+      before_script:
+          - mysql -e 'CREATE DATABASE api_platform_test;'
+      env: APP_ENV=mysql
   allow_failures:
       env: SYMFONY_DEPRECATIONS_HELPER=0
 
@@ -41,8 +54,10 @@ install:
 
 script:
   - vendor/bin/phpunit
-  - if [[ $deps = 'beta' ]]; then vendor/bin/behat --format=progress --tags='~@nobeta'; fi
-  - if [[ $deps != 'beta' ]]; then vendor/bin/behat --format=progress; fi
+  - if [[ $APP_ENV = 'test' && $deps = 'beta' ]]; then vendor/bin/behat --format=progress --tags='~@nobeta&&~@postgres'; fi
+  - if [[ $APP_ENV = 'test' && $deps != 'beta' ]]; then vendor/bin/behat --format=progress --tags='~@postgres'; fi
+  - if [[ $APP_ENV = 'postgres' ]]; then vendor/bin/behat --tags='~@sqlite' --format=progress; fi
+  - if [[ $APP_ENV = 'mysql' ]]; then vendor/bin/behat --tags='~@postgres' --format=progress; fi
   - tests/Fixtures/app/console api:swagger:export > swagger.json && swagger-cli validate swagger.json && rm swagger.json
   - if [[ $lint = 1 ]]; then php php-cs-fixer.phar fix --dry-run --diff --no-ansi; fi
   - if [[ $lint = 1 ]]; then phpstan analyse -c phpstan.neon -l5 --ansi src tests; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,9 @@ cache:
 init:
   - SET PATH=c:\tools\php71;%PATH%
 
+environment:
+    APP_ENV: 'test'
+
 install:
   - ps: Set-Service wuauserv -StartupType Manual
   - cinst -y php
@@ -26,5 +29,5 @@ install:
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - php vendor\behat\behat\bin\behat --format=progress
+  - php vendor\behat\behat\bin\behat --format=progress --tags='~@postgres'
   - php vendor\phpunit\phpunit\phpunit

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -3,16 +3,16 @@ default:
     default:
       contexts:
         - 'FeatureContext': { doctrine: '@doctrine' }
+        - 'JsonContext'
         - 'HydraContext'
         - 'SwaggerContext'
         - 'HttpCacheContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
-        - 'Behatch\Context\JsonContext'
   extensions:
     'Behat\Symfony2Extension':
       kernel:
-        env:       'test'
+        env:       '%env(APP_ENV)%'
         debug:     'true'
         path:      'tests/Fixtures/app/AppKernel.php'
         bootstrap: 'tests/Fixtures/app/bootstrap.php'
@@ -28,10 +28,10 @@ coverage:
     default:
       contexts:
         - 'FeatureContext': { doctrine: '@doctrine' }
+        - 'JsonContext'
         - 'HydraContext'
         - 'SwaggerContext'
         - 'HttpCacheContext'
         - 'CoverageContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
-        - 'Behatch\Context\JsonContext'

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyAggregateOffer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCarColor;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDate;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyFriend;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyGroup;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyOffer;
@@ -743,6 +744,25 @@ final class FeatureContext implements Context, SnippetAcceptingContext
 
         $person->pets->add($personToPet);
         $this->manager->persist($person);
+
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is :nb dummydate objects with dummyDate
+     */
+    public function thereIsDummyDateObjectsWithDummyDate(int $nb)
+    {
+        $descriptions = ['Smart dummy.', 'Not so smart dummy.'];
+
+        for ($i = 1; $i <= $nb; ++$i) {
+            $date = new \DateTime(sprintf('2015-04-%d', $i), new \DateTimeZone('UTC'));
+
+            $dummy = new DummyDate();
+            $dummy->dummyDate = $date;
+
+            $this->manager->persist($dummy);
+        }
 
         $this->manager->flush();
     }

--- a/features/bootstrap/JsonContext.php
+++ b/features/bootstrap/JsonContext.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Behat\Gherkin\Node\PyStringNode;
+use Behatch\Context\JsonContext as BaseJsonContext;
+use Behatch\HttpCall\HttpCallResultPool;
+use Behatch\Json\Json;
+
+final class JsonContext extends BaseJsonContext
+{
+    public function __construct(HttpCallResultPool $httpCallResultPool)
+    {
+        parent::__construct($httpCallResultPool);
+    }
+
+    private function sortArrays($obj)
+    {
+        $isObject = is_object($obj);
+
+        foreach ($obj as $key => $value) {
+            if (null === $value || is_scalar($value)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                sort($value);
+            }
+
+            $value = $this->sortArrays($value);
+
+            $isObject ? $obj->{$key} = $value : $obj[$key] = $value;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * @Then /^the JSON should be deep equal to:$/
+     */
+    public function theJsonShouldBeDeepEqualTo(PyStringNode $content)
+    {
+        $actual = $this->getJson();
+        try {
+            $expected = new Json($content);
+        } catch (\Exception $e) {
+            throw new \Exception('The expected JSON is not a valid');
+        }
+
+        $actual = new Json(json_encode($this->sortArrays($actual->getContent())));
+        $expected = new Json(json_encode($this->sortArrays($expected->getContent())));
+
+        $this->assertSame(
+            (string) $expected,
+            (string) $actual,
+            "The json is equal to:\n".$actual->encode()
+        );
+    }
+}

--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -656,6 +656,15 @@ Feature: Date filter on collections
 
   @dropSchema
   @createSchema
+  Scenario: Get collection filtered by date that is not a datetime
+    Given there is "30" dummydate objects with dummyDate
+    When I send a "GET" request to "/dummy_dates?dummyDate[after]=2015-04-28"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @dropSchema
+  @createSchema
   Scenario: Get collection filtered by embedded date
     Given there is "2" embedded dummy objects with dummyDate and embeddedDummy
     When I send a "GET" request to "/embedded_dummies?embeddedDummy.dummyDate[after]=2015-04-28"

--- a/features/doctrine/numeric_filter.feature
+++ b/features/doctrine/numeric_filter.feature
@@ -4,37 +4,9 @@ Feature: Numeric filter on collections
   I need to retrieve collections with numerical value
 
   @createSchema
-  Scenario: Get collection by id equals 9.99 which is not possible
-    Given there is "30" dummy objects
-    When I send a "GET" request to "/dummies?id=9.99"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be valid according to this schema:
-    """
-    {
-      "type": "object",
-      "properties": {
-        "@context": {"pattern": "^/contexts/Dummy$"},
-        "@id": {"pattern": "^/dummies"},
-        "@type": {"pattern": "^hydra:Collection$"},
-        "hydra:member": {
-          "type": "array",
-          "maxItems": 0
-        },
-        "hydra:view": {
-          "type": "object",
-          "properties": {
-            "@id": {"pattern": "^/dummies\\?id=9.99$"},
-            "@type": {"pattern": "^hydra:PartialCollectionView$"}
-          }
-        }
-      }
-    }
-    """
-
-  Scenario: Get collection by id 10
-    When I send a "GET" request to "/dummies?id=10"
+  Scenario: Get collection by dummyPrice=9.99
+    Given there is "10" dummy objects with dummyPrice
+    When I send a "GET" request to "/dummies?dummyPrice=9.99"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
@@ -53,27 +25,32 @@ Feature: Numeric filter on collections
             "properties": {
               "@id": {
                 "oneOf": [
-                  {"pattern": "^/dummies/10$"}
+                  {"pattern": "^/dummies/1$"},
+                  {"pattern": "^/dummies/5$"},
+                  {"pattern": "^/dummies/9$"}
                 ]
               }
             }
-          }
+          },
+          "maxItems": 3,
+          "uniqueItems": true
         },
+        "hydra:totalItems": {"pattern": "^3$"},
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?id=10"},
+            "@id": {"pattern": "^/dummies\\?dummyPrice=9.99"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }
       }
     }
     """
-
 
   @dropSchema
-  Scenario: Get collection ordered by a non valid properties
-    When I send a "GET" request to "/dummies?unknown=0"
+  Scenario: Get collection by non-numeric dummyPrice=marty
+    Given there is "10" dummy objects with dummyPrice
+    When I send a "GET" request to "/dummies?dummyPrice=marty"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
@@ -98,50 +75,15 @@ Feature: Numeric filter on collections
                 ]
               }
             }
-          }
+          },
+          "maxItems": 3,
+          "uniqueItems": true
         },
+        "hydra:totalItems": {"pattern": "^20$"},
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?unknown=0"},
-            "@type": {"pattern": "^hydra:PartialCollectionView$"}
-          }
-        }
-      }
-    }
-    """
-
-    When I send a "GET" request to "/dummies?unknown=1"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be valid according to this schema:
-    """
-    {
-      "type": "object",
-      "properties": {
-        "@context": {"pattern": "^/contexts/Dummy$"},
-        "@id": {"pattern": "^/dummies$"},
-        "@type": {"pattern": "^hydra:Collection$"},
-        "hydra:member": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@id": {
-                "oneOf": [
-                  {"pattern": "^/dummies/1$"},
-                  {"pattern": "^/dummies/2$"},
-                  {"pattern": "^/dummies/3$"}
-                ]
-              }
-            }
-          }
-        },
-        "hydra:view": {
-          "type": "object",
-          "properties": {
-            "@id": {"pattern": "^/dummies\\?unknown=1"},
+            "@id": {"pattern": "^/dummies\\?dummyPrice=marty"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }

--- a/features/http_cache/tags.feature
+++ b/features/http_cache/tags.feature
@@ -1,3 +1,4 @@
+@sqlite
 Feature: Cache invalidation through HTTP Cache tags
   In order to have a fast API
   As an API software developer

--- a/features/main/composite.feature
+++ b/features/main/composite.feature
@@ -11,7 +11,7 @@ Feature: Retrieve data with Composite identifiers
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
+    And the JSON should be deep equal to:
     """
     {
       "@context": "/contexts/CompositeItem",

--- a/features/main/uuid.feature
+++ b/features/main/uuid.feature
@@ -10,7 +10,7 @@ Feature: Using uuid identifier on resource
     """
     {
       "name": "My Dummy",
-      "uuid": "41B29566-144B-11E6-A148-3E1D05DEFE78"
+      "uuid": "41b29566-144b-11e6-a148-3e1d05defe78"
     }
     """
     Then the response status code should be 201
@@ -18,7 +18,7 @@ Feature: Using uuid identifier on resource
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
   Scenario: Get a resource
-    When I send a "GET" request to "/uuid_identifier_dummies/41B29566-144B-11E6-A148-3E1D05DEFE78"
+    When I send a "GET" request to "/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
@@ -26,9 +26,9 @@ Feature: Using uuid identifier on resource
     """
     {
       "@context": "/contexts/UuidIdentifierDummy",
-      "@id": "/uuid_identifier_dummies/41B29566-144B-11E6-A148-3E1D05DEFE78",
+      "@id": "/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78",
       "@type": "UuidIdentifierDummy",
-      "uuid": "41B29566-144B-11E6-A148-3E1D05DEFE78",
+      "uuid": "41b29566-144b-11e6-a148-3e1d05defe78",
       "name": "My Dummy"
     }
     """
@@ -46,9 +46,9 @@ Feature: Using uuid identifier on resource
       "@type": "hydra:Collection",
       "hydra:member": [
           {
-              "@id": "/uuid_identifier_dummies/41B29566-144B-11E6-A148-3E1D05DEFE78",
+              "@id": "/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78",
               "@type": "UuidIdentifierDummy",
-              "uuid": "41B29566-144B-11E6-A148-3E1D05DEFE78",
+              "uuid": "41b29566-144b-11e6-a148-3e1d05defe78",
               "name": "My Dummy"
           }
       ],
@@ -58,7 +58,7 @@ Feature: Using uuid identifier on resource
 
   Scenario: Update a resource
     When I add "Content-Type" header equal to "application/ld+json"
-    And I send a "PUT" request to "/uuid_identifier_dummies/41B29566-144B-11E6-A148-3E1D05DEFE78" with body:
+    And I send a "PUT" request to "/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78" with body:
     """
     {
       "name": "My Dummy modified"
@@ -71,9 +71,9 @@ Feature: Using uuid identifier on resource
     """
     {
       "@context": "/contexts/UuidIdentifierDummy",
-      "@id": "/uuid_identifier_dummies/41B29566-144B-11E6-A148-3E1D05DEFE78",
+      "@id": "/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78",
       "@type": "UuidIdentifierDummy",
-      "uuid": "41B29566-144B-11E6-A148-3E1D05DEFE78",
+      "uuid": "41b29566-144b-11e6-a148-3e1d05defe78",
       "name": "My Dummy modified"
     }
     """
@@ -99,6 +99,6 @@ Feature: Using uuid identifier on resource
 
   @dropSchema
   Scenario: Delete a resource
-    When I send a "DELETE" request to "/uuid_identifier_dummies/41B29566-144B-11E6-A148-3E1D05DEFE78"
+    When I send a "DELETE" request to "/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78"
     Then the response status code should be 204
     And the response should be empty

--- a/features/serializer/property_filter.feature
+++ b/features/serializer/property_filter.feature
@@ -235,7 +235,6 @@ Feature: Filter with serialization attributes on items and collections
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And print last JSON response
     And the JSON should be valid according to this schema:
     """
     {

--- a/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
@@ -18,7 +18,8 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Util\RequestParser;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -340,5 +341,18 @@ abstract class AbstractFilter implements FilterInterface
         }
 
         return [$alias, $propertyParts['field'], $propertyParts['associations']];
+    }
+
+    /**
+     * Gets the Doctrine Type of a given property/resourceClass.
+     *
+     * @return Type|string|null
+     */
+    protected function getDoctrineFieldType(string $property, string $resourceClass)
+    {
+        $propertyParts = $this->splitPropertyParts($property, $resourceClass);
+        $metadata = $this->getNestedMetadata($resourceClass, $propertyParts['associations']);
+
+        return $metadata->getTypeOfField($propertyParts['field']);
     }
 }

--- a/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
@@ -60,12 +60,10 @@ class NumericFilter extends AbstractFilter
             if (!$this->isPropertyMapped($property, $resourceClass) || !$this->isNumericField($property, $resourceClass)) {
                 continue;
             }
-            $propertyParts = $this->splitPropertyParts($property, $resourceClass);
-            $metadata = $this->getNestedMetadata($resourceClass, $propertyParts['associations']);
 
             $description[$property] = [
                 'property' => $property,
-                'type' => $this->getType($metadata->getTypeOfField($propertyParts['field'])),
+                'type' => $this->getType($this->getDoctrineFieldType($property, $resourceClass)),
                 'required' => false,
             ];
         }
@@ -80,9 +78,9 @@ class NumericFilter extends AbstractFilter
      *
      * @return string
      */
-    private function getType(string $doctrineType): string
+    private function getType(string $doctrineType = null): string
     {
-        if (DBALType::DECIMAL === $doctrineType) {
+        if (null === $doctrineType || DBALType::DECIMAL === $doctrineType) {
             return 'string';
         }
 
@@ -100,15 +98,14 @@ class NumericFilter extends AbstractFilter
     {
         if (
             !$this->isPropertyEnabled($property, $resourceClass) ||
-            !$this->isPropertyMapped($property, $resourceClass) ||
-            !$this->isNumericField($property, $resourceClass)
+            !$this->isPropertyMapped($property, $resourceClass)
         ) {
             return;
         }
 
         if (!is_numeric($value)) {
             $this->logger->notice('Invalid filter ignored', [
-                'exception' => new InvalidArgumentException(sprintf('Invalid numeric value for "%s" property', $property)),
+                'exception' => new InvalidArgumentException(sprintf('Invalid numeric value for "%s::%s" property', $resourceClass, $property)),
             ]);
 
             return;
@@ -120,11 +117,20 @@ class NumericFilter extends AbstractFilter
         if ($this->isPropertyNested($property, $resourceClass)) {
             list($alias, $field) = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $resourceClass);
         }
+
+        if (!isset(self::DOCTRINE_NUMERIC_TYPES[$this->getDoctrineFieldType($property, $resourceClass)])) {
+            $this->logger->notice('Invalid filter ignored', [
+                'exception' => new InvalidArgumentException(sprintf('The field "%s" of class "%s" is not a doctrine numeric type.', $field, $resourceClass)),
+            ]);
+
+            return;
+        }
+
         $valueParameter = $queryNameGenerator->generateParameterName($field);
 
         $queryBuilder
             ->andWhere(sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
-            ->setParameter($valueParameter, $value);
+            ->setParameter($valueParameter, $value, $this->getDoctrineFieldType($property, $resourceClass));
     }
 
     /**

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -746,7 +746,7 @@ class SearchFilterTest extends KernelTestCase
 
     public function testTripleJoin()
     {
-        $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => 'bar']);
+        $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '2']);
         $requestStack = new RequestStack();
         $requestStack->push($request);
         $queryBuilder = $this->repository->createQueryBuilder('o');
@@ -770,7 +770,7 @@ class SearchFilterTest extends KernelTestCase
 
     public function testJoinLeft()
     {
-        $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => 'bar']);
+        $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '3']);
         $requestStack = new RequestStack();
         $requestStack->push($request);
         $queryBuilder = $this->repository->createQueryBuilder('o');

--- a/tests/Fixtures/TestBundle/Entity/DummyDate.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyDate.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Dummy Date.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @ApiResource
+ * @ApiResource(attributes={
+ *     "filters"={
+ *         "my_dummy_date.date",
+ *     }
+ * })
+ * @ORM\Entity
+ */
+class DummyDate
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var \DateTime The dummy date
+     *
+     * @ORM\Column(type="date")
+     */
+    public $dummyDate;
+
+    /**
+     * Get id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/User.php
+++ b/tests/Fixtures/TestBundle/Entity/User.php
@@ -23,6 +23,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * A User.
  *
  * @ORM\Entity
+ * @ORM\Table(name="user_test")
  * @ApiResource(attributes={
  *     "normalization_context"={"groups"={"user", "user-read"}},
  *     "denormalization_context"={"groups"={"user", "user-write"}}

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -47,6 +47,13 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load($this->getRootDir().'/config/config.yml');
+        $environment = $this->getEnvironment();
+
+        // patch for behat not supporting %env(APP_ENV)% in older versions
+        if ($appEnv = $_SERVER['APP_ENV'] ?? null && $appEnv !== $environment) {
+            $environment = $appEnv;
+        }
+
+        $loader->load("{$this->getRootDir()}/config/config_{$environment}.yml");
     }
 }

--- a/tests/Fixtures/app/config/config_mysql.yml
+++ b/tests/Fixtures/app/config/config_mysql.yml
@@ -1,0 +1,11 @@
+imports:
+    - { resource: parameters_mysql.yml }
+    - { resource: config_test.yml }
+
+doctrine:
+    dbal:
+        driver:   'pdo_mysql'
+        dbname:   '%dbname%'
+        user:     '%user%'
+        password: '%password%'
+        host:     '%host%'

--- a/tests/Fixtures/app/config/config_postgres.yml
+++ b/tests/Fixtures/app/config/config_postgres.yml
@@ -1,0 +1,11 @@
+imports:
+    - { resource: parameters_postgres.yml }
+    - { resource: config_test.yml }
+
+doctrine:
+    dbal:
+        driver:   'pdo_pgsql'
+        dbname:   '%dbname%'
+        user:     '%user%'
+        password: '%password%'
+        host:     '%host%'

--- a/tests/Fixtures/app/config/config_test.yml
+++ b/tests/Fixtures/app/config/config_test.yml
@@ -19,9 +19,9 @@ framework:
 
 doctrine:
     dbal:
-        driver:                        'pdo_sqlite'
-        path:                          '%kernel.cache_dir%/db.sqlite'
-        charset:                       'UTF8'
+        driver:   'pdo_sqlite'
+        path:     '%kernel.cache_dir%/db.sqlite'
+        charset:  'UTF8'
 
     orm:
         auto_generate_proxy_classes:   '%kernel.debug%'
@@ -119,6 +119,11 @@ services:
         parent:    'api_platform.doctrine.orm.date_filter'
         arguments: [ { 'dummyDate': ~, 'relatedDummy.dummyDate': ~, 'embeddedDummy.dummyDate': ~ } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.date' } ]
+
+    app.my_dummy_date_resource.date_filter:
+        parent:    'api_platform.doctrine.orm.date_filter'
+        arguments: [ { 'dummyDate': ~ } ]
+        tags:      [ { name: 'api_platform.filter', id: 'my_dummy_date.date' } ]
 
     app.my_dummy_resource.range_filter:
         parent:    'api_platform.doctrine.orm.range_filter'

--- a/tests/Fixtures/app/config/parameters_mysql.yml
+++ b/tests/Fixtures/app/config/parameters_mysql.yml
@@ -1,0 +1,5 @@
+parameters:
+    dbname:   'api_platform_test'
+    user:     'travis'
+    password: ''
+    host:     'localhost'

--- a/tests/Fixtures/app/config/parameters_postgres.yml
+++ b/tests/Fixtures/app/config/parameters_postgres.yml
@@ -1,0 +1,5 @@
+parameters:
+    dbname:   'api_platform_test'
+    user:     'postgres'
+    password: ''
+    host:     'localhost'

--- a/tests/Fixtures/app/console
+++ b/tests/Fixtures/app/console
@@ -13,8 +13,8 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
-$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
+$env = $input->getParameterOption(array('--env', '-e'), $_SERVER['APP_ENV'] ?? 'test');
+$debug = $_SERVER['SYMFONY_DEBUG'] ?? 0 && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
 
 if ($debug) {
     Debug::enable();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

Stated in [Advanced field value conversion using custom mapping types](http://docs.doctrine-project.org/en/latest/cookbook/advanced-field-value-conversion-using-custom-mapping-types.html):

> When using DQL queries, the convertToPHPValueSQL and convertToDatabaseValueSQL methods only apply to identification variables and path expressions in SELECT clauses. Expressions in WHERE clauses are not wrapped!

We won't see any difference in sqlite for example ([know why here](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/known-vendor-issues.html)) but I'm definitely seeing one in Oracle where the date parameter has the wrong format and therefore leads to a bad query. Maybe we should use this also in numeric filters.

/edit: 

- [x] Add something to skip the ordering of relations while comparing values in JSON
- [x] Adding postgresql to travis:
  I wouldn't think this would be so hard haha. Few bugs discovered:
  - [x] filtering on any integer field with a string containing a decimal (eg`9.3`) will throw (fixed but changes behavior as they're ignored)
  - [x] actually sqlite `LIKE` filters are case insensitive whereas postgres is case sensitive. This renders a few tests useless on sqlite.
  - [x] in `features/numeric_filters` we DO NOT test the numeric filter but only the search filter... (renamed)
  - [x] add numeric filters tests
  - [x] there is weird stuff going on in search_filter which should not be there (mainly on `id` and `associations`) maybe this should've been called `text_filter`. For example we can't say that an identifier is always named `id` [assumption made here](https://github.com/api-platform/core/blob/master/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php#L209) (fixed by using metadata)
  - [x] needs more tests on AbstractFilter (convert) + test iriconvert new method
- [ ] Why does `tags.feature` fail on postgresql?
```
And the header "Cache-Tags" should not exist
And "/relation_embedders,/related_dummies,/third_levels" IRIs should be purged
IRIs "/relation_embedders,/related_dummies/1,/related_dummies,/third_levels/1,/third_levels" does not match expected "/relation_embedders,/related_dummies,/third_levels".
```
- [x] Why does `fos_user.feature` fail? My guess is bad table name?
```
An exception occurred while executing 'INSERT INTO User (username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, id, fullname) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params ["dummy.user", "dummy.user", "dummy.user@example.com", "dummy.user@example.com", 0, null, "$2y$13$h11wei5V1h8MHUrolsKhCuJo9DgkEDsl62wQVVTJYiTYuncjzRPL6", null, null, null, "a:0:{}", 1, "Dummy User"]:
SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "User"
LINE 1: INSERT INTO User (username, username_canonical, email, email...
                    ^
```

Debug instructions:

```
docker run --name postgres -e POSTGRES_PASSWORD=api-platform -d postgres:9.6.5-alpine
```

```diff
# tests/Fixtures/app/config/config.yml
 doctrine:
     dbal:
-        default_connection: '%default_connection%'
+        default_connection: 'postgres'
@@ -28,10 +28,10 @@ doctrine:
             postgres:
                 driver:   'pdo_pgsql'
-                dbname:   'api_platform_test'
+                dbname:   'postgres'
                 user:     'postgres'
-                password: ''
-                host:     'localhost'
+                password: 'api-platform'
+                host:     '172.17.0.2' # docker inspect
```