### PR TITLE
fix #1479 allow to override SubresourceOperations through metadata

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -51,5 +51,10 @@ final class ApiResource
     /**
      * @var array
      */
+    public $subresourceOperations;
+
+    /**
+     * @var array
+     */
     public $attributes = [];
 }

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -87,6 +87,9 @@ final class ApiLoader extends Loader
 
             if (null !== $collectionOperations = $resourceMetadata->getCollectionOperations()) {
                 foreach ($collectionOperations as $operationName => $operation) {
+                    if ('subresource' === substr($operationName, -11)) {
+                        continue;
+                    }
                     $this->addRoute($routeCollection, $resourceClass, $operationName, $operation, $resourceShortName, OperationType::COLLECTION);
                 }
             }
@@ -115,12 +118,13 @@ final class ApiLoader extends Loader
                             'collection' => $operation['collection'],
                             'operationId' => $operationId,
                         ],
-                    ],
-                    $operation['requirements'] ?? [],
-                    [],
-                    '',
-                    [],
-                    ['GET']
+                    ] + $operations['defaults'],
+                    $operation['requirements'],
+                    $operation['options'],
+                    $operation['host'],
+                    $operation['schemes'],
+                    ['GET'],
+                    $operation['condition']
                 ));
             }
         }

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -87,9 +87,6 @@ final class ApiLoader extends Loader
 
             if (null !== $collectionOperations = $resourceMetadata->getCollectionOperations()) {
                 foreach ($collectionOperations as $operationName => $operation) {
-                    if ('subresource' === substr($operationName, -11)) {
-                        continue;
-                    }
                     $this->addRoute($routeCollection, $resourceClass, $operationName, $operation, $resourceShortName, OperationType::COLLECTION);
                 }
             }
@@ -118,13 +115,13 @@ final class ApiLoader extends Loader
                             'collection' => $operation['collection'],
                             'operationId' => $operationId,
                         ],
-                    ] + $operations['defaults'],
-                    $operation['requirements'],
-                    $operation['options'],
-                    $operation['host'],
-                    $operation['schemes'],
+                    ] + $operation['defaults'] ?? [],
+                    $operation['requirements'] ?? [],
+                    $operation['options'] ?? [],
+                    $operation['host'] ?? '',
+                    $operation['schemes'] ?? [],
                     ['GET'],
-                    $operation['condition']
+                    $operation['condition'] ?? ''
                 ));
             }
         }

--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -47,6 +47,7 @@ final class XmlExtractor extends AbstractExtractor
                 'iri' => $this->phpize($resource, 'iri', 'string'),
                 'itemOperations' => $this->getOperations($resource, 'itemOperation'),
                 'collectionOperations' => $this->getOperations($resource, 'collectionOperation'),
+                'subresourceOperations' => $this->getOperations($resource, 'subresourceOperation'),
                 'attributes' => $this->getAttributes($resource, 'attribute') ?: null,
                 'properties' => $this->getProperties($resource) ?: null,
             ];

--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -67,6 +67,7 @@ final class YamlExtractor extends AbstractExtractor
                 'iri' => $this->phpize($resourceYaml, 'iri', 'string'),
                 'itemOperations' => $resourceYaml['itemOperations'] ?? null,
                 'collectionOperations' => $resourceYaml['collectionOperations'] ?? null,
+                'subresourceOperations' => $resourceYaml['subresourceOperations'] ?? null,
                 'attributes' => $resourceYaml['attributes'] ?? null,
             ];
 

--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -90,12 +90,13 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
                 $annotation->iri,
                 $annotation->itemOperations,
                 $annotation->collectionOperations,
-                $annotation->attributes
+                $annotation->attributes,
+                $annotation->subresourceOperations
             );
         }
 
         $resourceMetadata = $parentResourceMetadata;
-        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'attributes'] as $property) {
+        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'attributes'] as $property) {
             $resourceMetadata = $this->createWith($resourceMetadata, $property, $annotation->$property);
         }
 

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
@@ -84,7 +84,7 @@ final class ExtractorResourceMetadataFactory implements ResourceMetadataFactoryI
      */
     private function update(ResourceMetadata $resourceMetadata, array $metadata): ResourceMetadata
     {
-        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'attributes'] as $property) {
+        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'attributes'] as $property) {
             if (null === $metadata[$property] || null !== $resourceMetadata->{'get'.ucfirst($property)}()) {
                 continue;
             }

--- a/src/Metadata/Resource/ResourceMetadata.php
+++ b/src/Metadata/Resource/ResourceMetadata.php
@@ -25,15 +25,17 @@ final class ResourceMetadata
     private $iri;
     private $itemOperations;
     private $collectionOperations;
+    private $subresourceOperations;
     private $attributes;
 
-    public function __construct(string $shortName = null, string $description = null, string $iri = null, array $itemOperations = null, array $collectionOperations = null, array $attributes = null)
+    public function __construct(string $shortName = null, string $description = null, string $iri = null, array $itemOperations = null, array $collectionOperations = null, array $attributes = null, array $subresourceOperations = null)
     {
         $this->shortName = $shortName;
         $this->description = $description;
         $this->iri = $iri;
         $this->itemOperations = $itemOperations;
         $this->collectionOperations = $collectionOperations;
+        $this->subresourceOperations = $subresourceOperations;
         $this->attributes = $attributes;
     }
 
@@ -49,10 +51,6 @@ final class ResourceMetadata
 
     /**
      * Returns a new instance with the given short name.
-     *
-     * @param string $shortName
-     *
-     * @return self
      */
     public function withShortName(string $shortName): self
     {
@@ -74,10 +72,6 @@ final class ResourceMetadata
 
     /**
      * Returns a new instance with the given description.
-     *
-     * @param string $description
-     *
-     * @return self
      */
     public function withDescription(string $description): self
     {
@@ -99,10 +93,6 @@ final class ResourceMetadata
 
     /**
      * Returns a new instance with the given IRI.
-     *
-     * @param string $iri
-     *
-     * @return self
      */
     public function withIri(string $iri): self
     {
@@ -124,10 +114,6 @@ final class ResourceMetadata
 
     /**
      * Returns a new instance with the given item operations.
-     *
-     * @param array $itemOperations
-     *
-     * @return self
      */
     public function withItemOperations(array $itemOperations): self
     {
@@ -149,10 +135,6 @@ final class ResourceMetadata
 
     /**
      * Returns a new instance with the given collection operations.
-     *
-     * @param array $collectionOperations
-     *
-     * @return self
      */
     public function withCollectionOperations(array $collectionOperations): self
     {
@@ -163,12 +145,30 @@ final class ResourceMetadata
     }
 
     /**
+     * Gets subresource operations.
+     *
+     * @return array|null
+     */
+    public function getSubresourceOperations()
+    {
+        return $this->subresourceOperations;
+    }
+
+    /**
+     * Returns a new instance with the given subresource operations.
+     */
+    public function withSubresourceOperations(array $subresourceOperations): self
+    {
+        $metadata = clone $this;
+        $metadata->subresourceOperations = $subresourceOperations;
+
+        return $metadata;
+    }
+
+    /**
      * Gets a collection operation attribute, optionally fallback to a resource attribute.
      *
-     * @param string|null $operationName
-     * @param string      $key
-     * @param mixed       $defaultValue
-     * @param bool        $resourceFallback
+     * @param mixed $defaultValue
      *
      * @return mixed
      */
@@ -180,10 +180,7 @@ final class ResourceMetadata
     /**
      * Gets an item operation attribute, optionally fallback to a resource attribute.
      *
-     * @param string|null $operationName
-     * @param string      $key
-     * @param mixed       $defaultValue
-     * @param bool        $resourceFallback
+     * @param mixed $defaultValue
      *
      * @return mixed
      */
@@ -193,13 +190,21 @@ final class ResourceMetadata
     }
 
     /**
+     * Gets a subresource operation attribute, optionally fallback to a resource attribute.
+     *
+     * @param mixed $defaultValue
+     *
+     * @return mixed
+     */
+    public function getSubresourceOperationAttribute(string $operationName = null, string $key, $defaultValue = null, bool $resourceFallback = false)
+    {
+        return $this->getOperationAttribute($this->subresourceOperations, $operationName, $key, $defaultValue, $resourceFallback);
+    }
+
+    /**
      * Gets an operation attribute, optionally fallback to a resource attribute.
      *
-     * @param array|null  $operations
-     * @param string|null $operationName
-     * @param string      $key
-     * @param mixed       $defaultValue
-     * @param bool        $resourceFallback
+     * @param mixed $defaultValue
      *
      * @return mixed
      */
@@ -229,8 +234,7 @@ final class ResourceMetadata
     /**
      * Gets an attribute.
      *
-     * @param string $key
-     * @param mixed  $defaultValue
+     * @param mixed $defaultValue
      *
      * @return mixed
      */
@@ -245,10 +249,6 @@ final class ResourceMetadata
 
     /**
      * Returns a new instance with the given attribute.
-     *
-     * @param array $attributes
-     *
-     * @return self
      */
     public function withAttributes(array $attributes): self
     {

--- a/src/Metadata/schema/metadata.xsd
+++ b/src/Metadata/schema/metadata.xsd
@@ -22,6 +22,7 @@
                 <xsd:element name="property" minOccurs="0" maxOccurs="unbounded" type="property"/>
                 <xsd:element name="itemOperations" minOccurs="0" maxOccurs="unbounded" type="itemOperations"/>
                 <xsd:element name="collectionOperations" minOccurs="0" maxOccurs="unbounded" type="collectionOperations"/>
+                <xsd:element name="subresourceOperations" minOccurs="0" maxOccurs="unbounded" type="subresourceOperations"/>
             </xsd:sequence>
 
             <xsd:attribute type="xsd:string" name="class" use="required"/>
@@ -50,6 +51,19 @@
     </xsd:complexType>
 
     <xsd:complexType name="collectionOperation">
+        <xsd:sequence minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="attribute" minOccurs="1" maxOccurs="unbounded" type="attribute"/>
+        </xsd:sequence>
+        <xsd:attribute type="xsd:string" name="name"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="subresourceOperations">
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="subresourceOperation" minOccurs="0" maxOccurs="unbounded" type="subresourceOperation"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="subresourceOperation">
         <xsd:sequence minOccurs="1" maxOccurs="unbounded">
             <xsd:element name="attribute" minOccurs="1" maxOccurs="unbounded" type="attribute"/>
         </xsd:sequence>

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -102,7 +102,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
                     self::SUBRESOURCE_SUFFIX
                 );
 
-                $collectionOperation = $rootResourceMetadata->getCollectionOperations()[$operation['operation_name']] ?? [];
+                $subresourceOperation = $rootResourceMetadata->getSubresourceOperations()[$operation['operation_name']] ?? [];
 
                 $operation['route_name'] = sprintf(
                     '%s%s_%s',
@@ -111,7 +111,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
                     $operation['operation_name']
                 );
 
-                $operation['path'] = $collectionOperation['path'] ?? sprintf(
+                $operation['path'] = $subresourceOperation['path'] ?? sprintf(
                     '/%s/{id}/%s%s',
                     $this->pathSegmentNameGenerator->getSegmentName($rootShortname, true),
                     $this->pathSegmentNameGenerator->getSegmentName($operation['property'], $operation['collection']),
@@ -134,10 +134,10 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
                     $operation['shortNames'][] = $resourceMetadata->getShortName();
                 }
 
-                $collectionOperation = $rootResourceMetadata->getCollectionOperations()[$operation['operation_name']] ?? [];
+                $subresourceOperation = $rootResourceMetadata->getSubresourceOperations()[$operation['operation_name']] ?? [];
 
-                if (isset($collectionOperation['path'])) {
-                    $operation['path'] = $collectionOperation['path'];
+                if (isset($subresourceOperation['path'])) {
+                    $operation['path'] = $subresourceOperation['path'];
                 } else {
                     $operation['path'] = str_replace(self::FORMAT_SUFFIX, '', $parentOperation['path']);
                     if ($parentOperation['collection']) {
@@ -149,7 +149,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             }
 
             foreach (self::ROUTE_OPTIONS as $routeOption => $defaultValue) {
-                $operation[$routeOption] = $collectionOperation[$routeOption] ?? $defaultValue;
+                $operation[$routeOption] = $subresourceOperation[$routeOption] ?? $defaultValue;
             }
 
             $tree[$operation['route_name']] = $operation;

--- a/tests/Fixtures/FileConfigurations/resources.xml
+++ b/tests/Fixtures/FileConfigurations/resources.xml
@@ -25,6 +25,11 @@
                 <attribute name="path">the/collection/path</attribute>
             </collectionOperation>
         </collectionOperations>
+        <subresourceOperations>
+            <subresourceOperation name="my_collection_subresource">
+                <attribute name="path">the/subresource/path</attribute>
+            </subresourceOperation>
+        </subresourceOperations>
         <attribute name="normalization_context">
             <attribute name="groups">
                 <attribute>default</attribute>

--- a/tests/Fixtures/FileConfigurations/resources.yml
+++ b/tests/Fixtures/FileConfigurations/resources.yml
@@ -12,6 +12,9 @@ resources:
             my_collection_op:
                 method: 'POST'
                 path: 'the/collection/path'
+        subresourceOperations:
+            my_collection_subresource:
+                path: 'the/subresource/path'
         attributes:
             normalization_context:
                 groups: ['default']

--- a/tests/Fixtures/FileConfigurations/single_resource.yml
+++ b/tests/Fixtures/FileConfigurations/single_resource.yml
@@ -10,6 +10,9 @@
         my_collection_op:
             method: 'POST'
             path: 'the/collection/path'
+    subresourceOperations:
+        my_collection_subresource:
+            path: 'the/subresource/path'
     attributes:
         normalization_context:
             groups: ['default']

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -42,6 +42,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $this->assertEquals('http://example.com', $metadata->getIri());
         $this->assertEquals(['foo' => ['bar' => true]], $metadata->getItemOperations());
         $this->assertEquals(['baz' => ['tab' => false]], $metadata->getCollectionOperations());
+        $this->assertEquals(['sub' => ['bus' => false]], $metadata->getSubresourceOperations());
         $this->assertEquals(['a' => 1], $metadata->getAttributes());
     }
 
@@ -53,6 +54,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $annotation->iri = 'http://example.com';
         $annotation->itemOperations = ['foo' => ['bar' => true]];
         $annotation->collectionOperations = ['baz' => ['tab' => false]];
+        $annotation->subresourceOperations = ['sub' => ['bus' => false]];
         $annotation->attributes = ['a' => 1];
 
         $reader = $this->prophesize(Reader::class);

--- a/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -38,6 +38,9 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
             'collectionOperations' => [
                 'my_collection_op' => ['method' => 'POST', 'path' => 'the/collection/path'],
             ],
+            'subresourceOperations' => [
+                'my_collection_subresource' => ['path' => 'the/subresource/path'],
+            ],
             'iri' => 'someirischema',
             'attributes' => [
                 'normalization_context' => [
@@ -53,7 +56,7 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
             ],
         ];
 
-        foreach (['shortName', 'description', 'itemOperations', 'collectionOperations', 'iri', 'attributes'] as $property) {
+        foreach (['shortName', 'description', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'iri', 'attributes'] as $property) {
             $wither = 'with'.ucfirst($property);
             $resourceMetadata = $resourceMetadata->$wither($metadata[$property]);
         }

--- a/tests/Metadata/Resource/ResourceMetadataTest.php
+++ b/tests/Metadata/Resource/ResourceMetadataTest.php
@@ -23,7 +23,7 @@ class ResourceMetadataTest extends TestCase
 {
     public function testValueObject()
     {
-        $metadata = new ResourceMetadata('shortName', 'desc', 'http://example.com/foo', ['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], ['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], ['baz' => 'bar']);
+        $metadata = new ResourceMetadata('shortName', 'desc', 'http://example.com/foo', ['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], ['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], ['baz' => 'bar'], ['sop1' => ['sub' => 'bus']]);
         $this->assertEquals('shortName', $metadata->getShortName());
         $this->assertEquals('desc', $metadata->getDescription());
         $this->assertEquals('http://example.com/foo', $metadata->getIri());
@@ -42,6 +42,10 @@ class ResourceMetadataTest extends TestCase
         $this->assertEquals(['baz' => 'bar'], $metadata->getAttributes());
         $this->assertEquals('bar', $metadata->getAttribute('baz'));
         $this->assertEquals('z', $metadata->getAttribute('notExist', 'z'));
+        $this->assertEquals(['sop1' => ['sub' => 'bus']], $metadata->getSubresourceOperations());
+        $this->assertEquals('bus', $metadata->getSubresourceOperationAttribute('sop1', 'sub'));
+        $this->assertEquals('sub', $metadata->getSubresourceOperationAttribute('sop1', 'bus', 'sub', false));
+        $this->assertEquals('bar', $metadata->getSubresourceOperationAttribute('sop1', 'baz', 'sub', true));
 
         $newMetadata = $metadata->withShortName('name');
         $this->assertNotSame($metadata, $newMetadata);

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -146,9 +146,12 @@ class SubresourceOperationFactoryTest extends TestCase
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
-        $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn((new ResourceMetadata('dummyEntity'))->withCollectionOperations([
+        $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn((new ResourceMetadata('dummyEntity'))->withSubresourceOperations([
             'subcollections_get_subresource' => [
                 'path' => '/dummy_entities/{id}/foobars',
+            ],
+            'subcollections_another_subresource_get_subresource' => [
+                'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_foobar.{_format}',
             ],
         ]));
 
@@ -237,7 +240,7 @@ class SubresourceOperationFactoryTest extends TestCase
                     ['subcollection', RelatedDummyEntity::class, true],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_get_subresource',
-                'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_subresource.{_format}',
+                'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_foobar.{_format}',
                 'operation_name' => 'subcollections_another_subresource_get_subresource',
             ] + SubresourceOperationFactory::ROUTE_OPTIONS,
             'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource' => [
@@ -251,7 +254,7 @@ class SubresourceOperationFactoryTest extends TestCase
                     ['anotherSubresource', DummyEntity::class, false],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource',
-                'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_subresource/subresource.{_format}',
+                'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_foobar/subresource.{_format}',
                 'operation_name' => 'subcollections_another_subresource_subresource_get_subresource',
             ] + SubresourceOperationFactory::ROUTE_OPTIONS,
         ], $subresourceOperationFactory->create(DummyEntity::class));

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -71,7 +71,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource.{_format}',
-            ],
+                'operation_name' => 'subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
             'api_dummy_entities_subresource_another_subresource_get_subresource' => [
                 'property' => 'anotherSubresource',
                 'collection' => false,
@@ -83,7 +84,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 ],
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource.{_format}',
-            ],
+                'operation_name' => 'subresource_another_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
             'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource' => [
                 'property' => 'subcollection',
                 'collection' => true,
@@ -96,7 +98,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 ],
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource/subcollections.{_format}',
-            ],
+                'operation_name' => 'subresource_another_subresource_subcollections_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
             'api_dummy_entities_subcollections_get_subresource' => [
                 'property' => 'subcollection',
                 'collection' => true,
@@ -107,7 +110,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections.{_format}',
-            ],
+                'operation_name' => 'subcollections_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
             'api_dummy_entities_subcollections_another_subresource_get_subresource' => [
                 'property' => 'anotherSubresource',
                 'collection' => false,
@@ -119,7 +123,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections/{subcollection}/another_subresource.{_format}',
-            ],
+                'operation_name' => 'subcollections_another_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
             'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource' => [
                 'property' => 'subresource',
                 'collection' => false,
@@ -132,7 +137,123 @@ class SubresourceOperationFactoryTest extends TestCase
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections/{subcollection}/another_subresource/subresource.{_format}',
+                'operation_name' => 'subcollections_another_subresource_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+        ], $subresourceOperationFactory->create(DummyEntity::class));
+    }
+
+    public function testCreateByOverriding()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
+        $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn((new ResourceMetadata('dummyEntity'))->withCollectionOperations([
+            'subcollections_get_subresource' => [
+                'path' => '/dummy_entities/{id}/foobars',
             ],
+        ]));
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection(['foo', 'subresource', 'subcollection']));
+        $propertyNameCollectionFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection(['bar', 'anotherSubresource']));
+
+        $subresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class));
+        $subresourceMetadataCollection = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, true));
+        $anotherSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'foo')->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subcollection')->shouldBeCalled()->willReturn($subresourceMetadataCollection);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar')->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource')->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
+
+        $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
+        $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresource');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('subcollection', true)->shouldBeCalled()->willReturn('subcollections');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity', true)->shouldBeCalled()->willReturn('dummy_entities');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('anotherSubresource', false)->shouldBeCalled()->willReturn('another_subresource');
+
+        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $pathSegmentNameGeneratorProphecy->reveal());
+
+        $this->assertEquals([
+            'api_dummy_entities_subresource_get_subresource' => [
+                'property' => 'subresource',
+                'collection' => false,
+                'resource_class' => RelatedDummyEntity::class,
+                'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/subresource.{_format}',
+                'operation_name' => 'subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_subresource_another_subresource_get_subresource' => [
+                'property' => 'anotherSubresource',
+                'collection' => false,
+                'resource_class' => DummyEntity::class,
+                'shortNames' => ['dummyEntity', 'relatedDummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                    ['subresource', RelatedDummyEntity::class, false],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_another_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/subresource/another_subresource.{_format}',
+                'operation_name' => 'subresource_another_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource' => [
+                'property' => 'subcollection',
+                'collection' => true,
+                'resource_class' => RelatedDummyEntity::class,
+                'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                    ['subresource', RelatedDummyEntity::class, false],
+                    ['anotherSubresource', DummyEntity::class, false],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource',
+                'path' => '/dummy_entities/{id}/subresource/another_subresource/subcollections.{_format}',
+                'operation_name' => 'subresource_another_subresource_subcollections_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_subcollections_get_subresource' => [
+                'property' => 'subcollection',
+                'collection' => true,
+                'resource_class' => RelatedDummyEntity::class,
+                'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_subcollections_get_subresource',
+                'path' => '/dummy_entities/{id}/foobars',
+                'operation_name' => 'subcollections_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_subcollections_another_subresource_get_subresource' => [
+                'property' => 'anotherSubresource',
+                'collection' => false,
+                'resource_class' => DummyEntity::class,
+                'shortNames' => ['dummyEntity', 'relatedDummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                    ['subcollection', RelatedDummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_subcollections_another_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_subresource.{_format}',
+                'operation_name' => 'subcollections_another_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource' => [
+                'property' => 'subresource',
+                'collection' => false,
+                'resource_class' => RelatedDummyEntity::class,
+                'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                    ['subcollection', RelatedDummyEntity::class, true],
+                    ['anotherSubresource', DummyEntity::class, false],
+                ],
+                'route_name' => 'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_subresource/subresource.{_format}',
+                'operation_name' => 'subcollections_another_subresource_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1479 
| License       | MIT
| Doc PR        | TODO

Also backported #1472 to subresources