### PR TITLE
Fix annotation filters + OrderBy autowiring capabilities

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -53,7 +53,7 @@ class OrderFilter extends AbstractFilter
      */
     protected $orderParameterName;
 
-    public function __construct(ManagerRegistry $managerRegistry, RequestStack $requestStack, string $orderParameterName, LoggerInterface $logger = null, array $properties = null)
+    public function __construct(ManagerRegistry $managerRegistry, RequestStack $requestStack, string $orderParameterName = 'order', LoggerInterface $logger = null, array $properties = null)
     {
         if (null !== $properties) {
             $properties = array_map(function ($propertyOptions) {

--- a/src/Util/AnnotationFilterExtractorTrait.php
+++ b/src/Util/AnnotationFilterExtractorTrait.php
@@ -51,19 +51,23 @@ trait AnnotationFilterExtractorTrait
 
         if ($filterAnnotation->properties) {
             foreach ($filterAnnotation->properties as $property => $strategy) {
-                $properties[$property] = $strategy;
+                if (is_int($property)) {
+                    $properties[$strategy] = null;
+                } else {
+                    $properties[$property] = $strategy;
+                }
             }
 
             return $properties;
         }
 
+        if (null !== $reflectionProperty) {
+            $properties[$reflectionProperty->getName()] = $filterAnnotation->strategy ?: null;
+
+            return $properties;
+        }
+
         if ($filterAnnotation->strategy) {
-            if (null !== $reflectionProperty) {
-                $properties[$reflectionProperty->getName()] = $filterAnnotation->strategy;
-
-                return $properties;
-            }
-
             foreach ($reflectionClass->getProperties() as $reflectionProperty) {
                 $properties[$reflectionProperty->getName()] = $filterAnnotation->strategy;
             }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
@@ -73,7 +73,7 @@ class AnnotationFilterPassTest extends TestCase
         $containerBuilderProphecy->setDefinition('annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_api_platform_core_bridge_doctrine_orm_filter_search_filter', Argument::that(function ($def) {
             $this->assertInstanceOf(Definition::class, $def);
             $this->assertEquals(SearchFilter::class, $def->getClass());
-            $this->assertEquals($def->getArguments(), ['$properties' => ['description', 'relatedDummy.name', 'name']]);
+            $this->assertEquals(['$properties' => ['description' => null, 'relatedDummy.name' => null, 'name' => null]], $def->getArguments());
 
             return true;
         }))->shouldBeCalled();
@@ -81,7 +81,7 @@ class AnnotationFilterPassTest extends TestCase
         $containerBuilderProphecy->setDefinition('annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_api_platform_core_serializer_filter_group_filter', Argument::that(function ($def) {
             $this->assertInstanceOf(Definition::class, $def);
             $this->assertEquals(GroupFilter::class, $def->getClass());
-            $this->assertEquals($def->getArguments(), ['$parameterName' => 'foobar']);
+            $this->assertEquals(['$parameterName' => 'foobar'], $def->getArguments());
 
             return true;
         }))->shouldBeCalled();
@@ -89,7 +89,7 @@ class AnnotationFilterPassTest extends TestCase
         $containerBuilderProphecy->setDefinition('annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_api_platform_core_bridge_doctrine_orm_filter_date_filter', Argument::that(function ($def) {
             $this->assertInstanceOf(Definition::class, $def);
             $this->assertEquals(DateFilter::class, $def->getClass());
-            $this->assertEquals($def->getArguments(), []);
+            $this->assertEquals(['$properties' => ['dummyDate' => null]], $def->getArguments());
 
             return true;
         }))->shouldBeCalled();

--- a/tests/Fixtures/DummyEntityFilterAnnotated.php
+++ b/tests/Fixtures/DummyEntityFilterAnnotated.php
@@ -1,0 +1,36 @@
+<?php
+
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use ApiPlatform\Core\Annotation\ApiFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
+
+/**
+ * @ApiFilter(OrderFilter::class, arguments={"orderParameterName"="positionOrder"}, properties={"position"})
+ */
+class DummyEntityFilterAnnotated
+{
+    public $position;
+
+    /**
+     * @ApiFilter(OrderFilter::class)
+     */
+    public $priority;
+
+    /**
+     * @ApiFilter(OrderFilter::class, strategy="ASC")
+     */
+    public $number;
+}

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -15,9 +15,11 @@ namespace ApiPlatform\Core\Tests\Util;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Core\Serializer\Filter\GroupFilter;
 use ApiPlatform\Core\Serializer\Filter\PropertyFilter;
+use ApiPlatform\Core\Tests\Fixtures\DummyEntityFilterAnnotated;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Util\AnnotationFilterExtractor;
 use Doctrine\Common\Annotations\Reader;
@@ -60,6 +62,25 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
             ['parameterName' => 'foobargroups'],
             GroupFilter::class,
           ],
+        ]);
+    }
+
+    public function testReadOrderAnnotations()
+    {
+        $reflectionClass = new \ReflectionClass(DummyEntityFilterAnnotated::class);
+        $readerProphecy = $this->prophesize(Reader::class);
+        $services = [];
+
+        $this->assertEquals($this->extractor->getFilters($reflectionClass), [
+            'annotated_api_platform_core_tests_fixtures_dummy_entity_filter_annotated_api_platform_core_bridge_doctrine_orm_filter_order_filter' => [
+                [
+                    'orderParameterName' => 'positionOrder',
+                    'properties' => [
+                        'position' => null, 'priority' => null, 'number' => 'ASC',
+                    ],
+                ],
+                OrderFilter::class,
+            ],
         ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | needed for https://github.com/api-platform/docs/pull/314

Allows:

```
@ApiFilter(OrderFilter::class, properties={"one", "two"}
```

Also removes the required `orderParameterName` argument in the filter.
