### PR TITLE
Split GraphQL config from REST config

### DIFF
--- a/src/Action/GraphqlEntrypointAction.php
+++ b/src/Action/GraphqlEntrypointAction.php
@@ -67,7 +67,7 @@ final class GraphqlEntrypointAction
             $executionResult = new ExecutionResult(null, [$e]);
         }
 
-        return new JsonResponse($executionResult->toArray($this->debug), !$executionResult->errors ? Response::HTTP_OK : Response::HTTP_BAD_REQUEST);
+        return new JsonResponse($executionResult->toArray($this->debug), $executionResult->errors ? Response::HTTP_BAD_REQUEST : Response::HTTP_OK);
     }
 
     private function parseRequest(Request $request): array

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -56,5 +56,10 @@ final class ApiResource
     /**
      * @var array
      */
+    public $graphql;
+
+    /**
+     * @var array
+     */
     public $attributes = [];
 }

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -109,7 +109,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
             $normalizedIdentifiers = isset($identifiers[$identifier]) ? $this->normalizeIdentifiers($identifiers[$identifier], $manager, $identifierResourceClass) : [];
 
             switch ($relationType) {
-                //MANY_TO_MANY relations need an explicit join so that the identifier part can be retrieved
+                // MANY_TO_MANY relations need an explicit join so that the identifier part can be retrieved
                 case ClassMetadataInfo::MANY_TO_MANY:
                     $joinAlias = $queryNameGenerator->generateJoinAlias($previousAssociationProperty);
 

--- a/src/Bridge/Graphql/Executor.php
+++ b/src/Bridge/Graphql/Executor.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Bridge\Graphql;
 
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\GraphQL;
+use GraphQL\Type\Schema;
 
 /**
  * Wrapper for the GraphQL facade.
@@ -28,8 +29,8 @@ final class Executor implements ExecutorInterface
     /**
      * {@inheritdoc}
      */
-    public function executeQuery(...$args): ExecutionResult
+    public function executeQuery(Schema $schema, $source, $rootValue = null, $context = null, array $variableValues = null, string $operationName = null, callable $fieldResolver = null, array $validationRules = null): ExecutionResult
     {
-        return GraphQL::executeQuery(...$args);
+        return GraphQL::executeQuery($schema, $source, $rootValue, $context, $variableValues, $operationName, $fieldResolver, $validationRules);
     }
 }

--- a/src/Bridge/Graphql/ExecutorInterface.php
+++ b/src/Bridge/Graphql/ExecutorInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Graphql;
 
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Type\Schema;
 
 /**
  * Wrapper for the GraphQL facade.
@@ -26,10 +27,6 @@ interface ExecutorInterface
 {
     /**
      * @see http://webonyx.github.io/graphql-php/executing-queries/#using-facade-method
-     *
-     * @param array ...$args
-     *
-     * @return ExecutionResult
      */
-    public function executeQuery(...$args): ExecutionResult;
+    public function executeQuery(Schema $schema, $source, $rootValue = null, $context = null, array $variableValues = null, string $operationName = null, callable $fieldResolver = null, array $validationRules = null): ExecutionResult;
 }

--- a/src/Bridge/Graphql/Resolver/CollectionResolverFactory.php
+++ b/src/Bridge/Graphql/Resolver/CollectionResolverFactory.php
@@ -54,9 +54,9 @@ final class CollectionResolverFactory extends AbstractResolverFactory implements
     /**
      * @throws \Exception
      */
-    public function createCollectionResolver(string $resourceClass, string $rootClass, string $operationName): callable
+    public function createCollectionResolver(string $resourceClass, string $rootClass): callable
     {
-        return function ($root, $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operationName) {
+        return function ($root, $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass) {
             if (null !== $request = $this->requestStack->getCurrentRequest()) {
                 $request->attributes->set(
                     '_graphql_collections_args',
@@ -74,7 +74,7 @@ final class CollectionResolverFactory extends AbstractResolverFactory implements
 
             $context = $this->resourceMetadataFactory
                 ->create($resourceClass)
-                ->getCollectionOperationAttribute($operationName, 'normalization_context', [], true);
+                ->getGraphqlAttribute('query', 'normalization_context', [], true);
 
             if (!$this->paginationEnabled) {
                 $data = [];

--- a/src/Bridge/Graphql/Resolver/CollectionResolverFactoryInterface.php
+++ b/src/Bridge/Graphql/Resolver/CollectionResolverFactoryInterface.php
@@ -22,5 +22,5 @@ namespace ApiPlatform\Core\Bridge\Graphql\Resolver;
  */
 interface CollectionResolverFactoryInterface
 {
-    public function createCollectionResolver(string $resourceClass, string $rootClass, string $operationName): callable;
+    public function createCollectionResolver(string $resourceClass, string $rootClass): callable;
 }

--- a/src/Bridge/Graphql/Resolver/ItemResolverFactory.php
+++ b/src/Bridge/Graphql/Resolver/ItemResolverFactory.php
@@ -48,9 +48,9 @@ final class ItemResolverFactory extends AbstractResolverFactory implements ItemR
     /**
      * @throws \Exception
      */
-    public function createItemResolver(string $resourceClass, string $rootClass, string $operationName): callable
+    public function createItemResolver(string $resourceClass, string $rootClass): callable
     {
-        return function ($root, $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operationName) {
+        return function ($root, $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass) {
             $rootProperty = $info->fieldName;
             $rootIdentifiers = $this->identifiersExtractor->getIdentifiersFromResourceClass($rootClass);
             if (isset($root[$rootProperty])) {
@@ -89,7 +89,7 @@ final class ItemResolverFactory extends AbstractResolverFactory implements ItemR
                 null,
                 ['graphql' => true] + $this->resourceMetadataFactory
                     ->create($resourceClass)
-                    ->getItemOperationAttribute($operationName, 'normalization_context', [], true)
+                    ->getGraphqlAttribute('query', 'normalization_context', [], true)
             ) : null;
         };
     }

--- a/src/Bridge/Graphql/Resolver/ItemResolverFactoryInterface.php
+++ b/src/Bridge/Graphql/Resolver/ItemResolverFactoryInterface.php
@@ -22,5 +22,5 @@ namespace ApiPlatform\Core\Bridge\Graphql\Resolver;
  */
 interface ItemResolverFactoryInterface
 {
-    public function createItemResolver(string $resourceClass, string $rootClass, string $operationName): callable;
+    public function createItemResolver(string $resourceClass, string $rootClass): callable;
 }

--- a/src/Bridge/Graphql/Type/SchemaBuilder.php
+++ b/src/Bridge/Graphql/Type/SchemaBuilder.php
@@ -67,7 +67,12 @@ final class SchemaBuilder implements SchemaBuilderInterface
     {
         $queryFields = [];
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
-            $queryFields += $this->getQueryFields($resourceClass);
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+            if (!isset($resourceMetadata->getGraphql()['query'])) {
+                continue;
+            }
+
+            $queryFields += $this->getQueryFields($resourceClass, $resourceMetadata);
         }
 
         return new Schema([
@@ -81,10 +86,9 @@ final class SchemaBuilder implements SchemaBuilderInterface
     /**
      * Gets the query fields of the schema.
      */
-    private function getQueryFields(string $resourceClass): array
+    private function getQueryFields(string $resourceClass, ResourceMetadata $resourceMetadata): array
     {
         $queryFields = [];
-        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         $shortName = $resourceMetadata->getShortName();
 
         if ($fieldConfiguration = $this->getResourceFieldConfiguration(null, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass), $resourceClass)) {

--- a/src/Bridge/Graphql/Type/SchemaBuilder.php
+++ b/src/Bridge/Graphql/Type/SchemaBuilder.php
@@ -29,7 +29,6 @@ use GraphQL\Type\Definition\Type as GraphQLType;
 use GraphQL\Type\Definition\WrappingType;
 use GraphQL\Type\Schema;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -67,9 +66,8 @@ final class SchemaBuilder implements SchemaBuilderInterface
     public function getSchema(): Schema
     {
         $queryFields = [];
-
-        foreach ($this->resourceNameCollectionFactory->create() as $resource) {
-            $queryFields += $this->getQueryFields($resource);
+        foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
+            $queryFields += $this->getQueryFields($resourceClass);
         }
 
         return new Schema([
@@ -83,44 +81,42 @@ final class SchemaBuilder implements SchemaBuilderInterface
     /**
      * Gets the query fields of the schema.
      */
-    private function getQueryFields(string $resource): array
+    private function getQueryFields(string $resourceClass): array
     {
         $queryFields = [];
-        $resourceMetadata = $this->resourceMetadataFactory->create($resource);
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         $shortName = $resourceMetadata->getShortName();
 
-        foreach ($this->getOperations($resourceMetadata, true, true) as $operationName => $queryItemOperation) {
-            $fieldNamePrefix = 'get' === $operationName ? '' : $operationName;
-            if ($fieldConfiguration = $this->getResourceFieldConfiguration(null, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resource), $resource, $operationName)) {
-                $fieldConfiguration['args'] += $this->getResourceIdentifiersArgumentsConfiguration($resource, $operationName);
-                $queryFields[lcfirst($fieldNamePrefix.$shortName)] = $fieldConfiguration;
-            }
+        if ($fieldConfiguration = $this->getResourceFieldConfiguration(null, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass), $resourceClass)) {
+            $fieldConfiguration['args'] += $this->getResourceIdentifiersArgumentsConfiguration($resourceClass);
+            $queryFields[lcfirst($shortName)] = $fieldConfiguration;
         }
 
-        foreach ($this->getOperations($resourceMetadata, true, false) as $operationName => $queryCollectionOperation) {
-            $fieldNamePrefix = 'get' === $operationName ? '' : $operationName;
-            if ($fieldConfiguration = $this->getResourceFieldConfiguration(null, new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, $resource)), $resource, $operationName)) {
-                $queryFields[lcfirst($fieldNamePrefix.Inflector::pluralize($shortName))] = $fieldConfiguration;
-            }
+        if ($fieldConfiguration = $this->getResourceFieldConfiguration(null, new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, $resourceClass)), $resourceClass)) {
+            $queryFields[lcfirst(Inflector::pluralize($shortName))] = $fieldConfiguration;
         }
 
         return $queryFields;
     }
 
     /**
-     * Get the field configuration of a resource.
+     * Gets the field configuration of a resource.
      *
      * @see http://webonyx.github.io/graphql-php/type-system/object-types/
      *
      * @return array|null
      */
-    private function getResourceFieldConfiguration(string $fieldDescription = null, Type $type, string $rootResource, string $operationName, bool $isInput = false)
+    private function getResourceFieldConfiguration(string $fieldDescription = null, Type $type, string $rootResource, bool $isInput = false)
     {
         try {
-            $graphqlType = $this->convertType($type, $operationName, $isInput);
+            $graphqlType = $this->convertType($type, $isInput);
             $graphqlWrappedType = $graphqlType instanceof WrappingType ? $graphqlType->getWrappedType() : $graphqlType;
             $isInternalGraphqlType = in_array($graphqlWrappedType, GraphQLType::getInternalTypes(), true);
-            $className = $isInternalGraphqlType ? '' : ($type->isCollection() ? $type->getCollectionValueType()->getClassName() : $type->getClassName());
+            if ($isInternalGraphqlType) {
+                $className = '';
+            } else {
+                $className = $type->isCollection() ? $type->getCollectionValueType()->getClassName() : $type->getClassName();
+            }
 
             $args = [];
             if ($this->paginationEnabled && !$isInternalGraphqlType && $type->isCollection() && !$isInput) {
@@ -139,7 +135,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
             if ($isInternalGraphqlType || $isInput) {
                 $resolve = null;
             } else {
-                $resolve = $type->isCollection() ? $this->collectionResolverFactory->createCollectionResolver($className, $rootResource, $operationName) : $this->itemResolverFactory->createItemResolver($className, $rootResource, $operationName);
+                $resolve = $type->isCollection() ? $this->collectionResolverFactory->createCollectionResolver($className, $rootResource) : $this->itemResolverFactory->createItemResolver($className, $rootResource);
             }
 
             return [
@@ -158,21 +154,21 @@ final class SchemaBuilder implements SchemaBuilderInterface
      *
      * @throws \LogicException
      */
-    private function getResourceIdentifiersArgumentsConfiguration(string $resource, string $operationName): array
+    private function getResourceIdentifiersArgumentsConfiguration(string $resourceClass): array
     {
         $arguments = [];
-        $identifiers = $this->identifiersExtractor->getIdentifiersFromResourceClass($resource);
+        $identifiers = $this->identifiersExtractor->getIdentifiersFromResourceClass($resourceClass);
         foreach ($identifiers as $identifier) {
-            $propertyMetadata = $this->propertyMetadataFactory->create($resource, $identifier);
+            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $identifier);
             $propertyType = $propertyMetadata->getType();
             if (null === $propertyType) {
                 continue;
             }
 
-            $arguments[$identifier] = $this->getResourceFieldConfiguration($propertyMetadata->getDescription(), $propertyType, $resource, $operationName, true);
+            $arguments[$identifier] = $this->getResourceFieldConfiguration($propertyMetadata->getDescription(), $propertyType, $resourceClass, true);
         }
         if (!$arguments) {
-            throw new \LogicException("Missing identifier field for resource \"$resource\".");
+            throw new \LogicException("Missing identifier field for resource \"$resourceClass\".");
         }
 
         return $arguments;
@@ -183,7 +179,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
      *
      * @throws InvalidTypeException
      */
-    private function convertType(Type $type, string $operationName, bool $isInput = false): GraphQLType
+    private function convertType(Type $type, bool $isInput = false): GraphQLType
     {
         switch ($type->getBuiltinType()) {
             case Type::BUILTIN_TYPE_BOOL:
@@ -211,7 +207,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
                     throw new InvalidTypeException();
                 }
 
-                $graphqlType = $this->getResourceObjectType($className, $resourceMetadata, $operationName, $isInput);
+                $graphqlType = $this->getResourceObjectType($className, $resourceMetadata, $isInput);
                 break;
             default:
                 throw new InvalidTypeException();
@@ -229,10 +225,9 @@ final class SchemaBuilder implements SchemaBuilderInterface
      *
      * @return ObjectType|InputObjectType
      */
-    private function getResourceObjectType(string $resource, ResourceMetadata $resourceMetadata, string $operationName, bool $isInput = false)
+    private function getResourceObjectType(string $resource, ResourceMetadata $resourceMetadata, bool $isInput = false)
     {
         $shortName = $resourceMetadata->getShortName().($isInput ? 'Input' : '');
-
         if (isset($this->resourceTypesCache[$shortName])) {
             return $this->resourceTypesCache[$shortName];
         }
@@ -240,8 +235,8 @@ final class SchemaBuilder implements SchemaBuilderInterface
         $configuration = [
             'name' => $shortName,
             'description' => $resourceMetadata->getDescription(),
-            'fields' => function () use ($resource, $operationName, $isInput) {
-                return $this->getResourceObjectTypeFields($resource, $operationName, $isInput);
+            'fields' => function () use ($resource, $isInput) {
+                return $this->getResourceObjectTypeFields($resource, $isInput);
             },
         ];
 
@@ -251,18 +246,16 @@ final class SchemaBuilder implements SchemaBuilderInterface
     /**
      * Gets the fields of the type of the given resource.
      */
-    private function getResourceObjectTypeFields(string $resource, string $operationName, bool $isInput = false): array
+    private function getResourceObjectTypeFields(string $resource, bool $isInput = false): array
     {
         $fields = [];
-
         foreach ($this->propertyNameCollectionFactory->create($resource) as $property) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resource, $property);
-            if (null === ($propertyType = $propertyMetadata->getType())
-                || !$propertyMetadata->isReadable()) {
+            if (null === ($propertyType = $propertyMetadata->getType()) || !$propertyMetadata->isReadable()) {
                 continue;
             }
 
-            if ($fieldConfiguration = $this->getResourceFieldConfiguration($propertyMetadata->getDescription(), $propertyType, $resource, $operationName, $isInput)) {
+            if ($fieldConfiguration = $this->getResourceFieldConfiguration($propertyMetadata->getDescription(), $propertyType, $resource, $isInput)) {
                 $fields[$property] = $fieldConfiguration;
             }
         }
@@ -286,7 +279,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
         }
 
         $edgeObjectTypeConfiguration = [
-            'name' => $shortName.'Edge',
+            'name' => "{$shortName}Edge",
             'description' => "Edge of $shortName.",
             'fields' => [
                 'node' => $resourceType,
@@ -295,7 +288,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
         ];
         $edgeObjectType = $isInput ? new InputObjectType($edgeObjectTypeConfiguration) : new ObjectType($edgeObjectTypeConfiguration);
         $pageInfoObjectTypeConfiguration = [
-            'name' => $shortName.'PageInfo',
+            'name' => "{$shortName}PageInfo",
             'description' => 'Information about the current page.',
             'fields' => [
                 'endCursor' => GraphQLType::string(),
@@ -305,7 +298,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
         $pageInfoObjectType = $isInput ? new InputObjectType($pageInfoObjectTypeConfiguration) : new ObjectType($pageInfoObjectTypeConfiguration);
 
         $configuration = [
-            'name' => $shortName.'Connection',
+            'name' => "{$shortName}Connection",
             'description' => "Connection for $shortName.",
             'fields' => [
                 'edges' => GraphQLType::listOf($edgeObjectType),
@@ -313,29 +306,6 @@ final class SchemaBuilder implements SchemaBuilderInterface
             ],
         ];
 
-        return $this->resourceTypesCache[$shortName.'Connection'] = $isInput ? new InputObjectType($configuration) : new ObjectType($configuration);
-    }
-
-    /**
-     * Get the available operations for a resource.
-     */
-    private function getOperations(ResourceMetadata $resourceMetadata, bool $isQuery, bool $isItem): \Traversable
-    {
-        $operations = $isItem ? $resourceMetadata->getItemOperations() : $resourceMetadata->getCollectionOperations();
-        if (null === $operations) {
-            return yield from [];
-        }
-
-        foreach ($operations as $operationName => $operation) {
-            if (isset($operation['controller']) || !isset($operation['method'])) {
-                continue;
-            }
-
-            if ($isQuery && Request::METHOD_GET !== $operation['method'] || !$isQuery && Request::METHOD_GET === $operation['method']) {
-                continue;
-            }
-
-            yield $operationName => $operation;
-        }
+        return $this->resourceTypesCache["{$shortName}Connection"] = $isInput ? new InputObjectType($configuration) : new ObjectType($configuration);
     }
 }

--- a/src/DataProvider/SubresourceDataProviderInterface.php
+++ b/src/DataProvider/SubresourceDataProviderInterface.php
@@ -27,7 +27,7 @@ interface SubresourceDataProviderInterface
      *
      * @param string $resourceClass The root resource class
      * @param array  $identifiers   Identifiers and their values
-     * @param array  $context       The context indicate the conjuction between collection properties (identifiers) and their class
+     * @param array  $context       The context indicates the conjunction between collection properties (identifiers) and their class
      * @param string $operationName
      *
      * @throws ResourceClassNotSupportedException

--- a/src/Metadata/Extractor/AbstractExtractor.php
+++ b/src/Metadata/Extractor/AbstractExtractor.php
@@ -50,8 +50,6 @@ abstract class AbstractExtractor implements ExtractorInterface
 
     /**
      * Extracts metadata from a given path.
-     *
-     * @param string $path
      */
     abstract protected function extractPath(string $path);
 }

--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -68,6 +68,7 @@ final class YamlExtractor extends AbstractExtractor
                 'itemOperations' => $resourceYaml['itemOperations'] ?? null,
                 'collectionOperations' => $resourceYaml['collectionOperations'] ?? null,
                 'subresourceOperations' => $resourceYaml['subresourceOperations'] ?? null,
+                'graphql' => $resourceYaml['graphql'] ?? null,
                 'attributes' => $resourceYaml['attributes'] ?? null,
             ];
 

--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -65,12 +65,7 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
     /**
      * Returns the metadata from the decorated factory if available or throws an exception.
      *
-     * @param ResourceMetadata|null $parentPropertyMetadata
-     * @param string                $resourceClass
-     *
      * @throws ResourceClassNotFoundException
-     *
-     * @return ResourceMetadata
      */
     private function handleNotFound(ResourceMetadata $parentPropertyMetadata = null, string $resourceClass): ResourceMetadata
     {
@@ -91,12 +86,13 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
                 $annotation->itemOperations,
                 $annotation->collectionOperations,
                 $annotation->attributes,
-                $annotation->subresourceOperations
+                $annotation->subresourceOperations,
+                $annotation->graphql
             );
         }
 
         $resourceMetadata = $parentResourceMetadata;
-        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'attributes'] as $property) {
+        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'graphql', 'attributes'] as $property) {
             $resourceMetadata = $this->createWith($resourceMetadata, $property, $annotation->$property);
         }
 
@@ -106,21 +102,18 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
     /**
      * Creates a new instance of metadata if the property is not already set.
      *
-     * @param ResourceMetadata $resourceMetadata
-     * @param string           $property
-     * @param mixed            $value
-     *
-     * @return ResourceMetadata
+     * @param mixed $value
      */
     private function createWith(ResourceMetadata $resourceMetadata, string $property, $value): ResourceMetadata
     {
-        $getter = 'get'.ucfirst($property);
+        $upperProperty = ucfirst($property);
+        $getter = "get$upperProperty";
 
         if (null !== $resourceMetadata->$getter()) {
             return $resourceMetadata;
         }
 
-        $wither = 'with'.ucfirst($property);
+        $wither = "with$upperProperty";
 
         return $resourceMetadata->$wither($value);
     }

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
@@ -84,7 +84,7 @@ final class ExtractorResourceMetadataFactory implements ResourceMetadataFactoryI
      */
     private function update(ResourceMetadata $resourceMetadata, array $metadata): ResourceMetadata
     {
-        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'attributes'] as $property) {
+        foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'graphql', 'attributes'] as $property) {
             if (null === $metadata[$property] || null !== $resourceMetadata->{'get'.ucfirst($property)}()) {
                 continue;
             }

--- a/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
@@ -82,6 +82,13 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
             $resourceMetadata = $this->normalize(false, $resourceMetadata, $itemOperations);
         }
 
+        $graphql = $resourceMetadata->getGraphql();
+        if (null === $graphql) {
+            $resourceMetadata = $resourceMetadata->withGraphql(['query' => []]);
+        } else {
+            $resourceMetadata = $this->normalizeGraphQl($resourceMetadata, $graphql);
+        }
+
         return $resourceMetadata;
     }
 
@@ -120,5 +127,17 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
         }
 
         return $collection ? $resourceMetadata->withCollectionOperations($newOperations) : $resourceMetadata->withItemOperations($newOperations);
+    }
+
+    private function normalizeGraphQl(ResourceMetadata $resourceMetadata, array $operations)
+    {
+        foreach ($operations as $operationName => $operation) {
+            if (is_int($operationName) && is_string($operation)) {
+                unset($operations[$operationName]);
+                $operations[$operation] = [];
+            }
+        }
+
+        return $resourceMetadata->withGraphql($operations);
     }
 }

--- a/src/Metadata/Resource/ResourceMetadata.php
+++ b/src/Metadata/Resource/ResourceMetadata.php
@@ -26,9 +26,10 @@ final class ResourceMetadata
     private $itemOperations;
     private $collectionOperations;
     private $subresourceOperations;
+    private $graphql;
     private $attributes;
 
-    public function __construct(string $shortName = null, string $description = null, string $iri = null, array $itemOperations = null, array $collectionOperations = null, array $attributes = null, array $subresourceOperations = null)
+    public function __construct(string $shortName = null, string $description = null, string $iri = null, array $itemOperations = null, array $collectionOperations = null, array $attributes = null, array $subresourceOperations = null, array $graphql = null)
     {
         $this->shortName = $shortName;
         $this->description = $description;
@@ -36,6 +37,7 @@ final class ResourceMetadata
         $this->itemOperations = $itemOperations;
         $this->collectionOperations = $collectionOperations;
         $this->subresourceOperations = $subresourceOperations;
+        $this->graphql = $graphql;
         $this->attributes = $attributes;
     }
 
@@ -222,6 +224,22 @@ final class ResourceMetadata
     }
 
     /**
+     * @return mixed
+     */
+    public function getGraphqlAttribute(string $operationName, string $key, $defaultValue = null, bool $resourceFallback = false)
+    {
+        if (isset($this->graphql[$operationName][$key])) {
+            return $this->graphql[$operationName][$key];
+        }
+
+        if ($resourceFallback && isset($this->attributes[$key])) {
+            return $this->attributes[$key];
+        }
+
+        return $defaultValue;
+    }
+
+    /**
      * Gets attributes.
      *
      * @return array|null
@@ -254,6 +272,27 @@ final class ResourceMetadata
     {
         $metadata = clone $this;
         $metadata->attributes = $attributes;
+
+        return $metadata;
+    }
+
+    /**
+     * Gets options of for the GraphQL query.
+     *
+     * @return array|null
+     */
+    public function getGraphql()
+    {
+        return $this->graphql;
+    }
+
+    /**
+     * Returns a new instance with the given GraphQL options.
+     */
+    public function withGraphql(array $graphql): self
+    {
+        $metadata = clone $this;
+        $metadata->graphql = $graphql;
 
         return $metadata;
     }

--- a/src/Metadata/schema/metadata.xsd
+++ b/src/Metadata/schema/metadata.xsd
@@ -23,6 +23,7 @@
                 <xsd:element name="itemOperations" minOccurs="0" maxOccurs="unbounded" type="itemOperations"/>
                 <xsd:element name="collectionOperations" minOccurs="0" maxOccurs="unbounded" type="collectionOperations"/>
                 <xsd:element name="subresourceOperations" minOccurs="0" maxOccurs="unbounded" type="subresourceOperations"/>
+                <xsd:element name="graphql" minOccurs="0" type="graphql"/>
             </xsd:sequence>
 
             <xsd:attribute type="xsd:string" name="class" use="required"/>
@@ -38,8 +39,8 @@
     </xsd:complexType>
 
     <xsd:complexType name="itemOperation">
-        <xsd:sequence minOccurs="1" maxOccurs="unbounded">
-            <xsd:element name="attribute" minOccurs="1" maxOccurs="unbounded" type="attribute"/>
+        <xsd:sequence maxOccurs="unbounded">
+            <xsd:element name="attribute" maxOccurs="unbounded" type="attribute"/>
         </xsd:sequence>
         <xsd:attribute type="xsd:string" name="name"/>
     </xsd:complexType>
@@ -51,8 +52,21 @@
     </xsd:complexType>
 
     <xsd:complexType name="collectionOperation">
-        <xsd:sequence minOccurs="1" maxOccurs="unbounded">
-            <xsd:element name="attribute" minOccurs="1" maxOccurs="unbounded" type="attribute"/>
+        <xsd:sequence maxOccurs="unbounded">
+            <xsd:element name="attribute" maxOccurs="unbounded" type="attribute"/>
+        </xsd:sequence>
+        <xsd:attribute type="xsd:string" name="name"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="graphql">
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="operation" minOccurs="0" maxOccurs="unbounded" type="operation"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="operation">
+        <xsd:sequence maxOccurs="unbounded">
+            <xsd:element name="attribute" maxOccurs="unbounded" type="attribute"/>
         </xsd:sequence>
         <xsd:attribute type="xsd:string" name="name"/>
     </xsd:complexType>

--- a/tests/Annotation/AnnotatedClass.php
+++ b/tests/Annotation/AnnotatedClass.php
@@ -22,6 +22,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *     iri="http://example.com/res",
  *     itemOperations={"foo":{"bar"}},
  *     collectionOperations={"bar":{"foo"}},
+ *     graphql={"query"={"normalization_context"={"groups"={"foo", "bar"}}}},
  *     attributes={"foo":"bar"}
  * )
  *

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -30,13 +30,15 @@ class ApiResourceTest extends TestCase
         $resource->iri = 'http://example.com/res';
         $resource->itemOperations = ['foo' => ['bar']];
         $resource->collectionOperations = ['bar' => ['foo']];
+        $resource->graphql = ['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]];
         $resource->attributes = ['foo' => 'bar'];
 
-        $this->assertEquals('shortName', $resource->shortName);
-        $this->assertEquals('description', $resource->description);
-        $this->assertEquals('http://example.com/res', $resource->iri);
-        $this->assertEquals(['bar' => ['foo']], $resource->collectionOperations);
-        $this->assertEquals(['foo' => 'bar'], $resource->attributes);
+        $this->assertSame('shortName', $resource->shortName);
+        $this->assertSame('description', $resource->description);
+        $this->assertSame('http://example.com/res', $resource->iri);
+        $this->assertSame(['bar' => ['foo']], $resource->collectionOperations);
+        $this->assertSame(['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]], $resource->graphql);
+        $this->assertSame(['foo' => 'bar'], $resource->attributes);
     }
 
     public function testApiResourceAnnotation()
@@ -44,10 +46,11 @@ class ApiResourceTest extends TestCase
         $reader = new AnnotationReader();
         $resource = $reader->getClassAnnotation(new \ReflectionClass(AnnotatedClass::class), ApiResource::class);
 
-        $this->assertEquals('shortName', $resource->shortName);
-        $this->assertEquals('description', $resource->description);
-        $this->assertEquals('http://example.com/res', $resource->iri);
-        $this->assertEquals(['bar' => ['foo']], $resource->collectionOperations);
-        $this->assertEquals(['foo' => 'bar'], $resource->attributes);
+        $this->assertSame('shortName', $resource->shortName);
+        $this->assertSame('description', $resource->description);
+        $this->assertSame('http://example.com/res', $resource->iri);
+        $this->assertSame(['bar' => ['foo']], $resource->collectionOperations);
+        $this->assertSame(['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]], $resource->graphql);
+        $this->assertSame(['foo' => 'bar'], $resource->attributes);
     }
 }

--- a/tests/Bridge/Graphql/Resolver/CollectionResolverFactoryTest.php
+++ b/tests/Bridge/Graphql/Resolver/CollectionResolverFactoryTest.php
@@ -54,7 +54,7 @@ class CollectionResolverFactoryTest extends TestCase
             'Object2',
         ], [], [], false);
 
-        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';
@@ -72,7 +72,7 @@ class CollectionResolverFactoryTest extends TestCase
             'Object2',
         ], $subresource, ['rootIdentifier' => 'valueRootIdentifier'], false);
 
-        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('subresourceClass', 'rootClass', 'foo');
+        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('subresourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';
@@ -90,7 +90,7 @@ class CollectionResolverFactoryTest extends TestCase
             'Object2',
         ], [], [], true);
 
-        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';
@@ -125,7 +125,7 @@ class CollectionResolverFactoryTest extends TestCase
 
         $mockedCollectionResolverFactory = $this->mockCollectionResolverFactory($collectionPaginatorProphecy->reveal(), [], [], true);
 
-        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';

--- a/tests/Bridge/Graphql/Resolver/CollectionResolverFactoryTest.php
+++ b/tests/Bridge/Graphql/Resolver/CollectionResolverFactoryTest.php
@@ -39,7 +39,7 @@ class CollectionResolverFactoryTest extends TestCase
     {
         $mockedCollectionResolverFactory = $this->mockCollectionResolverFactory([], [], [], $paginationEnabled);
 
-        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedCollectionResolverFactory->createCollectionResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';

--- a/tests/Bridge/Graphql/Resolver/ItemResolverFactoryTest.php
+++ b/tests/Bridge/Graphql/Resolver/ItemResolverFactoryTest.php
@@ -33,7 +33,7 @@ class ItemResolverFactoryTest extends TestCase
     {
         $mockedItemResolverFactory = $this->mockItemResolverFactory(null, null, [], null);
 
-        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';
@@ -45,7 +45,7 @@ class ItemResolverFactoryTest extends TestCase
     {
         $mockedItemResolverFactory = $this->mockItemResolverFactory('Item1', null, ['id' => 3], 3);
 
-        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';
@@ -57,7 +57,7 @@ class ItemResolverFactoryTest extends TestCase
     {
         $mockedItemResolverFactory = $this->mockItemResolverFactory('Item1', null, ['relation1' => 1, 'relation2' => 2], 'relation1=1;relation2=2');
 
-        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';
@@ -73,7 +73,7 @@ class ItemResolverFactoryTest extends TestCase
     {
         $mockedItemResolverFactory = $this->mockItemResolverFactory('Item1', null, ['relation1' => ['link1' => 1, 'link2' => 3], 'relation2' => 2], null);
 
-        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass', 'foo');
+        $resolver = $mockedItemResolverFactory->createItemResolver('resourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';
@@ -88,7 +88,7 @@ class ItemResolverFactoryTest extends TestCase
     {
         $mockedItemResolverFactory = $this->mockItemResolverFactory('Item1', $subresource, ['rootIdentifier' => 'valueRootIdentifier'], null);
 
-        $resolver = $mockedItemResolverFactory->createItemResolver('subresourceClass', 'rootClass', 'foo');
+        $resolver = $mockedItemResolverFactory->createItemResolver('subresourceClass', 'rootClass');
 
         $resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
         $resolveInfoProphecy->fieldName = 'rootProperty';

--- a/tests/Bridge/Graphql/Type/SchemaBuilderTest.php
+++ b/tests/Bridge/Graphql/Type/SchemaBuilderTest.php
@@ -50,13 +50,34 @@ class SchemaBuilderTest extends TestCase
         $mockedSchemaBuilder->getSchema();
     }
 
-    public function testGetSchemaNullOperation()
+    public function testGetSchemaAllFields()
     {
-        $propertyMetadataMockBuilder = function () {
-            return new PropertyMetadata();
+        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
+            return new PropertyMetadata(
+                new Type(
+                    $builtinType,
+                    false,
+                    'GraphqlResource3' === $resourceClassName ? 'unknownResource' : $resourceClassName
+                ),
+                "{$builtinType}Description",
+                null,
+                null,
+                null,
+                null,
+                null,
+                Type::BUILTIN_TYPE_INT === $builtinType
+            );
         };
-        $mockedSchemaBuilder = $this->mockSchemaBuilder($propertyMetadataMockBuilder, false, true);
-        $this->assertEquals([], $mockedSchemaBuilder->getSchema()->getConfig()->getQuery()->getFields());
+
+        $mockedSchemaBuilder = $this->mockSchemaBuilder($propertyMetadataMockBuilder, false);
+        $this->assertEquals([
+            'shortName1',
+            'shortName1s',
+            'shortName2',
+            'shortName2s',
+            'shortName3',
+            'shortName3s',
+        ], array_keys($mockedSchemaBuilder->getSchema()->getConfig()->getQuery()->getFields()));
     }
 
     public function testGetSchemaResourceClassNotFound()
@@ -66,9 +87,9 @@ class SchemaBuilderTest extends TestCase
                 new Type(
                     $builtinType,
                     false,
-                    'item3' === $resourceClassName ? 'unknownResource' : $resourceClassName
+                    'GraphqlResource3' === $resourceClassName ? 'unknownResource' : $resourceClassName
                 ),
-                $builtinType.'Description',
+                "{$builtinType}Description",
                 null,
                 null,
                 null,
@@ -83,26 +104,26 @@ class SchemaBuilderTest extends TestCase
 
         // objectProperty has been skipped.
         /** @var ObjectType $type */
-        $type = $queryFields['itemShortName3']->getType();
-        $this->assertArrayNotHasKey('objectProperty', array_keys($type->getFields()));
+        $type = $queryFields['shortName3']->getType();
+        $this->assertArrayNotHasKey('objectProperty', $type->getFields());
     }
 
     /**
      * @dataProvider paginationProvider
      */
-    public function testGetSchema($paginationEnabled, $expected)
+    public function testGetSchema($paginationEnabled)
     {
         $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
             return new PropertyMetadata(
                 new Type(
                     $builtinType,
                     false,
-                    'item3' === $resourceClassName ? \DateTime::class : $resourceClassName,
-                    Type::BUILTIN_TYPE_OBJECT === $builtinType && 'item3' !== $resourceClassName,
+                    'GraphqlResource3' === $resourceClassName ? \DateTime::class : $resourceClassName,
+                    Type::BUILTIN_TYPE_OBJECT === $builtinType && 'GraphqlResource3' !== $resourceClassName,
                     null,
                     Type::BUILTIN_TYPE_OBJECT === $builtinType ? new Type(Type::BUILTIN_TYPE_STRING, false, $resourceClassName) : null
                 ),
-                $builtinType.'Description',
+                "{$builtinType}Description",
                 true,
                 null,
                 null,
@@ -115,22 +136,16 @@ class SchemaBuilderTest extends TestCase
         $queryFields = $schema->getConfig()->getQuery()->getFields();
 
         $this->assertEquals([
-            'itemShortName1',
-            'itemShortName1s',
-            'itemShortName2',
-            'itemShortName2s',
-            'itemShortName3',
-            'itemShortName3s',
-            'collectionShortName1',
-            'collectionShortName1s',
-            'collectionShortName2',
-            'collectionShortName2s',
-            'collectionShortName3',
-            'collectionShortName3s',
+            'shortName1',
+            'shortName1s',
+            'shortName2',
+            'shortName2s',
+            'shortName3',
+            'shortName3s',
         ], array_keys($queryFields));
 
         /** @var ObjectType $type */
-        $type = $queryFields['itemShortName2']->getType();
+        $type = $queryFields['shortName2']->getType();
         $resourceTypeFields = $type->getFields();
         $this->assertEquals(
             ['intProperty', 'floatProperty', 'stringProperty', 'boolProperty', 'objectProperty'],
@@ -139,15 +154,15 @@ class SchemaBuilderTest extends TestCase
 
         // Types are equal because of the cache.
         /** @var ObjectType $type */
-        $type = $queryFields['collectionShortName1']->getType();
+        $type = $queryFields['shortName1']->getType();
         if ($paginationEnabled) {
             /** @var ObjectType $objectPropertyFieldType */
             $objectPropertyFieldType = $type->getFields()['objectProperty']->getType();
-            $this->assertEquals($objectPropertyFieldType->name, 'collectionShortName1Connection');
+            $this->assertEquals($objectPropertyFieldType->name, 'ShortName1Connection');
             /** @var ListOfType $edgesType */
             $edgesType = $objectPropertyFieldType->getFields()['edges']->getType();
             $edgeType = $edgesType->getWrappedType();
-            $this->assertEquals($edgeType->name, 'collectionShortName1Edge');
+            $this->assertEquals($edgeType->name, 'ShortName1Edge');
             $this->assertEquals($edgeType->getFields()['cursor']->getType(), GraphQLType::nonNull(GraphQLType::string()));
             $this->assertEquals(
                 $type,
@@ -164,7 +179,7 @@ class SchemaBuilderTest extends TestCase
 
         // DateTime is considered as a string instead of an object.
         /** @var ObjectType $type */
-        $type = $queryFields['itemShortName3']->getType();
+        $type = $queryFields['shortName3']->getType();
         /** @var ListOfType $objectPropertyFieldType */
         $objectPropertyFieldType = $type->getFields()['objectProperty']->getType();
         $this->assertEquals(GraphQLType::nonNull(GraphQLType::string()), $objectPropertyFieldType);
@@ -172,10 +187,13 @@ class SchemaBuilderTest extends TestCase
 
     public function paginationProvider()
     {
-        return [[true, null], [false, null]];
+        return [
+            [true],
+            [false],
+        ];
     }
 
-    private function mockSchemaBuilder($propertyMetadataMockBuilder, bool $paginationEnabled, bool $nullOperation = false): SchemaBuilder
+    private function mockSchemaBuilder($propertyMetadataMockBuilder, bool $paginationEnabled): SchemaBuilder
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
@@ -186,41 +204,26 @@ class SchemaBuilderTest extends TestCase
         $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
 
         $resourceClassNames = [];
-        $resourceTypes = ['item', 'collection'];
-        foreach ($resourceTypes as $resourceType) {
-            for ($i = 1; $i <= 3; ++$i) {
-                $resourceClassName = $resourceType.$i;
-                $resourceClassNames[] = $resourceClassName;
-                $resourceMetadata = new ResourceMetadata(
-                    $resourceType.'ShortName'.$i,
-                    $resourceType.'Description'.$i,
-                    null,
-                    $nullOperation ? null : [
-                        'get' => ['method' => 'GET'],
-                        'post' => ['method' => 'POST'],
-                        'op' => ['method' => 'GET', 'controller' => 'controller.name'],
-                    ],
-                    $nullOperation ? null : [
-                        'get' => ['method' => 'GET'],
-                        'post' => ['method' => 'POST'],
-                        'op' => ['method' => 'GET', 'controller' => 'controller.name'],
-                    ]
-                );
-                $resourceMetadataFactoryProphecy->create($resourceClassName)->willReturn($resourceMetadata);
-                $resourceMetadataFactoryProphecy->create('unknownResource')->willThrow(new ResourceClassNotFoundException());
+        for ($i = 1; $i <= 3; ++$i) {
+            $resourceClassName = "GraphqlResource$i";
+            $resourceClassNames[] = $resourceClassName;
+            $resourceMetadata = new ResourceMetadata(
+                "ShortName$i",
+                "Description$i"
+            );
+            $resourceMetadataFactoryProphecy->create($resourceClassName)->willReturn($resourceMetadata);
+            $resourceMetadataFactoryProphecy->create('unknownResource')->willThrow(new ResourceClassNotFoundException());
 
-                $propertyNames = [];
-                foreach (Type::$builtinTypes as $builtinType) {
-                    $propertyName = $builtinType.'Property';
-                    $propertyNames[] = $propertyName;
-                    $propertyMetadata = $propertyMetadataMockBuilder($builtinType, $resourceClassName);
-                    $propertyMetadataFactoryProphecy->create($resourceClassName, $propertyName)->willReturn($propertyMetadata);
-                }
-                $propertyNameCollection = new PropertyNameCollection($propertyNames);
-                $propertyNameCollectionFactoryProphecy->create($resourceClassName)->willReturn($propertyNameCollection);
-
-                $identifiersExtractorProphecy->getIdentifiersFromResourceClass($resourceClassName)->willReturn(['intProperty']);
+            $propertyNames = [];
+            foreach (Type::$builtinTypes as $builtinType) {
+                $propertyName = "{$builtinType}Property";
+                $propertyNames[] = $propertyName;
+                $propertyMetadataFactoryProphecy->create($resourceClassName, $propertyName)->willReturn($propertyMetadataMockBuilder($builtinType, $resourceClassName));
             }
+            $propertyNameCollection = new PropertyNameCollection($propertyNames);
+            $propertyNameCollectionFactoryProphecy->create($resourceClassName)->willReturn($propertyNameCollection);
+
+            $identifiersExtractorProphecy->getIdentifiersFromResourceClass($resourceClassName)->willReturn(['intProperty']);
         }
         $resourceNameCollection = new ResourceNameCollection($resourceClassNames);
         $resourceNameCollectionFactoryProphecy->create()->willReturn($resourceNameCollection);

--- a/tests/Bridge/Graphql/Type/SchemaBuilderTest.php
+++ b/tests/Bridge/Graphql/Type/SchemaBuilderTest.php
@@ -209,7 +209,13 @@ class SchemaBuilderTest extends TestCase
             $resourceClassNames[] = $resourceClassName;
             $resourceMetadata = new ResourceMetadata(
                 "ShortName$i",
-                "Description$i"
+                "Description$i",
+                null,
+                null,
+                null,
+                null,
+                null,
+                ['query' => []]
             );
             $resourceMetadataFactoryProphecy->create($resourceClassName)->willReturn($resourceMetadata);
             $resourceMetadataFactoryProphecy->create('unknownResource')->willThrow(new ResourceClassNotFoundException());

--- a/tests/Fixtures/FileConfigurations/resources.xml
+++ b/tests/Fixtures/FileConfigurations/resources.xml
@@ -30,6 +30,15 @@
                 <attribute name="path">the/subresource/path</attribute>
             </subresourceOperation>
         </subresourceOperations>
+        <graphql>
+            <operation name="query">
+                <attribute name="normalization_context">
+                    <attribute name="groups">
+                        <attribute>graphql</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+        </graphql>
         <attribute name="normalization_context">
             <attribute name="groups">
                 <attribute>default</attribute>

--- a/tests/Fixtures/FileConfigurations/resources.yml
+++ b/tests/Fixtures/FileConfigurations/resources.yml
@@ -15,6 +15,10 @@ resources:
         subresourceOperations:
             my_collection_subresource:
                 path: 'the/subresource/path'
+        graphql:
+            query:
+                normalization_context:
+                    groups: ['graphql']
         attributes:
             normalization_context:
                 groups: ['default']

--- a/tests/Fixtures/FileConfigurations/single_resource.yml
+++ b/tests/Fixtures/FileConfigurations/single_resource.yml
@@ -13,6 +13,10 @@
     subresourceOperations:
         my_collection_subresource:
             path: 'the/subresource/path'
+    graphql:
+        query:
+            normalization_context:
+                groups: ['graphql']
     attributes:
         normalization_context:
             groups: ['default']

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -32,7 +32,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
     /**
      * @dataProvider getCreateDependencies
      */
-    public function testCreate(ProphecyInterface $reader, ProphecyInterface $decorated = null, $expectedShortName, $expectedDescription)
+    public function testCreate(ProphecyInterface $reader, ProphecyInterface $decorated = null, string $expectedShortName, string $expectedDescription)
     {
         $factory = new AnnotationResourceMetadataFactory($reader->reveal(), $decorated ? $decorated->reveal() : null);
         $metadata = $factory->create(Dummy::class);
@@ -44,6 +44,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $this->assertEquals(['baz' => ['tab' => false]], $metadata->getCollectionOperations());
         $this->assertEquals(['sub' => ['bus' => false]], $metadata->getSubresourceOperations());
         $this->assertEquals(['a' => 1], $metadata->getAttributes());
+        $this->assertEquals(['foo' => 'bar'], $metadata->getGraphql());
     }
 
     public function getCreateDependencies()
@@ -56,6 +57,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $annotation->collectionOperations = ['baz' => ['tab' => false]];
         $annotation->subresourceOperations = ['sub' => ['bus' => false]];
         $annotation->attributes = ['a' => 1];
+        $annotation->graphql = ['foo' => 'bar'];
 
         $reader = $this->prophesize(Reader::class);
         $reader->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotation)->shouldBeCalled();

--- a/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -41,6 +41,13 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
             'subresourceOperations' => [
                 'my_collection_subresource' => ['path' => 'the/subresource/path'],
             ],
+            'graphql' => [
+                'query' => [
+                    'normalization_context' => [
+                        AbstractNormalizer::GROUPS => ['graphql'],
+                    ],
+                ],
+            ],
             'iri' => 'someirischema',
             'attributes' => [
                 'normalization_context' => [
@@ -56,7 +63,7 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
             ],
         ];
 
-        foreach (['shortName', 'description', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'iri', 'attributes'] as $property) {
+        foreach (['shortName', 'description', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'graphql', 'iri', 'attributes'] as $property) {
             $wither = 'with'.ucfirst($property);
             $resourceMetadata = $resourceMetadata->$wither($metadata[$property]);
         }

--- a/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
@@ -41,19 +41,19 @@ class OperationResourceMetadataFactoryTest extends TestCase
 
         return [
             // Item operations
-            [new ResourceMetadata(null, null, null, null, []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT'], 'delete' => ['method' => 'DELETE']], [])],
-            [new ResourceMetadata(null, null, null, null, []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT'], 'patch' => ['method' => 'PATCH'], 'delete' => ['method' => 'DELETE']], []), $jsonapi],
-            [new ResourceMetadata(null, null, null, ['get'], []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET']], [])],
-            [new ResourceMetadata(null, null, null, ['put'], []), new ResourceMetadata(null, null, null, ['put' => ['method' => 'PUT']], [])],
-            [new ResourceMetadata(null, null, null, ['delete'], []), new ResourceMetadata(null, null, null, ['delete' => ['method' => 'DELETE']], [])],
-            [new ResourceMetadata(null, null, null, ['patch'], []), new ResourceMetadata(null, null, null, ['patch' => []], [])],
-            [new ResourceMetadata(null, null, null, ['patch'], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH']], []), $jsonapi],
+            [new ResourceMetadata(null, null, null, null, [], null, [], []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT'], 'delete' => ['method' => 'DELETE']], [], null, [], [])],
+            [new ResourceMetadata(null, null, null, null, [], null, [], []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT'], 'patch' => ['method' => 'PATCH'], 'delete' => ['method' => 'DELETE']], [], null, [], []), $jsonapi],
+            [new ResourceMetadata(null, null, null, ['get'], [], null, [], []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET']], [], null, [], [])],
+            [new ResourceMetadata(null, null, null, ['put'], [], null, [], []), new ResourceMetadata(null, null, null, ['put' => ['method' => 'PUT']], [], null, [], [])],
+            [new ResourceMetadata(null, null, null, ['delete'], [], null, [], []), new ResourceMetadata(null, null, null, ['delete' => ['method' => 'DELETE']], [], null, [], [])],
+            [new ResourceMetadata(null, null, null, ['patch'], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => []], [], null, [], [])],
+            [new ResourceMetadata(null, null, null, ['patch'], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH']], [], null, [], []), $jsonapi],
 
             // Collection operations
-            [new ResourceMetadata(null, null, null, []), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']])],
-            [new ResourceMetadata(null, null, null, [], ['get']), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET']])],
-            [new ResourceMetadata(null, null, null, [], ['post']), new ResourceMetadata(null, null, null, [], ['post' => ['method' => 'POST']])],
-            [new ResourceMetadata(null, null, null, [], ['options']), new ResourceMetadata(null, null, null, [], ['options' => []])],
+            [new ResourceMetadata(null, null, null, [], null, null, [], []), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']], null, [], [])],
+            [new ResourceMetadata(null, null, null, [], ['get'], null, [], []), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET']], null, [], [])],
+            [new ResourceMetadata(null, null, null, [], ['post'], null, [], []), new ResourceMetadata(null, null, null, [], ['post' => ['method' => 'POST']], null, [], [])],
+            [new ResourceMetadata(null, null, null, [], ['options'], null, [], []), new ResourceMetadata(null, null, null, [], ['options' => []], null, [], [])],
         ];
     }
 }

--- a/tests/Metadata/Resource/ResourceMetadataTest.php
+++ b/tests/Metadata/Resource/ResourceMetadataTest.php
@@ -23,52 +23,71 @@ class ResourceMetadataTest extends TestCase
 {
     public function testValueObject()
     {
-        $metadata = new ResourceMetadata('shortName', 'desc', 'http://example.com/foo', ['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], ['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], ['baz' => 'bar'], ['sop1' => ['sub' => 'bus']]);
-        $this->assertEquals('shortName', $metadata->getShortName());
-        $this->assertEquals('desc', $metadata->getDescription());
-        $this->assertEquals('http://example.com/foo', $metadata->getIri());
-        $this->assertEquals(['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], $metadata->getItemOperations());
-        $this->assertEquals('a', $metadata->getItemOperationAttribute('iop1', 'foo', 'z', false));
-        $this->assertEquals('bar', $metadata->getItemOperationAttribute('iop1', 'baz', 'z', true));
-        $this->assertEquals('bar', $metadata->getItemOperationAttribute(null, 'baz', 'z', true));
-        $this->assertEquals('z', $metadata->getItemOperationAttribute('iop1', 'notExist', 'z', true));
-        $this->assertEquals('z', $metadata->getItemOperationAttribute('notExist', 'notExist', 'z', true));
-        $this->assertEquals(['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], $metadata->getCollectionOperations());
-        $this->assertEquals('c', $metadata->getCollectionOperationAttribute('cop1', 'foo', 'z', false));
-        $this->assertEquals('bar', $metadata->getCollectionOperationAttribute('cop1', 'baz', 'z', true));
-        $this->assertEquals('bar', $metadata->getCollectionOperationAttribute(null, 'baz', 'z', true));
-        $this->assertEquals('z', $metadata->getCollectionOperationAttribute('cop1', 'notExist', 'z', true));
-        $this->assertEquals('z', $metadata->getCollectionOperationAttribute('notExist', 'notExist', 'z', true));
-        $this->assertEquals(['baz' => 'bar'], $metadata->getAttributes());
-        $this->assertEquals('bar', $metadata->getAttribute('baz'));
-        $this->assertEquals('z', $metadata->getAttribute('notExist', 'z'));
-        $this->assertEquals(['sop1' => ['sub' => 'bus']], $metadata->getSubresourceOperations());
-        $this->assertEquals('bus', $metadata->getSubresourceOperationAttribute('sop1', 'sub'));
-        $this->assertEquals('sub', $metadata->getSubresourceOperationAttribute('sop1', 'bus', 'sub', false));
-        $this->assertEquals('bar', $metadata->getSubresourceOperationAttribute('sop1', 'baz', 'sub', true));
+        $metadata = new ResourceMetadata('shortName', 'desc', 'http://example.com/foo', ['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], ['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], ['baz' => 'bar'], ['sop1' => ['sub' => 'bus']], ['query' => ['foo' => 'graphql']]);
+        $this->assertSame('shortName', $metadata->getShortName());
+        $this->assertSame('desc', $metadata->getDescription());
+        $this->assertSame('http://example.com/foo', $metadata->getIri());
+        $this->assertSame(['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], $metadata->getItemOperations());
+        $this->assertSame('a', $metadata->getItemOperationAttribute('iop1', 'foo', 'z', false));
+        $this->assertSame('bar', $metadata->getItemOperationAttribute('iop1', 'baz', 'z', true));
+        $this->assertSame('bar', $metadata->getItemOperationAttribute(null, 'baz', 'z', true));
+        $this->assertSame('z', $metadata->getItemOperationAttribute('iop1', 'notExist', 'z', true));
+        $this->assertSame('z', $metadata->getItemOperationAttribute('notExist', 'notExist', 'z', true));
+        $this->assertSame(['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], $metadata->getCollectionOperations());
+        $this->assertSame('c', $metadata->getCollectionOperationAttribute('cop1', 'foo', 'z', false));
+        $this->assertSame('bar', $metadata->getCollectionOperationAttribute('cop1', 'baz', 'z', true));
+        $this->assertSame('bar', $metadata->getCollectionOperationAttribute(null, 'baz', 'z', true));
+        $this->assertSame('z', $metadata->getCollectionOperationAttribute('cop1', 'notExist', 'z', true));
+        $this->assertSame('z', $metadata->getCollectionOperationAttribute('notExist', 'notExist', 'z', true));
+        $this->assertSame(['baz' => 'bar'], $metadata->getAttributes());
+        $this->assertSame('bar', $metadata->getAttribute('baz'));
+        $this->assertSame('z', $metadata->getAttribute('notExist', 'z'));
+        $this->assertSame(['sop1' => ['sub' => 'bus']], $metadata->getSubresourceOperations());
+        $this->assertSame('bus', $metadata->getSubresourceOperationAttribute('sop1', 'sub'));
+        $this->assertSame('sub', $metadata->getSubresourceOperationAttribute('sop1', 'bus', 'sub', false));
+        $this->assertSame('bar', $metadata->getSubresourceOperationAttribute('sop1', 'baz', 'sub', true));
+        $this->assertSame('graphql', $metadata->getGraphqlAttribute('query', 'foo'));
+        $this->assertSame('bar', $metadata->getGraphqlAttribute('query', 'baz', null, true));
+        $this->assertSame('hey', $metadata->getGraphqlAttribute('query', 'notExist', 'hey', true));
 
         $newMetadata = $metadata->withShortName('name');
         $this->assertNotSame($metadata, $newMetadata);
-        $this->assertEquals('name', $newMetadata->getShortName());
+        $this->assertSame('name', $newMetadata->getShortName());
 
         $newMetadata = $metadata->withDescription('description');
         $this->assertNotSame($metadata, $newMetadata);
-        $this->assertEquals('description', $newMetadata->getDescription());
+        $this->assertSame('description', $newMetadata->getDescription());
 
         $newMetadata = $metadata->withIri('foo:bar');
         $this->assertNotSame($metadata, $newMetadata);
-        $this->assertEquals('foo:bar', $newMetadata->getIri());
+        $this->assertSame('foo:bar', $newMetadata->getIri());
 
         $newMetadata = $metadata->withItemOperations(['a' => ['b' => 'c']]);
         $this->assertNotSame($metadata, $newMetadata);
-        $this->assertEquals(['a' => ['b' => 'c']], $newMetadata->getItemOperations());
+        $this->assertSame(['a' => ['b' => 'c']], $newMetadata->getItemOperations());
+    }
 
-        $newMetadata = $metadata->withCollectionOperations(['a' => ['b' => 'c']]);
+    /**
+     * @dataProvider getWithMethods
+     */
+    public function testWithMethods(string $name, $value)
+    {
+        $metadata = new ResourceMetadata();
+        $newMetadata = call_user_func([$metadata, "with$name"], $value);
         $this->assertNotSame($metadata, $newMetadata);
-        $this->assertEquals(['a' => ['b' => 'c']], $newMetadata->getCollectionOperations());
+        $this->assertSame($value, call_user_func([$newMetadata, "get$name"]));
+    }
 
-        $newMetadata = $metadata->withAttributes(['a' => ['b' => 'c']]);
-        $this->assertNotSame($metadata, $newMetadata);
-        $this->assertEquals(['a' => ['b' => 'c']], $newMetadata->getAttributes());
+    public function getWithMethods(): array
+    {
+        return [
+            ['ShortName', 'shortName'],
+            ['Description', 'description'],
+            ['Iri', 'iri'],
+            ['ItemOperations', ['a' => ['b' => 'c']]],
+            ['CollectionOperations', ['a' => ['b' => 'c']]],
+            ['Attributes', ['a' => ['b' => 'c']]],
+            ['Graphql', ['query' => ['b' => 'c']]],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Instead of guessing the REST operation corresponding to the GraphQL query and use its configuration, this PR decouple GraphQL from REST, and allow to use different configuration for REST and for GraphQL.

For instance, to configure the `normalization_context` for GraphQL, use the following snippet:

```php
/**
 * @ApiResource(graphqlQuery={"normalization_context"={"groups"={"a"}}})
 */
class MyResource {}
```

If an option is defined in the `attributes` but not in `graphqlQuery`, the option in `attributes` will be used as fallback.

TODO:

* [x] Fix the commented test
* [x] Allow to expose some resources in GraphQL but not in REST, and the reverse

ping @raoulclais @alanpoulain 