### PR TITLE
reduce log level to "error" of exceptions that map to non server error codes

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -172,6 +172,7 @@
         <service id="api_platform.listener.exception" class="ApiPlatform\Core\EventListener\ExceptionListener">
             <argument>api_platform.action.exception</argument>
             <argument type="service" id="logger" on-invalid="null" />
+            <argument>%api_platform.exception_to_status%</argument>
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-96" />
             <tag name="monolog.logger" channel="request" />

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\EventListener;
 
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener as BaseExceptionListener;
+use Psr\Log\LoggerInterface;
 
 /**
  * Handles requests errors.
@@ -24,6 +25,23 @@ use Symfony\Component\HttpKernel\EventListener\ExceptionListener as BaseExceptio
  */
 final class ExceptionListener extends BaseExceptionListener
 {
+    /**
+     * @var array
+     */
+    private $exceptionToStatus;
+
+    /**
+     * @param mixed $controller
+     * @param LoggerInterface $logger
+     * @param array $exceptionToStatus
+     */
+    public function __construct($controller, LoggerInterface $logger = null, array $exceptionToStatus = null)
+    {
+        parent::__construct($controller, $logger);
+
+        $this->exceptionToStatus = $exceptionToStatus ?? [];
+    }
+
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
         $request = $event->getRequest();
@@ -36,5 +54,36 @@ final class ExceptionListener extends BaseExceptionListener
         }
 
         parent::onKernelException($event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function logException(\Exception $exception, $message)
+    {
+        if (null === $this->logger) {
+            parent::logException($exception, $message);
+
+            return;
+        }
+
+        $exceptionClass = get_class($exception);
+        $statusCode = null;
+
+        foreach ($this->exceptionToStatus as $class => $status) {
+            if (is_a($exceptionClass, $class, true)) {
+                $statusCode = $status;
+
+                break;
+            }
+        }
+
+        if (null === $statusCode || $statusCode >= 500) {
+            parent::logException($exception, $message);
+
+            return;
+        }
+
+        $this->logger->error($message, ['exception' => $exception]);
     }
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\EventListener;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener as BaseExceptionListener;
-use Psr\Log\LoggerInterface;
 
 /**
  * Handles requests errors.
@@ -31,9 +31,9 @@ final class ExceptionListener extends BaseExceptionListener
     private $exceptionToStatus;
 
     /**
-     * @param mixed $controller
+     * @param mixed           $controller
      * @param LoggerInterface $logger
-     * @param array $exceptionToStatus
+     * @param array           $exceptionToStatus
      */
     public function __construct($controller, LoggerInterface $logger = null, array $exceptionToStatus = null)
     {
@@ -57,7 +57,7 @@ final class ExceptionListener extends BaseExceptionListener
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function logException(\Exception $exception, $message)
     {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -30,16 +30,11 @@ final class ExceptionListener extends BaseExceptionListener
      */
     private $exceptionToStatus;
 
-    /**
-     * @param mixed           $controller
-     * @param LoggerInterface $logger
-     * @param array           $exceptionToStatus
-     */
-    public function __construct($controller, LoggerInterface $logger = null, array $exceptionToStatus = null)
+    public function __construct($controller, LoggerInterface $logger = null, array $exceptionToStatus = [])
     {
         parent::__construct($controller, $logger);
 
-        $this->exceptionToStatus = $exceptionToStatus ?? [];
+        $this->exceptionToStatus = $exceptionToStatus;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
@@ -67,11 +62,9 @@ final class ExceptionListener extends BaseExceptionListener
             return;
         }
 
-        $exceptionClass = get_class($exception);
         $statusCode = null;
-
         foreach ($this->exceptionToStatus as $class => $status) {
-            if (is_a($exceptionClass, $class, true)) {
+            if ($exception instanceof $class) {
                 $statusCode = $status;
 
                 break;

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -101,9 +101,9 @@ class ExceptionListenerTest extends TestCase
     public function dataLogLevel()
     {
         return [
-            [ \Exception::class, true ],
-            [ NotFoundHttpException::class, false ],
-            [ InvalidArgumentException::class, false ],
+            [\Exception::class, true],
+            [NotFoundHttpException::class, false],
+            [InvalidArgumentException::class, false],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Critical error level may trigger dev notification (email), which is not desired for exceptions that map to anything but http server error codes.

This PR reduces the log level of all exceptions that map to a status code < 500 and is in line with symfonys default exception listeners handling of `HttpException`s.