### PR TITLE
Allow another query builder alias

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -54,7 +54,7 @@ final class FilterEagerLoadingExtension implements QueryCollectionExtensionInter
         }
 
         $joinParts = $queryBuilder->getDQLPart('join');
-        $originAlias = 'o';
+        $originAlias = $queryBuilder->getRootAliases()[0];
 
         if (!$joinParts || !isset($joinParts[$originAlias])) {
             return;

--- a/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
@@ -41,6 +41,8 @@ final class OrderExtension implements QueryCollectionExtensionInterface
      */
     public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+
         $classMetaData = $queryBuilder->getEntityManager()->getClassMetadata($resourceClass);
         $identifiers = $classMetaData->getIdentifier();
         if (null !== $this->resourceMetadataFactory) {
@@ -54,9 +56,9 @@ final class OrderExtension implements QueryCollectionExtensionInterface
                     }
                     if (false === ($pos = strpos($field, '.'))) {
                         // Configure default filter with property
-                        $field = 'o.'.$field;
+                        $field = "{$rootAlias}.{$field}";
                     } else {
-                        $alias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, 'o', substr($field, 0, $pos));
+                        $alias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $rootAlias, substr($field, 0, $pos));
                         $field = sprintf('%s.%s', $alias, substr($field, $pos + 1));
                     }
                     $queryBuilder->addOrderBy($field, $order);
@@ -68,7 +70,7 @@ final class OrderExtension implements QueryCollectionExtensionInterface
 
         if (null !== $this->order) {
             foreach ($identifiers as $identifier) {
-                $queryBuilder->addOrderBy('o.'.$identifier, $this->order);
+                $queryBuilder->addOrderBy("{$rootAlias}.{$identifier}", $this->order);
             }
         }
     }

--- a/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
@@ -89,7 +89,7 @@ class BooleanFilter extends AbstractFilter
             return;
         }
 
-        $alias = 'o';
+        $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {

--- a/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
@@ -85,7 +85,7 @@ class DateFilter extends AbstractFilter
             return;
         }
 
-        $alias = 'o';
+        $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {

--- a/src/Bridge/Doctrine/Orm/Filter/ExistsFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/ExistsFilter.php
@@ -92,7 +92,7 @@ class ExistsFilter extends AbstractFilter
             return;
         }
 
-        $alias = 'o';
+        $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {

--- a/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
@@ -111,7 +111,7 @@ class NumericFilter extends AbstractFilter
             return;
         }
 
-        $alias = 'o';
+        $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {

--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -119,7 +119,7 @@ class OrderFilter extends AbstractFilter
             return;
         }
 
-        $alias = 'o';
+        $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {

--- a/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
@@ -70,7 +70,7 @@ class RangeFilter extends AbstractFilter
             return;
         }
 
-        $alias = 'o';
+        $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -184,7 +184,7 @@ class SearchFilter extends AbstractFilter
             return;
         }
 
-        $alias = 'o';
+        $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -108,10 +108,11 @@ class ItemDataProvider implements ItemDataProviderInterface, RestrictedDataProvi
      */
     private function addWhereForIdentifiers(array $identifiers, QueryBuilder $queryBuilder, ClassMetadata $classMetadata)
     {
+        $alias = $queryBuilder->getRootAliases()[0];
         foreach ($identifiers as $identifier => $value) {
             $placeholder = ':id_'.$identifier;
             $expression = $queryBuilder->expr()->eq(
-                'o.'.$identifier,
+                "{$alias}.{$identifier}",
                 $placeholder
             );
 

--- a/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
@@ -58,12 +58,13 @@ final class QueryBuilderHelper
     private static function getExistingJoin(QueryBuilder $queryBuilder, string $alias, string $association)
     {
         $parts = $queryBuilder->getDQLPart('join');
+        $rootAlias = $queryBuilder->getRootAliases()[0];
 
-        if (!isset($parts['o'])) {
+        if (!isset($parts[$rootAlias])) {
             return null;
         }
 
-        foreach ($parts['o'] as $join) {
+        foreach ($parts[$rootAlias] as $join) {
             /** @var Join $join */
             if (sprintf('%s.%s', $alias, $association) === $join->getJoin()) {
                 return $join;

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
@@ -123,6 +123,7 @@ class FilterEagerLoadingExtensionTest extends TestCase
         $qb = $this->prophesize(QueryBuilder::class);
         $qb->getDQLPart('where')->shouldBeCalled()->willReturn(new Expr\Andx());
         $qb->getDQLPart('join')->shouldBeCalled()->willReturn(null);
+        $qb->getRootAliases()->shouldBeCalled()->willReturn(['o']);
         $qb->getEntityManager()->willReturn($em);
 
         $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);

--- a/tests/Bridge/Doctrine/Orm/Extension/OrderExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/OrderExtensionTest.php
@@ -41,6 +41,7 @@ class OrderExtensionTest extends TestCase
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
 
         $queryBuilderProphecy->getEntityManager()->shouldBeCalled()->willReturn($emProphecy->reveal());
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $orderExtensionTest = new OrderExtension('asc');
@@ -60,6 +61,7 @@ class OrderExtensionTest extends TestCase
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
 
         $queryBuilderProphecy->getEntityManager()->shouldBeCalled()->willReturn($emProphecy->reveal());
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $orderExtensionTest = new OrderExtension();
@@ -82,6 +84,7 @@ class OrderExtensionTest extends TestCase
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
 
         $queryBuilderProphecy->getEntityManager()->shouldBeCalled()->willReturn($emProphecy->reveal());
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $orderExtensionTest = new OrderExtension('asc', $resourceMetadataFactoryProphecy->reveal());
@@ -105,6 +108,7 @@ class OrderExtensionTest extends TestCase
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
 
         $queryBuilderProphecy->getEntityManager()->shouldBeCalled()->willReturn($emProphecy->reveal());
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $orderExtensionTest = new OrderExtension('asc', $resourceMetadataFactoryProphecy->reveal());
@@ -129,6 +133,7 @@ class OrderExtensionTest extends TestCase
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
 
         $queryBuilderProphecy->getEntityManager()->shouldBeCalled()->willReturn($emProphecy->reveal());
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $orderExtensionTest = new OrderExtension('asc', $resourceMetadataFactoryProphecy->reveal());

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -34,6 +34,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class SearchFilterTest extends KernelTestCase
 {
+    const ALIAS = 'oo';
+
     /**
      * @var ManagerRegistry
      */
@@ -99,7 +101,7 @@ class SearchFilterTest extends KernelTestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
-        $queryBuilder = $this->repository->createQueryBuilder('o');
+        $queryBuilder = $this->repository->createQueryBuilder(self::ALIAS);
 
         $filter = new SearchFilter(
             $this->managerRegistry,
@@ -434,7 +436,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'exact',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.name = :name_p1', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'exact',
                     ],
@@ -449,7 +451,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'exact',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE LOWER(o.name) = LOWER(:name_p1)', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) = LOWER(:name_p1)', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'exact',
                     ],
@@ -467,7 +469,7 @@ class SearchFilterTest extends KernelTestCase
                     ],
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.name IN (:name_p1)', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN (:name_p1)', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => [
                             'CaSE',
@@ -488,7 +490,7 @@ class SearchFilterTest extends KernelTestCase
                     ],
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE LOWER(o.name) IN (:name_p1)', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) IN (:name_p1)', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => [
                             'case',
@@ -506,7 +508,7 @@ class SearchFilterTest extends KernelTestCase
                     'foo' => 'exact',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s', self::ALIAS, Dummy::class),
                     'parameters' => [],
                 ],
             ],
@@ -523,7 +525,7 @@ class SearchFilterTest extends KernelTestCase
                     'relatedDummies' => [['foo']],
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.name = :name_p1 AND o.relatedDummy = :relatedDummy_p2', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1 AND %1$s.relatedDummy = :relatedDummy_p2', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'relatedDummy_p2' => 'foo',
                     ],
@@ -538,7 +540,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.name LIKE CONCAT(\'%%\', :name_p1, \'%%\')', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1, \'%%\')', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -553,7 +555,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE LOWER(o.name) LIKE LOWER(CONCAT(\'%%\', :name_p1, \'%%\'))', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1, \'%%\'))', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -568,7 +570,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.name LIKE CONCAT(:name_p1, \'%%\')', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1, \'%%\')', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -583,7 +585,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE LOWER(o.name) LIKE LOWER(CONCAT(:name_p1, \'%%\'))', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1, \'%%\'))', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -598,7 +600,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.name LIKE CONCAT(\'%%\', :name_p1)', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1)', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -613,7 +615,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE LOWER(o.name) LIKE LOWER(CONCAT(\'%%\', :name_p1))', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1))', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -628,7 +630,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.name LIKE CONCAT(:name_p1, \'%%\') OR o.name LIKE CONCAT(\'%% \', :name_p1, \'%%\')', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1, \'%%\')', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -643,7 +645,7 @@ class SearchFilterTest extends KernelTestCase
                     'name' => 'partial',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE LOWER(o.name) LIKE LOWER(CONCAT(:name_p1, \'%%\')) OR LOWER(o.name) LIKE LOWER(CONCAT(\'%% \', :name_p1, \'%%\'))', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1, \'%%\'))', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'partial',
                     ],
@@ -659,7 +661,7 @@ class SearchFilterTest extends KernelTestCase
                     'relatedDummy' => 'exact',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o WHERE o.relatedDummy = :relatedDummy_p1', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s WHERE %1$s.relatedDummy = :relatedDummy_p1', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'relatedDummy_p1' => 'exact',
                     ],
@@ -675,7 +677,7 @@ class SearchFilterTest extends KernelTestCase
                     'relatedDummy.id' => '/related_dummies/1',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o INNER JOIN o.relatedDummy relatedDummy_a1 WHERE relatedDummy_a1.id = :id_p1', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummy relatedDummy_a1 WHERE relatedDummy_a1.id = :id_p1', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'id_p1' => 1,
                     ],
@@ -693,7 +695,7 @@ class SearchFilterTest extends KernelTestCase
                     'relatedDummies' => '1',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o INNER JOIN o.relatedDummies relatedDummies_a1 WHERE o.relatedDummy IN (:relatedDummy_p1) AND relatedDummies_a1.id = :relatedDummies_p2', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummies relatedDummies_a1 WHERE %1$s.relatedDummy IN (:relatedDummy_p1) AND relatedDummies_a1.id = :relatedDummies_p2', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'relatedDummy_p1' => [1, 2],
                         'relatedDummies_p2' => 1,
@@ -711,7 +713,7 @@ class SearchFilterTest extends KernelTestCase
                     'relatedDummy.symfony' => 'exact',
                 ],
                 [
-                    'dql' => sprintf('SELECT o FROM %s o INNER JOIN o.relatedDummy relatedDummy_a1 WHERE o.name = :name_p1 AND relatedDummy_a1.symfony = :symfony_p2', Dummy::class),
+                    'dql' => sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummy relatedDummy_a1 WHERE %1$s.name = :name_p1 AND relatedDummy_a1.symfony = :symfony_p2', self::ALIAS, Dummy::class),
                     'parameters' => [
                         'name_p1' => 'exact',
                         'symfony_p2' => 'exact',
@@ -726,7 +728,7 @@ class SearchFilterTest extends KernelTestCase
         $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'foo']);
         $requestStack = new RequestStack();
         $requestStack->push($request);
-        $queryBuilder = $this->repository->createQueryBuilder('o');
+        $queryBuilder = $this->repository->createQueryBuilder(self::ALIAS);
         $filter = new SearchFilter(
             $this->managerRegistry,
             $requestStack,
@@ -736,11 +738,11 @@ class SearchFilterTest extends KernelTestCase
             ['relatedDummy.symfony' => null]
         );
 
-        $queryBuilder->innerJoin('o.relatedDummy', 'relateddummy_a1');
+        $queryBuilder->innerJoin(sprintf('%s.relatedDummy', self::ALIAS), 'relateddummy_a1');
 
         $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, 'op');
         $actual = strtolower($queryBuilder->getQuery()->getDQL());
-        $expected = strtolower(sprintf('SELECT o FROM %s o inner join o.relatedDummy relateddummy_a1 WHERE relateddummy_a1.symfony = :symfony_p1', Dummy::class));
+        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s inner join %1$s.relatedDummy relateddummy_a1 WHERE relateddummy_a1.symfony = :symfony_p1', self::ALIAS, Dummy::class));
         $this->assertEquals($actual, $expected);
     }
 
@@ -749,7 +751,7 @@ class SearchFilterTest extends KernelTestCase
         $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '2']);
         $requestStack = new RequestStack();
         $requestStack->push($request);
-        $queryBuilder = $this->repository->createQueryBuilder('o');
+        $queryBuilder = $this->repository->createQueryBuilder(self::ALIAS);
         $filter = new SearchFilter(
             $this->managerRegistry,
             $requestStack,
@@ -759,12 +761,12 @@ class SearchFilterTest extends KernelTestCase
             ['relatedDummy.symfony' => null, 'relatedDummy.thirdLevel.level' => null]
         );
 
-        $queryBuilder->innerJoin('o.relatedDummy', 'relateddummy_a1');
+        $queryBuilder->innerJoin(sprintf('%s.relatedDummy', self::ALIAS), 'relateddummy_a1');
         $queryBuilder->innerJoin('relateddummy_a1.thirdLevel', 'thirdLevel_a1');
 
         $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, 'op');
         $actual = strtolower($queryBuilder->getQuery()->getDQL());
-        $expected = strtolower(sprintf('SELECT o FROM %s o inner join o.relatedDummy relateddummy_a1 inner join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', Dummy::class));
+        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s inner join %1$s.relatedDummy relateddummy_a1 inner join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', self::ALIAS, Dummy::class));
         $this->assertEquals($actual, $expected);
     }
 
@@ -773,8 +775,8 @@ class SearchFilterTest extends KernelTestCase
         $request = Request::create('/api/dummies', 'GET', ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '3']);
         $requestStack = new RequestStack();
         $requestStack->push($request);
-        $queryBuilder = $this->repository->createQueryBuilder('o');
-        $queryBuilder->leftJoin('o.relatedDummy', 'relateddummy_a1');
+        $queryBuilder = $this->repository->createQueryBuilder(self::ALIAS);
+        $queryBuilder->leftJoin(sprintf('%s.relatedDummy', self::ALIAS), 'relateddummy_a1');
 
         $filter = new SearchFilter(
             $this->managerRegistry,
@@ -787,7 +789,36 @@ class SearchFilterTest extends KernelTestCase
 
         $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, 'op');
         $actual = strtolower($queryBuilder->getQuery()->getDQL());
-        $expected = strtolower(sprintf('SELECT o FROM %s o left join o.relatedDummy relateddummy_a1 left join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', Dummy::class));
+        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s left join %1$s.relatedDummy relateddummy_a1 left join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', self::ALIAS, Dummy::class));
         $this->assertEquals($actual, $expected);
+    }
+
+    public function testApplyWithAnotherAlias()
+    {
+        $request = Request::create('/api/dummies', 'GET', ['name' => 'exact']);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $queryBuilder = $this->repository->createQueryBuilder('somealias');
+
+        $filter = new SearchFilter(
+            $this->managerRegistry,
+            $requestStack,
+            $this->iriConverter,
+            $this->propertyAccessor,
+            null,
+            [
+                'id' => null,
+                'name' => null,
+            ]
+        );
+
+        $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, 'op');
+        $actualDql = $queryBuilder->getQuery()->getDQL();
+
+        $expectedDql = sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', 'somealias', Dummy::class);
+
+        $this->assertEquals($expectedDql, $actualDql);
     }
 }

--- a/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
@@ -58,6 +58,7 @@ class ItemDataProviderTest extends TestCase
         $queryBuilderProphecy->getQuery()->willReturn($queryProphecy->reveal())->shouldBeCalled();
         $queryBuilderProphecy->expr()->willReturn($exprProphecy->reveal())->shouldBeCalled();
         $queryBuilderProphecy->andWhere($comparison)->shouldBeCalled();
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
         $queryBuilderProphecy->setParameter(':id_id', 1, DBALType::INTEGER)->shouldBeCalled();
 
         $queryBuilder = $queryBuilderProphecy->reveal();
@@ -95,6 +96,7 @@ class ItemDataProviderTest extends TestCase
         $queryBuilderProphecy->getQuery()->willReturn($queryProphecy->reveal())->shouldBeCalled();
         $queryBuilderProphecy->expr()->willReturn($exprProphecy->reveal())->shouldBeCalled();
         $queryBuilderProphecy->andWhere($comparison)->shouldBeCalled();
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
 
         $queryBuilderProphecy->setParameter(':id_ida', 1, DBALType::INTEGER)->shouldBeCalled();
         $queryBuilderProphecy->setParameter(':id_idb', 2, DBALType::INTEGER)->shouldBeCalled();
@@ -155,6 +157,7 @@ class ItemDataProviderTest extends TestCase
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilderProphecy->expr()->willReturn($exprProphecy->reveal())->shouldBeCalled();
         $queryBuilderProphecy->andWhere($comparison)->shouldBeCalled();
+        $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
         $queryBuilderProphecy->setParameter(':id_id', 1, DBALType::INTEGER)->shouldBeCalled();
 
         $queryBuilder = $queryBuilderProphecy->reveal();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR allow creating our own query builder and apply filter to it.

There was a "bug" forcing the main alias to be `o` but it's not necessarily the case when creating our own query builder.