### PR TITLE
Fix: Passing nor an unknown iri nor an array in an embedded relation throws an error

### DIFF
--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -442,3 +442,28 @@ Feature: Relations support
       "related": null
     }
     """
+
+  Scenario: Issue #1547 Passing wrong argument to a relation
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/relation_embedders" with body:
+    """
+    {
+      "related": "certainly not an iri"
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON node "hydra:description" should contain "Expected IRI or nested document"
+
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/relation_embedders" with body:
+    """
+    {
+      "related": 8
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON node "hydra:description" should contain "Expected IRI or nested document"

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -285,7 +285,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             }
         }
 
-        if (!$this->resourceClassResolver->isResourceClass($className) || $propertyMetadata->isWritableLink()) {
+        if (
+            !$this->resourceClassResolver->isResourceClass($className) ||
+            ($propertyMetadata->isWritableLink() && is_array($value))
+        ) {
             return $this->serializer->denormalize($value, $className, $format, $this->createRelationSerializationContext($className, $context));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

`POST /relation_embedders`
with body:
```json
{
  "related": "foo"
}
```

will throw an error:
```Type error: Argument 2 passed to ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory::create() must be of the type string, integer given, called in src/Serializer/AbstractItemNormalizer.php on line 163 (Behat\Testwork\Call\Exception\FatalThrowableError)```

This is because "related" is marked as a "writable link"

