### PR TITLE
Improved joins when using the properties filter

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -137,16 +137,22 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 continue;
             }
 
-            if ($inAttributes = isset($context[AbstractNormalizer::ATTRIBUTES][$association])) {
-                // prepare the child context
-                $context[AbstractNormalizer::ATTRIBUTES] = $context[AbstractNormalizer::ATTRIBUTES][$association];
-            } else {
-                unset($context[AbstractNormalizer::ATTRIBUTES]);
+            if ($useAttributes = isset($context[AbstractNormalizer::ATTRIBUTES])) {
+                if ($inAttributes = isset($context[AbstractNormalizer::ATTRIBUTES][$association])) {
+                    // prepare the child context
+                    $context[AbstractNormalizer::ATTRIBUTES] = $context[AbstractNormalizer::ATTRIBUTES][$association];
+                } else {
+                    unset($context[AbstractNormalizer::ATTRIBUTES]);
+                }
             }
 
+            $isNotReadableLink = false === $propertyMetadata->isReadableLink();
             if (
-                ((!$inAttributes && false === $propertyMetadata->isReadableLink()) || false === $propertyMetadata->isReadable()) &&
-                false === $propertyMetadata->getAttribute('fetchEager', false)
+                false === $propertyMetadata->getAttribute('fetchEager', false) &&
+                (
+                    false === $propertyMetadata->isReadable() ||
+                    ((!$useAttributes && $isNotReadableLink) || ($useAttributes && !$inAttributes))
+                )
             ) {
                 continue;
             }

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -137,13 +137,15 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 continue;
             }
 
-            if ($useAttributes = isset($context[AbstractNormalizer::ATTRIBUTES])) {
+            if (isset($context[AbstractNormalizer::ATTRIBUTES])) {
                 if ($inAttributes = isset($context[AbstractNormalizer::ATTRIBUTES][$association])) {
                     // prepare the child context
                     $context[AbstractNormalizer::ATTRIBUTES] = $context[AbstractNormalizer::ATTRIBUTES][$association];
                 } else {
                     unset($context[AbstractNormalizer::ATTRIBUTES]);
                 }
+            } else {
+                $inAttributes = null;
             }
 
             $isNotReadableLink = false === $propertyMetadata->isReadableLink();
@@ -151,7 +153,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 false === $propertyMetadata->getAttribute('fetchEager', false) &&
                 (
                     false === $propertyMetadata->isReadable() ||
-                    ((!$useAttributes && $isNotReadableLink) || ($useAttributes && !$inAttributes))
+                    ((null === $inAttributes && $isNotReadableLink) || (false === $inAttributes))
                 )
             ) {
                 continue;

--- a/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -689,6 +689,47 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
+    public function testNotInAttributes()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $relationPropertyMetadata = new PropertyMetadata();
+        $relationPropertyMetadata = $relationPropertyMetadata->withReadableLink(true);
+
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', ['serializer_groups' => ['foo']])->willReturn($relationPropertyMetadata)->shouldBeCalled();
+
+        $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
+
+        $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
+        $classMetadataProphecy->associationMappings = [
+            'relatedDummy' => ['fetch' => 3, 'joinColumns' => [['nullable' => true]], 'targetEntity' => RelatedDummy::class],
+        ];
+
+        $relatedClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
+        $relatedClassMetadataProphecy->associationMappings = [];
+
+        $emProphecy = $this->prophesize(EntityManager::class);
+        $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
+
+        $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
+        $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+
+        $request = Request::create('/api/dummies', 'GET', []);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
+        $serializerContextBuilderProphecy->createFromRequest($request, true)->shouldBeCalled()->willReturn([AbstractNormalizer::GROUPS => ['foo'], AbstractNormalizer::ATTRIBUTES => ['relatedDummy']]);
+
+        $queryBuilder = $queryBuilderProphecy->reveal();
+        $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, $requestStack, $serializerContextBuilderProphecy->reveal(), true);
+        $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
+    }
+
     public function testApplyToCollectionNoPartial()
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Follows #1546. This PR allows API Platform to add useful SQL `JOIN` clauses and to remove the useless ones according to properties selected by the client using the [property filter](https://api-platform.com/docs/core/filters#property-filter).
That's a massive performance improvement when using this filter.

I'll also use this feature later to improve the generated SQL queries when using GraphQL. It will allow to only fetch what is required for a given GraphQL query while to reducing dramatically the number of issued SQL queries for a whole GraphQL request.