### PR TITLE
Allow passing `itemsPerPage=0`

### DIFF
--- a/features/hydra/collection.feature
+++ b/features/hydra/collection.feature
@@ -395,3 +395,45 @@ Feature: Collections support
       "additionalProperties": false
     }
     """
+
+  @dropSchema
+  @createSchema
+  Scenario: Allow passing "0" to `itemsPerPage`
+    When I send a "GET" request to "/dummies?itemsPerPage=0"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:totalItems": {"type":"number", "maximum": 30},
+        "hydra:member": {
+          "type": "array",
+          "minItems": 0,
+          "maxItems": 0
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?itemsPerPage=0$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"},
+            "hydra:first": {"pattern": "^/dummies\\?itemsPerPage=0&page=1$"},
+            "hydra:last": {"pattern": "^/dummies\\?itemsPerPage=0&page=1$"},
+            "hydra:previous": {"pattern": "^/dummies\\?itemsPerPage=0&page=1$"},
+            "hydra:next": {"pattern": "^/dummies\\?itemsPerPage=0&page=1$"}
+          }
+        },
+        "hydra:search": {}
+      },
+      "additionalProperties": false
+    }
+    """
+
+    When I send a "GET" request to "/dummies?itemsPerPage=0&page=2"
+    Then the response status code should be 400
+    And the JSON node "hydra:description" should be equal to "Page should not be greater than 1 if itemsPegPage is equal to 0"

--- a/src/Bridge/Doctrine/Orm/AbstractPaginator.php
+++ b/src/Bridge/Doctrine/Orm/AbstractPaginator.php
@@ -46,6 +46,10 @@ abstract class AbstractPaginator implements \IteratorAggregate, PartialPaginator
      */
     public function getCurrentPage(): float
     {
+        if (0 >= $this->maxResults) {
+            return 1;
+        }
+
         return floor($this->firstResult / $this->maxResults) + 1.;
     }
 

--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -93,11 +93,17 @@ final class PaginationExtension implements QueryResultCollectionExtensionInterfa
             $itemsPerPage = (null !== $this->maximumItemPerPage && $itemsPerPage >= $this->maximumItemPerPage ? $this->maximumItemPerPage : $itemsPerPage);
         }
 
-        if (0 >= $itemsPerPage) {
-            throw new InvalidArgumentException('Item per page parameter should not be less than or equal to 0');
+        if (0 > $itemsPerPage) {
+            throw new InvalidArgumentException('Item per page parameter should not be less than 0');
         }
 
-        $firstResult = ($this->getPaginationParameter($request, $this->pageParameterName, 1) - 1) * $itemsPerPage;
+        $page = $this->getPaginationParameter($request, $this->pageParameterName, 1);
+
+        if (0 === $itemsPerPage && 1 < $page) {
+            throw new InvalidArgumentException('Page should not be greater than 1 if itemsPegPage is equal to 0');
+        }
+
+        $firstResult = ($page - 1) * $itemsPerPage;
         if ($request->attributes->get('_graphql')) {
             $collectionArgs = $request->attributes->get('_graphql_collections_args', []);
             if (isset($collectionArgs[$resourceClass]['after'])) {

--- a/src/Bridge/Doctrine/Orm/Paginator.php
+++ b/src/Bridge/Doctrine/Orm/Paginator.php
@@ -32,6 +32,10 @@ final class Paginator extends AbstractPaginator implements PaginatorInterface
      */
     public function getLastPage(): float
     {
+        if (0 >= $this->maxResults) {
+            return 1;
+        }
+
         return ceil($this->getTotalItems() / $this->maxResults) ?: 1.;
     }
 

--- a/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -67,14 +67,10 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    /**
-     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Item per page parameter should not be less than or equal to 0
-     */
     public function testApplyToCollectionWithItemPerPageZero()
     {
         $requestStack = new RequestStack();
-        $requestStack->push(new Request(['pagination' => true, 'itemsPerPage' => 0, '_page' => 2]));
+        $requestStack->push(new Request(['pagination' => true, 'itemsPerPage' => 0, '_page' => 1]));
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
@@ -86,8 +82,8 @@ class PaginationExtensionTest extends TestCase
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
-        $queryBuilderProphecy->setFirstResult(40)->willReturn($queryBuilderProphecy)->shouldNotBeCalled();
-        $queryBuilderProphecy->setMaxResults(40)->shouldNotBeCalled();
+        $queryBuilderProphecy->setFirstResult(0)->willReturn($queryBuilderProphecy)->shouldBeCalled();
+        $queryBuilderProphecy->setMaxResults(0)->shouldBeCalled();
         $queryBuilder = $queryBuilderProphecy->reveal();
 
         $extension = new PaginationExtension(
@@ -105,7 +101,43 @@ class PaginationExtensionTest extends TestCase
 
     /**
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Item per page parameter should not be less than or equal to 0
+     * @expectedExceptionMessage Page should not be greater than 1 if itemsPegPage is equal to 0
+     */
+    public function testApplyToCollectionWithItemPerPageZeroAndPage2()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['pagination' => true, 'itemsPerPage' => 0, '_page' => 2]));
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $attributes = [
+            'pagination_enabled' => true,
+            'pagination_client_enabled' => true,
+            'pagination_items_per_page' => 0,
+        ];
+        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes))->shouldBeCalled();
+        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+
+        $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
+        $queryBuilderProphecy->setFirstResult(0)->willReturn($queryBuilderProphecy)->shouldNotBeCalled();
+        $queryBuilderProphecy->setMaxResults(0)->shouldNotBeCalled();
+        $queryBuilder = $queryBuilderProphecy->reveal();
+
+        $extension = new PaginationExtension(
+            $this->prophesize(ManagerRegistry::class)->reveal(),
+            $requestStack,
+            $resourceMetadataFactory,
+            true,
+            false,
+            false,
+            0,
+            '_page'
+        );
+        $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
+    }
+
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Item per page parameter should not be less than 0
      */
     public function testApplyToCollectionWithItemPerPageLessThen0()
     {
@@ -116,7 +148,7 @@ class PaginationExtensionTest extends TestCase
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
-            'pagination_items_per_page' => 0,
+            'pagination_items_per_page' => -20,
         ];
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes))->shouldBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | Well really really minor :)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Specifying `itemsPerPage=0` is quite a handy feature if you just need a total count of the items (particularly if you use a filter), so I added this possibility.

There is a really small BC break (but you might see it as a bugfix ?): 

  * If you specify `itemsPerPage=0`, you will not have a 400 status code but a 200 with `hydra:member` set to `[]` and the `hydra:totalItems` set to the total number of items.

I kept the 400 error when you specify `itemsPerPage=0&page=2` (page > 1) but I can easily remove it, it's just weird to make this call but the `page` parameter is just ignored if I remove the exception.