### PR TITLE
[SymfonyBundle] Fixed the configuration

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -40,9 +40,21 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('title')->defaultValue('')->info('The title of the API.')->end()
-                ->scalarNode('description')->defaultValue('')->info('The description of the API.')->end()
-                ->scalarNode('version')->defaultValue('0.0.0')->info('The version of the API.')->end()
+                ->scalarNode('title')
+                    ->info('The title of the API.')
+                    ->cannotBeEmpty()
+                    ->defaultValue('')
+                ->end()
+                ->scalarNode('description')
+                    ->info('The description of the API.')
+                    ->cannotBeEmpty()
+                    ->defaultValue('')
+                ->end()
+                ->scalarNode('version')
+                    ->info('The version of the API.')
+                    ->cannotBeEmpty()
+                    ->defaultValue('0.0.0')
+                ->end()
                 ->scalarNode('default_operation_path_resolver')
                     ->beforeNormalization()->always(function ($v) {
                         @trigger_error('The use of the `default_operation_path_resolver` has been deprecated in 2.1 and will be removed in 3.0. Use `path_segment_name_generator` instead.', E_USER_DEPRECATED);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | I guess
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

The value of title/description/version should not be empty.
If there are empty, we got the following exception:

```
Type error: Argument 8 passed to ApiPlatform\Core\Bridge\Symfony\Bundle\Action\SwaggerUiAction::__construct() must be of the type string, null given, called in /var/www/server/backend/var/cache/dev/appDevDebugProjectContainer.php on line 1155
```

How to reproduce:

```
#config.yml
api_platform:
    title: #nothing explicitly 
```
