### PR TITLE
Always return a float in Paginator::getLastPage()

### DIFF
--- a/src/Bridge/Doctrine/Orm/Paginator.php
+++ b/src/Bridge/Doctrine/Orm/Paginator.php
@@ -72,7 +72,7 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
     public function getLastPage(): float
     {
         if (0 >= $this->maxResults) {
-            return 1;
+            return 1.;
         }
 
         return ceil($this->totalItems / $this->maxResults) ?: 1.;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n:a
| License       | MIT
| Doc PR        | n/a

Follows #1561.