### PR TITLE
Implement the Relay Global Object Identification Specification

### DIFF
--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -1,4 +1,92 @@
 Feature: GraphQL collection support
+  @createSchema
+  @dropSchema
+  Scenario: Retrieve a collection through a GraphQL query
+    Given there is 4 dummy objects with relatedDummy and its thirdLevel
+    When I send the following GraphQL request:
+    """
+    {
+      dummies {
+        ...dummyFields
+      }
+    }
+    fragment dummyFields on DummyConnection {
+      edges {
+        node {
+          id
+          name
+          relatedDummy {
+            name
+            thirdLevel {
+              id
+              level
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummies.edges[2].node.name" should be equal to "Dummy #3"
+    And the JSON node "data.dummies.edges[2].node.relatedDummy.name" should be equal to "RelatedDummy #3"
+    And the JSON node "data.dummies.edges[2].node.relatedDummy.thirdLevel.level" should be equal to "3"
+
+  @createSchema
+  @dropSchema
+  Scenario: Retrieve an nonexistent collection through a GraphQL query
+    When I send the following GraphQL request:
+    """
+    {
+      dummies {
+        edges {
+          node {
+            name
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummies.edges" should have 0 element
+    And the JSON node "data.dummies.pageInfo.endCursor" should be null
+    And the JSON node "data.dummies.pageInfo.hasNextPage" should be false
+
+  @createSchema
+  @dropSchema
+  Scenario: Retrieve a collection with a nested collection through a GraphQL query
+    Given there is 4 dummy objects having each 3 relatedDummies
+    When I send the following GraphQL request:
+    """
+    {
+      dummies {
+        edges {
+          node {
+            name
+            relatedDummies {
+              edges {
+                node {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummies.edges[2].node.name" should be equal to "Dummy #3"
+    And the JSON node "data.dummies.edges[2].node.relatedDummies.edges[1].node.name" should be equal to "RelatedDummy23"
 
   @createSchema
   @dropSchema

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -83,6 +83,91 @@ Feature: GraphQL introspection support
     And the JSON node "data.type3.fields[1].name" should be equal to "cursor"
     And the JSON node "data.type3.fields[0].type.name" should be equal to "DummyAggregateOffer"
 
+  Scenario: Retrieve the Relay's node interface
+    When I send the following GraphQL request:
+    """
+    {
+      __type(name: "Node") {
+        name
+        kind
+        fields {
+          name
+          type {
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON should be deep equal to:
+    """
+    {
+      "data": {
+        "__type": {
+          "name": "Node",
+          "kind": "INTERFACE",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "name": "ID",
+                  "kind": "SCALAR"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+
+  Scenario: Retrieve the Relay's node field
+    When I send the following GraphQL request:
+    """
+    {
+      __schema {
+        queryType {
+          fields {
+            name
+            type {
+              name
+              kind
+            }
+            args {
+              name
+              type {
+                kind
+                ofType {
+                  name
+                  kind
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.__schema.queryType.fields[0].name" should be equal to "node"
+    And the JSON node "data.__schema.queryType.fields[0].type.name" should be equal to "Node"
+    And the JSON node "data.__schema.queryType.fields[0].type.kind" should be equal to "INTERFACE"
+    And the JSON node "data.__schema.queryType.fields[0].args[0].name" should be equal to "id"
+    And the JSON node "data.__schema.queryType.fields[0].args[0].type.kind" should be equal to "NON_NULL"
+    And the JSON node "data.__schema.queryType.fields[0].args[0].type.ofType.name" should be equal to "ID"
+    And the JSON node "data.__schema.queryType.fields[0].args[0].type.ofType.kind" should be equal to "SCALAR"
+
   @dropSchema
   Scenario: Retrieve an item through a GraphQL query
     Given there is 4 dummy objects with relatedDummy

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -9,7 +9,7 @@
 
         <!-- Resolvers -->
 
-        <service id="api_platform.graphql.resolver.collection_factory" class="ApiPlatform\Core\Graphql\Resolver\CollectionResolverFactory" public="false">
+        <service id="api_platform.graphql.resolver.factory.collection" class="ApiPlatform\Core\Graphql\Resolver\Factory\CollectionResolverFactory" public="false">
             <argument type="service" id="api_platform.collection_data_provider" />
             <argument type="service" id="api_platform.subresource_data_provider" />
             <argument type="service" id="serializer" />
@@ -19,15 +19,15 @@
             <argument>%api_platform.collection.pagination.enabled%</argument>
         </service>
 
-        <service id="api_platform.graphql.resolver.item_factory" class="ApiPlatform\Core\Graphql\Resolver\ItemResolverFactory" public="false">
+        <service id="api_platform.graphql.resolver.factory.item_mutation" class="ApiPlatform\Core\Graphql\Resolver\Factory\ItemMutationResolverFactory" public="false">
             <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.data_persister" />
             <argument type="service" id="serializer" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
         </service>
 
-        <service id="api_platform.graphql.resolver.item_mutation_factory" class="ApiPlatform\Core\Graphql\Resolver\ItemMutationResolverFactory" public="false">
+        <service id="api_platform.graphql.resolver.item" class="ApiPlatform\Core\Graphql\Resolver\ItemResolver" public="false">
             <argument type="service" id="api_platform.iri_converter" />
-            <argument type="service" id="api_platform.data_persister" />
             <argument type="service" id="serializer" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
         </service>
@@ -41,9 +41,9 @@
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
-            <argument type="service" id="api_platform.graphql.resolver.collection_factory" />
-            <argument type="service" id="api_platform.graphql.resolver.item_factory" />
-            <argument type="service" id="api_platform.graphql.resolver.item_mutation_factory" />
+            <argument type="service" id="api_platform.graphql.resolver.factory.collection" />
+            <argument type="service" id="api_platform.graphql.resolver.factory.item_mutation" />
+            <argument type="service" id="api_platform.graphql.resolver.item" />
             <argument type="service" id="api_platform.graphql.resolver.resource_field" />
             <argument>%api_platform.collection.pagination.enabled%</argument>
         </service>

--- a/src/Graphql/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/Graphql/Resolver/Factory/CollectionResolverFactory.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Graphql\Resolver;
+namespace ApiPlatform\Core\Graphql\Resolver\Factory;
 
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
@@ -64,8 +64,8 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
                 );
             }
 
-            if (isset($source[$rootProperty = $info->fieldName], $source['#item'])) {
-                $rootResolvedFields = $this->identifiersExtractor->getIdentifiersFromItem(unserialize($source['#item']));
+            if (isset($source[$rootProperty = $info->fieldName], $source[ItemNormalizer::ITEM_KEY])) {
+                $rootResolvedFields = $this->identifiersExtractor->getIdentifiersFromItem(unserialize($source[ItemNormalizer::ITEM_KEY]));
                 $subresource = $this->getSubresource($rootClass, $rootResolvedFields, array_keys($rootResolvedFields), $rootProperty, $resourceClass, true);
                 $collection = $subresource ?? [];
             } else {

--- a/src/Graphql/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/Graphql/Resolver/Factory/ItemMutationResolverFactory.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Graphql\Resolver;
+namespace ApiPlatform\Core\Graphql\Resolver\Factory;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;

--- a/src/Graphql/Resolver/Factory/ResolverFactoryInterface.php
+++ b/src/Graphql/Resolver/Factory/ResolverFactoryInterface.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Graphql\Resolver;
+namespace ApiPlatform\Core\Graphql\Resolver\Factory;
 
 /**
  * Builds a GraphQL resolver.

--- a/src/Graphql/Resolver/ItemResolver.php
+++ b/src/Graphql/Resolver/ItemResolver.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Graphql\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\ClassInfoTrait;
 use GraphQL\Type\Definition\ResolveInfo;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -26,9 +27,12 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @experimental
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemResolverFactory implements ResolverFactoryInterface
+final class ItemResolver
 {
+    use ClassInfoTrait;
+
     private $iriConverter;
     private $normalizer;
     private $resourceMetadataFactory;
@@ -40,28 +44,26 @@ final class ItemResolverFactory implements ResolverFactoryInterface
         $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
 
-    public function __invoke(string $resourceClass = null, string $rootClass = null, string $operationName = null): callable
+    public function __invoke($source, $args, $context, ResolveInfo $info)
     {
-        return function ($source, $args, $context, ResolveInfo $info) use ($resourceClass) {
-            // Data already fetched and normalized (field or nested resource)
-            if (isset($source[$info->fieldName])) {
-                return $source[$info->fieldName];
-            }
+        // Data already fetched and normalized (field or nested resource)
+        if (isset($source[$info->fieldName])) {
+            return $source[$info->fieldName];
+        }
 
-            if (!isset($args['id'])) {
-                return null;
-            }
+        if (!isset($args['id'])) {
+            return null;
+        }
 
-            // TODO: initialize the EagerLoading extension
-            try {
-                $item = $this->iriConverter->getItemFromIri($args['id']);
-            } catch (ItemNotFoundException $e) {
-                return null;
-            }
+        // TODO: initialize the EagerLoading extension
+        try {
+            $item = $this->iriConverter->getItemFromIri($args['id']);
+        } catch (ItemNotFoundException $e) {
+            return null;
+        }
 
-            $normalizationContext = $this->resourceMetadataFactory->create($resourceClass)->getGraphqlAttribute('query', 'normalization_context', [], true);
+        $normalizationContext = $this->resourceMetadataFactory->create($this->getObjectClass($item))->getGraphqlAttribute('query', 'normalization_context', [], true);
 
-            return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext + ['attributes' => $info->getFieldSelection(PHP_INT_MAX)]);
-        };
+        return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext + ['attributes' => $info->getFieldSelection(PHP_INT_MAX)]);
     }
 }

--- a/src/Graphql/Resolver/ResourceFieldResolver.php
+++ b/src/Graphql/Resolver/ResourceFieldResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Graphql\Resolver;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Graphql\Serializer\ItemNormalizer;
 use GraphQL\Type\Definition\ResolveInfo;
 
 /**
@@ -35,8 +36,8 @@ final class ResourceFieldResolver
     public function __invoke($source, $args, $context, ResolveInfo $info)
     {
         $property = null;
-        if ('id' === $info->fieldName && isset($source['#item'])) {
-            return $this->iriConverter->getIriFromItem(unserialize($source['#item']));
+        if ('id' === $info->fieldName && isset($source[ItemNormalizer::ITEM_KEY])) {
+            return $this->iriConverter->getIriFromItem(unserialize($source[ItemNormalizer::ITEM_KEY]));
         }
 
         if ('_id' === $info->fieldName && isset($source['id'])) {

--- a/src/Graphql/Serializer/ItemNormalizer.php
+++ b/src/Graphql/Serializer/ItemNormalizer.php
@@ -32,6 +32,7 @@ use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
 final class ItemNormalizer extends AbstractItemNormalizer
 {
     const FORMAT = 'graphql';
+    const ITEM_KEY = '#item';
 
     /**
      * {@inheritdoc}
@@ -39,7 +40,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
     public function normalize($object, $format = null, array $context = [])
     {
         $data = parent::normalize($object, $format, $context);
-        $data['#item'] = serialize($object); // calling serialize prevent weird normalization process done by Webonyx's GraphQL PHP
+        $data[self::ITEM_KEY] = serialize($object); // calling serialize prevent weird normalization process done by Webonyx's GraphQL PHP
 
         return $data;
     }

--- a/src/Graphql/Type/SchemaBuilder.php
+++ b/src/Graphql/Type/SchemaBuilder.php
@@ -106,7 +106,6 @@ final class SchemaBuilder implements SchemaBuilderInterface
             return $this->graphqlTypes['#node'];
         }
 
-
         return $this->graphqlTypes['#node'] = new InterfaceType([
             'name' => 'Node',
             'description' => 'A node, according to the Relay specification.',

--- a/src/Graphql/Type/SchemaBuilder.php
+++ b/src/Graphql/Type/SchemaBuilder.php
@@ -14,14 +14,17 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Graphql\Type;
 
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
-use ApiPlatform\Core\Graphql\Resolver\ResolverFactoryInterface;
+use ApiPlatform\Core\Graphql\Resolver\Factory\ResolverFactoryInterface;
+use ApiPlatform\Core\Graphql\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Util\ClassInfoTrait;
 use Doctrine\Common\Util\Inflector;
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use GraphQL\Type\Definition\WrappingType;
@@ -40,25 +43,27 @@ use Symfony\Component\PropertyInfo\Type;
  */
 final class SchemaBuilder implements SchemaBuilderInterface
 {
+    use ClassInfoTrait;
+
     private $propertyNameCollectionFactory;
     private $propertyMetadataFactory;
     private $resourceNameCollectionFactory;
     private $resourceMetadataFactory;
     private $collectionResolverFactory;
-    private $itemResolverFactory;
+    private $itemResolver;
     private $itemMutationResolverFactory;
     private $defaultFieldResolver;
     private $paginationEnabled;
-    private $resourceTypesCache = [];
+    private $graphqlTypes = [];
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, ResolverFactoryInterface $collectionResolverFactory, ResolverFactoryInterface $itemResolverFactory, ResolverFactoryInterface $itemMutationResolverFactory, callable $defaultFieldResolver, bool $paginationEnabled = true)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, ResolverFactoryInterface $collectionResolverFactory, ResolverFactoryInterface $itemMutationResolverFactory, callable $itemResolver, callable $defaultFieldResolver, bool $paginationEnabled = true)
     {
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->collectionResolverFactory = $collectionResolverFactory;
-        $this->itemResolverFactory = $itemResolverFactory;
+        $this->itemResolver = $itemResolver;
         $this->itemMutationResolverFactory = $itemMutationResolverFactory;
         $this->defaultFieldResolver = $defaultFieldResolver;
         $this->paginationEnabled = $paginationEnabled;
@@ -66,13 +71,12 @@ final class SchemaBuilder implements SchemaBuilderInterface
 
     public function getSchema(): Schema
     {
-        $queryFields = [];
+        $queryFields = ['node' => $this->getNodeQueryField()];
         $mutationFields = [];
 
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             $graphqlConfiguration = $resourceMetadata->getGraphql() ?? [];
-
             foreach ($graphqlConfiguration as $operationName => $value) {
                 if ('query' === $operationName) {
                     $queryFields += $this->getQueryFields($resourceClass, $resourceMetadata);
@@ -94,6 +98,45 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 'fields' => $mutationFields,
             ]),
         ]);
+    }
+
+    private function getNodeInterface(): InterfaceType
+    {
+        if (isset($this->graphqlTypes['#node'])) {
+            return $this->graphqlTypes['#node'];
+        }
+
+
+        return $this->graphqlTypes['#node'] = new InterfaceType([
+            'name' => 'Node',
+            'description' => 'A node, according to the Relay specification.',
+            'fields' => [
+                'id' => [
+                    'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    'description' => 'The id of this node.',
+                ],
+            ],
+            'resolveType' => function ($value) {
+                if (!isset($value[ItemNormalizer::ITEM_KEY])) {
+                    return null;
+                }
+
+                $resourceClass = $this->getObjectClass(unserialize($value[ItemNormalizer::ITEM_KEY]));
+
+                return $this->graphqlTypes[$resourceClass][null][false] ?? null;
+            },
+        ]);
+    }
+
+    private function getNodeQueryField(): array
+    {
+        return [
+            'type' => $this->getNodeInterface(),
+            'args' => [
+                'id' => ['type' => GraphQLType::nonNull(GraphQLType::id())],
+            ],
+            'resolve' => $this->itemResolver,
+        ];
     }
 
     /**
@@ -124,9 +167,13 @@ final class SchemaBuilder implements SchemaBuilderInterface
         $shortName = $resourceMetadata->getShortName();
         $resourceType = new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass);
 
-        if ($fieldConfiguration = $this->getResourceFieldConfiguration(ucfirst("{$mutationName}s a $shortName."), $resourceType, $resourceClass, false, true, $mutationName)) {
-            $fieldConfiguration['args'] += ['input' => $this->getResourceFieldConfiguration(null, $resourceType, $resourceClass, true, true, $mutationName)];
-            $fieldConfiguration['resolve'] = $resourceType->isCollection() ? null : $this->itemMutationResolverFactory->__invoke($resourceClass, null, $mutationName);
+        if ($fieldConfiguration = $this->getResourceFieldConfiguration(ucfirst("{$mutationName}s a $shortName."), $resourceType, $resourceClass, false, $mutationName)) {
+            $fieldConfiguration['args'] += ['input' => $this->getResourceFieldConfiguration(null, $resourceType, $resourceClass, true, $mutationName)];
+
+            if (!$resourceType->isCollection()) {
+                $itemMutationResolverFactory = $this->itemMutationResolverFactory;
+                $fieldConfiguration['resolve'] = $itemMutationResolverFactory($resourceClass, null, $mutationName);
+            }
         }
 
         return $fieldConfiguration;
@@ -139,10 +186,13 @@ final class SchemaBuilder implements SchemaBuilderInterface
      *
      * @return array|null
      */
-    private function getResourceFieldConfiguration(string $fieldDescription = null, Type $type, string $rootResource, bool $isInput = false, bool $isMutation = false, string $mutationName = null)
+    private function getResourceFieldConfiguration(string $fieldDescription = null, Type $type, string $rootResource, bool $input = false, string $mutationName = null)
     {
         try {
-            $graphqlType = $this->convertType($type, $isInput, $isMutation, $mutationName);
+            if (null === $graphqlType = $this->convertType($type, $input, $mutationName)) {
+                return null;
+            }
+
             $graphqlWrappedType = $graphqlType instanceof WrappingType ? $graphqlType->getWrappedType() : $graphqlType;
             $isInternalGraphqlType = \in_array($graphqlWrappedType, GraphQLType::getInternalTypes(), true);
             if ($isInternalGraphqlType) {
@@ -152,7 +202,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
             }
 
             $args = [];
-            if ($this->paginationEnabled && !$isInternalGraphqlType && $type->isCollection() && !$isInput && !$isMutation) {
+            if ($this->paginationEnabled && !$isInternalGraphqlType && $type->isCollection() && !$input && null === $mutationName) {
                 $args = [
                     'first' => [
                         'type' => GraphQLType::int(),
@@ -165,11 +215,13 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 ];
             }
 
-            if ($isInternalGraphqlType || $isInput || $isMutation) {
+            if ($isInternalGraphqlType || $input || null !== $mutationName) {
                 $resolve = null;
-            } else {
-                $resolverFactory = $type->isCollection() ? $this->collectionResolverFactory : $this->itemResolverFactory;
+            } elseif ($type->isCollection()) {
+                $resolverFactory = $this->collectionResolverFactory;
                 $resolve = $resolverFactory($className, $rootResource);
+            } else {
+                $resolve = $this->itemResolver;
             }
 
             return [
@@ -179,8 +231,10 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 'resolve' => $resolve,
             ];
         } catch (InvalidTypeException $e) {
-            return null;
+            // just ignore invalid types
         }
+
+        return null;
     }
 
     /**
@@ -188,8 +242,9 @@ final class SchemaBuilder implements SchemaBuilderInterface
      *
      * @throws InvalidTypeException
      */
-    private function convertType(Type $type, bool $isInput = false, bool $isMutation = false, string $mutationName = null): GraphQLType
+    private function convertType(Type $type, bool $input = false, string $mutationName = null)
     {
+        $resourceClass = null;
         switch ($builtinType = $type->getBuiltinType()) {
             case Type::BUILTIN_TYPE_BOOL:
                 $graphqlType = GraphQLType::boolean();
@@ -209,24 +264,28 @@ final class SchemaBuilder implements SchemaBuilderInterface
                     break;
                 }
 
-                $className = $type->isCollection() ? $type->getCollectionValueType()->getClassName() : $type->getClassName();
+                $resourceClass = $type->isCollection() ? $type->getCollectionValueType()->getClassName() : $type->getClassName();
                 try {
-                    $resourceMetadata = $this->resourceMetadataFactory->create($className);
+                    $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+                    if ([] === $resourceMetadata->getGraphql() ?? []) {
+                        return null;
+                    }
                 } catch (ResourceClassNotFoundException $e) {
-                    throw new InvalidTypeException(sprintf('The class "%s" does not exist.', $className));
+                    // Skip objects that are not resources for now
+                    return null;
                 }
 
-                $graphqlType = $this->getResourceObjectType($className, $resourceMetadata, $isInput, $isMutation, $mutationName);
+                $graphqlType = $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $mutationName);
                 break;
             default:
                 throw new InvalidTypeException(sprintf('The type "%s" is not supported.', $builtinType));
         }
 
         if ($type->isCollection()) {
-            return $this->paginationEnabled ? $this->getResourcePaginatedCollectionType($graphqlType, $isInput) : GraphQLType::listOf($graphqlType);
+            return $this->paginationEnabled ? $this->getResourcePaginatedCollectionType($resourceClass, $graphqlType, $input) : GraphQLType::listOf($graphqlType);
         }
 
-        return $type->isNullable() || ($isMutation && 'update' === $mutationName) ? $graphqlType : GraphQLType::nonNull($graphqlType);
+        return $type->isNullable() || (null !== $mutationName && 'update' === $mutationName) ? $graphqlType : GraphQLType::nonNull($graphqlType);
     }
 
     /**
@@ -234,30 +293,37 @@ final class SchemaBuilder implements SchemaBuilderInterface
      *
      * @return ObjectType|InputObjectType
      */
-    private function getResourceObjectType(string $resource, ResourceMetadata $resourceMetadata, bool $isInput = false, bool $isMutation = false, string $mutationName = null)
+    private function getResourceObjectType(string $resourceClass, ResourceMetadata $resourceMetadata, bool $input = false, string $mutationName = null): GraphQLType
     {
-        $shortName = $resourceMetadata->getShortName().($isInput ? 'Input' : '').($isMutation ? ucfirst($mutationName).'Mutation' : '');
+        $shortName = $resourceMetadata->getShortName();
+        if ($input) {
+            $shortName .= 'Input';
+        }
+        if (null !== $mutationName) {
+            $shortName .= ucfirst($mutationName).'Mutation';
+        }
 
-        if (isset($this->resourceTypesCache[$shortName])) {
-            return $this->resourceTypesCache[$shortName];
+        if (isset($this->graphqlTypes[$resourceClass][$mutationName][$input])) {
+            return $this->graphqlTypes[$resourceClass][$mutationName][$input];
         }
 
         $configuration = [
             'name' => $shortName,
             'description' => $resourceMetadata->getDescription(),
             'resolveField' => $this->defaultFieldResolver,
-            'fields' => function () use ($resource, $isInput, $isMutation, $mutationName) {
-                return $this->getResourceObjectTypeFields($resource, $isInput, $isMutation, $mutationName);
+            'fields' => function () use ($resourceClass, $input, $mutationName) {
+                return $this->getResourceObjectTypeFields($resourceClass, $input, $mutationName);
             },
+            'interfaces' => [$this->getNodeInterface()],
         ];
 
-        return $this->resourceTypesCache[$shortName] = $isInput ? new InputObjectType($configuration) : new ObjectType($configuration);
+        return $this->graphqlTypes[$resourceClass][$mutationName][$input] = $input ? new InputObjectType($configuration) : new ObjectType($configuration);
     }
 
     /**
      * Gets the fields of the type of the given resource.
      */
-    private function getResourceObjectTypeFields(string $resource, bool $isInput = false, bool $isMutation = false, string $mutationName = null): array
+    private function getResourceObjectTypeFields(string $resource, bool $input = false, string $mutationName = null): array
     {
         $fields = [];
         $idField = ['type' => GraphQLType::id()];
@@ -266,7 +332,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
             return ['id' => $idField];
         }
 
-        if (!$isInput || 'create' !== $mutationName) {
+        if (!$input || 'create' !== $mutationName) {
             $fields['id'] = $idField;
         }
 
@@ -274,13 +340,13 @@ final class SchemaBuilder implements SchemaBuilderInterface
             $propertyMetadata = $this->propertyMetadataFactory->create($resource, $property);
             if (
                 null === ($propertyType = $propertyMetadata->getType())
-                || (!$isInput && !$isMutation && !$propertyMetadata->isReadable())
-                || ($isMutation && !$propertyMetadata->isWritable())
+                || (!$input && null === $mutationName && !$propertyMetadata->isReadable())
+                || (null !== $mutationName && !$propertyMetadata->isWritable())
             ) {
                 continue;
             }
 
-            if ($fieldConfiguration = $this->getResourceFieldConfiguration($propertyMetadata->getDescription(), $propertyType, $resource, $isInput, $isMutation, $mutationName)) {
+            if ($fieldConfiguration = $this->getResourceFieldConfiguration($propertyMetadata->getDescription(), $propertyType, $resource, $input, $mutationName)) {
                 $fields['id' === $property ? '_id' : $property] = $fieldConfiguration;
             }
         }
@@ -295,12 +361,15 @@ final class SchemaBuilder implements SchemaBuilderInterface
      *
      * @return ObjectType|InputObjectType
      */
-    private function getResourcePaginatedCollectionType($resourceType, bool $isInput = false)
+    private function getResourcePaginatedCollectionType(string $resourceClass, GraphQLType $resourceType, bool $input = false): GraphQLType
     {
-        $shortName = $resourceType->name.($isInput ? 'Input' : '');
+        $shortName = $resourceType->name;
+        if ($input) {
+            $shortName .= 'Input';
+        }
 
-        if (isset($this->resourceTypesCache["{$shortName}Connection"])) {
-            return $this->resourceTypesCache["{$shortName}Connection"];
+        if (isset($this->graphqlTypes[$resourceClass]['connection'][$input])) {
+            return $this->graphqlTypes[$resourceClass]['connection'][$input];
         }
 
         $edgeObjectTypeConfiguration = [
@@ -311,7 +380,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 'cursor' => GraphQLType::nonNull(GraphQLType::string()),
             ],
         ];
-        $edgeObjectType = $isInput ? new InputObjectType($edgeObjectTypeConfiguration) : new ObjectType($edgeObjectTypeConfiguration);
+        $edgeObjectType = $input ? new InputObjectType($edgeObjectTypeConfiguration) : new ObjectType($edgeObjectTypeConfiguration);
         $pageInfoObjectTypeConfiguration = [
             'name' => "{$shortName}PageInfo",
             'description' => 'Information about the current page.',
@@ -320,7 +389,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 'hasNextPage' => GraphQLType::nonNull(GraphQLType::boolean()),
             ],
         ];
-        $pageInfoObjectType = $isInput ? new InputObjectType($pageInfoObjectTypeConfiguration) : new ObjectType($pageInfoObjectTypeConfiguration);
+        $pageInfoObjectType = $input ? new InputObjectType($pageInfoObjectTypeConfiguration) : new ObjectType($pageInfoObjectTypeConfiguration);
 
         $configuration = [
             'name' => "{$shortName}Connection",
@@ -331,6 +400,6 @@ final class SchemaBuilder implements SchemaBuilderInterface
             ],
         ];
 
-        return $this->resourceTypesCache["{$shortName}Connection"] = $isInput ? new InputObjectType($configuration) : new ObjectType($configuration);
+        return $this->graphqlTypes[$resourceClass]['connection'][$input] = $input ? new InputObjectType($configuration) : new ObjectType($configuration);
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -242,9 +242,9 @@ class ApiPlatformExtensionTest extends TestCase
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setDefinition('api_platform.action.graphql_entrypoint')->shouldNotBeCalled();
-        $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.collection_factory')->shouldNotBeCalled();
-        $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.item_factory')->shouldNotBeCalled();
-        $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.item_mutation_factory')->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.collection')->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.item_mutation')->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.item')->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.resource_field')->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.executor')->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.schema_builder')->shouldNotBeCalled();
@@ -583,9 +583,9 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.action.entrypoint',
             'api_platform.graphql.executor',
             'api_platform.graphql.schema_builder',
-            'api_platform.graphql.resolver.collection_factory',
-            'api_platform.graphql.resolver.item_factory',
-            'api_platform.graphql.resolver.item_mutation_factory',
+            'api_platform.graphql.resolver.factory.collection',
+            'api_platform.graphql.resolver.factory.item_mutation',
+            'api_platform.graphql.resolver.item',
             'api_platform.graphql.resolver.resource_field',
             'api_platform.graphql.normalizer.item',
             'api_platform.jsonld.normalizer.item',

--- a/tests/Fixtures/TestBundle/Entity/Node.php
+++ b/tests/Fixtures/TestBundle/Entity/Node.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @see https://github.com/api-platform/core/pull/904#issuecomment-294132077
- * @ApiResource
+ * @ApiResource(graphql={})
  * @ORM\Entity
  */
 class Node

--- a/tests/Graphql/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/Graphql/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -11,13 +11,14 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Graphql\Resolver;
+namespace ApiPlatform\Core\Tests\Graphql\Resolver\Factory;
 
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
-use ApiPlatform\Core\Graphql\Resolver\CollectionResolverFactory;
+use ApiPlatform\Core\Graphql\Resolver\Factory\CollectionResolverFactory;
+use ApiPlatform\Core\Graphql\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
@@ -95,7 +96,7 @@ class CollectionResolverFactoryTest extends TestCase
 
         $source = [
             'relatedDummies' => [],
-            '#item' => serialize($dummy),
+            ItemNormalizer::ITEM_KEY => serialize($dummy),
         ];
 
         $this->assertEquals($expected, $resolver($source, [], null, $resolveInfo));

--- a/tests/Graphql/Resolver/Factory/ItemMutationResolverFactoryTest.php
+++ b/tests/Graphql/Resolver/Factory/ItemMutationResolverFactoryTest.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Graphql\Resolver;
+namespace ApiPlatform\Core\Tests\Graphql\Resolver\Factory;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
-use ApiPlatform\Core\Graphql\Resolver\ItemMutationResolverFactory;
-use ApiPlatform\Core\Graphql\Resolver\ResolverFactoryInterface;
+use ApiPlatform\Core\Graphql\Resolver\Factory\ItemMutationResolverFactory;
+use ApiPlatform\Core\Graphql\Resolver\Factory\ResolverFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;

--- a/tests/Graphql/Resolver/ItemResolverTest.php
+++ b/tests/Graphql/Resolver/ItemResolverTest.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Tests\Graphql\Resolver;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
-use ApiPlatform\Core\Graphql\Resolver\ItemResolverFactory;
+use ApiPlatform\Core\Graphql\Resolver\ItemResolver;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
@@ -29,12 +29,11 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author Alan Poulain <contact@alanpoulain.eu>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class ItemResolverFactoryTest extends TestCase
+class ItemResolverTest extends TestCase
 {
     public function testCreateItemResolverNoItem()
     {
-        $resolverFactory = $this->createItemResolverFactory(null);
-        $resolver = $resolverFactory(RelatedDummy::class, Dummy::class, 'operationName');
+        $resolver = $this->createItemResolver(null);
 
         $resolveInfo = new ResolveInfo([]);
         $resolveInfo->fieldName = 'name';
@@ -45,8 +44,7 @@ class ItemResolverFactoryTest extends TestCase
 
     public function testCreateItemResolver()
     {
-        $resolverFactory = $this->createItemResolverFactory(new RelatedDummy());
-        $resolver = $resolverFactory(RelatedDummy::class, Dummy::class, 'operationName');
+        $resolver = $this->createItemResolver(new RelatedDummy());
 
         $resolveInfo = new ResolveInfo([]);
         $resolveInfo->fieldName = 'name';
@@ -60,8 +58,7 @@ class ItemResolverFactoryTest extends TestCase
      */
     public function testCreateSubresourceItemResolver($normalizedSubresource)
     {
-        $resolverFactory = $this->createItemResolverFactory(new Dummy());
-        $resolver = $resolverFactory(RelatedDummy::class, Dummy::class, 'operationName');
+        $resolver = $this->createItemResolver(new Dummy());
 
         $resolveInfo = new ResolveInfo([]);
         $resolveInfo->fieldName = 'relatedDummy';
@@ -78,7 +75,7 @@ class ItemResolverFactoryTest extends TestCase
         ];
     }
 
-    private function createItemResolverFactory($item): ItemResolverFactory
+    private function createItemResolver($item): ItemResolver
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $getItemFromIri = $iriConverterProphecy->getItemFromIri('/related_dummies/3');
@@ -91,7 +88,7 @@ class ItemResolverFactoryTest extends TestCase
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy', null, null, null, null, ['normalization_context' => ['groups' => ['foo']]]));
         $resourceMetadataFactoryProphecy->create(RelatedDummy::class)->willReturn(new ResourceMetadata('RelatedDummy', null, null, null, null, ['normalization_context' => ['groups' => ['foo']]]));
 
-        return new ItemResolverFactory(
+        return new ItemResolver(
             $iriConverterProphecy->reveal(),
             $normalizerProphecy->reveal(),
             $resourceMetadataFactoryProphecy->reveal()

--- a/tests/Graphql/Resolver/ResourceFieldResolverTest.php
+++ b/tests/Graphql/Resolver/ResourceFieldResolverTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Graphql\Resolver;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Graphql\Resolver\ResourceFieldResolver;
+use ApiPlatform\Core\Graphql\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use GraphQL\Type\Definition\ResolveInfo;
 use PHPUnit\Framework\TestCase;
@@ -33,7 +34,7 @@ class ResourceFieldResolverTest extends TestCase
         $resolveInfo->fieldNodes = [];
 
         $resolver = new ResourceFieldResolver($iriConverterProphecy->reveal());
-        $this->assertEquals('/dummies/1', $resolver(['#item' => serialize($dummy)], [], [], $resolveInfo));
+        $this->assertEquals('/dummies/1', $resolver([ItemNormalizer::ITEM_KEY => serialize($dummy)], [], [], $resolveInfo));
     }
 
     public function testOriginalId()

--- a/tests/Graphql/Serializer/ItemNormalizerTest.php
+++ b/tests/Graphql/Serializer/ItemNormalizerTest.php
@@ -96,7 +96,7 @@ class ItemNormalizerTest extends TestCase
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
-        $this->assertEquals(['name' => 'hello', '#item' => serialize($dummy)], $normalizer->normalize($dummy, ItemNormalizer::FORMAT, ['resources' => []]));
+        $this->assertEquals(['name' => 'hello', ItemNormalizer::ITEM_KEY => serialize($dummy)], $normalizer->normalize($dummy, ItemNormalizer::FORMAT, ['resources' => []]));
     }
 
     public function testDenormalize()

--- a/tests/Graphql/Type/SchemaBuilderTest.php
+++ b/tests/Graphql/Type/SchemaBuilderTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Graphql\Type;
 
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
-use ApiPlatform\Core\Graphql\Resolver\ResolverFactoryInterface;
+use ApiPlatform\Core\Graphql\Resolver\Factory\ResolverFactoryInterface;
 use ApiPlatform\Core\Graphql\Type\SchemaBuilder;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -57,6 +57,7 @@ class SchemaBuilderTest extends TestCase
 
         $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, false);
         $this->assertEquals([
+            'node',
             'shortName1',
             'shortName1s',
             'shortName2',
@@ -122,6 +123,7 @@ class SchemaBuilderTest extends TestCase
         $queryFields = $schema->getConfig()->getQuery()->getFields();
 
         $this->assertEquals([
+            'node',
             'shortName1',
             'shortName1s',
             'shortName2',
@@ -186,7 +188,6 @@ class SchemaBuilderTest extends TestCase
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $collectionResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
-        $itemResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
         $itemMutationResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
 
         $resourceClassNames = [];
@@ -219,7 +220,6 @@ class SchemaBuilderTest extends TestCase
         $resourceNameCollectionFactoryProphecy->create()->willReturn($resourceNameCollection);
 
         $collectionResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {});
-        $itemResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {});
         $itemMutationResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {});
 
         return new SchemaBuilder(
@@ -228,8 +228,8 @@ class SchemaBuilderTest extends TestCase
             $resourceNameCollectionFactoryProphecy->reveal(),
             $resourceMetadataFactoryProphecy->reveal(),
             $collectionResolverFactoryProphecy->reveal(),
-            $itemResolverFactoryProphecy->reveal(),
             $itemMutationResolverFactoryProphecy->reveal(),
+            function () {},
             function () {},
             $paginationEnabled
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Implementation of the GraphQL's [Relay Global Object Identification Specification](https://facebook.github.io/relay/graphql/objectidentification.htm) using hypermedia IRIs.

You can now execute this kind of queries on the GraphQL endpoint:

```graphql
    {
      node(id: "/product/ABC") {
        id
        ... on Product {
          name
        }
      }
    }
```

Note: I'll probably extract the GraphQL type builder in a from the `SchemaBuilder` in a following PR.