### PR TITLE
Set required Hydra property when relation is not nullable.

### DIFF
--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -4,11 +4,11 @@ Feature: Documentation support
   I need to know Hydra specifications of objects I send and receive
 
   Scenario: Checks that the Link pointing to the Hydra documentation is set
-    Given I send a "GET" request to "/"
+    When I send a "GET" request to "/"
     Then the header "Link" should be equal to '<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
 
   Scenario: Retrieve the API vocabulary
-    Given I send a "GET" request to "/docs.jsonld"
+    When I send a "GET" request to "/docs.jsonld"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
@@ -43,6 +43,7 @@ Feature: Documentation support
     And the Hydra class "CustomNormalizedDummy" exists
     And the Hydra class "CustomWritableIdentifierDummy" exists
     And the Hydra class "Dummy" exists
+    And the Hydra class "NotNullableRelationDummy" exists
     And the Hydra class "RelatedDummy" exists
     And the Hydra class "RelationEmbedder" exists
     And the Hydra class "ThirdLevel" exists
@@ -60,6 +61,7 @@ Feature: Documentation support
     And "name" property is readable for Hydra class "Dummy"
     And "name" property is writable for Hydra class "Dummy"
     And "name" property is required for Hydra class "Dummy"
+    And "dummyFriend" property is required for Hydra class "NotNullableRelationDummy"
     And "plainPassword" property is not readable for Hydra class "User"
     And "plainPassword" property is writable for Hydra class "User"
     And "plainPassword" property is not required for Hydra class "User"

--- a/tests/Fixtures/TestBundle/Entity/NotNullableRelationDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/NotNullableRelationDummy.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Not Nullable Relation Dummy.
+ *
+ * @ApiResource
+ * @ORM\Entity
+ */
+class NotNullableRelationDummy
+{
+    /**
+     * @var string The dummy name
+     *
+     * @ORM\Column
+     * @Assert\NotBlank
+     * @ApiProperty(iri="http://schema.org/name")
+     */
+    private $name;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="DummyFriend")
+     * @ORM\JoinColumn(name="dummyfriend_id", referencedColumnName="id", nullable=false)
+     */
+    private $dummyFriend;
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Gets dummyFriend.
+     *
+     * @return DummyFriend
+     */
+    public function getDummyFriend()
+    {
+        return $this->dummyFriend;
+    }
+
+    /**
+     * Sets dummyFriend.
+     *
+     * @param DummyFriend $dummyFriend the value to set
+     */
+    public function setDummyFriend(DummyFriend $dummyFriend)
+    {
+        $this->dummyFriend = $dummyFriend;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1567
| License       | MIT
| Doc PR        |

Implement #1567 by checking if the relation is required.
