### PR TITLE
GraphQL + data provider refactoring: automatically add SQL join clauses

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,4 +12,5 @@ parameters:
 
         # False positives
         - '#Call to an undefined method Doctrine\\Common\\Persistence\\ObjectManager::getConnection\(\)#'
-        - '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryResult(Item|Collection)ExtensionInterface::getResult\(\) invoked with 3 parameters, 1 required#'
+        - '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryResult(Item|Collection)ExtensionInterface::supportsResult\(\) invoked with 3 parameters, 1-2 required\.#'
+        - '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryResult(Item|Collection)ExtensionInterface::getResult\(\) invoked with 4 parameters, 1 required\.#'

--- a/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
@@ -42,7 +42,7 @@ class CollectionDataProvider implements ContextAwareCollectionDataProviderInterf
         $this->collectionExtensions = $collectionExtensions;
     }
 
-    public function supports(string $resourceClass, string $operationName = null, array $conext = []): bool
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
     {
         return null !== $this->managerRegistry->getManagerForClass($resourceClass);
     }

--- a/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/CollectionDataProvider.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm;
 
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\ContextAwareQueryCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryResultCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
-use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -27,14 +28,13 @@ use Doctrine\Common\Persistence\ManagerRegistry;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-class CollectionDataProvider implements CollectionDataProviderInterface, RestrictedDataProviderInterface
+class CollectionDataProvider implements ContextAwareCollectionDataProviderInterface, RestrictedDataProviderInterface
 {
     private $managerRegistry;
     private $collectionExtensions;
 
     /**
-     * @param ManagerRegistry                     $managerRegistry
-     * @param QueryCollectionExtensionInterface[] $collectionExtensions
+     * @param QueryCollectionExtensionInterface[]|ContextAwareQueryCollectionExtensionInterface[] $collectionExtensions
      */
     public function __construct(ManagerRegistry $managerRegistry, array $collectionExtensions = [])
     {
@@ -42,7 +42,7 @@ class CollectionDataProvider implements CollectionDataProviderInterface, Restric
         $this->collectionExtensions = $collectionExtensions;
     }
 
-    public function supports(string $resourceClass, string $operationName = null): bool
+    public function supports(string $resourceClass, string $operationName = null, array $conext = []): bool
     {
         return null !== $this->managerRegistry->getManagerForClass($resourceClass);
     }
@@ -52,7 +52,7 @@ class CollectionDataProvider implements CollectionDataProviderInterface, Restric
      *
      * @throws RuntimeException
      */
-    public function getCollection(string $resourceClass, string $operationName = null)
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
     {
         $manager = $this->managerRegistry->getManagerForClass($resourceClass);
 
@@ -64,10 +64,10 @@ class CollectionDataProvider implements CollectionDataProviderInterface, Restric
         $queryBuilder = $repository->createQueryBuilder('o');
         $queryNameGenerator = new QueryNameGenerator();
         foreach ($this->collectionExtensions as $extension) {
-            $extension->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operationName);
+            $extension->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
 
-            if ($extension instanceof QueryResultCollectionExtensionInterface && $extension->supportsResult($resourceClass, $operationName)) {
-                return $extension->getResult($queryBuilder, $resourceClass, $operationName);
+            if ($extension instanceof QueryResultCollectionExtensionInterface && $extension->supportsResult($resourceClass, $operationName, $context)) {
+                return $extension->getResult($queryBuilder, $resourceClass, $operationName, $context);
             }
         }
 

--- a/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryCollectionExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryCollectionExtensionInterface.php
@@ -17,12 +17,11 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * Interface of Doctrine ORM query extensions for collection queries.
+ * Context aware extension.
  *
- * @author Samuel ROZE <samuel.roze@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface QueryCollectionExtensionInterface
+interface ContextAwareQueryCollectionExtensionInterface extends QueryCollectionExtensionInterface
 {
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null);
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = []);
 }

--- a/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryItemExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryItemExtensionInterface.php
@@ -16,18 +16,17 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * Interface of Doctrine ORM query extensions that supports result production
- * for specific cases such as pagination.
+ * Context aware extension.
  *
- * @author Samuel ROZE <samuel.roze@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface QueryResultCollectionExtensionInterface extends QueryCollectionExtensionInterface
+interface ContextAwareQueryItemExtensionInterface extends QueryItemExtensionInterface
 {
-    public function supportsResult(string $resourceClass, string $operationName = null): bool;
+    public function supportsResult(string $resourceClass, string $operationName = null, array $context = []): bool;
 
     /**
      * @return mixed
      */
-    public function getResult(QueryBuilder $queryBuilder);
+    public function getResult(QueryBuilder $queryBuilder, string $resourceClass = null, string $operationName = null, array $context = []);
+
 }

--- a/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryItemExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryItemExtensionInterface.php
@@ -28,5 +28,4 @@ interface ContextAwareQueryItemExtensionInterface extends QueryItemExtensionInte
      * @return mixed
      */
     public function getResult(QueryBuilder $queryBuilder, string $resourceClass = null, string $operationName = null, array $context = []);
-
 }

--- a/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryResultCollectionExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryResultCollectionExtensionInterface.php
@@ -16,18 +16,16 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * Interface of Doctrine ORM query extensions that supports result production
- * for specific cases such as pagination.
+ * Context aware extension.
  *
- * @author Samuel ROZE <samuel.roze@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface QueryResultCollectionExtensionInterface extends QueryCollectionExtensionInterface
+interface ContextAwareQueryResultCollectionExtensionInterface extends QueryResultCollectionExtensionInterface
 {
-    public function supportsResult(string $resourceClass, string $operationName = null): bool;
+    public function supportsResult(string $resourceClass, string $operationName = null, array $context = []): bool;
 
     /**
      * @return mixed
      */
-    public function getResult(QueryBuilder $queryBuilder);
+    public function getResult(QueryBuilder $queryBuilder, string $resourceClass = null, string $operationName = null, array $context = []);
 }

--- a/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryResultItemExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/ContextAwareQueryResultItemExtensionInterface.php
@@ -16,18 +16,16 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * Interface of Doctrine ORM query extensions that supports result production
- * for specific cases such as pagination.
+ * Context aware extension.
  *
- * @author Samuel ROZE <samuel.roze@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface QueryResultCollectionExtensionInterface extends QueryCollectionExtensionInterface
+interface ContextAwareQueryResultItemExtensionInterface extends QueryResultItemExtensionInterface
 {
-    public function supportsResult(string $resourceClass, string $operationName = null): bool;
+    public function supportsResult(string $resourceClass, string $operationName = null, array $context = []): bool;
 
     /**
      * @return mixed
      */
-    public function getResult(QueryBuilder $queryBuilder);
+    public function getResult(QueryBuilder $queryBuilder, string $resourceClass = null, string $operationName = null, array $context = []);
 }

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -54,9 +54,9 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
      */
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, int $maxJoins = 30, bool $forceEager = true, RequestStack $requestStack = null, SerializerContextBuilderInterface $serializerContextBuilder = null, bool $fetchPartial = false, ClassMetadataFactoryInterface $classMetadataFactory = null)
     {
-        if (null !== $this->serializerContextBuilder) {
-            @trigger_error('Passing an instance of "%s" is deprecated since version 2.2 and will be removed in 3.0. Use the "normalization_context" of the data provider\'s context instead.', E_USER_DEPRECATED);
-        }
+        //if (null !== $this->serializerContextBuilder) {
+        //    @trigger_error('Passing an instance of "%s" is deprecated since version 2.2 and will be removed in 3.0. Use the "normalization_context" of the data provider\'s context instead.', E_USER_DEPRECATED);
+        //}
 
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
@@ -84,7 +84,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
 
         if (!$normalizationContext = $context['normalization_context'] ?? false) {
             $contextType = isset($context['api_denormalize']) ? 'denormalization_context' : 'normalization_context';
-            $normalizationContext =  $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
+            $normalizationContext = $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
         }
 
         $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $options, $normalizationContext);
@@ -101,7 +101,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
 
         if (!$normalizationContext = $context['normalization_context'] ?? false) {
             $contextType = isset($context['api_denormalize']) ? 'denormalization_context' : 'normalization_context';
-            $normalizationContext =  $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
+            $normalizationContext = $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
         }
 
         $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $options, $normalizationContext);

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\EagerLoadingTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\PropertyNotFoundException;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Exception\RuntimeException;
@@ -37,7 +38,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
  * @author Antoine Bluchet <soyuka@gmail.com>
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
-final class EagerLoadingExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensionInterface, QueryItemExtensionInterface
 {
     use EagerLoadingTrait;
 
@@ -53,6 +54,10 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
      */
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, int $maxJoins = 30, bool $forceEager = true, RequestStack $requestStack = null, SerializerContextBuilderInterface $serializerContextBuilder = null, bool $fetchPartial = false, ClassMetadataFactoryInterface $classMetadataFactory = null)
     {
+        if (null !== $this->serializerContextBuilder) {
+            @trigger_error('Passing an instance of "%s" is deprecated since version 2.2 and will be removed in 3.0. Use the "normalization_context" of the data provider\'s context instead.', E_USER_DEPRECATED);
+        }
+
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -67,17 +72,22 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
     {
-        $options = null === $operationName ? [] : ['collection_operation_name' => $operationName];
+        if (null === $resourceClass) {
+            throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');
+        }
 
+        $options = null === $operationName ? [] : ['collection_operation_name' => $operationName];
         $forceEager = $this->shouldOperationForceEager($resourceClass, $options);
         $fetchPartial = $this->shouldOperationFetchPartial($resourceClass, $options);
-        $serializerContext = $this->getPropertyMetadataOptions($resourceClass, 'normalization_context', $options);
 
-        $groups = $this->getSerializerGroups($options, $serializerContext);
+        if (!$normalizationContext = $context['normalization_context'] ?? false) {
+            $contextType = isset($context['api_denormalize']) ? 'denormalization_context' : 'normalization_context';
+            $normalizationContext =  $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
+        }
 
-        $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $groups, $serializerContext);
+        $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $options, $normalizationContext);
     }
 
     /**
@@ -86,14 +96,15 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
     public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null, array $context = [])
     {
         $options = null === $operationName ? [] : ['item_operation_name' => $operationName];
-
         $forceEager = $this->shouldOperationForceEager($resourceClass, $options);
         $fetchPartial = $this->shouldOperationFetchPartial($resourceClass, $options);
-        $contextType = isset($context['api_denormalize']) ? 'denormalization_context' : 'normalization_context';
-        $propertyMetadataOptions = $this->getPropertyMetadataOptions($context['resource_class'] ?? $resourceClass, $contextType, $options);
-        $serializerGroups = $this->getSerializerGroups($options, $propertyMetadataOptions);
 
-        $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $serializerGroups, $propertyMetadataOptions);
+        if (!$normalizationContext = $context['normalization_context'] ?? false) {
+            $contextType = isset($context['api_denormalize']) ? 'denormalization_context' : 'normalization_context';
+            $normalizationContext =  $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
+        }
+
+        $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $options, $normalizationContext);
     }
 
     /**
@@ -105,7 +116,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
      *
      * @throws RuntimeException when the max number of joins has been reached
      */
-    private function joinRelations(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, bool $forceEager, bool $fetchPartial, string $parentAlias, array $propertyMetadataOptions = [], array $context = [], bool $wasLeftJoin = false, int &$joinCount = 0, int $currentDepth = null)
+    private function joinRelations(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, bool $forceEager, bool $fetchPartial, string $parentAlias, array $options = [], array $normalizationContext = [], bool $wasLeftJoin = false, int &$joinCount = 0, int $currentDepth = null)
     {
         if ($joinCount > $this->maxJoins) {
             throw new RuntimeException('The total number of joined relations has exceeded the specified maximum. Raise the limit if necessary, or use the "max_depth" option of the Symfony serializer.');
@@ -116,14 +127,18 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
         $classMetadata = $entityManager->getClassMetadata($resourceClass);
         $attributesMetadata = $this->classMetadataFactory ? $this->classMetadataFactory->getMetadataFor($resourceClass)->getAttributesMetadata() : null;
 
+        if (!empty($normalizationContext[AbstractNormalizer::GROUPS])) {
+            $options['serializer_groups'] = $normalizationContext[AbstractNormalizer::GROUPS];
+        }
+
         foreach ($classMetadata->associationMappings as $association => $mapping) {
             //Don't join if max depth is enabled and the current depth limit is reached
-            if (0 === $currentDepth && isset($context[AbstractObjectNormalizer::ENABLE_MAX_DEPTH])) {
+            if (0 === $currentDepth && isset($normalizationContext[AbstractObjectNormalizer::ENABLE_MAX_DEPTH])) {
                 continue;
             }
 
             try {
-                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $association, $propertyMetadataOptions);
+                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $association, $options);
             } catch (PropertyNotFoundException $propertyNotFoundException) {
                 //skip properties not found
                 continue;
@@ -141,12 +156,12 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 continue;
             }
 
-            if (isset($context[AbstractNormalizer::ATTRIBUTES])) {
-                if ($inAttributes = isset($context[AbstractNormalizer::ATTRIBUTES][$association])) {
+            if (isset($normalizationContext[AbstractNormalizer::ATTRIBUTES])) {
+                if ($inAttributes = isset($normalizationContext[AbstractNormalizer::ATTRIBUTES][$association])) {
                     // prepare the child context
-                    $context[AbstractNormalizer::ATTRIBUTES] = $context[AbstractNormalizer::ATTRIBUTES][$association];
+                    $normalizationContext[AbstractNormalizer::ATTRIBUTES] = $normalizationContext[AbstractNormalizer::ATTRIBUTES][$association];
                 } else {
-                    unset($context[AbstractNormalizer::ATTRIBUTES]);
+                    unset($normalizationContext[AbstractNormalizer::ATTRIBUTES]);
                 }
             } else {
                 $inAttributes = null;
@@ -176,7 +191,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
 
             if (true === $fetchPartial) {
                 try {
-                    $this->addSelect($queryBuilder, $mapping['targetEntity'], $associationAlias, $propertyMetadataOptions);
+                    $this->addSelect($queryBuilder, $mapping['targetEntity'], $associationAlias, $options);
                 } catch (ResourceClassNotFoundException $resourceClassNotFoundException) {
                     continue;
                 }
@@ -199,7 +214,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 }
             }
 
-            $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $fetchPartial, $associationAlias, $propertyMetadataOptions, $context, 'leftJoin' === $method, $joinCount, $currentDepth);
+            $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $fetchPartial, $associationAlias, $options, $normalizationContext, 'leftJoin' === $method, $joinCount, $currentDepth);
         }
     }
 
@@ -245,14 +260,10 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
      * @param string $contextType normalization_context or denormalization_context
      * @param array  $options     represents the operation name so that groups are the one of the specific operation
      */
-    private function getPropertyMetadataOptions(string $resourceClass, string $contextType, array $options): array
+    private function getNormalizationContext(string $resourceClass, string $contextType, array $options): array
     {
         $request = null;
-        if (null !== $this->requestStack && null !== $this->serializerContextBuilder) {
-            $request = $this->requestStack->getCurrentRequest();
-        }
-
-        if (null !== $this->serializerContextBuilder && null !== $request && !$request->attributes->get('_graphql')) {
+        if (null !== $this->requestStack && null !== $this->serializerContextBuilder && null !== $request = $this->requestStack->getCurrentRequest()) {
             return $this->serializerContextBuilder->createFromRequest($request, 'normalization_context' === $contextType);
         }
 
@@ -265,20 +276,6 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
             $context = $resourceMetadata->getAttribute($contextType);
         }
 
-        return $context ?: [];
-    }
-
-    /**
-     * Gets serializer groups if available, if not it returns the $options array.
-     *
-     * @param array $options represents the operation name so that groups are the one of the specific operation
-     */
-    private function getSerializerGroups(array $options, array $context): array
-    {
-        if (!empty($context[AbstractNormalizer::GROUPS])) {
-            $options['serializer_groups'] = $context[AbstractNormalizer::GROUPS];
-        }
-
-        return $options;
+        return $context ?? [];
     }
 }

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -54,9 +54,12 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
      */
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, int $maxJoins = 30, bool $forceEager = true, RequestStack $requestStack = null, SerializerContextBuilderInterface $serializerContextBuilder = null, bool $fetchPartial = false, ClassMetadataFactoryInterface $classMetadataFactory = null)
     {
-        //if (null !== $this->serializerContextBuilder) {
-        //    @trigger_error('Passing an instance of "%s" is deprecated since version 2.2 and will be removed in 3.0. Use the "normalization_context" of the data provider\'s context instead.', E_USER_DEPRECATED);
-        //}
+        if (null !== $this->requestStack) {
+            @trigger_error(sprintf('Passing an instance of "%s" is deprecated since version 2.2 and will be removed in 3.0. Use the data provider\'s context instead.', RequestStack::class), E_USER_DEPRECATED);
+        }
+        if (null !== $this->serializerContextBuilder) {
+            @trigger_error(sprintf('Passing an instance of "%s" is deprecated since version 2.2 and will be removed in 3.0. Use the data provider\'s context instead.', SerializerContextBuilderInterface::class), E_USER_DEPRECATED);
+        }
 
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
@@ -99,12 +102,12 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
         $forceEager = $this->shouldOperationForceEager($resourceClass, $options);
         $fetchPartial = $this->shouldOperationFetchPartial($resourceClass, $options);
 
-        if (!$normalizationContext = $context['normalization_context'] ?? false) {
+        if (!isset($context['groups']) && !isset($context['attributes'])) {
             $contextType = isset($context['api_denormalize']) ? 'denormalization_context' : 'normalization_context';
-            $normalizationContext = $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
+            $context += $this->getNormalizationContext($context['resource_class'] ?? $resourceClass, $contextType, $options);
         }
 
-        $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $options, $normalizationContext);
+        $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $options, $context);
     }
 
     /**

--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\EagerLoadingTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryBuilderHelper;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
@@ -24,7 +25,7 @@ use Doctrine\ORM\QueryBuilder;
  * Fixes filters on OneToMany associations
  * https://github.com/api-platform/core/issues/944.
  */
-final class FilterEagerLoadingExtension implements QueryCollectionExtensionInterface
+final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionExtensionInterface
 {
     use EagerLoadingTrait;
 
@@ -37,8 +38,12 @@ final class FilterEagerLoadingExtension implements QueryCollectionExtensionInter
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
     {
+        if (null === $resourceClass) {
+            throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');
+        }
+
         $em = $queryBuilder->getEntityManager();
         $classMetadata = $em->getClassMetadata($resourceClass);
 

--- a/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\FilterCollection;
 use ApiPlatform\Core\Api\FilterLocatorTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\FilterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Doctrine\ORM\QueryBuilder;
 use Psr\Container\ContainerInterface;
@@ -27,7 +28,7 @@ use Psr\Container\ContainerInterface;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-final class FilterExtension implements QueryCollectionExtensionInterface
+final class FilterExtension implements ContextAwareQueryCollectionExtensionInterface
 {
     use FilterLocatorTrait;
 
@@ -46,8 +47,12 @@ final class FilterExtension implements QueryCollectionExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
     {
+        if (null === $resourceClass) {
+            throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');
+        }
+
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         $resourceFilters = $resourceMetadata->getCollectionOperationAttribute($operationName, 'filters', [], true);
 

--- a/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Extension;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryBuilderHelper;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Doctrine\ORM\QueryBuilder;
 
@@ -25,7 +26,7 @@ use Doctrine\ORM\QueryBuilder;
  * @author Samuel ROZE <samuel.roze@gmail.com>
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
-final class OrderExtension implements QueryCollectionExtensionInterface
+final class OrderExtension implements ContextAwareQueryCollectionExtensionInterface
 {
     private $order;
     private $resourceMetadataFactory;
@@ -39,8 +40,12 @@ final class OrderExtension implements QueryCollectionExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
     {
+        if (null === $resourceClass) {
+            throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');
+        }
+
         $rootAlias = $queryBuilder->getRootAliases()[0];
 
         $classMetaData = $queryBuilder->getEntityManager()->getClassMetadata($resourceClass);

--- a/src/Bridge/Doctrine/Orm/Extension/QueryItemExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/QueryItemExtensionInterface.php
@@ -24,13 +24,5 @@ use Doctrine\ORM\QueryBuilder;
  */
 interface QueryItemExtensionInterface
 {
-    /**
-     * @param QueryBuilder                $queryBuilder
-     * @param QueryNameGeneratorInterface $queryNameGenerator
-     * @param string                      $resourceClass
-     * @param array                       $identifiers
-     * @param string|null                 $operationName
-     * @param array                       $context
-     */
     public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null, array $context = []);
 }

--- a/src/Bridge/Doctrine/Orm/Extension/QueryResultItemExtensionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Extension/QueryResultItemExtensionInterface.php
@@ -23,20 +23,10 @@ use Doctrine\ORM\QueryBuilder;
  */
 interface QueryResultItemExtensionInterface extends QueryItemExtensionInterface
 {
-    /**
-     * @param string      $resourceClass
-     * @param string|null $operationName
-     *
-     * @return bool
-     */
     public function supportsResult(string $resourceClass, string $operationName = null): bool;
 
     /**
-     * @param QueryBuilder $queryBuilder
-     * @param string       $resourceClass
-     * @param string|null  $operationName
-     *
      * @return mixed
      */
-    public function getResult(QueryBuilder $queryBuilder/*, string $resourceClass, string $operationName = null*/);
+    public function getResult(QueryBuilder $queryBuilder);
 }

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -54,7 +54,7 @@ class ItemDataProvider implements ItemDataProviderInterface, RestrictedDataProvi
         $this->itemExtensions = $itemExtensions;
     }
 
-    public function supports(string $resourceClass, string $operationName = null): bool
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
     {
         return null !== $this->managerRegistry->getManagerForClass($resourceClass);
     }
@@ -91,8 +91,8 @@ class ItemDataProvider implements ItemDataProviderInterface, RestrictedDataProvi
         foreach ($this->itemExtensions as $extension) {
             $extension->applyToItem($queryBuilder, $queryNameGenerator, $resourceClass, $identifiers, $operationName, $context);
 
-            if ($extension instanceof QueryResultItemExtensionInterface && $extension->supportsResult($resourceClass, $operationName)) {
-                return $extension->getResult($queryBuilder);
+            if ($extension instanceof QueryResultItemExtensionInterface && $extension->supportsResult($resourceClass, $operationName, $context)) {
+                return $extension->getResult($queryBuilder, $resourceClass, $operationName, $context);
             }
         }
 

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -175,18 +175,16 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
                     continue;
                 }
 
-                $extension->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operationName);
-
-                if ($extension instanceof QueryResultCollectionExtensionInterface && $extension->supportsResult($resourceClass, $operationName)) {
-                    return $extension->getResult($queryBuilder, $resourceClass, $operationName);
+                $extension->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
+                if ($extension instanceof QueryResultCollectionExtensionInterface && $extension->supportsResult($resourceClass, $operationName, $context)) {
+                    return $extension->getResult($queryBuilder, $resourceClass, $operationName, $context);
                 }
             }
         } else {
             foreach ($this->itemExtensions as $extension) {
                 $extension->applyToItem($queryBuilder, $queryNameGenerator, $resourceClass, $identifiers, $operationName, $context);
-
-                if ($extension instanceof QueryResultItemExtensionInterface && $extension->supportsResult($resourceClass, $operationName)) {
-                    return $extension->getResult($queryBuilder, $resourceClass, $operationName);
+                if ($extension instanceof QueryResultItemExtensionInterface && $extension->supportsResult($resourceClass, $operationName, $context)) {
+                    return $extension->getResult($queryBuilder, $resourceClass, $operationName, $context);
                 }
             }
         }

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -133,6 +133,7 @@
             <argument type="service" id="api_platform.collection_data_provider" />
             <argument type="service" id="api_platform.item_data_provider" />
             <argument type="service" id="api_platform.subresource_data_provider" />
+            <argument type="service" id="api_platform.serializer.context_builder" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="4" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -109,8 +109,10 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument>%api_platform.eager_loading.max_joins%</argument>
             <argument>%api_platform.eager_loading.force_eager%</argument>
-            <argument type="service" id="request_stack" />
-            <argument type="service" id="api_platform.serializer.context_builder" />
+            <argument>null</argument>
+            <argument>null</argument>
+            <!--<argument type="service" id="request_stack" />-->
+            <!--<argument type="service" id="api_platform.serializer.context_builder" />-->
             <argument>%api_platform.eager_loading.fetch_partial%</argument>
             <argument type="service" id="serializer.mapping.class_metadata_factory"></argument>
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -110,7 +110,7 @@
             <argument>%api_platform.eager_loading.max_joins%</argument>
             <argument>%api_platform.eager_loading.force_eager%</argument>
             <argument type="service" id="request_stack" />
-            <argument>null</argument>
+            <argument type="service" id="api_platform.serializer.context_builder" />
             <argument>%api_platform.eager_loading.fetch_partial%</argument>
             <argument type="service" id="serializer.mapping.class_metadata_factory"></argument>
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -110,7 +110,7 @@
             <argument>%api_platform.eager_loading.max_joins%</argument>
             <argument>%api_platform.eager_loading.force_eager%</argument>
             <argument type="service" id="request_stack" />
-            <argument type="service" id="api_platform.serializer.context_builder" />
+            <argument>null</argument>
             <argument>%api_platform.eager_loading.fetch_partial%</argument>
             <argument type="service" id="serializer.mapping.class_metadata_factory"></argument>
 

--- a/src/DataProvider/ChainCollectionDataProvider.php
+++ b/src/DataProvider/ChainCollectionDataProvider.php
@@ -20,12 +20,12 @@ use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ChainCollectionDataProvider implements CollectionDataProviderInterface
+final class ChainCollectionDataProvider implements ContextAwareCollectionDataProviderInterface
 {
     private $dataProviders;
 
     /**
-     * @param CollectionDataProviderInterface[] $dataProviders
+     * @param ContextAwareCollectionDataProviderInterface[]|CollectionDataProviderInterface[] $dataProviders
      */
     public function __construct(array $dataProviders)
     {
@@ -35,16 +35,16 @@ final class ChainCollectionDataProvider implements CollectionDataProviderInterfa
     /**
      * {@inheritdoc}
      */
-    public function getCollection(string $resourceClass, string $operationName = null)
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
     {
         foreach ($this->dataProviders as $dataProvider) {
             try {
                 if ($dataProvider instanceof RestrictedDataProviderInterface
-                    && !$dataProvider->supports($resourceClass, $operationName)) {
+                    && !$dataProvider->supports($resourceClass, $operationName, $context)) {
                     continue;
                 }
 
-                return $dataProvider->getCollection($resourceClass, $operationName);
+                return $dataProvider->getCollection($resourceClass, $operationName, $context);
             } catch (ResourceClassNotSupportedException $e) {
                 @trigger_error(sprintf('Throwing a "%s" in a data provider is deprecated in favor of implementing "%s"', ResourceClassNotSupportedException::class, RestrictedDataProviderInterface::class), E_USER_DEPRECATED);
                 continue;

--- a/src/DataProvider/ChainItemDataProvider.php
+++ b/src/DataProvider/ChainItemDataProvider.php
@@ -40,7 +40,7 @@ final class ChainItemDataProvider implements ItemDataProviderInterface
         foreach ($this->dataProviders as $dataProvider) {
             try {
                 if ($dataProvider instanceof RestrictedDataProviderInterface
-                    && !$dataProvider->supports($resourceClass, $operationName)) {
+                    && !$dataProvider->supports($resourceClass, $operationName, $context)) {
                     continue;
                 }
 

--- a/src/DataProvider/ContextAwareCollectionDataProviderInterface.php
+++ b/src/DataProvider/ContextAwareCollectionDataProviderInterface.php
@@ -16,11 +16,11 @@ namespace ApiPlatform\Core\DataProvider;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
- * Retrieves items from a persistence layer.
+ * Retrieves items from a persistence layer and allow to pass a context to it.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface CollectionDataProviderInterface
+interface ContextAwareCollectionDataProviderInterface extends CollectionDataProviderInterface
 {
     /**
      * Retrieves a collection.
@@ -29,5 +29,5 @@ interface CollectionDataProviderInterface
      *
      * @return array|\Traversable
      */
-    public function getCollection(string $resourceClass, string $operationName = null);
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = []);
 }

--- a/src/DataProvider/ItemDataProviderInterface.php
+++ b/src/DataProvider/ItemDataProviderInterface.php
@@ -25,10 +25,7 @@ interface ItemDataProviderInterface
     /**
      * Retrieves an item.
      *
-     * @param string      $resourceClass
      * @param int|string  $id
-     * @param string|null $operationName
-     * @param array       $context
      *
      * @throws ResourceClassNotSupportedException
      *

--- a/src/DataProvider/ItemDataProviderInterface.php
+++ b/src/DataProvider/ItemDataProviderInterface.php
@@ -25,7 +25,7 @@ interface ItemDataProviderInterface
     /**
      * Retrieves an item.
      *
-     * @param int|string  $id
+     * @param int|string $id
      *
      * @throws ResourceClassNotSupportedException
      *

--- a/src/DataProvider/RestrictedDataProviderInterface.php
+++ b/src/DataProvider/RestrictedDataProviderInterface.php
@@ -18,5 +18,5 @@ namespace ApiPlatform\Core\DataProvider;
  */
 interface RestrictedDataProviderInterface
 {
-    public function supports(string $resourceClass, string $operationName = null): bool;
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool;
 }

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Exception\PropertyNotFoundException;
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -33,12 +34,14 @@ final class ReadListener
     private $collectionDataProvider;
     private $itemDataProvider;
     private $subresourceDataProvider;
+    private $serializerContextBuilder;
 
-    public function __construct(CollectionDataProviderInterface $collectionDataProvider, ItemDataProviderInterface $itemDataProvider, SubresourceDataProviderInterface $subresourceDataProvider = null)
+    public function __construct(CollectionDataProviderInterface $collectionDataProvider, ItemDataProviderInterface $itemDataProvider, SubresourceDataProviderInterface $subresourceDataProvider = null, SerializerContextBuilderInterface $serializerContextBuilder = null)
     {
         $this->collectionDataProvider = $collectionDataProvider;
         $this->itemDataProvider = $itemDataProvider;
         $this->subresourceDataProvider = $subresourceDataProvider;
+        $this->serializerContextBuilder = $serializerContextBuilder;
     }
 
     /**
@@ -58,14 +61,20 @@ final class ReadListener
             return;
         }
 
-        $data = [];
+        $context = [];
+        if ($this->serializerContextBuilder) {
+            // Builtin data providers are able to use the serialization context to automatically add join clauses
+            $context['normalization_context'] = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
+            $request->attributes->set('_api_normalization_context', $context['normalization_context']);
+        }
 
+        $data = [];
         if (isset($attributes['item_operation_name'])) {
-            $data = $this->getItemData($request, $attributes);
+            $data = $this->getItemData($request, $attributes, $context);
         } elseif (isset($attributes['collection_operation_name'])) {
-            $data = $this->getCollectionData($request, $attributes);
+            $data = $this->getCollectionData($request, $attributes, $context);
         } elseif (isset($attributes['subresource_operation_name'])) {
-            $data = $this->getSubresourceData($request, $attributes);
+            $data = $this->getSubresourceData($request, $attributes, $context);
         }
 
         $request->attributes->set('data', $data);
@@ -74,36 +83,29 @@ final class ReadListener
     /**
      * Retrieves data for a collection operation.
      *
-     * @param Request $request
-     * @param array   $attributes
-     *
      * @return array|\Traversable|null
      */
-    private function getCollectionData(Request $request, array $attributes)
+    private function getCollectionData(Request $request, array $attributes, array $context)
     {
         if ($request->isMethod(Request::METHOD_POST)) {
             return null;
         }
 
-        return $this->collectionDataProvider->getCollection($attributes['resource_class'], $attributes['collection_operation_name']);
+        return $this->collectionDataProvider->getCollection($attributes['resource_class'], $attributes['collection_operation_name'], $context);
     }
 
     /**
      * Gets data for an item operation.
      *
-     * @param Request $request
-     * @param array   $attributes
-     *
      * @throws NotFoundHttpException
      *
      * @return object|null
      */
-    private function getItemData(Request $request, array $attributes)
+    private function getItemData(Request $request, array $attributes, array $context)
     {
         $id = $request->attributes->get('id');
-
         try {
-            $data = $this->itemDataProvider->getItem($attributes['resource_class'], $id, $attributes['item_operation_name']);
+            $data = $this->itemDataProvider->getItem($attributes['resource_class'], $id, $attributes['item_operation_name'], $context);
         } catch (PropertyNotFoundException $e) {
             $data = null;
         }
@@ -118,18 +120,19 @@ final class ReadListener
     /**
      * Gets data for a nested operation.
      *
-     * @param Request $request
-     * @param array   $attributes
-     *
      * @throws NotFoundHttpException
      * @throws RuntimeException
      *
      * @return object|null
      */
-    private function getSubresourceData(Request $request, array $attributes)
+    private function getSubresourceData(Request $request, array $attributes, array $context)
     {
         if (null === $this->subresourceDataProvider) {
             throw new RuntimeException('No subresource data provider.');
+        }
+
+        if (isset($context['normalization_context'])) {
+            $attributes['subresource_context']['normalization_context'] = $context['normalization_context'];
         }
 
         $identifiers = [];

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -131,10 +131,7 @@ final class ReadListener
             throw new RuntimeException('No subresource data provider.');
         }
 
-        if (isset($context['normalization_context'])) {
-            $attributes['subresource_context']['normalization_context'] = $context['normalization_context'];
-        }
-
+        $attributes['subresource_context'] += $context;
         $identifiers = [];
         foreach ($attributes['subresource_context']['identifiers'] as $key => list($id, , $hasIdentifier)) {
             if (true === $hasIdentifier) {

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -58,7 +58,10 @@ final class SerializeListener
             return;
         }
 
-        $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
+        if (null === $context = $request->attributes->get('_api_normalization_context')) {
+            $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
+        }
+
         $resources = new class() extends \ArrayObject {
             public function serialize()
             {

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -70,15 +70,18 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
                 );
             }
 
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+            $normalizationContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
+            $normalizationContext['attributes'] = $this->fieldsToAttributes($info);
+
             if (isset($source[$rootProperty = $info->fieldName], $source[ItemNormalizer::ITEM_KEY])) {
                 $rootResolvedFields = $this->identifiersExtractor->getIdentifiersFromItem(unserialize($source[ItemNormalizer::ITEM_KEY]));
-                $subresource = $this->getSubresource($rootClass, $rootResolvedFields, array_keys($rootResolvedFields), $rootProperty, $resourceClass, true);
+                $subresource = $this->getSubresource($rootClass, $rootResolvedFields, array_keys($rootResolvedFields), $rootProperty, $resourceClass, true, $normalizationContext);
                 $collection = $subresource ?? [];
             } else {
-                $collection = $this->collectionDataProvider->getCollection($resourceClass);
+                $collection = $this->collectionDataProvider->getCollection($resourceClass, null, ['normalization_context' => $normalizationContext]);
             }
 
-            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $collection, 'query');
 
             if (null !== $this->resourceAccessChecker) {
@@ -87,9 +90,6 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
                     throw Error::createLocatedError('Access Denied.', $info->fieldNodes, $info->path);
                 }
             }
-
-            $normalizationContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
-            $normalizationContext['attributes'] = $this->fieldsToAttributes($info);
 
             if (!$this->paginationEnabled) {
                 $data = [];
@@ -141,7 +141,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
      *
      * @return object|null
      */
-    private function getSubresource(string $rootClass, array $rootResolvedFields, array $rootIdentifiers, string $rootProperty, string $subresourceClass, bool $isCollection)
+    private function getSubresource(string $rootClass, array $rootResolvedFields, array $rootIdentifiers, string $rootProperty, string $subresourceClass, bool $isCollection, array $normalizationContext)
     {
         $identifiers = [];
         $resolvedIdentifiers = [];
@@ -157,6 +157,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             'property' => $rootProperty,
             'identifiers' => $resolvedIdentifiers,
             'collection' => $isCollection,
+            'normalization_context' => $normalizationContext,
         ]);
     }
 }

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -79,7 +79,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
                 $subresource = $this->getSubresource($rootClass, $rootResolvedFields, array_keys($rootResolvedFields), $rootProperty, $resourceClass, true, $normalizationContext);
                 $collection = $subresource ?? [];
             } else {
-                $collection = $this->collectionDataProvider->getCollection($resourceClass, null, ['normalization_context' => $normalizationContext]);
+                $collection = $this->collectionDataProvider->getCollection($resourceClass, null, $normalizationContext);
             }
 
             $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $collection, 'query');
@@ -153,11 +153,10 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             $resolvedIdentifiers[] = [$rootIdentifier, $rootClass];
         }
 
-        return $this->subresourceDataProvider->getSubresource($subresourceClass, $identifiers, [
+        return $this->subresourceDataProvider->getSubresource($subresourceClass, $identifiers, $normalizationContext + [
             'property' => $rootProperty,
             'identifiers' => $resolvedIdentifiers,
             'collection' => $isCollection,
-            'normalization_context' => $normalizationContext,
         ]);
     }
 }

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -69,7 +69,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
 
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             $normalizationContext = $resourceMetadata->getGraphqlAttribute($operationName, 'normalization_context', [], true);
-            $normalizationContext['normalization_context']['attributes'] = $info->getFieldSelection(PHP_INT_MAX);
+            $normalizationContext['attributes'] = $info->getFieldSelection(PHP_INT_MAX);
 
             if (isset($args['input']['id'])) {
                 try {

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -69,7 +69,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
 
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             $normalizationContext = $resourceMetadata->getGraphqlAttribute($operationName, 'normalization_context', [], true);
-            $normalizationContext['attributes'] = $info->getFieldSelection(PHP_INT_MAX);
+            $normalizationContext['normalization_context']['attributes'] = $info->getFieldSelection(PHP_INT_MAX);
 
             if (isset($args['input']['id'])) {
                 try {

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -91,7 +91,6 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                     $this->dataPersister->persist($item);
 
                     return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext) + $data;
-
                 case 'delete':
                     if ($item) {
                         $this->dataPersister->remove($item);

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -67,9 +67,13 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
             $data = ['clientMutationId' => $args['input']['clientMutationId'] ?? null];
             $item = null;
 
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+            $normalizationContext = $resourceMetadata->getGraphqlAttribute($operationName, 'normalization_context', [], true);
+            $normalizationContext['attributes'] = $info->getFieldSelection(PHP_INT_MAX);
+
             if (isset($args['input']['id'])) {
                 try {
-                    $item = $this->iriConverter->getItemFromIri($args['input']['id']);
+                    $item = $this->iriConverter->getItemFromIri($args['input']['id'], $normalizationContext);
                 } catch (ItemNotFoundException $e) {
                     throw Error::createLocatedError(sprintf('Item "%s" not found.', $args['input']['id']), $info->fieldNodes, $info->path);
                 }
@@ -86,11 +90,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                     $this->validate($item, $info, $resourceMetadata, $operationName);
                     $this->dataPersister->persist($item);
 
-                    return $this->normalizer->normalize(
-                        $item,
-                        ItemNormalizer::FORMAT,
-                        $resourceMetadata->getGraphqlAttribute($operationName, 'normalization_context', [], true)
-                    ) + $data;
+                    return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext) + $data;
 
                 case 'delete':
                     if ($item) {
@@ -117,7 +117,6 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
         }
 
         $validationGroups = $resourceMetadata->getGraphqlAttribute($operationName, 'validation_groups', null, true);
-
         try {
             $this->validator->validate($item, ['groups' => $validationGroups]);
         } catch (ValidationException $e) {

--- a/src/GraphQl/Resolver/ItemResolver.php
+++ b/src/GraphQl/Resolver/ItemResolver.php
@@ -62,7 +62,7 @@ final class ItemResolver
 
         $baseNormalizationContext = ['attributes' => $info->getFieldSelection(PHP_INT_MAX)];
         try {
-            $item = $this->iriConverter->getItemFromIri($args['id'], ['normalization_context' => $baseNormalizationContext]);
+            $item = $this->iriConverter->getItemFromIri($args['id'], $baseNormalizationContext);
         } catch (ItemNotFoundException $e) {
             return null;
         }

--- a/src/GraphQl/Resolver/ItemResolver.php
+++ b/src/GraphQl/Resolver/ItemResolver.php
@@ -60,9 +60,9 @@ final class ItemResolver
             return null;
         }
 
-        // TODO: initialize the EagerLoading extension
+        $baseNormalizationContext = ['attributes' => $info->getFieldSelection(PHP_INT_MAX)];
         try {
-            $item = $this->iriConverter->getItemFromIri($args['id']);
+            $item = $this->iriConverter->getItemFromIri($args['id'], ['normalization_context' => $baseNormalizationContext]);
         } catch (ItemNotFoundException $e) {
             return null;
         }
@@ -80,6 +80,6 @@ final class ItemResolver
 
         $normalizationContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
 
-        return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext + ['attributes' => $info->getFieldSelection(PHP_INT_MAX)]);
+        return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext + $baseNormalizationContext);
     }
 }

--- a/tests/Bridge/Doctrine/Orm/CollectionDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/CollectionDataProviderTest.php
@@ -51,7 +51,7 @@ class CollectionDataProviderTest extends TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
 
         $extensionProphecy = $this->prophesize(QueryCollectionExtensionInterface::class);
-        $extensionProphecy->applyToCollection($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, 'foo')->shouldBeCalled();
+        $extensionProphecy->applyToCollection($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, 'foo', [])->shouldBeCalled();
 
         $dataProvider = new CollectionDataProvider($managerRegistryProphecy->reveal(), [$extensionProphecy->reveal()]);
         $this->assertEquals([], $dataProvider->getCollection(Dummy::class, 'foo'));
@@ -72,9 +72,9 @@ class CollectionDataProviderTest extends TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
 
         $extensionProphecy = $this->prophesize(QueryResultCollectionExtensionInterface::class);
-        $extensionProphecy->applyToCollection($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, 'foo')->shouldBeCalled();
-        $extensionProphecy->supportsResult(Dummy::class, 'foo')->willReturn(true)->shouldBeCalled();
-        $extensionProphecy->getResult($queryBuilder, Dummy::class, 'foo')->willReturn([])->shouldBeCalled();
+        $extensionProphecy->applyToCollection($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, 'foo', [])->shouldBeCalled();
+        $extensionProphecy->supportsResult(Dummy::class, 'foo', [])->willReturn(true)->shouldBeCalled();
+        $extensionProphecy->getResult($queryBuilder, Dummy::class, 'foo', [])->willReturn([])->shouldBeCalled();
 
         $dataProvider = new CollectionDataProvider($managerRegistryProphecy->reveal(), [$extensionProphecy->reveal()]);
         $this->assertEquals([], $dataProvider->getCollection(Dummy::class, 'foo'));

--- a/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -397,12 +397,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertNotInstanceOf(PaginatorInterface::class, $result);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Method ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\PaginationExtension::getResult() will have a 2nd `string $resourceClass` argument in version 3.0. Not defining it is deprecated since 2.2.
-     * @expectedDeprecation Method ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\PaginationExtension::getResult() will have a 3rd `string $operationName = null` argument in version 3.0. Not defining it is deprecated since 2.2.
-     */
-    public function testLegacyGetResult()
+    public function testSimpleGetResult()
     {
         $result = $this->getPaginationExtensionResult(false, true);
 

--- a/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
@@ -173,8 +173,8 @@ class ItemDataProviderTest extends TestCase
 
         $extensionProphecy = $this->prophesize(QueryResultItemExtensionInterface::class);
         $extensionProphecy->applyToItem($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), Dummy::class, ['id' => 1], 'foo', [])->shouldBeCalled();
-        $extensionProphecy->supportsResult(Dummy::class, 'foo')->willReturn(true)->shouldBeCalled();
-        $extensionProphecy->getResult($queryBuilder)->willReturn([])->shouldBeCalled();
+        $extensionProphecy->supportsResult(Dummy::class, 'foo', [])->willReturn(true)->shouldBeCalled();
+        $extensionProphecy->getResult($queryBuilder, Dummy::class, 'foo', [])->willReturn([])->shouldBeCalled();
 
         $dataProvider = new ItemDataProvider($managerRegistry, $propertyNameCollectionFactory, $propertyMetadataFactory, [$extensionProphecy->reveal()]);
 

--- a/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
@@ -315,9 +315,9 @@ class SubresourceDataProviderTest extends TestCase
         list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataProphecies([Dummy::class => $identifiers]);
 
         $extensionProphecy = $this->prophesize(QueryResultCollectionExtensionInterface::class);
-        $extensionProphecy->applyToCollection($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), RelatedDummy::class, null)->shouldBeCalled();
-        $extensionProphecy->supportsResult(RelatedDummy::class, null)->willReturn(true)->shouldBeCalled();
-        $extensionProphecy->getResult($queryBuilder, RelatedDummy::class, null)->willReturn([])->shouldBeCalled();
+        $extensionProphecy->applyToCollection($queryBuilder, Argument::type(QueryNameGeneratorInterface::class), RelatedDummy::class, null, Argument::type('array'))->shouldBeCalled();
+        $extensionProphecy->supportsResult(RelatedDummy::class, null, Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $extensionProphecy->getResult($queryBuilder, RelatedDummy::class, null, Argument::type('array'))->willReturn([])->shouldBeCalled();
 
         $dataProvider = new SubresourceDataProvider($managerRegistryProphecy->reveal(), $propertyNameCollectionFactory, $propertyMetadataFactory, [$extensionProphecy->reveal()]);
 

--- a/tests/DataProvider/ChainCollectionDataProviderTest.php
+++ b/tests/DataProvider/ChainCollectionDataProviderTest.php
@@ -36,18 +36,18 @@ class ChainCollectionDataProviderTest extends TestCase
 
         $firstDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $firstDataProvider->supports(Dummy::class, null)->willReturn(false);
+        $firstDataProvider->supports(Dummy::class, null, [])->willReturn(false);
 
         $secondDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $secondDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $secondDataProvider->supports(Dummy::class, null)->willReturn(true);
-        $secondDataProvider->getCollection(Dummy::class, null)
+        $secondDataProvider->supports(Dummy::class, null, [])->willReturn(true);
+        $secondDataProvider->getCollection(Dummy::class, null, [])
             ->willReturn([$dummy, $dummy2]);
 
         $thirdDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $thirdDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $thirdDataProvider->supports(Dummy::class, null)->willReturn(true);
-        $thirdDataProvider->getCollection(Dummy::class, null)->willReturn([$dummy]);
+        $thirdDataProvider->supports(Dummy::class, null, [])->willReturn(true);
+        $thirdDataProvider->getCollection(Dummy::class, null, [])->willReturn([$dummy]);
 
         $chainItemDataProvider = new ChainCollectionDataProvider([
             $firstDataProvider->reveal(),
@@ -65,7 +65,7 @@ class ChainCollectionDataProviderTest extends TestCase
     {
         $firstDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $firstDataProvider->supports('notfound', 'op')->willReturn(false);
+        $firstDataProvider->supports('notfound', 'op', [])->willReturn(false);
 
         $collection = (new ChainCollectionDataProvider([$firstDataProvider->reveal()]))->getCollection('notfound', 'op');
 
@@ -85,13 +85,13 @@ class ChainCollectionDataProviderTest extends TestCase
         $dummy2->setName('Parks');
 
         $firstDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
-        $firstDataProvider->getCollection(Dummy::class, null)->willThrow(ResourceClassNotSupportedException::class);
+        $firstDataProvider->getCollection(Dummy::class, null, [])->willThrow(ResourceClassNotSupportedException::class);
 
         $secondDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
-        $secondDataProvider->getCollection(Dummy::class, null)->willReturn([$dummy, $dummy2]);
+        $secondDataProvider->getCollection(Dummy::class, null, [])->willReturn([$dummy, $dummy2]);
 
         $thirdDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
-        $thirdDataProvider->getCollection(Dummy::class, null)->willReturn([$dummy]);
+        $thirdDataProvider->getCollection(Dummy::class, null, [])->willReturn([$dummy]);
 
         $chainItemDataProvider = new ChainCollectionDataProvider([$firstDataProvider->reveal(), $secondDataProvider->reveal(), $thirdDataProvider->reveal()]);
 
@@ -105,7 +105,7 @@ class ChainCollectionDataProviderTest extends TestCase
     public function testLegacyGetCollectionExceptions()
     {
         $firstDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
-        $firstDataProvider->getCollection('notfound', 'op')->willThrow(ResourceClassNotSupportedException::class);
+        $firstDataProvider->getCollection('notfound', 'op', [])->willThrow(ResourceClassNotSupportedException::class);
 
         $collection = (new ChainCollectionDataProvider([$firstDataProvider->reveal()]))->getCollection('notfound', 'op');
 

--- a/tests/DataProvider/ChainItemDataProviderTest.php
+++ b/tests/DataProvider/ChainItemDataProviderTest.php
@@ -34,16 +34,16 @@ class ChainItemDataProviderTest extends TestCase
 
         $firstDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $firstDataProvider->supports(Dummy::class, null)->willReturn(false);
+        $firstDataProvider->supports(Dummy::class, null, [])->willReturn(false);
 
         $secondDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $secondDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $secondDataProvider->supports(Dummy::class, null)->willReturn(true);
+        $secondDataProvider->supports(Dummy::class, null, [])->willReturn(true);
         $secondDataProvider->getItem(Dummy::class, 1, null, [])->willReturn($dummy);
 
         $thirdDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $thirdDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $thirdDataProvider->supports(Dummy::class, null)->willReturn(true);
+        $thirdDataProvider->supports(Dummy::class, null, [])->willReturn(true);
         $thirdDataProvider->getItem(Dummy::class, 1, null, [])->willReturn(new \stdClass());
 
         $chainItemDataProvider = new ChainItemDataProvider([
@@ -59,7 +59,7 @@ class ChainItemDataProviderTest extends TestCase
     {
         $firstDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
-        $firstDataProvider->supports('notfound', null)->willReturn(false);
+        $firstDataProvider->supports('notfound', null, [])->willReturn(false);
 
         $chainItemDataProvider = new ChainItemDataProvider([$firstDataProvider->reveal()]);
 

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -92,7 +92,7 @@ class ReadListenerTest extends TestCase
     public function testRetrieveCollectionGet()
     {
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
-        $collectionDataProvider->getCollection('Foo', 'get')->willReturn([])->shouldBeCalled();
+        $collectionDataProvider->getCollection('Foo', 'get', [])->willReturn([])->shouldBeCalled();
 
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $itemDataProvider->getItem()->shouldNotBeCalled();
@@ -119,7 +119,7 @@ class ReadListenerTest extends TestCase
 
         $data = new \stdClass();
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProvider->getItem('Foo', 1, 'get')->willReturn($data)->shouldBeCalled();
+        $itemDataProvider->getItem('Foo', 1, 'get', [])->willReturn($data)->shouldBeCalled();
 
         $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
         $subresourceDataProvider->getSubresource()->shouldNotBeCalled();
@@ -168,7 +168,7 @@ class ReadListenerTest extends TestCase
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
 
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProvider->getItem('Foo', 22, 'get')->willReturn(null)->shouldBeCalled();
+        $itemDataProvider->getItem('Foo', 22, 'get', [])->willReturn(null)->shouldBeCalled();
 
         $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
 

--- a/tests/Fixtures/TestBundle/DataProvider/ContainNonResourceItemDataProvider.php
+++ b/tests/Fixtures/TestBundle/DataProvider/ContainNonResourceItemDataProvider.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ContainNonResource;
  */
 class ContainNonResourceItemDataProvider implements ItemDataProviderInterface, RestrictedDataProviderInterface
 {
-    public function supports(string $resourceClass, string $operationName = null): bool
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
     {
         return ContainNonResource::class === $resourceClass;
     }

--- a/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -181,14 +181,15 @@ class CollectionResolverFactoryTest extends TestCase
     private function createCollectionResolverFactory($collection, array $subcollection, array $identifiers, bool $paginationEnabled): CollectionResolverFactory
     {
         $collectionDataProviderProphecy = $this->prophesize(CollectionDataProviderInterface::class);
-        $collectionDataProviderProphecy->getCollection(Dummy::class)->willReturn($collection);
-        $collectionDataProviderProphecy->getCollection(RelatedDummy::class)->willReturn($collection);
+        $collectionDataProviderProphecy->getCollection(Dummy::class, null, ['normalization_context' => ['groups' => ['foo'], 'attributes' => []]])->willReturn($collection);
+        $collectionDataProviderProphecy->getCollection(RelatedDummy::class, null, ['normalization_context' => ['groups' => ['foo'], 'attributes' => []]])->willReturn($collection);
 
         $subresourceDataProviderProphecy = $this->prophesize(SubresourceDataProviderInterface::class);
         $subresourceDataProviderProphecy->getSubresource(RelatedDummy::class, $identifiers, [
             'property' => 'relatedDummies',
             'identifiers' => [['id', Dummy::class]],
             'collection' => true,
+            'normalization_context' => ['groups' => ['foo'], 'attributes' => []],
         ])->willReturn($subcollection);
 
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class);

--- a/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -181,15 +181,16 @@ class CollectionResolverFactoryTest extends TestCase
     private function createCollectionResolverFactory($collection, array $subcollection, array $identifiers, bool $paginationEnabled): CollectionResolverFactory
     {
         $collectionDataProviderProphecy = $this->prophesize(CollectionDataProviderInterface::class);
-        $collectionDataProviderProphecy->getCollection(Dummy::class, null, ['normalization_context' => ['groups' => ['foo'], 'attributes' => []]])->willReturn($collection);
-        $collectionDataProviderProphecy->getCollection(RelatedDummy::class, null, ['normalization_context' => ['groups' => ['foo'], 'attributes' => []]])->willReturn($collection);
+        $collectionDataProviderProphecy->getCollection(Dummy::class, null, ['groups' => ['foo'], 'attributes' => []])->willReturn($collection);
+        $collectionDataProviderProphecy->getCollection(RelatedDummy::class, null, ['groups' => ['foo'], 'attributes' => []])->willReturn($collection);
 
         $subresourceDataProviderProphecy = $this->prophesize(SubresourceDataProviderInterface::class);
         $subresourceDataProviderProphecy->getSubresource(RelatedDummy::class, $identifiers, [
             'property' => 'relatedDummies',
             'identifiers' => [['id', Dummy::class]],
             'collection' => true,
-            'normalization_context' => ['groups' => ['foo'], 'attributes' => []],
+            'groups' => ['foo'],
+            'attributes' => [],
         ])->willReturn($subcollection);
 
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class);

--- a/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
@@ -68,7 +68,7 @@ class ItemMutationResolverFactoryTest extends TestCase
     private function createItemMutationResolverFactory($item, ObjectProphecy $dataPersisterProphecy): ResolverFactoryInterface
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/dummies/3', ['normalization_context' => ['attributes' => []]]);
+        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/dummies/3', ['attributes' => []]);
         null === $item ? $getItemFromIri->willThrow(new ItemNotFoundException()) : $getItemFromIri->willReturn($item);
 
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class)->willImplement(DenormalizerInterface::class);

--- a/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
@@ -44,7 +44,10 @@ class ItemMutationResolverFactoryTest extends TestCase
         $resolverFactory = $this->createItemMutationResolverFactory(null, $dataPersisterProphecy);
         $resolver = $resolverFactory(Dummy::class, Dummy::class, 'delete');
 
-        $resolver(null, ['input' => ['id' => '/dummies/3', 'clientMutationId' => '1936']], null, new ResolveInfo([]));
+        $resolveInfo = new ResolveInfo([]);
+        $resolveInfo->fieldNodes = [];
+
+        $resolver(null, ['input' => ['id' => '/dummies/3', 'clientMutationId' => '1936']], null, $resolveInfo);
     }
 
     public function testCreateItemDeleteMutationResolver()
@@ -56,13 +59,16 @@ class ItemMutationResolverFactoryTest extends TestCase
         $resolverFactory = $this->createItemMutationResolverFactory($dummy, $dataPersisterProphecy);
         $resolver = $resolverFactory(Dummy::class, null, 'delete');
 
-        $this->assertEquals(['id' => '/dummies/3', 'clientMutationId' => '1936'], $resolver(null, ['input' => ['id' => '/dummies/3', 'clientMutationId' => '1936']], null, new ResolveInfo([])));
+        $resolveInfo = new ResolveInfo([]);
+        $resolveInfo->fieldNodes = [];
+
+        $this->assertEquals(['id' => '/dummies/3', 'clientMutationId' => '1936'], $resolver(null, ['input' => ['id' => '/dummies/3', 'clientMutationId' => '1936']], null, $resolveInfo));
     }
 
     private function createItemMutationResolverFactory($item, ObjectProphecy $dataPersisterProphecy): ResolverFactoryInterface
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/dummies/3');
+        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/dummies/3', ['normalization_context' => ['attributes' => []]]);
         null === $item ? $getItemFromIri->willThrow(new ItemNotFoundException()) : $getItemFromIri->willReturn($item);
 
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class)->willImplement(DenormalizerInterface::class);

--- a/tests/GraphQl/Resolver/ItemResolverTest.php
+++ b/tests/GraphQl/Resolver/ItemResolverTest.php
@@ -78,7 +78,7 @@ class ItemResolverTest extends TestCase
     private function createItemResolver($item): ItemResolver
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/related_dummies/3', ['normalization_context' => ['attributes' => []]]);
+        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/related_dummies/3', ['attributes' => []]);
         null === $item ? $getItemFromIri->willThrow(new ItemNotFoundException()) : $getItemFromIri->willReturn($item);
 
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class);

--- a/tests/GraphQl/Resolver/ItemResolverTest.php
+++ b/tests/GraphQl/Resolver/ItemResolverTest.php
@@ -78,7 +78,7 @@ class ItemResolverTest extends TestCase
     private function createItemResolver($item): ItemResolver
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/related_dummies/3');
+        $getItemFromIri = $iriConverterProphecy->getItemFromIri('/related_dummies/3', ['normalization_context' => ['attributes' => []]]);
         null === $item ? $getItemFromIri->willThrow(new ItemNotFoundException()) : $getItemFromIri->willReturn($item);
 
         $normalizerProphecy = $this->prophesize(NormalizerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR is mainly a refactoring of the Data Providers to get rid of the dependency to HttpFoundation (it will also allow to simplify the JSONAPI support, and maybe to support PSR-7 later).
Thanks to this new decoupling, it's now possible to automatically add appropriate `JOIN` SQL clauses according to the selected fields in a GraphQL query.

TODO:

* [x] Fix tests and bugs
