### PR TITLE
[Routing] Also copy the Host in the Router::match

### DIFF
--- a/src/Bridge/Symfony/Routing/Router.php
+++ b/src/Bridge/Symfony/Routing/Router.php
@@ -75,6 +75,7 @@ final class Router implements RouterInterface, UrlGeneratorInterface
         $context = (new RequestContext())->fromRequest($request);
         $context->setPathInfo($pathInfo);
         $context->setScheme($baseContext->getScheme());
+        $context->setHost($baseContext->getHost());
 
         try {
             $this->router->setContext($context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

---

BTW, we could just clone the context, and replace few information:

```php
    public function match($pathInfo)
    {
        $baseContext = $this->router->getContext();
        $pathInfo = str_replace($baseContext->getBaseUrl(), '', $pathInfo);

        $context = clone $baseContext;
        $context->setMethod('GET');
        $context->setPathInfo($pathInfo);

        $this->router->setContext($context);
        try {
            return $this->router->match($pathInfo);
        } finally {
            $this->router->setContext($baseContext);
        }
    }
```

---

Why do I hit all the bugs :/