### PR TITLE
[WIP] General batch endpoint

### DIFF
--- a/src/Action/BatchEndpointAction.php
+++ b/src/Action/BatchEndpointAction.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Action;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Provides an endpoint for batch processing by splitting up
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class BatchEndpointAction
+{
+    /**
+     * @var HttpKernelInterface
+     */
+    private $kernel;
+
+    /**
+     * @var array
+     */
+    private $validKeys = [
+        'path',
+        'method',
+        'headers',
+        'body',
+    ];
+
+    /**
+     * @param HttpKernelInterface $kernel
+     */
+    public function __construct(HttpKernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * Execute multiple subrequests from batch request.
+     *
+     * @param Request $request
+     * @param array   $data
+     *
+     * @return array
+     */
+    public function __invoke(Request $request, array $data = null): array
+    {
+        if (!$this->validateBatchData((array) $data)) {
+            throw new BadRequestHttpException('Batch request data not accepted.');
+        }
+
+        $result = [];
+
+        foreach ($data as $k => $item) {
+
+            // Copy current headers if no specific provided for simplicity
+            // otherwise one would have to provide Content-Type with every
+            // single entry.
+            if (!isset($item['headers'])) {
+                $item['headers'] = $request->headers->all();
+            }
+
+            $result[] = $this->convertResponse(
+                $this->executeSubRequest(
+                    $k,
+                    $item['path'],
+                    $item['method'],
+                    $item['headers'],
+                    $item['body']
+                )
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Converts a response into an array.
+     *
+     * @param Response $response
+     *
+     * @return array
+     */
+    private function convertResponse(Response $response): array
+    {
+        return [
+            'status' => $response->getStatusCode(),
+            'body' => $response->getContent(),
+            'headers' => $response->headers->all(),
+        ];
+    }
+
+    /**
+     * Validates that the keys are all correctly present.
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    private function validateBatchData(array $data)
+    {
+        if (0 === count($data)) {
+            return false;
+        }
+
+        foreach ($data as $item) {
+            if (0 !== count(array_diff(array_keys($item), $this->validKeys))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Executes a subrequest.
+     *
+     * @param int    $index
+     * @param string $path
+     * @param string $method
+     * @param array  $headers
+     * @param string $body
+     *
+     * @return Response
+     */
+    private function executeSubRequest(int $index, string $path, string $method, array $headers, string $body): Response
+    {
+        $subRequest = Request::create($path, $method, [], [], [], [], $body);
+        $subRequest->headers->replace($headers);
+
+        try {
+            return $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        } catch (\Exception $e) {
+            return Response::create(sprintf('Batch element #%d failed, check the log files.', $index), 400);
+        }
+    }
+}

--- a/src/Action/BatchEndpointAction.php
+++ b/src/Action/BatchEndpointAction.php
@@ -72,6 +72,9 @@ class BatchEndpointAction
                 $item['headers'] = $request->headers->all();
             }
 
+            // Make sure Content-Length is always correct
+            $item['headers']['content-length'] = strlen($item['body']);
+
             $result[] = $this->convertResponse(
                 $this->executeSubRequest(
                     $k,

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -145,6 +145,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     {
         $container->setParameter('api_platform.enable_entrypoint', $config['enable_entrypoint']);
         $container->setParameter('api_platform.enable_docs', $config['enable_docs']);
+        $container->setParameter('api_platform.enable_batch_endpoint', $config['enable_batch_endpoint']);
         $container->setParameter('api_platform.title', $config['title']);
         $container->setParameter('api_platform.description', $config['description']);
         $container->setParameter('api_platform.version', $config['version']);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -145,7 +145,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     {
         $container->setParameter('api_platform.enable_entrypoint', $config['enable_entrypoint']);
         $container->setParameter('api_platform.enable_docs', $config['enable_docs']);
-        $container->setParameter('api_platform.enable_batch_endpoint', $config['enable_batch_endpoint']);
+        $container->setParameter('api_platform.batch_endpoint', $config['batch_endpoint']);
         $container->setParameter('api_platform.title', $config['title']);
         $container->setParameter('api_platform.description', $config['description']);
         $container->setParameter('api_platform.version', $config['version']);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -101,6 +101,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_swagger_ui')->defaultValue(class_exists(TwigBundle::class))->info('Enable Swagger ui.')->end()
                 ->booleanNode('enable_entrypoint')->defaultTrue()->info('Enable the entrypoint')->end()
                 ->booleanNode('enable_docs')->defaultTrue()->info('Enable the docs')->end()
+                ->booleanNode('enable_batch_endpoint')->defaultFalse()->info('Enable the batch endpoint')->end()
 
                 ->arrayNode('oauth')
                     ->canBeEnabled()

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -101,7 +101,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_swagger_ui')->defaultValue(class_exists(TwigBundle::class))->info('Enable Swagger ui.')->end()
                 ->booleanNode('enable_entrypoint')->defaultTrue()->info('Enable the entrypoint')->end()
                 ->booleanNode('enable_docs')->defaultTrue()->info('Enable the docs')->end()
-                ->booleanNode('enable_batch_endpoint')->defaultFalse()->info('Enable the batch endpoint')->end()
+                ->scalarNode('batch_endpoint')->defaultValue('')->info('Set the batch endpoint path. If an empty string is provided, the endpoint is disabled.')->end()
 
                 ->arrayNode('oauth')
                     ->canBeEnabled()

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -40,6 +40,7 @@
             <argument>%api_platform.graphql.enabled%</argument>
             <argument>%api_platform.enable_entrypoint%</argument>
             <argument>%api_platform.enable_docs%</argument>
+            <argument>%api_platform.enable_batch_endpoint%</argument>
 
             <tag name="routing.loader" />
         </service>
@@ -193,6 +194,10 @@
 
         <service id="api_platform.action.entrypoint" class="ApiPlatform\Core\Action\EntrypointAction" public="true">
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
+        </service>
+
+        <service id="api_platform.action.batch_endpoint" class="ApiPlatform\Core\Action\BatchEndpointAction" public="true">
+            <argument type="service" id="http_kernel" />
         </service>
 
         <service id="api_platform.action.documentation" class="ApiPlatform\Core\Documentation\Action\DocumentationAction" public="true">

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -40,7 +40,7 @@
             <argument>%api_platform.graphql.enabled%</argument>
             <argument>%api_platform.enable_entrypoint%</argument>
             <argument>%api_platform.enable_docs%</argument>
-            <argument>%api_platform.enable_batch_endpoint%</argument>
+            <argument>%api_platform.batch_endpoint%</argument>
 
             <tag name="routing.loader" />
         </service>

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -53,8 +53,9 @@ final class ApiLoader extends Loader
     private $graphqlEnabled;
     private $entrypointEnabled;
     private $docsEnabled;
+    private $batchEndpointEnabled;
 
-    public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, OperationPathResolverInterface $operationPathResolver, ContainerInterface $container, array $formats, array $resourceClassDirectories = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $graphqlEnabled = false, bool $entrypointEnabled = true, bool $docsEnabled = true)
+    public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, OperationPathResolverInterface $operationPathResolver, ContainerInterface $container, array $formats, array $resourceClassDirectories = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $graphqlEnabled = false, bool $entrypointEnabled = true, bool $docsEnabled = true, bool $batchEndpointEnabled = false)
     {
         $this->fileLoader = new XmlFileLoader(new FileLocator($kernel->locateResource('@ApiPlatformBundle/Resources/config/routing')));
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
@@ -67,6 +68,7 @@ final class ApiLoader extends Loader
         $this->graphqlEnabled = $graphqlEnabled;
         $this->entrypointEnabled = $entrypointEnabled;
         $this->docsEnabled = $docsEnabled;
+        $this->batchEndpointEnabled = $batchEndpointEnabled;
     }
 
     /**
@@ -128,6 +130,23 @@ final class ApiLoader extends Loader
                     $operation['condition'] ?? ''
                 ));
             }
+        }
+
+        if ($this->batchEndpointEnabled) {
+            $routeCollection->add(RouteNameGenerator::ROUTE_NAME_PREFIX . 'batch_endpoint', new Route(
+                '/batch', // TODO: make configurable
+                [
+                    '_controller' => self::DEFAULT_ACTION_PATTERN.'batch_endpoint',
+                    '_format' => null,
+                    '_api_batch_request' => true,
+                    '_api_respond' => true,
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['POST']
+            ));
         }
 
         return $routeCollection;

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -53,9 +53,9 @@ final class ApiLoader extends Loader
     private $graphqlEnabled;
     private $entrypointEnabled;
     private $docsEnabled;
-    private $batchEndpointEnabled;
+    private $batchEndpoint;
 
-    public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, OperationPathResolverInterface $operationPathResolver, ContainerInterface $container, array $formats, array $resourceClassDirectories = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $graphqlEnabled = false, bool $entrypointEnabled = true, bool $docsEnabled = true, bool $batchEndpointEnabled = false)
+    public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, OperationPathResolverInterface $operationPathResolver, ContainerInterface $container, array $formats, array $resourceClassDirectories = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $graphqlEnabled = false, bool $entrypointEnabled = true, bool $docsEnabled = true, string $batchEndpoint = '')
     {
         $this->fileLoader = new XmlFileLoader(new FileLocator($kernel->locateResource('@ApiPlatformBundle/Resources/config/routing')));
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
@@ -132,9 +132,9 @@ final class ApiLoader extends Loader
             }
         }
 
-        if ($this->batchEndpointEnabled) {
+        if ('' !== $this->batchEndpoint) {
             $routeCollection->add(RouteNameGenerator::ROUTE_NAME_PREFIX . 'batch_endpoint', new Route(
-                '/batch', // TODO: make configurable
+                $this->batchEndpoint,
                 [
                     '_controller' => self::DEFAULT_ACTION_PATTERN.'batch_endpoint',
                     '_format' => null,

--- a/src/Util/RequestAttributesExtractor.php
+++ b/src/Util/RequestAttributesExtractor.php
@@ -45,6 +45,10 @@ final class RequestAttributesExtractor
             $result['subresource_context'] = $subresourceContext;
         }
 
+        if ($isBatchRequest = $request->attributes->get('_api_batch_request')) {
+            $result['batch_request'] = true;
+        }
+
         if (null === $result['resource_class']) {
             return [];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | TODO
| Fixed tickets | 
| License       | MIT
| Doc PR        | TODO

One of the major disadvantages of REST is that under certain circumstances you need a lot of requests to get to a desired state whether that is for data retrieval or data creation does not really matter. I think for data retrieval you should think about using GraphQL which we already have support for (awesome!).
This PR is about improving batch creation of new data via REST.
Imagine you have a quiz and you need to store 50 answers to that quiz. That would be 50 requests in my case because an answer is a resource.

So then I started thinking about how my batch endpoint should look like. Then, as I was thinking about the concept, I figured I could maybe build a general solution so I quickly put together this WIP to outline and allow for discussions 😄 

It's far from being complete but here's the idea:
There's a general endpoint `/batch` that accepts `POST` requests. The structure is an array that represents single requests as if they would've been executed one at the time. Example:

```
POST /batch HTTP/1.1
Accept: application/json
Content-Type: application/json
Content-Length: 201

[
{
  "path": "/quizanswer",
  "method": "POST",
  "body": "..."
},
{
  "path": "/quizanswer",
  "method": "POST",
  "body": "..."
},
{
  "path": "/quizanswer",
  "method": "POST",
  "body": "..."
},
]
```

If you want you can also add `headers` which by default are the same as the ones from the master request (otherwise you would have to provide `Content-Type` etc. for every single entry).
The special batch endpoint then just takes every single entry and executes a sub request for them. So internally they are handled exactly as if you executed 50 isolated requests one after the other but from the outside, it's just one request. Neat, no? 😄 
As a response you get an array with the most important data from each of the requests.

This allows you to batch-create any data. You can even combine different endpoints in the same request! It's a general purpose API endpoint bringing maximum flexibility to API Platform. I would not recommend to mix multiple resources in one batch request but I think we should leave that decisions to the developers.

Here's a few things to consider, todo's or just remarks:

* [x] Agree on the concept. Do you like it? Does it make sense to you?
* [ ] Unit tests, once agreed on concept.
* [x] Make `/batch` path configurable, do you even like the name?
* [x] Is an array with `path`, `method`etc. too cumbersome? Better ideas? I thought about just providing the requests in HTTP format (so `POST /quizanswer....`) but that would be a lot of repetition for e.g. `Host: ..` which is useless in that case anyway.
* [ ] ~~Should we use `207` as status code for that even though `207` is WebDav? But `Multi-Status` is somehow correct.~~ Stick to http://www.odata.org/documentation/odata-version-3-0/batch-processing, so we use `202 Accepted`.
* [ ] Swagger integration
* [ ] more?
