### PR TITLE
Update ErrorFormatGuesser to handle custom formats and improve guess…

### DIFF
--- a/src/Util/ErrorFormatGuesser.php
+++ b/src/Util/ErrorFormatGuesser.php
@@ -46,12 +46,12 @@ final class ErrorFormatGuesser
         $defaultFormat = [];
 
         foreach ($errorFormats as $format => $errorMimeTypes) {
-            if ([] === $defaultFormat) {
-                $defaultFormat = ['key' => $format, 'value' => $errorMimeTypes];
-            }
-
             if (array_intersect($requestMimeTypes, $errorMimeTypes)) {
                 return ['key' => $format, 'value' => $errorMimeTypes];
+            }
+
+            if (!$defaultFormat) {
+                $defaultFormat = ['key' => $format, 'value' => $errorMimeTypes];
             }
         }
 

--- a/tests/Util/ErrorFormatGuesserTest.php
+++ b/tests/Util/ErrorFormatGuesserTest.php
@@ -48,4 +48,45 @@ class ErrorFormatGuesserTest extends TestCase
         $this->assertEquals('xml', $format['key']);
         $this->assertEquals('text/xml', $format['value'][0]);
     }
+
+    public function testGuessCustomErrorFormat()
+    {
+        $request = new Request();
+        $request->setRequestFormat('custom_json_format');
+
+        $format = ErrorFormatGuesser::guessErrorFormat($request, ['xml' => ['text/xml'], 'custom_json_format' => ['application/json']]);
+        $this->assertEquals('custom_json_format', $format['key']);
+        $this->assertEquals('application/json', $format['value'][0]);
+    }
+
+    public function testGuessErrorFormatFromAcceptHeader()
+    {
+        $request = new Request();
+        $request->headers->set('accept', 'application/ld+json');
+
+        $format = ErrorFormatGuesser::guessErrorFormat($request, ['xml' => ['text/xml'], 'jsonld' => ['application/ld+json', 'application/json']]);
+        $this->assertEquals('jsonld', $format['key']);
+        $this->assertEquals('application/ld+json', $format['value'][0]);
+    }
+
+    public function testGuessErrorFormatFromContentTypeHeader()
+    {
+        $request = new Request();
+        $request->headers->set('content-type', 'application/ld+json');
+
+        $format = ErrorFormatGuesser::guessErrorFormat($request, ['xml' => ['text/xml'], 'jsonld' => ['application/ld+json', 'application/json']]);
+        $this->assertEquals('jsonld', $format['key']);
+        $this->assertEquals('application/ld+json', $format['value'][0]);
+    }
+
+    public function testGuessErrorFormatFromAcceptHeaderFirst()
+    {
+        $request = new Request();
+        $request->headers->set('accept', 'text/xml');
+        $request->headers->set('content-type', 'application/ld+json');
+
+        $format = ErrorFormatGuesser::guessErrorFormat($request, ['xml' => ['text/xml'], 'jsonld' => ['application/ld+json', 'application/json']]);
+        $this->assertEquals('xml', $format['key']);
+        $this->assertEquals('text/xml', $format['value'][0]);
+    }
 }

--- a/tests/Util/ErrorFormatGuesserTest.php
+++ b/tests/Util/ErrorFormatGuesserTest.php
@@ -58,35 +58,4 @@ class ErrorFormatGuesserTest extends TestCase
         $this->assertEquals('custom_json_format', $format['key']);
         $this->assertEquals('application/json', $format['value'][0]);
     }
-
-    public function testGuessErrorFormatFromAcceptHeader()
-    {
-        $request = new Request();
-        $request->headers->set('accept', 'application/ld+json');
-
-        $format = ErrorFormatGuesser::guessErrorFormat($request, ['xml' => ['text/xml'], 'jsonld' => ['application/ld+json', 'application/json']]);
-        $this->assertEquals('jsonld', $format['key']);
-        $this->assertEquals('application/ld+json', $format['value'][0]);
-    }
-
-    public function testGuessErrorFormatFromContentTypeHeader()
-    {
-        $request = new Request();
-        $request->headers->set('content-type', 'application/ld+json');
-
-        $format = ErrorFormatGuesser::guessErrorFormat($request, ['xml' => ['text/xml'], 'jsonld' => ['application/ld+json', 'application/json']]);
-        $this->assertEquals('jsonld', $format['key']);
-        $this->assertEquals('application/ld+json', $format['value'][0]);
-    }
-
-    public function testGuessErrorFormatFromAcceptHeaderFirst()
-    {
-        $request = new Request();
-        $request->headers->set('accept', 'text/xml');
-        $request->headers->set('content-type', 'application/ld+json');
-
-        $format = ErrorFormatGuesser::guessErrorFormat($request, ['xml' => ['text/xml'], 'jsonld' => ['application/ld+json', 'application/json']]);
-        $this->assertEquals('xml', $format['key']);
-        $this->assertEquals('text/xml', $format['value'][0]);
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Wanted to implement custom error formats based on the format requested by the client, the issue was that whatever the request format the errors were always in the first error format configured. This PR has for purpose to improve the way the `ErrorFormatGuesser` is guessing the current format from the request and the configuration.

The logic is as following:
1- Check if request format has been set
2- Check if configuration for the format exist and return it if Yes
3- Otherwise guess MIME type from request headers (Accept, Content-Type)
4- Check if configuration for the MIME type exist and return it if Yes
5- Otherwise fallback to first error format configured

Example of configuration:
```yaml
api_platform:
    mapping:
        paths: ['%kernel.project_dir%/src/Database/Models']
    formats:
        json:     ['application/json']
        xml:      ['application/xml', 'text/xml']
    error_formats:
        custom_error_json: ['application/json']
        custom_error_xml:  ['application/xml', 'text/xml']
```

Return table

| Request format | Accept Header | Content-Type Header | Return
| -------------- | -------------- | --------------------- | -------
| / | / | / | `['key' => 'custom_error_xml', 'value' => ['application/xml', 'text/xml']]`
| custom_error_xml | / | / | `['key' => 'custom_error_xml', 'value' => ['application/xml', 'text/xml']]`
| / | application/json | / | `['key' => 'custom_error_json', 'value' => ['application/json']]`
| / | / | text/xml | `['key' => 'custom_error_xml', 'value' => ['application/xml', 'text/xml']]`
| custom_error_xml | application/json | text/xml | `['key' => 'custom_error_xml', 'value' => ['application/xml', 'text/xml']]`

The priority order to guess the format is: Request format > Accept Header > Content-Type Header > Fallback to first error format configured.
