### PR TITLE
 Fix OrderExtension to provide ordering with embedded fields

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
@@ -52,7 +52,9 @@ final class OrderExtension implements QueryCollectionExtensionInterface
                         $field = $order;
                         $order = 'ASC';
                     }
-                    if (false === ($pos = strpos($field, '.'))) {
+
+                    if (false === ($pos = \strpos($field, '.'))
+                        || isset($classMetaData->embeddedClasses[\substr($field, 0, $pos)])) {
                         // Configure default filter with property
                         $field = 'o.'.$field;
                     } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1670
| License       | MIT
| Doc PR        | -

This PR is related to `2.1` version and would be updated too in master branch.    
To push it to `master` branch, we have to add the code `$queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);` in my test.    
Do i need to open a second PR ?