### PR TITLE
Add a xmls:type to rdfs:range in case of an iterable type

### DIFF
--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -71,6 +71,7 @@ Feature: Documentation support
     And the value of the node "hydra:property.range" of the property "name" of the Hydra class "Dummy" is "xmls:string"
     And the value of the node "hydra:property.range" of the property "relatedDummy" of the Hydra class "Dummy" is "https://schema.org/Product"
     And the value of the node "hydra:property.range" of the property "relatedDummies" of the Hydra class "Dummy" is "https://schema.org/Product"
+    And the value of the node "hydra:property.range" of the property "jsonData" of the Hydra class "Dummy" is "xmls:list"
     And the value of the node "hydra:title" of the property "name" of the Hydra class "Dummy" is "name"
     And the value of the node "hydra:description" of the property "name" of the Hydra class "Dummy" is "The dummy name"
     # Operations

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -348,6 +348,9 @@ final class DocumentationNormalizer implements NormalizerInterface
                 return 'xmls:decimal';
             case Type::BUILTIN_TYPE_BOOL:
                 return 'xmls:boolean';
+            case Type::BUILTIN_TYPE_ARRAY:
+            case Type::BUILTIN_TYPE_ITERABLE:
+                return 'xmls:list';
             case Type::BUILTIN_TYPE_OBJECT:
                 if (null === $className = $type->getClassName()) {
                     return null;

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -44,7 +44,7 @@ class DocumentationNormalizerTest extends TestCase
         $documentation = new Documentation(new ResourceNameCollection(['dummy' => 'dummy']), $title, $desc, $version, []);
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create('dummy', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['name', 'description', 'relatedDummy']));
+        $propertyNameCollectionFactoryProphecy->create('dummy', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['name', 'description', 'jsonData', 'relatedDummy']));
 
         $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET', 'hydra_context' => ['hydra:foo' => 'bar', 'hydra:title' => 'foobar']], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']], []);
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
@@ -54,6 +54,7 @@ class DocumentationNormalizerTest extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create('dummy', 'name')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'name', true, true, true, true, false, false, null, null, []));
         $propertyMetadataFactoryProphecy->create('dummy', 'description')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'description', true, true, true, true, false, false, null, null, ['jsonld_context' => ['@type' => '@id']]));
+        $propertyMetadataFactoryProphecy->create('dummy', 'jsonData')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_ARRAY), 'jsonData', true, true, true, true, true, false, null, null, []));
         $subresourceMetadata = new SubresourceMetadata('relatedDummy', false);
         $propertyMetadataFactoryProphecy->create('dummy', 'relatedDummy')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummy', true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'relatedDummy')), 'This is a name.', true, true, true, true, false, false, null, null, [], $subresourceMetadata));
 
@@ -167,6 +168,21 @@ class DocumentationNormalizerTest extends TestCase
                             'hydra:readable' => true,
                             'hydra:writable' => true,
                             'hydra:description' => 'description',
+                        ],
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#dummy/jsonData',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'jsonData',
+                                'domain' => '#dummy',
+                                'range' => 'xmls:list',
+                            ],
+                            'hydra:title' => 'jsonData',
+                            'hydra:required' => true,
+                            'hydra:readable' => true,
+                            'hydra:writable' => true,
+                            'hydra:description' => 'jsonData',
                         ],
                         [
                             '@type' => 'hydra:SupportedProperty',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

This is necessary for a documentation parser like api-platform/api-doc-parser to know a field is a for example a json_array.
I am not sure this is the best way to do this, because the documentation of RDF/XML is unclear about list types, but at least it's a datatype in the XML Schema: https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#list-datatypes.