### PR TITLE
Support Flex directory structure for YAML and XML configs

### DIFF
--- a/features/main/configurable.feature
+++ b/features/main/configurable.feature
@@ -44,7 +44,6 @@ Feature: Configurable resource CRUD
     }
     """
 
-  @dropSchema
   Scenario: Retrieve the ConfigDummy resource
     When I send a "GET" request to "/fileconfigdummies/1"
     Then the response status code should be 200
@@ -59,5 +58,22 @@ Feature: Configurable resource CRUD
       "id": 1,
       "name": "ConfigDummy",
       "foo": "Foo"
+    }
+    """
+
+  @dropSchema
+  Scenario: Entities can be configured using a Flex-like directory structure
+    When I send a "GET" request to "/flex_configs"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+         "@context": "/contexts/FlexConfig",
+         "@id": "/flex_configs",
+         "@type": "hydra:Collection",
+         "hydra:member": [],
+         "hydra:totalItems": 0
     }
     """

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -525,7 +525,9 @@ class ApiPlatformExtensionTest extends TestCase
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
 
+        $containerBuilderProphecy->getParameter('kernel.project_dir')->willReturn(__DIR__);
         $containerBuilderProphecy->getParameter('kernel.debug')->willReturn(false);
+
         $containerBuilderProphecy->getDefinition('api_platform.http_cache.purger.varnish')->willReturn(new Definition());
 
         return $containerBuilderProphecy;

--- a/tests/Fixtures/TestBundle/Entity/FlexConfig.php
+++ b/tests/Fixtures/TestBundle/Entity/FlexConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * This entity is configure in tests/Fixtures/app/config/api_platform/flex.yaml.
+ *
+ * @ORM\Entity
+ */
+class FlexConfig
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -70,6 +70,7 @@ class AppKernel extends Kernel
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
         $environment = $this->getEnvironment();
+        $c->setParameter('kernel.project_dir', __DIR__);
 
         // patch for behat not supporting %env(APP_ENV)% in older versions
         if (($appEnv = $_SERVER['APP_ENV'] ?? 'test') && $appEnv !== $environment) {

--- a/tests/Fixtures/app/config/api_platform/flex.yaml
+++ b/tests/Fixtures/app/config/api_platform/flex.yaml
@@ -1,0 +1,1 @@
+ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FlexConfig: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | api-platform#383

Example usage:

```yaml
# config/api_platform/greeting.yaml
App\Entity\Greeting: ~
```