### PR TITLE
remove @dropSchema and drop the schema in @createSchema instead

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,6 @@ The command to launch Behat tests is:
 ./vendor/bin/behat --stop-on-failure -vvv
 ```
 
-You may need to clear the cache manually before running behat tests because of the temporary sql database. To do so, just remove the `test` cache directory:
-
-```
-rm -r tests/Fixtures/app/cache/test
-```
-
 ## Squash your commits
 
 If you have 3 commits. So start with:

--- a/features/authorization/deny.feature
+++ b/features/authorization/deny.feature
@@ -65,7 +65,6 @@ Feature: Authorization checking
     Then the response status code should be 403
     And the response should be in JSON
 
-  @dropSchema
   Scenario: An user can retrieve an item he owns
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -110,16 +110,9 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function createDatabase()
     {
-        $this->schemaTool->createSchema($this->classes);
-    }
-
-    /**
-     * @AfterScenario @dropSchema
-     */
-    public function dropDatabase()
-    {
         $this->schemaTool->dropSchema($this->classes);
         $this->doctrine->getManager()->clear();
+        $this->schemaTool->createSchema($this->classes);
     }
 
     /**

--- a/features/doctrine/boolean_filter.feature
+++ b/features/doctrine/boolean_filter.feature
@@ -370,7 +370,6 @@ Feature: Boolean filter on collections
     """
     And the JSON node "hydra:totalItems" should be equal to 15
 
-  @dropSchema
   Scenario: Get collection filtered by non valid properties
     When I send a "GET" request to "/dummies?unknown=0"
     Then the response status code should be 200

--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -264,7 +264,6 @@ Feature: Date filter on collections
     }
     """
 
-  @dropSchema
   Scenario: Get collection filtered by association date
     Given there are 30 dummy objects with dummyDate and relatedDummy
     When I send a "GET" request to "/dummies?relatedDummy.dummyDate[after]=2015-04-28"
@@ -384,7 +383,6 @@ Feature: Date filter on collections
     }
     """
 
-  @dropSchema
   @createSchema
   Scenario: Get collection filtered by association date
     Given there are 2 dummy objects with dummyDate and relatedDummy
@@ -672,7 +670,6 @@ Feature: Date filter on collections
     }
     """
 
-  @dropSchema
   @createSchema
   Scenario: Get collection filtered by date that is not a datetime
     Given there are 30 dummydate objects with dummyDate
@@ -681,7 +678,6 @@ Feature: Date filter on collections
     And the JSON node "hydra:totalItems" should be equal to 3
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
-  @dropSchema
   @createSchema
   Scenario: Get collection filtered by date that is an immutable date variant
     Given there are 30 dummyimmutabledate objects with dummyDate
@@ -690,7 +686,6 @@ Feature: Date filter on collections
     And the JSON node "hydra:totalItems" should be equal to 3
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
-  @dropSchema
   @createSchema
   Scenario: Get collection filtered by embedded date
     Given there are 2 embedded dummy objects with dummyDate and embeddedDummy

--- a/features/doctrine/exists_filter.feature
+++ b/features/doctrine/exists_filter.feature
@@ -34,7 +34,6 @@ Feature: Exists filter on collections
     }
     """
 
-  @dropSchema
   Scenario: Get collection where exists does exist
     When I send a "GET" request to "/dummies?dummyBoolean[exists]=1"
     Then the response status code should be 200

--- a/features/doctrine/multiple_filter.feature
+++ b/features/doctrine/multiple_filter.feature
@@ -4,7 +4,6 @@ Feature: Multiple filters on collections
   I need to retrieve collections filtered by multiple parameters
 
   @createSchema
-  @dropSchema
   Scenario: Get collection filtered by multiple parameters
     Given there are 30 dummy objects with dummyDate and dummyBoolean true
     And there are 20 dummy objects with dummyDate and dummyBoolean false

--- a/features/doctrine/numeric_filter.feature
+++ b/features/doctrine/numeric_filter.feature
@@ -47,7 +47,6 @@ Feature: Numeric filter on collections
     }
     """
 
-  @dropSchema
   Scenario: Get collection by non-numeric dummyPrice=marty
     Given there are 10 dummy objects with dummyPrice
     When I send a "GET" request to "/dummies?dummyPrice=marty"

--- a/features/doctrine/order_filter.feature
+++ b/features/doctrine/order_filter.feature
@@ -599,7 +599,6 @@ Feature: Order filter on collections
     }
     """
 
-  @dropSchema
   Scenario: Get collection ordered by a non valid properties and on which order filter has been enabled in whitelist mode
     When I send a "GET" request to "/dummies?order[alias]=asc"
     Then the response status code should be 200

--- a/features/doctrine/range_filter.feature
+++ b/features/doctrine/range_filter.feature
@@ -344,7 +344,6 @@ Feature: Range filter on collections
     }
     """
 
-  @dropSchema
   Scenario: Filter for entities within an impossible range
     When I send a "GET" request to "/dummies?dummyPrice[gt]=19.99"
     Then the response status code should be 200

--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -4,7 +4,6 @@ Feature: Search filter on collections
   I need to search for collections properties
 
   @createSchema
-  @dropSchema
   Scenario: Test ManyToMany with filter on join table
     Given there is a RelatedDummy with 4 friends
     When I add "Accept" header equal to "application/hal+json"
@@ -340,7 +339,6 @@ Feature: Search filter on collections
     }
     """
 
-  @dropSchema
   Scenario: Search for entities within an impossible range
     When I send a "GET" request to "/dummies?name=MuYm"
     Then the response status code should be 200
@@ -370,7 +368,6 @@ Feature: Search filter on collections
     """
 
   @createSchema
-  @dropSchema
   Scenario: Search related collection by name
     Given there are 3 dummy objects having each 3 relatedDummies
     When I add "Accept" header equal to "application/hal+json"
@@ -461,7 +458,6 @@ Feature: Search filter on collections
     """
 
 
-  @dropSchema
   Scenario: Get collection ordered by a non valid properties
     When I send a "GET" request to "/dummies?unknown=0"
     Then the response status code should be 200

--- a/features/filter/property_filter.feature
+++ b/features/filter/property_filter.feature
@@ -11,7 +11,6 @@ Feature: Set properties to include
     And the JSON node "alias" should be equal to "Alias #0"
     And the JSON node "relatedDummies" should not exist
 
-  @dropSchema
   Scenario: Test relation embedding
     When I send a "GET" request to "/dummies/1?properties[]=name&properties[]=alias&properties[relatedDummy][]=name"
     And the JSON node "name" should be equal to "Dummy #1"

--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -40,7 +40,6 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
 
-  @dropSchema
   Scenario: An anonymous user tries to create a resource he is not allowed to
     When I send the following GraphQL request:
     """

--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -1,6 +1,5 @@
 Feature: GraphQL collection support
   @createSchema
-  @dropSchema
   Scenario: Retrieve a collection through a GraphQL query
     Given there are 4 dummy objects with relatedDummy and its thirdLevel
     When I send the following GraphQL request:
@@ -34,7 +33,6 @@ Feature: GraphQL collection support
     And the JSON node "data.dummies.edges[2].node.relatedDummy.thirdLevel.level" should be equal to 3
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve an nonexistent collection through a GraphQL query
     When I send the following GraphQL request:
     """
@@ -60,7 +58,6 @@ Feature: GraphQL collection support
     And the JSON node "data.dummies.pageInfo.hasNextPage" should be false
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a collection with a nested collection through a GraphQL query
     Given there are 4 dummy objects having each 3 relatedDummies
     When I send the following GraphQL request:
@@ -89,7 +86,6 @@ Feature: GraphQL collection support
     And the JSON node "data.dummies.edges[2].node.relatedDummies.edges[1].node.name" should be equal to "RelatedDummy23"
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a collection and an item through a GraphQL query
     Given there are 3 dummy objects with dummyDate
     And there are 2 dummy group objects
@@ -117,7 +113,6 @@ Feature: GraphQL collection support
     And the JSON node "data.dummyGroup.foo" should be equal to "Foo #2"
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a specific number of items in a collection through a GraphQL query
     Given there are 4 dummy objects
     When I send the following GraphQL request:
@@ -138,7 +133,6 @@ Feature: GraphQL collection support
     And the JSON node "data.dummies.edges" should have 2 elements
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a specific number of items in a nested collection through a GraphQL query
     Given there are 2 dummy objects having each 5 relatedDummies
     When I send the following GraphQL request:
@@ -167,7 +161,6 @@ Feature: GraphQL collection support
     And the JSON node "data.dummies.edges[0].node.relatedDummies.edges" should have 2 elements
 
   @createSchema
-  @dropSchema
   Scenario: Paginate through collections through a GraphQL query
     Given there are 4 dummy objects having each 4 relatedDummies
     When I send the following GraphQL request:
@@ -321,7 +314,6 @@ Feature: GraphQL collection support
     And the JSON node "data.dummies.edges" should have 0 element
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve an item with composite primitive identifiers through a GraphQL query
     Given there are composite primitive identifiers objects
     When I send the following GraphQL request:
@@ -338,7 +330,6 @@ Feature: GraphQL collection support
     And the JSON node "data.compositePrimitiveItem.description" should be equal to "This is bar."
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve an item with composite identifiers through a GraphQL query
     Given there are Composite identifier objects
     When I send the following GraphQL request:

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -4,7 +4,6 @@ Feature: Collections filtering
   I need to be able to set filters
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a collection filtered using the boolean filter
     Given there is 1 dummy object with dummyBoolean true
     And there is 1 dummy object with dummyBoolean false
@@ -25,7 +24,6 @@ Feature: Collections filtering
     And the JSON node "data.dummies.edges[0].node.dummyBoolean" should be false
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a collection filtered using the date filter
     Given there are 3 dummy objects with dummyDate
     When I send the following GraphQL request:
@@ -45,7 +43,6 @@ Feature: Collections filtering
     And the JSON node "data.dummies.edges[0].node.dummyDate" should be equal to "2015-04-02T00:00:00+00:00"
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a collection filtered using the search filter
     Given there are 10 dummy objects
     When I send the following GraphQL request:
@@ -65,7 +62,6 @@ Feature: Collections filtering
     And the JSON node "data.dummies.edges[0].node.id" should be equal to "/dummies/2"
 
   @createSchema
-  @dropSchema
   Scenario: Retrieve a collection filtered using the search filter
     Given there are 3 dummy objects having each 3 relatedDummies
     When I send the following GraphQL request:

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -194,7 +194,6 @@ Feature: GraphQL introspection support
     And the JSON node "data.__type.fields[9].name" should be equal to "jsonData"
     And the JSON node "data.__type.fields[9].type.name" should be equal to "Iterable"
 
-  @dropSchema
   Scenario: Retrieve an item through a GraphQL query
     Given there are 4 dummy objects with relatedDummy
     When I send the following GraphQL request:

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -104,7 +104,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.createDummy.jsonData.bar.qux[2]" should be null
     And the JSON node "data.createDummy.clientMutationId" should be equal to "myId"
 
-  @dropSchema
   Scenario: Delete an item through a mutation
     When I send the following GraphQL request:
     """
@@ -122,7 +121,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.deleteFoo.clientMutationId" should be equal to "anotherId"
 
   @createSchema
-  @dropSchema
   Scenario: Delete an item with composite identifiers through a mutation
     Given there are Composite identifier objects
     When I send the following GraphQL request:
@@ -141,7 +139,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.deleteCompositeRelation.clientMutationId" should be equal to "myId"
 
   @createSchema
-  @dropSchema
   Scenario: Modify an item through a mutation
     Given there are 1 foo objects with fake names
     When I send the following GraphQL request:
@@ -183,7 +180,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.updateCompositeRelation.value" should be equal to "Modified value."
     And the JSON node "data.updateCompositeRelation.clientMutationId" should be equal to "myId"
 
-  @dropSchema
   Scenario: Trigger a validation error
     When I send the following GraphQL request:
     """

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -107,7 +107,6 @@ Feature: GraphQL query support
     And I send the GraphQL request with operation "DummyWithId1"
     And the JSON node "data.dummyItem.name" should be equal to "Dummy #1"
 
-  @dropSchema
   Scenario: Retrieve an nonexistent item through a GraphQL query
     When I send the following GraphQL request:
     """

--- a/features/hal/hal.feature
+++ b/features/hal/hal.feature
@@ -176,7 +176,6 @@ Feature: HAL support
     }
     """
 
-  @dropSchema
   Scenario: Get a collection
     When I add "Accept" header equal to "application/hal+json"
     And I send a "GET" request to "/dummies"

--- a/features/hal/problem.feature
+++ b/features/hal/problem.feature
@@ -29,7 +29,6 @@ Feature: Error handling valid according to RFC 7807 (application/problem+json)
     }
     """
 
-  @dropSchema
   Scenario: Get an error during deserialization of simple relation
     When I add "Content-Type" header equal to "application/json"
     And I add "Accept" header equal to "application/json"

--- a/features/http_cache/headers.feature
+++ b/features/http_cache/headers.feature
@@ -4,7 +4,6 @@ Feature: Default values of HTTP cache headers
   I need to be able to set default cache headers values
 
   @createSchema
-  @dropSchema
   Scenario: Cache headers default value
     When I send a "GET" request to "/relation_embedders"
     Then the response status code should be 200

--- a/features/http_cache/tags.feature
+++ b/features/http_cache/tags.feature
@@ -93,7 +93,6 @@ Feature: Cache invalidation through HTTP Cache tags
     Then the response status code should be 201
     And "/relation1s,/relation2s/1" IRIs should be purged
 
-  @dropSchema
   Scenario: Update a Relation1
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/relation1s/1" with body:

--- a/features/hydra/collection.feature
+++ b/features/hydra/collection.feature
@@ -358,7 +358,6 @@ Feature: Collections support
     }
     """
 
-  @dropSchema
   Scenario: Filter with non-exact match
     When I send a "GET" request to "/dummies?name=Dummy%20%238"
     Then the response status code should be 200
@@ -396,7 +395,6 @@ Feature: Collections support
     }
     """
 
-  @dropSchema
   @createSchema
   Scenario: Allow passing 0 to `itemsPerPage`
     When I send a "GET" request to "/dummies?itemsPerPage=0"

--- a/features/hydra/error.feature
+++ b/features/hydra/error.feature
@@ -85,7 +85,6 @@ Feature: Error handling
     And the JSON node "hydra:description" should exist
     And the JSON node "trace" should exist
 
-    @dropSchema
     Scenario: Get an error during update of an existing resource with a non-allowed update operation
       When I add "Content-Type" header equal to "application/ld+json"
       And I send a "POST" request to "/dummies" with body:
@@ -119,7 +118,6 @@ Feature: Error handling
       And the JSON node "@id" should be equal to "/related_dummies/1"
       And the JSON node "symfony" should be equal to "laravel"
 
-    @dropSchema
     Scenario: Do not get an error during update of an existing relation with a non-allowed update operation
       When I add "Content-Type" header equal to "application/ld+json"
       And I send a "POST" request to "/relation_embedders" with body:

--- a/features/integration/fos_user.feature
+++ b/features/integration/fos_user.feature
@@ -31,7 +31,6 @@ Feature: FOSUser integration
     """
     And the password "azerty" for user 1 should be hashed
 
-  @dropSchema
   Scenario: Delete a user
     When I send a "DELETE" request to "/users/1"
     Then the response status code should be 204

--- a/features/jsonapi/collection_attributes.feature
+++ b/features/jsonapi/collection_attributes.feature
@@ -8,7 +8,6 @@ Feature: JSON API collections support
     And I add "Content-Type" header equal to "application/vnd.api+json"
 
   @createSchema
-  @dropSchema
   Scenario: Correctly serialize a collection
     Given there is a CircularReference
     When I send a "GET" request to "/circular_references/1"

--- a/features/jsonapi/errors.feature
+++ b/features/jsonapi/errors.feature
@@ -35,7 +35,6 @@ Feature: JSON API error handling
     }
     """
 
-  @dropSchema
   Scenario: Get a validation error on an relationship
     Given there is a RelatedDummy
     And there is a DummyFriend

--- a/features/jsonapi/filtering.feature
+++ b/features/jsonapi/filtering.feature
@@ -23,7 +23,6 @@ Feature: JSON API filter handling
     And the JSON should be valid according to the JSON API schema
     And the JSON node "data" should have 0 elements
 
-  @dropSchema
   Scenario: Apply filters based on the 'filter' query parameter with second level arguments
     When I send a "GET" request to "/dummies?filter[dummyDate][after]=2015-04-28"
     Then the response status code should be 200

--- a/features/jsonapi/jsonapi.feature
+++ b/features/jsonapi/jsonapi.feature
@@ -230,7 +230,6 @@ Feature: JSON API basic support
     And the JSON node "data.attributes.name" should be equal to "Jane Doe"
     And the JSON node "data.attributes.age" should be equal to the number 23
 
-  @dropSchema
   Scenario: Embed a relation in a parent object
     When I send a "POST" request to "/relation_embedders" with body:
     """

--- a/features/jsonapi/ordering.feature
+++ b/features/jsonapi/ordering.feature
@@ -99,7 +99,6 @@ Feature: JSON API order handling
     }
     """
 
-  @dropSchema
   Scenario: Get collection ordered on two properties previously whitelisted
     When I send a "GET" request to "/dummies?sort=description,-id"
     Then the JSON should be valid according to the JSON API schema

--- a/features/jsonapi/pagination.feature
+++ b/features/jsonapi/pagination.feature
@@ -24,7 +24,6 @@ Feature: JSON API pagination handling
     And the JSON node "data" should have 1 elements
     And the JSON node "meta.currentPage" should be equal to the number 4
 
-  @dropSchema
   Scenario: Get a paginated collection according to custom items per page in request
     When I send a "GET" request to "/dummies?page[itemsPerPage]=15"
     Then the response status code should be 200

--- a/features/main/circular_reference.feature
+++ b/features/main/circular_reference.feature
@@ -33,7 +33,6 @@ Feature: Circular references handling
     }
     """
 
-  @dropSchema
   Scenario: Fetch circular reference
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/circular_references" with body:

--- a/features/main/composite.feature
+++ b/features/main/composite.feature
@@ -4,7 +4,6 @@ Feature: Retrieve data with Composite identifiers
   I need to retrieve all collections
 
   @createSchema
-  @dropSchema
   Scenario: Get a collection with composite identifiers
     Given there are Composite identifier objects
     When I send a "GET" request to "/composite_items"
@@ -36,7 +35,6 @@ Feature: Retrieve data with Composite identifiers
     """
 
   @createSchema
-  @dropSchema
   Scenario: Get collection with composite identifiers
     Given there are Composite identifier objects
     When I send a "GET" request to "/composite_relations"
@@ -125,7 +123,6 @@ Feature: Retrieve data with Composite identifiers
     When I send a "GET" request to "/composite_relations/compositeLabel=1;"
     Then the response status code should be 404
 
-  @dropSchema
   Scenario: Get first composite item
     Given there are Composite identifier objects
     When I send a "GET" request to "/composite_items/1"

--- a/features/main/configurable.feature
+++ b/features/main/configurable.feature
@@ -44,7 +44,6 @@ Feature: Configurable resource CRUD
     }
     """
 
-  @dropSchema
   Scenario: Retrieve the ConfigDummy resource
     When I send a "GET" request to "/fileconfigdummies/1"
     Then the response status code should be 200

--- a/features/main/content_negotiation.feature
+++ b/features/main/content_negotiation.feature
@@ -109,7 +109,6 @@ Feature: Content Negotiation support
     Then the response status code should be 406
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
 
-  @dropSchema
   Scenario: If the request format is HTML, the error should be in HTML
     When I add "Accept" header equal to "text/html"
     And I send a "GET" request to "/dummies/666"

--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -477,7 +477,6 @@ Feature: Create-Retrieve-Update-Delete
     }
     """
 
-  @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/dummies/1"
     Then the response status code should be 204

--- a/features/main/crud_abstract.feature
+++ b/features/main/crud_abstract.feature
@@ -102,7 +102,6 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
       }
       """
 
-  @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/abstract_dummies/1"
     Then the response status code should be 204

--- a/features/main/custom_identifier.feature
+++ b/features/main/custom_identifier.feature
@@ -97,7 +97,6 @@ Feature: Using custom identifier on resource
     And "name" property is readable for Hydra class "CustomIdentifierDummy"
     And "name" property is writable for Hydra class "CustomIdentifierDummy"
 
-  @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/custom_identifier_dummies/1"
     Then the response status code should be 204

--- a/features/main/custom_normalized.feature
+++ b/features/main/custom_normalized.feature
@@ -158,7 +158,6 @@ Feature: Using custom normalized entity
     And "alias" property is readable for Hydra class "CustomNormalizedDummy"
     And "alias" property is writable for Hydra class "CustomNormalizedDummy"
 
-  @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/custom_normalized_dummies/1"
     Then the response status code should be 204

--- a/features/main/custom_operation.feature
+++ b/features/main/custom_operation.feature
@@ -17,7 +17,6 @@ Feature: Custom operation
     }
     """
 
-  @dropSchema
   Scenario: Custom normalization operation
     When I send a "GET" request to "/custom/1/normalization"
     Then the JSON should be equal to:

--- a/features/main/custom_writable_identifier.feature
+++ b/features/main/custom_writable_identifier.feature
@@ -101,7 +101,6 @@ Feature: Using custom writable identifier on resource
     And "slug" property is readable for Hydra class "CustomWritableIdentifierDummy"
     And "slug" property is writable for Hydra class "CustomWritableIdentifierDummy"
 
-  @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/custom_writable_identifier_dummies/slug_modified"
     Then the response status code should be 204

--- a/features/main/default_order.feature
+++ b/features/main/default_order.feature
@@ -61,7 +61,6 @@ Feature: Default order
     }
     """
 
-  @dropSchema
   Scenario: Override custom order by association
     Given there are 5 fooDummy objects with fake names
     When I send a "GET" request to "/foo_dummies?itemsPerPage=10"

--- a/features/main/overridden_operation.feature
+++ b/features/main/overridden_operation.feature
@@ -126,7 +126,6 @@ Feature: Create-Retrieve-Update-Delete with a Overridden Operation context
     }
     """
 
-  @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/overridden_operation_dummies/1"
     Then the response status code should be 204

--- a/features/main/recursive.feature
+++ b/features/main/recursive.feature
@@ -36,7 +36,6 @@ Feature: Max depth handling
     }
     """
 
-  @dropSchema
   Scenario: Make the resource recursive
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "recursives/1" with body:

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -514,7 +514,6 @@ Feature: Relations support
     }
     """
 
-  @dropSchema
   Scenario: Issue #1547 Passing wrong argument to a relation
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/relation_embedders" with body:

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -349,7 +349,6 @@ Feature: Subresource support
     }
     """
 
-  @dropSchema
   Scenario: test
     When I send a "GET" request to "/dummy_products/2"
     And the response status code should be 200

--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -44,7 +44,6 @@ Feature: Table inheritance
     }
     """
 
-  @dropSchema
   Scenario: Get the parent entity collection
     When I send a "GET" request to "/dummy_table_inheritances"
     Then the response status code should be 200
@@ -237,7 +236,6 @@ Feature: Table inheritance
     }
     """
 
-  @dropSchema
   Scenario: Get the parent entity collection which contains multiple inherited children type
     When I send a "GET" request to "/dummy_table_inheritances"
     Then the response status code should be 200

--- a/features/main/uuid.feature
+++ b/features/main/uuid.feature
@@ -97,7 +97,6 @@ Feature: Using uuid identifier on resource
     }
     """
 
-  @dropSchema
   Scenario: Delete a resource
     When I send a "DELETE" request to "/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78"
     Then the response status code should be 204

--- a/features/security/send_security_headers.feature
+++ b/features/security/send_security_headers.feature
@@ -21,7 +21,6 @@ Feature: Send security header
     And the header "X-Content-Type-Options" should be equal to "nosniff"
     And the header "X-Frame-Options" should be equal to "deny"
 
-  @dropSchema
   Scenario: Error validation responses must always contain security headers
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummies" with body:

--- a/features/security/strong_typing.feature
+++ b/features/security/strong_typing.feature
@@ -121,7 +121,6 @@ Feature: Handle properly invalid data submitted to the API
     And the JSON node "hydra:title" should be equal to "An error occurred"
     And the JSON node "hydra:description" should be equal to 'The type of the "name" attribute must be "string", "integer" given.'
 
-  @dropSchema
   Scenario: According to the JSON spec, allow numbers without explicit floating point for JSON formats
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummies" with body:

--- a/features/security/unknown_attributes.feature
+++ b/features/security/unknown_attributes.feature
@@ -4,7 +4,6 @@ Feature: Ignore unknown attributes
   I can send unsupported attributes that will be ignored
 
   @createSchema
-  @dropSchema
   Scenario: Create a resource
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummies" with body:

--- a/features/serializer/group_filter.feature
+++ b/features/serializer/group_filter.feature
@@ -952,7 +952,6 @@ Feature: Filter with serialization groups on items and collections
     }
     """
 
-  @dropSchema
   Scenario: Create a resource by groups dummy, dummy_baz, with overriding and with whitelist
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummy_groups?override_whitelisted_groups[]=dummy&override_whitelisted_groups[]=dummy_baz" with body:

--- a/features/serializer/property_filter.feature
+++ b/features/serializer/property_filter.feature
@@ -571,7 +571,6 @@ Feature: Filter with serialization attributes on items and collections
     }
     """
 
-  @dropSchema
   Scenario: Create a resource by attributes foo, bar, group.foo, group.baz and group.qux
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummy_properties?properties[]=foo&properties[]=bar&properties[group][]=foo&properties[group][]=baz&properties[group][]=qux" with body:

--- a/features/swagger/docs.feature
+++ b/features/swagger/docs.feature
@@ -80,7 +80,6 @@ Feature: Documentation support
     Then the response status code should be 200
     And I should see text matching "My Dummy API"
 
-  @dropSchema
   Scenario: Swagger UI is enabled for an arbitrary endpoint
     Given I add "Accept" header equal to "text/html"
     And I send a "GET" request to "/dummies"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1642 
| License       | MIT
| Doc PR        | ~

As told in #1642, I don't think `@dropSchema` is usefull. It is really easier to just drop the schema before creating it.

It simplifies the mental process of contributing to api-platform (especially in files [containing multiple `@dropSchema` / `@createSchema`](https://github.com/api-platform/core/blob/v2.2.0-beta.1/features/doctrine/date_filter.feature) )

I think the hint about removing the database file in `CONTRIBUTING.md` does not stands anymore as the database will be dropped on the first `@createSchema` call.