### PR TITLE
Allow empty operations in XML configs

### DIFF
--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -73,22 +73,25 @@ final class XmlExtractor extends AbstractExtractor
         }
 
         $operationsParent = $graphql ? 'graphql' : "{$operationType}s";
-
         if (!isset($resource->$operationsParent)) {
             return null;
         }
 
-        return $this->getAttributes($resource->$operationsParent, $operationType);
+        return $this->getAttributes($resource->$operationsParent, $operationType, true);
     }
 
     /**
      * Recursively transforms an attribute structure into an associative array.
      */
-    private function getAttributes(\SimpleXMLElement $resource, string $elementName): array
+    private function getAttributes(\SimpleXMLElement $resource, string $elementName, bool $topLevel = false): array
     {
         $attributes = [];
         foreach ($resource->$elementName as $attribute) {
             $value = isset($attribute->attribute[0]) ? $this->getAttributes($attribute, 'attribute') : XmlUtils::phpize($attribute);
+            // allow empty operations definition, like <collectionOperation name="post" />
+            if ($topLevel && '' === $value) {
+                $value = [];
+            }
             if (isset($attribute['name'])) {
                 $attributes[(string) $attribute['name']] = $value;
             } else {

--- a/src/Metadata/schema/metadata.xsd
+++ b/src/Metadata/schema/metadata.xsd
@@ -39,7 +39,7 @@
     </xsd:complexType>
 
     <xsd:complexType name="itemOperation">
-        <xsd:sequence maxOccurs="unbounded">
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="attribute" maxOccurs="unbounded" type="attribute"/>
         </xsd:sequence>
         <xsd:attribute type="xsd:string" name="name"/>
@@ -52,7 +52,7 @@
     </xsd:complexType>
 
     <xsd:complexType name="collectionOperation">
-        <xsd:sequence maxOccurs="unbounded">
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="attribute" maxOccurs="unbounded" type="attribute"/>
         </xsd:sequence>
         <xsd:attribute type="xsd:string" name="name"/>

--- a/tests/Fixtures/FileConfigurations/empty-operation.xml
+++ b/tests/Fixtures/FileConfigurations/empty-operation.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
+    <resource class="App\Entity\Greeting">
+        <collectionOperations>
+            <collectionOperation name="get">
+                <attribute name="filters">
+                    <attribute>greeting.search_filter</attribute>
+                </attribute>
+            </collectionOperation>
+            <collectionOperation name="post" />
+        </collectionOperations>
+        <itemOperations>
+            <itemOperation name="get" />
+            <itemOperation name="put" />
+        </itemOperations>
+    </resource>
+</resources>

--- a/tests/Metadata/Extractor/XmlExtractorTest.php
+++ b/tests/Metadata/Extractor/XmlExtractorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Extractor;
+
+use ApiPlatform\Core\Metadata\Extractor\XmlExtractor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class XmlExtractorTest extends TestCase
+{
+    public function testEmptyOperation()
+    {
+        $resources = (new XmlExtractor([__DIR__.'/../../Fixtures/FileConfigurations/empty-operation.xml']))->getResources();
+
+        $this->assertSame(['filters' => ['greeting.search_filter']], $resources['App\Entity\Greeting']['collectionOperations']['get']);
+        $this->assertSame([], $resources['App\Entity\Greeting']['collectionOperations']['post']);
+        $this->assertSame(['get' => [], 'put' => []], $resources['App\Entity\Greeting']['itemOperations']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

A companion PR of #1470.

Now instead of:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<!-- api/config/api_platform/resources.xml -->

<resources xmlns="https://api-platform.com/schema/metadata"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="https://api-platform.com/schema/metadata
           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
    <resource class="App\Entity\Greeting">
        <collectionOperations>
            <collectionOperation name="get">
                <attribute name="method">GET</attribute>
            </collectionOperation>
        </collectionOperations>
    </resource>
</resources>
```

It's possible to write:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<resources xmlns="https://api-platform.com/schema/metadata"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="https://api-platform.com/schema/metadata
           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
    <resource class="App\Entity\Greeting">
        <collectionOperations>
            <collectionOperation name="get" />
        </collectionOperations>
    </resource>
</resources>
```