### PR TITLE
Fix deprecation notice on filters applied on collection without params

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
@@ -65,6 +65,8 @@ final class FilterExtension implements ContextAwareQueryCollectionExtensionInter
                 continue;
             }
 
+            $context['filters'] = $context['filters'] ?? [];
+
             $filter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
         }
     }

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterExtensionTest.php
@@ -41,7 +41,7 @@ class FilterExtensionTest extends TestCase
         $queryBuilder = $queryBuilderProphecy->reveal();
 
         $ormFilterProphecy = $this->prophesize(FilterInterface::class);
-        $ormFilterProphecy->apply($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get', [])->shouldBeCalled();
+        $ormFilterProphecy->apply($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get', ['filters' => []])->shouldBeCalled();
 
         $ordinaryFilterProphecy = $this->prophesize(ApiFilterInterface::class);
 
@@ -70,7 +70,7 @@ class FilterExtensionTest extends TestCase
         $queryBuilder = $queryBuilderProphecy->reveal();
 
         $filterProphecy = $this->prophesize(FilterInterface::class);
-        $filterProphecy->apply($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get', [])->shouldBeCalled();
+        $filterProphecy->apply($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get', ['filters' => []])->shouldBeCalled();
 
         $orderExtensionTest = new FilterExtension($resourceMetadataFactoryProphecy->reveal(), new FilterCollection(['dummyFilter' => $filterProphecy->reveal()]));
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

À vous deprecation notice by routing to the new filter system.