### PR TITLE
[GraphQL] Fix type for subresource

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -54,11 +54,36 @@ Feature: GraphQL mutation support
     And the JSON node "data.createFoo.bar" should be equal to "new"
     And the JSON node "data.createFoo.clientMutationId" should be equal to "myId"
 
+  Scenario: Create an item with a subresource
+    Given there are 1 dummy objects with relatedDummy
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createDummy(input: {_id: 1, name: "A dummy", foo: [], relatedDummy: "/related_dummies/1", clientMutationId: "myId"}) {
+        id
+        name
+        foo
+        relatedDummy {
+          name
+        }
+        clientMutationId
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createDummy.id" should be equal to "/dummies/2"
+    And the JSON node "data.createDummy.name" should be equal to "A dummy"
+    And the JSON node "data.createDummy.foo" should have 0 elements
+    And the JSON node "data.createDummy.relatedDummy.name" should be equal to "RelatedDummy #1"
+    And the JSON node "data.createDummy.clientMutationId" should be equal to "myId"
+
   Scenario: Create an item with an iterable field
     When I send the following GraphQL request:
     """
     mutation {
-      createDummy(input: {_id: 1, name: "A dummy", foo: [], jsonData: {bar:{baz:3,qux:[7.6,false,null]}}, clientMutationId: "myId"}) {
+      createDummy(input: {_id: 2, name: "A dummy", foo: [], jsonData: {bar:{baz:3,qux:[7.6,false,null]}}, clientMutationId: "myId"}) {
         id
         name
         foo
@@ -70,7 +95,7 @@ Feature: GraphQL mutation support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.createDummy.id" should be equal to "/dummies/1"
+    And the JSON node "data.createDummy.id" should be equal to "/dummies/3"
     And the JSON node "data.createDummy.name" should be equal to "A dummy"
     And the JSON node "data.createDummy.foo" should have 0 elements
     And the JSON node "data.createDummy.jsonData.bar.baz" should be equal to the number 3

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -341,7 +341,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 $graphqlType = $this->graphqlTypes['#iterable'];
                 break;
             case Type::BUILTIN_TYPE_OBJECT:
-                if (is_a($type->getClassName(), \DateTimeInterface::class, true)) {
+                if (($input && $depth > 0) || is_a($type->getClassName(), \DateTimeInterface::class, true)) {
                     $graphqlType = GraphQLType::string();
                     break;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/api-platform/issues/535
| License       | MIT
| Doc PR        |

Nested mutations are not a part of the specification. See:
- https://github.com/webonyx/graphql-php/issues/189
- https://github.com/facebook/graphql/issues/252
- https://github.com/graphql/graphql-js/issues/672
Moreover, it would be laborious to implement it. We would have to change the behavior of the ItemNormalizer and we would have to move the validation/access control of the resolver elsewhere to be reused in the normalizer.
Therefore, it seems a better solution to force IRIs for subresources in mutations.
This PR also fixes an issue with input types: pagination should not be used for them.