### PR TITLE
Allow to declare multiple filters with same class

### DIFF
--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -50,24 +50,18 @@ Feature: Search filter on collections
         },
 				"hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummy_cars{?availableAt[before],availableAt[strictly_before],availableAt[after],availableAt[strictly_after],canSell,foobar[],foobargroups[],colors.prop,name}",
+        "hydra:template": "\/dummy_cars{?availableAt[before],availableAt[strictly_before],availableAt[after],availableAt[strictly_after],canSell,foobar[],foobargroups[],foobargroups_override[],colors.prop,name}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
             "@type": "IriTemplateMapping",
-            "variable": "availableAt[before]",
-            "property": "availableAt",
-            "required": false
-          },
-          {
-            "@type": "IriTemplateMapping",
-            "variable": "availableAt[strictly_before]",
-            "property": "availableAt",
-            "required": false
-          },
-          {
-            "@type": "IriTemplateMapping",
             "variable": "availableAt[after]",
+            "property": "availableAt",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "availableAt[before]",
             "property": "availableAt",
             "required": false
           },
@@ -79,8 +73,20 @@ Feature: Search filter on collections
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "availableAt[strictly_before]",
+            "property": "availableAt",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "canSell",
             "property": "canSell",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "colors.prop",
+            "property": "colors.prop",
             "required": false
           },
           {
@@ -97,8 +103,8 @@ Feature: Search filter on collections
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "colors.prop",
-            "property": "colors.prop",
+            "variable": "foobargroups_override[]",
+            "property": null,
             "required": false
           },
           {

--- a/src/Annotation/ApiFilter.php
+++ b/src/Annotation/ApiFilter.php
@@ -29,6 +29,11 @@ final class ApiFilter
     /**
      * @var string
      */
+    public $id;
+
+    /**
+     * @var string
+     */
     public $strategy;
 
     /**

--- a/src/Util/AnnotationFilterExtractorTrait.php
+++ b/src/Util/AnnotationFilterExtractorTrait.php
@@ -87,7 +87,7 @@ trait AnnotationFilterExtractorTrait
 
         foreach ($this->getFilterAnnotations($reader->getClassAnnotations($reflectionClass)) as $filterAnnotation) {
             $filterClass = $filterAnnotation->filterClass;
-            $id = $this->generateFilterId($reflectionClass, $filterClass);
+            $id = $this->generateFilterId($reflectionClass, $filterClass, $filterAnnotation->id);
 
             if (!isset($filters[$id])) {
                 $filters[$id] = [$filterAnnotation->arguments, $filterClass];
@@ -101,7 +101,7 @@ trait AnnotationFilterExtractorTrait
         foreach ($reflectionClass->getProperties() as $reflectionProperty) {
             foreach ($this->getFilterAnnotations($reader->getPropertyAnnotations($reflectionProperty)) as $filterAnnotation) {
                 $filterClass = $filterAnnotation->filterClass;
-                $id = $this->generateFilterId($reflectionClass, $filterClass);
+                $id = $this->generateFilterId($reflectionClass, $filterClass, $filterAnnotation->id);
 
                 if (!isset($filters[$id])) {
                     $filters[$id] = [$filterAnnotation->arguments, $filterClass];
@@ -131,11 +131,14 @@ trait AnnotationFilterExtractorTrait
      *
      * @param \ReflectionClass $reflectionClass the reflection class of a Resource
      * @param string           $filterClass     the filter class
+     * @param string           $filterId        the filter id
      *
      * @return string
      */
-    private function generateFilterId(\ReflectionClass $reflectionClass, string $filterClass): string
+    private function generateFilterId(\ReflectionClass $reflectionClass, string $filterClass, string $filterId = null): string
     {
-        return 'annotated_'.Inflector::tableize(str_replace('\\', '', $reflectionClass->getName().(new \ReflectionClass($filterClass))->getName()));
+        $suffix = null !== $filterId ? '_'.$filterId : $filterId;
+
+        return 'annotated_'.Inflector::tableize(str_replace('\\', '', $reflectionClass->getName().(new \ReflectionClass($filterClass))->getName().$suffix));
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -35,6 +35,7 @@ use Symfony\Component\Serializer\Annotation as Serializer;
  * @ApiFilter(BooleanFilter::class)
  * @ApiFilter(PropertyFilter::class, arguments={"parameterName": "foobar"})
  * @ApiFilter(GroupFilter::class, arguments={"parameterName": "foobargroups"})
+ * @ApiFilter(GroupFilter::class, arguments={"parameterName": "foobargroups_override"}, id="override")
  */
 class DummyCar
 {

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -62,6 +62,10 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
             ['parameterName' => 'foobargroups'],
             GroupFilter::class,
           ],
+          'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_serializer_filter_group_filter_override' => [
+            ['parameterName' => 'foobargroups_override'],
+            GroupFilter::class,
+          ],
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | not yet

When using multiple filters of the same class with @ApiFilter annotation( for example `GroupFilter::class`, one with option `overrideDefaultGroups:true` and the other one with `overrideDefaultGroups:false` ), only the first one was registered. 
This PR try to fix that by adding an 'id' option to the ApiFilter filter annotation to make it unique per-class and per-filter. 