### PR TITLE
throw NotFound exception when use plain identifiers

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -315,7 +315,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             // repeat the code so that IRIs keep working with the json format
             if (true === $this->allowPlainIdentifiers && $this->itemDataProvider) {
                 try {
-                    return $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true]);
+                    $item = $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true]);
+
+                    if (null === $item) {
+                        throw new ItemNotFoundException(sprintf('Item with id "%s" not found for class "%s".', $value, $className));
+                    }
+
+                    return $item;
                 } catch (ItemNotFoundException $e) {
                     throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
                 } catch (InvalidArgumentException $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

There is PR https://github.com/api-platform/core/pull/1365 that introduce "allow_plain_identifiers". But there is a problem, if you send identifier for entity that not present in database, it try to set it to object as "null", and if this field is required like "setFoo(Foo $foo)" - than we have 500 error.

Default DataProvider never throw ItemNotFound, since have "return $queryBuilder->getQuery()->getOneOrNullResult();", and AbstractItemNormalizer never have "} catch (ItemNotFoundException $e) {"

This PR fix this and behavior when we use "allow_plain_identifiers" becomes same as with iriConverter.
