### PR TITLE
Fix wrong automatic configuration for Sf flex

### DIFF
--- a/features/main/configurable.feature
+++ b/features/main/configurable.feature
@@ -44,6 +44,7 @@ Feature: Configurable resource CRUD
     }
     """
 
+  @dropSchema
   Scenario: Retrieve the ConfigDummy resource
     When I send a "GET" request to "/fileconfigdummies/1"
     Then the response status code should be 200
@@ -58,22 +59,5 @@ Feature: Configurable resource CRUD
       "id": 1,
       "name": "ConfigDummy",
       "foo": "Foo"
-    }
-    """
-
-  @dropSchema
-  Scenario: Entities can be configured using a Flex-like directory structure
-    When I send a "GET" request to "/flex_configs"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-         "@context": "/contexts/FlexConfig",
-         "@id": "/flex_configs",
-         "@type": "hydra:Collection",
-         "hydra:member": [],
-         "hydra:totalItems": 0
     }
     """

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -246,13 +246,14 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
     private function getResourcesToWatch(ContainerBuilder $container, array $resourcesPaths): array
     {
-        // Flex structure
+        $paths = array_unique(array_merge($resourcesPaths, $this->getBundlesResourcesPaths($container)));
+
+        // Flex structure (only if nothing specified)
         $projectDir = $container->getParameter('kernel.project_dir');
-        if (is_dir($dir = "$projectDir/config/api_platform")) {
-            $resourcesPaths[] = $dir;
+        if (!$paths && is_dir($dir = "$projectDir/config/api_platform")) {
+            $paths = [$dir];
         }
 
-        $paths = array_unique(array_merge($resourcesPaths, $this->getBundlesResourcesPaths($container)));
         $resources = ['yml' => [], 'xml' => [], 'dir' => []];
 
         foreach ($paths as $path) {


### PR DESCRIPTION
This was an issue for some people that decided to change the way the folder
of configuration of api platform is defined.

The idea of this fix is to not interfer with the user configuration.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none, but still an issue
| License       | MIT
| Doc PR        | N/A

# Reproducer
```yaml
# api platform configuration
api_platform:
    mapping:
        paths: ['%kernel.project_dir%/config/api_platform/resources']
```

_Then imagine having the `%kernel.project_dir%/config/api_platform/routes` folder._

# Before the fix
The dump of resources folders is:

```
array:2 [
  0 => "/var/www/apps/cadi-back/config/api_platform/resources"
  1 => "/var/www/apps/cadi-back/config/api_platform"
]
```

# After the fix
The dump of resources folder is:
```
array:1 [
  0 => "/var/www/apps/cadi-back/config/api_platform/resources"
]
```