### PR TITLE
More query parameter validation (follow #1692)

### DIFF
--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -109,7 +109,6 @@ Feature: Validate filters based upon filter description
     Then the response status code should be 400
     And the JSON node "detail" should be equal to 'Query parameter "enum" must be one of "in-enum, mune-ni"'
 
-  @dropSchema
   Scenario: Test filter multipleOf
     When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=4"
     Then the response status code should be 200
@@ -117,3 +116,52 @@ Feature: Validate filters based upon filter description
     When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=3"
     Then the response status code should be 400
     And the JSON node "detail" should be equal to 'Query parameter "multiple-of" must multiple of 2'
+
+  Scenario: Test filter array items csv format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-min-2=a,b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-min-2=a"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "csv-min-2" must contain more than 2 values'
+
+  Scenario: Test filter array items csv format maxItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-max-3=a,b,c"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-max-3=a,b,c,d"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "csv-max-3" must contain less than 3 values'
+
+  Scenario: Test filter array items tsv format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&tsv-min-2=a\tb"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&tsv-min-2=a,b"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "tsv-min-2" must contain more than 2 values'
+
+  Scenario: Test filter array items pipes format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&pipes-min-2=a|b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&pipes-min-2=a,b"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "pipes-min-2" must contain more than 2 values'
+
+  Scenario: Test filter array items ssv format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&ssv-min-2=a b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&ssv-min-2=a,b"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "ssv-min-2" must contain more than 2 values'
+
+  @dropSchema
+  Scenario: Test filter array items unique items
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-uniques=a,b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-uniques=a,a"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "csv-uniques" must contain unique values'

--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -2,16 +2,18 @@ Feature: Validate filters based upon filter description
 
   @createSchema
   Scenario: Required filter should not throw an error if set
-    When I am on "/filter_validators?required=foo"
+    When I am on "/filter_validators?required=foo&required-allow-empty=&arrayRequired[foo]="
     Then the response status code should be 200
 
-    When I am on "/filter_validators?required="
-    Then the response status code should be 200
+  Scenario: Required filter that does not allow empty value should throw an error if empty
+    When I am on "/filter_validators?required=&required-allow-empty=&arrayRequired[foo]="
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "required" does not allow empty value'
 
   Scenario: Required filter should throw an error if not set
     When I am on "/filter_validators"
     Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "required" is required'
+    Then the JSON node "detail" should match '/^Query parameter "required" is required\nQuery parameter "required-allow-empty" is required$/'
 
   Scenario: Required filter should not throw an error if set
     When I am on "/array_filter_validators?arrayRequired[]=foo&indexedArrayRequired[foo]=foo"

--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -84,7 +84,6 @@ Feature: Validate filters based upon filter description
     When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3[]=12345"
     Then the response status code should be 200
 
-  @dropSchema
   Scenario: Test filter bounds: min length
     When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=123"
     Then the response status code should be 200
@@ -92,3 +91,29 @@ Feature: Validate filters based upon filter description
     When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=12"
     Then the response status code should be 400
     And the JSON node "detail" should be equal to 'Query parameter "min-length-3" length must be greater than or equal to 3'
+
+  Scenario: Test filter pattern
+    When I am on "/filter_validators?required=foo&required-allow-empty&pattern=pattern"
+    When I am on "/filter_validators?required=foo&required-allow-empty&pattern=nrettap"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&pattern=not-pattern"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "pattern" must match pattern /^(pattern|nrettap)$/'
+
+  Scenario: Test filter enum
+    When I am on "/filter_validators?required=foo&required-allow-empty&enum=in-enum"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&enum=not-in-enum"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "enum" must be one of "in-enum, mune-ni"'
+
+  @dropSchema
+  Scenario: Test filter multipleOf
+    When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=4"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=3"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "multiple-of" must multiple of 2'

--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -64,7 +64,6 @@ Feature: Validate filters based upon filter description
     Then the response status code should be 400
     And the JSON node "detail" should be equal to 'Query parameter "minimum" must be greater than or equal to 5'
 
-  @dropSchema
   Scenario: Test filter bounds: exclusiveMinimum
     When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=6"
     Then the response status code should be 200
@@ -72,3 +71,24 @@ Feature: Validate filters based upon filter description
     When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=5"
     Then the response status code should be 400
     And the JSON node "detail" should be equal to 'Query parameter "exclusiveMinimum" must be greater than 5'
+
+  Scenario: Test filter bounds: max length
+    When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3=123"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3=1234"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "max-length-3" length must be lower than or equal to 3'
+
+  Scenario: Do not throw an error if value is not an array
+    When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3[]=12345"
+    Then the response status code should be 200
+
+  @dropSchema
+  Scenario: Test filter bounds: min length
+    When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=123"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=12"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "min-length-3" length must be greater than or equal to 3'

--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -39,3 +39,36 @@ Feature: Validate filters based upon filter description
     When I am on "/array_filter_validators?arrayRequired[]=foo&indexedArrayRequired[bar]=bar"
     Then the response status code should be 400
     And the JSON node "detail" should be equal to 'Query parameter "indexedArrayRequired[foo]" is required'
+
+  Scenario: Test filter bounds: maximum
+    When I am on "/filter_validators?required=foo&required-allow-empty&maximum=10"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&maximum=11"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "maximum" must be less than or equal to 10'
+
+  Scenario: Test filter bounds: exclusiveMaximum
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMaximum=9"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMaximum=10"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "exclusiveMaximum" must be less than 10'
+
+  Scenario: Test filter bounds: minimum
+    When I am on "/filter_validators?required=foo&required-allow-empty&minimum=5"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&minimum=0"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "minimum" must be greater than or equal to 5'
+
+  @dropSchema
+  Scenario: Test filter bounds: exclusiveMinimum
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=6"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=5"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "exclusiveMinimum" must be greater than 5'

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -23,9 +23,13 @@
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="64" />
         </service>
 
-        <service id="api_platform.listener.view.validate_query_parameters" class="ApiPlatform\Core\Filter\QueryParameterValidateListener" public="false">
-            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+        <service id="api_platform.validator.query_parameter_validator" class="ApiPlatform\Core\Filter\QueryParameterValidator" public="false">
             <argument type="service" id="api_platform.filter_locator" />
+        </service>
+
+        <service id="api_platform.listener.view.validate_query_parameters" class="ApiPlatform\Core\EventListener\QueryParameterValidateListener" public="false">
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.validator.query_parameter_validator" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="16" />
         </service>

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -23,6 +23,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface as SymfonyValidator
  * Validates an item using the Symfony validator component.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final
  */
 class Validator implements ValidatorInterface
 {

--- a/src/EventListener/QueryParameterValidateListener.php
+++ b/src/EventListener/QueryParameterValidateListener.php
@@ -43,7 +43,8 @@ final class QueryParameterValidateListener
             !$request->isMethodSafe()
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !isset($attributes['collection_operation_name'])
-            || 'get' !== ($operationName = $attributes['collection_operation_name'])
+            || !($operationName = $attributes['collection_operation_name'])
+            || 'GET' !== $request->getMethod()
         ) {
             return;
         }

--- a/src/EventListener/QueryParameterValidateListener.php
+++ b/src/EventListener/QueryParameterValidateListener.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\EventListener;
+
+use ApiPlatform\Core\Filter\QueryParameterValidator;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+/**
+ * Validates query parameters depending on filter description.
+ *
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+final class QueryParameterValidateListener
+{
+    private $resourceMetadataFactory;
+
+    private $queryParameterValidator;
+
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, QueryParameterValidator $queryParameterValidator)
+    {
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->queryParameterValidator = $queryParameterValidator;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        $request = $event->getRequest();
+        if (
+            !$request->isMethodSafe()
+            || !($attributes = RequestAttributesExtractor::extractAttributes($request))
+            || !isset($attributes['collection_operation_name'])
+            || 'get' !== ($operationName = $attributes['collection_operation_name'])
+        ) {
+            return;
+        }
+
+        $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
+        $resourceFilters = $resourceMetadata->getCollectionOperationAttribute($operationName, 'filters', [], true);
+
+        $this->queryParameterValidator->validateFilters($attributes['resource_class'], $resourceFilters, $request);
+    }
+}

--- a/src/EventListener/QueryParameterValidateListener.php
+++ b/src/EventListener/QueryParameterValidateListener.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\EventListener;
 use ApiPlatform\Core\Filter\QueryParameterValidator;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use ApiPlatform\Core\Util\RequestParser;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
@@ -46,10 +47,12 @@ final class QueryParameterValidateListener
         ) {
             return;
         }
+        $queryString = RequestParser::getQueryString($request);
+        $queryParameters = $queryString ? RequestParser::parseRequestParams($queryString) : [];
 
         $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
         $resourceFilters = $resourceMetadata->getCollectionOperationAttribute($operationName, 'filters', [], true);
 
-        $this->queryParameterValidator->validateFilters($attributes['resource_class'], $resourceFilters, $request);
+        $this->queryParameterValidator->validateFilters($attributes['resource_class'], $resourceFilters, $queryParameters);
     }
 }

--- a/src/Filter/QueryParameterValidateListener.php
+++ b/src/Filter/QueryParameterValidateListener.php
@@ -62,6 +62,7 @@ final class QueryParameterValidateListener
             foreach ($filter->getDescription($attributes['resource_class']) as $name => $data) {
                 $errorList = $this->checkRequired($errorList, $name, $data, $request);
                 $errorList = $this->checkBounds($errorList, $name, $data, $request);
+                $errorList = $this->checkLength($errorList, $name, $data, $request);
             }
         }
 
@@ -178,4 +179,39 @@ final class QueryParameterValidateListener
 
         return $errorList;
     }
+
+    private function checkLength(array $errorList, string $name, array $data, Request $request): array
+    {
+        $maxLength = $data['swagger']['maxLength'] ?? null;
+        $minLength = $data['swagger']['minLength'] ?? null;
+
+        $value = $request->query->get($name);
+        if (empty($value) && '0' !== $value || !\is_string($value)) {
+            return $errorList;
+        }
+
+        // if (!is_string($value)) {
+        //         $errorList[] = sprintf('Query parameter "%s" must be less than or equal to %s', $name, $maximum);
+        //         return $errorList;
+        // }
+
+        if (null !== $maxLength && mb_strlen($value) > $maxLength) {
+            $errorList[] = sprintf('Query parameter "%s" length must be lower than or equal to %s', $name, $maxLength);
+        }
+
+        if (null !== $minLength && mb_strlen($value) < $minLength) {
+            $errorList[] = sprintf('Query parameter "%s" length must be greater than or equal to %s', $name, $minLength);
+        }
+
+        return $errorList;
+    }
+
+    // TODO grouper les filtres required dans une classe
+    // avoir deux entités, une required, une pour le reste
+    // pattern	string	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3.
+    // maxItems	integer	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2.
+    // minItems	integer	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3.
+    // uniqueItems	boolean	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4.
+    // enum	[*]	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
+    // multipleOf
 }

--- a/src/Filter/QueryParameterValidateListener.php
+++ b/src/Filter/QueryParameterValidateListener.php
@@ -39,12 +39,13 @@ final class QueryParameterValidateListener
         $this->setFilterLocator($filterLocator);
 
         $this->validators = [
-            new Validator\Required(),
+            new Validator\ArrayItems(),
             new Validator\Bounds(),
-            new Validator\Length(),
-            new Validator\Pattern(),
             new Validator\Enum(),
+            new Validator\Length(),
             new Validator\MultipleOf(),
+            new Validator\Pattern(),
+            new Validator\Required(),
         ];
     }
 
@@ -80,10 +81,4 @@ final class QueryParameterValidateListener
             throw new FilterValidationException($errorList);
         }
     }
-
-    // TODO grouper les filtres required dans une classe
-    // avoir deux entités, une required, une pour le reste
-    // maxItems	integer	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2.
-    // minItems	integer	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3.
-    // uniqueItems	boolean	See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4.
 }

--- a/src/Filter/QueryParameterValidator.php
+++ b/src/Filter/QueryParameterValidator.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Core\Filter;
 use ApiPlatform\Core\Api\FilterLocatorTrait;
 use ApiPlatform\Core\Exception\FilterValidationException;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Validates query parameters depending on filter description.
@@ -44,9 +43,10 @@ class QueryParameterValidator
         ];
     }
 
-    public function validateFilters(string $resourceClass, array $resourceFilters, Request $request): void
+    public function validateFilters(string $resourceClass, array $resourceFilters, array $queryParameters): void
     {
         $errorList = [];
+
         foreach ($resourceFilters as $filterId) {
             if (!$filter = $this->getFilter($filterId)) {
                 continue;
@@ -54,7 +54,7 @@ class QueryParameterValidator
 
             foreach ($filter->getDescription($resourceClass) as $name => $data) {
                 foreach ($this->validators as $validator) {
-                    $errorList = array_merge($errorList, $validator->validate($name, $data, $request->query->all()));
+                    $errorList = array_merge($errorList, $validator->validate($name, $data, $queryParameters));
                 }
             }
         }

--- a/src/Filter/QueryParameterValidator.php
+++ b/src/Filter/QueryParameterValidator.php
@@ -44,7 +44,7 @@ class QueryParameterValidator
         ];
     }
 
-    public function validateFilters(string $resourceClass, array $resourceFilters, Request $request)
+    public function validateFilters(string $resourceClass, array $resourceFilters, Request $request): void
     {
         $errorList = [];
         foreach ($resourceFilters as $filterId) {

--- a/src/Filter/QueryParameterValidator.php
+++ b/src/Filter/QueryParameterValidator.php
@@ -54,7 +54,7 @@ class QueryParameterValidator
 
             foreach ($filter->getDescription($resourceClass) as $name => $data) {
                 foreach ($this->validators as $validator) {
-                    $errorList = array_merge($errorList, $validator->validate($name, $data, $request));
+                    $errorList = array_merge($errorList, $validator->validate($name, $data, $request->query->all()));
                 }
             }
         }

--- a/src/Filter/Validator/ArrayItems.php
+++ b/src/Filter/Validator/ArrayItems.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class ArrayItems implements ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array
+    {
+        if (!$request->query->has($name)) {
+            return [];
+        }
+
+        $maxItems = $filterDescription['swagger']['maxItems'] ?? null;
+        $minItems = $filterDescription['swagger']['minItems'] ?? null;
+        $uniqueItems = $filterDescription['swagger']['uniqueItems'] ?? false;
+
+        $errorList = [];
+
+        $value = $this->getValue($name, $filterDescription, $request);
+        $nbItems = \count($value);
+
+        if (null !== $maxItems && $nbItems > $maxItems) {
+            $errorList[] = sprintf('Query parameter "%s" must contain less than %d values', $name, $maxItems);
+        }
+
+        if (null !== $minItems && $nbItems < $minItems) {
+            $errorList[] = sprintf('Query parameter "%s" must contain more than %d values', $name, $minItems);
+        }
+
+        if (true === $uniqueItems && $nbItems > \count(array_unique($value))) {
+            $errorList[] = sprintf('Query parameter "%s" must contain unique values', $name);
+        }
+
+        return $errorList;
+    }
+
+    private function getValue(string $name, array $filterDescription, Request $request): array
+    {
+        $value = $request->query->get($name);
+
+        if (empty($value) && '0' !== $value) {
+            return [];
+        }
+
+        if (\is_array($value)) {
+            return $value;
+        }
+
+        $collectionFormat = $filterDescription['swagger']['collectionFormat'] ?? 'csv';
+
+        return explode(self::getSeparator($collectionFormat), $value);
+    }
+
+    private static function getSeparator(string $collectionFormat): string
+    {
+        switch ($collectionFormat) {
+            case 'csv':
+                return ',';
+            case 'ssv':
+                return ' ';
+            case 'tsv':
+                return '\t';
+            case 'pipes':
+                return '|';
+            default:
+                throw new \InvalidArgumentException(sprintf('Unkwown collection format %s', $collectionFormat));
+        }
+    }
+}

--- a/src/Filter/Validator/ArrayItems.php
+++ b/src/Filter/Validator/ArrayItems.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Filter\Validator;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class ArrayItems implements ValidatorInterface
+final class ArrayItems implements ValidatorInterface
 {
     public function validate(string $name, array $filterDescription, Request $request): array
     {

--- a/src/Filter/Validator/ArrayItems.php
+++ b/src/Filter/Validator/ArrayItems.php
@@ -76,7 +76,7 @@ class ArrayItems implements ValidatorInterface
             case 'pipes':
                 return '|';
             default:
-                throw new \InvalidArgumentException(sprintf('Unkwown collection format %s', $collectionFormat));
+                throw new \InvalidArgumentException(sprintf('Unknown collection format %s', $collectionFormat));
         }
     }
 }

--- a/src/Filter/Validator/ArrayItems.php
+++ b/src/Filter/Validator/ArrayItems.php
@@ -61,7 +61,7 @@ class ArrayItems implements ValidatorInterface
 
         $collectionFormat = $filterDescription['swagger']['collectionFormat'] ?? 'csv';
 
-        return explode(self::getSeparator($collectionFormat), $value);
+        return explode(self::getSeparator($collectionFormat), $value) ?: [];
     }
 
     private static function getSeparator(string $collectionFormat): string

--- a/src/Filter/Validator/ArrayItems.php
+++ b/src/Filter/Validator/ArrayItems.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Filter\Validator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 final class ArrayItems implements ValidatorInterface
 {
-    public function validate(string $name, array $filterDescription, Request $request): array
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(string $name, array $filterDescription, array $queryParameters): array
     {
-        if (!$request->query->has($name)) {
+        if (!\array_key_exists($name, $queryParameters)) {
             return [];
         }
 
@@ -29,7 +30,7 @@ final class ArrayItems implements ValidatorInterface
 
         $errorList = [];
 
-        $value = $this->getValue($name, $filterDescription, $request);
+        $value = $this->getValue($name, $filterDescription, $queryParameters);
         $nbItems = \count($value);
 
         if (null !== $maxItems && $nbItems > $maxItems) {
@@ -47,9 +48,9 @@ final class ArrayItems implements ValidatorInterface
         return $errorList;
     }
 
-    private function getValue(string $name, array $filterDescription, Request $request): array
+    private function getValue(string $name, array $filterDescription, array $queryParameters): array
     {
-        $value = $request->query->get($name);
+        $value = $queryParameters[$name] ?? null;
 
         if (empty($value) && '0' !== $value) {
             return [];

--- a/src/Filter/Validator/Bounds.php
+++ b/src/Filter/Validator/Bounds.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Bounds implements ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array
+    {
+        $value = $request->query->get($name);
+        if (empty($value) && '0' !== $value) {
+            return [];
+        }
+
+        $maximum = $filterDescription['swagger']['maximum'] ?? null;
+        $minimum = $filterDescription['swagger']['minimum'] ?? null;
+
+        $errorList = [];
+
+        if (null !== $maximum) {
+            if (($filterDescription['swagger']['exclusiveMaximum'] ?? false) && $value >= $maximum) {
+                $errorList[] = sprintf('Query parameter "%s" must be less than %s', $name, $maximum);
+            } elseif ($value > $maximum) {
+                $errorList[] = sprintf('Query parameter "%s" must be less than or equal to %s', $name, $maximum);
+            }
+        }
+
+        if (null !== $minimum) {
+            if (($filterDescription['swagger']['exclusiveMinimum'] ?? false) && $value <= $minimum) {
+                $errorList[] = sprintf('Query parameter "%s" must be greater than %s', $name, $minimum);
+            } elseif ($value < $minimum) {
+                $errorList[] = sprintf('Query parameter "%s" must be greater than or equal to %s', $name, $minimum);
+            }
+        }
+
+        return $errorList;
+    }
+}

--- a/src/Filter/Validator/Bounds.php
+++ b/src/Filter/Validator/Bounds.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Filter\Validator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 final class Bounds implements ValidatorInterface
 {
-    public function validate(string $name, array $filterDescription, Request $request): array
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(string $name, array $filterDescription, array $queryParameters): array
     {
-        $value = $request->query->get($name);
+        $value = $queryParameters[$name] ?? null;
         if (empty($value) && '0' !== $value) {
             return [];
         }

--- a/src/Filter/Validator/Bounds.php
+++ b/src/Filter/Validator/Bounds.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Filter\Validator;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class Bounds implements ValidatorInterface
+final class Bounds implements ValidatorInterface
 {
     public function validate(string $name, array $filterDescription, Request $request): array
     {

--- a/src/Filter/Validator/Enum.php
+++ b/src/Filter/Validator/Enum.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Filter\Validator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 final class Enum implements ValidatorInterface
 {
-    public function validate(string $name, array $filterDescription, Request $request): array
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(string $name, array $filterDescription, array $queryParameters): array
     {
-        $value = $request->query->get($name);
+        $value = $queryParameters[$name] ?? null;
         if (empty($value) && '0' !== $value || !\is_string($value)) {
             return [];
         }

--- a/src/Filter/Validator/Enum.php
+++ b/src/Filter/Validator/Enum.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Filter\Validator;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class Enum implements ValidatorInterface
+final class Enum implements ValidatorInterface
 {
     public function validate(string $name, array $filterDescription, Request $request): array
     {

--- a/src/Filter/Validator/Enum.php
+++ b/src/Filter/Validator/Enum.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Enum implements ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array
+    {
+        $value = $request->query->get($name);
+        if (empty($value) && '0' !== $value || !\is_string($value)) {
+            return [];
+        }
+
+        $enum = $filterDescription['swagger']['enum'] ?? null;
+
+        if (null !== $enum && !\in_array($value, $enum, true)) {
+            return [
+                sprintf('Query parameter "%s" must be one of "%s"', $name, implode(', ', $enum)),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Filter/Validator/Length.php
+++ b/src/Filter/Validator/Length.php
@@ -13,19 +13,20 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Filter\Validator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 final class Length implements ValidatorInterface
 {
-    public function validate(string $name, array $filterDescription, Request $request): array
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(string $name, array $filterDescription, array $queryParameters): array
     {
-        $maxLength = $filterDescription['swagger']['maxLength'] ?? null;
-        $minLength = $filterDescription['swagger']['minLength'] ?? null;
-
-        $value = $request->query->get($name);
+        $value = $queryParameters[$name] ?? null;
         if (empty($value) && '0' !== $value || !\is_string($value)) {
             return [];
         }
+
+        $maxLength = $filterDescription['swagger']['maxLength'] ?? null;
+        $minLength = $filterDescription['swagger']['minLength'] ?? null;
 
         $errorList = [];
 

--- a/src/Filter/Validator/Length.php
+++ b/src/Filter/Validator/Length.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Length implements ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array
+    {
+        $maxLength = $filterDescription['swagger']['maxLength'] ?? null;
+        $minLength = $filterDescription['swagger']['minLength'] ?? null;
+
+        $value = $request->query->get($name);
+        if (empty($value) && '0' !== $value || !\is_string($value)) {
+            return [];
+        }
+
+        $errorList = [];
+
+        if (null !== $maxLength && mb_strlen($value) > $maxLength) {
+            $errorList[] = sprintf('Query parameter "%s" length must be lower than or equal to %s', $name, $maxLength);
+        }
+
+        if (null !== $minLength && mb_strlen($value) < $minLength) {
+            $errorList[] = sprintf('Query parameter "%s" length must be greater than or equal to %s', $name, $minLength);
+        }
+
+        return $errorList;
+    }
+}

--- a/src/Filter/Validator/Length.php
+++ b/src/Filter/Validator/Length.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Filter\Validator;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class Length implements ValidatorInterface
+final class Length implements ValidatorInterface
 {
     public function validate(string $name, array $filterDescription, Request $request): array
     {

--- a/src/Filter/Validator/MultipleOf.php
+++ b/src/Filter/Validator/MultipleOf.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Filter\Validator;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class MultipleOf implements ValidatorInterface
+final class MultipleOf implements ValidatorInterface
 {
     public function validate(string $name, array $filterDescription, Request $request): array
     {

--- a/src/Filter/Validator/MultipleOf.php
+++ b/src/Filter/Validator/MultipleOf.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class MultipleOf implements ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array
+    {
+        $value = $request->query->get($name);
+        if (empty($value) && '0' !== $value || !\is_string($value)) {
+            return [];
+        }
+
+        $multipleOf = $filterDescription['swagger']['multipleOf'] ?? null;
+
+        if (null !== $multipleOf && 0 !== ($value % $multipleOf)) {
+            return [
+                sprintf('Query parameter "%s" must multiple of %s', $name, $multipleOf),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Filter/Validator/MultipleOf.php
+++ b/src/Filter/Validator/MultipleOf.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Filter\Validator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 final class MultipleOf implements ValidatorInterface
 {
-    public function validate(string $name, array $filterDescription, Request $request): array
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(string $name, array $filterDescription, array $queryParameters): array
     {
-        $value = $request->query->get($name);
+        $value = $queryParameters[$name] ?? null;
         if (empty($value) && '0' !== $value || !\is_string($value)) {
             return [];
         }

--- a/src/Filter/Validator/Pattern.php
+++ b/src/Filter/Validator/Pattern.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Pattern implements ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array
+    {
+        $value = $request->query->get($name);
+        if (empty($value) && '0' !== $value || !\is_string($value)) {
+            return [];
+        }
+
+        $pattern = $filterDescription['swagger']['pattern'] ?? null;
+
+        if (null !== $pattern && !preg_match($pattern, $value)) {
+            return [
+                sprintf('Query parameter "%s" must match pattern %s', $name, $pattern),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Filter/Validator/Pattern.php
+++ b/src/Filter/Validator/Pattern.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Filter\Validator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 final class Pattern implements ValidatorInterface
 {
-    public function validate(string $name, array $filterDescription, Request $request): array
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(string $name, array $filterDescription, array $queryParameters): array
     {
-        $value = $request->query->get($name);
+        $value = $queryParameters[$name] ?? null;
         if (empty($value) && '0' !== $value || !\is_string($value)) {
             return [];
         }

--- a/src/Filter/Validator/Pattern.php
+++ b/src/Filter/Validator/Pattern.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Filter\Validator;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class Pattern implements ValidatorInterface
+final class Pattern implements ValidatorInterface
 {
     public function validate(string $name, array $filterDescription, Request $request): array
     {

--- a/src/Filter/Validator/Required.php
+++ b/src/Filter/Validator/Required.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Required implements ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array
+    {
+        // filter is not required, the `checkRequired` method can not break
+        if (!($filterDescription['required'] ?? false)) {
+            return [];
+        }
+
+        // if query param is not given, then break
+        if (!$this->requestHasQueryParameter($request, $name)) {
+            return [
+                sprintf('Query parameter "%s" is required', $name),
+            ];
+        }
+
+        // if query param is empty and the configuration does not allow it
+        if (!($filterDescription['swagger']['allowEmptyValue'] ?? false) && empty($this->requestGetQueryParameter($request, $name))) {
+            return [
+                sprintf('Query parameter "%s" does not allow empty value', $name),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * Test if request has required parameter.
+     */
+    private function requestHasQueryParameter(Request $request, string $name): bool
+    {
+        $matches = [];
+        parse_str($name, $matches);
+        if (!$matches) {
+            return false;
+        }
+
+        $rootName = array_keys($matches)[0] ?? '';
+        if (!$rootName) {
+            return false;
+        }
+
+        if (\is_array($matches[$rootName])) {
+            $keyName = array_keys($matches[$rootName])[0];
+
+            $queryParameter = $request->query->get($rootName);
+
+            return \is_array($queryParameter) && isset($queryParameter[$keyName]);
+        }
+
+        return $request->query->has($rootName);
+    }
+
+    /**
+     * Test if required filter is valid. It validates array notation too like "required[bar]".
+     */
+    private function requestGetQueryParameter(Request $request, string $name)
+    {
+        $matches = [];
+        parse_str($name, $matches);
+        if (empty($matches)) {
+            return null;
+        }
+
+        $rootName = array_keys($matches)[0] ?? '';
+        if (!$rootName) {
+            return null;
+        }
+
+        if (\is_array($matches[$rootName])) {
+            $keyName = array_keys($matches[$rootName])[0];
+
+            $queryParameter = $request->query->get($rootName);
+
+            if (\is_array($queryParameter) && isset($queryParameter[$keyName])) {
+                return $queryParameter[$keyName];
+            }
+
+            return null;
+        }
+
+        return $request->query->get($rootName);
+    }
+}

--- a/src/Filter/Validator/Required.php
+++ b/src/Filter/Validator/Required.php
@@ -60,12 +60,12 @@ class Required implements ValidatorInterface
         if (\is_array($matches[$rootName])) {
             $keyName = array_keys($matches[$rootName])[0];
 
-            $queryParameter = $request->query->get($rootName);
+            $queryParameter = $request->query->get((string) $rootName);
 
             return \is_array($queryParameter) && isset($queryParameter[$keyName]);
         }
 
-        return $request->query->has($rootName);
+        return $request->query->has((string) $rootName);
     }
 
     /**
@@ -87,7 +87,7 @@ class Required implements ValidatorInterface
         if (\is_array($matches[$rootName])) {
             $keyName = array_keys($matches[$rootName])[0];
 
-            $queryParameter = $request->query->get($rootName);
+            $queryParameter = $request->query->get((string) $rootName);
 
             if (\is_array($queryParameter) && isset($queryParameter[$keyName])) {
                 return $queryParameter[$keyName];
@@ -96,6 +96,6 @@ class Required implements ValidatorInterface
             return null;
         }
 
-        return $request->query->get($rootName);
+        return $request->query->get((string) $rootName);
     }
 }

--- a/src/Filter/Validator/Required.php
+++ b/src/Filter/Validator/Required.php
@@ -61,7 +61,7 @@ final class Required implements ValidatorInterface
         if (\is_array($matches[$rootName])) {
             $keyName = array_keys($matches[$rootName])[0];
 
-            $queryParameter = $queryParameters[(string) $rootName];
+            $queryParameter = $queryParameters[(string) $rootName] ?? null;
 
             return \is_array($queryParameter) && isset($queryParameter[$keyName]);
         }
@@ -90,7 +90,7 @@ final class Required implements ValidatorInterface
         if (\is_array($matches[$rootName])) {
             $keyName = array_keys($matches[$rootName])[0];
 
-            $queryParameter = $queryParameters[(string) $rootName];
+            $queryParameter = $queryParameters[(string) $rootName] ?? null;
 
             if (\is_array($queryParameter) && isset($queryParameter[$keyName])) {
                 return $queryParameter[$keyName];

--- a/src/Filter/Validator/Required.php
+++ b/src/Filter/Validator/Required.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Filter\Validator;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class Required implements ValidatorInterface
+final class Required implements ValidatorInterface
 {
     public function validate(string $name, array $filterDescription, Request $request): array
     {

--- a/src/Filter/Validator/ValidatorInterface.php
+++ b/src/Filter/Validator/ValidatorInterface.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Filter\Validator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 interface ValidatorInterface
 {
-    public function validate(string $name, array $filterDescription, Request $request): array;
+    /**
+     * @var string        the parameter name to validate
+     * @var array<string, mixed> $filterDescription the filter descriptions as returned by `ApiPlatform\Core\Api\FilterInterface::getDescription()`
+     * @var array<string, mixed> $queryParameters the list of query parameter
+     */
+    public function validate(string $name, array $filterDescription, array $queryParameters): array;
 }

--- a/src/Filter/Validator/ValidatorInterface.php
+++ b/src/Filter/Validator/ValidatorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Filter\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface ValidatorInterface
+{
+    public function validate(string $name, array $filterDescription, Request $request): array;
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1236,6 +1236,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.swagger.action.ui',
             'api_platform.swagger.listener.ui',
             'api_platform.validator',
+            'api_platform.validator.query_parameter_validator',
             'test.api_platform.client',
         ];
 

--- a/tests/EventListener/QueryParameterValidateListenerTest.php
+++ b/tests/EventListener/QueryParameterValidateListenerTest.php
@@ -59,7 +59,7 @@ class QueryParameterValidateListenerTest extends TestCase
         $eventProphecy = $this->prophesize(RequestEvent::class);
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
-        $this->queryParameterValidor->validateFilters(Dummy::class, ['some_inexistent_filter'], $request)->shouldBeCalled();
+        $this->queryParameterValidor->validateFilters(Dummy::class, ['some_inexistent_filter'], [])->shouldBeCalled();
 
         $this->assertNull(
             $this->testedInstance->onKernelRequest($eventProphecy->reveal())
@@ -80,7 +80,7 @@ class QueryParameterValidateListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $this->queryParameterValidor
-            ->validateFilters(Dummy::class, ['some_filter'], $request)
+            ->validateFilters(Dummy::class, ['some_filter'], [])
             ->shouldBeCalled()
             ->willThrow(new FilterValidationException(['Query parameter "required" is required']));
         $this->expectException(FilterValidationException::class);
@@ -96,9 +96,12 @@ class QueryParameterValidateListenerTest extends TestCase
         $this->setUpWithFilters(['some_filter']);
 
         $request = new Request(
-            ['required' => 'foo'],
             [],
-            ['_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get']
+            [],
+            ['_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get'],
+            [],
+            [],
+            ['QUERY_STRING' => 'required=foo']
         );
         $request->setMethod('GET');
 
@@ -106,7 +109,7 @@ class QueryParameterValidateListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $this->queryParameterValidor
-            ->validateFilters(Dummy::class, ['some_filter'], $request)
+            ->validateFilters(Dummy::class, ['some_filter'], ['required' => 'foo'])
             ->shouldBeCalled();
 
         $this->assertNull(

--- a/tests/EventListener/QueryParameterValidateListenerTest.php
+++ b/tests/EventListener/QueryParameterValidateListenerTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Filter;
+namespace ApiPlatform\Core\Tests\EventListener;
 
 use ApiPlatform\Core\EventListener\QueryParameterValidateListener;
 use ApiPlatform\Core\Exception\FilterValidationException;

--- a/tests/EventListener/QueryParameterValidateListenerTest.php
+++ b/tests/EventListener/QueryParameterValidateListenerTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Filter;
 
 use ApiPlatform\Core\Api\FilterInterface;
+use ApiPlatform\Core\EventListener\QueryParameterValidateListener;
 use ApiPlatform\Core\Exception\FilterValidationException;
-use ApiPlatform\Core\Filter\QueryParameterValidateListener;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;

--- a/tests/Filter/QueryParameterValidatorTest.php
+++ b/tests/Filter/QueryParameterValidatorTest.php
@@ -19,7 +19,6 @@ use ApiPlatform\Core\Filter\QueryParameterValidator;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class QueryParameterValidatorTest.
@@ -48,7 +47,7 @@ class QueryParameterValidatorTest extends TestCase
      */
     public function testOnKernelRequestWithUnsafeMethod()
     {
-        $request = new Request();
+        $request = [];
 
         $this->assertNull(
             $this->testedInstance->validateFilters(Dummy::class, [], $request)
@@ -60,7 +59,7 @@ class QueryParameterValidatorTest extends TestCase
      */
     public function testOnKernelRequestWithWrongFilter()
     {
-        $request = new Request();
+        $request = [];
 
         $this->assertNull(
             $this->testedInstance->validateFilters(Dummy::class, ['some_inexistent_filter'], $request)
@@ -72,7 +71,7 @@ class QueryParameterValidatorTest extends TestCase
      */
     public function testOnKernelRequestWithRequiredFilterNotSet()
     {
-        $request = new Request();
+        $request = [];
 
         $filterProphecy = $this->prophesize(FilterInterface::class);
         $filterProphecy
@@ -102,9 +101,7 @@ class QueryParameterValidatorTest extends TestCase
      */
     public function testOnKernelRequestWithRequiredFilter()
     {
-        $request = new Request(
-            ['required' => 'foo']
-        );
+        $request = ['required' => 'foo'];
 
         $this->filterLocatorProphecy
             ->has('some_filter')

--- a/tests/Filter/QueryParameterValidatorTest.php
+++ b/tests/Filter/QueryParameterValidatorTest.php
@@ -11,11 +11,12 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Test\Filter;
+namespace ApiPlatform\Core\Tests\Filter;
 
 use ApiPlatform\Core\Api\FilterInterface;
 use ApiPlatform\Core\Exception\FilterValidationException;
 use ApiPlatform\Core\Filter\QueryParameterValidator;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Filter/QueryParameterValidatorTest.php
+++ b/tests/Filter/QueryParameterValidatorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Test\Filter;
+
+use ApiPlatform\Core\Api\FilterInterface;
+use ApiPlatform\Core\Exception\FilterValidationException;
+use ApiPlatform\Core\Filter\QueryParameterValidator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class QueryParameterValidatorTest.
+ *
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class QueryParameterValidatorTest extends TestCase
+{
+    private $testedInstance;
+    private $filterLocatorProphecy;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->filterLocatorProphecy = $this->prophesize(ContainerInterface::class);
+
+        $this->testedInstance = new QueryParameterValidator(
+            $this->filterLocatorProphecy->reveal()
+        );
+    }
+
+    /**
+     * unsafe method should not use filter validations.
+     */
+    public function testOnKernelRequestWithUnsafeMethod()
+    {
+        $request = new Request();
+
+        $this->assertNull(
+            $this->testedInstance->validateFilters(Dummy::class, [], $request)
+        );
+    }
+
+    /**
+     * If the tested filter is non-existant, then nothing should append.
+     */
+    public function testOnKernelRequestWithWrongFilter()
+    {
+        $request = new Request();
+
+        $this->assertNull(
+            $this->testedInstance->validateFilters(Dummy::class, ['some_inexistent_filter'], $request)
+        );
+    }
+
+    /**
+     * if the required parameter is not set, throw an FilterValidationException.
+     */
+    public function testOnKernelRequestWithRequiredFilterNotSet()
+    {
+        $request = new Request();
+
+        $filterProphecy = $this->prophesize(FilterInterface::class);
+        $filterProphecy
+            ->getDescription(Dummy::class)
+            ->shouldBeCalled()
+            ->willReturn([
+                'required' => [
+                    'required' => true,
+                ],
+            ]);
+        $this->filterLocatorProphecy
+            ->has('some_filter')
+            ->shouldBeCalled()
+            ->willReturn(true);
+        $this->filterLocatorProphecy
+            ->get('some_filter')
+            ->shouldBeCalled()
+            ->willReturn($filterProphecy->reveal());
+
+        $this->expectException(FilterValidationException::class);
+        $this->expectExceptionMessage('Query parameter "required" is required');
+        $this->testedInstance->validateFilters(Dummy::class, ['some_filter'], $request);
+    }
+
+    /**
+     * if the required parameter is set, no exception should be throwned.
+     */
+    public function testOnKernelRequestWithRequiredFilter()
+    {
+        $request = new Request(
+            ['required' => 'foo']
+        );
+
+        $this->filterLocatorProphecy
+            ->has('some_filter')
+            ->shouldBeCalled()
+            ->willReturn(true);
+        $filterProphecy = $this->prophesize(FilterInterface::class);
+        $filterProphecy
+            ->getDescription(Dummy::class)
+            ->shouldBeCalled()
+            ->willReturn([
+                'required' => [
+                    'required' => true,
+                ],
+            ]);
+        $this->filterLocatorProphecy
+            ->get('some_filter')
+            ->shouldBeCalled()
+            ->willReturn($filterProphecy->reveal());
+
+        $this->assertNull(
+            $this->testedInstance->validateFilters(Dummy::class, ['some_filter'], $request)
+        );
+    }
+}

--- a/tests/Filter/Validator/ArrayItemsTest.php
+++ b/tests/Filter/Validator/ArrayItemsTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Filter\Validator;
+
+use ApiPlatform\Core\Filter\Validator\ArrayItems;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class ArrayItemsTest extends TestCase
+{
+    public function testNonDefinedFilter()
+    {
+        $request = new Request();
+        $filter = new ArrayItems();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testEmptyQueryParameter()
+    {
+        $request = new Request(['some_filter' => '']);
+        $filter = new ArrayItems();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testNonMatchingParameter()
+    {
+        $filter = new ArrayItems();
+
+        $filterDefinition = [
+            'swagger' => [
+                'maxItems' => 3,
+                'minItems' => 2,
+            ],
+        ];
+
+        $request = new Request(['some_filter' => ['foo', 'bar', 'bar', 'foo']]);
+        $this->assertEquals(
+            ['Query parameter "some_filter" must contain less than 3 values'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $request = new Request(['some_filter' => ['foo']]);
+        $this->assertEquals(
+            ['Query parameter "some_filter" must contain more than 2 values'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingParameter()
+    {
+        $filter = new ArrayItems();
+
+        $filterDefinition = [
+            'swagger' => [
+                'maxItems' => 3,
+                'minItems' => 2,
+            ],
+        ];
+
+        $request = new Request(['some_filter' => ['foo', 'bar']]);
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $request = new Request(['some_filter' => ['foo', 'bar', 'baz']]);
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testNonMatchingUniqueItems()
+    {
+        $filter = new ArrayItems();
+
+        $filterDefinition = [
+            'swagger' => [
+                'uniqueItems' => true,
+            ],
+        ];
+
+        $request = new Request(['some_filter' => ['foo', 'bar', 'bar', 'foo']]);
+        $this->assertEquals(
+            ['Query parameter "some_filter" must contain unique values'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingUniqueItems()
+    {
+        $filter = new ArrayItems();
+
+        $filterDefinition = [
+            'swagger' => [
+                'uniqueItems' => true,
+            ],
+        ];
+
+        $request = new Request(['some_filter' => ['foo', 'bar', 'baz']]);
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testSeparators()
+    {
+        $filter = new ArrayItems();
+
+        $filterDefinition = [
+            'swagger' => [
+                'maxItems' => 2,
+                'uniqueItems' => true,
+                'collectionFormat' => 'csv',
+            ],
+        ];
+
+        $request = new Request(['some_filter' => 'foo,bar,bar']);
+        $this->assertEquals(
+            [
+                'Query parameter "some_filter" must contain less than 2 values',
+                'Query parameter "some_filter" must contain unique values',
+            ],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition['swagger']['collectionFormat'] = 'ssv';
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition['swagger']['collectionFormat'] = 'ssv';
+        $request = new Request(['some_filter' => 'foo bar bar']);
+        $this->assertEquals(
+            [
+                'Query parameter "some_filter" must contain less than 2 values',
+                'Query parameter "some_filter" must contain unique values',
+            ],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition['swagger']['collectionFormat'] = 'tsv';
+        $request = new Request(['some_filter' => 'foo\tbar\tbar']);
+        $this->assertEquals(
+            [
+                'Query parameter "some_filter" must contain less than 2 values',
+                'Query parameter "some_filter" must contain unique values',
+            ],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition['swagger']['collectionFormat'] = 'pipes';
+        $request = new Request(['some_filter' => 'foo|bar|bar']);
+        $this->assertEquals(
+            [
+                'Query parameter "some_filter" must contain less than 2 values',
+                'Query parameter "some_filter" must contain unique values',
+            ],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testSeparatorsUnknownSeparator()
+    {
+        $filter = new ArrayItems();
+
+        $filterDefinition = [
+            'swagger' => [
+                'maxItems' => 2,
+                'uniqueItems' => true,
+                'collectionFormat' => 'unknownFormat',
+            ],
+        ];
+        $request = new Request(['some_filter' => 'foo,bar,bar']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown collection format unknownFormat');
+
+        $filter->validate('some_filter', $filterDefinition, $request);
+    }
+}

--- a/tests/Filter/Validator/ArrayItemsTest.php
+++ b/tests/Filter/Validator/ArrayItemsTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Filter\Validator;
 
 use ApiPlatform\Core\Filter\Validator\ArrayItems;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
@@ -24,7 +23,7 @@ class ArrayItemsTest extends TestCase
 {
     public function testNonDefinedFilter()
     {
-        $request = new Request();
+        $request = [];
         $filter = new ArrayItems();
 
         $this->assertEmpty(
@@ -34,7 +33,7 @@ class ArrayItemsTest extends TestCase
 
     public function testEmptyQueryParameter()
     {
-        $request = new Request(['some_filter' => '']);
+        $request = ['some_filter' => ''];
         $filter = new ArrayItems();
 
         $this->assertEmpty(
@@ -53,13 +52,13 @@ class ArrayItemsTest extends TestCase
             ],
         ];
 
-        $request = new Request(['some_filter' => ['foo', 'bar', 'bar', 'foo']]);
+        $request = ['some_filter' => ['foo', 'bar', 'bar', 'foo']];
         $this->assertEquals(
             ['Query parameter "some_filter" must contain less than 3 values'],
             $filter->validate('some_filter', $filterDefinition, $request)
         );
 
-        $request = new Request(['some_filter' => ['foo']]);
+        $request = ['some_filter' => ['foo']];
         $this->assertEquals(
             ['Query parameter "some_filter" must contain more than 2 values'],
             $filter->validate('some_filter', $filterDefinition, $request)
@@ -77,12 +76,12 @@ class ArrayItemsTest extends TestCase
             ],
         ];
 
-        $request = new Request(['some_filter' => ['foo', 'bar']]);
+        $request = ['some_filter' => ['foo', 'bar']];
         $this->assertEmpty(
             $filter->validate('some_filter', $filterDefinition, $request)
         );
 
-        $request = new Request(['some_filter' => ['foo', 'bar', 'baz']]);
+        $request = ['some_filter' => ['foo', 'bar', 'baz']];
         $this->assertEmpty(
             $filter->validate('some_filter', $filterDefinition, $request)
         );
@@ -98,7 +97,7 @@ class ArrayItemsTest extends TestCase
             ],
         ];
 
-        $request = new Request(['some_filter' => ['foo', 'bar', 'bar', 'foo']]);
+        $request = ['some_filter' => ['foo', 'bar', 'bar', 'foo']];
         $this->assertEquals(
             ['Query parameter "some_filter" must contain unique values'],
             $filter->validate('some_filter', $filterDefinition, $request)
@@ -115,7 +114,7 @@ class ArrayItemsTest extends TestCase
             ],
         ];
 
-        $request = new Request(['some_filter' => ['foo', 'bar', 'baz']]);
+        $request = ['some_filter' => ['foo', 'bar', 'baz']];
         $this->assertEmpty(
             $filter->validate('some_filter', $filterDefinition, $request)
         );
@@ -133,7 +132,7 @@ class ArrayItemsTest extends TestCase
             ],
         ];
 
-        $request = new Request(['some_filter' => 'foo,bar,bar']);
+        $request = ['some_filter' => 'foo,bar,bar'];
         $this->assertEquals(
             [
                 'Query parameter "some_filter" must contain less than 2 values',
@@ -148,7 +147,7 @@ class ArrayItemsTest extends TestCase
         );
 
         $filterDefinition['swagger']['collectionFormat'] = 'ssv';
-        $request = new Request(['some_filter' => 'foo bar bar']);
+        $request = ['some_filter' => 'foo bar bar'];
         $this->assertEquals(
             [
                 'Query parameter "some_filter" must contain less than 2 values',
@@ -158,7 +157,7 @@ class ArrayItemsTest extends TestCase
         );
 
         $filterDefinition['swagger']['collectionFormat'] = 'tsv';
-        $request = new Request(['some_filter' => 'foo\tbar\tbar']);
+        $request = ['some_filter' => 'foo\tbar\tbar'];
         $this->assertEquals(
             [
                 'Query parameter "some_filter" must contain less than 2 values',
@@ -168,7 +167,7 @@ class ArrayItemsTest extends TestCase
         );
 
         $filterDefinition['swagger']['collectionFormat'] = 'pipes';
-        $request = new Request(['some_filter' => 'foo|bar|bar']);
+        $request = ['some_filter' => 'foo|bar|bar'];
         $this->assertEquals(
             [
                 'Query parameter "some_filter" must contain less than 2 values',
@@ -189,7 +188,7 @@ class ArrayItemsTest extends TestCase
                 'collectionFormat' => 'unknownFormat',
             ],
         ];
-        $request = new Request(['some_filter' => 'foo,bar,bar']);
+        $request = ['some_filter' => 'foo,bar,bar'];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown collection format unknownFormat');

--- a/tests/Filter/Validator/BoundsTest.php
+++ b/tests/Filter/Validator/BoundsTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Filter\Validator;
+
+use ApiPlatform\Core\Filter\Validator\Bounds;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class BoundsTest extends TestCase
+{
+    public function testNonDefinedFilter()
+    {
+        $request = new Request();
+        $filter = new Bounds();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testEmptyQueryParameter()
+    {
+        $request = new Request(['some_filter' => '']);
+        $filter = new Bounds();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testNonMatchingMinimum()
+    {
+        $request = new Request(['some_filter' => '9']);
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'swagger' => [
+                'minimum' => 10,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be greater than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'minimum' => 10,
+                'exclusiveMinimum' => false,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be greater than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'minimum' => 9,
+                'exclusiveMinimum' => true,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be greater than 9'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingMinimum()
+    {
+        $request = new Request(['some_filter' => '10']);
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'swagger' => [
+                'minimum' => 10,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'minimum' => 9,
+                'exclusiveMinimum' => false,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testNonMatchingMaximum()
+    {
+        $request = new Request(['some_filter' => '11']);
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'swagger' => [
+                'maximum' => 10,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be less than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'maximum' => 10,
+                'exclusiveMaximum' => false,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be less than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'maximum' => 9,
+                'exclusiveMaximum' => true,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be less than 9'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingMaximum()
+    {
+        $request = new Request(['some_filter' => '10']);
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'swagger' => [
+                'maximum' => 10,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'maximum' => 10,
+                'exclusiveMaximum' => false,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+}

--- a/tests/Filter/Validator/BoundsTest.php
+++ b/tests/Filter/Validator/BoundsTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Filter\Validator;
 
 use ApiPlatform\Core\Filter\Validator\Bounds;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
@@ -24,27 +23,25 @@ class BoundsTest extends TestCase
 {
     public function testNonDefinedFilter()
     {
-        $request = new Request();
         $filter = new Bounds();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], [])
         );
     }
 
     public function testEmptyQueryParameter()
     {
-        $request = new Request(['some_filter' => '']);
         $filter = new Bounds();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], ['some_filter' => ''])
         );
     }
 
     public function testNonMatchingMinimum()
     {
-        $request = new Request(['some_filter' => '9']);
+        $request = ['some_filter' => '9'];
         $filter = new Bounds();
 
         $filterDefinition = [
@@ -85,7 +82,7 @@ class BoundsTest extends TestCase
 
     public function testMatchingMinimum()
     {
-        $request = new Request(['some_filter' => '10']);
+        $request = ['some_filter' => '10'];
         $filter = new Bounds();
 
         $filterDefinition = [
@@ -112,7 +109,7 @@ class BoundsTest extends TestCase
 
     public function testNonMatchingMaximum()
     {
-        $request = new Request(['some_filter' => '11']);
+        $request = ['some_filter' => '11'];
         $filter = new Bounds();
 
         $filterDefinition = [
@@ -153,7 +150,7 @@ class BoundsTest extends TestCase
 
     public function testMatchingMaximum()
     {
-        $request = new Request(['some_filter' => '10']);
+        $request = ['some_filter' => '10'];
         $filter = new Bounds();
 
         $filterDefinition = [

--- a/tests/Filter/Validator/EnumTest.php
+++ b/tests/Filter/Validator/EnumTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Filter\Validator;
 
 use ApiPlatform\Core\Filter\Validator\Enum;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
@@ -24,27 +23,24 @@ class EnumTest extends TestCase
 {
     public function testNonDefinedFilter()
     {
-        $request = new Request();
         $filter = new Enum();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], [])
         );
     }
 
     public function testEmptyQueryParameter()
     {
-        $request = new Request(['some_filter' => '']);
         $filter = new Enum();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], ['some_filter' => ''])
         );
     }
 
     public function testNonMatchingParameter()
     {
-        $request = new Request(['some_filter' => 'foobar']);
         $filter = new Enum();
 
         $filterDefinition = [
@@ -55,13 +51,12 @@ class EnumTest extends TestCase
 
         $this->assertEquals(
             ['Query parameter "some_filter" must be one of "foo, bar"'],
-            $filter->validate('some_filter', $filterDefinition, $request)
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'foobar'])
         );
     }
 
     public function testMatchingParameter()
     {
-        $request = new Request(['some_filter' => 'foo']);
         $filter = new Enum();
 
         $filterDefinition = [
@@ -71,7 +66,7 @@ class EnumTest extends TestCase
         ];
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $filterDefinition, $request)
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'foo'])
         );
     }
 }

--- a/tests/Filter/Validator/EnumTest.php
+++ b/tests/Filter/Validator/EnumTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Filter\Validator;
+
+use ApiPlatform\Core\Filter\Validator\Enum;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class EnumTest extends TestCase
+{
+    public function testNonDefinedFilter()
+    {
+        $request = new Request();
+        $filter = new Enum();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testEmptyQueryParameter()
+    {
+        $request = new Request(['some_filter' => '']);
+        $filter = new Enum();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testNonMatchingParameter()
+    {
+        $request = new Request(['some_filter' => 'foobar']);
+        $filter = new Enum();
+
+        $filterDefinition = [
+            'swagger' => [
+                'enum' => ['foo', 'bar'],
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be one of "foo, bar"'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingParameter()
+    {
+        $request = new Request(['some_filter' => 'foo']);
+        $filter = new Enum();
+
+        $filterDefinition = [
+            'swagger' => [
+                'enum' => ['foo', 'bar'],
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+}

--- a/tests/Filter/Validator/LengthTest.php
+++ b/tests/Filter/Validator/LengthTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Filter\Validator;
+
+use ApiPlatform\Core\Filter\Validator\Length;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class LengthTest extends TestCase
+{
+    public function testNonDefinedFilter()
+    {
+        $request = new Request();
+        $filter = new Length();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testEmptyQueryParameter()
+    {
+        $request = new Request(['some_filter' => '']);
+        $filter = new Length();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testNonMatchingParameter()
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'swagger' => [
+                'minLength' => 3,
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be greater than or equal to 3'],
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'ab']))
+        );
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be lower than or equal to 5'],
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcdef']))
+        );
+    }
+
+    public function testNonMatchingParameterWithOnlyOneDefinition()
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'swagger' => [
+                'minLength' => 3,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be greater than or equal to 3'],
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'ab']))
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be lower than or equal to 5'],
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcdef']))
+        );
+    }
+
+    public function testMatchingParameter()
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'swagger' => [
+                'minLength' => 3,
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abc']))
+        );
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcd']))
+        );
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcde']))
+        );
+    }
+
+    public function testMatchingParameterWithOneDefinition()
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'swagger' => [
+                'minLength' => 3,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abc']))
+        );
+
+        $filterDefinition = [
+            'swagger' => [
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcde']))
+        );
+    }
+}

--- a/tests/Filter/Validator/LengthTest.php
+++ b/tests/Filter/Validator/LengthTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Filter\Validator;
 
 use ApiPlatform\Core\Filter\Validator\Length;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
@@ -24,21 +23,19 @@ class LengthTest extends TestCase
 {
     public function testNonDefinedFilter()
     {
-        $request = new Request();
         $filter = new Length();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], [])
         );
     }
 
     public function testEmptyQueryParameter()
     {
-        $request = new Request(['some_filter' => '']);
         $filter = new Length();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], ['some_filter' => ''])
         );
     }
 
@@ -55,12 +52,12 @@ class LengthTest extends TestCase
 
         $this->assertEquals(
             ['Query parameter "some_filter" length must be greater than or equal to 3'],
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'ab']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'ab'])
         );
 
         $this->assertEquals(
             ['Query parameter "some_filter" length must be lower than or equal to 5'],
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcdef']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcdef'])
         );
     }
 
@@ -76,7 +73,7 @@ class LengthTest extends TestCase
 
         $this->assertEquals(
             ['Query parameter "some_filter" length must be greater than or equal to 3'],
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'ab']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'ab'])
         );
 
         $filterDefinition = [
@@ -87,7 +84,7 @@ class LengthTest extends TestCase
 
         $this->assertEquals(
             ['Query parameter "some_filter" length must be lower than or equal to 5'],
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcdef']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcdef'])
         );
     }
 
@@ -103,15 +100,15 @@ class LengthTest extends TestCase
         ];
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abc']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abc'])
         );
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcd']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcd'])
         );
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcde']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcde'])
         );
     }
 
@@ -126,7 +123,7 @@ class LengthTest extends TestCase
         ];
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abc']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abc'])
         );
 
         $filterDefinition = [
@@ -136,7 +133,7 @@ class LengthTest extends TestCase
         ];
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $filterDefinition, new Request(['some_filter' => 'abcde']))
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcde'])
         );
     }
 }

--- a/tests/Filter/Validator/MultipleOfTest.php
+++ b/tests/Filter/Validator/MultipleOfTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Filter\Validator;
+
+use ApiPlatform\Core\Filter\Validator\MultipleOf;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class MultipleOfTest extends TestCase
+{
+    public function testNonDefinedFilter()
+    {
+        $request = new Request();
+        $filter = new MultipleOf();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testEmptyQueryParameter()
+    {
+        $request = new Request(['some_filter' => '']);
+        $filter = new MultipleOf();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testNonMatchingParameter()
+    {
+        $request = new Request(['some_filter' => '8']);
+        $filter = new MultipleOf();
+
+        $filterDefinition = [
+            'swagger' => [
+                'multipleOf' => 3,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must multiple of 3'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingParameter()
+    {
+        $request = new Request(['some_filter' => '8']);
+        $filter = new MultipleOf();
+
+        $filterDefinition = [
+            'swagger' => [
+                'multipleOf' => 4,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+}

--- a/tests/Filter/Validator/MultipleOfTest.php
+++ b/tests/Filter/Validator/MultipleOfTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Filter\Validator;
 
 use ApiPlatform\Core\Filter\Validator\MultipleOf;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
@@ -24,17 +23,16 @@ class MultipleOfTest extends TestCase
 {
     public function testNonDefinedFilter()
     {
-        $request = new Request();
         $filter = new MultipleOf();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], [])
         );
     }
 
     public function testEmptyQueryParameter()
     {
-        $request = new Request(['some_filter' => '']);
+        $request = ['some_filter' => ''];
         $filter = new MultipleOf();
 
         $this->assertEmpty(
@@ -44,7 +42,7 @@ class MultipleOfTest extends TestCase
 
     public function testNonMatchingParameter()
     {
-        $request = new Request(['some_filter' => '8']);
+        $request = ['some_filter' => '8'];
         $filter = new MultipleOf();
 
         $filterDefinition = [
@@ -61,7 +59,7 @@ class MultipleOfTest extends TestCase
 
     public function testMatchingParameter()
     {
-        $request = new Request(['some_filter' => '8']);
+        $request = ['some_filter' => '8'];
         $filter = new MultipleOf();
 
         $filterDefinition = [

--- a/tests/Filter/Validator/PatternTest.php
+++ b/tests/Filter/Validator/PatternTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Filter\Validator;
 
 use ApiPlatform\Core\Filter\Validator\Pattern;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
@@ -24,11 +23,10 @@ class PatternTest extends TestCase
 {
     public function testNonDefinedFilter()
     {
-        $request = new Request();
         $filter = new Pattern();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], [])
         );
     }
 
@@ -43,13 +41,13 @@ class PatternTest extends TestCase
         ];
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => '']))
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => ''])
         );
 
         $weirdParameter = new \stdClass();
         $weirdParameter->foo = 'non string value should not exists';
         $this->assertEmpty(
-            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => $weirdParameter]))
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => $weirdParameter])
         );
     }
 
@@ -65,7 +63,7 @@ class PatternTest extends TestCase
 
         $this->assertEquals(
             ['Query parameter "some_filter" must match pattern /foo/'],
-            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => '0']))
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => '0'])
         );
     }
 
@@ -81,7 +79,7 @@ class PatternTest extends TestCase
 
         $this->assertEquals(
             ['Query parameter "some_filter" must match pattern /foo/'],
-            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => 'bar']))
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => 'bar'])
         );
     }
 
@@ -96,7 +94,7 @@ class PatternTest extends TestCase
         ];
 
         $this->assertEmpty(
-            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => 'this is a foo '.random_int(0, 10).' and it should match']))
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => 'this is a foo '.random_int(0, 10).' and it should match'])
         );
     }
 }

--- a/tests/Filter/Validator/PatternTest.php
+++ b/tests/Filter/Validator/PatternTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Filter\Validator;
+
+use ApiPlatform\Core\Filter\Validator\Pattern;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class PatternTest extends TestCase
+{
+    public function testNonDefinedFilter()
+    {
+        $request = new Request();
+        $filter = new Pattern();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+    }
+
+    public function testFilterWithEmptyValue()
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'swagger' => [
+                'pattern' => '/foo/',
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => '']))
+        );
+
+        $weirdParameter = new \stdClass();
+        $weirdParameter->foo = 'non string value should not exists';
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => $weirdParameter]))
+        );
+    }
+
+    public function testFilterWithZeroAsParameter()
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'swagger' => [
+                'pattern' => '/foo/',
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must match pattern /foo/'],
+            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => '0']))
+        );
+    }
+
+    public function testFilterWithNonMatchingValue()
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'swagger' => [
+                'pattern' => '/foo/',
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must match pattern /foo/'],
+            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => 'bar']))
+        );
+    }
+
+    public function testFilterWithNonchingValue()
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'swagger' => [
+                'pattern' => '/foo \d+/',
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, new Request(['some_filter' => 'this is a foo '.random_int(0, 10).' and it should match']))
+        );
+    }
+}

--- a/tests/Filter/Validator/RequiredTest.php
+++ b/tests/Filter/Validator/RequiredTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Filter\Validator;
+
+use ApiPlatform\Core\Filter\Validator\Required;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class RequiredTest.
+ *
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class RequiredTest extends TestCase
+{
+    public function testNonRequiredFilter()
+    {
+        $request = new Request();
+        $filter = new Required();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', [], $request)
+        );
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', ['required' => false], $request)
+        );
+    }
+
+    public function testRequiredFilterNotInQuery()
+    {
+        $request = new Request();
+        $filter = new Required();
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" is required'],
+            $filter->validate('some_filter', ['required' => true], $request)
+        );
+    }
+
+    public function testRequiredFilterIsPresent()
+    {
+        $request = new Request(['some_filter' => 'some_value']);
+        $filter = new Required();
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', ['required' => true], $request)
+        );
+    }
+
+    public function testEmptyValueNotAllowed()
+    {
+        $request = new Request(['some_filter' => '']);
+        $filter = new Required();
+
+        $explicitFilterDefinition = [
+            'required' => true,
+            'swagger' => [
+                'allowEmptyValue' => false,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" does not allow empty value'],
+            $filter->validate('some_filter', $explicitFilterDefinition, $request)
+        );
+
+        $implicitFilterDefinition = [
+            'required' => true,
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" does not allow empty value'],
+            $filter->validate('some_filter', $implicitFilterDefinition, $request)
+        );
+    }
+
+    public function testEmptyValueAllowed()
+    {
+        $request = new Request(['some_filter' => '']);
+        $filter = new Required();
+
+        $explicitFilterDefinition = [
+            'required' => true,
+            'swagger' => [
+                'allowEmptyValue' => true,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, $request)
+        );
+    }
+}

--- a/tests/Filter/Validator/RequiredTest.php
+++ b/tests/Filter/Validator/RequiredTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Filter\Validator;
 
 use ApiPlatform\Core\Filter\Validator\Required;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class RequiredTest.
@@ -26,11 +25,11 @@ class RequiredTest extends TestCase
 {
     public function testNonRequiredFilter()
     {
-        $request = new Request();
+        $request = [];
         $filter = new Required();
 
         $this->assertEmpty(
-            $filter->validate('some_filter', [], $request)
+            $filter->validate('some_filter', [], [])
         );
 
         $this->assertEmpty(
@@ -40,7 +39,7 @@ class RequiredTest extends TestCase
 
     public function testRequiredFilterNotInQuery()
     {
-        $request = new Request();
+        $request = [];
         $filter = new Required();
 
         $this->assertEquals(
@@ -51,7 +50,7 @@ class RequiredTest extends TestCase
 
     public function testRequiredFilterIsPresent()
     {
-        $request = new Request(['some_filter' => 'some_value']);
+        $request = ['some_filter' => 'some_value'];
         $filter = new Required();
 
         $this->assertEmpty(
@@ -61,7 +60,7 @@ class RequiredTest extends TestCase
 
     public function testEmptyValueNotAllowed()
     {
-        $request = new Request(['some_filter' => '']);
+        $request = ['some_filter' => ''];
         $filter = new Required();
 
         $explicitFilterDefinition = [
@@ -88,7 +87,7 @@ class RequiredTest extends TestCase
 
     public function testEmptyValueAllowed()
     {
-        $request = new Request(['some_filter' => '']);
+        $request = ['some_filter' => ''];
         $filter = new Required();
 
         $explicitFilterDefinition = [

--- a/tests/Fixtures/TestBundle/Document/FilterValidator.php
+++ b/tests/Fixtures/TestBundle/Document/FilterValidator.php
@@ -15,6 +15,13 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\ArrayItemsFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\BoundsFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\EnumFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\LengthFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\MultipleOfFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\PatternFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
@@ -26,7 +33,14 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  *
  * @ApiResource(attributes={
  *     "filters"={
- *         RequiredFilter::class
+ *         ArrayItemsFilter::class,
+ *         BoundsFilter::class,
+ *         EnumFilter::class,
+ *         LengthFilter::class,
+ *         MultipleOfFilter::class,
+ *         PatternFilter::class,
+ *         RequiredFilter::class,
+ *         RequiredAllowEmptyFilter::class
  *     }
  * })
  * @ODM\Document

--- a/tests/Fixtures/TestBundle/Entity/FilterValidator.php
+++ b/tests/Fixtures/TestBundle/Entity/FilterValidator.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\BoundsFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\LengthFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
 use Doctrine\ORM\Mapping as ORM;
@@ -28,6 +29,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ApiResource(attributes={
  *     "filters"={
  *         BoundsFilter::class,
+ *         LengthFilter::class,
  *         RequiredFilter::class,
  *         RequiredAllowEmptyFilter::class
  *     }

--- a/tests/Fixtures/TestBundle/Entity/FilterValidator.php
+++ b/tests/Fixtures/TestBundle/Entity/FilterValidator.php
@@ -16,7 +16,10 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\BoundsFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\EnumFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\LengthFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\MultipleOfFilter;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\PatternFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
 use Doctrine\ORM\Mapping as ORM;
@@ -29,7 +32,10 @@ use Doctrine\ORM\Mapping as ORM;
  * @ApiResource(attributes={
  *     "filters"={
  *         BoundsFilter::class,
+ *         EnumFilter::class,
  *         LengthFilter::class,
+ *         MultipleOfFilter::class,
+ *         PatternFilter::class,
  *         RequiredFilter::class,
  *         RequiredAllowEmptyFilter::class
  *     }

--- a/tests/Fixtures/TestBundle/Entity/FilterValidator.php
+++ b/tests/Fixtures/TestBundle/Entity/FilterValidator.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\ArrayItemsFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\BoundsFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\EnumFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\LengthFilter;
@@ -31,6 +32,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ApiResource(attributes={
  *     "filters"={
+ *         ArrayItemsFilter::class,
  *         BoundsFilter::class,
  *         EnumFilter::class,
  *         LengthFilter::class,

--- a/tests/Fixtures/TestBundle/Entity/FilterValidator.php
+++ b/tests/Fixtures/TestBundle/Entity/FilterValidator.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -25,7 +26,8 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ApiResource(attributes={
  *     "filters"={
- *         RequiredFilter::class
+ *         RequiredFilter::class,
+ *         RequiredAllowEmptyFilter::class
  *     }
  * })
  * @ORM\Entity

--- a/tests/Fixtures/TestBundle/Entity/FilterValidator.php
+++ b/tests/Fixtures/TestBundle/Entity/FilterValidator.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\BoundsFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
 use Doctrine\ORM\Mapping as ORM;
@@ -26,6 +27,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ApiResource(attributes={
  *     "filters"={
+ *         BoundsFilter::class,
  *         RequiredFilter::class,
  *         RequiredAllowEmptyFilter::class
  *     }

--- a/tests/Fixtures/TestBundle/Filter/ArrayItemsFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/ArrayItemsFilter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
+use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 class ArrayItemsFilter extends AbstractFilter
 {
+    use PropertyHelperTrait;
+
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
     }

--- a/tests/Fixtures/TestBundle/Filter/ArrayItemsFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/ArrayItemsFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class ArrayItemsFilter extends AbstractFilter
+{
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+    }
+
+    // This function is only used to hook in documentation generators (supported by Swagger and Hydra)
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'csv-min-2' => [
+                'property' => 'csv-min-2',
+                'type' => 'array',
+                'required' => false,
+                'swagger' => [
+                    'minItems' => 2,
+                ],
+            ],
+            'csv-max-3' => [
+                'property' => 'csv-max-3',
+                'type' => 'array',
+                'required' => false,
+                'swagger' => [
+                    'maxItems' => 3,
+                ],
+            ],
+            'ssv-min-2' => [
+                'property' => 'ssv-min-2',
+                'type' => 'array',
+                'required' => false,
+                'swagger' => [
+                    'collectionFormat' => 'ssv',
+                    'minItems' => 2,
+                ],
+            ],
+            'tsv-min-2' => [
+                'property' => 'tsv-min-2',
+                'type' => 'array',
+                'required' => false,
+                'swagger' => [
+                    'collectionFormat' => 'tsv',
+                    'minItems' => 2,
+                ],
+            ],
+            'pipes-min-2' => [
+                'property' => 'pipes-min-2',
+                'type' => 'array',
+                'required' => false,
+                'swagger' => [
+                    'collectionFormat' => 'pipes',
+                    'minItems' => 2,
+                ],
+            ],
+            'csv-uniques' => [
+                'property' => 'csv-uniques',
+                'type' => 'array',
+                'required' => false,
+                'swagger' => [
+                    'uniqueItems' => true,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/TestBundle/Filter/BoundsFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/BoundsFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class BoundsFilter extends AbstractFilter
+{
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+    }
+
+    // This function is only used to hook in documentation generators (supported by Swagger and Hydra)
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'maximum' => [
+                'property' => 'maximum',
+                'type' => 'number',
+                'required' => false,
+                'swagger' => [
+                    'maximum' => 10,
+                ],
+            ],
+            'exclusiveMaximum' => [
+                'property' => 'maximum',
+                'type' => 'number',
+                'required' => false,
+                'swagger' => [
+                    'maximum' => 10,
+                    'exclusiveMaximum' => true,
+                ],
+            ],
+            'minimum' => [
+                'property' => 'minimum',
+                'type' => 'number',
+                'required' => false,
+                'swagger' => [
+                    'minimum' => 5,
+                ],
+            ],
+            'exclusiveMinimum' => [
+                'property' => 'exclusiveMinimum',
+                'type' => 'number',
+                'required' => false,
+                'swagger' => [
+                    'minimum' => 5,
+                    'exclusiveMinimum' => true,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/TestBundle/Filter/BoundsFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/BoundsFilter.php
@@ -29,7 +29,7 @@ class BoundsFilter extends AbstractFilter
         return [
             'maximum' => [
                 'property' => 'maximum',
-                'type' => 'number',
+                'type' => 'float',
                 'required' => false,
                 'swagger' => [
                     'maximum' => 10,
@@ -37,7 +37,7 @@ class BoundsFilter extends AbstractFilter
             ],
             'exclusiveMaximum' => [
                 'property' => 'maximum',
-                'type' => 'number',
+                'type' => 'float',
                 'required' => false,
                 'swagger' => [
                     'maximum' => 10,
@@ -46,7 +46,7 @@ class BoundsFilter extends AbstractFilter
             ],
             'minimum' => [
                 'property' => 'minimum',
-                'type' => 'number',
+                'type' => 'float',
                 'required' => false,
                 'swagger' => [
                     'minimum' => 5,
@@ -54,7 +54,7 @@ class BoundsFilter extends AbstractFilter
             ],
             'exclusiveMinimum' => [
                 'property' => 'exclusiveMinimum',
-                'type' => 'number',
+                'type' => 'float',
                 'required' => false,
                 'swagger' => [
                     'minimum' => 5,

--- a/tests/Fixtures/TestBundle/Filter/BoundsFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/BoundsFilter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
+use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 class BoundsFilter extends AbstractFilter
 {
+    use PropertyHelperTrait;
+
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
     }

--- a/tests/Fixtures/TestBundle/Filter/EnumFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/EnumFilter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
+use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 class EnumFilter extends AbstractFilter
 {
+    use PropertyHelperTrait;
+
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
     }

--- a/tests/Fixtures/TestBundle/Filter/EnumFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/EnumFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class EnumFilter extends AbstractFilter
+{
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+    }
+
+    // This function is only used to hook in documentation generators (supported by Swagger and Hydra)
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'enum' => [
+                'property' => 'enum',
+                'type' => 'string',
+                'required' => false,
+                'swagger' => [
+                    'enum' => ['in-enum', 'mune-ni'],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/TestBundle/Filter/LengthFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/LengthFilter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
+use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 class LengthFilter extends AbstractFilter
 {
+    use PropertyHelperTrait;
+
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
     }

--- a/tests/Fixtures/TestBundle/Filter/LengthFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/LengthFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class LengthFilter extends AbstractFilter
+{
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+    }
+
+    // This function is only used to hook in documentation generators (supported by Swagger and Hydra)
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'max-length-3' => [
+                'property' => 'max-length-3',
+                'type' => 'string',
+                'required' => false,
+                'swagger' => [
+                    'maxLength' => 3,
+                ],
+            ],
+            'min-length-3' => [
+                'property' => 'min-length-3',
+                'type' => 'string',
+                'required' => false,
+                'swagger' => [
+                    'minLength' => 3,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/TestBundle/Filter/MultipleOfFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/MultipleOfFilter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
+use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 class MultipleOfFilter extends AbstractFilter
 {
+    use PropertyHelperTrait;
+
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
     }

--- a/tests/Fixtures/TestBundle/Filter/MultipleOfFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/MultipleOfFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class MultipleOfFilter extends AbstractFilter
+{
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+    }
+
+    // This function is only used to hook in documentation generators (supported by Swagger and Hydra)
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'multiple-of' => [
+                'property' => 'multiple-of',
+                'type' => 'number',
+                'required' => false,
+                'swagger' => [
+                    'multipleOf' => 2,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/TestBundle/Filter/MultipleOfFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/MultipleOfFilter.php
@@ -29,7 +29,7 @@ class MultipleOfFilter extends AbstractFilter
         return [
             'multiple-of' => [
                 'property' => 'multiple-of',
-                'type' => 'number',
+                'type' => 'float',
                 'required' => false,
                 'swagger' => [
                     'multipleOf' => 2,

--- a/tests/Fixtures/TestBundle/Filter/PatternFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/PatternFilter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
+use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 class PatternFilter extends AbstractFilter
 {
+    use PropertyHelperTrait;
+
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
     }

--- a/tests/Fixtures/TestBundle/Filter/PatternFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/PatternFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class PatternFilter extends AbstractFilter
+{
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+    }
+
+    // This function is only used to hook in documentation generators (supported by Swagger and Hydra)
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'pattern' => [
+                'property' => 'pattern',
+                'type' => 'string',
+                'required' => false,
+                'swagger' => [
+                    'pattern' => '/^(pattern|nrettap)$/',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/TestBundle/Filter/RequiredAllowEmptyFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/RequiredAllowEmptyFilter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
+use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 
 class RequiredAllowEmptyFilter extends AbstractFilter
 {
+    use PropertyHelperTrait;
+
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
     }

--- a/tests/Fixtures/TestBundle/Filter/RequiredAllowEmptyFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/RequiredAllowEmptyFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class RequiredAllowEmptyFilter extends AbstractFilter
+{
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+    }
+
+    // This function is only used to hook in documentation generators (supported by Swagger and Hydra)
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'required-allow-empty' => [
+                'property' => 'required-allow-empty',
+                'type' => 'string',
+                'required' => true,
+                'swagger' => [
+                    'allowEmptyValue' => true,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -144,6 +144,10 @@ services:
     ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter:
         arguments: [ '@doctrine' ]
         tags: [ 'api_platform.filter' ]
+    
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\BoundsFilter:
+        arguments: [ '@doctrine' ]
+        tags: [ 'api_platform.filter' ]
 
     ApiPlatform\Core\Tests\Fixtures\TestBundle\Controller\:
         resource: '../../TestBundle/Controller'

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -153,9 +153,21 @@ services:
         arguments: [ '@doctrine' ]
         tags: [ 'api_platform.filter' ]
 
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\PatternFilter:
+        arguments: [ '@doctrine' ]
+        tags: [ 'api_platform.filter' ]
+    
     ApiPlatform\Core\Tests\Fixtures\TestBundle\Controller\:
         resource: '../../TestBundle/Controller'
         tags: ['controller.service_arguments']
+
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\EnumFilter:
+        arguments: [ '@doctrine' ]
+        tags: [ 'api_platform.filter' ]
+
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\MultipleOfFilter:
+        arguments: [ '@doctrine' ]
+        tags: [ 'api_platform.filter' ]
 
     app.config_dummy_resource.action:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Action\ConfigCustom'

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -141,6 +141,10 @@ services:
         arguments: ['@doctrine']
         tags: ['api_platform.filter']
 
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter:
+        arguments: [ '@doctrine' ]
+        tags: [ 'api_platform.filter' ]
+
     ApiPlatform\Core\Tests\Fixtures\TestBundle\Controller\:
         resource: '../../TestBundle/Controller'
         tags: ['controller.service_arguments']

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -169,6 +169,10 @@ services:
         arguments: [ '@doctrine' ]
         tags: [ 'api_platform.filter' ]
 
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\ArrayItemsFilter:
+        arguments: [ '@doctrine' ]
+        tags: [ 'api_platform.filter' ]
+
     app.config_dummy_resource.action:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Action\ConfigCustom'
         arguments: ['@api_platform.item_data_provider']

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -148,6 +148,10 @@ services:
     ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\BoundsFilter:
         arguments: [ '@doctrine' ]
         tags: [ 'api_platform.filter' ]
+    
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\LengthFilter:
+        arguments: [ '@doctrine' ]
+        tags: [ 'api_platform.filter' ]
 
     ApiPlatform\Core\Tests\Fixtures\TestBundle\Controller\:
         resource: '../../TestBundle/Controller'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kind of
| New feature?  | yes
| BC breaks?    | if filter config was wrongly configured
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1627 
| License       | MIT
| Doc PR        | Doc PR will follow if PR is approved

This follows #1692 

It implements all other validation filters from [OpenApi specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object)

This might break wrongly configured api though. I see two possible solutions here:

  * make this a `[Might break]` as we can consider wrongly configured sites a "bug"
  * add a new configuration key `validate_filters`, default to `false`, and deprecate it being to `false`, encouraging people to set it to `true`, and remove the configuration key in 3.0