### PR TITLE
Add a api_platform.metadata_cache parameter

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -458,7 +458,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     private function registerCacheConfiguration(ContainerBuilder $container)
     {
         // Don't use system cache pool in dev
-        if (!$container->getParameter('kernel.debug')) {
+        if ($container->hasParameter('api_platform.metadata_cache') ? $container->getParameter('api_platform.metadata_cache') : !$container->getParameter('kernel.debug')) {
             return;
         }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -723,6 +723,9 @@ class ApiPlatformExtensionTest extends TestCase
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
 
+        $containerBuilderProphecy->hasParameter('api_platform.metadata_cache')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->getParameter('api_platform.metadata_cache')->willReturn(true)->shouldBeCalled();
+
         return $containerBuilderProphecy;
     }
 }

--- a/tests/Fixtures/app/config/config_test.yml
+++ b/tests/Fixtures/app/config/config_test.yml
@@ -73,6 +73,8 @@ fos_user:
 parameters:
     container.autowiring.strict_mode: true
     container.dumper.inline_class_loader: true
+    # Enable the metadata cache to speedup the builds
+    api_platform.metadata_cache: true
 
 services:
     contain_non_resource.item_data_provider:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Follows https://github.com/api-platform/core/issues/1724#issuecomment-367701990

TODO: fix tests

It's significant on my computer:

**Before**

Behat: 2m18.08s (2.16Gb)
PHPUnit: Time: 21.17 seconds, Memory: 104.25MB

**After**

Behat: 0m42.23s (498.70Mb)
Time: 25.72 seconds, Memory: 102.25MB

Can you try with your code base @jdeniau?


