### PR TITLE
Fix initialization of the serialization context

### DIFF
--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -70,8 +70,8 @@ final class ReadListener
         $context = null === $filters ? [] : ['filters' => $filters];
         if ($this->serializerContextBuilder) {
             // Builtin data providers are able to use the serialization context to automatically add join clauses
-            $context['normalization_context'] = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
-            $request->attributes->set('_api_normalization_context', $context['normalization_context']);
+            $context += $normalizationContext = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
+            $request->attributes->set('_api_normalization_context', $normalizationContext);
         }
 
         $data = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

According to https://github.com/api-platform/core/blob/fb7cc479046c03352d96dedc57d97f1dbc3fe323/src/EventListener/ReadListener.php#L73, the normalization context array is in the `normalization_context` index of the context array. So, if we pass the whole context array to the `EagerLoadingExtension::joinRelations()` method, we can't properly retrieve groups, max depth and attributes.