### PR TITLE
If docs are disabled, do not try to add a link header to the docs

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -129,7 +129,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerApiKeysConfiguration($container, $config, $loader);
         $this->registerSwaggerConfiguration($container, $config, $loader);
         $this->registerJsonApiConfiguration($formats, $loader);
-        $this->registerJsonLdConfiguration($formats, $loader);
+        $this->registerJsonLdConfiguration($container, $formats, $loader, $config['enable_docs']);
         $this->registerJsonHalConfiguration($formats, $loader);
         $this->registerJsonProblemConfiguration($errorFormats, $loader);
         $this->registerGraphqlConfiguration($container, $config, $loader);
@@ -366,10 +366,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     /**
      * Registers the JSON-LD and Hydra configuration.
      *
-     * @param array         $formats
-     * @param XmlFileLoader $loader
+     * @param ContainerBuilder $container
+     * @param array            $formats
+     * @param XmlFileLoader    $loader
+     * @param bool             $docEnabled
      */
-    private function registerJsonLdConfiguration(array $formats, XmlFileLoader $loader)
+    private function registerJsonLdConfiguration(ContainerBuilder $container, array $formats, XmlFileLoader $loader, bool $docEnabled)
     {
         if (!isset($formats['jsonld'])) {
             return;
@@ -377,6 +379,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $loader->load('jsonld.xml');
         $loader->load('hydra.xml');
+
+        if (!$docEnabled) {
+            $container->removeDefinition('api_platform.hydra.listener.response.add_link_header');
+        }
     }
 
     /**

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -344,6 +344,20 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load($config, $containerBuilder);
     }
 
+    public function testDisabledDocsRemovesAddLinkHeaderService()
+    {
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
+        $containerBuilderProphecy->removeDefinition('api_platform.hydra.listener.response.add_link_header')->shouldBeCalled();
+        $containerBuilderProphecy->setParameter('api_platform.enable_docs', false)->shouldBeCalled();
+        $containerBuilderProphecy->setParameter('api_platform.enable_docs', true)->shouldNotBeCalled();
+        $containerBuilder = $containerBuilderProphecy->reveal();
+
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['enable_docs'] = false;
+
+        $this->extension->load($config, $containerBuilder);
+    }
+
     private function getPartialContainerBuilderProphecy($test = false)
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Even if the docs are disabled, the `AddLinkHeader` listener tries to add a `Link` header to the `api_doc` route. But the generator fails if the route does not exists, triggers a 500 instead of having an expected result.

Checking for the parameter `%api_platform.enable_docs%` solves the problem.
