### PR TITLE
Ease custom operation configuration

### DIFF
--- a/features/main/custom_operation.feature
+++ b/features/main/custom_operation.feature
@@ -26,3 +26,45 @@ Feature: Custom operation
         "foo": "foo"
     }
     """
+
+  Scenario: Custom normalization operation with shorthand configuration
+    When I send a "POST" request to "/short_custom/denormalization"
+    And I add "Content-Type" header equal to "application/ld+json"
+    Then the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/CustomActionDummy",
+        "@id": "/custom_action_dummies/2",
+        "@type": "CustomActionDummy",
+        "id": 2,
+        "foo": "short declaration"
+    }
+    """
+
+  Scenario: Custom normalization operation with shorthand configuration
+    When I send a "GET" request to "/short_custom/2/normalization"
+    Then the JSON should be equal to:
+    """
+    {
+        "id": 2,
+        "foo": "short"
+    }
+    """
+
+  Scenario: Custom collection name without specific route
+    When I send a "GET" request to "/custom_action_collection_dummies"
+    Then the response status code should be 200
+    Then the JSON node "hydra:member" should have 2 elements
+
+  Scenario: Custom operation name without specific route
+    When I send a "GET" request to "/custom_action_collection_dummies/1"
+    Then the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/CustomActionDummy",
+        "@id": "/custom_action_dummies/1",
+        "@type": "CustomActionDummy",
+        "id": 1,
+        "foo": "custom!"
+    }
+    """

--- a/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
@@ -121,6 +121,8 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
 
             if ($supported && !isset($operation['method']) && !isset($operation['route_name'])) {
                 $operation['method'] = $upperOperationName;
+            } elseif (!$supported && !isset($operation['method']) && !isset($operation['route_name'])) {
+                $operation['route_name'] = $operationName;
             }
 
             $newOperations[$operationName] = $operation;

--- a/tests/Fixtures/TestBundle/Controller/CustomActionController.php
+++ b/tests/Fixtures/TestBundle/Controller/CustomActionController.php
@@ -62,4 +62,43 @@ class CustomActionController extends Controller
 
         return $object;
     }
+
+    /**
+     * @Route(
+     *     name="short_custom_normalization",
+     *     path="/short_custom/{id}/normalization",
+     *     defaults={"_api_resource_class"=CustomActionDummy::class, "_api_item_operation_name"="custom_normalization"}
+     * )
+     * @Method("GET")
+     */
+    public function shortCustomNormalizationAction(CustomActionDummy $data)
+    {
+        $data->setFoo('short');
+
+        return $this->json($data);
+    }
+
+    /**
+     * @Route(
+     *     name="short_custom_denormalization",
+     *     path="/short_custom/denormalization",
+     *     defaults={
+     *         "_api_resource_class"=CustomActionDummy::class,
+     *         "_api_collection_operation_name"="custom_denormalization",
+     *         "_api_receive"=false
+     *     }
+     * )
+     * @Method("POST")
+     */
+    public function shortCustomDenormalizationAction(Request $request)
+    {
+        if ($request->attributes->has('data')) {
+            throw new \RuntimeException('The "data" attribute must not be set.');
+        }
+
+        $object = new CustomActionDummy();
+        $object->setFoo('short declaration');
+
+        return $object;
+    }
 }

--- a/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
@@ -20,10 +20,14 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ApiResource(itemOperations={
  *     "get",
- *     "custom_normalization"={"route_name"="custom_normalization"}
+ *     "get_custom"={"method"="GET", "path"="custom_action_collection_dummies/{id}"},
+ *     "custom_normalization"={"route_name"="custom_normalization"},
+ *     "short_custom_normalization",
  * }, collectionOperations={
  *     "get",
- *     "custom_denormalization"={"route_name"="custom_denormalization"}
+ *     "get_custom"={"method"="GET", "path"="custom_action_collection_dummies"},
+ *     "custom_denormalization"={"route_name"="custom_denormalization"},
+ *     "short_custom_denormalization",
  * })
  *
  * @author Kévin Dunglas <dunglas@gmail.com>

--- a/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
@@ -46,14 +46,18 @@ class OperationResourceMetadataFactoryTest extends TestCase
             [new ResourceMetadata(null, null, null, ['get'], [], null, [], []), new ResourceMetadata(null, null, null, ['get' => ['method' => 'GET']], [], null, [], [])],
             [new ResourceMetadata(null, null, null, ['put'], [], null, [], []), new ResourceMetadata(null, null, null, ['put' => ['method' => 'PUT']], [], null, [], [])],
             [new ResourceMetadata(null, null, null, ['delete'], [], null, [], []), new ResourceMetadata(null, null, null, ['delete' => ['method' => 'DELETE']], [], null, [], [])],
-            [new ResourceMetadata(null, null, null, ['patch'], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => []], [], null, [], [])],
+            [new ResourceMetadata(null, null, null, ['patch'], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => ['route_name' => 'patch']], [], null, [], [])],
             [new ResourceMetadata(null, null, null, ['patch'], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH']], [], null, [], []), $jsonapi],
+            [new ResourceMetadata(null, null, null, ['untouched' => ['method' => 'GET']], [], null, [], []), new ResourceMetadata(null, null, null, ['untouched' => ['method' => 'GET']], [], null, [], []), $jsonapi],
+            [new ResourceMetadata(null, null, null, ['untouched_custom' => ['route_name' => 'custom_route']], [], null, [], []), new ResourceMetadata(null, null, null, ['untouched_custom' => ['route_name' => 'custom_route']], [], null, [], []), $jsonapi],
 
             // Collection operations
             [new ResourceMetadata(null, null, null, [], null, null, [], []), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST']], null, [], [])],
             [new ResourceMetadata(null, null, null, [], ['get'], null, [], []), new ResourceMetadata(null, null, null, [], ['get' => ['method' => 'GET']], null, [], [])],
             [new ResourceMetadata(null, null, null, [], ['post'], null, [], []), new ResourceMetadata(null, null, null, [], ['post' => ['method' => 'POST']], null, [], [])],
-            [new ResourceMetadata(null, null, null, [], ['options'], null, [], []), new ResourceMetadata(null, null, null, [], ['options' => []], null, [], [])],
+            [new ResourceMetadata(null, null, null, [], ['options'], null, [], []), new ResourceMetadata(null, null, null, [], ['options' => ['route_name' => 'options']], null, [], [])],
+            [new ResourceMetadata(null, null, null, [], ['untouched' => ['method' => 'GET']], null, [], []), new ResourceMetadata(null, null, null, [], ['untouched' => ['method' => 'GET']], null, [], [])],
+            [new ResourceMetadata(null, null, null, [], ['untouched_custom' => ['route_name' => 'custom_route']], null, [], []), new ResourceMetadata(null, null, null, [], ['untouched_custom' => ['route_name' => 'custom_route']], null, [], [])],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | will open this is upvoted

Inspired by and following #1470  This PR aims to give a shortcut configuration for custom operation. Over the time I find my self repeating this code a lot. 

Before:
```
/**
 * @ApiResource(
 *     collectionOperations={
 *         "get",
 *         "post",
 *         "custom_denormalization_action"={"route_name"="custom_denormalization_action"},
 *     },
 *     itemOperations={
 *         "get",
 *         "put",
 *         "custom_normalization_action"={"route_name"="custom_normalization_action"},
 *     }
 * )
 */
```
After:
```
/**
 * @ApiResource(
 *     collectionOperations={"get", "post", "custom_denormalization_action"},
 *     itemOperations={"get", "put", "custom_normalization_action"}
 * )
 */
```
