### PR TITLE
BugFix: Fix object state inconsistency after persitence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ install:
 
 script:
   - vendor/bin/phpunit
-  - if [[ $APP_ENV != 'postgres' ]]; then vendor/bin/behat --format=progress; fi
-  - if [[ $APP_ENV = 'postgres' ]]; then vendor/bin/behat --tags='~@sqlite' --format=progress; fi
+  - if [[ $APP_ENV != 'postgres' ]]; then vendor/bin/behat --suite=default --format=progress; fi
+  - if [[ $APP_ENV = 'postgres' ]]; then vendor/bin/behat --suite=postgres --format=progress; fi
   - tests/Fixtures/app/console api:swagger:export > swagger.json && swagger-cli validate swagger.json && rm swagger.json
   - if [[ $lint = 1 ]]; then php php-cs-fixer.phar fix --dry-run --diff --no-ansi; fi
   - if [[ $lint = 1 ]]; then phpstan analyse -c phpstan.neon -l5 --ansi src tests; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Coverage will be available in `coverage/index.html`.
 The command to launch Behat tests is:
 
 ```
-./vendor/bin/behat --stop-on-failure -vvv
+./vendor/bin/behat --suite=default --stop-on-failure -vvv
 ```
 
 You may need to clear the cache manually before running behat tests because of the temporary sql database. To do so, just remove the `test` cache directory:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,12 @@ install:
   - echo extension=php_mbstring.dll >> php.ini
   - echo extension=php_intl.dll >> php.ini
   - echo extension=php_pdo_sqlite.dll >> php.ini
-  - echo memory_limit=1G >> php.ini
+  - echo memory_limit=3G >> php.ini
   - cd %APPVEYOR_BUILD_FOLDER%
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar install --no-interaction --no-progress
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - php vendor\behat\behat\bin\behat --format=progress --tags='~@postgres'
+  - php vendor\behat\behat\bin\behat --format=progress --suite=default
   - php vendor\phpunit\phpunit\phpunit

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -13,6 +13,19 @@ default:
         - 'Behatch\Context\RestContext'
       filters:
         tags: ~@postgres
+    postgres:
+      contexts:
+        - 'FeatureContext': { doctrine: '@doctrine' }
+        - 'GraphqlContext'
+        - 'JsonContext'
+        - 'HydraContext'
+        - 'SwaggerContext'
+        - 'HttpCacheContext'
+        - 'JsonApiContext': { doctrine: '@doctrine', jsonApiSchemaFile: 'tests/Fixtures/JsonSchema/jsonapi.json' }
+        - 'Behat\MinkExtension\Context\MinkContext'
+        - 'Behatch\Context\RestContext'
+      filters:
+        tags: ~@sqlite
   extensions:
     'Behat\Symfony2Extension':
       kernel:

--- a/features/doctrine/order_filter.feature
+++ b/features/doctrine/order_filter.feature
@@ -305,7 +305,6 @@ Feature: Order filter on collections
     Given there are 30 dummy objects
     When I send a "GET" request to "/dummies?order[name]=desc&order[id]=desc"
     Then the response status code should be 200
-    Then print last JSON response
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be valid according to this schema:
     """

--- a/features/main/exposed_state.feature
+++ b/features/main/exposed_state.feature
@@ -1,0 +1,47 @@
+@postgres
+Feature: Expose persisted object state
+  In order to use an hypermedia API
+  As a client software developer
+  I need to be able to retrieve the exact state of resources after persistence.
+
+  @createSchema
+  Scenario: Create a resource with truncable value should return the correct object state
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/truncated_dummies" with body:
+    """
+    {
+      "value": "20.3325"
+    }
+    """
+    Then the response status code should be 201
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/TruncatedDummy",
+      "@id": "/truncated_dummies/1",
+      "@type": "TruncatedDummy",
+      "value": "20.3",
+      "id": 1
+    }
+    """
+
+  @dropSchema
+  Scenario: Update a resource with truncable value value should return the correct object state
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/truncated_dummies/1" with body:
+    """
+    {
+      "value": "42.42"
+    }
+    """
+    Then the response status code should be 200
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/TruncatedDummy",
+      "@id": "/truncated_dummies/1",
+      "@type": "TruncatedDummy",
+      "value": "42.4",
+      "id": 1
+    }
+    """

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -72,9 +72,7 @@ Feature: Relations support
       },
       "relatedToDummyFriend": [],
       "dummyBoolean": null,
-      "embeddedDummy": null,
-      "id": 1,
-      "symfony": "symfony",
+      "embeddedDummy": [],
       "age": null
     }
     """
@@ -476,8 +474,7 @@ Feature: Relations support
       },
       "relatedToDummyFriend": [],
       "dummyBoolean": null,
-      "embeddedDummy": null,
-      "symfony": "symfony",
+      "embeddedDummy": [],
       "age": null
     }
     """

--- a/src/Bridge/Doctrine/Common/DataPersister.php
+++ b/src/Bridge/Doctrine/Common/DataPersister.php
@@ -53,6 +53,7 @@ final class DataPersister implements DataPersisterInterface
 
         $manager->persist($data);
         $manager->flush();
+        $manager->refresh($data);
     }
 
     /**

--- a/tests/Bridge/Doctrine/Common/DataPersisterTest.php
+++ b/tests/Bridge/Doctrine/Common/DataPersisterTest.php
@@ -50,6 +50,7 @@ class DataPersisterTest extends TestCase
         $objectManagerProphecy = $this->prophesize(ObjectManager::class);
         $objectManagerProphecy->persist($dummy)->shouldBeCalled();
         $objectManagerProphecy->flush()->shouldBeCalled();
+        $objectManagerProphecy->refresh($dummy)->shouldBeCalled();
 
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($objectManagerProphecy->reveal())->shouldBeCalled();

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceRelated.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceRelated.php
@@ -78,4 +78,29 @@ class DummyTableInheritanceRelated
 
         return $this;
     }
+
+    /**
+     * @param $child
+     *
+     * @return $this
+     */
+    public function addChild($child)
+    {
+        $this->children->add($child);
+        $child->setParent($this);
+
+        return $this;
+    }
+
+    /**
+     * @param $child
+     *
+     * @return $this
+     */
+    public function removeChild($child)
+    {
+        $this->children->remove($child);
+
+        return $this;
+    }
 }

--- a/tests/Fixtures/TestBundle/Entity/TruncatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/TruncatedDummy.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ApiResource()
+ */
+class TruncatedDummy
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="decimal", precision=4, scale=1, nullable=false)
+     */
+    public $value;
+
+    /**
+     * Get id.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The state of the object presented after a POST/PUT operation doesn't reflects the actual status of the persisted object(s).

With an entity declared with `@ORM\Column(type="decimal", precision=4, scale=1, nullable=false)` for example:

# before:

POST/PUT request to the entity with value
```
{
     "value": 20.334"
}
```

would return 
```
{
   ...
   "value": 20.334"
   ...
}
```

but then the GET would return 
```
{
   ...
   "value": 20.3"
   ...
}
```

# After
The exposed values  in GET/PUT/POST are always consistent
```
{
   ...
   "value": 20.3"
   ...
}
```

# Misc
I also found that tests marked with the `@postgres` tag were never run on the CI, so I've fixed that also

# TODO
- [x] ensure postgres suite test are running on the CI
- [x] add a failling test
- [x] Update the status after persistence
- [x] Update false positives tests