### PR TITLE
Strip slashes from definitionKey

### DIFF
--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -451,6 +451,7 @@ final class DocumentationNormalizer implements NormalizerInterface
         } else {
             $definitionKey = $this->getDefinitionKey($resourceMetadata->getShortName(), (array) ($serializerContext[AbstractNormalizer::GROUPS] ?? []));
         }
+        $definitionKey = str_replace('/', '-', $definitionKey);
 
         if (!isset($definitions[$definitionKey])) {
             $definitions[$definitionKey] = [];  // Initialize first to prevent infinite loop


### PR DESCRIPTION
To allow shortNames with slashes and avoid swagger ui resolver error

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I'd like to update some resource's short names to include a prefix - e.g. component/hero instead of just hero.

It seemed the simplest way I found in previous issues was to change the short name. It works well except in the swagger ui which results in a Resolver error where it cannot resolve the reference if it has another slash in it.

The easiest fix I could think would be to strip the slashes as I've done in this PR.

Alternatively I'd look to tag each resource to group them together is they are an instance on AbstractComponent in my case. But tagging doesn't seem so easy to do dynamically at the moment, even with the DocumentationNormalizer.

Happy for feedback if there's a better solution though. I'd personally quite like a 'route_prefix' option instead but I'm not sure how useful it'd be for others.