### PR TITLE
fix property name in ContextAwareFilter to support GraphQL

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/AbstractContextAwareFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractContextAwareFilter.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Dkd\Populate\Exception;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Debug\ExceptionHandler;
+use TYPO3\Flow\Error\DebugExceptionHandler;
 
 abstract class AbstractContextAwareFilter extends AbstractFilter implements ContextAwareFilterInterface
 {
@@ -29,9 +32,21 @@ abstract class AbstractContextAwareFilter extends AbstractFilter implements Cont
             return;
         }
 
+        foreach ($context['filters'] as $filterName => $filterValue) {
+            if (isset($this->properties[$filterName])) {
+                continue;
+            }
+            $alternativeFilterName = str_replace('_', '.', $filterName);
+            if (!isset($this->properties[$alternativeFilterName])) {
+                continue;
+            }
+            unset($context['filters'][$filterName]);
+            $context['filters'][$alternativeFilterName] = $filterValue;
+        }
+
         foreach ($context['filters'] as $property => $value) {
-            $property = str_replace('_', '.', $property);
-            $this->filterProperty($property, $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
+            $this->filterProperty($property, $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operationName,
+                $context);
         }
     }
 }

--- a/src/Bridge/Doctrine/Orm/Filter/AbstractContextAwareFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractContextAwareFilter.php
@@ -30,6 +30,7 @@ abstract class AbstractContextAwareFilter extends AbstractFilter implements Cont
         }
 
         foreach ($context['filters'] as $property => $value) {
+            $property = str_replace('_', '.', $property);
             $this->filterProperty($property, $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
         }
     }

--- a/tests/Bridge/Doctrine/Orm/Filter/AbstractFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/AbstractFilterTest.php
@@ -94,6 +94,11 @@ abstract class AbstractFilterTest extends KernelTestCase
             $requestStack = new RequestStack();
             $requestStack->push(Request::create('/api/dummies', 'GET', $filterParameters));
         }
+        var_dump([
+            '$properties' => $properties,
+            '$filterParameters' => $filterParameters,
+            '$expectedParameters' => $expectedParameters
+        ]);
 
         $queryBuilder = $this->repository->createQueryBuilder($this->alias);
         $filterCallable = $filterFactory($this->managerRegistry, $requestStack, $properties);

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -707,6 +707,23 @@ class SearchFilterTest extends AbstractFilterTest
                 ],
                 $filterFactory,
             ],
+            'nested property with GraphQL nesting syntax' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                    'relatedDummy_symfony' => null,
+                ],
+                [
+                    'name' => 'exact',
+                    'relatedDummy.symfony' => 'exact',
+                ],
+                sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummy relatedDummy_a1 WHERE %1$s.name = :name_p1 AND relatedDummy_a1.symfony = :symfony_p2', $this->alias, Dummy::class),
+                [
+                    'name_p1' => 'exact',
+                    'symfony_p2' => 'exact',
+                ],
+                $filterFactory,
+            ],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1714
| License       | MIT
| Doc PR        | -

GraphQL filter properties use a underscore instead of dot to separate nested fields, which causes some issues like #1714 where nested filters are not applied. This change replaces the underscore with a dot in the AbstractContextAwareFilter to have one common syntax further down.