### PR TITLE
Add query extension when using custom data provider

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPass.php
@@ -57,7 +57,12 @@ final class DoctrineQueryExtensionPass implements CompilerPassInterface
         }
 
         foreach ($itemDataProviders as $itemDataProvider) {
-            $container->getDefinition((string) $itemDataProvider)->replaceArgument(3, $itemExtensions);
+            $definition = $container->getDefinition((string) $itemDataProvider);
+            try {
+                $definition->replaceArgument(3, $itemExtensions);
+            } catch (OutOfBoundsException $exception) {
+                $definition->addArgument($itemExtensions);
+            }
         }
 
         foreach ($subresourceDataProviders as $subresourceDataProvider) {

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineQueryExtensionPass.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
 /**
  * Injects query extensions.


### PR DESCRIPTION
When using custom data provider the query extensions is not working properly. By applying this PR, we can inject the query extension based on service tag.

But we have problem with autowire service because the compiler execute before autowire, can you help us to fix this problem?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | [need doc change]

*Please update this template with something that matches your PR*
