### PR TITLE
Remove Request::METHOD_* constants & uppercase HTTP methods

### DIFF
--- a/features/bootstrap/GraphqlContext.php
+++ b/features/bootstrap/GraphqlContext.php
@@ -17,7 +17,6 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behatch\Context\RestContext;
 use Behatch\HttpCall\Request;
-use Symfony\Component\HttpFoundation\Request as HttpFoundationRequest;
 
 /**
  * Context for GraphQL.
@@ -99,6 +98,6 @@ final class GraphqlContext implements Context
     private function sendGraphqlRequest()
     {
         $this->request->setHttpHeader('Accept', null);
-        $this->restContext->iSendARequestTo(HttpFoundationRequest::METHOD_GET, '/graphql?'.http_build_query($this->graphqlRequest));
+        $this->restContext->iSendARequestTo('GET', '/graphql?'.http_build_query($this->graphqlRequest));
     }
 }

--- a/src/Api/OperationMethodResolverInterface.php
+++ b/src/Api/OperationMethodResolverInterface.php
@@ -16,13 +16,15 @@ namespace ApiPlatform\Core\Api;
 use ApiPlatform\Core\Exception\RuntimeException;
 
 /**
- * Resolves the HTTP method associated with an operation.
+ * Resolves the uppercased HTTP method associated with an operation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 interface OperationMethodResolverInterface
 {
     /**
+     * Resolves the uppercased HTTP method associated with a collection operation.
+     *
      * @param string $resourceClass
      * @param string $operationName
      *
@@ -33,6 +35,8 @@ interface OperationMethodResolverInterface
     public function getCollectionOperationMethod(string $resourceClass, string $operationName): string;
 
     /**
+     * Resolves the uppercased HTTP method associated with an item operation.
+     *
      * @param string $resourceClass
      * @param string $operationName
      *

--- a/src/Bridge/Doctrine/EventListener/WriteListener.php
+++ b/src/Bridge/Doctrine/EventListener/WriteListener.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Core\Bridge\Doctrine\EventListener;
 use ApiPlatform\Core\EventListener\WriteListener as BaseWriteListener;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 
 /**
@@ -58,10 +57,10 @@ final class WriteListener
         }
 
         switch ($request->getMethod()) {
-            case Request::METHOD_POST:
+            case 'POST':
                 $objectManager->persist($controllerResult);
                 break;
-            case Request::METHOD_DELETE:
+            case 'DELETE':
                 $objectManager->remove($controllerResult);
                 $event->setControllerResult(null);
                 break;

--- a/src/Bridge/FosUser/EventListener.php
+++ b/src/Bridge/FosUser/EventListener.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Core\Bridge\FosUser;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 
 /**
@@ -52,7 +51,7 @@ final class EventListener
         }
 
         switch ($request->getMethod()) {
-            case Request::METHOD_DELETE:
+            case 'DELETE':
                 $this->userManager->deleteUser($user);
                 $event->setControllerResult(null);
                 break;

--- a/src/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProvider.php
+++ b/src/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProvider.php
@@ -24,7 +24,6 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Nelmio\ApiDocBundle\Extractor\AnnotationsProviderInterface;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -140,7 +139,7 @@ final class ApiPlatformProvider implements AnnotationsProviderInterface
             $data['output'] = sprintf('%s:%s:%s', ApiPlatformParser::OUT_PREFIX, $resourceClass, $operationName);
         }
 
-        if ($collection && Request::METHOD_GET === $method) {
+        if ($collection && 'GET' === $method) {
             $resourceFilters = $resourceMetadata->getCollectionOperationAttribute($operationName, 'filters', [], true);
 
             $data['filters'] = [];

--- a/src/Bridge/Symfony/Routing/OperationMethodResolver.php
+++ b/src/Bridge/Symfony/Routing/OperationMethodResolver.php
@@ -89,7 +89,7 @@ final class OperationMethodResolver implements OperationMethodResolverInterface
         }
 
         if (null !== $method) {
-            return $method;
+            return strtoupper($method);
         }
 
         if (null === $routeName = $this->getRouteName($resourceMetadata, $operationName, $operationType)) {

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -18,7 +18,6 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use ApiPlatform\Core\Validator\EventListener\ValidateListener as MainValidateListener;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -56,7 +55,7 @@ final class ValidateListener
         $request = $event->getRequest();
         if (
             $request->isMethodSafe(false)
-            || $request->isMethod(Request::METHOD_DELETE)
+            || $request->isMethod('DELETE')
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
         ) {

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -49,10 +49,10 @@ final class DeserializeListener
         $request = $event->getRequest();
         if (
             $request->isMethodSafe(false)
-            || $request->isMethod(Request::METHOD_DELETE)
+            || $request->isMethod('DELETE')
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || ('' === ($requestContent = $request->getContent()) && $request->isMethod(Request::METHOD_PUT))
+            || ('' === ($requestContent = $request->getContent()) && $request->isMethod('PUT'))
         ) {
             return;
         }

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -93,7 +93,7 @@ final class ReadListener
      */
     private function getCollectionData(Request $request, array $attributes, array $context)
     {
-        if ($request->isMethod(Request::METHOD_POST)) {
+        if ($request->isMethod('POST')) {
             return null;
         }
 

--- a/src/EventListener/RespondListener.php
+++ b/src/EventListener/RespondListener.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\EventListener;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 
@@ -25,8 +24,8 @@ use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 final class RespondListener
 {
     const METHOD_TO_CODE = [
-        Request::METHOD_POST => Response::HTTP_CREATED,
-        Request::METHOD_DELETE => Response::HTTP_NO_CONTENT,
+        'POST' => Response::HTTP_CREATED,
+        'DELETE' => Response::HTTP_NO_CONTENT,
     ];
 
     /**

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\EventListener;
 
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 
 /**
@@ -48,12 +47,12 @@ class WriteListener
         }
 
         switch ($request->getMethod()) {
-            case Request::METHOD_PUT:
-            case Request::METHOD_PATCH:
-            case Request::METHOD_POST:
+            case 'PUT':
+            case 'PATCH':
+            case 'POST':
                 $this->dataPersister->persist($controllerResult);
                 break;
-            case Request::METHOD_DELETE:
+            case 'DELETE':
                 $this->dataPersister->remove($controllerResult);
                 $event->setControllerResult(null);
                 break;

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -69,7 +69,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         $context['operation_type'] = $operationType ?: OperationType::ITEM;
 
         if (!$normalization && !isset($context['api_allow_update'])) {
-            $context['api_allow_update'] = in_array($request->getMethod(), [Request::METHOD_PUT, Request::METHOD_PATCH], true);
+            $context['api_allow_update'] = in_array($request->getMethod(), ['PUT', 'PATCH'], true);
         }
 
         $context['resource_class'] = $attributes['resource_class'];

--- a/src/Validator/EventListener/ValidateListener.php
+++ b/src/Validator/EventListener/ValidateListener.php
@@ -17,7 +17,6 @@ use ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use ApiPlatform\Core\Validator\ValidatorInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 
 /**
@@ -46,7 +45,7 @@ final class ValidateListener
         $request = $event->getRequest();
         if (
             $request->isMethodSafe(false)
-            || $request->isMethod(Request::METHOD_DELETE)
+            || $request->isMethod('DELETE')
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
         ) {

--- a/tests/Bridge/Doctrine/EventListener/WriteListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/WriteListenerTest.php
@@ -46,7 +46,7 @@ class WriteListenerTest extends TestCase
         $writeListener = new WriteListener($managerRegistryProphecy->reveal());
         $httpKernelProphecy = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->attributes->set('_api_resource_class', 'Dummy');
         $event = new GetResponseForControllerResultEvent($httpKernelProphecy->reveal(), $request, HttpKernelInterface::MASTER_REQUEST, $dummy);
 
@@ -70,7 +70,7 @@ class WriteListenerTest extends TestCase
 
         $writeListener = new WriteListener($managerRegistryProphecy->reveal());
         $request = new Request();
-        $request->setMethod(Request::METHOD_DELETE);
+        $request->setMethod('DELETE');
         $request->attributes->set('_api_resource_class', 'Dummy');
         $event = $this->prophesize(GetResponseForControllerResultEvent::class);
         $event->setControllerResult(null)->shouldBeCalled();
@@ -93,7 +93,7 @@ class WriteListenerTest extends TestCase
         $writeListener = new WriteListener($managerRegistryProphecy->reveal());
         $httpKernelProphecy = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
-        $request->setMethod(Request::METHOD_HEAD);
+        $request->setMethod('HEAD');
         $event = new GetResponseForControllerResultEvent($httpKernelProphecy->reveal(), $request, HttpKernelInterface::MASTER_REQUEST, $dummy);
 
         $this->assertNull($writeListener->onKernelView($event));
@@ -113,7 +113,7 @@ class WriteListenerTest extends TestCase
         $writeListener = new WriteListener($managerRegistryProphecy->reveal());
         $httpKernelProphecy = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $event = new GetResponseForControllerResultEvent($httpKernelProphecy->reveal(), $request, HttpKernelInterface::MASTER_REQUEST, $dummy);
 
         $this->assertNull($writeListener->onKernelView($event));
@@ -134,7 +134,7 @@ class WriteListenerTest extends TestCase
         $writeListener = new WriteListener($managerRegistryProphecy->reveal());
         $httpKernelProphecy = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
-        $request->setMethod(Request::METHOD_DELETE);
+        $request->setMethod('DELETE');
         $request->attributes->set('_api_resource_class', 'Dummy');
         $event = new GetResponseForControllerResultEvent($httpKernelProphecy->reveal(), $request, HttpKernelInterface::MASTER_REQUEST, $dummy);
 

--- a/tests/Bridge/FosUser/EventListenerTest.php
+++ b/tests/Bridge/FosUser/EventListenerTest.php
@@ -31,7 +31,7 @@ class EventListenerTest extends TestCase
         $user = $this->prophesize(UserInterface::class);
 
         $request = new Request([], [], ['_api_resource_class' => User::class, '_api_item_operation_name' => 'delete']);
-        $request->setMethod(Request::METHOD_DELETE);
+        $request->setMethod('DELETE');
 
         $manager = $this->prophesize(UserManagerInterface::class);
         $manager->deleteUser($user)->shouldBeCalled();
@@ -50,7 +50,7 @@ class EventListenerTest extends TestCase
         $user = $this->prophesize(UserInterface::class);
 
         $request = new Request([], [], ['_api_resource_class' => User::class, '_api_item_operation_name' => 'put']);
-        $request->setMethod(Request::METHOD_PUT);
+        $request->setMethod('PUT');
 
         $manager = $this->prophesize(UserManagerInterface::class);
         $manager->updateUser($user)->shouldBeCalled();
@@ -82,7 +82,7 @@ class EventListenerTest extends TestCase
     public function testNotUser()
     {
         $request = new Request([], [], ['_api_resource_class' => User::class, '_api_item_operation_name' => 'put']);
-        $request->setMethod(Request::METHOD_PUT);
+        $request->setMethod('PUT');
 
         $manager = $this->prophesize(UserManagerInterface::class);
         $manager->deleteUser()->shouldNotBeCalled();

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
@@ -195,7 +195,7 @@ class ValidateListenerTest extends TestCase
             '_api_receive' => $receive,
         ]);
 
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $event = new GetResponseForControllerResultEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $data);
 
         return [$resourceMetadataFactory, $event];

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -34,7 +34,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['data' => new \stdClass()]);
-        $request->setMethod(Request::METHOD_GET);
+        $request->setMethod('GET');
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -52,7 +52,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'put'], [], [], [], '');
-        $request->setMethod(Request::METHOD_PUT);
+        $request->setMethod('PUT');
         $request->headers->set('Content-Type', 'application/json');
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
@@ -71,7 +71,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['data' => new \stdClass()], [], [], [], '{}');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -89,7 +89,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_receive' => false]);
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -128,7 +128,7 @@ class DeserializeListenerTest extends TestCase
 
     public function methodProvider()
     {
-        return [[Request::METHOD_POST, false], [Request::METHOD_PUT, true]];
+        return [['POST', false], ['PUT', true]];
     }
 
     public function testContentNegotiation()
@@ -136,7 +136,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post'], [], [], [], '{}');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->headers->set('Content-Type', 'text/xml');
         $request->setFormat('xml', 'text/xml'); // Workaround to avoid weird behaviors
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
@@ -164,7 +164,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post'], [], [], [], '{}');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->headers->set('Content-Type', 'application/rdf+xml');
         $request->setRequestFormat('xml');
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
@@ -192,7 +192,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post'], [], [], [], '{}');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->setRequestFormat('unknown');
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -77,7 +77,7 @@ class ReadListenerTest extends TestCase
         $subresourceDataProvider->getSubresource()->shouldNotBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_format' => 'json', '_api_mime_type' => 'application/json'], [], [], [], '{}');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
 
         $event = $this->prophesize(GetResponseEvent::class);
         $event->getRequest()->willReturn($request)->shouldBeCalled();
@@ -101,7 +101,7 @@ class ReadListenerTest extends TestCase
         $subresourceDataProvider->getSubresource()->shouldNotBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json'], [], [], ['QUERY_STRING' => 'foo=bar']);
-        $request->setMethod(Request::METHOD_GET);
+        $request->setMethod('GET');
 
         $event = $this->prophesize(GetResponseEvent::class);
         $event->getRequest()->willReturn($request)->shouldBeCalled();
@@ -125,7 +125,7 @@ class ReadListenerTest extends TestCase
         $subresourceDataProvider->getSubresource()->shouldNotBeCalled();
 
         $request = new Request([], [], ['id' => 1, '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json']);
-        $request->setMethod(Request::METHOD_GET);
+        $request->setMethod('GET');
 
         $event = $this->prophesize(GetResponseEvent::class);
         $event->getRequest()->willReturn($request)->shouldBeCalled();
@@ -149,7 +149,7 @@ class ReadListenerTest extends TestCase
         $subresourceDataProvider->getSubresource('Foo', ['id' => 1], ['identifiers' => [['id', 'Bar', true]], 'property' => 'bar'], 'get')->willReturn($data)->shouldBeCalled();
 
         $request = new Request([], [], ['id' => 1, '_api_resource_class' => 'Foo', '_api_subresource_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json', '_api_subresource_context' => ['identifiers' => [['id', 'Bar', true]], 'property' => 'bar']]);
-        $request->setMethod(Request::METHOD_GET);
+        $request->setMethod('GET');
 
         $event = $this->prophesize(GetResponseEvent::class);
         $event->getRequest()->willReturn($request)->shouldBeCalled();
@@ -173,7 +173,7 @@ class ReadListenerTest extends TestCase
         $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
 
         $request = new Request([], [], ['id' => 22, '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json']);
-        $request->setMethod(Request::METHOD_GET);
+        $request->setMethod('GET');
 
         $event = $this->prophesize(GetResponseEvent::class);
         $event->getRequest()->willReturn($request)->shouldBeCalled();

--- a/tests/EventListener/RespondListenerTest.php
+++ b/tests/EventListener/RespondListenerTest.php
@@ -68,7 +68,7 @@ class RespondListenerTest extends TestCase
         $kernelProphecy = $this->prophesize(HttpKernelInterface::class);
 
         $request = new Request([], [], ['_api_respond' => true]);
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->setRequestFormat('xml');
 
         $event = new GetResponseForControllerResultEvent(
@@ -96,7 +96,7 @@ class RespondListenerTest extends TestCase
 
         $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('xml');
-        $request->setMethod(Request::METHOD_DELETE);
+        $request->setMethod('DELETE');
 
         $event = new GetResponseForControllerResultEvent(
             $kernelProphecy->reveal(),

--- a/tests/EventListener/WriteListenerTest.php
+++ b/tests/EventListener/WriteListenerTest.php
@@ -45,7 +45,7 @@ class WriteListenerTest extends TestCase
             $dummy
         );
 
-        foreach ([Request::METHOD_PATCH, Request::METHOD_PUT, Request::METHOD_POST] as $httpMethod) {
+        foreach (['PATCH', 'PUT', 'POST'] as $httpMethod) {
             $request->setMethod($httpMethod);
 
             (new WriteListener($dataPersisterProphecy->reveal()))->onKernelView($event);
@@ -62,7 +62,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy)->shouldBeCalled();
 
         $request = new Request();
-        $request->setMethod(Request::METHOD_DELETE);
+        $request->setMethod('DELETE');
         $request->attributes->set('_api_resource_class', Dummy::class);
 
         $event = new GetResponseForControllerResultEvent(
@@ -86,7 +86,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
 
         $request = new Request();
-        $request->setMethod(Request::METHOD_HEAD);
+        $request->setMethod('HEAD');
         $request->attributes->set('_api_resource_class', Dummy::class);
 
         $event = new GetResponseForControllerResultEvent(
@@ -110,7 +110,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
 
         $request = new Request();
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
 
         $event = new GetResponseForControllerResultEvent(
             $this->prophesize(HttpKernelInterface::class)->reveal(),
@@ -133,7 +133,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
 
         $request = new Request();
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->attributes->set('_api_resource_class', 'Dummy');
 
         $event = new GetResponseForControllerResultEvent(

--- a/tests/Serializer/SerializerContextBuilderTest.php
+++ b/tests/Serializer/SerializerContextBuilderTest.php
@@ -67,12 +67,12 @@ class SerializerContextBuilderTest extends TestCase
         $expected = ['bar' => 'baz', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1'];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
-        $request = Request::create('/foos', Request::METHOD_POST);
+        $request = Request::create('/foos', 'POST');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
         $expected = ['bar' => 'baz', 'collection_operation_name' => 'post',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => false, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos'];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
-        $request = Request::create('/foos', Request::METHOD_PUT);
+        $request = Request::create('/foos', 'PUT');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'put', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
         $expected = ['bar' => 'baz', 'collection_operation_name' => 'put', 'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => true, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos'];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));

--- a/tests/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Validator/EventListener/ValidateListenerTest.php
@@ -121,7 +121,7 @@ class ValidateListenerTest extends TestCase
             '_api_receive' => $receive,
         ]);
 
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $event = new GetResponseForControllerResultEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $data);
 
         return [$resourceMetadataFactory, $event];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A
