### PR TITLE
Update ChainSubresourceDataProvider to take into account RestrictedDataProviderInterface

### DIFF
--- a/src/DataProvider/ChainSubresourceDataProvider.php
+++ b/src/DataProvider/ChainSubresourceDataProvider.php
@@ -37,12 +37,19 @@ final class ChainSubresourceDataProvider implements SubresourceDataProviderInter
      */
     public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null)
     {
-        foreach ($this->dataProviders as $dataProviders) {
+        foreach ($this->dataProviders as $dataProvider) {
             try {
-                return $dataProviders->getSubresource($resourceClass, $identifiers, $context, $operationName);
+                if ($dataProvider instanceof RestrictedDataProviderInterface && !$dataProvider->supports($resourceClass, $operationName, $context)) {
+                    continue;
+                }
+
+                return $dataProvider->getSubresource($resourceClass, $identifiers, $context, $operationName);
             } catch (ResourceClassNotSupportedException $e) {
+                @trigger_error(sprintf('Throwing a "%s" in a data provider is deprecated in favor of implementing "%s"', ResourceClassNotSupportedException::class, RestrictedDataProviderInterface::class), E_USER_DEPRECATED);
                 continue;
             }
         }
+
+        return ($context['collection'] ?? false) ? [] : null;
     }
 }

--- a/tests/DataProvider/ChainSubresourcedataProviderTest.php
+++ b/tests/DataProvider/ChainSubresourcedataProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\DataProvider;
 
 use ApiPlatform\Core\DataProvider\ChainSubresourceDataProvider;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
@@ -25,6 +26,62 @@ use PHPUnit\Framework\TestCase;
 class ChainSubresourcedataProviderTest extends TestCase
 {
     public function testGetSubresource()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('Rosa');
+        $dummy2 = new Dummy();
+        $dummy2->setName('Parks');
+
+        $context = ['identifiers' => ['id' => Dummy::class], 'property' => 'relatedDummies'];
+        $firstDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+        $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
+        $firstDataProvider->supports(Dummy::class, 'get', $context)->willReturn(false);
+        $firstDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get')->willReturn([$dummy, $dummy2])->willThrow(ResourceClassNotSupportedException::class);
+
+        $secondDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+        $secondDataProvider->willImplement(RestrictedDataProviderInterface::class);
+        $secondDataProvider->supports(Dummy::class, 'get', $context)->willReturn(true);
+        $secondDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get')->willReturn([$dummy, $dummy2]);
+
+        $thirdDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+        $thirdDataProvider->willImplement(RestrictedDataProviderInterface::class);
+        $thirdDataProvider->supports(Dummy::class, 'get', $context)->willReturn(true);
+        $thirdDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get')->willReturn([$dummy]);
+
+        $chainSubresourceDataProvider = new ChainSubresourceDataProvider([$firstDataProvider->reveal(), $secondDataProvider->reveal(), $thirdDataProvider->reveal()]);
+
+        $this->assertEquals([$dummy, $dummy2], $chainSubresourceDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get'));
+    }
+
+    public function testGetSubresourceExceptionsItem()
+    {
+        $context = ['collection' => false];
+        $firstDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+        $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
+        $firstDataProvider->supports(Dummy::class, 'get', $context)->willReturn(false);
+
+        $chainSubresourceDataProvider = new ChainSubresourceDataProvider([$firstDataProvider->reveal()]);
+
+        $this->assertNull($chainSubresourceDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get'));
+    }
+
+    public function testGetSubresourceExceptionsCollection()
+    {
+        $context = ['collection' => true];
+        $firstDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+        $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
+        $firstDataProvider->supports(Dummy::class, 'get', $context)->willReturn(false);
+
+        $chainSubresourceDataProvider = new ChainSubresourceDataProvider([$firstDataProvider->reveal()]);
+
+        $this->assertEquals([], $chainSubresourceDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" in a data provider is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
+     */
+    public function testLegacyGetSubresource()
     {
         $dummy = new Dummy();
         $dummy->setName('Rosa');
@@ -46,7 +103,11 @@ class ChainSubresourcedataProviderTest extends TestCase
         $this->assertEquals([$dummy, $dummy2], $chainSubresourceDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get'));
     }
 
-    public function testGetCollectionExeptions()
+    /**
+     * @group legacy
+     * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" in a data provider is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
+     */
+    public function testLegacyGetCollectionExeptions()
     {
         $firstDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
         $firstDataProvider->getSubresource('notfound', ['id' => 1], [], 'get')->willThrow(ResourceClassNotSupportedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`ChainItemDataProvider` and `ChainCollectionDataProvider` were able to handle data providers that implements `RestrictedDataProviderInterface`. 
I added the same logic for `ChainSubresourceDataProvider`.

My usecase is to create a custom `SubresourceDataProvider` that is supported only if a certain key is present in the context. 

Adding support for `RestrictedDataProviderInterface::supports()` is prettier than throwing a `ResourceClassNotSupportedException` in the `SubresourceDataProviderInterface::getSubresource()` method.

That's my first contribution to an open source project, feedbacks are welcome.