### PR TITLE
fix bc break regaring the FilterEagerLoadingExtension

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -138,7 +138,7 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
             $alias = substr($joinString, 0, $pos);
             $association = substr($joinString, $pos + 1);
             $condition = str_replace($aliases, $replacements, $joinPart->getCondition());
-            $newAlias = QueryBuilderHelper::addJoinOnce($queryBuilderClone, $queryNameGenerator, $alias, $association, $joinPart->getJoinType(), $joinPart->getConditionType(), $condition);
+            $newAlias = QueryBuilderHelper::addJoinOnce($queryBuilderClone, $queryNameGenerator, $alias, $association, $joinPart->getJoinType(), $joinPart->getConditionType(), $condition, $originAlias);
             $aliases[] = "{$joinPart->getAlias()}.";
             $replacements[] = "$newAlias.";
         }

--- a/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
@@ -30,9 +30,9 @@ final class QueryBuilderHelper
     /**
      * Adds a join to the queryBuilder if none exists.
      */
-    public static function addJoinOnce(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $association, string $joinType = null, string $conditionType = null, string $condition = null): string
+    public static function addJoinOnce(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $association, string $joinType = null, string $conditionType = null, string $condition = null, string $originAlias = null): string
     {
-        $join = self::getExistingJoin($queryBuilder, $alias, $association);
+        $join = self::getExistingJoin($queryBuilder, $alias, $association, $originAlias);
 
         if (null !== $join) {
             return $join->getAlias();
@@ -55,10 +55,10 @@ final class QueryBuilderHelper
      *
      * @return Join|null
      */
-    private static function getExistingJoin(QueryBuilder $queryBuilder, string $alias, string $association)
+    private static function getExistingJoin(QueryBuilder $queryBuilder, string $alias, string $association, string $originAlias = null)
     {
         $parts = $queryBuilder->getDQLPart('join');
-        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $rootAlias = $originAlias ?? $queryBuilder->getRootAliases()[0];
 
         if (!isset($parts[$rootAlias])) {
             return null;

--- a/tests/Bridge/Doctrine/Orm/Util/QueryBuilderHelperTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryBuilderHelperTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Util;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryBuilderHelper;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+class QueryBuilderHelperTest extends TestCase
+{
+    /**
+     * @dataProvider provideAddJoinOnce
+     *
+     * @param string|null $originAlias
+     */
+    public function testAddJoinOnce(string $originAliasForJoinOnce = null, string $expectedAlias)
+    {
+        $queryBuilder = new QueryBuilder($this->prophesize(EntityManagerInterface::class)->reveal());
+        $queryBuilder->from('foo', 'f');
+        $queryBuilder->from('foo', 'f2');
+        $queryBuilder->join('f.bar', 'b');
+        $queryBuilder->join('f2.bar', 'b2');
+
+        $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
+
+        QueryBuilderHelper::addJoinOnce(
+            $queryBuilder,
+            $queryNameGenerator->reveal(),
+            $originAliasForJoinOnce ?? 'f',
+            'bar',
+            null,
+            null,
+            null,
+            $originAliasForJoinOnce
+        );
+
+        $this->assertSame($expectedAlias,
+            $queryBuilder->getDQLPart('join')[$originAliasForJoinOnce ?? 'f'][0]->getAlias());
+    }
+
+    public function provideAddJoinOnce(): array
+    {
+        return [
+            [
+                null,
+                'b',
+            ],
+            [
+                'f2',
+                'b2',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`$queryBuilder->getRootAliases()[0]` is not working in the case of the FilterEagerLoadingExtension because it uses subquery and the first root alias is not necessarily the one we want
