### PR TITLE
Fix a BC break introduced by #1547

### DIFF
--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -513,7 +513,7 @@ Feature: Relations support
     """
 
   @dropSchema
-  Scenario: Issue #1547 Passing wrong argument to a relation
+  Scenario: Passing an invalid IRI to a relation
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/relation_embedders" with body:
     """
@@ -524,8 +524,11 @@ Feature: Relations support
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON node "hydra:description" should contain "Expected IRI or nested document"
+    And the JSON node "hydra:description" should contain "Invalid value provided (invalid IRI?)."
 
+  @wip
+  @dropSchema
+  Scenario: Passing an invalid type to a relation
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/relation_embedders" with body:
     """
@@ -536,4 +539,4 @@ Feature: Relations support
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON node "hydra:description" should contain "Expected IRI or nested document"
+    And the JSON node "hydra:description" should contain "Invalid value provided (invalid IRI?)."

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -160,6 +160,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = [])
     {
+        if (!\is_string($attribute)) {
+            throw new InvalidArgumentException('Invalid value provided (invalid IRI?).');
+        }
+
         $propertyMetadata = $this->propertyMetadataFactory->create($context['resource_class'], $attribute, $this->getFactoryOptions($context));
         $type = $propertyMetadata->getType();
 
@@ -299,7 +303,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if (
             !$this->resourceClassResolver->isResourceClass($className) ||
-            ($propertyMetadata->isWritableLink() && \is_array($value))
+            $propertyMetadata->isWritableLink()
         ) {
             $context['resource_class'] = $className;
             $context['api_allow_update'] = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

A normalizer can work on any data type, not only on arrays. This PR reverts a BC break introduced in #1547  preventing non arrays to be normalized, and provides an alternative fix.

ping @jdeniau @ymarillet