### PR TITLE
[GraphQL] Embedded entities support for mutations

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -106,6 +106,22 @@ Feature: GraphQL mutation support
     And the JSON node "data.createDummy.arrayData[1]" should be equal to baz
     And the JSON node "data.createDummy.clientMutationId" should be equal to "myId"
 
+  Scenario: Create an item with an embedded field
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createRelatedDummy(input: {_id: 2, symfony: "symfony", embeddedDummy: {dummyName: "Embedded"}, clientMutationId: "myId"}) {
+        id
+        clientMutationId
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createRelatedDummy.id" should be equal to "/related_dummies/2"
+    And the JSON node "data.createRelatedDummy.clientMutationId" should be equal to "myId"
+
   Scenario: Delete an item through a mutation
     When I send the following GraphQL request:
     """

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -122,6 +122,28 @@ Feature: GraphQL mutation support
     And the JSON node "data.createRelatedDummy.id" should be equal to "/related_dummies/2"
     And the JSON node "data.createRelatedDummy.clientMutationId" should be equal to "myId"
 
+  Scenario: Create an item and update a nested resource through a mutation
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createRelationEmbedder(input: {paris: "paris", krondstadt: "Krondstadt", anotherRelated: {id: 2, symfony: "laravel"}, clientMutationId: "myId"}) {
+        id
+        anotherRelated {
+          id
+          symfony
+        }
+        clientMutationId
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createRelationEmbedder.id" should be equal to "/relation_embedders/1"
+    And the JSON node "data.createRelationEmbedder.anotherRelated.id" should be equal to "/related_dummies/2"
+    And the JSON node "data.createRelationEmbedder.anotherRelated.symfony" should be equal to "laravel"
+    And the JSON node "data.createRelationEmbedder.clientMutationId" should be equal to "myId"
+
   Scenario: Delete an item through a mutation
     When I send the following GraphQL request:
     """

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -23,13 +23,14 @@ namespace ApiPlatform\Core\GraphQl\Serializer;
 
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
+use ApiPlatform\Core\Serializer\ItemNormalizer as GenericItemNormalizer;
 
 /**
  * GraphQL normalizer.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+final class ItemNormalizer extends GenericItemNormalizer
 {
     const FORMAT = 'graphql';
     const ITEM_KEY = '#item';
@@ -39,7 +40,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = parent::normalize($object, $format, $context);
+        $data = AbstractItemNormalizer::normalize($object, $format, $context);
         $data[self::ITEM_KEY] = serialize($object); // calling serialize prevent weird normalization process done by Webonyx's GraphQL PHP
 
         return $data;

--- a/src/GraphQl/Type/Definition/InputUnionType.php
+++ b/src/GraphQl/Type/Definition/InputUnionType.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type\Definition;
+
+use GraphQL\Error\Error;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\LeafType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Utils\Utils;
+
+/**
+ * Represents an union of other input types.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class InputUnionType extends Type implements InputType, LeafType
+{
+    /**
+     * @var InputObjectType[]
+     */
+    private $types;
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @throws InvariantViolation
+     */
+    public function __construct(array $config)
+    {
+        if (!isset($config['name'])) {
+            $config['name'] = $this->tryInferName();
+        }
+
+        Utils::assertValidName($config['name']);
+
+        $this->name = $config['name'];
+        $this->description = $config['description'] ?? null;
+        $this->config = $config;
+    }
+
+    /**
+     * @throws InvariantViolation
+     *
+     * @return InputObjectType[]
+     */
+    public function getTypes(): array
+    {
+        if (null !== $this->types) {
+            return $this->types;
+        }
+
+        if (($types = $this->config['types'] ?? null) && \is_callable($types)) {
+            $types = \call_user_func($this->config['types']);
+        }
+
+        if (!\is_array($types)) {
+            throw new InvariantViolation(
+                "{$this->name} types must be an Array or a callable which returns an Array."
+            );
+        }
+
+        return $this->types = $types;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertValid()
+    {
+        parent::assertValid();
+
+        $types = $this->getTypes();
+        Utils::invariant(\count($types) > 0, "{$this->name} types must not be empty");
+
+        $includedTypeNames = [];
+        foreach ($types as $inputType) {
+            Utils::invariant(
+                $inputType instanceof InputType,
+                "{$this->name} may only contain input types, it cannot contain: %s.",
+                Utils::printSafe($inputType)
+            );
+            Utils::invariant(
+                !isset($includedTypeNames[$inputType->name]),
+                "{$this->name} can include {$inputType->name} type only once."
+            );
+            $includedTypeNames[$inputType->name] = true;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws InvariantViolation
+     */
+    public function serialize($value)
+    {
+        foreach ($this->getTypes() as $type) {
+            if ($type instanceof LeafType) {
+                try {
+                    return $type->serialize($value);
+                } catch (\Exception $e) {
+                }
+            }
+        }
+
+        throw new InvariantViolation(sprintf('Types in union cannot represent value: %s', Utils::printSafe($value)));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws Error
+     */
+    public function parseValue($value)
+    {
+        foreach ($this->getTypes() as $type) {
+            if ($type instanceof LeafType) {
+                try {
+                    return $type->parseValue($value);
+                } catch (\Exception $e) {
+                }
+            }
+        }
+
+        throw new Error(sprintf('Types in union cannot represent value: %s', Utils::printSafeJson($value)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseLiteral($valueNode)
+    {
+        foreach ($this->getTypes() as $type) {
+            if ($type instanceof LeafType && null !== $parsed = $type->parseLiteral($valueNode)) {
+                return $parsed;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isValidValue($value): bool
+    {
+        foreach ($this->getTypes() as $type) {
+            if ($type instanceof LeafType && $type->isValidValue($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isValidLiteral($valueNode): bool
+    {
+        foreach ($this->getTypes() as $type) {
+            if ($type instanceof LeafType && $type->isValidLiteral($valueNode)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -18,9 +18,11 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
 /**
  * Generic item normalizer.
  *
+ * @final
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+class ItemNormalizer extends AbstractItemNormalizer
 {
     /**
      * {@inheritdoc}

--- a/tests/GraphQl/Type/Definition/InputUnionTypeTest.php
+++ b/tests/GraphQl/Type/Definition/InputUnionTypeTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Type\Definition;
+
+use ApiPlatform\Core\GraphQl\Type\Definition\InputUnionType;
+use GraphQL\Error\Error;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Type\Definition\LeafType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\StringType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class InputUnionTypeTest extends TestCase
+{
+    public function testGetTypesNotSet()
+    {
+        $inputUnionType = new InputUnionType([]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage('InputUnion types must be an Array or a callable which returns an Array.');
+
+        $inputUnionType->getTypes();
+    }
+
+    public function testGetTypesInvalid()
+    {
+        $inputUnionType = new InputUnionType(['types' => 1]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage('InputUnion types must be an Array or a callable which returns an Array.');
+
+        $inputUnionType->getTypes();
+    }
+
+    public function testGetTypesCallable()
+    {
+        $inputUnionType = new InputUnionType(['types' => function () {
+            return ['foo'];
+        }]);
+
+        $this->assertEquals(['foo'], $inputUnionType->getTypes());
+    }
+
+    public function testGetTypes()
+    {
+        $inputUnionType = new InputUnionType(['types' => ['bar']]);
+
+        $this->assertEquals(['bar'], $inputUnionType->getTypes());
+    }
+
+    public function testAssertValidEmptyTypes()
+    {
+        $inputUnionType = new InputUnionType(['types' => []]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage('InputUnion types must not be empty');
+
+        $inputUnionType->assertValid();
+    }
+
+    public function testAssertValidNotInputObjectTypes()
+    {
+        $inputUnionType = new InputUnionType(['types' => ['foo']]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage('InputUnion may only contain input types, it cannot contain: "foo".');
+
+        $inputUnionType->assertValid();
+    }
+
+    public function testAssertValidDuplicateTypes()
+    {
+        $type = $this->prophesize(StringType::class)->reveal();
+        $inputUnionType = new InputUnionType(['types' => [$type, $type]]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage('InputUnion can include String type only once.');
+
+        $inputUnionType->assertValid();
+    }
+
+    public function testSerializeNotLeafType()
+    {
+        $type = $this->prophesize(ObjectType::class)->reveal();
+        $inputUnionType = new InputUnionType(['types' => [$type]]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage('Types in union cannot represent value: "foo"');
+
+        $inputUnionType->serialize('foo');
+    }
+
+    public function testSerialize()
+    {
+        $type = $this->prophesize(LeafType::class);
+        $type->serialize('foo')->shouldBeCalled();
+        $inputUnionType = new InputUnionType(['types' => [$type->reveal()]]);
+
+        $inputUnionType->serialize('foo');
+    }
+
+    public function testParseValueNotLeafType()
+    {
+        $type = $this->prophesize(ObjectType::class)->reveal();
+        $inputUnionType = new InputUnionType(['types' => [$type]]);
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Types in union cannot represent value: "foo"');
+
+        $inputUnionType->parseValue('foo');
+    }
+
+    public function testParseValue()
+    {
+        $type = $this->prophesize(LeafType::class);
+        $type->parseValue('foo')->shouldBeCalled();
+        $inputUnionType = new InputUnionType(['types' => [$type->reveal()]]);
+
+        $inputUnionType->parseValue('foo');
+    }
+
+    public function testParseLiteralNotLeafType()
+    {
+        $type = $this->prophesize(ObjectType::class)->reveal();
+        $inputUnionType = new InputUnionType(['types' => [$type]]);
+
+        $this->assertNull($inputUnionType->parseLiteral(new StringValueNode(['value' => 'foo'])));
+    }
+
+    public function testParseLiteral()
+    {
+        $type = $this->prophesize(LeafType::class);
+        $node = new StringValueNode(['value' => 'foo']);
+        $type->parseLiteral($node)->shouldBeCalled();
+        $inputUnionType = new InputUnionType(['types' => [$type->reveal()]]);
+
+        $inputUnionType->parseLiteral($node);
+    }
+
+    public function testIsValidValueNotLeafType()
+    {
+        $type = $this->prophesize(ObjectType::class)->reveal();
+        $inputUnionType = new InputUnionType(['types' => [$type]]);
+
+        $this->assertFalse($inputUnionType->isValidValue('foo'));
+    }
+
+    public function testIsValidValueInvalid()
+    {
+        $type = $this->prophesize(LeafType::class);
+        $type->isValidValue('foo')->willReturn(false)->shouldBeCalled();
+        $inputUnionType = new InputUnionType(['types' => [$type->reveal()]]);
+
+        $this->assertFalse($inputUnionType->isValidValue('foo'));
+    }
+
+    public function testIsValidValue()
+    {
+        $type = $this->prophesize(LeafType::class);
+        $type->isValidValue('foo')->willReturn(true)->shouldBeCalled();
+        $inputUnionType = new InputUnionType(['types' => [$type->reveal()]]);
+
+        $this->assertTrue($inputUnionType->isValidValue('foo'));
+    }
+
+    public function testIsValidLiteralNotLeafType()
+    {
+        $type = $this->prophesize(ObjectType::class)->reveal();
+        $inputUnionType = new InputUnionType(['types' => [$type]]);
+
+        $this->assertFalse($inputUnionType->isValidLiteral(new StringValueNode(['value' => 'foo'])));
+    }
+
+    public function testIsValidLiteralInvalid()
+    {
+        $type = $this->prophesize(LeafType::class);
+        $node = new StringValueNode(['value' => 'foo']);
+        $type->isValidLiteral($node)->willReturn(false)->shouldBeCalled();
+        $inputUnionType = new InputUnionType(['types' => [$type->reveal()]]);
+
+        $this->assertFalse($inputUnionType->isValidLiteral($node));
+    }
+
+    public function testIsValidLiteral()
+    {
+        $type = $this->prophesize(LeafType::class);
+        $node = new StringValueNode(['value' => 'foo']);
+        $type->isValidLiteral($node)->willReturn(true)->shouldBeCalled();
+        $inputUnionType = new InputUnionType(['types' => [$type->reveal()]]);
+
+        $this->assertTrue($inputUnionType->isValidLiteral($node));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1750
| License       | MIT
| Doc PR        |

TODO:
- [x] Unit tests

Add a new InputUnionType to allow using either an IRI or data for relations.
It allows to modify embedded entities or to update a related existing resource (#1363).