### PR TITLE
add context subresource_resources to cache key hash

### DIFF
--- a/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
+++ b/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
@@ -39,7 +39,8 @@ final class CachedRouteNameResolver implements RouteNameResolverInterface
      */
     public function getRouteName(string $resourceClass, $operationType /**, array $context = []**/): string
     {
-        $cacheKey = self::CACHE_KEY_PREFIX.md5(serialize([$resourceClass, $operationType]));
+        $context = \func_num_args() > 2 ? func_get_arg(2) : [];
+        $cacheKey = self::CACHE_KEY_PREFIX.md5(serialize([$resourceClass, $operationType, $context['subresource_resources'] ?? null]));
 
         try {
             $cacheItem = $this->cacheItemPool->getItem($cacheKey);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1769 
| License       | MIT
| Doc PR        | N/A

This makes sure that if the same resource class is used as a sub resource on multiple other entities, the cache keys do not collide. Code comes from 2.2, but works in 2.1 with all tests passing.