### PR TITLE
Backport: fix route name resolver cache with subresources

### DIFF
--- a/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
+++ b/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
@@ -39,7 +39,8 @@ final class CachedRouteNameResolver implements RouteNameResolverInterface
      */
     public function getRouteName(string $resourceClass, $operationType /**, array $context = []**/): string
     {
-        $cacheKey = self::CACHE_KEY_PREFIX.md5(serialize([$resourceClass, $operationType]));
+        $context = \func_num_args() > 2 ? func_get_arg(2) : [];
+        $cacheKey = self::CACHE_KEY_PREFIX.md5(serialize([$resourceClass, $operationType, $context['subresource_resources'] ?? null]));
 
         try {
             $cacheItem = $this->cacheItemPool->getItem($cacheKey);


### PR DESCRIPTION
Prefering a cherry-pick of 3b53ff2e9041697b8a182beb21dd4ef4b29c3542
https://github.com/api-platform/core/pull/1770
https://github.com/api-platform/core/issues/1769