### PR TITLE
Allow to deactivate fetch join collection

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -144,7 +144,7 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
      */
     public function getResult(QueryBuilder $queryBuilder, string $resourceClass = null, string $operationName = null, array $context = [])
     {
-        $doctrineOrmPaginator = new DoctrineOrmPaginator($queryBuilder, $this->useFetchJoinCollection($queryBuilder));
+        $doctrineOrmPaginator = new DoctrineOrmPaginator($queryBuilder, $this->useFetchJoinCollection($queryBuilder, $resourceClass, $operationName));
         $doctrineOrmPaginator->setUseOutputWalkers($this->useOutputWalkers($queryBuilder));
 
         $resourceMetadata = null === $resourceClass ? null : $this->resourceMetadataFactory->create($resourceClass);
@@ -193,14 +193,20 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
      * Determines whether the Paginator should fetch join collections, if the root entity uses composite identifiers it should not.
      *
      * @see https://github.com/doctrine/doctrine2/issues/2910
-     *
-     * @param QueryBuilder $queryBuilder
-     *
-     * @return bool
      */
-    private function useFetchJoinCollection(QueryBuilder $queryBuilder): bool
+    private function useFetchJoinCollection(QueryBuilder $queryBuilder, string $resourceClass = null, string $operationName = null): bool
     {
-        return !QueryChecker::hasRootEntityWithCompositeIdentifier($queryBuilder, $this->managerRegistry);
+        if (QueryChecker::hasRootEntityWithCompositeIdentifier($queryBuilder, $this->managerRegistry)) {
+            return false;
+        }
+
+        if (null === $resourceClass) {
+            return true;
+        }
+
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+
+        return  $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_fetch_join_collection', true, true);
     }
 
     /**

--- a/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -424,6 +424,14 @@ class PaginationExtensionTest extends TestCase
         $this->assertInstanceOf(PaginatorInterface::class, $result);
     }
 
+    public function testGetResultWithoutFetchJoinCollection()
+    {
+        $result = $this->getPaginationExtensionResult(false, false, false);
+
+        $this->assertInstanceOf(PartialPaginatorInterface::class, $result);
+        $this->assertInstanceOf(PaginatorInterface::class, $result);
+    }
+
     public function testGetResultWithPartial()
     {
         $result = $this->getPaginationExtensionResult(true);
@@ -440,7 +448,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertInstanceOf(PaginatorInterface::class, $result);
     }
 
-    private function getPaginationExtensionResult(bool $partial = false, bool $legacy = false)
+    private function getPaginationExtensionResult(bool $partial = false, bool $legacy = false, bool $fetchJoinCollection = true)
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['partial' => $partial]));
@@ -448,7 +456,7 @@ class PaginationExtensionTest extends TestCase
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
 
         if (!$legacy) {
-            $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], ['pagination_partial' => false, 'pagination_client_partial' => true]))->shouldBeCalled();
+            $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], ['pagination_partial' => false, 'pagination_client_partial' => true, 'pagination_fetch_join_collection' => $fetchJoinCollection]))->shouldBeCalled();
         }
 
         $configuration = new Configuration();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Having this option by default is a good choice since it offers better and more accurate perfomance in many situations. However there is some cases when having the fetch join collection counter productive : like many items retrieved for a simple query without join, as it forces to have 2 queries (first the disctinct, then an IN queries which is worst for performance in heavy table)

This commit allow users to set use fetch join collection to false (it still is true by default) in their resource / operation attributes for those special cases.

### Todo

 * [x] Test (not sure if it's doable)
 * [x] Docs