### PR TITLE
Serializer listener performance - anonymous class not serializable

### DIFF
--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\EventListener;
 
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Serializer\ResourceList;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -59,11 +60,7 @@ final class SerializeListener
         }
 
         $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
-        $resources = new class() extends \ArrayObject {
-            public function serialize()
-            {
-            }
-        };
+        $resources = new ResourceList();
         $context['resources'] = &$resources;
         $request->attributes->set('_api_normalization_context', $context);
 

--- a/src/Serializer/ResourceList.php
+++ b/src/Serializer/ResourceList.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Serializer;
+
+/**
+ * @internal
+ */
+class ResourceList extends \ArrayObject
+{
+    public function serialize()
+    {
+    }
+}

--- a/tests/EventListener/SerializeListenerTest.php
+++ b/tests/EventListener/SerializeListenerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\EventListener;
 
 use ApiPlatform\Core\EventListener\SerializeListener;
+use ApiPlatform\Core\Serializer\ResourceList;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -105,11 +106,22 @@ class SerializeListenerTest extends TestCase
     {
         $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'collection_operation_name' => 'get'];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize(Argument::any(), 'xml', Argument::that(function ($context) use ($expectedContext) {
-            unset($context['resources']);
 
-            return $context === $expectedContext;
-        }))->willReturn('bar')->shouldBeCalled();
+        $serializerProphecy
+            ->serialize(
+                Argument::any(),
+                'xml',
+                Argument::allOf(
+                    Argument::that(function (array $context) {
+                        return $context['resources'] instanceof ResourceList;
+                    }),
+                    Argument::withEntry('request_uri', ''),
+                    Argument::withEntry('resource_class', 'Foo'),
+                    Argument::withEntry('collection_operation_name', 'get')
+                )
+            )
+            ->willReturn('bar')
+            ->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get']);
         $request->setRequestFormat('xml');
@@ -130,11 +142,21 @@ class SerializeListenerTest extends TestCase
     {
         $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'item_operation_name' => 'get'];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize(Argument::any(), 'xml', Argument::that(function ($context) use ($expectedContext) {
-            unset($context['resources']);
-
-            return $context === $expectedContext;
-        }))->willReturn('bar')->shouldBeCalled();
+        $serializerProphecy
+            ->serialize(
+                Argument::any(),
+                'xml',
+                Argument::allOf(
+                    Argument::that(function (array $context) {
+                        return $context['resources'] instanceof ResourceList;
+                    }),
+                    Argument::withEntry('request_uri', ''),
+                    Argument::withEntry('resource_class', 'Foo'),
+                    Argument::withEntry('item_operation_name', 'get')
+                )
+            )
+            ->willReturn('bar')
+            ->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
         $request->setRequestFormat('xml');

--- a/tests/Serializer/ResourceListTest.php
+++ b/tests/Serializer/ResourceListTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Serializer;
+
+use ApiPlatform\Core\Serializer\ResourceList;
+use PHPUnit\Framework\TestCase;
+
+class ResourceListTest extends TestCase
+{
+    /**
+     * @var ResourceList
+     */
+    private $resourceList;
+
+    public function setUp()
+    {
+        $this->resourceList = new ResourceList();
+    }
+
+    public function testImplementsArrayObject()
+    {
+        $this->assertInstanceOf(\ArrayObject::class, $this->resourceList);
+    }
+
+    public function testSerialize()
+    {
+        $this->resourceList['foo'] = 'bar';
+
+        $this->assertEquals('N;', \serialize($this->resourceList));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1307
| License       | MIT
| Doc PR        | 

In #1307, an anonymous class was introduced to fix a performance problem but it introduced another.

In these `ItemNormalizers`:
https://github.com/api-platform/core/blob/master/src/Hal/Serializer/ItemNormalizer.php#L219
https://github.com/api-platform/core/blob/master/src/JsonApi/Serializer/ItemNormalizer.php#L337

the context is serialized to produce a cache key, but anonymous classes are not serializable: https://3v4l.org/tvMGa.
This effectively disables the intended caching in the HAL and Json API item normalizers.

Blackfire comparison for a HAL endpoint returning 500 items
https://blackfire.io/profiles/compare/8994c0b0-8a09-4ae7-9c38-dd8ad72ecc22/graph

11% improvement.