### PR TITLE
Fix Cached identifiers extractor support for stringable identifers.

### DIFF
--- a/src/Api/CachedIdentifiersExtractor.php
+++ b/src/Api/CachedIdentifiersExtractor.php
@@ -76,6 +76,11 @@ final class CachedIdentifiersExtractor implements IdentifiersExtractorInterface
                 continue;
             }
 
+            if (method_exists($identifiers[$propertyName], '__toString')) {
+                $identifiers[$propertyName] = (string) $identifiers[$propertyName];
+                continue;
+            }
+
             $relatedResourceClass = $this->getObjectClass($identifiers[$propertyName]);
             if (!$relatedIdentifiers = $this->localCache[$relatedResourceClass] ?? false) {
                 $relatedCacheKey = self::CACHE_KEY_PREFIX.md5($relatedResourceClass);

--- a/tests/Api/CachedIdentifiersExtractorTest.php
+++ b/tests/Api/CachedIdentifiersExtractorTest.php
@@ -81,7 +81,7 @@ class CachedIdentifiersExtractorTest extends TestCase
         $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy), 'Trigger the local cache');
     }
 
-    public function testSecondPassWithRelatedNotCached()
+    public function testFirstPassWithRelated()
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
         $keyRelated = 'iri_identifiers'.md5(RelatedDummy::class);
@@ -114,7 +114,7 @@ class CachedIdentifiersExtractorTest extends TestCase
         $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy), 'Trigger the local cache');
     }
 
-    public function testSecondPassWithRelatedCached()
+    public function testSecondPassWithRelated()
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
         $keyRelated = 'iri_identifiers'.md5(RelatedDummy::class);

--- a/tests/Api/IdentifiersExtractorTest.php
+++ b/tests/Api/IdentifiersExtractorTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Doctrine\Generator\Uuid;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use PHPUnit\Framework\TestCase;
@@ -76,6 +77,18 @@ class IdentifiersExtractorTest extends TestCase
         $dummy->setId(1);
 
         $this->assertEquals(['id' => 1], $identifiersExtractor->getIdentifiersFromItem($dummy));
+    }
+
+    public function testGetStringableIdentifiersFromItem()
+    {
+        list($propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy) = $this->getMetadataFactoryProphecies(Dummy::class, ['id']);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal());
+
+        $dummy = new Dummy();
+        $dummy->setId(new Uuid());
+
+        $this->assertEquals(['id' => 'foo'], $identifiersExtractor->getIdentifiersFromItem($dummy));
     }
 
     public function testGetCompositeIdentifiersFromItem()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

#1101 introduced support for string castable identifier, which was later refactored to `IdentifiersExtractorInterface`, but the support was not maintained in the `CachedIdentifiersExtractor`.

My app uses ramsey uuids for identifiers, and I noticed caching not working here. Using object identifiers effectively disabled the caching of the `CachedIdentifiersExtractor`, making it call the decorated `IdentifiersExtractor` every time.

This change results in a 20% performance boost for my app with an endpoint returning 500 resources:
https://blackfire.io/profiles/compare/0ff6fc7d-afe1-4303-80c3-5a584a933239/graph
