### PR TITLE
Persist data in Doctrine DataPersister only if needed

### DIFF
--- a/src/Bridge/Doctrine/Common/DataPersister.php
+++ b/src/Bridge/Doctrine/Common/DataPersister.php
@@ -51,7 +51,10 @@ final class DataPersister implements DataPersisterInterface
             return;
         }
 
-        $manager->persist($data);
+        if (!$manager->contains($data)) {
+            $manager->persist($data);
+        }
+
         $manager->flush();
         $manager->refresh($data);
     }

--- a/tests/Bridge/Doctrine/Common/DataPersisterTest.php
+++ b/tests/Bridge/Doctrine/Common/DataPersisterTest.php
@@ -48,7 +48,24 @@ class DataPersisterTest extends TestCase
         $dummy = new Dummy();
 
         $objectManagerProphecy = $this->prophesize(ObjectManager::class);
+        $objectManagerProphecy->contains($dummy)->willReturn(false);
         $objectManagerProphecy->persist($dummy)->shouldBeCalled();
+        $objectManagerProphecy->flush()->shouldBeCalled();
+        $objectManagerProphecy->refresh($dummy)->shouldBeCalled();
+
+        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
+        $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($objectManagerProphecy->reveal())->shouldBeCalled();
+
+        (new DataPersister($managerRegistryProphecy->reveal()))->persist($dummy);
+    }
+
+    public function testPersistIfEntityAlreadyManaged()
+    {
+        $dummy = new Dummy();
+
+        $objectManagerProphecy = $this->prophesize(ObjectManager::class);
+        $objectManagerProphecy->contains($dummy)->willReturn(true);
+        $objectManagerProphecy->persist($dummy)->shouldNotBeCalled();
         $objectManagerProphecy->flush()->shouldBeCalled();
         $objectManagerProphecy->refresh($dummy)->shouldBeCalled();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Fix a BC in 2.2.
In 2.1, a `persist` was made **only** on a POST.
In 2.2, the call is also made on a PUT or a PATCH.
See the difference:
- https://github.com/api-platform/core/blob/2.1/src/Bridge/Doctrine/EventListener/WriteListener.php#L57
- https://github.com/api-platform/core/blob/2.2/src/EventListener/WriteListener.php#L49

This PR fix this BC by making the call only when needed, when the entity is not already managed (see http://www.doctrine-project.org/api/orm/2.5/class-Doctrine.ORM.EntityManager.html#_contains).
This BC could result in some issues if changes are done outside the persisted entity: the call to `persist` overrides the changes.