### PR TITLE
[GraphQL] Fix update mutation when ID can be denormalized

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -106,7 +106,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.createDummy.arrayData[1]" should be equal to baz
     And the JSON node "data.createDummy.clientMutationId" should be equal to "myId"
 
-  @dropSchema
   Scenario: Delete an item through a mutation
     When I send the following GraphQL request:
     """
@@ -123,7 +122,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.deleteFoo.id" should be equal to "/foos/1"
     And the JSON node "data.deleteFoo.clientMutationId" should be equal to "anotherId"
 
-  @createSchema
   @dropSchema
   Scenario: Delete an item with composite identifiers through a mutation
     Given there are Composite identifier objects
@@ -143,7 +141,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.deleteCompositeRelation.clientMutationId" should be equal to "myId"
 
   @createSchema
-  @dropSchema
   Scenario: Modify an item through a mutation
     Given there are 1 dummy objects
     When I send the following GraphQL request:
@@ -167,7 +164,6 @@ Feature: GraphQL mutation support
     And the JSON node "data.updateDummy.dummyDate" should be equal to "2018-06-05T00:00:00+00:00"
     And the JSON node "data.updateDummy.clientMutationId" should be equal to "myId"
 
-  @createSchema
   Scenario: Modify an item with composite identifiers through a mutation
     Given there are Composite identifier objects
     When I send the following GraphQL request:

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -145,14 +145,15 @@ Feature: GraphQL mutation support
   @createSchema
   @dropSchema
   Scenario: Modify an item through a mutation
-    Given there are 1 foo objects with fake names
+    Given there are 1 dummy objects
     When I send the following GraphQL request:
     """
     mutation {
-      updateFoo(input: {id: "/foos/1", bar: "Modified description.", clientMutationId: "myId"}) {
+      updateDummy(input: {id: "/dummies/1", description: "Modified description.", dummyDate: "2018-06-05", clientMutationId: "myId"}) {
         id
         name
-        bar
+        description
+        dummyDate
         clientMutationId
       }
     }
@@ -160,10 +161,11 @@ Feature: GraphQL mutation support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.updateFoo.id" should be equal to "/foos/1"
-    And the JSON node "data.updateFoo.name" should be equal to "Hawsepipe"
-    And the JSON node "data.updateFoo.bar" should be equal to "Modified description."
-    And the JSON node "data.updateFoo.clientMutationId" should be equal to "myId"
+    And the JSON node "data.updateDummy.id" should be equal to "/dummies/1"
+    And the JSON node "data.updateDummy.name" should be equal to "Dummy #1"
+    And the JSON node "data.updateDummy.description" should be equal to "Modified description."
+    And the JSON node "data.updateDummy.dummyDate" should be equal to "2018-06-05T00:00:00+00:00"
+    And the JSON node "data.updateDummy.clientMutationId" should be equal to "myId"
 
   @createSchema
   Scenario: Modify an item with composite identifiers through a mutation

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -85,6 +85,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
             switch ($operationName) {
                 case 'create':
                 case 'update':
+                    unset($args['input']['id']);
                     $context = null === $item ? ['resource_class' => $resourceClass] : ['resource_class' => $resourceClass, 'object_to_populate' => $item];
                     $item = $this->normalizer->denormalize($args['input'], $resourceClass, ItemNormalizer::FORMAT, $context);
                     $this->validate($item, $info, $resourceMetadata, $operationName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Fix an issue in update mutations, when an ID can be denormalized.
For instance, in `Dummy` entity, since there is `setId` method, an update cannot be done.
The error is the following:
`The type of the "id" attribute must be "int", "string" given.`
The first commit is the failing test.
Maybe we also need to add the possibility to change the ID (using `_id` argument)?