### PR TITLE
Convert the route prefix attribute name to snake case

### DIFF
--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -193,7 +193,7 @@ final class ApiLoader extends Loader
             }
         }
 
-        $path = trim(trim($resourceMetadata->getAttribute('routePrefix', '')), '/');
+        $path = trim(trim($resourceMetadata->getAttribute('route_prefix', '')), '/');
         $path .= $this->operationPathResolver->resolveOperationPath($resourceShortName, $operation, $operationType, $operationName);
 
         $route = new Route(

--- a/tests/Annotation/AnnotatedClass.php
+++ b/tests/Annotation/AnnotatedClass.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *     itemOperations={"foo"={"bar"}},
  *     collectionOperations={"bar"={"foo"}},
  *     graphql={"query"={"normalization_context"={"groups"={"foo", "bar"}}}},
- *     attributes={"foo"="bar", "routePrefix"="/whatever"},
+ *     attributes={"foo"="bar", "route_prefix"="/whatever"},
  * )
  *
  * @author Marcus Speight <marcus@pmconnect.co.uk>

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -51,6 +51,6 @@ class ApiResourceTest extends TestCase
         $this->assertSame('http://example.com/res', $resource->iri);
         $this->assertSame(['bar' => ['foo']], $resource->collectionOperations);
         $this->assertSame(['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]], $resource->graphql);
-        $this->assertSame(['foo' => 'bar', 'routePrefix' => '/whatever'], $resource->attributes);
+        $this->assertSame(['foo' => 'bar', 'route_prefix' => '/whatever'], $resource->attributes);
     }
 }

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -106,7 +106,7 @@ class ApiLoaderTest extends TestCase
             'put' => ['method' => 'PUT'],
             'delete' => ['method' => 'DELETE'],
         ]);
-        $resourceMetadata = $resourceMetadata->withAttributes(['routePrefix' => '/foobar-prefix']);
+        $resourceMetadata = $resourceMetadata->withAttributes(['route_prefix' => '/foobar-prefix']);
 
         $routeCollection = $this->getApiLoaderWithResourceMetadata($resourceMetadata)->load(null);
 

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -43,7 +43,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $this->assertEquals(['foo' => ['bar' => true]], $metadata->getItemOperations());
         $this->assertEquals(['baz' => ['tab' => false]], $metadata->getCollectionOperations());
         $this->assertEquals(['sub' => ['bus' => false]], $metadata->getSubresourceOperations());
-        $this->assertEquals(['a' => 1, 'routePrefix' => '/foobar'], $metadata->getAttributes());
+        $this->assertEquals(['a' => 1, 'route_prefix' => '/foobar'], $metadata->getAttributes());
         $this->assertEquals(['foo' => 'bar'], $metadata->getGraphql());
     }
 
@@ -56,7 +56,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $annotation->itemOperations = ['foo' => ['bar' => true]];
         $annotation->collectionOperations = ['baz' => ['tab' => false]];
         $annotation->subresourceOperations = ['sub' => ['bus' => false]];
-        $annotation->attributes = ['a' => 1, 'routePrefix' => '/foobar'];
+        $annotation->attributes = ['a' => 1, 'route_prefix' => '/foobar'];
         $annotation->graphql = ['foo' => 'bar'];
 
         $reader = $this->prophesize(Reader::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Indeed, all our attributes use snake case except this one.

cc @Toflar
