### PR TITLE
Serializer Property Metadata should not overwrite readableLink/writableLink

### DIFF
--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -101,9 +101,6 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
      */
     private function transformLinkStatus(PropertyMetadata $propertyMetadata, array $normalizationGroups = null, array $denormalizationGroups = null): PropertyMetadata
     {
-        $propertyMetadata = $propertyMetadata->withReadableLink(true);
-        $propertyMetadata = $propertyMetadata->withWritableLink(true);
-
         // No need to check link status if property is not readable and not writable
         if (false === $propertyMetadata->isReadable() && false === $propertyMetadata->isWritable()) {
             return $propertyMetadata;
@@ -129,8 +126,12 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
 
         $relatedGroups = $this->getResourceSerializerGroups($relatedClass);
 
-        $propertyMetadata = $propertyMetadata->withReadableLink(null !== $normalizationGroups && !empty(array_intersect($normalizationGroups, $relatedGroups)));
-        $propertyMetadata = $propertyMetadata->withWritableLink(null !== $denormalizationGroups && !empty(array_intersect($denormalizationGroups, $relatedGroups)));
+        if (null === $propertyMetadata->isReadableLink()) {
+            $propertyMetadata = $propertyMetadata->withReadableLink(null !== $normalizationGroups && !empty(array_intersect($normalizationGroups, $relatedGroups)));
+        }
+        if (null === $propertyMetadata->isWritableLink()) {
+            $propertyMetadata = $propertyMetadata->withWritableLink(null !== $denormalizationGroups && !empty(array_intersect($denormalizationGroups, $relatedGroups)));
+        }
 
         return $propertyMetadata;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ????
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Note: I have not updated tests to discuss this first.

Background:
Take a look at this gist:
https://gist.github.com/bendavies/f1895a4089035d754b099d7b69a04c39

What I have is an Entity with a self referencing relation `parent`.

What I want to serialize (`desired.json`) is the `parent` in `_links`, but not in `_embedded`. 

I have tried to do this by explicitly setting `readableLink` to false, but this is overwritten by `SerializerPropertyMetadataFactory` because the serialization group currently takes priority.

What should take priority, `ApiResource` annotations or serializations groups?
If it is serialization groups (as it currently is), is it possible to achieve my desired output without writing a custom normalizer?

Discussed on slack with @dunglas, but bringing the discussion here.