### PR TITLE
Allow a POST request to have an empty body

### DIFF
--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -47,12 +47,16 @@ final class DeserializeListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
+        $method = $request->getMethod();
         if (
             $request->isMethodSafe(false)
-            || $request->isMethod('DELETE')
+            || 'DELETE' === $method
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || ('' === ($requestContent = $request->getContent()) && $request->isMethod('PUT'))
+            || (
+                    '' === ($requestContent = $request->getContent())
+                    && ('POST' === $method || 'PUT' === $method)
+               )
         ) {
             return;
         }

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -47,12 +47,15 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testDoNotCallWhenPutAndEmptyRequestContent()
+    /**
+     * @dataProvider allowedEmptyRequestMethodsProvider
+     */
+    public function testDoNotCallWhenSendingAndEmptyRequestContent($method)
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
         $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'put'], [], [], [], '');
-        $request->setMethod('PUT');
+        $request->setMethod($method);
         $request->headers->set('Content-Type', 'application/json');
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
@@ -64,6 +67,11 @@ class DeserializeListenerTest extends TestCase
 
         $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), self::FORMATS);
         $listener->onKernelRequest($eventProphecy->reveal());
+    }
+
+    public function allowedEmptyRequestMethodsProvider()
+    {
+        return [['PUT'], ['POST']];
     }
 
     public function testDoNotCallWhenRequestNotManaged()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | somehow
| BC breaks?    | maybe?
| Deprecations? | no
| Tests pass?   | dunno yet
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Hi, 

A POST request with an empty body and a content-type set to json throw a `syntax error` exception at deserialization.

This PR propose to allow empty content for POST request (just like empty content for `PUT` is already ok).

Didn’t find any strong indication to forbid empty post request by a quick search.

see also: http://lists.w3.org/Archives/Public/ietf-http-wg/2010JulSep/0272.html


(note, will write test if the idea is accepted ;) )
```json
{
    "@context": "/api/v2/contexts/Error",
    "@type": "hydra:Error",
    "hydra:title": "An error occurred",
    "hydra:description": "Syntax error",
    "trace": [
        {
            "namespace": "",
            "short_class": "",
            "class": "",
            "type": "",
            "function": "",
            "file": "/var/www/w2c/api/vendor/symfony/serializer/Encoder/JsonDecode.php",
            "line": 78,
            "args": []
        },
        …
    ]
}```