### PR TITLE
Fallback attributes in the @ApiResource annotation

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Annotation;
 
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use Doctrine\Common\Util\Inflector;
+
 /**
  * ApiResource annotation.
  *
@@ -20,9 +23,58 @@ namespace ApiPlatform\Core\Annotation;
  *
  * @Annotation
  * @Target({"CLASS"})
+ * @Attributes(
+ *     @Attribute("accessControl", type="string"),
+ *     @Attribute("accessControlMessage", type="string"),
+ *     @Attribute("attributes", type="array"),
+ *     @Attribute("collectionOperations", type="array"),
+ *     @Attribute("denormalizationContext", type="array"),
+ *     @Attribute("description", type="string"),
+ *     @Attribute("fetchPartial", type="bool"),
+ *     @Attribute("forceEager", type="bool"),
+ *     @Attribute("filters", type="string[]"),
+ *     @Attribute("graphql", type="array"),
+ *     @Attribute("iri", type="string"),
+ *     @Attribute("itemOperations", type="array"),
+ *     @Attribute("maximumItemsPerPage", type="int"),
+ *     @Attribute("normalizationContext", type="array"),
+ *     @Attribute("order", type="array"),
+ *     @Attribute("paginationClientEnabled", type="bool"),
+ *     @Attribute("paginationClientItemsPerPage", type="bool"),
+ *     @Attribute("paginationClientPartial", type="bool"),
+ *     @Attribute("paginationEnabled", type="bool"),
+ *     @Attribute("paginationFetchJoinCollection", type="bool"),
+ *     @Attribute("paginationItemsPerPage", type="int"),
+ *     @Attribute("paginationPartial", type="bool"),
+ *     @Attribute("routePrefix", type="string"),
+ *     @Attribute("shortName", type="string"),
+ *     @Attribute("subresourceOperations", type="array"),
+ *     @Attribute("validationGroups", type="mixed")
+ * )
  */
 final class ApiResource
 {
+    const ATTRIBUTES = [
+        'accessControl',
+        'accessControlMessage',
+        'denormalizationContext',
+        'fetchPartial',
+        'forceEager',
+        'filters',
+        'maximumItemsPerPage',
+        'normalizationContext',
+        'order',
+        'paginationClientEnabled',
+        'paginationClientItemsPerPage',
+        'paginationClientPartial',
+        'paginationEnabled',
+        'paginationFetchJoinCollection',
+        'paginationItemsPerPage',
+        'paginationPartial',
+        'routePrefix',
+        'validationGroups',
+    ];
+
     /**
      * @var string
      */
@@ -62,4 +114,25 @@ final class ApiResource
      * @var array
      */
     public $attributes = [];
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(array $values = [])
+    {
+        if (isset($values['attributes'])) {
+            $this->attributes = $values['attributes'];
+            unset($values['attributes']);
+        }
+
+        foreach ($values as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->$key = $value;
+            } elseif (\in_array($key, self::ATTRIBUTES, true)) {
+                $this->attributes += [Inflector::tableize($key) => $value];
+            } else {
+                throw new InvalidArgumentException(sprintf('Unknown property "%s" on annotation "%s".', $key, self::class));
+            }
+        }
+    }
 }

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -54,27 +54,6 @@ use Doctrine\Common\Util\Inflector;
  */
 final class ApiResource
 {
-    const ATTRIBUTES = [
-        'accessControl',
-        'accessControlMessage',
-        'denormalizationContext',
-        'fetchPartial',
-        'forceEager',
-        'filters',
-        'maximumItemsPerPage',
-        'normalizationContext',
-        'order',
-        'paginationClientEnabled',
-        'paginationClientItemsPerPage',
-        'paginationClientPartial',
-        'paginationEnabled',
-        'paginationFetchJoinCollection',
-        'paginationItemsPerPage',
-        'paginationPartial',
-        'routePrefix',
-        'validationGroups',
-    ];
-
     /**
      * @var string
      */
@@ -116,6 +95,132 @@ final class ApiResource
     public $attributes = [];
 
     /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $accessControl;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $accessControlMessage;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $denormalizationContext;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $fetchPartial;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $forceEager;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string[]
+     */
+    private $filters;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var int
+     */
+    private $maximumItemsPerPage;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $normalizationContext;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $order;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationClientEnabled;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationClientItemsPerPage;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationClientPartial;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationEnabled;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationFetchJoinCollection;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var int
+     */
+    private $paginationItemsPerPage;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var int
+     */
+    private $paginationPartial;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $routePrefix;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var mixed
+     */
+    private $validationGroups;
+
+    /**
      * @throws InvalidArgumentException
      */
     public function __construct(array $values = [])
@@ -126,12 +231,16 @@ final class ApiResource
         }
 
         foreach ($values as $key => $value) {
-            if (property_exists($this, $key)) {
-                $this->$key = $value;
-            } elseif (\in_array($key, self::ATTRIBUTES, true)) {
-                $this->attributes += [Inflector::tableize($key) => $value];
-            } else {
+            if (!property_exists($this, $key)) {
                 throw new InvalidArgumentException(sprintf('Unknown property "%s" on annotation "%s".', $key, self::class));
+            }
+
+            $property = new \ReflectionProperty($this, $key);
+
+            if ($property->isPublic()) {
+                $this->$key = $value;
+            } else {
+                $this->attributes += [Inflector::tableize($key) => $value];
             }
         }
     }

--- a/tests/Annotation/AnnotatedClass.php
+++ b/tests/Annotation/AnnotatedClass.php
@@ -24,6 +24,9 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *     collectionOperations={"bar"={"foo"}},
  *     graphql={"query"={"normalization_context"={"groups"={"foo", "bar"}}}},
  *     attributes={"foo"="bar", "route_prefix"="/whatever"},
+ *     routePrefix="/foo",
+ *     accessControl="has_role('ROLE_FOO')",
+ *     accessControlMessage="You are not foo."
  * )
  *
  * @author Marcus Speight <marcus@pmconnect.co.uk>

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Annotation;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\AnnotatedClass;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 
@@ -99,5 +100,18 @@ class ApiResourceTest extends TestCase
             'access_control' => "has_role('ROLE_FOO')",
             'access_control_message' => 'You are not foo.',
         ], $resource->attributes);
+    }
+
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Unknown property "invalidAttribute" on annotation "ApiPlatform\Core\Annotation\ApiResource".
+     */
+    public function testConstructWithInvalidAttribute()
+    {
+        new ApiResource([
+            'shortName' => 'shortName',
+            'routePrefix' => '/foo',
+            'invalidAttribute' => 'exception',
+        ]);
     }
 }

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -22,23 +22,65 @@ use PHPUnit\Framework\TestCase;
  */
 class ApiResourceTest extends TestCase
 {
-    public function testAssignation()
+    public function testConstruct()
     {
-        $resource = new ApiResource();
-        $resource->shortName = 'shortName';
-        $resource->description = 'description';
-        $resource->iri = 'http://example.com/res';
-        $resource->itemOperations = ['foo' => ['bar']];
-        $resource->collectionOperations = ['bar' => ['foo']];
-        $resource->graphql = ['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]];
-        $resource->attributes = ['foo' => 'bar'];
+        $resource = new ApiResource([
+            'accessControl' => 'has_role("ROLE_FOO")',
+            'accessControlMessage' => 'You are not foo.',
+            'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux']],
+            'collectionOperations' => ['bar' => ['foo']],
+            'denormalizationContext' => ['groups' => ['foo']],
+            'description' => 'description',
+            'fetchPartial' => true,
+            'forceEager' => false,
+            'filters' => ['foo', 'bar'],
+            'graphql' => ['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]],
+            'iri' => 'http://example.com/res',
+            'itemOperations' => ['foo' => ['bar']],
+            'maximumItemsPerPage' => 42,
+            'normalizationContext' => ['groups' => ['bar']],
+            'order' => ['foo', 'bar' => 'ASC'],
+            'paginationClientEnabled' => true,
+            'paginationClientItemsPerPage' => true,
+            'paginationClientPartial' => true,
+            'paginationEnabled' => true,
+            'paginationFetchJoinCollection' => true,
+            'paginationItemsPerPage' => 42,
+            'paginationPartial' => true,
+            'routePrefix' => '/foo',
+            'shortName' => 'shortName',
+            'subresourceOperations' => [],
+            'validationGroups' => ['foo', 'bar'],
+        ]);
 
         $this->assertSame('shortName', $resource->shortName);
         $this->assertSame('description', $resource->description);
         $this->assertSame('http://example.com/res', $resource->iri);
+        $this->assertSame(['foo' => ['bar']], $resource->itemOperations);
         $this->assertSame(['bar' => ['foo']], $resource->collectionOperations);
+        $this->assertSame([], $resource->subresourceOperations);
         $this->assertSame(['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]], $resource->graphql);
-        $this->assertSame(['foo' => 'bar'], $resource->attributes);
+        $this->assertEquals([
+            'access_control' => 'has_role("ROLE_FOO")',
+            'access_control_message' => 'You are not foo.',
+            'denormalization_context' => ['groups' => ['foo']],
+            'fetch_partial' => true,
+            'foo' => 'bar',
+            'force_eager' => false,
+            'filters' => ['foo', 'bar'],
+            'maximum_items_per_page' => 42,
+            'normalization_context' => ['groups' => ['bar']],
+            'order' => ['foo', 'bar' => 'ASC'],
+            'pagination_client_enabled' => true,
+            'pagination_client_items_per_page' => true,
+            'pagination_client_partial' => true,
+            'pagination_enabled' => true,
+            'pagination_fetch_join_collection' => true,
+            'pagination_items_per_page' => 42,
+            'pagination_partial' => true,
+            'route_prefix' => '/foo',
+            'validation_groups' => ['baz', 'qux'],
+        ], $resource->attributes);
     }
 
     public function testApiResourceAnnotation()
@@ -51,6 +93,11 @@ class ApiResourceTest extends TestCase
         $this->assertSame('http://example.com/res', $resource->iri);
         $this->assertSame(['bar' => ['foo']], $resource->collectionOperations);
         $this->assertSame(['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]], $resource->graphql);
-        $this->assertSame(['foo' => 'bar', 'route_prefix' => '/whatever'], $resource->attributes);
+        $this->assertEquals([
+            'foo' => 'bar',
+            'route_prefix' => '/whatever',
+            'access_control' => "has_role('ROLE_FOO')",
+            'access_control_message' => 'You are not foo.',
+        ], $resource->attributes);
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
@@ -58,7 +58,7 @@ class AnnotationFilterPassTest extends TestCase
 
         $reader->getClassAnnotations(Argument::type(\ReflectionClass::class))->will(function ($args) {
             if (Dummy::class === $args[0]->name) {
-                return [new ApiFilter(['value' => SearchFilter::class, 'strategy' => 'exact', 'properties' => ['description', 'relatedDummy.name', 'name']]), new ApiResource(), new ApiFilter(['value' => GroupFilter::class, 'arguments' => ['parameterName' => 'foobar']])];
+                return [new ApiFilter(['value' => SearchFilter::class, 'strategy' => 'exact', 'properties' => ['description', 'relatedDummy.name', 'name']]), new ApiResource([]), new ApiFilter(['value' => GroupFilter::class, 'arguments' => ['parameterName' => 'foobar']])];
             }
 
             return [];

--- a/tests/Fixtures/AnnotatedClass.php
+++ b/tests/Fixtures/AnnotatedClass.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Annotation;
+namespace ApiPlatform\Core\Tests\Fixtures;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -49,15 +49,16 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
 
     public function getCreateDependencies()
     {
-        $annotation = new ApiResource();
-        $annotation->shortName = 'shortName';
-        $annotation->description = 'description';
-        $annotation->iri = 'http://example.com';
-        $annotation->itemOperations = ['foo' => ['bar' => true]];
-        $annotation->collectionOperations = ['baz' => ['tab' => false]];
-        $annotation->subresourceOperations = ['sub' => ['bus' => false]];
-        $annotation->attributes = ['a' => 1, 'route_prefix' => '/foobar'];
-        $annotation->graphql = ['foo' => 'bar'];
+        $annotation = new ApiResource([
+            'shortName' => 'shortName',
+            'description' => 'description',
+            'iri' => 'http://example.com',
+            'itemOperations' => ['foo' => ['bar' => true]],
+            'collectionOperations' => ['baz' => ['tab' => false]],
+            'subresourceOperations' => ['sub' => ['bus' => false]],
+            'attributes' => ['a' => 1, 'route_prefix' => '/foobar'],
+            'graphql' => ['foo' => 'bar'],
+        ]);
 
         $reader = $this->prophesize(Reader::class);
         $reader->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotation)->shouldBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This PR adds the ability to configure resource attributes directly at the first level of the `@ApiResource` annotation. This improves the DX by adding autocompletion on annotation properties with modern IDEs.

Attribute keys are normally in snake_case but we use lowerCamelCase at the first level of the `@ApiResource` annotation. So I made the choice to define them also in lowerCamelCase here but they are then normalized to snake_case.

About private properties (see the second commit), they are "virtual" because of this issue: https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112. I don't like that, so if you have a better idea, just tell me.

In the same way, what about priorities? For example, actually: `validationGroups={"foo"}, attributes={"validation_groups"={"bar"}}` = `['bar']`.
Are you agree? Or do you want `['foo']` or `['foo', 'bar']` instead? 