### PR TITLE
GraphQL: fix creating or updating an ID

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -183,6 +183,44 @@ Feature: GraphQL mutation support
     And the JSON node "data.updateCompositeRelation.value" should be equal to "Modified value."
     And the JSON node "data.updateCompositeRelation.clientMutationId" should be equal to "myId"
 
+  Scenario: Create an item with a custom UUID
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createWritableId(input: {_id: "c6b722fe-0331-48c4-a214-f81f9f1ca082", name: "Foo", clientMutationId: "m"}) {
+        id
+        _id
+        name
+        clientMutationId
+      }
+    }
+    """
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createWritableId.id" should be equal to "/writable_ids/c6b722fe-0331-48c4-a214-f81f9f1ca082"
+    And the JSON node "data.createWritableId._id" should be equal to "c6b722fe-0331-48c4-a214-f81f9f1ca082"
+    And the JSON node "data.createWritableId.name" should be equal to "Foo"
+    And the JSON node "data.createWritableId.clientMutationId" should be equal to "m"
+
+  Scenario: Update an item with a custom UUID
+    When I send the following GraphQL request:
+    """
+    mutation {
+      updateWritableId(input: {id: "/writable_ids/c6b722fe-0331-48c4-a214-f81f9f1ca082", _id: "f8a708b2-310f-416c-9aef-b1b5719dfa47", name: "Foo", clientMutationId: "m"}) {
+        id
+        _id
+        name
+        clientMutationId
+      }
+    }
+    """
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.updateWritableId.id" should be equal to "/writable_ids/f8a708b2-310f-416c-9aef-b1b5719dfa47"
+    And the JSON node "data.updateWritableId._id" should be equal to "f8a708b2-310f-416c-9aef-b1b5719dfa47"
+    And the JSON node "data.updateWritableId.name" should be equal to "Foo"
+    And the JSON node "data.updateWritableId.clientMutationId" should be equal to "m"
+
   @dropSchema
   Scenario: Trigger a validation error
     When I send the following GraphQL request:

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -86,6 +86,10 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                 case 'create':
                 case 'update':
                     unset($args['input']['id']);
+                    if (isset($args['input']['_id'])) {
+                        $args['input']['id'] = $args['input']['_id'];
+                    }
+
                     $context = null === $item ? ['resource_class' => $resourceClass] : ['resource_class' => $resourceClass, 'object_to_populate' => $item];
                     $item = $this->normalizer->denormalize($args['input'], $resourceClass, ItemNormalizer::FORMAT, $context);
                     $this->validate($item, $info, $resourceMetadata, $operationName);

--- a/tests/Fixtures/TestBundle/Entity/WritableId.php
+++ b/tests/Fixtures/TestBundle/Entity/WritableId.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @ApiResource
+ * @ORM\Entity
+ */
+class WritableId
+{
+    /**
+     * @ORM\Id
+     * @Assert\Uuid
+     * @ORM\Column(type="guid")
+     */
+    public $id;
+
+    /**
+     * @ORM\Column
+     */
+    public $name;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently, it's not possible to set or update an ID (in the case where it is not autogenerated).
This PR fixes this bug.