### PR TITLE
Fix identifier cache

### DIFF
--- a/src/Api/IdentifiersExtractor.php
+++ b/src/Api/IdentifiersExtractor.php
@@ -32,12 +32,18 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
     private $propertyNameCollectionFactory;
     private $propertyMetadataFactory;
     private $propertyAccessor;
+    private $resourceClassResolver;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, PropertyAccessorInterface $propertyAccessor = null)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, PropertyAccessorInterface $propertyAccessor = null, ResourceClassResolverInterface $resourceClassResolver = null)
     {
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
+        $this->resourceClassResolver = $resourceClassResolver;
+
+        if (null === $this->resourceClassResolver) {
+            @trigger_error(sprintf('Not injecting %s in the CachedIdentifiersExtractor might introduce cache issues with object identifiers.', ResourceClassResolverInterface::class), E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -68,14 +74,19 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
             if (null === $identifier || false === $identifier) {
                 continue;
             }
+
             $identifier = $identifiers[$propertyName] = $this->propertyAccessor->getValue($item, $propertyName);
+
             if (!\is_object($identifier)) {
                 continue;
-            } elseif (method_exists($identifier, '__toString')) {
-                $identifiers[$propertyName] = (string) $identifier;
+            }
+
+            $relatedResourceClass = $this->getObjectClass($identifier);
+
+            if (null !== $this->resourceClassResolver && !$this->resourceClassResolver->isResourceClass($relatedResourceClass)) {
                 continue;
             }
-            $relatedResourceClass = $this->getObjectClass($identifier);
+
             $relatedItem = $identifier;
             unset($identifiers[$propertyName]);
             foreach ($this->propertyNameCollectionFactory->create($relatedResourceClass) as $relatedPropertyName) {

--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -28,6 +28,7 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
     use ClassInfoTrait;
 
     private $resourceNameCollectionFactory;
+    private $localIsResourceClassCache = [];
 
     public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory)
     {
@@ -69,12 +70,16 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
      */
     public function isResourceClass(string $type): bool
     {
+        if (isset($this->localIsResourceClassCache[$type])) {
+            return $this->localIsResourceClassCache[$type];
+        }
+
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
             if ($type === $resourceClass) {
-                return true;
+                return $this->localIsResourceClassCache[$type] = true;
             }
         }
 
-        return false;
+        return $this->localIsResourceClassCache[$type] = false;
     }
 }

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -217,12 +217,14 @@
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
         </service>
 
         <service id="api_platform.identifiers_extractor.cached" class="ApiPlatform\Core\Api\CachedIdentifiersExtractor" decorates="api_platform.identifiers_extractor" public="false">
             <argument type="service" id="api_platform.cache.identifiers_extractor" />
             <argument type="service" id="api_platform.identifiers_extractor.cached.inner" />
             <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
         </service>
 
         <!-- Subresources -->

--- a/tests/Api/CachedIdentifiersExtractorTest.php
+++ b/tests/Api/CachedIdentifiersExtractorTest.php
@@ -29,16 +29,21 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedIdentifiersExtractorTest extends TestCase
 {
-    public function identifiersProvider()
+    public function itemProvider()
     {
-        yield [1, 1];
-        yield [$uuid = new Uuid(), $uuid->__toString()];
+        $dummy = new Dummy();
+        $dummy->setId($id = 1);
+        yield [$dummy, ['id' => $id]];
+
+        $dummy = new Dummy();
+        $dummy->setId($id = new Uuid());
+        yield [$dummy, ['id' => $id]];
     }
 
     /**
-     * @dataProvider identifiersProvider
+     * @dataProvider itemProvider
      */
-    public function testFirstPass($identifier, $identifierValue)
+    public function testFirstPass($item, $expected)
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
 
@@ -50,29 +55,25 @@ class CachedIdentifiersExtractorTest extends TestCase
         $cacheItemPool->getItem($key)->shouldBeCalled()->willReturn($cacheItem);
         $cacheItemPool->save($cacheItem)->shouldBeCalled();
 
-        $dummy = new Dummy();
-        $dummy->setId($identifier);
-
         $decoration = $this->prophesize(IdentifiersExtractorInterface::class);
-        $decoration->getIdentifiersFromItem($dummy)->shouldBeCalled()->willReturn(['id' => $identifierValue]);
+        $decoration->getIdentifiersFromItem($item)->shouldBeCalled()->willReturn($expected);
 
         $identifiersExtractor = new CachedIdentifiersExtractor($cacheItemPool->reveal(), $decoration->reveal(), null, $this->getResourceClassResolver());
 
-        $expectedResult = ['id' => $identifierValue];
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy));
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy), 'Trigger the local cache');
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item), 'Trigger the local cache');
 
         $decoration->getIdentifiersFromResourceClass(Dummy::class)->shouldBeCalled()->willReturn(['id']);
 
         $expectedResult = ['id'];
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromResourceClass(Dummy::class));
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromResourceClass(Dummy::class), 'Trigger the local cache');
+        $this->assertSame($expectedResult, $identifiersExtractor->getIdentifiersFromResourceClass(Dummy::class));
+        $this->assertSame($expectedResult, $identifiersExtractor->getIdentifiersFromResourceClass(Dummy::class), 'Trigger the local cache');
     }
 
     /**
-     * @dataProvider identifiersProvider
+     * @dataProvider itemProvider
      */
-    public function testSecondPass($identifier, $identifierValue)
+    public function testSecondPass($item, $expected)
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
 
@@ -83,20 +84,49 @@ class CachedIdentifiersExtractorTest extends TestCase
         $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
         $cacheItemPool->getItem($key)->shouldBeCalled()->willReturn($cacheItem);
 
-        $dummy = new Dummy();
-        $dummy->setId($identifier);
-
         $decoration = $this->prophesize(IdentifiersExtractorInterface::class);
-        $decoration->getIdentifiersFromItem($dummy)->shouldNotBeCalled();
+        $decoration->getIdentifiersFromItem($item)->shouldNotBeCalled();
 
         $identifiersExtractor = new CachedIdentifiersExtractor($cacheItemPool->reveal(), $decoration->reveal(), null, $this->getResourceClassResolver());
 
-        $expectedResult = ['id' => $identifierValue];
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy));
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy), 'Trigger the local cache');
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item), 'Trigger the local cache');
     }
 
-    public function testFirstPassWithRelated()
+    public function identifiersRelatedProvider()
+    {
+        $related = new RelatedDummy();
+        $related->setId($relatedId = 2);
+
+        $dummy = new Dummy();
+        $dummy->setId($id = 1);
+        $dummy->setRelatedDummy($related);
+
+        yield [$dummy, ['id' => $id, 'relatedDummy' => $relatedId]];
+
+        $related = new RelatedDummy();
+        $related->setId($relatedId = 1);
+
+        $dummy = new Dummy();
+        $dummy->setId($id = new Uuid());
+        $dummy->setRelatedDummy($related);
+
+        yield [$dummy, ['id' => $id, 'relatedDummy' => $relatedId]];
+
+        $related = new RelatedDummy();
+        $related->setId($relatedId = new Uuid());
+
+        $dummy = new Dummy();
+        $dummy->setId($id = new Uuid());
+        $dummy->setRelatedDummy($related);
+
+        yield [$dummy, ['id' => $id, 'relatedDummy' => $relatedId]];
+    }
+
+    /**
+     * @dataProvider identifiersRelatedProvider
+     */
+    public function testFirstPassWithRelated($item, $expected)
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
         $keyRelated = 'iri_identifiers'.md5(RelatedDummy::class);
@@ -112,24 +142,19 @@ class CachedIdentifiersExtractorTest extends TestCase
         $cacheItemPool->getItem($key)->shouldBeCalled()->willReturn($cacheItem);
         $cacheItemPool->getItem($keyRelated)->shouldBeCalled()->willReturn($cacheItemRelated);
 
-        $related = new RelatedDummy();
-        $related->setId(1);
-
-        $dummy = new Dummy();
-        $dummy->setId(1);
-        $dummy->setRelatedDummy($related);
-
         $decoration = $this->prophesize(IdentifiersExtractorInterface::class);
-        $decoration->getIdentifiersFromItem($dummy)->shouldBeCalled()->willReturn(['id' => 1, 'relatedDummy' => 1]);
+        $decoration->getIdentifiersFromItem($item)->shouldBeCalled()->willReturn($expected);
 
         $identifiersExtractor = new CachedIdentifiersExtractor($cacheItemPool->reveal(), $decoration->reveal(), null, $this->getResourceClassResolver());
 
-        $expectedResult = ['id' => 1, 'relatedDummy' => 1];
-        $this->assertEquals(['id' => 1, 'relatedDummy' => 1], $identifiersExtractor->getIdentifiersFromItem($dummy));
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy), 'Trigger the local cache');
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item), 'Trigger the local cache');
     }
 
-    public function testSecondPassWithRelated()
+    /**
+     * @dataProvider identifiersRelatedProvider
+     */
+    public function testSecondPassWithRelated($item, $expected)
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
         $keyRelated = 'iri_identifiers'.md5(RelatedDummy::class);
@@ -146,21 +171,13 @@ class CachedIdentifiersExtractorTest extends TestCase
         $cacheItemPool->getItem($key)->shouldBeCalled()->willReturn($cacheItem);
         $cacheItemPool->getItem($keyRelated)->shouldBeCalled()->willReturn($cacheItemRelated);
 
-        $related = new RelatedDummy();
-        $related->setId(1);
-
-        $dummy = new Dummy();
-        $dummy->setId(1);
-        $dummy->setRelatedDummy($related);
-
         $decoration = $this->prophesize(IdentifiersExtractorInterface::class);
-        $decoration->getIdentifiersFromItem($dummy)->shouldNotBeCalled();
+        $decoration->getIdentifiersFromItem($item)->shouldNotBeCalled();
 
         $identifiersExtractor = new CachedIdentifiersExtractor($cacheItemPool->reveal(), $decoration->reveal(), null, $this->getResourceClassResolver());
 
-        $expectedResult = ['id' => 1, 'relatedDummy' => 1];
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy));
-        $this->assertEquals($expectedResult, $identifiersExtractor->getIdentifiersFromItem($dummy), 'Trigger the local cache');
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
+        $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item), 'Trigger the local cache');
     }
 
     /**

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Api\IdentifiersExtractor;
 use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Bridge\Symfony\Routing\IriConverter;
 use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolverInterface;
@@ -60,7 +61,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $converter->getItemFromIri('/users/3');
     }
@@ -92,7 +93,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $converter->getItemFromIri('/users/3');
     }
@@ -128,7 +129,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $converter->getItemFromIri('/users/3');
     }
@@ -162,7 +163,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $converter->getItemFromIri('/users/3', ['fetch_data' => true]);
     }
@@ -191,7 +192,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $this->assertEquals($converter->getIriFromResourceClass(Dummy::class), '/dummies');
     }
@@ -224,7 +225,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $converter->getIriFromResourceClass(Dummy::class);
     }
@@ -253,7 +254,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $this->assertEquals($converter->getSubresourceIriFromResourceClass(Dummy::class, ['subresource_identifiers' => ['id' => 1], 'subresource_resources' => [RelatedDummy::class => 1]]), '/dummies/1/related_dummies');
     }
@@ -286,7 +287,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $converter->getSubresourceIriFromResourceClass(Dummy::class, ['subresource_identifiers' => ['id' => 1], 'subresource_resources' => [RelatedDummy::class => 1]]);
     }
@@ -315,7 +316,7 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $this->assertEquals($converter->getItemIriFromResourceClass(Dummy::class, ['id' => 1]), '/dummies/1');
     }
@@ -348,8 +349,18 @@ class IriConverterTest extends TestCase
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
             null,
-            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory)
+            new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver())
         );
         $converter->getItemIriFromResourceClass(Dummy::class, ['id' => 1]);
+    }
+
+    private function getResourceClassResolver()
+    {
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(Argument::type('string'))->will(function ($args) {
+            return true;
+        });
+
+        return $resourceClassResolver->reveal();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1781 (last comment)
| License       | MIT
| Doc PR        | na

My original fix https://github.com/api-platform/core/pull/1101 is wrong. Indeed when an relation Entity is an object AND has a `__toString()` method it won't be considered as relation in the file, where it should.

This is only a partial fix because https://github.com/api-platform/core/pull/1478 is the proper fix for the string issue on uuid identifiers for example. 