### PR TITLE
fix local graphql tests (again)

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -27,11 +27,11 @@ Feature: GraphQL mutation support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.__type.fields[0].name" should contain "delete"
-    And the JSON node "data.__type.fields[0].description" should match '/^Deletes a [A-z]+\.$/'
-    And the JSON node "data.__type.fields[0].type.name" should match "/^delete[A-z]+Payload$/"
+    And the JSON node "data.__type.fields[0].description" should match '/^Deletes a [A-z0-9]+\.$/'
+    And the JSON node "data.__type.fields[0].type.name" should match "/^delete[A-z0-9]+Payload$/"
     And the JSON node "data.__type.fields[0].type.kind" should be equal to "OBJECT"
     And the JSON node "data.__type.fields[0].args[0].name" should be equal to "input"
-    And the JSON node "data.__type.fields[0].args[0].type.name" should match "/^delete[A-z]+Input$/"
+    And the JSON node "data.__type.fields[0].args[0].type.name" should match "/^delete[A-z0-9]+Input$/"
     And the JSON node "data.__type.fields[0].args[0].type.kind" should be equal to "INPUT_OBJECT"
 
   Scenario: Create an item


### PR DESCRIPTION
Please be careful on trying behat suite on your environments... Second time I have to fix regexp ^^".

See #1761 

It's painful to debug travis if the local suite doesn't pass. @dunglas my guess is that the regex of travis linux aren't based on the same as the one on my local env. I don't see how it's possible if that's not the case.