### PR TITLE
[GraphQL] Fix identifiers

### DIFF
--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -85,11 +85,6 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
             switch ($operationName) {
                 case 'create':
                 case 'update':
-                    unset($args['input']['id']);
-                    if (isset($args['input']['_id'])) {
-                        $args['input']['id'] = $args['input']['_id'];
-                    }
-
                     $context = null === $item ? ['resource_class' => $resourceClass] : ['resource_class' => $resourceClass, 'object_to_populate' => $item];
                     $item = $this->normalizer->denormalize($args['input'], $resourceClass, ItemNormalizer::FORMAT, $context);
                     $this->validate($item, $info, $resourceMetadata, $operationName);

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -23,13 +23,14 @@ namespace ApiPlatform\Core\GraphQl\Serializer;
 
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
+use ApiPlatform\Core\Serializer\ItemNormalizer as BaseItemNormalizer;
 
 /**
  * GraphQL normalizer.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+final class ItemNormalizer extends BaseItemNormalizer
 {
     const FORMAT = 'graphql';
     const ITEM_KEY = '#item';
@@ -37,9 +38,17 @@ final class ItemNormalizer extends AbstractItemNormalizer
     /**
      * {@inheritdoc}
      */
+    public function supportsNormalization($data, $format = null)
+    {
+        return self::FORMAT === $format && parent::supportsNormalization($data, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = parent::normalize($object, $format, $context);
+        $data = AbstractItemNormalizer::normalize($object, $format, $context);
         $data[self::ITEM_KEY] = serialize($object); // calling serialize prevent weird normalization process done by Webonyx's GraphQL PHP
 
         return $data;
@@ -57,16 +66,35 @@ final class ItemNormalizer extends AbstractItemNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsDenormalization($data, $type, $format = null)
     {
-        return self::FORMAT === $format && parent::supportsNormalization($data, $format);
+        return self::FORMAT === $format && parent::supportsDenormalization($data, $type, $format);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    protected function getAllowedAttributes($classOrObject, array $context, $attributesAsString = false)
     {
-        return self::FORMAT === $format && parent::supportsDenormalization($data, $type, $format);
+        $allowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
+
+        if (($context['api_denormalize'] ?? false) && false !== ($indexId = array_search('id', $allowedAttributes, true))) {
+            $allowedAttributes[] = '_id';
+            array_splice($allowedAttributes, $indexId, 1);
+        }
+
+        return $allowedAttributes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = [])
+    {
+        if ('_id' === $attribute) {
+            $attribute = 'id';
+        }
+
+        parent::setAttributeValue($object, $attribute, $value, $format, $context);
     }
 }

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -18,9 +18,11 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
 /**
  * Generic item normalizer.
  *
+ * @final
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+class ItemNormalizer extends AbstractItemNormalizer
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Related to https://github.com/api-platform/core/pull/1803.

The commit https://github.com/api-platform/core/commit/d7ada1bc5a0b4f548bce061a8a9129f79c000d37 is bringing issues when merging 2.2 into master.
It's because with this commit the generic item normalizer is used instead of the abstract one.
But in 2.2 this commit https://github.com/api-platform/core/commit/4e489cd9b1b859981c4b69aaf95cfeb7a9611575#diff-3c0fe204222ffb162653db261a74ca6aR89 has begun to invert `id` with `id`.
But it's not finished and when merging 2.2 into master, it highlights the issue.

This PR is fixing it by using the normalizer instead of the mutation resolver.