### PR TITLE
Improve DX for PaginationExtension reusability

### DIFF
--- a/src/Bridge/Doctrine/Orm/Util/PaginationTrait.php
+++ b/src/Bridge/Doctrine/Orm/Util/PaginationTrait.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Util;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\AbstractPaginator;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator as DoctrineOrmPaginator;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+trait PaginationTrait
+{
+    private $managerRegistry;
+
+    /**
+     * Determines whether the Paginator should fetch join collections, if the root entity uses composite identifiers it should not.
+     *
+     * @see https://github.com/doctrine/doctrine2/issues/2910
+     *
+     * @param QueryBuilder $queryBuilder
+     *
+     * @return bool
+     */
+    private function useFetchJoinCollection(QueryBuilder $queryBuilder): bool
+    {
+        return !QueryChecker::hasRootEntityWithCompositeIdentifier($queryBuilder, $this->managerRegistry);
+    }
+
+    /**
+     * Determines whether output walkers should be used.
+     *
+     * @param QueryBuilder $queryBuilder
+     *
+     * @return bool
+     */
+    private function useOutputWalkers(QueryBuilder $queryBuilder): bool
+    {
+        /*
+         * "Cannot count query that uses a HAVING clause. Use the output walkers for pagination"
+         *
+         * @see https://github.com/doctrine/doctrine2/blob/900b55d16afdcdeb5100d435a7166d3a425b9873/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php#L50
+         */
+        if (QueryChecker::hasHavingClause($queryBuilder)) {
+            return true;
+        }
+
+        /*
+         * "Paginating an entity with foreign key as identifier only works when using the Output Walkers. Call Paginator#setUseOutputWalkers(true) before iterating the paginator."
+         *
+         * @see https://github.com/doctrine/doctrine2/blob/900b55d16afdcdeb5100d435a7166d3a425b9873/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php#L87
+         */
+        if (QueryChecker::hasRootEntityWithForeignKeyIdentifier($queryBuilder, $this->managerRegistry)) {
+            return true;
+        }
+
+        /*
+         * "Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers."
+         *
+         * @see https://github.com/doctrine/doctrine2/blob/900b55d16afdcdeb5100d435a7166d3a425b9873/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php#L149
+         */
+        if (
+            QueryChecker::hasMaxResults($queryBuilder) &&
+            QueryChecker::hasOrderByOnToManyJoin($queryBuilder, $this->managerRegistry)
+        ) {
+            return true;
+        }
+
+        /*
+         * When using composite identifiers pagination will need Output walkers
+         */
+        if (QueryChecker::hasRootEntityWithCompositeIdentifier($queryBuilder, $this->managerRegistry)) {
+            return true;
+        }
+
+        // Disable output walkers by default (performance)
+        return false;
+    }
+
+    /**
+     * Creates a new Doctrine\ORM\Tools\Pagination\Paginator from a given QueryBuilder.
+     */
+    private function getDoctrinePaginator(QueryBuilder $queryBuilder): DoctrineOrmPaginator
+    {
+        $doctrineOrmPaginator = new DoctrineOrmPaginator($queryBuilder, $this->useFetchJoinCollection($queryBuilder));
+        $doctrineOrmPaginator->setUseOutputWalkers($this->useOutputWalkers($queryBuilder));
+
+        return $doctrineOrmPaginator;
+    }
+
+    /**
+     * Use this to get an instance of ApiPlatform\Core\Bridge\Doctrine\Orm\AbstractPaginator when the pagination is partial.
+     */
+    private function getPartialPaginator(DoctrineOrmPaginator $paginator)
+    {
+        return new class($paginator) extends AbstractPaginator {
+        };
+    }
+
+    /**
+     * Creates a new ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator.
+     */
+    private function getPaginator(DoctrineOrmPaginator $paginator)
+    {
+        return new Paginator($paginator);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/core/pull/1766
| License       | MIT
| Doc PR        | todo

See my comment:
https://github.com/api-platform/core/pull/1766#issuecomment-372967730 

With this patch you could transform [the code](https://github.com/api-platform/core/pull/1766#issuecomment-372583372) (that has to copy almost 90% of the PaginationExtension) to something like:

```
<?php
class MyDataProvider implements CollectionDataProviderInterface {
    use PaginationTrait;

    public function getCollection() {
        foreach ($this->collectionExtensions as $extension) {
            $extension->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);

            // This is the last extension we will call
            if ($extension instanceof PaginationExtension && $extension->supportsResult($resourceClass, $operationName)) {
                $query = $queryBuilder->getQuery();
                // do something on the query
                $this->addTranslatableQueryHints($query);

                // We can use Query to create the paginator
                $doctrineOrmPaginator = new DoctrineOrmPaginator($query, $this->useFetchJoinCollection($queryBuilder));
                $doctrineOrmPaginator->setUseOutputWalkers($this->useOutputWalkers($queryBuilder));

                // Use the PaginationExtension public method
                if ($extension->isPartialPaginationEnabled($request, $resourceMetadata, $operationName)) {
                  return $this->getPartialPaginator($doctrineOrmPaginator);
                }

                return $this->getPaginator($doctrineOrmPaginator);
            }
        }

        $query = $queryBuilder->getQuery();
        $this->addTranslatableQueryHints($query);
        return $query->getResult();
   }
}
```
