### PR TITLE
Ask target entity for its identifier instead of hardcoding to id

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -272,7 +272,8 @@ class SearchFilter extends AbstractContextAwareFilter
 
         if ($metadata->isCollectionValuedAssociation($association)) {
             $associationAlias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $alias, $association);
-            $associationField = 'id';
+            $targetEntityMetaData = $this->getClassMetadata($metadata->getAssociationMapping($association)['targetEntity']);
+            $associationField = $targetEntityMetaData->getIdentifier()[0];
         } else {
             $associationAlias = $alias;
             $associationField = $field;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I have absolutely no clue if this is a correct fix but I wanted to open a PR here to have someone point me into the right direction. The problem is that the `SearchFilter` does an INNER JOIN for relations and adds `WHERE $associationAlias.id` hardcoded to the search query. However, my target entity does not have `id` as its identifier. I named the column `uuid`.
