### PR TITLE
Enhance Api Platform Profiler

### DIFF
--- a/src/Bridge/Symfony/Bundle/DataCollector/RequestDataCollector.php
+++ b/src/Bridge/Symfony/Bundle/DataCollector/RequestDataCollector.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DataCollector;
 
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -40,15 +41,10 @@ final class RequestDataCollector extends DataCollector
 
         $this->data = [
             'resource_class' => $resourceClass,
-            'resource_metadata' => $resourceMetadata,
-            'method' => $request->getMethod(),
+            'resource_metadata' => $resourceMetadata ? $this->cloneVar($resourceMetadata) : null,
             'acceptable_content_types' => $request->getAcceptableContentTypes(),
+            'request_attributes' => RequestAttributesExtractor::extractAttributes($request),
         ];
-    }
-
-    public function getMethod(): string
-    {
-        return $this->data['method'] ?? '';
     }
 
     public function getAcceptableContentTypes(): array
@@ -64,6 +60,11 @@ final class RequestDataCollector extends DataCollector
     public function getResourceMetadata()
     {
         return $this->data['resource_metadata'] ?? null;
+    }
+
+    public function getRequestAttributes(): array
+    {
+        return $this->data['request_attributes'] ?? [];
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
@@ -1,33 +1,9 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
-{% macro operationLine(itemOrCollection, key, operation) %}
+{% macro operationLine(key, operation, actualOperationName) %}
     <tr>
-        <td>
-            {{ key }}
-        </td>
-        <td>
-            {% if operation['method'] is defined %}
-                <em>Method:</em> {{ operation['method'] }}
-            {% elseif operation['route_name'] is defined %}
-                <em>Route name:</em> {{ operation['route_name'] }}
-            {% endif %}
-        </td>
-        <td>
-            <a
-                href="#"
-                class="sf-toggle link-inverse sf-toggle-on"
-                data-toggle-selector="#api-platform-line-{{ itemOrCollection }}-{{ key }}"
-                data-toggle-alt-content="Hide"
-                data-toggle-original-content="Show"
-            >
-                Show
-            </a>
-        </td>
-    </tr>
-    <tr id="api-platform-line-{{ itemOrCollection }}-{{ key }}">
-        <td colspan="3">
-            {{- dump(operation) -}}
-        </td>
+        <th scope="row" {{ key == actualOperationName ? 'class="status-success"' : '' }}>{{ key }}</th>
+        <td {{ key == actualOperationName ? 'class="status-success"' : '' }}>{{- profiler_dump(operation, 1) -}}</td>
     </tr>
 {% endmacro %}
 
@@ -38,19 +14,14 @@
         {{ include('@ApiPlatform/DataCollector/api-platform.svg') }}
     {% endset %}
 
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <b>Resource Class</b>
+            <span>{{ collector.resourceClass|default('Not an API Platform resource') }}</span>
+        </div>
+    {% endset %}
+
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
-{% endblock %}
-
-{% block head %}
-    {# Optional. Here you can link to or define your own CSS and JS contents. #}
-    {# Use {{ parent() }} to extend the default styles instead of overriding them. #}
-    {{ parent() }}
-
-    <style>
-        tr.sf-toggle-content.sf-toggle-visible {
-            display: table-row;
-        }
-    </style>
 {% endblock %}
 
 {% block menu %}
@@ -64,40 +35,12 @@
 {% endblock %}
 
 {% block panel %}
-    {# Optional, for showing the most details. #}
-    <h2>Acceptable Content Types</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Content Type</th>
-            </tr>
-        </thead>
-
-        <tbody>
-            {% for type in collector.acceptableContentTypes %}
-            <tr>
-                <td>{{ type }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    <table>
-        <thead>
-            <tr>
-                <th>
-                    Resource class
-                </th>
-            </tr>
-        </thead>
-
-        <tbody>
-            <tr>
-                <td>
-                    {{ collector.resourceClass|default('Not an API Platform resource') }}
-                </td>
-            <tr>
-        </tbody>
-    </table>
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.resourceClass|default('Not an API Platform resource') }}</span>
+            <span class="label">Resource class</span>
+        </div>
+    </div>
 
     {% if collector.resourceMetadata %}
         <h2>Metadata</h2>
@@ -105,13 +48,10 @@
         <table>
             <thead>
                 <tr>
-                    <th>
+                    <th scope="col" class="key">
                         Item operations
                     </th>
-                    <th>
-                        Method / Route name
-                    </th>
-                    <th>
+                    <th scope="col">
                         Attributes
                     </th>
                 </tr>
@@ -119,7 +59,7 @@
 
             <tbody>
                 {% for key, itemOperation in collector.resourceMetadata.itemOperations %}
-                    {{ apiPlatform.operationLine('item', key, itemOperation) }}
+                    {{ apiPlatform.operationLine(key, itemOperation, collector.requestAttributes.item_operation_name) }}
                 {% endfor %}
             </tbody>
         </table>
@@ -127,13 +67,10 @@
         <table>
             <thead>
                 <tr>
-                    <th>
+                    <th scope="col" class="key">
                         Collection operations
                     </th>
-                    <th>
-                        Method / Route name
-                    </th>
-                    <th>
+                    <th scope="col">
                         Attributes
                     </th>
                 </tr>
@@ -141,7 +78,7 @@
 
             <tbody>
                 {% for key, collectionOperation in collector.resourceMetadata.collectionOperations %}
-                    {{ apiPlatform.operationLine('collection', key, collectionOperation) }}
+                    {{ apiPlatform.operationLine(key, collectionOperation, collector.requestAttributes.collection_operation_name) }}
                 {% endfor %}
             </tbody>
         </table>
@@ -171,23 +108,38 @@
         <table>
             <thead>
                 <tr>
-                    <th colspan="100%">
+                    <th scope="col" class="key">
                         Attributes
                     </th>
+                    <th scope="col" colspan="100%"></th>
                 </tr>
             </thead>
 
             <tbody>
                 {% for key, value in collector.resourceMetadata.attributes if key != 'filters' %}
                     <tr>
-                        <td>
+                        <th scope="row">
                             {{ key }}
-                        </td>
+                        </th>
                         <td>
-                            <pre>
-                                {{- dump(value) -}}
-                            </pre>
+                            {{- profiler_dump(value, 2) -}}
                         </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <h2>Acceptable Content Types</h2>
+        <table>
+            <thead>
+            <tr>
+                <th>Content Type</th>
+            </tr>
+            </thead>
+
+            <tbody>
+                {% for type in collector.acceptableContentTypes %}
+                    <tr>
+                        <td>{{ type }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
@@ -2,8 +2,8 @@
 
 {% macro operationLine(key, operation, actualOperationName) %}
     <tr>
-        <th scope="row" {{ key == actualOperationName ? 'class="status-success"' : '' }}>{{ key }}</th>
-        <td {{ key == actualOperationName ? 'class="status-success"' : '' }}>{{- profiler_dump(operation, 1) -}}</td>
+        <th scope="row"{% if key == actualOperationName %} class="status-success"{% endif %}>{{ key }}</th>
+        <td{% if key == actualOperationName %} class="status-success"{% endif %}>{{- profiler_dump(operation, 1) -}}</td>
     </tr>
 {% endmacro %}
 
@@ -111,7 +111,7 @@
                     <th scope="col" class="key">
                         Attributes
                     </th>
-                    <th scope="col" colspan="100%"></th>
+                    <th scope="col" ></th>
                 </tr>
             </thead>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR aims to improve the Datacollector by : 

- Use the `profiler_dump()` function for a cleaner rendering
- Format the keys of the arrays and limit their size in the array
- Highlight the Resource class and move the Acceptable content type at the bottom
- Presents the attributes on 2 columns only
- Highlight the actual operation
- Add the resource class display from the toolbar

@jdeniau I hope this is going in the direction you initially had in mind, and that the change from 3 to 2 columns is ok, IMO mot of the time the really interesting information is/was not the method nor route name only.

I remove the request method from the collector has it was not used in the template and this information is already present in other panels...

before: 
![screenshot-2018-4-8 symfony profiler 1](https://user-images.githubusercontent.com/4977112/38468394-5e2acee8-3b45-11e8-8eba-418eb5833893.png)


after:
![screenshot-2018-4-8 symfony profiler](https://user-images.githubusercontent.com/4977112/38468395-67c364ce-3b45-11e8-8b88-16326bfba140.png)

<img width="246" alt="capture d ecran 2018-04-08 a 08 45 52" src="https://user-images.githubusercontent.com/4977112/38468413-94b9daa8-3b45-11e8-8932-804de8f126dd.png">

If people like it, I'd like then to improve the filter parts by injecting the filter locator into the dataCollector, that would allow:
 - to expose at the Filter Class at least (but maybe also attributes etc)
 - to highlight in read the filters declared that doesn't match a real filter service that are "silently ignored" today IIRC

Another idea that I have would be to display the actual result number near by the toolbar icon.
The idea would be to check if the result is a Paginator and get the total items number out of it or display 1 on an item operation. (It is sometime not quick to get this information as it stands in the bottom of the response in JSON-LD) at least