### PR TITLE
feature: allow plain identifiers in json api

### DIFF
--- a/features/jsonapi/jsonapi.feature
+++ b/features/jsonapi/jsonapi.feature
@@ -120,6 +120,46 @@ Feature: JSON API basic support
     And the JSON node "data.relationships.relatedDummies.data" should have 2 elements
     And the JSON node "data.relationships.relatedDummy.data.id" should be equal to "/related_dummies/2"
 
+  Scenario: Create a dummy with relations and plain identifiers
+    Given there is a RelatedDummy
+    When I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "data": {
+        "type": "dummy",
+        "attributes": {
+          "name": "Dummy with relations",
+          "dummyDate": "2015-03-01T10:00:00+00:00"
+        },
+        "relationships": {
+          "relatedDummy": {
+            "data": {
+              "type": "related-dummy",
+              "id": "/related_dummies/2"
+            }
+          },
+          "relatedDummies": {
+            "data": [
+              {
+                "type": "related-dummy",
+                "id": "1"
+              },
+              {
+                "type": "related-dummy",
+                "id": "2"
+              }
+            ]
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    And the JSON node "data.relationships.relatedDummies.data" should have 2 elements
+    And the JSON node "data.relationships.relatedDummy.data.id" should be equal to "/related_dummies/2"
+
   Scenario: Update a resource with a many-to-many relationship via PATCH
     When I send a "PATCH" request to "/dummies/1" with body:
     """

--- a/src/Bridge/Symfony/Bundle/Resources/config/jsonapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/jsonapi.xml
@@ -39,6 +39,8 @@
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="api_platform.jsonapi.name_converter.reserved_attribute_name" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.item_data_provider" />
+            <argument>%api_platform.allow_plain_identifiers%</argument>
 
             <tag name="serializer.normalizer" priority="8" />
         </service>

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\JsonApi\Serializer;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -40,9 +41,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
     private $componentsCache = [];
     private $resourceMetadataFactory;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ResourceMetadataFactoryInterface $resourceMetadataFactory)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ResourceMetadataFactoryInterface $resourceMetadataFactory, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, null, $itemDataProvider, $allowPlainIdentifiers);
 
         $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
@@ -160,6 +161,10 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $context['resource_class'] = $className;
 
             return $this->serializer->denormalize($value, $className, $format, $context);
+        }
+
+        if (true === $this->allowPlainIdentifiers && $this->itemDataProvider && (null !== $item = $this->itemDataProvider->getItem($className, $value['id'], null, $context + ['fetch_data' => true]))) {
+            return $item;
         }
 
         if (!\is_array($value) || !isset($value['id'], $value['type'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1833
| License       | MIT
| Doc PR        | 

This PRs allows to use "allow_plain_identifiers" in JSON API.
