### PR TITLE
Add a new `getIriFromPlainIdentifier` method and remove ItemDataProvider from AbstractItemNormalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2.3.0
 
-* Introduce a new interface `IriPlainIdentifierAwareConverterInterface`
-* Add `getIriFromPlainIdentifier` in `IriPlainIdentifierAwareConverterInterface` to be able to retrieve an iri from an ID
+* Introduce a new interface `IriToIdentifierConverterInterface`
+* Add `getIriFromPlainIdentifier` in `IriToIdentifierConverterInterface` to be able to retrieve an iri from an ID
+* IriConverter now implements `IriToIdentifierConverterInterface`
 * [deprecated] Passing an implementation of `ItemDataProviderInterface` in an implementation of `AbstractItemNormalizer` is deprecated and will be not possible in 3.0
 
 ## 2.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.0
+
+* Introduce a new interface `IriPlainIdentifierAwareConverterInterface`
+* Add `getIriFromPlainIdentifier` in `IriPlainIdentifierAwareConverterInterface` to be able to retrieve an iri from an ID
+* [deprecated] Passing an implementation of `ItemDataProviderInterface` in an implementation of `AbstractItemNormalizer` is deprecated and will be not possible in 3.0
+
 ## 2.2.5
 
 * Fix a various issues preventing the metadata cache to work properly (performance fix)

--- a/src/Api/IriPlainIdentifierAwareConverterInterface.php
+++ b/src/Api/IriPlainIdentifierAwareConverterInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Api;
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Core\Exception\RuntimeException;
+
+/**
+ * Converts a plain identifier to an IRI
+ *
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+interface IriPlainIdentifierAwareConverterInterface extends IriConverterInterface
+{
+    /**
+     * Gets the IRI associated with the given plain identifier.
+     *
+     * @param string|int|array $id
+     * @param string           $resourceClass
+     * @param int              $referenceType
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return string
+     */
+    public function getIriFromPlainIdentifier($id, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
+}

--- a/src/Api/IriToIdentifierConverterInterface.php
+++ b/src/Api/IriToIdentifierConverterInterface.php
@@ -14,20 +14,18 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Api;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use ApiPlatform\Core\Exception\ItemNotFoundException;
-use ApiPlatform\Core\Exception\RuntimeException;
 
 /**
- * Converts a plain identifier to an IRI
+ * Converts a plain identifier to an IRI.
  *
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
  */
-interface IriPlainIdentifierAwareConverterInterface extends IriConverterInterface
+interface IriToIdentifierConverterInterface
 {
     /**
      * Gets the IRI associated with the given plain identifier.
      *
-     * @param string|int|array $id
+     * @param array $id
      * @param string           $resourceClass
      * @param int              $referenceType
      *
@@ -35,5 +33,5 @@ interface IriPlainIdentifierAwareConverterInterface extends IriConverterInterfac
      *
      * @return string
      */
-    public function getIriFromPlainIdentifier($id, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
+    public function getIriFromPlainIdentifier(array $id, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
 }

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -60,7 +60,7 @@ final class IriConverter implements IriToIdentifierConverterInterface, IriConver
         $this->identifierDenormalizer = $identifierDenormalizer;
 
         if (null === $identifiersExtractor) {
-            @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3.', IdentifiersExtractorInterface::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3.', IdentifiersExtractorInterface::class), E_USER_DEPRECATED);
             $this->identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, $propertyAccessor ?? PropertyAccess::createPropertyAccessor());
         }
     }
@@ -110,11 +110,11 @@ final class IriConverter implements IriToIdentifierConverterInterface, IriConver
     /**
      * {@inheritdoc}
      */
-    public function getIriFromPlainIdentifier($id, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
+    public function getIriFromPlainIdentifier(array $id, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
         $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
         try {
-            return $this->router->generate($routeName, ['id' => \is_array($id) ? implode(';', $id) : $id], $referenceType);
+            return $this->router->generate($routeName, ['id' => implode(';', $id)], $referenceType);
         } catch (RuntimeException $e) {
             throw new InvalidArgumentException(sprintf(
                 'Unable to generate an IRI for the item of type "%s"',

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -16,9 +16,8 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 use ApiPlatform\Core\Api\IdentifiersExtractor;
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
-use ApiPlatform\Core\Api\IriPlainIdentifierAwareConverterInterface;
+use ApiPlatform\Core\Api\IriToIdentifierConverterInterface;
 use ApiPlatform\Core\Api\OperationType;
-use ApiPlatform\Core\Api\PlainIdentifierConverterInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\OperationDataProviderTrait;
@@ -42,7 +41,7 @@ use Symfony\Component\Routing\RouterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class IriConverter implements IriPlainIdentifierAwareConverterInterface
+final class IriConverter implements IriToIdentifierConverterInterface, IriConverterInterface
 {
     use ClassInfoTrait;
     use OperationDataProviderTrait;
@@ -61,7 +60,7 @@ final class IriConverter implements IriPlainIdentifierAwareConverterInterface
         $this->identifierDenormalizer = $identifierDenormalizer;
 
         if (null === $identifiersExtractor) {
-            @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3', IdentifiersExtractorInterface::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3.', IdentifiersExtractorInterface::class), E_USER_DEPRECATED);
             $this->identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, $propertyAccessor ?? PropertyAccess::createPropertyAccessor());
         }
     }
@@ -114,7 +113,6 @@ final class IriConverter implements IriPlainIdentifierAwareConverterInterface
     public function getIriFromPlainIdentifier($id, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
         $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
-
         try {
             return $this->router->generate($routeName, ['id' => \is_array($id) ? implode(';', $id) : $id], $referenceType);
         } catch (RuntimeException $e) {

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -88,7 +88,7 @@ class IriConverterTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Not injecting "ApiPlatform\Core\Api\IdentifiersExtractorInterface" is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3.
+     * @expectedDeprecation Not injecting "ApiPlatform\Core\Api\IdentifiersExtractorInterface" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3.
      * @expectedDeprecation Not injecting ApiPlatform\Core\Api\ResourceClassResolverInterface in the CachedIdentifiersExtractor might introduce cache issues with object identifiers.
      */
     public function testIdentifiersExtractorDeprecation()
@@ -113,6 +113,7 @@ class IriConverterTest extends TestCase
             $itemDataProviderProphecy->reveal(),
             $routeNameResolverProphecy->reveal(),
             $routerProphecy->reveal(),
+            null,
             null,
             null,
             $identifierDenormalizer->reveal()
@@ -254,9 +255,10 @@ class IriConverterTest extends TestCase
             $routerProphecy->reveal(),
             null,
             new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver()),
+            null,
             $identifierDenormalizer->reveal()
         );
-        $this->assertEquals($converter->getIriFromPlainIdentifier(1, Dummy::class), '/dummies/1');
+        $this->assertEquals($converter->getIriFromPlainIdentifier([1], Dummy::class), '/dummies/1');
     }
 
     /**
@@ -359,7 +361,7 @@ class IriConverterTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Not injecting "ApiPlatform\Core\Api\IdentifiersExtractorInterface" is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3.
+     * @expectedDeprecation Not injecting "ApiPlatform\Core\Api\IdentifiersExtractorInterface" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3.
      * @expectedDeprecation Not injecting ApiPlatform\Core\Api\ResourceClassResolverInterface in the CachedIdentifiersExtractor might introduce cache issues with object identifiers.
      */
     public function testLegacyConstructor()
@@ -421,9 +423,10 @@ class IriConverterTest extends TestCase
             $routerProphecy->reveal(),
             null,
             new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, null, $this->getResourceClassResolver()),
+            null,
             $identifierDenormalizer->reveal()
         );
-        $converter->getIriFromPlainIdentifier(1, Dummy::class);
+        $converter->getIriFromPlainIdentifier([1], Dummy::class);
     }
 
     /**
@@ -459,6 +462,7 @@ class IriConverterTest extends TestCase
             $routerProphecy->reveal(),
             null,
             $identifierExtractorProphecy->reveal(),
+            null,
             $identifierDenormalizer->reveal()
         );
         $converter->getIriFromItem($dummy);
@@ -466,7 +470,7 @@ class IriConverterTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Not injecting "ApiPlatform\Core\Api\IdentifiersExtractorInterface" is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3.
+     * @expectedDeprecation Not injecting "ApiPlatform\Core\Api\IdentifiersExtractorInterface" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3.
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
      * @expectedExceptionMessage Unable to generate an IRI for the item of type "ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy"
      */
@@ -495,7 +499,7 @@ class IriConverterTest extends TestCase
             $routerProphecy->reveal(),
             null
         );
-        $converter->getIriFromPlainIdentifier(1, Dummy::class);
+        $converter->getIriFromPlainIdentifier([1], Dummy::class);
     }
 
     private function getResourceClassResolver()

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -171,6 +171,8 @@ class Dummy
     public function setId($id)
     {
         $this->id = $id;
+
+        return $this;
     }
 
     public function setName($name)

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -737,9 +737,10 @@ class AbstractItemNormalizerTest extends TestCase
             return is_array($arg) && isset($arg['fetch_data']) && true === $arg['fetch_data'];
         };
 
-        $iriConverterProphecy = $this->prophesize(IriToIdentifierConverterInterface::class)->willImplement(IriConverterInterface::class);
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getItemFromIri('/related_dummies/1', Argument::that($getItemFromIriSecondArgCallback))->shouldBeCalled();
-        $iriConverterProphecy->getIriFromPlainIdentifier('1', RelatedDummy::class)->shouldBeCalled()->willReturn('/related_dummies/1');
+        $iriToIdentifierConverterProphecy = $this->prophesize(IriToIdentifierConverterInterface::class);
+        $iriToIdentifierConverterProphecy->getIriFromPlainIdentifier([1], RelatedDummy::class)->shouldBeCalled()->willReturn('/related_dummies/1');
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
@@ -758,6 +759,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             true,
+            $iriToIdentifierConverterProphecy->reveal(),
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -787,14 +789,15 @@ class AbstractItemNormalizerTest extends TestCase
             )
         )->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriToIdentifierConverterInterface::class)->willImplement(IriConverterInterface::class);
 
         $getItemFromIriSecondArgCallback = function ($arg) {
             return is_array($arg) && isset($arg['fetch_data']) && true === $arg['fetch_data'];
         };
 
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getItemFromIri('/related_dummies/1', Argument::that($getItemFromIriSecondArgCallback))->shouldBeCalled()->willThrow(new ItemNotFoundException('Item with id "1" not found for class "ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy".'));
-        $iriConverterProphecy->getIriFromPlainIdentifier('1', RelatedDummy::class)->shouldBeCalled()->willReturn('/related_dummies/1');
+        $iriToIdentifierConverterProphecy = $this->prophesize(IriToIdentifierConverterInterface::class);
+        $iriToIdentifierConverterProphecy->getIriFromPlainIdentifier([1], RelatedDummy::class)->shouldBeCalled()->willReturn('/related_dummies/1');
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
@@ -813,6 +816,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             true,
+            $iriToIdentifierConverterProphecy->reveal(),
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | multiples need to be sure
| License       | MIT
| Doc PR        | todo


As discussed with @soyuka in #1834 we should not use `ItemDataProvider` in the normalizer and the the process works totally with IRIs.

So I'm adding a new method to convert from plainIdentifiers to IRIs.
