### PR TITLE
value object as ApiResource

### DIFF
--- a/features/main/value_object.feature
+++ b/features/main/value_object.feature
@@ -1,0 +1,144 @@
+Feature: Value object as ApiResource
+  In order to keep ApiResource immutable
+  As a client software developer
+  I need to be able to use class without setters as ApiResource
+
+  @createSchema
+  Scenario: Create Value object resource
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/vo_dummy_cars" with body:
+    """
+    {
+        "mileage": 1500,
+        "bodyType": "suv",
+        "make": "CustomCar",
+        "insuranceCompany": {
+            "name": "Safe Drive Company"
+        },
+        "drivers": [
+            {
+                "firstName": "John",
+                "lastName": "Doe"
+            }
+        ]
+    }
+    """
+# TODO: add after OneToMany fix
+#        "inspections": [
+#            {
+#                "accepted": true,
+#                "performed": "2018-03-14 00:00:00"
+#            }
+#        ],
+    Then the response status code should be 201
+    And the JSON should be equal to:
+    """
+     {
+         "@context": "/contexts/VoDummyCar",
+         "@id": "/vo_dummy_cars/1",
+         "@type": "VoDummyCar",
+         "mileage": 1500,
+         "bodyType": "suv",
+         "make": "CustomCar",
+         "insuranceCompany": {
+             "@id": "/vo_dummy_insurance_companies/1",
+             "@type": "VoDummyInsuranceCompany",
+             "name": "Safe Drive Company"
+         },
+         "drivers": [
+             {
+                 "@id": "/vo_dummy_drivers/1",
+                 "@type": "VoDummyDriver",
+                 "firstName": "John",
+                 "lastName": "Doe"
+             }
+         ]
+     }
+    """
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @createSchema
+  Scenario: Create Value object without required params
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/vo_dummy_cars" with body:
+    """
+    {
+        "mileage": 1500,
+        "make": "CustomCar",
+        "insuranceCompany": {
+            "name": "Safe Drive Company"
+        }
+    }
+    """
+    Then the response status code should be 400
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "string",
+          "format": "^/contexts/Error$"
+        },
+        "type": {
+          "type": "string",
+          "format": "^hydra:Error$"
+        },
+        "hydra:title": {
+          "type": "string",
+          "format": "^An error occurred$"
+        },
+        "hydra:description": {
+          "type": "string",
+          "format": "^Cannot create an instance of ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\VoDummyCar from serialized data because its constructor requires parameter \"drivers\" to be present.$"
+        }
+      }
+    }
+    """
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @createSchema
+  Scenario: Create Value object without default param
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/vo_dummy_cars" with body:
+    """
+    {
+        "mileage": 1500,
+        "make": "CustomCar",
+        "insuranceCompany": {
+            "name": "Safe Drive Company"
+        },
+        "drivers": [
+            {
+                "firstName": "John",
+                "lastName": "Doe"
+            }
+        ]
+    }
+    """
+    Then the response status code should be 201
+    And the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/VoDummyCar",
+        "@id": "/vo_dummy_cars/1",
+        "@type": "VoDummyCar",
+        "mileage": 1500,
+        "bodyType": "coupe",
+        "make": "CustomCar",
+        "insuranceCompany": {
+            "@id": "/vo_dummy_insurance_companies/1",
+            "@type": "VoDummyInsuranceCompany",
+            "name": "Safe Drive Company"
+        },
+        "drivers": [
+            {
+                "@id": "/vo_dummy_drivers/1",
+                "@type": "VoDummyDriver",
+                "firstName": "John",
+                "lastName": "Doe"
+            }
+        ]
+    }
+    """
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -95,6 +95,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $loader->load('data_persister.xml');
         $loader->load('data_provider.xml');
         $loader->load('filter.xml');
+        $loader->load('property_info.xml');
 
         $container->registerForAutoconfiguration(DataPersisterInterface::class)
             ->addTag('api_platform.data_persister');

--- a/src/Bridge/Symfony/Bundle/Resources/config/property_info.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/property_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="false" />
+
+        <service id="api_platform.property_info.constructor_extractor" class="ApiPlatform\Core\PropertyInfo\ConstructorExtractor">
+            <tag name="property_info.access_extractor" priority="-900" />
+        </service>
+    </services>
+</container>

--- a/src/PropertyInfo/ConstructorExtractor.php
+++ b/src/PropertyInfo/ConstructorExtractor.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\PropertyInfo;
+
+use ReflectionClass;
+use ReflectionException;
+use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+
+class ConstructorExtractor implements PropertyAccessExtractorInterface
+{
+    public function isReadable($class, $property, array $context = [])
+    {
+        return;
+    }
+
+    public function isWritable($class, $property, array $context = [])
+    {
+        $constructor = (new ReflectionClass($class))->getConstructor();
+
+        if(!$constructor) {
+            return null; // give a chance for other PropertyExtractors
+        }
+
+        $constructorParameters = $constructor->getParameters();
+        foreach ($constructorParameters as $constructorParameter) {
+            if ($property === $constructorParameter->getName()) {
+                return true;
+            }
+        }
+
+        return null; // give a chance for other PropertyExtractors
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -558,6 +558,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.subresource_operation_factory.cached',
             'api_platform.serializer_locator',
             'api_platform.validator',
+            'api_platform.property_info.constructor_extractor',
         ];
 
         foreach ($definitions as $definition) {
@@ -724,6 +725,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.http_cache.purger.varnish_client',
             'api_platform.http_cache.listener.response.add_tags',
             'api_platform.validator',
+            'api_platform.property_info.constructor_extractor',
         ];
 
         foreach ($definitions as $definition) {

--- a/tests/Fixtures/TestBundle/Entity/VoDummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyCar.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource(attributes={
+ *     "normalization_context"={"groups"={"read", "write"}},
+ *     "denormalization_context"={"groups"={"write"}}
+ * })
+ * @ORM\Entity
+ */
+class VoDummyCar extends VoDummyVehicle
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @Groups({"write"})
+     */
+    private $mileage;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     * @Groups({"write"})
+     */
+    private $bodyType;
+
+//    /**
+//     * @var VoDummyInspection[]|Collection
+//     *
+//     * @ORM\OneToMany(targetEntity="VoDummyInspection", mappedBy="car", cascade={"persist"})
+//     * @Groups({"write"})
+//     */
+//    private $inspections;
+
+    public function __construct(
+        int $mileage,
+//        array $inspections,
+        string $make,
+        VoDummyInsuranceCompany $insuranceCompany,
+        array $drivers,
+        string $bodyType = 'coupe'
+    ) {
+        parent::__construct($make, $insuranceCompany, $drivers);
+        $this->mileage = $mileage;
+//        $this->inspections = new ArrayCollection($inspections);
+        $this->bodyType = $bodyType;
+    }
+
+    public function getMileage(): int
+    {
+        return $this->mileage;
+    }
+
+    public function getBodyType(): string
+    {
+        return $this->bodyType;
+    }
+
+//    public function getInspections(): Collection
+//    {
+//        return $this->inspections;
+//    }
+}

--- a/tests/Fixtures/TestBundle/Entity/VoDummyDriver.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyDriver.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class VoDummyDriver
+{
+    use VoDummyIdAwareTrait;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     * @Groups({"write"})
+     */
+    private $firstName;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     * @Groups({"write"})
+     */
+    private $lastName;
+
+    public function __construct(string $firstName, string $lastName)
+    {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/VoDummyIdAwareTrait.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyIdAwareTrait.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait VoDummyIdAwareTrait
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    protected $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/VoDummyInspection.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyInspection.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class VoDummyInspection
+{
+    use VoDummyIdAwareTrait;
+
+    /**
+     * @var boolean
+     *
+     * @ORM\Column(type="boolean")
+     * @Groups({"write"})
+     */
+    private $accepted;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(type="datetime")
+     * @Groups({"write"})
+     */
+    private $performed;
+
+//    /**
+//     * @var VoDummyCar
+//     *
+//     * @ORM\ManyToOne(targetEntity="VoDummyCar", inversedBy="inspections")
+//     * @Groups({"write"})
+//     */
+//    private $car;
+
+    public function __construct(bool $accepted, DateTime $performed/**, VoDummyCar $car**/)
+    {
+        $this->accepted = $accepted;
+        $this->performed = $performed;
+//        $this->car = $car;
+    }
+
+    public function isAccepted(): bool
+    {
+        return $this->accepted;
+    }
+
+    public function getPerformed(): DateTime
+    {
+        return $this->performed;
+    }
+
+//    public function getCar(): VoDummyCar
+//    {
+//        return $this->car;
+//    }
+}

--- a/tests/Fixtures/TestBundle/Entity/VoDummyInsuranceCompany.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyInsuranceCompany.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class VoDummyInsuranceCompany
+{
+    use VoDummyIdAwareTrait;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     * @Groups({"write"})
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/VoDummyNoConstructor.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyNoConstructor.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+class VoDummyNoConstructor
+{
+    use VoDummyIdAwareTrait;
+
+    public function setId(int $id): VoDummyNoConstructor
+    {
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/VoDummyVehicle.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyVehicle.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+abstract class VoDummyVehicle
+{
+    use VoDummyIdAwareTrait;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     * @Groups({"write"})
+     */
+    private $make;
+
+    /**
+     * @var VoDummyInsuranceCompany
+     *
+     * @ORM\ManyToOne(targetEntity="VoDummyInsuranceCompany", cascade={"persist"})
+     * @Groups({"write"})
+     */
+    private $insuranceCompany;
+
+    /**
+     * @var VoDummyDriver[]|Collection
+     *
+     * @ORM\ManyToMany(targetEntity="VoDummyDriver", cascade={"persist"})
+     * @Groups({"write"})
+     */
+    private $drivers;
+
+    public function __construct(
+        string $make,
+        VoDummyInsuranceCompany $insuranceCompany,
+        array $drivers
+    ) {
+        $this->make = $make;
+        $this->insuranceCompany = $insuranceCompany;
+        $this->drivers = new ArrayCollection($drivers);
+    }
+
+    public function getMake(): string
+    {
+        return $this->make;
+    }
+
+    public function getInsuranceCompany(): VoDummyInsuranceCompany
+    {
+        return $this->insuranceCompany;
+    }
+
+    /**
+     * @return VoDummyDriver[]|Collection
+     */
+    public function getDrivers(): Collection
+    {
+        return $this->drivers;
+    }
+}

--- a/tests/PropertyInfo/ConstructorExtractorTest.php
+++ b/tests/PropertyInfo/ConstructorExtractorTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\PropertyInfo;
+
+use ApiPlatform\Core\PropertyInfo\ConstructorExtractor;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\VoDummyCar;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\VoDummyNoConstructor;
+use PHPUnit\Framework\TestCase;
+
+class ConstructorExtractorTest extends TestCase
+{
+    /**
+     * @var ConstructorExtractor
+     */
+    private $constructorExtractor;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->constructorExtractor = new ConstructorExtractor();
+    }
+
+    public function testIsReadable()
+    {
+        $this->assertNull($this->constructorExtractor->isReadable(VoDummyCar::class, 'mileage'));
+    }
+
+    public function testIsWritable()
+    {
+        $this->assertNull($this->constructorExtractor->isWritable(VoDummyCar::class, 'id'));
+
+        $this->assertNull($this->constructorExtractor->isWritable(VoDummyNoConstructor::class, 'id'));
+
+        $this->assertTrue($this->constructorExtractor->isWritable(VoDummyCar::class, 'bodyType'));
+        $this->assertTrue($this->constructorExtractor->isWritable(VoDummyCar::class, 'drivers'));
+        $this->assertTrue($this->constructorExtractor->isWritable(VoDummyCar::class, 'drivers'));
+        $this->assertTrue($this->constructorExtractor->isWritable(VoDummyCar::class, 'insuranceCompany'));
+        $this->assertTrue($this->constructorExtractor->isWritable(VoDummyCar::class, 'make'));
+        $this->assertTrue($this->constructorExtractor->isWritable(VoDummyCar::class, 'mileage'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I'm aware that this PR still needs work, but I opened it to discuss about value objects as ApiResource.
To get the idea check behat test: https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-6af974d3c9848f846d1ee1e58d88564a and entity: https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-e1fa2952eafb66484a8db3d626ddba31
If you agree with it I'll do further work.

Found (potential) bug:
I've not hardly investigated it but it seems that `PurgeHttpCacheListener` has bug - i tries to get entity id before one is created, but not in every case - it not works on entities which I've added in this PR (`VoDummy*`). For now I commented the line which causes issue (https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-07581ee0a08a8e5193cb8a7ec890c3b7R83)

Questions:
- [ ] ConstructorExtractor (https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-71d84e71877454b3e75f141ed3b2f784) shouldn't be included in `symfony/property-access` ?
- [ ] method `instantiateObject` (https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-3e45e8e6ce08f8a7cbbbda1601d5ff29R170) is almost copied from symfony's `AbstractNormalizer` - it only adds execution of new method `prepareAttributeValue` (https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-3e45e8e6ce08f8a7cbbbda1601d5ff29R204)  - shouldn't it be included in `symfony/serializer`?

TODOS:
- [ ]  lack of required param should show violations (like validation error), not generic error (https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-6af974d3c9848f846d1ee1e58d88564aR93)
- [ ] add tests with IRI
- [ ] handle OneToMany circular (https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-6af974d3c9848f846d1ee1e58d88564aR26, https://github.com/api-platform/core/compare/master...komik966:vo-denormalizer?expand=1#diff-cb3c4ced4e06b3eb1231ca0473a03903R43)
- [ ] add documentation
- [ ] solve `PurgeHttpCacheListener` issue
