### PR TITLE
feature: improve ids management for association and fix invalid iri/uuid in SearchFilter

### DIFF
--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -20,37 +20,62 @@ Feature: Search filter on collections
     When I send a "GET" request to "/dummy_cars?colors.prop=red"
     Then the response status code should be 200
     And the JSON should be deep equal to:
-    """
+		"""
     {
-        "@context": "/contexts/DummyCar",
-        "@id": "/dummy_cars",
-        "@type": "hydra:Collection",
-        "hydra:member": [
+      "@context": "/contexts/DummyCar",
+      "@id": "/dummy_cars",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/dummy_cars/1",
+          "@type": "DummyCar",
+          "colors": [
             {
-                "@id": "/dummy_cars/1",
-                "@type": "DummyCar",
-                "colors": [
-                    {
-                        "@id": "/dummy_car_colors/1",
-                        "@type": "DummyCarColor",
-                        "prop": "red"
-                    },
-                    {
-                        "@id": "/dummy_car_colors/2",
-                        "@type": "DummyCarColor",
-                        "prop": "blue"
-                    }
-                ]
+              "@id": "/dummy_car_colors/1",
+              "@type": "DummyCarColor",
+              "prop": "red"
+            },
+            {
+              "@id": "/dummy_car_colors/2",
+              "@type": "DummyCarColor",
+              "prop": "blue"
             }
-        ],
-        "hydra:totalItems": 1,
-        "hydra:view": {
-            "@id": "/dummy_cars?colors.prop=red",
-            "@type": "hydra:PartialCollectionView"
-        },
-        "hydra:search": {
+          ],
+          "secondColors": [
+            {
+              "@id": "/dummy_car_colors/1",
+              "@type": "DummyCarColor",
+              "prop": "red"
+            },
+            {
+              "@id": "/dummy_car_colors/2",
+              "@type": "DummyCarColor",
+              "prop": "blue"
+            }
+          ],
+          "thirdColors": [
+            {
+              "@id": "/dummy_car_colors/1",
+              "@type": "DummyCarColor",
+              "prop": "red"
+            },
+            {
+              "@id": "/dummy_car_colors/2",
+              "@type": "DummyCarColor",
+              "prop": "blue"
+            }
+          ],
+          "uuid": []
+        }
+      ],
+      "hydra:totalItems": 1,
+      "hydra:view": {
+        "@id": "/dummy_cars?colors.prop=red",
+        "@type": "hydra:PartialCollectionView"
+      },
+      "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummy_cars{?availableAt[before],availableAt[strictly_before],availableAt[after],availableAt[strictly_after],canSell,foobar[],foobargroups[],foobargroups_override[],colors.prop,name}",
+        "hydra:template": "/dummy_cars{?availableAt[before],availableAt[strictly_before],availableAt[after],availableAt[strictly_after],canSell,foobar[],foobargroups[],foobargroups_override[],colors.prop,colors,colors[],secondColors,secondColors[],thirdColors,thirdColors[],uuid,uuid[],name}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -85,8 +110,20 @@ Feature: Search filter on collections
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "colors",
+            "property": "colors",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "colors.prop",
             "property": "colors.prop",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "colors[]",
+            "property": "colors",
             "required": false
           },
           {
@@ -111,6 +148,42 @@ Feature: Search filter on collections
             "@type": "IriTemplateMapping",
             "variable": "name",
             "property": "name",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "secondColors",
+            "property": "secondColors",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "secondColors[]",
+            "property": "secondColors",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "thirdColors",
+            "property": "thirdColors",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "thirdColors[]",
+            "property": "thirdColors",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "uuid",
+            "property": "uuid",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "uuid[]",
+            "property": "uuid",
             "required": false
           }
         ]
@@ -389,8 +462,7 @@ Feature: Search filter on collections
         "@id": {"pattern": "^/dummies$"},
         "@type": {"pattern": "^hydra:Collection$"},
         "hydra:member": {
-          "type": "array",
-          "maxItems": 0
+          "type": "array"
         },
         "hydra:view": {
           "type": "object",
@@ -655,3 +727,4 @@ Feature: Search filter on collections
       }
     }
     """
+

--- a/src/Bridge/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Bridge/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -31,6 +31,7 @@ trait SearchFilterTrait
 
     protected $iriConverter;
     protected $propertyAccessor;
+    protected $identifiersExtractor;
 
     /**
      * {@inheritdoc}

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter;
 
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\SearchFilterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\SearchFilterTrait;
@@ -21,6 +22,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -38,12 +40,17 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
 
     public const DOCTRINE_INTEGER_TYPE = DBALType::INTEGER;
 
-    public function __construct(ManagerRegistry $managerRegistry, ?RequestStack $requestStack, IriConverterInterface $iriConverter, PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null, array $properties = null)
+    public function __construct(ManagerRegistry $managerRegistry, ?RequestStack $requestStack, IriConverterInterface $iriConverter, PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null, array $properties = null, IdentifiersExtractorInterface $identifiersExtractor = null)
     {
         parent::__construct($managerRegistry, $requestStack, $logger, $properties);
 
+        if (null === $identifiersExtractor) {
+            @trigger_error('Not injecting ItemIdentifiersExtractor is deprecated since API Platform 2.5 and can lead to unexpected behaviors, it will not be possible anymore in API Platform 3.0.', E_USER_DEPRECATED);
+        }
+
         $this->iriConverter = $iriConverter;
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+        $this->identifiersExtractor = $identifiersExtractor;
     }
 
     protected function getIriConverter(): IriConverterInterface
@@ -76,6 +83,10 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         if ($this->isPropertyNested($property, $resourceClass)) {
             [$alias, $field, $associations] = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $resourceClass);
         }
+
+        /**
+         * @var ClassMetadata
+         */
         $metadata = $this->getNestedMetadata($resourceClass, $associations);
 
         $values = $this->normalizeValues((array) $value, $property);
@@ -84,7 +95,6 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         }
 
         $caseSensitive = true;
-
         if ($metadata->hasField($field)) {
             if ('id' === $field) {
                 $values = array_map([$this, 'getIdFromValue'], $values);
@@ -134,8 +144,16 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         }
 
         $values = array_map([$this, 'getIdFromValue'], $values);
+        $associationFieldIdentifier = 'id';
+        $doctrineTypeField = $this->getDoctrineFieldType($property, $resourceClass);
 
-        if (!$this->hasValidValues($values, $this->getDoctrineFieldType($property, $resourceClass))) {
+        if (null !== $this->identifiersExtractor) {
+            $associationResourceClass = $metadata->getAssociationTargetClass($field);
+            $associationFieldIdentifier = $this->identifiersExtractor->getIdentifiersFromResourceClass($associationResourceClass)[0];
+            $doctrineTypeField = $this->getDoctrineFieldType($associationFieldIdentifier, $associationResourceClass);
+        }
+
+        if (!$this->hasValidValues($values, $doctrineTypeField)) {
             $this->logger->notice('Invalid filter ignored', [
                 'exception' => new InvalidArgumentException(sprintf('Values for field "%s" are not valid according to the doctrine type.', $field)),
             ]);
@@ -145,10 +163,9 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
 
         $association = $field;
         $valueParameter = $queryNameGenerator->generateParameterName($association);
-
         if ($metadata->isCollectionValuedAssociation($association)) {
             $associationAlias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $alias, $association);
-            $associationField = 'id';
+            $associationField = $associationFieldIdentifier;
         } else {
             $associationAlias = $alias;
             $associationField = $field;

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -270,6 +270,7 @@
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="api_platform.resource_class_resolver" />
         </service>
+        <service id="ApiPlatform\Core\Api\IdentifiersExtractorInterface" alias="api_platform.identifiers_extractor.cached" />
 
         <service id="api_platform.identifier.converter" class="ApiPlatform\Core\Identifier\IdentifierConverter" public="false">
             <argument type="service" id="api_platform.identifiers_extractor.cached" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
@@ -66,7 +66,9 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <argument key="$identifiersExtractor" type="service" id="api_platform.identifiers_extractor.cached" />
         </service>
+
         <service id="ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\SearchFilter" alias="api_platform.doctrine_mongodb.odm.search_filter" />
 
         <service id="api_platform.doctrine_mongodb.odm.boolean_filter" class="ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\BooleanFilter" public="false" abstract="true">

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -55,6 +55,7 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <argument key="$identifiersExtractor" type="service" id="api_platform.identifiers_extractor.cached" />
         </service>
         <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter" alias="api_platform.doctrine.orm.search_filter" />
 

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -81,6 +81,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
             $pipeline = $aggregationBuilder->getPipeline();
         } catch (\OutOfRangeException $e) {
         }
+
         $this->assertEquals($expectedPipeline, $pipeline);
     }
 

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
 
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
@@ -329,6 +330,21 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         $this->doTestApplyWithAnotherAlias(true);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Not injecting ItemIdentifiersExtractor is deprecated since API Platform 2.5 and can lead to unexpected behaviors, it will not be possible anymore in API Platform 3.0.
+     */
+    public function testNotPassingIdentifiersExtractor()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/api/dummies', 'GET', []));
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverter = $iriConverterProphecy->reveal();
+        $propertyAccessor = self::$kernel->getContainer()->get('test.property_accessor');
+
+        return new SearchFilter($this->managerRegistry, $requestStack, $iriConverter, $propertyAccessor, null, null, null);
+    }
+
     private function doTestApplyWithAnotherAlias(bool $request)
     {
         $filters = ['name' => 'exact'];
@@ -391,8 +407,8 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'invalid values for relations' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1 AND %1$s.relatedDummy = :relatedDummy_p2', $this->alias, Dummy::class),
-                    ['relatedDummy_p2' => 'foo'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', $this->alias, Dummy::class),
+                    [],
                     $filterFactory,
                 ],
                 'partial' => [
@@ -436,8 +452,21 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'invalid value for relation' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.relatedDummy = :relatedDummy_p1', $this->alias, Dummy::class),
-                    ['relatedDummy_p1' => 'exact'],
+                    sprintf('SELECT %s FROM %s %1$s', $this->alias, Dummy::class),
+                    [],
+                    $filterFactory,
+                ],
+                'invalid iri for relation' => [
+                    [
+                        'id' => null,
+                        'name' => null,
+                        'relatedDummy' => null,
+                    ],
+                    [
+                        'relatedDummy' => '/related_dummie/1',
+                    ],
+                    sprintf('SELECT %s FROM %s %1$s', $this->alias, Dummy::class),
+                    [],
                     $filterFactory,
                 ],
                 'IRI value for relation' => [
@@ -483,6 +512,9 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         $iriConverter = $iriConverterProphecy->reveal();
         $propertyAccessor = self::$kernel->getContainer()->get('test.property_accessor');
 
-        return new SearchFilter($managerRegistry, $requestStack, $iriConverter, $propertyAccessor, null, $properties);
+        $identifierExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifierExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
+        return new SearchFilter($managerRegistry, $requestStack, $iriConverter, $propertyAccessor, null, $properties, $identifierExtractorProphecy->reveal());
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\DependencyInjection;
 
 use ApiPlatform\Core\Api\FilterInterface;
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\OperationAwareFormatsProviderInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
@@ -918,6 +919,7 @@ class ApiPlatformExtensionTest extends TestCase
             PropertyFilter::class => 'api_platform.serializer.property_filter',
             GroupFilter::class => 'api_platform.serializer.group_filter',
             OperationAwareFormatsProviderInterface::class => 'api_platform.formats_provider',
+            IdentifiersExtractorInterface::class => 'api_platform.identifiers_extractor.cached',
         ];
 
         foreach ($aliases as $alias => $service) {
@@ -1103,7 +1105,6 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.swagger.normalizer.documentation',
             'api_platform.validator',
         ];
-
         foreach ($definitions as $definition) {
             $containerBuilderProphecy->setDefinition($definition, Argument::type(Definition::class))->shouldBeCalled();
         }
@@ -1134,6 +1135,7 @@ class ApiPlatformExtensionTest extends TestCase
             MongoDbOdmNumericFilter::class => 'api_platform.doctrine_mongodb.odm.numeric_filter',
             MongoDbOdmOrderFilter::class => 'api_platform.doctrine_mongodb.odm.order_filter',
             MongoDbOdmRangeFilter::class => 'api_platform.doctrine_mongodb.odm.range_filter',
+            IdentifiersExtractorInterface::class => 'api_platform.identifiers_extractor.cached',
         ];
 
         foreach ($aliases as $alias => $service) {

--- a/tests/Fixtures/TestBundle/Document/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCar.php
@@ -54,9 +54,39 @@ class DummyCar
      * @ODM\ReferenceMany(targetDocument=DummyCarColor::class, mappedBy="car")
      *
      * @Serializer\Groups({"colors"})
-     * @ApiFilter(SearchFilter::class, properties={"colors.prop"="ipartial"})
+     * @ApiFilter(SearchFilter::class, properties={"colors.prop"="ipartial", "colors"="exact"})
      */
     private $colors;
+
+    /**
+     * @var mixed Something else
+     *
+     * @ODM\ReferenceMany(targetDocument=DummyCarColor::class, mappedBy="car")
+     *
+     * @Serializer\Groups({"colors"})
+     * @ApiFilter(SearchFilter::class, strategy="exact")
+     */
+    private $secondColors;
+
+    /**
+     * @var mixed Something else
+     *
+     * @ODM\ReferenceMany(targetDocument=DummyCarColor::class, mappedBy="car")
+     *
+     * @Serializer\Groups({"colors"})
+     * @ApiFilter(SearchFilter::class, strategy="exact")
+     */
+    private $thirdColors;
+
+    /**
+     * @var mixed Something else
+     *
+     * @ODM\ReferenceMany(targetDocument=UuidIdentifierDummy::class)
+     *
+     * @Serializer\Groups({"colors"})
+     * @ApiFilter(SearchFilter::class, strategy="exact")
+     */
+    private $uuid;
 
     /**
      * @var string
@@ -100,6 +130,36 @@ class DummyCar
         $this->colors = $colors;
 
         return $this;
+    }
+
+    public function getSecondColors()
+    {
+        return $this->secondColors;
+    }
+
+    public function setSecondColors($secondColors)
+    {
+        $this->secondColors = $secondColors;
+    }
+
+    public function getThirdColors()
+    {
+        return $this->thirdColors;
+    }
+
+    public function setThirdColors($thirdColors)
+    {
+        $this->thirdColors = $thirdColors;
+    }
+
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid($uuid)
+    {
+        $this->uuid = $uuid;
     }
 
     public function getName(): string

--- a/tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -56,9 +56,42 @@ class DummyCar
      * @ORM\OneToMany(targetEntity="DummyCarColor", mappedBy="car")
      *
      * @Serializer\Groups({"colors"})
-     * @ApiFilter(SearchFilter::class, properties={"colors.prop"="ipartial"})
+     * @ApiFilter(SearchFilter::class, properties={"colors.prop"="ipartial", "colors"="exact"})
      */
     private $colors;
+
+    /**
+     * @var mixed Something else
+     *
+     * @ORM\OneToMany(targetEntity="DummyCarColor", mappedBy="car")
+     *
+     * @Serializer\Groups({"colors"})
+     * @ApiFilter(SearchFilter::class, strategy="exact")
+     */
+    private $secondColors;
+
+    /**
+     * @var mixed Something else
+     *
+     * @ORM\OneToMany(targetEntity="DummyCarColor", mappedBy="car")
+     *
+     * @Serializer\Groups({"colors"})
+     * @ApiFilter(SearchFilter::class, strategy="exact")
+     */
+    private $thirdColors;
+
+    /**
+     * @var mixed Something else
+     *
+     * @ORM\ManyToMany(targetEntity="UuidIdentifierDummy", indexBy="uuid")
+     * * @ORM\JoinTable(name="uuid_cars",
+     *     joinColumns={@ORM\JoinColumn(name="car_id", referencedColumnName="id")},
+     *     inverseJoinColumns={@ORM\JoinColumn(name="uuid_uuid", referencedColumnName="uuid")}
+     * )
+     * @Serializer\Groups({"colors"})
+     * @ApiFilter(SearchFilter::class, strategy="exact")
+     */
+    private $uuid;
 
     /**
      * @var string
@@ -104,6 +137,39 @@ class DummyCar
         return $this;
     }
 
+    public function getSecondColors()
+    {
+        return $this->secondColors;
+    }
+
+    public function setSecondColors($secondColors)
+    {
+        $this->secondColors = $secondColors;
+    }
+
+    public function getThirdColors()
+    {
+        return $this->thirdColors;
+    }
+
+    public function setThirdColors($thirdColors)
+    {
+        $this->thirdColors = $thirdColors;
+    }
+
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid($uuid)
+    {
+        $this->uuid = $uuid;
+    }
+
+    /**
+     * Get name.
+     */
     public function getName(): string
     {
         return $this->name;

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -40,7 +40,7 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
 
         $this->assertEquals($this->extractor->getFilters($reflectionClass), [
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_bridge_doctrine_orm_filter_date_filter' => [
-                ['properties' => ['id' => 'exclude_null', 'colors' => 'exclude_null', 'name' => 'exclude_null', 'canSell' => 'exclude_null', 'availableAt' => 'exclude_null']],
+                ['properties' => ['id' => 'exclude_null', 'colors' => 'exclude_null', 'name' => 'exclude_null', 'canSell' => 'exclude_null', 'availableAt' => 'exclude_null', 'secondColors' => 'exclude_null', 'thirdColors' => 'exclude_null', 'uuid' => 'exclude_null']],
                 DateFilter::class,
             ],
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_bridge_doctrine_orm_filter_boolean_filter' => [
@@ -48,7 +48,7 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
                 BooleanFilter::class,
             ],
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_bridge_doctrine_orm_filter_search_filter' => [
-                ['properties' => ['name' => 'partial', 'colors.prop' => 'ipartial']],
+                ['properties' => ['name' => 'partial', 'colors.prop' => 'ipartial', 'colors' => 'exact', 'secondColors' => 'exact', 'thirdColors' => 'exact', 'uuid' => 'exact']],
                 SearchFilter::class,
             ],
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_serializer_filter_property_filter' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #775
| License       | MIT
| Doc PR        | 

This PRs update the ids management for association in the SearchFilter.

I've not updated the single at the moment because I think it should be done in another PR. 
This fixes #775.

Something I'm not sure is the behaviour, do we ignore the filter (this is the current implementation) or do we return 0 elements (like by replacing the invalid values with null instead of logging + return) ?