### PR TITLE
Allow sub-resources to have a custom controller

### DIFF
--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -110,7 +110,7 @@ final class ApiLoader extends Loader
                 $routeCollection->add($operation['route_name'], new Route(
                     $operation['path'],
                     [
-                        '_controller' => self::DEFAULT_ACTION_PATTERN.'get_subresource',
+                        '_controller' => $operation['controller'] ?? null ?: self::DEFAULT_ACTION_PATTERN.'get_subresource',
                         '_format' => null,
                         '_api_resource_class' => $operation['resource_class'],
                         '_api_subresource_operation_name' => $operation['route_name'],

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -26,7 +26,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
 {
     const SUBRESOURCE_SUFFIX = '_subresource';
     const FORMAT_SUFFIX = '.{_format}';
-    const ROUTE_OPTIONS = ['defaults' => [], 'requirements' => [], 'options' => [], 'host' => '', 'schemes' => [], 'condition' => ''];
+    const ROUTE_OPTIONS = ['defaults' => [], 'requirements' => [], 'options' => [], 'host' => '', 'schemes' => [], 'condition' => '', 'controller' => ''];
 
     private $resourceMetadataFactory;
     private $propertyNameCollectionFactory;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

This PR allows subresources to set custom controllers like that:
```php
/**
 * @ApiResource(
 *     subresourceOperations={
 *         "followers_get_subresource"={
 *              "controller"="App\Action\Test"
 *         }
 *     }
 * )
 *
 */
```
