### PR TITLE
Fix the Behat test suite with low dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "behat/mink-browserkit-driver": "^1.3.1",
         "behat/mink-extension": "^2.2",
         "behat/symfony2-extension": "^2.1.1",
-        "behatch/contexts": "^3.0@dev",
+        "behatch/contexts": "^3.1",
         "doctrine/annotations": "^1.2",
         "doctrine/doctrine-bundle": "^1.6.3",
         "doctrine/orm": "^2.5.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This PR fixes missing steps with low dependencies:
```
--- FeatureContext has missing steps. Define them with these snippets:
    /**
     * @Then the JSON node :arg1 should match :arg2
     */
    public function theJsonNodeShouldMatch($arg1, $arg2)
    {
        throw new PendingException();
    }
```
See https://travis-ci.org/api-platform/core/jobs/365496238#L699-L707 for example.