### PR TITLE
Fix relations denormalization with plain ids

### DIFF
--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -512,13 +512,50 @@ Feature: Relations support
     }
     """
 
+  Scenario: Passing a (valid) plain identifier on a relation
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "relatedDummy": "1",
+      "relatedDummies": ["1"],
+      "name": "Dummy with plain relations"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context":"/contexts/Dummy",
+      "@id":"/dummies/2",
+      "@type":"Dummy",
+      "description":null,
+      "dummy":null,
+      "dummyBoolean":null,
+      "dummyDate":null,
+      "dummyFloat":null,
+      "dummyPrice":null,
+      "relatedDummy":"/related_dummies/1",
+      "relatedDummies":["/related_dummies/1"],
+      "jsonData":[],
+      "arrayData":[],
+      "name_converted":null,
+      "id":2,
+      "name":"Dummy with plain relations",
+      "alias":null,
+      "foo":null
+    }
+    """
+
   @dropSchema
   Scenario: Passing an invalid IRI to a relation
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/relation_embedders" with body:
     """
     {
-      "related": "certainly not an iri"
+      "related": "certainly not an iri and not a plain identifier"
     }
     """
     Then the response status code should be 400

--- a/src/Exception/InvalidValueException.php
+++ b/src/Exception/InvalidValueException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Exception;
+
+class InvalidValueException extends InvalidArgumentException
+{
+}

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\InvalidValueException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -157,7 +158,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = [])
     {
         if (!\is_string($attribute)) {
-            throw new InvalidArgumentException('Invalid value provided (invalid IRI?).');
+            throw new InvalidValueException('Invalid value provided (invalid IRI?).');
         }
 
         $propertyMetadata = $this->propertyMetadataFactory->create($context['resource_class'], $attribute, $this->getFactoryOptions($context));
@@ -306,11 +307,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
             try {
                 return $this->serializer->denormalize($value, $className, $format, $context);
-            } catch (InvalidArgumentException $e) {
-                if ('Invalid value provided (invalid IRI?).' !== $e->getMessage()) {
-                    throw $e;
-                }
-
+            } catch (InvalidValueException $e) {
                 if (!$this->allowPlainIdentifiers || null === $this->itemDataProvider) {
                     throw $e;
                 }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -304,7 +304,17 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $context['resource_class'] = $className;
             $context['api_allow_update'] = true;
 
-            return $this->serializer->denormalize($value, $className, $format, $context);
+            try {
+                return $this->serializer->denormalize($value, $className, $format, $context);
+            } catch (InvalidArgumentException $e) {
+                if ('Invalid value provided (invalid IRI?).' !== $e->getMessage()) {
+                    throw $e;
+                }
+
+                if (!$this->allowPlainIdentifiers || null === $this->itemDataProvider) {
+                    throw $e;
+                }
+            }
         }
 
         if (!\is_array($value)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1840 
| License       | MIT
| Doc PR        | ~

#1547 introduced an `is_array` check to prevent the normalize to act on writable relations so that we could use plain identifiers, and was reverted by #1762 because not all relations are arrays, and can be iris.

But this revert triggered also the fact that we cannot use plain ids anymore on writable relations. This PR aims to fix that ; if we encounter the invalid argument exception while trying to denormalize the relation, and that we allowed plain identifiers and we have an item provider, we should try the next block if it's not an array. Now that I think about it, I should probably add a `!is_array` check or something ?

The tests passes, but I'm not sure how I can add a test to reflect this, so any hint would be welcomed...

BTW, shouldn't we add a more specific exception for the invalid iri ? Testing the message isn't specially clean IMO... and as it's not the scope of this PR, I had to make do with this.
