### PR TITLE
bugfix: fix introspection and re-declaration of config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "symfony/validator": "^3.3 || ^4.0",
         "symfony/web-profiler-bundle": "^3.3 || ^4.0",
         "symfony/yaml": "^3.3 || ^4.0",
-        "webonyx/graphql-php": "^0.10.2"
+        "webonyx/graphql-php": "^0.11.5"
     },
     "conflict": {
         "symfony/dependency-injection": "<3.4"

--- a/features/bootstrap/GraphqlContext.php
+++ b/features/bootstrap/GraphqlContext.php
@@ -78,6 +78,14 @@ final class GraphqlContext implements Context
     }
 
     /**
+     * @When I post the following GraphQL request:
+     */
+    public function IPostTheFollowingGraphqlRequest(PyStringNode $request)
+    {
+        $this->postGraphqlRequest($request);
+    }
+
+    /**
      * @When I send the GraphQL request with variables:
      */
     public function ISendTheGraphqlRequestWithVariables(PyStringNode $variables)
@@ -99,5 +107,13 @@ final class GraphqlContext implements Context
     {
         $this->request->setHttpHeader('Accept', null);
         $this->restContext->iSendARequestTo('GET', '/graphql?'.http_build_query($this->graphqlRequest));
+    }
+
+    private function postGraphqlRequest($body)
+    {
+        $this->request->setHttpHeader('Accept', null);
+        $this->request->setHttpHeader('Content-Type', 'application/json');
+
+        $this->restContext->iSendARequestTo('POST', '/graphql', $body);
     }
 }

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -168,6 +168,17 @@ Feature: GraphQL introspection support
     And the JSON node "data.__schema.queryType.fields[0].args[0].type.ofType.name" should be equal to "ID"
     And the JSON node "data.__schema.queryType.fields[0].args[0].type.ofType.kind" should be equal to "SCALAR"
 
+  Scenario: GraphiQL can print the documentation
+    When I post the following GraphQL request:
+    """
+    {"query":"\n  query IntrospectionQuery {\n    __schema {\n      queryType { name }\n      mutationType { name }\n      subscriptionType { name }\n      types {\n        ...FullType\n      }\n      directives {\n        name\n        description\n        locations\n        args {\n          ...InputValue\n        }\n      }\n    }\n  }\n\n  fragment FullType on __Type {\n    kind\n    name\n    description\n    fields(includeDeprecated: true) {\n      name\n      description\n      args {\n        ...InputValue\n      }\n      type {\n        ...TypeRef\n      }\n      isDeprecated\n      deprecationReason\n    }\n    inputFields {\n      ...InputValue\n    }\n    interfaces {\n      ...TypeRef\n    }\n    enumValues(includeDeprecated: true) {\n      name\n      description\n      isDeprecated\n      deprecationReason\n    }\n    possibleTypes {\n      ...TypeRef\n    }\n  }\n\n  fragment InputValue on __InputValue {\n    name\n    description\n    type { ...TypeRef }\n    defaultValue\n  }\n\n  fragment TypeRef on __Type {\n    kind\n    name\n    ofType {\n      kind\n      name\n      ofType {\n        kind\n        name\n        ofType {\n          kind\n          name\n          ofType {\n            kind\n            name\n            ofType {\n              kind\n              name\n              ofType {\n                kind\n                name\n                ofType {\n                  kind\n                  name\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n"}
+    """
+    Then the response status code should be 200
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.__schema.queryType.name" should be equal to "Query"
+    And the JSON node "data.__schema.mutationType.name" should be equal to "Mutation"
+    And the JSON node "data.__schema.types[0].kind" should be equal to "OBJECT"
+
   Scenario: Introspect an Iterable type field
     When I send the following GraphQL request:
     """

--- a/src/Bridge/Symfony/Bundle/Resources/public/init-graphiql.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-graphiql.js
@@ -61,8 +61,13 @@ function graphQLFetcher(graphQLParams) {
         return response.text();
     }).then(function (responseBody) {
         try {
-            return JSON.parse(responseBody);
+            var jsonResponse = JSON.parse(responseBody);
+            if (jsonResponse.errors !== undefined) {
+                console.error('An error occured when fetching the query:', jsonResponse.errors);
+            }
+            return jsonResponse;
         } catch (error) {
+            console.error(responseBody);
             return responseBody;
         }
     });

--- a/src/GraphQl/Type/Definition/InputUnionType.php
+++ b/src/GraphQl/Type/Definition/InputUnionType.php
@@ -18,7 +18,7 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\LeafType;
-use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Definition\UnionType;
 use GraphQL\Utils\Utils;
 
 /**
@@ -28,7 +28,7 @@ use GraphQL\Utils\Utils;
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-final class InputUnionType extends Type implements InputType, LeafType
+final class InputUnionType extends UnionType implements InputType, LeafType
 {
     /**
      * @var InputObjectType[]
@@ -36,15 +36,12 @@ final class InputUnionType extends Type implements InputType, LeafType
     private $types;
 
     /**
-     * @var array
-     */
-    private $config;
-
-    /**
      * @throws InvariantViolation
      */
     public function __construct(array $config)
     {
+        parent::__construct($config);
+
         if (!isset($config['name'])) {
             $config['name'] = $this->tryInferName();
         }
@@ -85,8 +82,6 @@ final class InputUnionType extends Type implements InputType, LeafType
      */
     public function assertValid()
     {
-        parent::assertValid();
-
         $types = $this->getTypes();
         Utils::invariant(\count($types) > 0, "{$this->name} types must not be empty");
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | maybe not needed


So, I was trying GraphiQL, and wanted to develop an little test app with it see https://github.com/Simperfit/graphql-api/commit/b521052ac8903c6ccf11ae1c3e703ee458f3cf73 but I got into a little bug on the re-declaration of config, that fixed, i've seen another error with the declared type in the `SchemaBuilder`.

As I don't really followed the GraphQL development, I'm trying to figure out how to fix this. 
