### PR TITLE
[GraphQL] Add totalCount field for paginated collections

### DIFF
--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -177,6 +177,7 @@ Feature: GraphQL collection support
                 }
                 cursor
               }
+              totalCount
               pageInfo {
                 endCursor
                 hasNextPage
@@ -185,6 +186,7 @@ Feature: GraphQL collection support
           }
           cursor
         }
+        totalCount
         pageInfo {
           endCursor
           hasNextPage
@@ -197,10 +199,12 @@ Feature: GraphQL collection support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.dummies.pageInfo.endCursor" should be equal to "Mw=="
     And the JSON node "data.dummies.pageInfo.hasNextPage" should be true
+    And the JSON node "data.dummies.totalCount" should be equal to 4
     And the JSON node "data.dummies.edges[1].node.name" should be equal to "Dummy #2"
     And the JSON node "data.dummies.edges[1].cursor" should be equal to "MQ=="
     And the JSON node "data.dummies.edges[1].node.relatedDummies.pageInfo.endCursor" should be equal to "Mw=="
     And the JSON node "data.dummies.edges[1].node.relatedDummies.pageInfo.hasNextPage" should be true
+    And the JSON node "data.dummies.edges[1].node.relatedDummies.totalCount" should be equal to 4
     And the JSON node "data.dummies.edges[1].node.relatedDummies.edges[0].node.name" should be equal to "RelatedDummy12"
     And the JSON node "data.dummies.edges[1].node.relatedDummies.edges[0].cursor" should be equal to "MA=="
     When I send the following GraphQL request:

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -118,6 +118,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             if ($collection instanceof PaginatorInterface && ($totalItems = $collection->getTotalItems()) > 0) {
                 $data['pageInfo']['endCursor'] = base64_encode((string) ($totalItems - 1));
                 $data['pageInfo']['hasNextPage'] = $collection->getCurrentPage() !== $collection->getLastPage() && (float) $collection->count() === $collection->getItemsPerPage();
+                $data['totalCount'] = $collection->getTotalItems();
             }
 
             foreach ($collection as $index => $object) {

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -118,7 +118,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             if ($collection instanceof PaginatorInterface && ($totalItems = $collection->getTotalItems()) > 0) {
                 $data['pageInfo']['endCursor'] = base64_encode((string) ($totalItems - 1));
                 $data['pageInfo']['hasNextPage'] = $collection->getCurrentPage() !== $collection->getLastPage() && (float) $collection->count() === $collection->getItemsPerPage();
-                $data['totalCount'] = $collection->getTotalItems();
+                $data['totalCount'] = $totalItems;
             }
 
             foreach ($collection as $index => $object) {

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -498,6 +498,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
             'fields' => [
                 'edges' => GraphQLType::listOf($edgeObjectType),
                 'pageInfo' => GraphQLType::nonNull($pageInfoObjectType),
+                'totalCount' => GraphQLType::nonNull(GraphQLType::int()),
             ],
         ];
 

--- a/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -171,7 +171,7 @@ class CollectionResolverFactoryTest extends TestCase
         $resolveInfo->fieldNodes = [];
 
         $this->assertEquals(
-            ['edges' => [['node' => 'normalizedObject1', 'cursor' => 'Mg==']], 'pageInfo' => ['endCursor' => 'MTY=', 'hasNextPage' => true]],
+            ['edges' => [['node' => 'normalizedObject1', 'cursor' => 'Mg==']], 'pageInfo' => ['endCursor' => 'MTY=', 'hasNextPage' => true], 'totalCount' => 17],
             $resolver(null, ['after' => $cursor], null, $resolveInfo)
         );
     }

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -122,7 +122,7 @@ class SchemaBuilderTest extends TestCase
         $schema = $mockedSchemaBuilder->getSchema();
         $queryFields = $schema->getConfig()->getQuery()->getFields();
 
-        $this->assertEquals([
+        $this->assertSame([
             'node',
             'shortName1',
             'shortName1s',
@@ -135,7 +135,7 @@ class SchemaBuilderTest extends TestCase
         /** @var ObjectType $type */
         $type = $queryFields['shortName2']->getType();
         $resourceTypeFields = $type->getFields();
-        $this->assertEquals(
+        $this->assertSame(
             ['id', 'intProperty', 'floatProperty', 'stringProperty', 'boolProperty', 'objectProperty', 'arrayProperty', 'iterableProperty'],
             array_keys($resourceTypeFields)
         );
@@ -146,30 +146,25 @@ class SchemaBuilderTest extends TestCase
         if ($paginationEnabled) {
             /** @var ObjectType $objectPropertyFieldType */
             $objectPropertyFieldType = $type->getFields()['objectProperty']->getType();
-            $this->assertEquals($objectPropertyFieldType->name, 'ShortName1Connection');
+            $this->assertSame('ShortName1Connection', $objectPropertyFieldType->name);
+            $this->assertEquals(GraphQLType::nonNull(GraphQLType::int()), $objectPropertyFieldType->getField('totalCount')->getType());
             /** @var ListOfType $edgesType */
             $edgesType = $objectPropertyFieldType->getFields()['edges']->getType();
             $edgeType = $edgesType->getWrappedType();
-            $this->assertEquals($edgeType->name, 'ShortName1Edge');
-            $this->assertEquals($edgeType->getFields()['cursor']->getType(), GraphQLType::nonNull(GraphQLType::string()));
-            $this->assertEquals(
-                $type,
-                $edgeType->getFields()['node']->getType()
-            );
+            $this->assertSame('ShortName1Edge', $edgeType->name);
+            $this->assertEquals(GraphQLType::nonNull(GraphQLType::string()), $edgeType->getField('cursor')->getType());
+            $this->assertEquals($type, $edgeType->getField('node')->getType());
         } else {
             /** @var ListOfType $objectPropertyFieldType */
             $objectPropertyFieldType = $type->getFields()['objectProperty']->getType();
-            $this->assertEquals(
-                $type,
-                $objectPropertyFieldType->getWrappedType()
-            );
+            $this->assertEquals($type, $objectPropertyFieldType->getWrappedType());
         }
 
         // DateTime is considered as a string instead of an object.
         /** @var ObjectType $type */
         $type = $queryFields['shortName3']->getType();
         /** @var ListOfType $objectPropertyFieldType */
-        $objectPropertyFieldType = $type->getFields()['objectProperty']->getType();
+        $objectPropertyFieldType = $type->getField('objectProperty')->getType();
         $this->assertEquals(GraphQLType::nonNull(GraphQLType::string()), $objectPropertyFieldType);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1862 
| License       | MIT

This feature adds `totalCount` field for paginated collections to GraphQL endpoint.
I will add tests later today.
