### PR TITLE
The OrderFilter is still triggering bad deprecation/function calls

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -81,8 +81,11 @@ class OrderFilter extends AbstractContextAwareFilter
      */
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
     {
+        if (isset($context['filters']) && !isset($context['filters'][$this->orderParameterName])) {
+            return;
+        }
+
         if (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName])) {
-            $context['filters'] = null;
             parent::apply($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
 
             return;

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -341,6 +341,18 @@ class OrderFilterTest extends AbstractFilterTest
                 null,
                 $orderFilterFactory,
             ],
+            'not having order should not throw a deprecation (select unchanged)' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                ],
+                [
+                    'name' => 'q',
+                ],
+                sprintf('SELECT o FROM %s o', Dummy::class),
+                null,
+                $orderFilterFactory,
+            ],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Follows #1663 and fix it correctly.
The added test throws a deprecation without the fix
