### PR TITLE
Allow GraphQL to filter on nested property

### DIFF
--- a/features/doctrine/order_filter.feature
+++ b/features/doctrine/order_filter.feature
@@ -830,3 +830,55 @@ Feature: Order filter on collections
       }
     }
     """
+
+  @createSchema
+  Scenario: Get collection ordered in descending order on a related property
+    Given there are 2 dummy objects with relatedDummy
+    When I send a "GET" request to "/dummies?order[relatedDummy.name]=desc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/2$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummies/1$"
+                }
+              }
+            }
+          ],
+          "additionalItems": false,
+          "maxItems": 2,
+          "minItems": 2
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?order%5BrelatedDummy.name%5D=desc"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -88,3 +88,27 @@ Feature: Collections filtering
     And the JSON node "data.dummies.edges[1].node.relatedDummies.edges" should have 0 elements
     And the JSON node "data.dummies.edges[2].node.relatedDummies.edges" should have 1 element
     And the JSON node "data.dummies.edges[2].node.relatedDummies.edges[0].node.name" should be equal to "RelatedDummy13"
+
+  @createSchema
+  Scenario: Retrieve a collection filtered using the related search filter
+    Given there are 1 dummy objects having each 2 relatedDummies
+    And there are 1 dummy objects having each 3 relatedDummies
+    When I add "Accept" header equal to "application/hal+json"
+    And I send a "GET" request to "/dummies?relatedDummies.name=RelatedDummy31"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "_embedded.item" should have 1 element
+    When I send the following GraphQL request:
+    """
+    {
+      dummies(relatedDummies_name: "RelatedDummy31") {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+    """
+    And the response status code should be 200
+    And the JSON node "data.dummies.edges" should have 1 element

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -93,11 +93,6 @@ Feature: Collections filtering
   Scenario: Retrieve a collection filtered using the related search filter
     Given there are 1 dummy objects having each 2 relatedDummies
     And there are 1 dummy objects having each 3 relatedDummies
-    When I add "Accept" header equal to "application/hal+json"
-    And I send a "GET" request to "/dummies?relatedDummies.name=RelatedDummy31"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the JSON node "_embedded.item" should have 1 element
     When I send the following GraphQL request:
     """
     {
@@ -112,3 +107,27 @@ Feature: Collections filtering
     """
     And the response status code should be 200
     And the JSON node "data.dummies.edges" should have 1 element
+
+  @createSchema
+  Scenario: Retrieve a collection ordered using nested properties
+    Given there are 2 dummy objects with relatedDummy
+    When I send the following GraphQL request:
+    """
+    {
+      dummies(order: {relatedDummy_name: "DESC"}) {
+        edges {
+          node {
+            name
+            relatedDummy {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummies.edges[0].node.name" should be equal to "Dummy #2"
+    And the JSON node "data.dummies.edges[1].node.name" should be equal to "Dummy #1"

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -77,14 +77,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             $dataProviderContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
             $dataProviderContext['attributes'] = $this->fieldsToAttributes($info);
-            $filters = $args;
-            foreach ($filters as $name => $value) {
-                if (strpos($name, '_')) {
-                    // Gives a chance to relations/nested fields
-                    $filters[str_replace('_', '.', $name)] = $value;
-                }
-            }
-            $dataProviderContext['filters'] = $filters;
+            $dataProviderContext['filters'] = $this->getNormalizedFilters($args);
 
             if (isset($rootClass, $source[$rootProperty = $info->fieldName], $source[ItemNormalizer::ITEM_KEY])) {
                 $rootResolvedFields = $this->identifiersExtractor->getIdentifiersFromItem(unserialize($source[ItemNormalizer::ITEM_KEY]));
@@ -170,5 +163,23 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             'identifiers' => $resolvedIdentifiers,
             'collection' => $isCollection,
         ]);
+    }
+
+    private function getNormalizedFilters(array $args): array
+    {
+        $filters = $args;
+        foreach ($filters as $name => $value) {
+            if (\is_array($value)) {
+                $filters[$name] = $this->getNormalizedFilters($value);
+                continue;
+            }
+
+            if (strpos($name, '_')) {
+                // Gives a chance to relations/nested fields.
+                $filters[str_replace('_', '.', $name)] = $value;
+            }
+        }
+
+        return $filters;
     }
 }

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -77,7 +77,14 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             $dataProviderContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
             $dataProviderContext['attributes'] = $this->fieldsToAttributes($info);
-            $dataProviderContext['filters'] = $args;
+            $filters = $args;
+            foreach ($filters as $name => $value) {
+                if (strpos($name, '_')) {
+                    // Gives a chance to relations/nested fields
+                    $filters[str_replace('_', '.', $name)] = $value;
+                }
+            }
+            $dataProviderContext['filters'] = $filters;
 
             if (isset($rootClass, $source[$rootProperty = $info->fieldName], $source[ItemNormalizer::ITEM_KEY])) {
                 $rootResolvedFields = $this->identifiersExtractor->getIdentifiersFromItem(unserialize($source[ItemNormalizer::ITEM_KEY]));

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -292,6 +292,13 @@ final class SchemaBuilder implements SchemaBuilderInterface
     private function convertFilterArgsToTypes(array $args): array
     {
         foreach ($args as $key => $value) {
+            if (strpos($key, '.')) {
+                // Declare relations/nested fields in a GraphQL compatible syntax.
+                $args[str_replace('.', '_', $key)] = $value;
+            }
+        }
+
+        foreach ($args as $key => $value) {
             if (!\is_array($value) || !isset($value['#name'])) {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1714, #1867
| License       | MIT
| Doc PR        | 

Possible replacement for #1743 without updating the filter but just the way filters are passed to the data provider.

ping @alanpoulain  @IonBazan
