### PR TITLE
[GraphQL] Use enum for OrderFilter

### DIFF
--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -4,6 +4,25 @@ Feature: Collections filtering
   I need to be able to set filters
 
   @createSchema
+  Scenario: Retrieve a collection orderes using the order filter
+    Given there are 3 dummy objects with dummyDate
+    When I send the following GraphQL request:
+    """
+    {
+      dummies(order: {dummyDate: DESC}) {
+        edges {
+          node {
+            id
+            dummyDate
+          }
+        }
+      }
+    }
+    """
+    Then the JSON node "data.dummies.edges" should have 3 elements
+    And the JSON node "data.dummies.edges[0].node.dummyDate" should be equal to "2015-04-02T00:00:00+00:00"
+
+  @createSchema
   Scenario: Retrieve a collection filtered using the boolean filter
     Given there is 1 dummy object with dummyBoolean true
     And there is 1 dummy object with dummyBoolean false

--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -112,7 +112,8 @@ class OrderFilter extends AbstractContextAwareFilter
 
             $description[sprintf('%s[%s]', $this->orderParameterName, $property)] = [
                 'property' => $property,
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ];
         }

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -32,12 +32,14 @@ class OrderFilterTest extends AbstractFilterTest
         $this->assertEquals([
             'order[id]' => [
                 'property' => 'id',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[name]' => [
                 'property' => 'name',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
         ], $filter->getDescription($this->resourceClass));
@@ -50,62 +52,74 @@ class OrderFilterTest extends AbstractFilterTest
         $this->assertEquals([
             'order[id]' => [
                 'property' => 'id',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[name]' => [
                 'property' => 'name',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[alias]' => [
                 'property' => 'alias',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[description]' => [
                 'property' => 'description',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[dummy]' => [
                 'property' => 'dummy',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[dummyDate]' => [
                 'property' => 'dummyDate',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[dummyFloat]' => [
                 'property' => 'dummyFloat',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[dummyPrice]' => [
                 'property' => 'dummyPrice',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[jsonData]' => [
                 'property' => 'jsonData',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[arrayData]' => [
                 'property' => 'arrayData',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[nameConverted]' => [
                 'property' => 'nameConverted',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
             'order[dummyBoolean]' => [
                 'property' => 'dummyBoolean',
-                'type' => 'string',
+                'type' => 'enum',
+                'values' => ['ASC', 'DESC'],
                 'required' => false,
             ],
         ], $filter->getDescription($this->resourceClass));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1864 
| License       | MIT

This PR changes the way `OrderFilter`'s GraphQL definition is built. It uses `EnumType` instead of `StringType` to define supported values.
