### PR TITLE
Page number int casting

### DIFF
--- a/features/hydra/collection.feature
+++ b/features/hydra/collection.feature
@@ -434,4 +434,4 @@ Feature: Collections support
 
     When I send a "GET" request to "/dummies?itemsPerPage=0&page=2"
     Then the response status code should be 400
-    And the JSON node "hydra:description" should be equal to "Page should not be greater than 1 if itemsPegPage is equal to 0"
+    And the JSON node "hydra:description" should be equal to "Page should not be greater than 1 if itemsPerPage is equal to 0"

--- a/features/jsonapi/pagination.feature
+++ b/features/jsonapi/pagination.feature
@@ -32,3 +32,7 @@ Feature: JSON API pagination handling
     And the JSON node "meta.totalItems" should be equal to the number 10
     And the JSON node "meta.itemsPerPage" should be equal to the number 15
     And the JSON node "meta.currentPage" should be equal to the number 1
+
+  Scenario: Get an error when provided page number is not valid
+    When I send a "GET" request to "/dummies?page[page]=0"
+    Then the response status code should be 400

--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -103,10 +103,14 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
             throw new InvalidArgumentException('Item per page parameter should not be less than 0');
         }
 
-        $page = $this->getPaginationParameter($request, $this->pageParameterName, 1);
+        $page = (int) $this->getPaginationParameter($request, $this->pageParameterName, 1);
+
+        if (1 > $page) {
+            throw new InvalidArgumentException('Page should not be less than 1');
+        }
 
         if (0 === $itemsPerPage && 1 < $page) {
-            throw new InvalidArgumentException('Page should not be greater than 1 if itemsPegPage is equal to 0');
+            throw new InvalidArgumentException('Page should not be greater than 1 if itemsPerPage is equal to 0');
         }
 
         $firstResult = ($page - 1) * $itemsPerPage;

--- a/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -101,7 +101,7 @@ class PaginationExtensionTest extends TestCase
 
     /**
      * @expectedException \ApiPlatform\Core\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Page should not be greater than 1 if itemsPegPage is equal to 0
+     * @expectedExceptionMessage Page should not be greater than 1 if itemsPerPage is equal to 0
      */
     public function testApplyToCollectionWithItemPerPageZeroAndPage2()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1860
| License       | MIT
| Doc PR        | no

This PR adds casting `page[page]` parameter to `int` and page number validation. It throws an error when page number is less than 1 and tries to convert a string to int when possible.
