### PR TITLE
Forward operation name in the iri converter

### DIFF
--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -87,7 +87,7 @@ final class IriConverter implements IriConverterInterface
             $context[ChainIdentifierDenormalizer::HAS_IDENTIFIER_DENORMALIZER] = true;
         }
 
-        if ($item = $this->itemDataProvider->getItem($parameters['_api_resource_class'], $identifiers, null, $context)) {
+        if ($item = $this->itemDataProvider->getItem($parameters['_api_resource_class'], $identifiers, $parameters['_api_item_operation_name'] ?? null, $context)) {
             return $item;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/api-platform/issues/644 kinda
| License       | MIT
| Doc PR        | na

Let's say you declare a custom operation to identify a resource by something different then `id`:

```yaml
resources:
    App\Product\Entity\Product:
        itemOperations:
            get:
                method: 'GET'
            put:
                method: 'PUT'
            get_by_code:
                method: 'GET'
                path: '/products/by_code/{id}'
```

Then, you just have to create a custom item data provider:

```php
<?php

declare(strict_types=1);

namespace App\Product\DataProvider;

use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
use App\Product\Entity\Product;
use Doctrine\Common\Persistence\ManagerRegistry;
use Symfony\Component\HttpKernel\Exception\HttpException;

final class ProductByCodeItemDataProvider implements ItemDataProviderInterface, RestrictedDataProviderInterface
{
    private $repository;

    public function __construct(ManagerRegistry $managerRegistry)
    {
        $this->repository = $managerRegistry->getManagerForClass(Product::class)->getRepository(Product::class);
    }

    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
    {
        $product = $id['id'];

        if (!$product) {
            throw new HttpException(400, 'No "product" parameter.');
        }

        $queryBuilder = $this->repository->createQueryBuilder('p');

        $queryBuilder->select('p')
            ->where('p.code = :product')
            ->setParameter('product', $product);

        return $queryBuilder->getQuery()->getOneOrNullResult();
    }

    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
    {
        return Product::class === $resourceClass && 'get_by_code' === $operationName;
    }
}
```

This is really easy to pull up. Still it won't work when denormalizing a custom IRI like `/api/products/by_code/12345`. The only thing missing was the `operationName` that we have in the IRIConverter. 
With this patch you can now use your custom IRIs in denormalization (`denormalizeRelation` in the normalizer for example).

ping @gries might fix your issue