### PR TITLE
Enable item route on collection subresources

### DIFF
--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -30,7 +30,7 @@ Feature: Subresource support
     And the response status code should be 404
     And the response should be in JSON
 
-  Scenario: Get subresource one to one relation
+  Scenario: Get recursive subresource one to many relation
     When I send a "GET" request to "/questions/1/answer/related_questions"
     And the response status code should be 200
     And the response should be in JSON
@@ -209,7 +209,7 @@ Feature: Subresource support
     }
     """
 
-  Scenario: Get filtered embedded relation collection
+  Scenario: Get filtered embedded relation subresource collection
     When I send a "GET" request to "/dummies/1/related_dummies?name=Hello"
     And the response status code should be 200
     And the response should be in JSON
@@ -272,7 +272,34 @@ Feature: Subresource support
     }
     """
 
-  Scenario: Get the embedded relation collection at the third level
+  Scenario: Get the subresource relation item
+    When I send a "GET" request to "/dummies/1/related_dummies/2"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedDummy",
+      "@id": "/related_dummies/2",
+      "@type": "https://schema.org/Product",
+      "id": 2,
+      "name": null,
+      "symfony": "symfony",
+      "dummyDate": null,
+      "thirdLevel": {
+        "@id": "/third_levels/1",
+        "@type": "ThirdLevel",
+        "fourthLevel": "/fourth_levels/1"
+      },
+      "relatedToDummyFriend": [],
+      "dummyBoolean": null,
+      "embeddedDummy": [],
+      "age": null
+    }
+    """
+
+  Scenario: Get the embedded relation subresource item at the third level
     When I send a "GET" request to "/dummies/1/related_dummies/1/third_level"
     And the response status code should be 200
     And the response should be in JSON
@@ -290,7 +317,7 @@ Feature: Subresource support
     }
     """
 
-  Scenario: Get the embedded relation collection at the fourth level
+  Scenario: Get the embedded relation subresource item at the fourth level
     When I send a "GET" request to "/dummies/1/related_dummies/1/third_level/fourth_level"
     And the response status code should be 200
     And the response should be in JSON
@@ -355,7 +382,7 @@ Feature: Subresource support
     }
     """
 
-  Scenario: test
+  Scenario: Recursive resource
     When I send a "GET" request to "/dummy_products/2"
     And the response status code should be 200
     And the response should be in JSON

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -152,7 +152,6 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
 
         $qb = $manager->createQueryBuilder();
         $alias = $queryNameGenerator->generateJoinAlias($identifier);
-        $relationType = $classMetadata->getAssociationMapping($previousAssociationProperty)['type'];
         $normalizedIdentifiers = [];
 
         if (isset($identifiers[$identifier])) {
@@ -164,25 +163,31 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
             }
         }
 
-        switch ($relationType) {
-            // MANY_TO_MANY relations need an explicit join so that the identifier part can be retrieved
-            case ClassMetadataInfo::MANY_TO_MANY:
-                $joinAlias = $queryNameGenerator->generateJoinAlias($previousAssociationProperty);
+        if ($classMetadata->hasAssociation($previousAssociationProperty)) {
+            $relationType = $classMetadata->getAssociationMapping($previousAssociationProperty)['type'];
+            switch ($relationType) {
+                // MANY_TO_MANY relations need an explicit join so that the identifier part can be retrieved
+                case ClassMetadataInfo::MANY_TO_MANY:
+                    $joinAlias = $queryNameGenerator->generateJoinAlias($previousAssociationProperty);
 
-                $qb->select($joinAlias)
-                    ->from($identifierResourceClass, $alias)
-                    ->innerJoin("$alias.$previousAssociationProperty", $joinAlias);
-                break;
-            case ClassMetadataInfo::ONE_TO_MANY:
-                $mappedBy = $classMetadata->getAssociationMapping($previousAssociationProperty)['mappedBy'];
-                $previousAlias = "$previousAlias.$mappedBy";
+                    $qb->select($joinAlias)
+                        ->from($identifierResourceClass, $alias)
+                        ->innerJoin("$alias.$previousAssociationProperty", $joinAlias);
+                    break;
+                case ClassMetadataInfo::ONE_TO_MANY:
+                    $mappedBy = $classMetadata->getAssociationMapping($previousAssociationProperty)['mappedBy'];
+                    $previousAlias = "$previousAlias.$mappedBy";
 
-                $qb->select($alias)
-                    ->from($identifierResourceClass, $alias);
-                break;
-            default:
-                $qb->select("IDENTITY($alias.$previousAssociationProperty)")
-                    ->from($identifierResourceClass, $alias);
+                    $qb->select($alias)
+                        ->from($identifierResourceClass, $alias);
+                    break;
+                default:
+                    $qb->select("IDENTITY($alias.$previousAssociationProperty)")
+                        ->from($identifierResourceClass, $alias);
+            }
+        } elseif ($classMetadata->isIdentifier($previousAssociationProperty)) {
+            $qb->select($alias)
+                ->from($identifierResourceClass, $alias);
         }
 
         // Add where clause for identifiers

--- a/src/Metadata/Property/Factory/AnnotationSubresourceMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationSubresourceMetadataFactory.php
@@ -52,7 +52,7 @@ final class AnnotationSubresourceMetadataFactory implements PropertyMetadataFact
             $annotation = $this->reader->getPropertyAnnotation($reflectionClass->getProperty($property), ApiSubresource::class);
 
             if (null !== $annotation) {
-                return $this->updateMetadata($annotation, $propertyMetadata);
+                return $this->updateMetadata($annotation, $propertyMetadata, $resourceClass);
             }
         }
 
@@ -70,19 +70,24 @@ final class AnnotationSubresourceMetadataFactory implements PropertyMetadataFact
             $annotation = $this->reader->getMethodAnnotation($reflectionMethod, ApiSubresource::class);
 
             if (null !== $annotation) {
-                return $this->updateMetadata($annotation, $propertyMetadata);
+                return $this->updateMetadata($annotation, $propertyMetadata, $resourceClass);
             }
         }
 
         return $propertyMetadata;
     }
 
-    private function updateMetadata(ApiSubresource $annotation, PropertyMetadata $propertyMetadata): PropertyMetadata
+    private function updateMetadata(ApiSubresource $annotation, PropertyMetadata $propertyMetadata, string $originResourceClass): PropertyMetadata
     {
         $type = $propertyMetadata->getType();
         $isCollection = $type->isCollection();
         $resourceClass = $isCollection ? $type->getCollectionValueType()->getClassName() : $type->getClassName();
         $maxDepth = $annotation->maxDepth;
+        // @ApiSubresource is on the class identifier (/collection/{id}/subcollection/{subcollectionId})
+        if (null === $resourceClass) {
+            $resourceClass = $originResourceClass;
+            $isCollection = false;
+        }
 
         return $propertyMetadata->withSubresource(new SubresourceMetadata($resourceClass, $isCollection, $maxDepth));
     }

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -79,6 +79,12 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             $subresource = $propertyMetadata->getSubresource();
             $subresourceClass = $subresource->getResourceClass();
             $subresourceMetadata = $this->resourceMetadataFactory->create($subresourceClass);
+            $isLastItem = $resourceClass === $parentOperation['resource_class'] && $propertyMetadata->isIdentifier();
+
+            // A subresource that is also an identifier can't be a start point
+            if ($isLastItem && (null === $parentOperation || false === $parentOperation['collection'])) {
+                continue;
+            }
 
             $visiting = "$resourceClass $property $subresourceClass";
 
@@ -135,10 +141,12 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             } else {
                 $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
                 $operation['identifiers'] = $parentOperation['identifiers'];
-                $operation['identifiers'][] = [$parentOperation['property'], $resourceClass, $parentOperation['collection']];
-
-                $operation['operation_name'] = str_replace('get'.self::SUBRESOURCE_SUFFIX, RouteNameGenerator::inflector($property, $operation['collection']).'_get'.self::SUBRESOURCE_SUFFIX, $parentOperation['operation_name']);
-
+                $operation['identifiers'][] = [$parentOperation['property'], $resourceClass, $isLastItem ? true : $parentOperation['collection']];
+                $operation['operation_name'] = str_replace(
+                    'get'.self::SUBRESOURCE_SUFFIX,
+                    RouteNameGenerator::inflector($isLastItem ? 'item' : $property, $operation['collection']).'_get'.self::SUBRESOURCE_SUFFIX,
+                    $parentOperation['operation_name']
+                );
                 $operation['route_name'] = str_replace($parentOperation['operation_name'], $operation['operation_name'], $parentOperation['route_name']);
 
                 if (!\in_array($resourceMetadata->getShortName(), $operation['shortNames'], true)) {
@@ -151,11 +159,17 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
                     $operation['path'] = $subresourceOperation['path'];
                 } else {
                     $operation['path'] = str_replace(self::FORMAT_SUFFIX, '', $parentOperation['path']);
+
                     if ($parentOperation['collection']) {
                         list($key) = end($operation['identifiers']);
                         $operation['path'] .= sprintf('/{%s}', $key);
                     }
-                    $operation['path'] .= sprintf('/%s%s', $this->pathSegmentNameGenerator->getSegmentName($property, $operation['collection']), self::FORMAT_SUFFIX);
+
+                    if ($isLastItem) {
+                        $operation['path'] .= self::FORMAT_SUFFIX;
+                    } else {
+                        $operation['path'] .= sprintf('/%s%s', $this->pathSegmentNameGenerator->getSegmentName($property, $operation['collection']), self::FORMAT_SUFFIX);
+                    }
                 }
             }
 

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -31,6 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class RelatedDummy extends ParentDummy
 {
     /**
+     * @ApiSubresource
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/api-platform/issues/644 kinda https://github.com/api-platform/core/pull/1875
| License       | MIT
| Doc PR        | na

Say you had a subresource on a collection:

```php
<?php
namespace App;
use App\Bar;

/**
 * @ApiResource
 */
class Foo {
  /**
   * @ApiSubresource
   * @var Bar[]
   */
  public $bars;
}
```

this was declaring the following routes:

```
/bars
/foo
/foo/{id}/bars
```

This patch enables subresource item operations:

```
/bars
/foo
/foo/{id}/bars
/foo/{id}/bars/{barId}
```

Note: I'll work on the subresource documentation soon it lacks lot of things :). 