### PR TITLE
[GraphQL] Access control message

### DIFF
--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -53,4 +53,4 @@ Feature: Authorization checking
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "errors[0].message" should be equal to "Access Denied."
+    And the JSON node "errors[0].message" should be equal to "Only admins can create a secured dummy."

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -89,13 +89,6 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
 
             $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $collection, 'query');
 
-            if (null !== $this->resourceAccessChecker) {
-                $isGranted = $resourceMetadata->getGraphqlAttribute('query', 'access_control', null, true);
-                if (null !== $isGranted && !$this->resourceAccessChecker->isGranted($resourceClass, $isGranted, ['object' => $collection])) {
-                    throw Error::createLocatedError('Access Denied.', $info->fieldNodes, $info->path);
-                }
-            }
-
             if (!$this->paginationEnabled) {
                 $data = [];
                 foreach ($collection as $index => $object) {

--- a/src/GraphQl/Resolver/ItemResolver.php
+++ b/src/GraphQl/Resolver/ItemResolver.php
@@ -19,7 +19,6 @@ use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Security\ResourceAccessCheckerInterface;
 use ApiPlatform\Core\Util\ClassInfoTrait;
-use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ResolveInfo;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -70,13 +69,6 @@ final class ItemResolver
         $resourceClass = $this->getObjectClass($item);
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $item, 'query');
-
-        if (null !== $this->resourceAccessChecker) {
-            $isGranted = $resourceMetadata->getGraphqlAttribute('query', 'access_control', null, true);
-            if (null !== $isGranted && !$this->resourceAccessChecker->isGranted($resourceClass, $isGranted, ['object' => $item])) {
-                throw Error::createLocatedError('Access Denied.', $info->fieldNodes, $info->path);
-            }
-        }
 
         $normalizationContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
 

--- a/src/GraphQl/Resolver/ResourceAccessCheckerTrait.php
+++ b/src/GraphQl/Resolver/ResourceAccessCheckerTrait.php
@@ -52,6 +52,6 @@ trait ResourceAccessCheckerTrait
             return;
         }
 
-        throw Error::createLocatedError('Access Denied.', $info->fieldNodes, $info->path);
+        throw Error::createLocatedError($resourceMetadata->getGraphqlAttribute($operationName ?? '', 'access_control_message', 'Access Denied.'), $info->fieldNodes, $info->path);
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -30,6 +30,12 @@ use Symfony\Component\Validator\Constraints as Assert;
  *     },
  *     itemOperations={
  *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *     },
+ *     graphql={
+ *         "query"={},
+ *         "delete"={},
+ *         "update"={},
+ *         "create"={"access_control"="has_role('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}
  *     }
  * )
  * @ORM\Entity


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Add `access_control_message` attribute like in REST.
