### PR TITLE
Move coverage jobs to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,191 @@
+version: 2
+
+reusable-steps:
+  - &clear-test-app-cache
+    run:
+      name: Clear test app cache
+      command: tests/Fixtures/app/console cache:clear
+  - &disable-php-memory-limit
+    run:
+      name: Disable PHP memory limit
+      command: echo 'memory_limit=-1' | sudo tee -a /usr/local/etc/php/php.ini
+  - &disable-xdebug-php-extension
+    run:
+      name: Disable Xdebug PHP extension
+      command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  - &restore-composer-cache
+    restore_cache:
+      keys:
+        - composer-cache-{{ .Revision }}
+        - composer-cache-{{ .Branch }}
+        - composer-cache
+  - &restore-npm-cache
+    restore_cache:
+      keys:
+        - npm-cache-{{ .Revision }}
+        - npm-cache-{{ .Branch }}
+        - npm-cache
+  - &save-composer-cache-by-branch
+    save_cache:
+      paths:
+        - ~/.composer/cache
+      key: composer-cache-{{ .Branch }}-{{ .BuildNum }}
+  - &save-composer-cache-by-revision
+    save_cache:
+      paths:
+        - ~/.composer/cache
+      key: composer-cache-{{ .Revision }}-{{ .BuildNum }}
+  - &save-npm-cache-by-branch
+    save_cache:
+      paths:
+        - ~/.npm
+      key: npm-cache-{{ .Branch }}-{{ .BuildNum }}
+  - &save-npm-cache-by-revision
+    save_cache:
+      paths:
+        - ~/.npm
+      key: npm-cache-{{ .Revision }}-{{ .BuildNum }}
+  - &update-composer
+    run:
+      name: Update Composer
+      command: composer self-update
+  - &update-project-dependencies
+    run:
+      name: Update project dependencies
+      command: composer update --prefer-dist --no-progress --no-suggest --ansi
+
+jobs:
+  phpunit-php-7.2-coverage:
+    docker:
+      - image: circleci/php:7.2-node-browsers
+    environment:
+      SYMFONY_DEPRECATIONS_HELPER: weak_vendors
+      APP_ENV: test
+    parallelism: 2
+    working_directory: ~/api-platform/core
+    steps:
+      - checkout
+      - *restore-composer-cache
+      - *restore-npm-cache
+      - *disable-xdebug-php-extension
+      - *disable-php-memory-limit
+      - *update-composer
+      - *update-project-dependencies
+      - *save-composer-cache-by-revision
+      - *save-composer-cache-by-branch
+      - *clear-test-app-cache
+      - run:
+          name: Run PHPUnit tests
+          command: |-
+            mkdir -p build/logs/tmp build/cov
+            find tests -name '*Test.php' | circleci tests split --split-by=timings | parallel -j10% --rpl '{_} s/\//_/g;' \
+              phpdbg -qrr vendor/bin/phpunit --coverage-php build/cov/coverage-{_}.cov --log-junit build/logs/tmp/{_}.xml --colors=always {}
+      - run:
+          name: Merge PHPUnit test reports
+          command: |-
+            mkdir -p build/logs/phpunit
+            npx junit-merge --out build/logs/phpunit/junit.xml --dir build/logs/tmp
+            rm -r build/logs/tmp
+      - store_test_results:
+          path: build/logs
+      - store_artifacts:
+          path: build/logs/phpunit/junit.xml
+          destination: build/logs/phpunit/junit.xml
+      - persist_to_workspace:
+          root: build
+          paths:
+            - cov
+      - *save-npm-cache-by-revision
+      - *save-npm-cache-by-branch
+
+  behat-php-7.2-coverage:
+    docker:
+      - image: circleci/php:7.2-node-browsers
+    environment:
+      SYMFONY_DEPRECATIONS_HELPER: weak_vendors
+      APP_ENV: test
+    parallelism: 2
+    working_directory: ~/api-platform/core
+    steps:
+      - checkout
+      - *restore-composer-cache
+      - *restore-npm-cache
+      - *disable-xdebug-php-extension
+      - *disable-php-memory-limit
+      - *update-composer
+      - *update-project-dependencies
+      - *save-composer-cache-by-revision
+      - *save-composer-cache-by-branch
+      - *clear-test-app-cache
+      - run:
+          name: Run Behat tests
+          command: |-
+            mkdir -p build/logs/tmp build/cov
+            for f in $(find features -name '*.feature' -not -path 'features/main/exposed_state.feature' | circleci tests split --split-by=timings); do
+              _f=${f//\//_}
+              FEATURE="${_f}" phpdbg -qrr vendor/bin/behat --profile=coverage --suite=default --tags=~@postgres --format=progress --out=std --format=junit --out=build/logs/tmp/"${_f}" "$f"
+            done
+      - run:
+          name: Merge Behat test reports
+          command: |-
+            mkdir -p build/logs/behat
+            npx junit-merge --out build/logs/behat/junit.xml --dir build/logs/tmp --recursive
+            rm -r build/logs/tmp
+      - store_test_results:
+          path: build/logs
+      - store_artifacts:
+          path: build/logs/behat/junit.xml
+          destination: build/logs/behat/junit.xml
+      - persist_to_workspace:
+          root: build
+          paths:
+            - cov
+      - *save-npm-cache-by-revision
+      - *save-npm-cache-by-branch
+
+  merge-and-upload-coverage:
+    docker:
+      - image: circleci/php:7.2-node-browsers
+    working_directory: ~/api-platform/core
+    steps:
+      - checkout
+      - *restore-npm-cache
+      - *disable-xdebug-php-extension
+      - *disable-php-memory-limit
+      - run:
+          name: Download phpcov
+          command: wget https://phar.phpunit.de/phpcov.phar
+      - attach_workspace:
+          at: build
+      - run:
+          name: Merge code coverage reports
+          command: |-
+            mkdir -p build/logs
+            phpdbg -qrr phpcov.phar merge --clover build/logs/clover.xml build/cov
+      - store_artifacts:
+          path: build/logs/clover.xml
+          destination: build/logs/clover.xml
+      - run:
+          name: Upload code coverage report to Coveralls
+          command: |-
+            if [ ! -z "$COVERALLS_REPO_TOKEN" ]; then
+              npx @cedx/coveralls build/logs/clover.xml
+            else
+              echo 'Skipped'
+            fi
+      - run:
+          name: Upload code coverage report to Codecov
+          command: npx codecov --file=build/logs/clover.xml --disable=gcov
+      - *save-npm-cache-by-revision
+      - *save-npm-cache-by-branch
+
+workflows:
+  version: 2
+  test-with-coverage:
+    jobs:
+      - phpunit-php-7.2-coverage
+      - behat-php-7.2-coverage
+      - merge-and-upload-coverage:
+          requires:
+            - phpunit-php-7.2-coverage
+            - behat-php-7.2-coverage

--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,10 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = false
 
+[.circleci/config.yml]
+indent_style = space
+indent_size = 2
+
 [.gitmodules]
 indent_style = tab
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-
 sudo: false
 
 cache:
@@ -17,8 +16,6 @@ matrix:
     - php: '7.0'
     - php: '7.1'
     - php: '7.2'
-    - php: '7.2'
-      env: coverage=1
     - php: '7.2'
       env: lint=1
     - php: '7.2'
@@ -43,18 +40,6 @@ matrix:
 before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - if [[ $coverage != 1 && $lint != 1 ]]; then
-      npm install -g swagger-cli;
-    fi
-  - if [[ $coverage = 1 ]]; then
-      mkdir -p build/logs build/cov;
-    fi
-  - if [[ $coverage = 1 ]]; then
-      wget https://phar.phpunit.de/phpcov.phar;
-    fi
-  - if [[ $coverage = 1 ]]; then
-      wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar;
-    fi
   - if [[ $lint = 1 ]]; then
       wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.8.4/php-cs-fixer.phar;
     fi
@@ -64,9 +49,6 @@ before_install:
   - export PATH="$PATH:$HOME/.composer/vendor/bin"
 
 install:
-  - if [[ $coverage = 1 ]]; then
-      composer require --dev --no-update 'phpunit/php-code-coverage:^5.2.2';
-    fi
   - if [[ $deps = 'low' ]]; then
       composer update --prefer-dist --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi;
     else
@@ -74,37 +56,29 @@ install:
     fi
 
 script:
-  - if [[ $coverage = 1 ]]; then
-      APP_ENV=test_phpunit phpdbg -qrr vendor/bin/phpunit --coverage-php build/cov/coverage-phpunit.cov;
-    elif [[ $lint != 1 ]]; then
-      APP_ENV=test_phpunit vendor/bin/phpunit;
+  - if [[ $lint != 1 ]]; then
+      tests/Fixtures/app/console cache:clear;
     fi
-  - if [[ $coverage = 1 ]]; then
-      for f in $(find features -name '*.feature' -not -path 'features/main/exposed_state.feature'); do
-        FEATURE=${f//\//_} phpdbg -qrr vendor/bin/behat --profile=coverage --suite=default --tags=~@postgress --format=progress $f || exit $?;
-      done;
-    elif [[ $APP_ENV = 'postgres' ]]; then
+  - if [[ $lint != 1 ]]; then
+      vendor/bin/phpunit;
+    fi
+  - if [[ $lint != 1 ]]; then
+      tests/Fixtures/app/console cache:clear;
+    fi
+  - if [[ $APP_ENV = 'postgres' ]]; then
       vendor/bin/behat --suite=postgres --format=progress;
     elif [[ $lint != 1 ]]; then
       vendor/bin/behat --suite=default --format=progress;
     fi
-  - if [[ $coverage = 1 ]]; then
-      phpdbg -qrr phpcov.phar merge --clover build/logs/clover.xml build/cov;
+  - if [[ $lint != 1 ]]; then
+      tests/Fixtures/app/console api:swagger:export > swagger.json && npx swagger-cli validate swagger.json && rm swagger.json;
     fi
-  - if [[ $coverage != 1 && $lint != 1 ]]; then
-      tests/Fixtures/app/console api:swagger:export > swagger.json && swagger-cli validate swagger.json && rm swagger.json;
-    fi
-  - if [[ $coverage != 1 && $lint != 1 ]]; then
-      tests/Fixtures/app/console api:swagger:export --yaml > swagger.yaml && swagger-cli validate --no-schema swagger.yaml && rm swagger.yaml;
+  - if [[ $lint != 1 ]]; then
+      tests/Fixtures/app/console api:swagger:export --yaml > swagger.yaml && npx swagger-cli validate --no-schema swagger.yaml && rm swagger.yaml;
     fi
   - if [[ $lint = 1 ]]; then
       php php-cs-fixer.phar fix --dry-run --diff --no-ansi;
     fi
   - if [[ $lint = 1 ]]; then
       phpstan analyse -c phpstan.neon -l5 --ansi src tests;
-    fi
-
-after_success:
-  - if [[ $coverage = 1 ]]; then
-      travis_retry php coveralls.phar;
     fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
         <ini name="memory_limit" value="-1" />
         <server name="KERNEL_DIR" value="tests/Fixtures/app/" />
         <server name="KERNEL_CLASS" value="AppKernel" />
-        <server name="APP_ENV" value="test_phpunit" />
+        <server name="APP_ENV" value="test" />
         <server name="LEGACY" value="0" />
     </php>
 

--- a/src/Test/DoctrineOrmFilterTestCase.php
+++ b/src/Test/DoctrineOrmFilterTestCase.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
+namespace ApiPlatform\Core\Test;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\FilterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-abstract class AbstractFilterTest extends KernelTestCase
+abstract class DoctrineOrmFilterTestCase extends KernelTestCase
 {
     /**
      * @var ManagerRegistry

--- a/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
-class BooleanFilterTest extends AbstractFilterTest
+class BooleanFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = BooleanFilter::class;
 

--- a/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
+use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDate;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyImmutableDate;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Vincent CHALAMON <vincentchalamon@gmail.com>
  */
-class DateFilterTest extends AbstractFilterTest
+class DateFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = DateFilter::class;
 

--- a/tests/Bridge/Doctrine/Orm/Filter/ExistsFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/ExistsFilterTest.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter;
+use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class ExistsFilterTest extends AbstractFilterTest
+class ExistsFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = ExistsFilter::class;
 

--- a/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\NumericFilter;
+use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
-class NumericFilterTest extends AbstractFilterTest
+class NumericFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = NumericFilter::class;
 

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Vincent CHALAMON <vincentchalamon@gmail.com>
  */
-class OrderFilterTest extends AbstractFilterTest
+class OrderFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = OrderFilter::class;
 

--- a/tests/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\RangeFilter;
+use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 
 /**
  * @author Lee Siong Chan <ahlee2326@me.com>
  */
-class RangeFilterTest extends AbstractFilterTest
+class RangeFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = RangeFilter::class;
 

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -28,7 +29,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * @author Julien Deniau <julien.deniau@mapado.com>
  * @author Vincent CHALAMON <vincentchalamon@gmail.com>
  */
-class SearchFilterTest extends AbstractFilterTest
+class SearchFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $alias = 'oo';
     protected $filterClass = SearchFilter::class;

--- a/tests/Fixtures/app/config/config_test_phpunit.yml
+++ b/tests/Fixtures/app/config/config_test_phpunit.yml
@@ -1,2 +1,0 @@
-imports:
-    - { resource: config_test.yml }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

I propose to use CircleCI for the test coverage jobs. Also includes some minor CI / test-related fixes.

Todo:
- [x] Use GNU Parallel (only for PHPUnit tests, as Behat tests modify the database...)
- [ ] Investigate why ApiPlatformExtensionTest takes a very long time
- [x] Remove coverage jobs from Travis CI
