### PR TITLE
add some local caches where they are missing

### DIFF
--- a/tests/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolverInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Cache\CacheException;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -63,39 +64,39 @@ class CachedRouteNameResolverTest extends TestCase
     public function testGetRouteNameForItemRouteOnCacheMiss()
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
-        $cacheItemProphecy->isHit()->willReturn(false)->shouldBeCalled();
-        $cacheItemProphecy->set('some_item_route')->shouldBeCalled();
+        $cacheItemProphecy->isHit()->willReturn(false)->shouldBeCalledTimes(1);
+        $cacheItemProphecy->set('some_item_route')->shouldBeCalledTimes(1);
 
         $cacheItemPoolProphecy = $this->prophesize(CacheItemPoolInterface::class);
-        $cacheItemPoolProphecy->getItem(Argument::type('string'))->willReturn($cacheItemProphecy);
-        $cacheItemPoolProphecy->save($cacheItemProphecy)->willReturn(true)->shouldBeCalled();
+        $cacheItemPoolProphecy->getItem(Argument::type('string'))->shouldBeCalledTimes(1)->willReturn($cacheItemProphecy);
+        $cacheItemPoolProphecy->save($cacheItemProphecy)->shouldBeCalledTimes(1)->willReturn(true);
 
         $decoratedProphecy = $this->prophesize(RouteNameResolverInterface::class);
-        $decoratedProphecy->getRouteName('AppBundle\Entity\User', false, [])->willReturn('some_item_route')->shouldBeCalled();
+        $decoratedProphecy->getRouteName('AppBundle\Entity\User', false, [])->willReturn('some_item_route')->shouldBeCalledTimes(1);
 
         $cachedRouteNameResolver = new CachedRouteNameResolver($cacheItemPoolProphecy->reveal(), $decoratedProphecy->reveal());
-        $actual = $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', false);
 
-        $this->assertSame('some_item_route', $actual);
+        $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', false));
+        $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', false), 'Trigger the local cache');
     }
 
     public function testGetRouteNameForItemRouteOnCacheHit()
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
-        $cacheItemProphecy->isHit()->willReturn(true)->shouldBeCalled();
-        $cacheItemProphecy->get()->willReturn('some_item_route')->shouldBeCalled();
+        $cacheItemProphecy->isHit()->shouldBeCalledTimes(1)->willReturn(true);
+        $cacheItemProphecy->get()->shouldBeCalledTimes(1)->willReturn('some_item_route');
 
         $cacheItemPoolProphecy = $this->prophesize(CacheItemPoolInterface::class);
-        $cacheItemPoolProphecy->getItem(Argument::type('string'))->willReturn($cacheItemProphecy);
+        $cacheItemPoolProphecy->getItem(Argument::type('string'))->shouldBeCalledTimes(1)->willReturn($cacheItemProphecy);
         $cacheItemPoolProphecy->save($cacheItemProphecy)->shouldNotBeCalled();
 
         $decoratedProphecy = $this->prophesize(RouteNameResolverInterface::class);
         $decoratedProphecy->getRouteName(Argument::cetera())->shouldNotBeCalled();
 
         $cachedRouteNameResolver = new CachedRouteNameResolver($cacheItemPoolProphecy->reveal(), $decoratedProphecy->reveal());
-        $actual = $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM);
 
-        $this->assertSame('some_item_route', $actual);
+        $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM));
+        $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM), 'Trigger the local cache');
     }
 
     /**
@@ -123,38 +124,55 @@ class CachedRouteNameResolverTest extends TestCase
     public function testGetRouteNameForCollectionRouteOnCacheMiss()
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
-        $cacheItemProphecy->isHit()->willReturn(false)->shouldBeCalled();
-        $cacheItemProphecy->set('some_collection_route')->shouldBeCalled();
+        $cacheItemProphecy->isHit()->shouldBeCalledTimes(1)->willReturn(false);
+        $cacheItemProphecy->set('some_collection_route')->shouldBeCalledTimes(1);
 
         $cacheItemPoolProphecy = $this->prophesize(CacheItemPoolInterface::class);
-        $cacheItemPoolProphecy->getItem(Argument::type('string'))->willReturn($cacheItemProphecy);
-        $cacheItemPoolProphecy->save($cacheItemProphecy)->willReturn(true)->shouldBeCalled();
+        $cacheItemPoolProphecy->getItem(Argument::type('string'))->shouldBeCalledTimes(1)->willReturn($cacheItemProphecy);
+        $cacheItemPoolProphecy->save($cacheItemProphecy)->shouldBeCalledTimes(1)->willReturn(true);
 
         $decoratedProphecy = $this->prophesize(RouteNameResolverInterface::class);
-        $decoratedProphecy->getRouteName('AppBundle\Entity\User', true, [])->willReturn('some_collection_route')->shouldBeCalled();
+        $decoratedProphecy->getRouteName('AppBundle\Entity\User', true, [])->willReturn('some_collection_route')->shouldBeCalledTimes(1);
 
         $cachedRouteNameResolver = new CachedRouteNameResolver($cacheItemPoolProphecy->reveal(), $decoratedProphecy->reveal());
-        $actual = $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', true);
 
-        $this->assertSame('some_collection_route', $actual);
+        $this->assertSame('some_collection_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', true));
+        $this->assertSame('some_collection_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', true), 'Trigger the local cache');
     }
 
     public function testGetRouteNameForCollectionRouteOnCacheHit()
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
-        $cacheItemProphecy->isHit()->willReturn(true)->shouldBeCalled();
-        $cacheItemProphecy->get()->willReturn('some_collection_route')->shouldBeCalled();
+        $cacheItemProphecy->isHit()->willReturn(true)->shouldBeCalledTimes(1);
+        $cacheItemProphecy->get()->willReturn('some_collection_route')->shouldBeCalledTimes(1);
 
         $cacheItemPoolProphecy = $this->prophesize(CacheItemPoolInterface::class);
-        $cacheItemPoolProphecy->getItem(Argument::type('string'))->willReturn($cacheItemProphecy);
+        $cacheItemPoolProphecy->getItem(Argument::type('string'))->shouldBeCalledTimes(1)->willReturn($cacheItemProphecy);
         $cacheItemPoolProphecy->save($cacheItemProphecy)->shouldNotBeCalled();
 
         $decoratedProphecy = $this->prophesize(RouteNameResolverInterface::class);
         $decoratedProphecy->getRouteName(Argument::cetera())->shouldNotBeCalled();
 
         $cachedRouteNameResolver = new CachedRouteNameResolver($cacheItemPoolProphecy->reveal(), $decoratedProphecy->reveal());
-        $actual = $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::COLLECTION);
 
-        $this->assertSame('some_collection_route', $actual);
+        $this->assertSame('some_collection_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::COLLECTION));
+        $this->assertSame('some_collection_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::COLLECTION), 'Trigger the local cache');
+    }
+
+    public function testGetRouteNameWithCacheItemThrowsCacheException()
+    {
+        $cacheException = $this->prophesize(CacheException::class);
+        $cacheException->willExtend(\Exception::class);
+
+        $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
+        $cacheItemPool->getItem(Argument::type('string'))->shouldBeCalledTimes(1)->willThrow($cacheException->reveal());
+
+        $decoratedProphecy = $this->prophesize(RouteNameResolverInterface::class);
+        $decoratedProphecy->getRouteName('AppBundle\Entity\User', OperationType::ITEM, [])->willReturn('some_item_route')->shouldBeCalledTimes(1);
+
+        $cachedRouteNameResolver = new CachedRouteNameResolver($cacheItemPool->reveal(), $decoratedProphecy->reveal());
+
+        $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM));
+        $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM), 'Trigger the local cache');
     }
 }

--- a/tests/Operation/Factory/CachedSubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/CachedSubresourceOperationFactoryTest.php
@@ -29,38 +29,40 @@ class CachedSubresourceOperationFactoryTest extends TestCase
     public function testCreateWithItemHit()
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
-        $cacheItem->isHit()->willReturn(true)->shouldBeCalled();
-        $cacheItem->get()->willReturn(['foo' => 'bar'])->shouldBeCalled();
+        $cacheItem->isHit()->willReturn(true)->shouldBeCalledTimes(1);
+        $cacheItem->get()->willReturn(['foo' => 'bar'])->shouldBeCalledTimes(1);
 
         $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
-        $cacheItemPool->getItem($this->generateCacheKey())->willReturn($cacheItem->reveal())->shouldBeCalled();
+        $cacheItemPool->getItem($this->generateCacheKey())->willReturn($cacheItem->reveal())->shouldBeCalledTimes(1);
 
         $decoratedSubresourceOperationFactory = $this->prophesize(SubresourceOperationFactoryInterface::class);
         $decoratedSubresourceOperationFactory->create()->shouldNotBeCalled();
 
         $cachedSubresourceOperationFactory = new CachedSubresourceOperationFactory($cacheItemPool->reveal(), $decoratedSubresourceOperationFactory->reveal());
-        $resultedSubresourceOperation = $cachedSubresourceOperationFactory->create(Dummy::class);
 
-        $this->assertEquals(['foo' => 'bar'], $resultedSubresourceOperation);
+        $expectedResult = ['foo' => 'bar'];
+        $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class));
+        $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     public function testCreateWithItemNotHit()
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
-        $cacheItem->isHit()->willReturn(false)->shouldBeCalled();
-        $cacheItem->set(['foo' => 'bar'])->willReturn($cacheItem->reveal())->shouldBeCalled();
+        $cacheItem->isHit()->willReturn(false)->shouldBeCalledTimes(1);
+        $cacheItem->set(['foo' => 'bar'])->willReturn($cacheItem->reveal())->shouldBeCalledTimes(1);
 
         $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
-        $cacheItemPool->getItem($this->generateCacheKey())->willReturn($cacheItem->reveal())->shouldBeCalled();
-        $cacheItemPool->save($cacheItem->reveal())->willReturn(true)->shouldBeCalled();
+        $cacheItemPool->getItem($this->generateCacheKey())->willReturn($cacheItem->reveal())->shouldBeCalledTimes(1);
+        $cacheItemPool->save($cacheItem->reveal())->willReturn(true)->shouldBeCalledTimes(1);
 
         $decoratedSubresourceOperationFactory = $this->prophesize(SubresourceOperationFactoryInterface::class);
-        $decoratedSubresourceOperationFactory->create(Dummy::class)->shouldBeCalled()->willReturn(['foo' => 'bar']);
+        $decoratedSubresourceOperationFactory->create(Dummy::class)->shouldBeCalledTimes(1)->willReturn(['foo' => 'bar']);
 
         $cachedSubresourceOperationFactory = new CachedSubresourceOperationFactory($cacheItemPool->reveal(), $decoratedSubresourceOperationFactory->reveal());
-        $resultedSubresourceOperation = $cachedSubresourceOperationFactory->create(Dummy::class);
 
-        $this->assertEquals(['foo' => 'bar'], $resultedSubresourceOperation);
+        $expectedResult = ['foo' => 'bar'];
+        $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class));
+        $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     public function testCreateWithGetCacheItemThrowsCacheException()
@@ -69,15 +71,16 @@ class CachedSubresourceOperationFactoryTest extends TestCase
         $cacheException->willExtend(\Exception::class);
 
         $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
-        $cacheItemPool->getItem($this->generateCacheKey())->willThrow($cacheException->reveal())->shouldBeCalled();
+        $cacheItemPool->getItem($this->generateCacheKey())->willThrow($cacheException->reveal())->shouldBeCalledTimes(1);
 
         $decoratedSubresourceOperationFactory = $this->prophesize(SubresourceOperationFactoryInterface::class);
-        $decoratedSubresourceOperationFactory->create(Dummy::class)->shouldBeCalled()->willReturn(['foo' => 'bar']);
+        $decoratedSubresourceOperationFactory->create(Dummy::class)->shouldBeCalledTimes(1)->willReturn(['foo' => 'bar']);
 
         $cachedSubresourceOperationFactory = new CachedSubresourceOperationFactory($cacheItemPool->reveal(), $decoratedSubresourceOperationFactory->reveal());
-        $resultedSubresourceOperation = $cachedSubresourceOperationFactory->create(Dummy::class);
 
-        $this->assertEquals(['foo' => 'bar'], $resultedSubresourceOperation);
+        $expectedResult = ['foo' => 'bar'];
+        $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class));
+        $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
     private function generateCacheKey(string $resourceClass = Dummy::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

We normally use local caches in conjunction with `CacheItemPool`s. They were missing here.
