### PR TITLE
[Bug] Fix integer Identifiers denormalization

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -733,6 +733,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
         $relatedDummy2->setName('RelatedDummy without friends');
         $this->manager->persist($relatedDummy2);
         $this->manager->flush();
+        $this->manager->clear();
     }
 
     /**

--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -10,6 +10,7 @@ Feature: Search filter on collections
     And I send a "GET" request to "/related_dummies?relatedToDummyFriend.dummyFriend=/dummy_friends/4"
     Then the response status code should be 200
     And the JSON node "_embedded.item" should have 1 element
+    And the JSON node "_embedded.item[0].id" should be equal to the number 1
     And the JSON node "_embedded.item[0]._links.relatedToDummyFriend" should have 4 elements
     And the JSON node "_embedded.item[0]._embedded.relatedToDummyFriend" should have 4 elements
 

--- a/features/main/non_resource.feature
+++ b/features/main/non_resource.feature
@@ -11,7 +11,7 @@ Feature: Non-resources handling
         "@context": "/contexts/ContainNonResource",
         "@id": "/contain_non_resources/1",
         "@type": "ContainNonResource",
-        "id": "1",
+        "id": 1,
         "nested": {
             "@id": "/contain_non_resources/1-nested",
             "@type": "ContainNonResource",

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -236,6 +236,10 @@
             <argument type="tagged" tag="api_platform.identifier.denormalizer" />
         </service>
 
+        <service id="api_platform.identifier.integer" class="ApiPlatform\Core\Identifier\Normalizer\IntegerDenormalizer" public="false">
+            <tag name="api_platform.identifier.denormalizer" />
+        </service>
+
         <service id="api_platform.identifier.date_normalizer" class="ApiPlatform\Core\Identifier\Normalizer\DateTimeIdentifierDenormalizer" public="false">
             <tag name="api_platform.identifier.denormalizer" />
         </service>

--- a/src/Identifier/Normalizer/ChainIdentifierDenormalizer.php
+++ b/src/Identifier/Normalizer/ChainIdentifierDenormalizer.php
@@ -62,9 +62,8 @@ class ChainIdentifierDenormalizer
                 throw new InvalidIdentifierException(sprintf('Invalid identifier "%1$s", "%1$s" was not found.', $key));
             }
 
+            $metadata = $this->getIdentifierMetadata($class, $key);
             foreach ($this->identifierDenormalizers as $normalizer) {
-                $metadata = $this->getIdentifierMetadata($class, $key);
-
                 if (!$normalizer->supportsDenormalization($identifiers[$key], $metadata)) {
                     continue;
                 }
@@ -82,8 +81,10 @@ class ChainIdentifierDenormalizer
 
     private function getIdentifierMetadata($class, $propertyName)
     {
-        $type = $this->propertyMetadataFactory->create($class, $propertyName)->getType();
+        if (!$type = $this->propertyMetadataFactory->create($class, $propertyName)->getType()) {
+            return null;
+        }
 
-        return $type && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() ? $type->getClassName() : null;
+        return Type::BUILTIN_TYPE_OBJECT === ($builtInType = $type->getBuiltinType()) ? $type->getClassName() : $builtInType;
     }
 }

--- a/src/Identifier/Normalizer/IntegerDenormalizer.php
+++ b/src/Identifier/Normalizer/IntegerDenormalizer.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Identifier\Normalizer;
+
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class IntegerDenormalizer implements DenormalizerInterface
+{
+    public function denormalize($data, $class, $format = null, array $context = []): int
+    {
+        return (int) $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        return Type::BUILTIN_TYPE_INT === $type && \is_string($data);
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -500,6 +500,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.filters',
             'api_platform.iri_converter',
             'api_platform.identifier.denormalizer',
+            'api_platform.identifier.integer',
             'api_platform.identifier.date_normalizer',
             'api_platform.identifier.uuid_normalizer',
             'api_platform.identifiers_extractor',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

Right now the Identifier Denormalizer will automatically result in the identifier being casted to string.
This basicaly break the search filter on related entities with a strict typehint on the `getId()` because when getting references to the object in the [getItemFromIri()](https://github.com/api-platform/core/blob/master/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php#L374) the call to `getId()` will result in a TypeError.

ping @soyuka 