### PR TITLE
Revert "Simplify boolean filter"

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
@@ -96,9 +96,11 @@ class BooleanFilter extends AbstractContextAwareFilter
             list($alias, $field) = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $resourceClass);
         }
 
-        $expr = $queryBuilder->expr();
+        $valueParameter = $queryNameGenerator->generateParameterName($field);
+
         $queryBuilder
-            ->andWhere($expr->eq(sprintf('%s.%s', $alias, $field), $expr->literal($value)));
+            ->andWhere(sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
+            ->setParameter($valueParameter, $value);
     }
 
     /**

--- a/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
@@ -67,7 +67,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
                 [
                     'dummyBoolean' => 'true',
                 ],
-                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = true', Dummy::class),
+                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = :dummyBoolean_p1', Dummy::class),
             ],
             'string ("false")' => [
                 [
@@ -78,7 +78,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
                 [
                     'dummyBoolean' => 'false',
                 ],
-                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = false', Dummy::class),
+                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = :dummyBoolean_p1', Dummy::class),
             ],
             'non-boolean' => [
                 [
@@ -100,7 +100,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
                 [
                     'dummyBoolean' => '0',
                 ],
-                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = false', Dummy::class),
+                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = :dummyBoolean_p1', Dummy::class),
             ],
             'numeric string ("1")' => [
                 [
@@ -111,7 +111,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
                 [
                     'dummyBoolean' => '1',
                 ],
-                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = true', Dummy::class),
+                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = :dummyBoolean_p1', Dummy::class),
             ],
             'nested properties' => [
                 [
@@ -122,7 +122,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
                 [
                     'relatedDummy.dummyBoolean' => '1',
                 ],
-                sprintf('SELECT o FROM %s o INNER JOIN o.relatedDummy relatedDummy_a1 WHERE relatedDummy_a1.dummyBoolean = true', Dummy::class),
+                sprintf('SELECT o FROM %s o INNER JOIN o.relatedDummy relatedDummy_a1 WHERE relatedDummy_a1.dummyBoolean = :dummyBoolean_p1', Dummy::class),
             ],
             'numeric string ("1") on non-boolean property' => [
                 [
@@ -180,7 +180,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
                     'name' => 'true',
                     'id' => '0',
                 ],
-                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = false', Dummy::class),
+                sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = :dummyBoolean_p1', Dummy::class),
             ],
         ];
     }


### PR DESCRIPTION
Reverts api-platform/core#1905

A value is a value, not a literal. If we go by this logic, then we'll use literals for many other things too, which would of course also be wrong.