### PR TITLE
RFC: denormalize - do not set null values on not nullable properties

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -204,6 +204,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return;
         }
 
+        if (null === $value && !$type->isNullable()) {
+            return;
+        }
         $this->validateType($attribute, $type, $value, $format);
         $this->setValue($object, $attribute, $value);
     }

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -223,12 +223,15 @@ class AbstractItemNormalizerTest extends TestCase
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
-            new PropertyNameCollection(['name', 'relatedDummy', 'relatedDummies'])
+            new PropertyNameCollection(['name', 'description', 'relatedDummy', 'relatedDummies'])
         )->shouldBeCalled();
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', false, true)
+        )->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'description', [])->willReturn(
+            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING, true), '', false, true)
         )->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn(
             new PropertyMetadata(
@@ -262,7 +265,8 @@ class AbstractItemNormalizerTest extends TestCase
         $iriConverterProphecy->getItemFromIri('/dummies/2', Argument::type('array'))->willReturn($relatedDummy2)->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
-        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'name', 'foo')->shouldBeCalled();
+        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'name', null)->shouldNotBeCalled();
+        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'description', 'bar')->shouldBeCalled();
         $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'relatedDummy', $relatedDummy1)->shouldBeCalled();
         $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'relatedDummies', [$relatedDummy2])->shouldBeCalled();
 
@@ -281,7 +285,8 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->setSerializer($serializerProphecy->reveal());
 
         $normalizer->denormalize([
-            'name' => 'foo',
+            'name' => null,
+            'description' => 'bar',
             'relatedDummy' => '/dummies/1',
             'relatedDummies' => ['/dummies/2'],
         ], Dummy::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This was discussed a little bit on slack this afternoon.
Should we *not* call setters with `null` values if the type is not nullable?

This seems to be consistent with the check on line 177.
https://github.com/api-platform/core/blob/592af017c6125928c3a25ddb2f512fa3e234967e/src/Serializer/AbstractItemNormalizer.php#L177-L180

We should respect the property info type `isNullable` value.

This is mainly to prevent denormalize errors when an api's resource may have a not nullable setter: `setFoo(string $foo)` but the api request as come in as `{"foo": null}`

Not sure what the drawbacks are here. I'm sure someone will point something out.

further work if this PR is deemed correct:
The same check should also be done when denormalizing relations.
