### PR TITLE
feature: add a way to always include null in the date filter

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
@@ -33,6 +33,7 @@ class DateFilter extends AbstractContextAwareFilter
     const EXCLUDE_NULL = 'exclude_null';
     const INCLUDE_NULL_BEFORE = 'include_null_before';
     const INCLUDE_NULL_AFTER = 'include_null_after';
+    const INCLUDE_NULL_BEFORE_AND_AFTER = 'include_null_before_and_after';
     const DOCTRINE_DATE_TYPES = [
         'date' => true,
         'datetime' => true,
@@ -189,8 +190,9 @@ class DateFilter extends AbstractContextAwareFilter
         if (null === $nullManagement || self::EXCLUDE_NULL === $nullManagement) {
             $queryBuilder->andWhere($baseWhere);
         } elseif (
-            (\in_array($operator, [self::PARAMETER_BEFORE, self::PARAMETER_STRICTLY_BEFORE], true) && self::INCLUDE_NULL_BEFORE === $nullManagement) ||
-            (\in_array($operator, [self::PARAMETER_AFTER, self::PARAMETER_STRICTLY_AFTER], true) && self::INCLUDE_NULL_AFTER === $nullManagement)
+            (self::INCLUDE_NULL_BEFORE === $nullManagement && \in_array($operator, [self::PARAMETER_BEFORE, self::PARAMETER_STRICTLY_BEFORE], true)) ||
+            (self::INCLUDE_NULL_AFTER === $nullManagement && \in_array($operator, [self::PARAMETER_AFTER, self::PARAMETER_STRICTLY_AFTER], true)) ||
+            (self::INCLUDE_NULL_BEFORE_AND_AFTER === $nullManagement && \in_array($operator, [self::PARAMETER_AFTER, self::PARAMETER_STRICTLY_AFTER, self::PARAMETER_BEFORE, self::PARAMETER_STRICTLY_BEFORE], true))
         ) {
             $queryBuilder->andWhere($queryBuilder->expr()->orX(
                 $baseWhere,

--- a/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
@@ -294,6 +294,17 @@ class DateFilterTest extends DoctrineOrmFilterTestCase
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyDate >= :dummyDate_p1 OR o.dummyDate IS NULL', Dummy::class),
             ],
+            'include null before and after (include_null_before_and_after)' => [
+                [
+                    'dummyDate' => 'include_null_before_and_after',
+                ],
+                [
+                    'dummyDate' => [
+                        'after' => '2015-04-05',
+                    ],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyDate >= :dummyDate_p1 OR o.dummyDate IS NULL', Dummy::class),
+            ],
             'bad date format' => [
                 [
                     'dummyDate' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #669 
| License       | MIT
| Doc PR        | todo

Add a way to always include null values.
