### PR TITLE
use name converter in ConstraintViolationListNormalizer

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
@@ -32,6 +32,7 @@
         <service id="api_platform.hydra.normalizer.constraint_violation_list" class="ApiPlatform\Core\Hydra\Serializer\ConstraintViolationListNormalizer" public="false">
             <argument type="service" id="api_platform.router" />
             <argument>%api_platform.validator.serialize_payload_fields%</argument>
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="serializer.normalizer" priority="64" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/problem.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/problem.xml
@@ -14,6 +14,7 @@
 
         <service id="api_platform.problem.normalizer.constraint_violation_list" class="ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer" public="false">
             <argument>%api_platform.validator.serialize_payload_fields%</argument>
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
             
             <tag name="serializer.normalizer" priority="16" />
         </service>

--- a/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Hydra\Serializer;
 
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Converts {@see \Symfony\Component\Validator\ConstraintViolationListInterface} to a Hydra error representation.
@@ -27,9 +28,9 @@ final class ConstraintViolationListNormalizer extends AbstractConstraintViolatio
 
     private $urlGenerator;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator, array $serializePayloadFields = null)
+    public function __construct(UrlGeneratorInterface $urlGenerator, array $serializePayloadFields = null, NameConverterInterface $nameConverter = null)
     {
-        parent::__construct($serializePayloadFields);
+        parent::__construct($serializePayloadFields, $nameConverter);
 
         $this->urlGenerator = $urlGenerator;
     }

--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Serializer;
 
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
@@ -28,9 +29,11 @@ abstract class AbstractConstraintViolationListNormalizer implements NormalizerIn
     const FORMAT = null; // Must be overrode
 
     private $serializePayloadFields;
+    private $nameConverter;
 
-    public function __construct(array $serializePayloadFields = null)
+    public function __construct(array $serializePayloadFields = null, NameConverterInterface $nameConverter = null)
     {
+        $this->nameConverter = $nameConverter;
         $this->serializePayloadFields = $serializePayloadFields;
     }
 
@@ -47,7 +50,10 @@ abstract class AbstractConstraintViolationListNormalizer implements NormalizerIn
         $violations = $messages = [];
 
         foreach ($constraintViolationList as $violation) {
-            $violationData = ['propertyPath' => $violation->getPropertyPath(), 'message' => $violation->getMessage()];
+            $violationData = [
+                'propertyPath' => $this->nameConverter ? $this->nameConverter->normalize($violation->getPropertyPath()) : $violation->getPropertyPath(),
+                'message' => $violation->getMessage(),
+            ];
 
             $constraint = $violation->getConstraint();
             if ($this->serializePayloadFields && $constraint && $constraint->payload) {

--- a/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
@@ -16,6 +16,8 @@ namespace ApiPlatform\Core\Tests\Hydra\Serializer;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Hydra\Serializer\ConstraintViolationListNormalizer;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -28,8 +30,9 @@ class ConstraintViolationNormalizerTest extends TestCase
     public function testSupportNormalization()
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
 
-        $normalizer = new ConstraintViolationListNormalizer($urlGeneratorProphecy->reveal(), []);
+        $normalizer = new ConstraintViolationListNormalizer($urlGeneratorProphecy->reveal(), [], $nameConverterProphecy->reveal());
 
         $this->assertTrue($normalizer->supportsNormalization(new ConstraintViolationList(), ConstraintViolationListNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new ConstraintViolationList(), 'xml'));
@@ -39,9 +42,14 @@ class ConstraintViolationNormalizerTest extends TestCase
     public function testNormalize()
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGeneratorProphecy->generate('api_jsonld_context', ['shortName' => 'ConstraintViolationList'])->willReturn('/context/foo')->shouldBeCalled();
+        $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
 
-        $normalizer = new ConstraintViolationListNormalizer($urlGeneratorProphecy->reveal(), ['severity', 'anotherField1']);
+        $urlGeneratorProphecy->generate('api_jsonld_context', ['shortName' => 'ConstraintViolationList'])->willReturn('/context/foo')->shouldBeCalled();
+        $nameConverterProphecy->normalize(Argument::type('string'))->will(function ($args) {
+            return '_'.$args[0];
+        });
+
+        $normalizer = new ConstraintViolationListNormalizer($urlGeneratorProphecy->reveal(), ['severity', 'anotherField1'], $nameConverterProphecy->reveal());
 
         // Note : we use NotNull constraint and not Constraint class because Constraint is abstract
         $constraint = new NotNull();
@@ -55,18 +63,18 @@ class ConstraintViolationNormalizerTest extends TestCase
             '@context' => '/context/foo',
             '@type' => 'ConstraintViolationList',
             'hydra:title' => 'An error occurred',
-            'hydra:description' => 'd: a
-4: 1',
+            'hydra:description' => '_d: a
+_4: 1',
             'violations' => [
                     [
-                        'propertyPath' => 'd',
+                        'propertyPath' => '_d',
                         'message' => 'a',
                         'payload' => [
                             'severity' => 'warning',
                         ],
                     ],
                     [
-                        'propertyPath' => '4',
+                        'propertyPath' => '_4',
                         'message' => '1',
                     ],
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

property paths in constraint violatiions weren't correct when using a name converter
