### PR TITLE
[WIP] Allow to filter attributes of related non-api-resource entities.

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -420,7 +420,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $this->normalizeCollectionOfRelations($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
         }
 
-        if ($type && ($className = $type->getClassName())) {
+        if ($type && $className = $type->getClassName()) {
             if ($this->resourceClassResolver->isResourceClass($className)) {
                 return $this->normalizeRelation($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
             }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -420,12 +420,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $this->normalizeCollectionOfRelations($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
         }
 
-        if (
-            $type &&
-            ($className = $type->getClassName()) &&
-            $this->resourceClassResolver->isResourceClass($className)
-        ) {
-            return $this->normalizeRelation($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
+        if ($type && ($className = $type->getClassName())) {
+            if ($this->resourceClassResolver->isResourceClass($className)) {
+                return $this->normalizeRelation($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
+            }
+            else {
+                $context = $this->createChildContext($context, $attribute);
+            }
         }
 
         unset($context['resource_class']);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -424,9 +424,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             if ($this->resourceClassResolver->isResourceClass($className)) {
                 return $this->normalizeRelation($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
             }
-            else {
-                $context = $this->createChildContext($context, $attribute);
-            }
+            $context = $this->createChildContext($context, $attribute);
         }
 
         unset($context['resource_class']);

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -132,6 +132,13 @@ class Dummy
     public $relatedDummies;
 
     /**
+     * @var NonApiResourceDummy A related non api resource dummy.
+     *
+     * @ORM\ManyToOne(targetEntity="NonApiResourceDummy")
+     */
+    public $nonApiResourceDummy;
+
+    /**
      * @var array serialize data
      *
      * @ORM\Column(type="json_array", nullable=true)
@@ -272,6 +279,16 @@ class Dummy
     public function addRelatedDummy(RelatedDummy $relatedDummy)
     {
         $this->relatedDummies->add($relatedDummy);
+    }
+
+    public function getNonApiResourceDummy()
+    {
+        return $this->nonApiResourceDummy;
+    }
+
+    public function setNonApiResourceDummy(NonApiResourceDummy $nonApiResourceDummy)
+    {
+        $this->nonApiResourceDummy = $nonApiResourceDummy;
     }
 
     /**

--- a/tests/Fixtures/TestBundle/Entity/NonApiResourceDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/NonApiResourceDummy.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class NonApiResourceDummy
+ *
+ * Provides a simple ORM entity that is not an API resource at the same time.
+ *
+ * @author Michael Petri <mpetri@lyska.io>
+ * @see https://github.com/api-platform/core/pull/1936#pullrequestreview-119415360
+ *
+ * @ORM\Entity
+ */
+class NonApiResourceDummy
+{
+
+    /**
+     * The unique entity id.
+     *
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * Gets the unique entity id.
+     *
+     * @return int
+     *   The unique entity id.
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+}


### PR DESCRIPTION
Problem:
In the case we've got an api resource which relates to an entity which isn't exposed as api resource. We can not filter the attributes of the related/child entity.

Solution:
Create child context and pass it to default normalization callback to ensure correct attribute filters are passed for non api resource entities.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -