### PR TITLE
[JSON-API] Add initial spec compliance on "Inclusion of Related Resou…

### DIFF
--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -1,0 +1,17 @@
+Feature: JSON API Inclusion of Related Resources
+  In order to be able to handle inclusion of related resources
+  As a client software developer
+  I need to be able to specify include parameters according to JSON API recommendation
+
+  Background:
+    Given I add "Accept" header equal to "application/vnd.api+json"
+    And I add "Content-Type" header equal to "application/vnd.api+json"
+
+  @createSchema
+  @dropSchema
+  Scenario: Request inclusion of a related resources on collection
+    Given there are 3 dummy objects
+    When I send a "GET" request to "/dummies/1?include=foo"
+    Then the response status code should be 400
+    And the response should be in JSON
+

--- a/src/Bridge/Symfony/Bundle/Resources/config/jsonapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/jsonapi.xml
@@ -57,6 +57,9 @@
         </service>
 
         <!-- Event listener -->
+        <service id="api_platform.jsonapi.listener.request.include_parameters" class="ApiPlatform\Core\JsonApi\EventListener\IncludeParametersListener">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="5" />
+        </service>
 
         <service id="api_platform.jsonapi.listener.request.transform_pagination_parameters" class="ApiPlatform\Core\JsonApi\EventListener\TransformPaginationParametersListener">
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="5" />

--- a/src/JsonApi/EventListener/IncludeParametersListener.php
+++ b/src/JsonApi/EventListener/IncludeParametersListener.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonApi\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @internal
+ *
+ * @see http://jsonapi.org/format/#fetching-includes
+ */
+final class IncludeParametersListener
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (
+            'jsonapi' !== $request->getRequestFormat() ||
+            !$request->attributes->get('_api_resource_class') ||
+            !$request->query->get('include')
+        ) {
+            return;
+        }
+
+        throw new BadRequestHttpException('Inclusion of related resources is not supported yet.');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Ref http://jsonapi.org/format/#fetching-includes

This add spec compliance in the first place.
I'll try to add support for this latter if no-ones beats me to it...