### PR TITLE
[GraphQL] Serialization

### DIFF
--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -187,6 +187,70 @@ Feature: GraphQL introspection support
     And the JSON node "data.__type.fields[9].name" should be equal to "jsonData"
     And the JSON node "data.__type.fields[9].type.name" should be equal to "Iterable"
 
+  Scenario: Retrieve entity - using serialization groups - fields
+    When I send the following GraphQL request:
+    """
+    {
+      typeQuery: __type(name: "DummyGroup") {
+        description,
+        fields {
+          name
+          type {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+      typeCreateInput: __type(name: "createDummyGroupInput") {
+        description,
+        inputFields {
+          name
+          type {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+      typeCreatePayload: __type(name: "createDummyGroupPayload") {
+        description,
+        fields {
+          name
+          type {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.typeQuery.fields" should have 2 elements
+    And the JSON node "data.typeQuery.fields[0].name" should be equal to "id"
+    And the JSON node "data.typeQuery.fields[1].name" should be equal to "foo"
+    And the JSON node "data.typeCreateInput.inputFields" should have 3 elements
+    And the JSON node "data.typeCreateInput.inputFields[0].name" should be equal to "bar"
+    And the JSON node "data.typeCreateInput.inputFields[1].name" should be equal to "baz"
+    And the JSON node "data.typeCreateInput.inputFields[2].name" should be equal to "clientMutationId"
+    And the JSON node "data.typeCreatePayload.fields" should have 4 elements
+    And the JSON node "data.typeCreatePayload.fields[0].name" should be equal to "id"
+    And the JSON node "data.typeCreatePayload.fields[1].name" should be equal to "bar"
+    And the JSON node "data.typeCreatePayload.fields[2].name" should be equal to "baz"
+    And the JSON node "data.typeCreatePayload.fields[3].name" should be equal to "clientMutationId"
+
   @dropSchema
   Scenario: Retrieve an item through a GraphQL query
     Given there are 4 dummy objects with relatedDummy

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -221,6 +221,27 @@ Feature: GraphQL mutation support
     And the JSON node "data.updateWritableId.name" should be equal to "Foo"
     And the JSON node "data.updateWritableId.clientMutationId" should be equal to "m"
 
+  Scenario: Use serialization groups
+    Given there are 1 dummy group objects
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createDummyGroup(input: {bar: "Bar", baz: "Baz", clientMutationId: "myId"}) {
+        id
+        bar
+        baz
+        clientMutationId
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createDummyGroup.id" should be equal to "/dummy_groups/2"
+    And the JSON node "data.createDummyGroup.bar" should be equal to "Bar"
+    And the JSON node "data.createDummyGroup.baz" should be null
+    And the JSON node "data.createDummyGroup.clientMutationId" should be equal to "myId"
+
   @dropSchema
   Scenario: Trigger a validation error
     When I send the following GraphQL request:

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -109,6 +109,21 @@ Feature: GraphQL query support
     And I send the GraphQL request with operation "DummyWithId1"
     And the JSON node "data.dummyItem.name" should be equal to "Dummy #1"
 
+  Scenario: Use serialization groups
+    Given there are 1 dummy group objects
+    When I send the following GraphQL request:
+    """
+    {
+      dummyGroup(id: "/dummy_groups/1") {
+        foo
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummyGroup.foo" should be equal to "Foo #1"
+
   @dropSchema
   Scenario: Retrieve an nonexistent item through a GraphQL query
     When I send the following GraphQL request:

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -86,6 +86,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                 case 'create':
                 case 'update':
                     $context = null === $item ? ['resource_class' => $resourceClass] : ['resource_class' => $resourceClass, 'object_to_populate' => $item];
+                    $context += $resourceMetadata->getGraphqlAttribute($operationName, 'denormalization_context', [], true);
                     $item = $this->normalizer->denormalize($args['input'], $resourceClass, ItemNormalizer::FORMAT, $context);
                     $this->validate($item, $info, $resourceMetadata, $operationName);
                     $this->dataPersister->persist($item);

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -432,7 +432,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
         }
 
         foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
-            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property);
+            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['graphql_operation_name' => $mutationName ?? 'query']);
             if (
                 null === ($propertyType = $propertyMetadata->getType())
                 || (!$input && null === $mutationName && false === $propertyMetadata->isReadable())

--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -162,6 +162,9 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
         } elseif (isset($options['item_operation_name'])) {
             $normalizationContext = $resourceMetadata->getItemOperationAttribute($options['item_operation_name'], 'normalization_context', null, true);
             $denormalizationContext = $resourceMetadata->getItemOperationAttribute($options['item_operation_name'], 'denormalization_context', null, true);
+        } elseif (isset($options['graphql_operation_name'])) {
+            $normalizationContext = $resourceMetadata->getGraphqlAttribute($options['graphql_operation_name'], 'normalization_context', null, true);
+            $denormalizationContext = $resourceMetadata->getGraphqlAttribute($options['graphql_operation_name'], 'denormalization_context', null, true);
         } else {
             $normalizationContext = $resourceMetadata->getAttribute('normalization_context');
             $denormalizationContext = $resourceMetadata->getAttribute('denormalization_context');

--- a/tests/Fixtures/TestBundle/Entity/DummyGroup.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyGroup.php
@@ -24,16 +24,26 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *
  * @ORM\Entity
  *
- * @ApiResource(attributes={
- *     "normalization_context"={"groups"={"dummy_read"}},
- *     "denormalization_context"={"groups"={"dummy_write"}},
- *     "filters"={
- *         "dummy_group.group",
- *         "dummy_group.override_group",
- *         "dummy_group.whitelist_group",
- *         "dummy_group.override_whitelist_group"
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"dummy_read"}},
+ *         "denormalization_context"={"groups"={"dummy_write"}},
+ *         "filters"={
+ *             "dummy_group.group",
+ *             "dummy_group.override_group",
+ *             "dummy_group.whitelist_group",
+ *             "dummy_group.override_whitelist_group"
+ *         }
+ *     },
+ *     graphql={
+ *         "query"={"normalization_context"={"groups"={"dummy_foo"}}},
+ *         "delete",
+ *         "create"={
+ *             "normalization_context"={"groups"={"dummy_bar"}},
+ *             "denormalization_context"={"groups"={"dummy_bar", "dummy_baz"}}
+ *         }
  *     }
- * })
+ * )
  */
 class DummyGroup
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

This PR fixes the serialization for GraphQL.
It was not working before although the serialization context could be added to the `graphql` attribute.
That's why I think it should target 2.2.
Documentation will follow if this PR is merged.