### PR TITLE
Subresource Filter Fix

### DIFF
--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -97,6 +97,7 @@ Feature: Relations support
       "@id": "/related_to_dummy_friends/dummyFriend=1;relatedDummy=1",
       "@type": "RelatedToDummyFriend",
       "name": "Friends relation",
+      "description": null,
       "dummyFriend": {
         "@id": "/dummy_friends/1",
         "@type": "DummyFriend",
@@ -117,6 +118,7 @@ Feature: Relations support
       "@id": "/related_to_dummy_friends/dummyFriend=1;relatedDummy=1",
       "@type": "RelatedToDummyFriend",
       "name": "Friends relation",
+      "description": null,
       "dummyFriend": {
         "@id": "/dummy_friends/1",
         "@type": "DummyFriend",

--- a/features/swagger/docs.feature
+++ b/features/swagger/docs.feature
@@ -69,7 +69,11 @@ Feature: Documentation support
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[1].in" should be equal to "query"
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[1].required" should be false
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[1].type" should be equal to "string"
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 2 element
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[2].name" should be equal to "description"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[2].in" should be equal to "query"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[2].required" should be false
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[2].type" should be equal to "string"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 3 element
 
     # Subcollection - check schema
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.schema.items.$ref" should be equal to "#/definitions/RelatedToDummyFriend-fakemanytomany"

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -154,7 +154,7 @@ final class DocumentationNormalizer implements NormalizerInterface
                     }
                 }
 
-                if ($parameters = $this->getFiltersParameters($resourceClass, $operationName, $subResourceMetadata, $definitions, $serializerContext)) {
+                if ($parameters = $this->getFiltersParameters($subresourceOperation['resource_class'], $operationName, $subResourceMetadata, $definitions, $serializerContext)) {
                     foreach ($parameters as $parameter) {
                         if (!\in_array($parameter['name'], $parametersMemory, true)) {
                             $pathOperation['parameters'][] = $parameter;

--- a/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
@@ -38,6 +38,14 @@ class RelatedToDummyFriend
     private $name;
 
     /**
+     * @var string|null The dummy description
+     *
+     * @ORM\Column(nullable=true)
+     * @Groups({"fakemanytomany", "friends"})
+     */
+    private $description;
+
+    /**
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="DummyFriend")
      * @ORM\JoinColumn(name="dummyfriend_id", referencedColumnName="id", nullable=false)
@@ -62,6 +70,22 @@ class RelatedToDummyFriend
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param null|string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
     }
 
     /**

--- a/tests/Fixtures/app/config/config_test.yml
+++ b/tests/Fixtures/app/config/config_test.yml
@@ -204,7 +204,7 @@ services:
 
     app.related_dummy_to_friend_resource.search_filter:
         parent:    'api_platform.doctrine.orm.search_filter'
-        arguments: [ { 'name': 'ipartial' } ]
+        arguments: [ { 'name': 'ipartial', 'description': 'ipartial' } ]
         tags:      [ { name: 'api_platform.filter', id: 'related_to_dummy_friend.name' } ]
 
     logger:


### PR DESCRIPTION
fix issue with subresource filters, was incorrectly adding filters for the parent instead of the subresource

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

DocumentationNormalizer was loading filters for the `ResourceClass` instead of the `SubresourceClass`, this resolves that issue. I didn't create a bug report and this will require no changes to documentation.
