### PR TITLE
[GraphQL] Fix response status code

### DIFF
--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -15,7 +15,7 @@ Feature: Authorization checking
       }
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
@@ -35,7 +35,7 @@ Feature: Authorization checking
       }
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
@@ -51,7 +51,7 @@ Feature: Authorization checking
       }
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -252,7 +252,7 @@ Feature: GraphQL mutation support
       }
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "name: This value should not be blank."

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -67,7 +67,7 @@ final class EntrypointAction
             $executionResult = new ExecutionResult(null, [$e]);
         }
 
-        return new JsonResponse($executionResult->toArray($this->debug), $executionResult->errors ? Response::HTTP_BAD_REQUEST : Response::HTTP_OK);
+        return new JsonResponse($executionResult->toArray($this->debug));
     }
 
     private function parseRequest(Request $request): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1952
| License       | MIT
| Doc PR        |

As discussed in #1952, the GraphQL entrypoint should always returns a 200 because GraphQL should not use HTTP status codes.