### PR TITLE
Fixes ignoring type checks during denormalization

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -336,9 +336,11 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $this->denormalizeRelation($attribute, $propertyMetadata, $className, $value, $format, $this->createChildContext($context, $attribute));
         }
 
-        if (empty($context[static::DISABLE_TYPE_ENFORCEMENT])) {
-            $this->validateType($attribute, $type, $value, $format);
+        if ($context[static::DISABLE_TYPE_ENFORCEMENT] ?? false) {
+            return $value;
         }
+
+        $this->validateType($attribute, $type, $value, $format);
 
         return $value;
     }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -336,7 +336,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $this->denormalizeRelation($attribute, $propertyMetadata, $className, $value, $format, $this->createChildContext($context, $attribute));
         }
 
-        $this->validateType($attribute, $type, $value, $format);
+        if (empty($context[static::DISABLE_TYPE_ENFORCEMENT])) {
+            $this->validateType($attribute, $type, $value, $format);
+        }
 
         return $value;
     }

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -626,6 +626,45 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->denormalize(['foo' => 42], Dummy::class);
     }
 
+    public function testTypeChecksCanBeDisabled()
+    {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
+            new PropertyNameCollection(['foo'])
+        )->shouldBeCalled();
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'foo', [])->willReturn(
+            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT), '', false, true, false, false)
+        )->shouldBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(DenormalizerInterface::class);
+
+        $normalizer = $this->getMockForAbstractClass(AbstractItemNormalizer::class, [
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $iriConverterProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $propertyAccessorProphecy->reveal(),
+            null,
+            null,
+            null,
+            false,
+            [],
+            [],
+            null,
+            true,
+        ]);
+        $normalizer->setSerializer($serializerProphecy->reveal());
+
+        $normalizer->denormalize(['foo' => 42], Dummy::class, null, ['disable_type_enforcement' => true]);
+    }
+
     public function testJsonAllowIntAsFloat()
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a (already explained)

This PR updates the denormalization process to honour the [ObjectNormalizer::DISABLE_TYPE_ENFORCEMENT](http://symfony.com/doc/current/components/serializer.html#recursive-denormalization-and-type-safety) flag, allowing invalid types to be handled by the validation layer instead of endpoints returning (by default) 500 status serialization errors.