### PR TITLE
[WIP] Allow oauth2 implicit flow in swagger ui.

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -310,6 +310,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.oauth.flow', $config['oauth']['flow']);
         $container->setParameter('api_platform.oauth.tokenUrl', $config['oauth']['tokenUrl']);
         $container->setParameter('api_platform.oauth.authorizationUrl', $config['oauth']['authorizationUrl']);
+        $container->setParameter('api_platform.oauth.redirectUrl', $config['oauth']['redirectUrl']);
         $container->setParameter('api_platform.oauth.scopes', $config['oauth']['scopes']);
     }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -113,6 +113,7 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('flow')->defaultValue('application')->info('The oauth flow grant type.')->end()
                         ->scalarNode('tokenUrl')->defaultValue('/oauth/v2/token')->info('The oauth token url.')->end()
                         ->scalarNode('authorizationUrl')->defaultValue('/oauth/v2/auth')->info('The oauth authentication url.')->end()
+                        ->scalarNode('redirectUrl')->defaultValue(null)->info('The oauth redirect url.')->end()
                         ->arrayNode('scopes')
                             ->prototype('scalar')->end()
                         ->end()

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -55,6 +55,7 @@
             <argument type="service" id="api_platform.serializer" />
             <argument type="service" id="twig" />
             <argument type="service" id="router" />
+            <argument type="service" id="assets.packages" />
             <argument>%api_platform.title%</argument>
             <argument>%api_platform.description%</argument>
             <argument>%api_platform.version%</argument>
@@ -66,6 +67,7 @@
             <argument>%api_platform.oauth.flow%</argument>
             <argument>%api_platform.oauth.tokenUrl%</argument>
             <argument>%api_platform.oauth.authorizationUrl%</argument>
+            <argument>%api_platform.oauth.redirectUrl%</argument>
             <argument>%api_platform.oauth.scopes%</argument>
         </service>
 

--- a/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -3,6 +3,7 @@
 window.onload = () => {
   const data = JSON.parse(document.getElementById('swagger-data').innerText);
   const ui = SwaggerUIBundle({
+    oauth2RedirectUrl: data.oauth.redirectUrl,
     spec: data.spec,
     dom_id: '#swagger-ui',
     validatorUrl: null,

--- a/src/Bridge/Symfony/Bundle/Resources/public/swagger-ui/oauth2-redirect.html
+++ b/src/Bridge/Symfony/Bundle/Resources/public/swagger-ui/oauth2-redirect.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en-US">
+<body onload="run()">
+</body>
+</html>
+<script>
+    'use strict';
+    function run () {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1);
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&")
+        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';})
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+            function (key, value) {
+                return key === "" ? value : decodeURIComponent(value)
+            }
+        ) : {}
+
+        isValid = qp.state === sentState
+
+        if ((
+                oauth2.auth.schema.get("flow") === "accessCode"||
+                oauth2.auth.schema.get("flow") === "authorizationCode"
+            ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+            } else {
+                let oauthErrorMsg
+                if (qp.error) {
+                    oauthErrorMsg = "["+qp.error+"]: " +
+                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
+                });
+            }
+        } else {
+            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+        }
+        window.close();
+    }
+</script>


### PR DESCRIPTION
Add missing oauth2-redirect.html for swagger-ui and provide api_platform.oauth.redirectUrl configuration to implement custom oauth2 client endpoint for swagger-ui.

This PR still needs work before reviewing! I just want share my current work in case of helping someone else. I will start work on this after finishing my other PR. 

Todos:
- [ ] PHPUnit tests
- [ ] Behat tests
- [ ] Move asset path creation to tempalte
- [ ] Update update-js.sh
- [ ] Target master branch

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
