### PR TITLE
[GraphQL] Deprecation support

### DIFF
--- a/features/bootstrap/GraphqlContext.php
+++ b/features/bootstrap/GraphqlContext.php
@@ -18,6 +18,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behatch\Context\RestContext;
 use Behatch\HttpCall\Request;
 use GraphQL\Type\Introspection;
+use PHPUnit\Framework\ExpectationFailedException;
 
 /**
  * Context for GraphQL.
@@ -103,6 +104,20 @@ final class GraphqlContext implements Context
     {
         $this->graphqlRequest = ['query' => Introspection::getIntrospectionQuery()];
         $this->sendGraphqlRequest();
+    }
+
+    /**
+     * @Then the GraphQL field :fieldName is deprecated for the reason :reason
+     */
+    public function theGraphQLFieldIsDeprecatedForTheReason(string $fieldName, string $reason)
+    {
+        foreach (json_decode($this->request->getContent(), true)['data']['__type']['fields'] as $field) {
+            if ($fieldName === $field['name'] && $field['isDeprecated'] && $reason === $field['deprecationReason']) {
+                return;
+            }
+        }
+
+        throw new ExpectationFailedException(sprintf('The field "%s" is not deprecated.', $fieldName));
     }
 
     private function sendGraphqlRequest()

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -76,6 +76,65 @@ Feature: GraphQL introspection support
     And the JSON node "data.type3.fields[1].name" should be equal to "cursor"
     And the JSON node "data.type3.fields[0].type.name" should be equal to "DummyAggregateOffer"
 
+  Scenario: Introspect deprecated queries
+    When I send the following GraphQL request:
+    """
+    {
+      __type (name: "Query") {
+        name
+        fields(includeDeprecated: true) {
+          name
+          isDeprecated
+          deprecationReason
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the GraphQL field "deprecatedResource" is deprecated for the reason "This resource is deprecated"
+    And the GraphQL field "deprecatedResources" is deprecated for the reason "This resource is deprecated"
+
+  Scenario: Introspect deprecated mutations
+    When I send the following GraphQL request:
+    """
+    {
+      __type (name: "Mutation") {
+        name
+        fields(includeDeprecated: true) {
+          name
+          isDeprecated
+          deprecationReason
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the GraphQL field "deleteDeprecatedResource" is deprecated for the reason "This resource is deprecated"
+    And the GraphQL field "updateDeprecatedResource" is deprecated for the reason "This resource is deprecated"
+    And the GraphQL field "createDeprecatedResource" is deprecated for the reason "This resource is deprecated"
+
+  Scenario: Introspect a deprecated field
+    When I send the following GraphQL request:
+    """
+    {
+      __type(name: "DeprecatedResource") {
+        fields(includeDeprecated: true) {
+          name
+          isDeprecated
+          deprecationReason
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the GraphQL field "deprecatedField" is deprecated for the reason "This field is deprecated"
+
   Scenario: Retrieve the Relay's node interface
     When I send the following GraphQL request:
     """

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Annotation;
 
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use Doctrine\Common\Annotations\Annotation\Attribute;
+
 /**
- * Property annotation.
+ * ApiProperty annotation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Annotation;
 
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 
 /**
@@ -28,6 +29,7 @@ use Doctrine\Common\Annotations\Annotation\Attribute;
  *     @Attribute("attributes", type="array"),
  *     @Attribute("collectionOperations", type="array"),
  *     @Attribute("denormalizationContext", type="array"),
+ *     @Attribute("deprecationReason", type="string"),
  *     @Attribute("description", type="string"),
  *     @Attribute("fetchPartial", type="bool"),
  *     @Attribute("forceEager", type="bool"),
@@ -112,6 +114,13 @@ final class ApiResource
      * @var array
      */
     private $denormalizationContext;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $deprecationReason;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112

--- a/tests/Fixtures/TestBundle/Entity/DeprecatedResource.php
+++ b/tests/Fixtures/TestBundle/Entity/DeprecatedResource.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource(deprecationReason="This resource is deprecated")
+ * @ORM\Entity
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DeprecatedResource
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    public $id;
+
+    /**
+     * @var string
+     *
+     * @ApiProperty(attributes={"deprecation_reason"="This field is deprecated"})
+     * @ORM\Column
+     */
+    public $deprecatedField;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Allows to deprecate GraphQL fields and resources:

```php
namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiProperty;
use ApiPlatform\Core\Annotation\ApiResource;

/**
 * @ApiResource(deprecationReason="This resource is deprecated")
 */
class DeprecatedResource
{
    public $id;

    /**
     * @ApiProperty(deprecationReason="This field is deprecated")
     */
    public $deprecatedField;
}
```

I'll add support for the same attribute in both Swagger and Hydra (using OWL) in subsequent Pull Requests.

~~As you can see, `@ApiProperty`'s doesn't support the simplified attributes syntax introduced in #1788 , it would be nice to support this too.~~ (fixed in #1963)

ping @alanpoulain 