### PR TITLE
Add resource fallback for ApiProperty

### DIFF
--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -29,9 +29,7 @@ namespace ApiPlatform\Core\Annotation;
  */
 final class ApiProperty
 {
-    use AttributesHydratorTrait {
-        hydrateAttributes as public __construct;
-    }
+    use AttributesHydratorTrait;
 
     /**
      * @var string
@@ -100,4 +98,12 @@ final class ApiProperty
      * @var array
      */
     private $swaggerContext;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(array $values = [])
+    {
+        $this->hydrateAttributes($values);
+    }
 }

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -21,7 +21,7 @@ namespace ApiPlatform\Core\Annotation;
  * @Annotation
  * @Target({"METHOD", "PROPERTY"})
  * @Attributes(
- *     @Attribute("fetcheable", type="bool"),
+ *     @Attribute("fetchable", type="bool"),
  *     @Attribute("fetchEager", type="bool"),
  *     @Attribute("jsonldContext", type="array"),
  *     @Attribute("swaggerContext", type="array")
@@ -76,7 +76,7 @@ final class ApiProperty
      *
      * @var bool
      */
-    private $fetcheable;
+    private $fetchable;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -20,9 +20,17 @@ namespace ApiPlatform\Core\Annotation;
  *
  * @Annotation
  * @Target({"METHOD", "PROPERTY"})
+ * @Attributes(
+ *     @Attribute("fetcheable", type="bool"),
+ *     @Attribute("fetchEager", type="bool"),
+ *     @Attribute("jsonldContext", type="array"),
+ *     @Attribute("swaggerContext", type="array")
+ * )
  */
 final class ApiProperty
 {
+    use AttributesHydratorTrait;
+
     /**
      * @var string
      */
@@ -64,7 +72,30 @@ final class ApiProperty
     public $identifier;
 
     /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $fetcheable;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $fetchEager;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
      * @var array
      */
-    public $attributes = [];
+    private $jsonldContext;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $swaggerContext;
 }

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -29,7 +29,9 @@ namespace ApiPlatform\Core\Annotation;
  */
 final class ApiProperty
 {
-    use AttributesHydratorTrait;
+    use AttributesHydratorTrait {
+        hydrateAttributes as public __construct;
+    }
 
     /**
      * @var string

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -55,7 +55,9 @@ use Doctrine\Common\Annotations\Annotation\Attribute;
  */
 final class ApiResource
 {
-    use AttributesHydratorTrait;
+    use AttributesHydratorTrait {
+        hydrateAttributes as public __construct;
+    }
 
     /**
      * @var string

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Annotation;
 
-use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Annotations\Annotation\Attribute;
 
 /**
  * ApiResource annotation.
@@ -34,6 +33,7 @@ use Doctrine\Common\Util\Inflector;
  *     @Attribute("forceEager", type="bool"),
  *     @Attribute("filters", type="string[]"),
  *     @Attribute("graphql", type="array"),
+ *     @Attribute("hydraContext", type="array"),
  *     @Attribute("iri", type="string"),
  *     @Attribute("itemOperations", type="array"),
  *     @Attribute("maximumItemsPerPage", type="int"),
@@ -49,11 +49,14 @@ use Doctrine\Common\Util\Inflector;
  *     @Attribute("routePrefix", type="string"),
  *     @Attribute("shortName", type="string"),
  *     @Attribute("subresourceOperations", type="array"),
+ *     @Attribute("swaggerContext", type="array"),
  *     @Attribute("validationGroups", type="mixed")
  * )
  */
 final class ApiResource
 {
+    use AttributesHydratorTrait;
+
     /**
      * @var string
      */
@@ -88,11 +91,6 @@ final class ApiResource
      * @var array
      */
     public $graphql;
-
-    /**
-     * @var array
-     */
-    public $attributes = [];
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
@@ -135,6 +133,13 @@ final class ApiResource
      * @var string[]
      */
     private $filters;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string[]
+     */
+    private $hydraContext;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
@@ -216,32 +221,14 @@ final class ApiResource
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
+     * @var array
+     */
+    private $swaggerContext;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
      * @var mixed
      */
     private $validationGroups;
-
-    /**
-     * @throws InvalidArgumentException
-     */
-    public function __construct(array $values = [])
-    {
-        if (isset($values['attributes'])) {
-            $this->attributes = $values['attributes'];
-            unset($values['attributes']);
-        }
-
-        foreach ($values as $key => $value) {
-            if (!property_exists($this, $key)) {
-                throw new InvalidArgumentException(sprintf('Unknown property "%s" on annotation "%s".', $key, self::class));
-            }
-
-            $property = new \ReflectionProperty($this, $key);
-
-            if ($property->isPublic()) {
-                $this->$key = $value;
-            } else {
-                $this->attributes += [Inflector::tableize($key) => $value];
-            }
-        }
-    }
 }

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -55,9 +55,7 @@ use Doctrine\Common\Annotations\Annotation\Attribute;
  */
 final class ApiResource
 {
-    use AttributesHydratorTrait {
-        hydrateAttributes as public __construct;
-    }
+    use AttributesHydratorTrait;
 
     /**
      * @var string
@@ -233,4 +231,12 @@ final class ApiResource
      * @var mixed
      */
     private $validationGroups;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(array $values = [])
+    {
+        $this->hydrateAttributes($values);
+    }
 }

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -32,7 +32,7 @@ trait AttributesHydratorTrait
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(array $values = [])
+    private function hydrateAttributes(array $values = [])
     {
         if (isset($values['attributes'])) {
             $this->attributes = $values['attributes'];

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -9,6 +9,16 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace ApiPlatform\Core\Annotation;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -42,7 +42,7 @@ trait AttributesHydratorTrait
     /**
      * @throws InvalidArgumentException
      */
-    private function hydrateAttributes(array $values = [])
+    private function hydrateAttributes(array $values)
     {
         if (isset($values['attributes'])) {
             $this->attributes = $values['attributes'];

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\Core\Annotation;
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use Doctrine\Common\Util\Inflector;
+
+/**
+ * Hydrates attributes from annotation's parameters.
+ *
+ * @internal
+ *
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+trait AttributesHydratorTrait
+{
+    /**
+     * @var array
+     */
+    public $attributes = [];
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(array $values = [])
+    {
+        if (isset($values['attributes'])) {
+            $this->attributes = $values['attributes'];
+            unset($values['attributes']);
+        }
+
+        foreach ($values as $key => $value) {
+            if (!property_exists($this, $key)) {
+                throw new InvalidArgumentException(sprintf('Unknown property "%s" on annotation "%s".', $key, self::class));
+            }
+
+            (new \ReflectionProperty($this, $key))->isPublic() ? $this->$key = $value : $this->attributes += [Inflector::tableize($key) => $value];
+        }
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -170,8 +170,14 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
                 $inAttributes = null;
             }
 
-            // Calls to getAttribute are nested for compatibility with the old camelCased notation
-            if (false === $fetchEager = $propertyMetadata->getAttribute('fetchEager', $propertyMetadata->getAttribute('fetch_eager'))) {
+            if (
+                (null === $fetchEager = $propertyMetadata->getAttribute('fetch_eager')) &&
+                (null !== $fetchEager = $propertyMetadata->getAttribute('fetchEager'))
+            ) {
+                @trigger_error('The "fetchEager" attribute is deprecated since 2.3. Please use "fetch_eager" instead.', E_USER_DEPRECATED);
+            }
+
+            if (false === $fetchEager) {
                 continue;
             }
 

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -170,7 +170,8 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
                 $inAttributes = null;
             }
 
-            if (false === $fetchEager = $propertyMetadata->getAttribute('fetchEager')) {
+            // Calls to getAttribute are nested for compatibility with the old camelCased notation
+            if (false === $fetchEager = $propertyMetadata->getAttribute('fetchEager', $propertyMetadata->getAttribute('fetch_eager'))) {
                 continue;
             }
 

--- a/tests/Annotation/ApiPropertyTest.php
+++ b/tests/Annotation/ApiPropertyTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class PropertyTest extends TestCase
+class ApiPropertyTest extends TestCase
 {
     public function testAssignation()
     {
@@ -43,5 +43,23 @@ class PropertyTest extends TestCase
         $this->assertEquals('http://example.com/prop', $property->iri);
         $this->assertTrue($property->identifier);
         $this->assertEquals(['foo' => 'bar'], $property->attributes);
+    }
+
+    public function testConstruct()
+    {
+        $property = new ApiProperty([
+            'fetcheable' => true,
+            'fetchEager' => false,
+            'jsonldContext' => ['foo' => 'bar'],
+            'swaggerContext' => ['foo' => 'baz'],
+            'attributes' => ['unknown' => 'unknown', 'fetcheable' => false],
+        ]);
+        $this->assertEquals([
+            'fetcheable' => false,
+            'fetch_eager' => false,
+            'jsonld_context' => ['foo' => 'bar'],
+            'swagger_context' => ['foo' => 'baz'],
+            'unknown' => 'unknown',
+        ], $property->attributes);
     }
 }

--- a/tests/Annotation/ApiPropertyTest.php
+++ b/tests/Annotation/ApiPropertyTest.php
@@ -48,14 +48,14 @@ class ApiPropertyTest extends TestCase
     public function testConstruct()
     {
         $property = new ApiProperty([
-            'fetcheable' => true,
+            'fetchable' => true,
             'fetchEager' => false,
             'jsonldContext' => ['foo' => 'bar'],
             'swaggerContext' => ['foo' => 'baz'],
-            'attributes' => ['unknown' => 'unknown', 'fetcheable' => false],
+            'attributes' => ['unknown' => 'unknown', 'fetchable' => false],
         ]);
         $this->assertEquals([
-            'fetcheable' => false,
+            'fetchable' => false,
             'fetch_eager' => false,
             'jsonld_context' => ['foo' => 'bar'],
             'swagger_context' => ['foo' => 'baz'],

--- a/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -810,6 +810,19 @@ class EagerLoadingExtensionTest extends TestCase
 
     public function testApplyToCollectionWithANonRedableButFetchEagerProperty()
     {
+        $this->doTestApplyToCollectionWithANonRedableButFetchEagerProperty(false);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyApplyToCollectionWithANonRedableButFetchEagerProperty()
+    {
+        $this->doTestApplyToCollectionWithANonRedableButFetchEagerProperty(true);
+    }
+
+    private function doTestApplyToCollectionWithANonRedableButFetchEagerProperty(bool $legacy)
+    {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
 
@@ -817,7 +830,7 @@ class EagerLoadingExtensionTest extends TestCase
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $relationPropertyMetadata = new PropertyMetadata();
-        $relationPropertyMetadata = $relationPropertyMetadata->withAttributes(['fetchEager' => true]);
+        $relationPropertyMetadata = $relationPropertyMetadata->withAttributes([$legacy ? 'fetchEager' : 'fetch_eager' => true]);
         $relationPropertyMetadata = $relationPropertyMetadata->withReadableLink(false);
         $relationPropertyMetadata = $relationPropertyMetadata->withReadable(false);
 
@@ -853,6 +866,19 @@ class EagerLoadingExtensionTest extends TestCase
 
     public function testApplyToCollectionWithARedableButNotFetchEagerProperty()
     {
+        $this->doTestApplyToCollectionWithARedableButNotFetchEagerProperty(false);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLeacyApplyToCollectionWithARedableButNotFetchEagerProperty()
+    {
+        $this->doTestApplyToCollectionWithARedableButNotFetchEagerProperty(true);
+    }
+
+    private function doTestApplyToCollectionWithARedableButNotFetchEagerProperty(bool $legacy)
+    {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
 
@@ -860,7 +886,7 @@ class EagerLoadingExtensionTest extends TestCase
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $relationPropertyMetadata = new PropertyMetadata();
-        $relationPropertyMetadata = $relationPropertyMetadata->withAttributes(['fetchEager' => false]);
+        $relationPropertyMetadata = $relationPropertyMetadata->withAttributes([$legacy ? 'fetchEager' : 'fetch_eager' => false]);
         $relationPropertyMetadata = $relationPropertyMetadata->withReadableLink(true);
         $relationPropertyMetadata = $relationPropertyMetadata->withReadable(true);
 

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
@@ -335,7 +335,7 @@ SQL;
         $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), false);
         $filterEagerLoadingExtension->applyToCollection($qb, $queryNameGenerator->reveal(), CompositeRelation::class, 'get');
 
-        $expected = <<<SQL
+        $expected = <<<DQL
 SELECT o
 FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeRelation o
 INNER JOIN o.compositeItem item
@@ -354,7 +354,7 @@ WHERE o.item IN(
     LEFT JOIN o_2.foo foo_2 WITH o_2.bar = item_2.foo
     WHERE item_2.field1 = :foo
 )
-SQL;
+DQL;
 
         $this->assertEquals($this->toDQLString($expected), $qb->getDQL());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n:a
| License       | MIT
| Doc PR        | n/a

Same as #1788 but for `@ApiProperty`. Also add support for some missing attributes in `@ApiResource`.