### PR TITLE
Allow DataPersister to return a new instance instead of mutating

### DIFF
--- a/src/Bridge/Doctrine/Common/DataPersister.php
+++ b/src/Bridge/Doctrine/Common/DataPersister.php
@@ -48,7 +48,7 @@ final class DataPersister implements DataPersisterInterface
     public function persist($data)
     {
         if (!$manager = $this->getManager($data)) {
-            return;
+            return $data;
         }
 
         if (!$manager->contains($data)) {
@@ -57,6 +57,8 @@ final class DataPersister implements DataPersisterInterface
 
         $manager->flush();
         $manager->refresh($data);
+
+        return $data;
     }
 
     /**

--- a/src/Bridge/Doctrine/EventListener/WriteListener.php
+++ b/src/Bridge/Doctrine/EventListener/WriteListener.php
@@ -58,7 +58,9 @@ final class WriteListener
 
         switch ($request->getMethod()) {
             case 'POST':
-                $objectManager->persist($controllerResult);
+                $event->setControllerResult(
+                    $objectManager->persist($controllerResult) ?? $controllerResult
+                );
                 break;
             case 'DELETE':
                 $objectManager->remove($controllerResult);

--- a/src/Bridge/Doctrine/EventListener/WriteListener.php
+++ b/src/Bridge/Doctrine/EventListener/WriteListener.php
@@ -58,9 +58,7 @@ final class WriteListener
 
         switch ($request->getMethod()) {
             case 'POST':
-                $event->setControllerResult(
-                    $objectManager->persist($controllerResult) ?? $controllerResult
-                );
+                $objectManager->persist($controllerResult);
                 break;
             case 'DELETE':
                 $objectManager->remove($controllerResult);

--- a/src/DataPersister/ChainDataPersister.php
+++ b/src/DataPersister/ChainDataPersister.php
@@ -51,7 +51,7 @@ final class ChainDataPersister implements DataPersisterInterface
     {
         foreach ($this->persisters as $persister) {
             if ($persister->supports($data)) {
-                $persister->persist($data);
+                return $persister->persist($data) ?? $data;
             }
         }
     }

--- a/src/DataPersister/DataPersisterInterface.php
+++ b/src/DataPersister/DataPersisterInterface.php
@@ -33,6 +33,8 @@ interface DataPersisterInterface
      * Persists the data.
      *
      * @param mixed $data
+     *
+     * @return object|void Void will not be supported in API Platform 3, an object should always be returned
      */
     public function persist($data);
 

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -50,10 +50,13 @@ class WriteListener
             case 'PUT':
             case 'PATCH':
             case 'POST':
-                $event->setControllerResult(
-                    $this->dataPersister->persist($controllerResult)
-                    ?? $controllerResult
-                );
+                $persistResult = $this->dataPersister->persist($controllerResult);
+
+                if (null === $persistResult) {
+                    @trigger_error(sprintf('Returning void from %s::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.', DataPersisterInterface::class), E_USER_DEPRECATED);
+                }
+
+                $event->setControllerResult($persistResult ?? $controllerResult);
                 break;
             case 'DELETE':
                 $this->dataPersister->remove($controllerResult);

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -50,7 +50,10 @@ class WriteListener
             case 'PUT':
             case 'PATCH':
             case 'POST':
-                $this->dataPersister->persist($controllerResult);
+                $event->setControllerResult(
+                    $this->dataPersister->persist($controllerResult)
+                    ?? $controllerResult
+                );
                 break;
             case 'DELETE':
                 $this->dataPersister->remove($controllerResult);

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -93,9 +93,13 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                     $context += $resourceMetadata->getGraphqlAttribute($operationName, 'denormalization_context', [], true);
                     $item = $this->normalizer->denormalize($args['input'], $resourceClass, ItemNormalizer::FORMAT, $context);
                     $this->validate($item, $info, $resourceMetadata, $operationName);
-                    $persistResult = $this->dataPersister->persist($item) ?? $item;
+                    $persistResult = $this->dataPersister->persist($item);
 
-                    return $this->normalizer->normalize($persistResult, ItemNormalizer::FORMAT, $normalizationContext) + $data;
+                    if (null === $persistResult) {
+                        @trigger_error(sprintf('Returning void from %s::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.', DataPersisterInterface::class), E_USER_DEPRECATED);
+                    }
+
+                    return $this->normalizer->normalize($persistResult ?? $item, ItemNormalizer::FORMAT, $normalizationContext) + $data;
                 case 'delete':
                     if ($item) {
                         $this->dataPersister->remove($item);

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -93,9 +93,9 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                     $context += $resourceMetadata->getGraphqlAttribute($operationName, 'denormalization_context', [], true);
                     $item = $this->normalizer->denormalize($args['input'], $resourceClass, ItemNormalizer::FORMAT, $context);
                     $this->validate($item, $info, $resourceMetadata, $operationName);
-                    $this->dataPersister->persist($item);
+                    $persistResult = $this->dataPersister->persist($item) ?? $item;
 
-                    return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext) + $data;
+                    return $this->normalizer->normalize($persistResult, ItemNormalizer::FORMAT, $normalizationContext) + $data;
                 case 'delete':
                     if ($item) {
                         $this->dataPersister->remove($item);

--- a/tests/Bridge/Doctrine/Common/DataPersisterTest.php
+++ b/tests/Bridge/Doctrine/Common/DataPersisterTest.php
@@ -56,7 +56,8 @@ class DataPersisterTest extends TestCase
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($objectManagerProphecy->reveal())->shouldBeCalled();
 
-        (new DataPersister($managerRegistryProphecy->reveal()))->persist($dummy);
+        $result = (new DataPersister($managerRegistryProphecy->reveal()))->persist($dummy);
+        $this->assertSame($dummy, $result);
     }
 
     public function testPersistIfEntityAlreadyManaged()
@@ -72,15 +73,19 @@ class DataPersisterTest extends TestCase
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($objectManagerProphecy->reveal())->shouldBeCalled();
 
-        (new DataPersister($managerRegistryProphecy->reveal()))->persist($dummy);
+        $result = (new DataPersister($managerRegistryProphecy->reveal()))->persist($dummy);
+        $this->assertSame($dummy, $result);
     }
 
     public function testPersistWithNullManager()
     {
+        $dummy = new Dummy();
+
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn(null)->shouldBeCalled();
 
-        (new DataPersister($managerRegistryProphecy->reveal()))->persist(new Dummy());
+        $result = (new DataPersister($managerRegistryProphecy->reveal()))->persist($dummy);
+        $this->assertSame($dummy, $result);
     }
 
     public function testRemove()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | *unit tests are green, bdd are red, master too seems wrecked 🎶*
| Fixed tickets | #1799 
| License       | MIT
| Doc PR        | @todo

closes #1799

`DataPersisterInterface` can now return the result of the persistence call instead of relying on data mutation. Thus allowing persistence layer to deal with immutable data.

At least, this PR breaks the technical detail that was implicitly using objects instance reference as an identifier for an entity, and conceptually I find this a huge win :)
