### PR TITLE
Add deprecation support for Hydra

### DIFF
--- a/features/bootstrap/HydraContext.php
+++ b/features/bootstrap/HydraContext.php
@@ -71,6 +71,14 @@ final class HydraContext implements Context
     }
 
     /**
+     * @Then the boolean value of the node :node of the Hydra class :class is true
+     */
+    public function assertBooleanNodeValueIs(string $nodeName, string $className)
+    {
+        Assert::assertTrue($this->propertyAccessor->getValue($this->getClassInfo($className), $nodeName));
+    }
+
+    /**
      * @Then the value of the node :node of the Hydra class :class is :value
      */
     public function assertNodeValueIs(string $nodeName, string $className, string $value)

--- a/features/bootstrap/HydraContext.php
+++ b/features/bootstrap/HydraContext.php
@@ -82,6 +82,14 @@ final class HydraContext implements Context
     }
 
     /**
+     * @Then the boolean value of the node :node of the property :prop of the Hydra class :class is true
+     */
+    public function assertPropertyNodeValueIsTrue(string $nodeName, string $propertyName, string $className)
+    {
+        Assert::assertTrue($this->propertyAccessor->getValue($this->getPropertyInfo($propertyName, $className), $nodeName));
+    }
+
+    /**
      * @Then the value of the node :node of the property :prop of the Hydra class :class is :value
      */
     public function assertPropertyNodeValueIs(string $nodeName, string $propertyName, string $className, string $value)
@@ -90,6 +98,14 @@ final class HydraContext implements Context
             $this->propertyAccessor->getValue($this->getPropertyInfo($propertyName, $className), $nodeName),
             $value
         );
+    }
+
+    /**
+     * @Then the boolean value of the node :node of the operation :operation of the Hydra class :class is true
+     */
+    public function assertOperationNodeBooleanValueIs(string $nodeName, string $operationMethod, string $className)
+    {
+        Assert::assertTrue($this->propertyAccessor->getValue($this->getOperation($operationMethod, $className), $nodeName));
     }
 
     /**

--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -84,6 +84,7 @@ Feature: Documentation support
     And the value of the node "hydra:title" of the operation "DELETE" of the Hydra class "Dummy" is "Deletes the Dummy resource."
     And the value of the node "returns" of the operation "DELETE" of the Hydra class "Dummy" is "owl:Nothing"
     # Deprecations
+    And the boolean value of the node "owl:deprecated" of the Hydra class "DeprecatedResource" is true
     And the boolean value of the node "owl:deprecated" of the property "deprecatedField" of the Hydra class "DeprecatedResource" is true
     And the boolean value of the node "owl:deprecated" of the property "The collection of DeprecatedResource resources" of the Hydra class "The API entrypoint" is true
     And the boolean value of the node "owl:deprecated" of the operation "GET" of the Hydra class "DeprecatedResource" is true

--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -83,3 +83,7 @@ Feature: Documentation support
     And the value of the node "hydra:title" of the operation "PUT" of the Hydra class "Dummy" is "Replaces the Dummy resource."
     And the value of the node "hydra:title" of the operation "DELETE" of the Hydra class "Dummy" is "Deletes the Dummy resource."
     And the value of the node "returns" of the operation "DELETE" of the Hydra class "Dummy" is "owl:Nothing"
+    # Deprecations
+    And the boolean value of the node "owl:deprecated" of the property "deprecatedField" of the Hydra class "DeprecatedResource" is true
+    And the boolean value of the node "owl:deprecated" of the property "The collection of DeprecatedResource resources" of the Hydra class "The API entrypoint" is true
+    And the boolean value of the node "owl:deprecated" of the operation "GET" of the Hydra class "DeprecatedResource" is true

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -152,6 +152,10 @@ final class DocumentationNormalizer implements NormalizerInterface
             $class['hydra:description'] = $description;
         }
 
+        if ($resourceMetadata->getAttribute('deprecation_reason')) {
+            $class['owl:deprecated'] = true;
+        }
+
         return $class;
     }
 

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -97,7 +97,7 @@ final class DocumentationNormalizer implements NormalizerInterface
             return;
         }
 
-        $entrypointProperties[] = [
+        $entrypointProperty = [
             '@type' => 'hydra:SupportedProperty',
             'hydra:property' => [
                 '@id' => sprintf('#Entrypoint/%s', lcfirst($shortName)),
@@ -119,6 +119,12 @@ final class DocumentationNormalizer implements NormalizerInterface
             'hydra:readable' => true,
             'hydra:writable' => false,
         ];
+
+        if ($resourceMetadata->getCollectionOperationAttribute('GET', 'deprecation_reason', null, true)) {
+            $entrypointProperty['owl:deprecated'] = true;
+        }
+
+        $entrypointProperties[] = $entrypointProperty;
     }
 
     /**
@@ -263,6 +269,10 @@ final class DocumentationNormalizer implements NormalizerInterface
         }
 
         $hydraOperation = $operation['hydra_context'] ?? [];
+        if ($resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'deprecation_reason', null, true)) {
+            $hydraOperation['owl:deprecated'] = true;
+        }
+
         $shortName = $resourceMetadata->getShortName();
 
         if ('GET' === $method && OperationType::COLLECTION === $operationType) {
@@ -502,6 +512,10 @@ final class DocumentationNormalizer implements NormalizerInterface
 
         if (null !== $description = $propertyMetadata->getDescription()) {
             $property['hydra:description'] = $description;
+        }
+
+        if ($propertyMetadata->getAttribute('deprecation_reason')) {
+            $property['owl:deprecated'] = true;
         }
 
         return $property;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Follows #1976 and  #1962. Add the `owl:deprecated` annotation to deprecated `operations` and `supportedProperties`.

```php
namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiProperty;
use ApiPlatform\Core\Annotation\ApiResource;

/**
 * @ApiResource(deprecationReason="This resource is deprecated")
 */
class DeprecatedResource
{
    public $id;

    /**
     * @ApiProperty(deprecationReason="This field is deprecated")
     */
    public $deprecatedField;
}
```

Unlike GraphQL, OWL and Hydra don't support deprecation messages.
