### PR TITLE
Support the "deprecationReason" attribute in the ApiProperty annotation

### DIFF
--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Annotation;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
 
 /**
  * ApiProperty annotation.
@@ -24,6 +25,7 @@ use Doctrine\Common\Annotations\Annotation\Attribute;
  * @Annotation
  * @Target({"METHOD", "PROPERTY"})
  * @Attributes(
+ *     @Attribute("deprecationReason", type="string"),
  *     @Attribute("fetchable", type="bool"),
  *     @Attribute("fetchEager", type="bool"),
  *     @Attribute("jsonldContext", type="array"),
@@ -73,6 +75,13 @@ final class ApiProperty
      * @var bool
      */
     public $identifier;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $deprecationReason;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Annotation;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Annotations\Annotation\Attribute;
-use Doctrine\Common\Annotations\Annotation\Attributes;
 
 /**
  * ApiProperty annotation.

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Annotation;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Annotations\Annotation\Attribute;
 
 /**
  * ApiResource annotation.

--- a/tests/Annotation/ApiPropertyTest.php
+++ b/tests/Annotation/ApiPropertyTest.php
@@ -48,6 +48,7 @@ class ApiPropertyTest extends TestCase
     public function testConstruct()
     {
         $property = new ApiProperty([
+            'deprecationReason' => 'this field is deprecated',
             'fetchable' => true,
             'fetchEager' => false,
             'jsonldContext' => ['foo' => 'bar'],
@@ -55,6 +56,7 @@ class ApiPropertyTest extends TestCase
             'attributes' => ['unknown' => 'unknown', 'fetchable' => false],
         ]);
         $this->assertEquals([
+            'deprecation_reason' => 'this field is deprecated',
             'fetchable' => false,
             'fetch_eager' => false,
             'jsonld_context' => ['foo' => 'bar'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Add support for the `deprecationReason` attribute.