### PR TITLE
[GraphQL] Fix iterable type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "symfony/twig-bundle": "^3.1 || ^4.0",
         "symfony/validator": "^3.3 || ^4.0",
         "symfony/yaml": "^3.3 || ^4.0",
-        "webonyx/graphql-php": "^0.11.5"
+        "webonyx/graphql-php": ">=0.12 <1.0"
     },
     "conflict": {
         "symfony/dependency-injection": "<3.3"

--- a/src/GraphQl/Type/Definition/IterableType.php
+++ b/src/GraphQl/Type/Definition/IterableType.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\GraphQl\Type\Definition;
 
 use GraphQL\Error\Error;
-use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\BooleanValueNode;
 use GraphQL\Language\AST\FloatValueNode;
 use GraphQL\Language\AST\IntValueNode;
@@ -44,7 +43,7 @@ final class IterableType extends ScalarType
     {
         // is_iterable
         if (!(\is_array($value) || $value instanceof \Traversable)) {
-            throw new InvariantViolation(sprintf('Iterable cannot represent non iterable value: %s', Utils::printSafe($value)));
+            throw new Error(sprintf('Iterable cannot represent non iterable value: %s', Utils::printSafe($value)));
         }
 
         return $value;
@@ -66,13 +65,14 @@ final class IterableType extends ScalarType
     /**
      * {@inheritdoc}
      */
-    public function parseLiteral($valueNode)
+    public function parseLiteral($valueNode, array $variables = null)
     {
         if ($valueNode instanceof ObjectValueNode || $valueNode instanceof ListValueNode) {
             return $this->parseIterableLiteral($valueNode);
         }
 
-        return null;
+        // Intentionally without message, as all information already in wrapped Exception
+        throw new \Exception();
     }
 
     /**

--- a/tests/GraphQl/Type/Definition/IterableTypeTest.php
+++ b/tests/GraphQl/Type/Definition/IterableTypeTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\GraphQl\Type\Definition;
 
 use ApiPlatform\Core\GraphQl\Type\Definition\IterableType;
 use GraphQL\Error\Error;
-use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\BooleanValueNode;
 use GraphQL\Language\AST\FloatValueNode;
 use GraphQL\Language\AST\IntValueNode;
@@ -36,8 +35,8 @@ class IterableTypeTest extends TestCase
     {
         $iterableType = new IterableType();
 
-        $this->expectException(InvariantViolation::class);
-        $this->expectExceptionMessage('Iterable cannot represent non iterable value: "foo"');
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Iterable cannot represent non iterable value: foo');
 
         $iterableType->serialize('foo');
 
@@ -60,7 +59,8 @@ class IterableTypeTest extends TestCase
     {
         $iterableType = new IterableType();
 
-        $this->assertNull($iterableType->parseLiteral(new IntValueNode(['value' => 1])));
+        $this->expectException(\Exception::class);
+        $iterableType->parseLiteral(new IntValueNode(['value' => 1]));
 
         $listValueNode = new ListValueNode(['values' => []]);
         $this->assertEquals([], $iterableType->parseLiteral($listValueNode));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/api-platform/issues/704
| License       | MIT
| Doc PR        |

Fix the iterable type after a BC in graphql-php.
Maybe we need to force users to require a specific version of graphql-php in order to avoid this kind of issue.
For example in the doc, instead of:
`composer require webonyx/graphql-php`
we would have:
`composer require webonyx/graphql-php:^0.12.0`
WDYT?