### PR TITLE
Implement CacheableSupportsMethodInterface introduced in Symfony 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
 
 matrix:
   include:
-    - php: '7.0'
     - php: '7.1'
     - php: '7.2'
     - php: '7.2'

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
 
         "doctrine/inflector": "^1.0",
         "psr/cache": "^1.0",
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^2.7 || ^3.0 || ^4.0",
         "symfony/property-access": "^2.7 || ^3.0 || ^4.0",
         "symfony/property-info": "^3.3.11 || ^4.0",
-        "symfony/serializer": "^3.1 || ^4.0",
+        "symfony/serializer": "^4.1",
         "willdurand/negotiation": "^2.0.3"
     },
     "require-dev": {

--- a/src/Hal/Serializer/EntrypointNormalizer.php
+++ b/src/Hal/Serializer/EntrypointNormalizer.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -25,7 +26,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class EntrypointNormalizer implements NormalizerInterface
+final class EntrypointNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonhal';
 
@@ -69,5 +70,13 @@ final class EntrypointNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return self::FORMAT === $format && $data instanceof Entrypoint;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -28,7 +29,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-final class CollectionFiltersNormalizer implements NormalizerInterface, NormalizerAwareInterface
+final class CollectionFiltersNormalizer implements NormalizerInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
 {
     use JsonLdContextTrait;
     use FilterLocatorTrait;
@@ -55,6 +56,14 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
     public function supportsNormalization($data, $format = null)
     {
         return $this->collectionNormalizer->supportsNormalization($data, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return $this->collectionNormalizer instanceof CacheableSupportsMethodInterface && $this->collectionNormalizer->hasCacheableSupportsMethod();
     }
 
     /**

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait;
 use ApiPlatform\Core\Serializer\ContextTrait;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -31,7 +32,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author Kevin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-final class CollectionNormalizer implements NormalizerInterface, NormalizerAwareInterface
+final class CollectionNormalizer implements NormalizerInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
 {
     use ContextTrait;
     use JsonLdContextTrait;
@@ -99,5 +100,13 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
         }
 
         return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -29,6 +29,7 @@ use ApiPlatform\Core\Operation\Factory\SubresourceOperationFactoryInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -36,7 +37,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class DocumentationNormalizer implements NormalizerInterface
+final class DocumentationNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonld';
 
@@ -580,5 +581,13 @@ final class DocumentationNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null, array $context = [])
     {
         return self::FORMAT === $format && $data instanceof Documentation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -25,7 +26,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class EntrypointNormalizer implements NormalizerInterface
+final class EntrypointNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonld';
 
@@ -73,5 +74,13 @@ final class EntrypointNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null, array $context = [])
     {
         return self::FORMAT === $format && $data instanceof Entrypoint;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Hydra/Serializer/ErrorNormalizer.php
+++ b/src/Hydra/Serializer/ErrorNormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Hydra\Serializer;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
 use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -24,7 +25,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-final class ErrorNormalizer implements NormalizerInterface
+final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonld';
 
@@ -64,5 +65,13 @@ final class ErrorNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -108,7 +108,7 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Norm
      */
     public function hasCacheableSupportsMethod(): bool
     {
-        return true;
+        return $this->collectionNormalizer instanceof CacheableSupportsMethodInterface && $this->collectionNormalizer->hasCacheableSupportsMethod();
     }
 
     /**

--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
 use ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait;
 use ApiPlatform\Core\Util\IriHelper;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -26,7 +27,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-final class PartialCollectionViewNormalizer implements NormalizerInterface, NormalizerAwareInterface
+final class PartialCollectionViewNormalizer implements NormalizerInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
 {
     use JsonLdContextTrait;
 
@@ -100,6 +101,14 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Norm
     public function supportsNormalization($data, $format = null)
     {
         return $this->collectionNormalizer->supportsNormalization($data, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 
     /**

--- a/src/Identifier/Normalizer/DateTimeIdentifierDenormalizer.php
+++ b/src/Identifier/Normalizer/DateTimeIdentifierDenormalizer.php
@@ -14,18 +14,16 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Identifier\Normalizer;
 
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
-final class DateTimeIdentifierDenormalizer extends DateTimeNormalizer implements DenormalizerInterface, CacheableSupportsMethodInterface
+final class DateTimeIdentifierDenormalizer extends DateTimeNormalizer
 {
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         try {
             return parent::denormalize($data, $class, $format, $context);
-        } catch (InvalidArgumentException $e) {
+        } catch (NotNormalizableValueException $e) {
             throw new InvalidIdentifierException($e->getMessage(), $e->getCode(), $e);
         }
     }

--- a/src/Identifier/Normalizer/DateTimeIdentifierDenormalizer.php
+++ b/src/Identifier/Normalizer/DateTimeIdentifierDenormalizer.php
@@ -15,10 +15,11 @@ namespace ApiPlatform\Core\Identifier\Normalizer;
 
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
-final class DateTimeIdentifierDenormalizer extends DateTimeNormalizer implements DenormalizerInterface
+final class DateTimeIdentifierDenormalizer extends DateTimeNormalizer implements DenormalizerInterface, CacheableSupportsMethodInterface
 {
     public function denormalize($data, $class, $format = null, array $context = [])
     {
@@ -27,5 +28,13 @@ final class DateTimeIdentifierDenormalizer extends DateTimeNormalizer implements
         } catch (InvalidArgumentException $e) {
             throw new InvalidIdentifierException($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Identifier/Normalizer/IntegerDenormalizer.php
+++ b/src/Identifier/Normalizer/IntegerDenormalizer.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Identifier\Normalizer;
 
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
-final class IntegerDenormalizer implements DenormalizerInterface
+final class IntegerDenormalizer implements DenormalizerInterface, CacheableSupportsMethodInterface
 {
     public function denormalize($data, $class, $format = null, array $context = []): int
     {
@@ -29,5 +30,13 @@ final class IntegerDenormalizer implements DenormalizerInterface
     public function supportsDenormalization($data, $type, $format = null): bool
     {
         return Type::BUILTIN_TYPE_INT === $type && \is_string($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\JsonApi\Serializer;
 
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -24,7 +25,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  *
  * @author Héctor Hurtarte <hectorh30@gmail.com>
  */
-final class ConstraintViolationListNormalizer implements NormalizerInterface
+final class ConstraintViolationListNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonapi';
 
@@ -58,6 +59,14 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return self::FORMAT === $format && $data instanceof ConstraintViolationListInterface;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 
     private function getSourcePointerFromViolation(ConstraintViolationInterface $violation)

--- a/src/JsonApi/Serializer/EntrypointNormalizer.php
+++ b/src/JsonApi/Serializer/EntrypointNormalizer.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -26,7 +27,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class EntrypointNormalizer implements NormalizerInterface
+final class EntrypointNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonapi';
 
@@ -71,5 +72,13 @@ final class EntrypointNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return self::FORMAT === $format && $data instanceof Entrypoint;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\JsonApi\Serializer;
 
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
 use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -22,7 +23,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Héctor Hurtarte <hectorh30@gmail.com>
  */
-final class ErrorNormalizer implements NormalizerInterface
+final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     use ErrorNormalizerTrait;
 
@@ -55,5 +56,13 @@ final class ErrorNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Problem/Serializer/ErrorNormalizer.php
+++ b/src/Problem/Serializer/ErrorNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Problem\Serializer;
 
 use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -23,7 +24,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ErrorNormalizer implements NormalizerInterface
+final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonproblem';
 
@@ -60,5 +61,13 @@ final class ErrorNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Serializer/AbstractCollectionNormalizer.php
+++ b/src/Serializer/AbstractCollectionNormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Serializer;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -25,7 +26,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
-abstract class AbstractCollectionNormalizer implements NormalizerInterface, NormalizerAwareInterface
+abstract class AbstractCollectionNormalizer implements NormalizerInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
 {
     use ContextTrait { initContext as protected; }
     use NormalizerAwareTrait;
@@ -50,6 +51,14 @@ abstract class AbstractCollectionNormalizer implements NormalizerInterface, Norm
     public function supportsNormalization($data, $format = null)
     {
         return static::FORMAT === $format && (\is_array($data) || $data instanceof \Traversable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 
     /**

--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Serializer;
 
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
@@ -24,7 +25,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  *
  * @internal
  */
-abstract class AbstractConstraintViolationListNormalizer implements NormalizerInterface
+abstract class AbstractConstraintViolationListNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = null; // Must be overrode
 
@@ -43,6 +44,14 @@ abstract class AbstractConstraintViolationListNormalizer implements NormalizerIn
     public function supportsNormalization($data, $format = null): bool
     {
         return static::FORMAT === $format && $data instanceof ConstraintViolationListInterface;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 
     protected function getMessagesAndViolations(ConstraintViolationListInterface $constraintViolationList): array

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -83,6 +83,14 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     /**
      * {@inheritdoc}
      */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function normalize($object, $format = null, array $context = [])
     {
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);

--- a/src/Swagger/Serializer/ApiGatewayNormalizer.php
+++ b/src/Swagger/Serializer/ApiGatewayNormalizer.php
@@ -115,6 +115,6 @@ final class ApiGatewayNormalizer implements NormalizerInterface, CacheableSuppor
      */
     public function hasCacheableSupportsMethod(): bool
     {
-        return true;
+        return $this->documentationNormalizer instanceof CacheableSupportsMethodInterface && $this->documentationNormalizer->hasCacheableSupportsMethod();
     }
 }

--- a/src/Swagger/Serializer/ApiGatewayNormalizer.php
+++ b/src/Swagger/Serializer/ApiGatewayNormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Swagger\Serializer;
 
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -24,7 +25,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
-final class ApiGatewayNormalizer implements NormalizerInterface
+final class ApiGatewayNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     private $documentationNormalizer;
 
@@ -107,5 +108,13 @@ final class ApiGatewayNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return $this->documentationNormalizer->supportsNormalization($data, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 }

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -31,6 +31,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -40,7 +41,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class DocumentationNormalizer implements NormalizerInterface
+final class DocumentationNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     use FilterLocatorTrait;
 
@@ -757,6 +758,14 @@ final class DocumentationNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return self::FORMAT === $format && $data instanceof Documentation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
     }
 
     /**

--- a/tests/Hal/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hal/Serializer/CollectionNormalizerTest.php
@@ -34,6 +34,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new \ArrayObject(), CollectionNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization([], 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \ArrayObject(), 'xml'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalizeApiSubLevel()

--- a/tests/Hal/Serializer/EntrypointNormalizerTest.php
+++ b/tests/Hal/Serializer/EntrypointNormalizerTest.php
@@ -42,6 +42,7 @@ class EntrypointNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($entrypoint, EntrypointNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization($entrypoint, 'json'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), EntrypointNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -86,6 +86,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($dummy, 'jsonhal'));
         $this->assertFalse($normalizer->supportsNormalization($dummy, 'xml'));
         $this->assertFalse($normalizer->supportsNormalization($std, 'jsonhal'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
@@ -22,6 +22,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -32,7 +33,9 @@ class CollectionFiltersNormalizerTest extends TestCase
     public function testSupportsNormalization()
     {
         $decoratedProphecy = $this->prophesize(NormalizerInterface::class);
+        $decoratedProphecy->willImplement(CacheableSupportsMethodInterface::class);
         $decoratedProphecy->supportsNormalization('foo', 'abc')->willReturn(true)->shouldBeCalled();
+        $decoratedProphecy->hasCacheableSupportsMethod()->willReturn(true)->shouldBeCalled();
 
         $normalizer = new CollectionFiltersNormalizer(
             $decoratedProphecy->reveal(),
@@ -42,6 +45,7 @@ class CollectionFiltersNormalizerTest extends TestCase
         );
 
         $this->assertTrue($normalizer->supportsNormalization('foo', 'abc'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testDoNothingIfSubLevel()

--- a/tests/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionNormalizerTest.php
@@ -44,6 +44,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new \ArrayObject(), CollectionNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization([], 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \ArrayObject(), 'xml'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalizeApiSubLevel()

--- a/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
@@ -37,6 +37,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new ConstraintViolationList(), ConstraintViolationListNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new ConstraintViolationList(), 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), ConstraintViolationListNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -89,7 +89,7 @@ class DocumentationNormalizerTest extends TestCase
             ],
         ]);
 
-        $apiDocumentationBuilder = new DocumentationNormalizer(
+        $documentationNormalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
@@ -347,6 +347,9 @@ class DocumentationNormalizerTest extends TestCase
             ],
             'hydra:entrypoint' => '/',
         ];
-        $this->assertEquals($expected, $apiDocumentationBuilder->normalize($documentation));
+        $this->assertEquals($expected, $documentationNormalizer->normalize($documentation));
+        $this->assertTrue($documentationNormalizer->supportsNormalization($documentation, 'jsonld'));
+        $this->assertFalse($documentationNormalizer->supportsNormalization($documentation, 'hal'));
+        $this->assertTrue($documentationNormalizer->hasCacheableSupportsMethod());
     }
 }

--- a/tests/Hydra/Serializer/EntrypointNormalizerTest.php
+++ b/tests/Hydra/Serializer/EntrypointNormalizerTest.php
@@ -42,6 +42,7 @@ class EntrypointNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($entrypoint, EntrypointNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization($entrypoint, 'json'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), EntrypointNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Hydra/Serializer/ErrorNormalizerTest.php
+++ b/tests/Hydra/Serializer/ErrorNormalizerTest.php
@@ -37,6 +37,7 @@ class ErrorNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new FlattenException(), ErrorNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new FlattenException(), 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), ErrorNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     /**

--- a/tests/Hydra/Serializer/ItemNormalizerTest.php
+++ b/tests/Hydra/Serializer/ItemNormalizerTest.php
@@ -48,6 +48,7 @@ class ItemNormalizerTest extends TestCase
         $normalizer = new ItemNormalizer($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $contextBuilderProphecy->reveal());
 
         $this->assertFalse($normalizer->supportsDenormalization('foo', ItemNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testSupportNormalization()
@@ -78,6 +79,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($dummy, 'jsonld'));
         $this->assertFalse($normalizer->supportsNormalization($dummy, 'xml'));
         $this->assertFalse($normalizer->supportsNormalization($std, 'jsonld'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
+++ b/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
 use ApiPlatform\Core\Hydra\Serializer\PartialCollectionViewNormalizer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -105,10 +106,13 @@ class PartialCollectionViewNormalizerTest extends TestCase
     public function testSupportsNormalization()
     {
         $decoratedNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
+        $decoratedNormalizerProphecy->willImplement(CacheableSupportsMethodInterface::class);
         $decoratedNormalizerProphecy->supportsNormalization(Argument::any(), null)->willReturn(true)->shouldBeCalled();
+        $decoratedNormalizerProphecy->hasCacheableSupportsMethod()->willReturn(true)->shouldBeCalled();
 
         $normalizer = new PartialCollectionViewNormalizer($decoratedNormalizerProphecy->reveal());
         $this->assertTrue($normalizer->supportsNormalization(new \stdClass()));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testSetNormalizer()

--- a/tests/Identifier/Normalizer/DateTimeIdentifierNormalizerTest.php
+++ b/tests/Identifier/Normalizer/DateTimeIdentifierNormalizerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Identifier\Normalizer;
+
+use ApiPlatform\Core\Identifier\Normalizer\DateTimeIdentifierDenormalizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DateTimeIdentifierNormalizerTest extends TestCase
+{
+    /**
+     * @expectedException \ApiPlatform\Core\Exception\InvalidIdentifierException
+     */
+    public function testDenormalize()
+    {
+        $normalizer = new DateTimeIdentifierDenormalizer();
+        $normalizer->denormalize('not valid', \DateTimeImmutable::class);
+    }
+
+    public function testHasCacheableSupportsMethod()
+    {
+        $this->assertTrue((new DateTimeIdentifierDenormalizer())->hasCacheableSupportsMethod());
+    }
+}

--- a/tests/Identifier/Normalizer/IntegerDenormalizerTest.php
+++ b/tests/Identifier/Normalizer/IntegerDenormalizerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Identifier\Normalizer;
+
+use ApiPlatform\Core\Identifier\Normalizer\IntegerDenormalizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class IntegerDenormalizerTest extends TestCase
+{
+    public function testDenormalize()
+    {
+        $this->assertSame(2, (new IntegerDenormalizer())->denormalize('2', 'int'));
+    }
+
+    public function testSupportsDenormalization()
+    {
+        $normalizer = new IntegerDenormalizer();
+        $this->assertTrue($normalizer->supportsDenormalization('1', 'int'));
+        $this->assertFalse($normalizer->supportsDenormalization([], 'int'));
+        $this->assertFalse($normalizer->supportsDenormalization('1', 'foo'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
+    }
+}

--- a/tests/JsonApi/Serializer/CollectionNormalizerTest.php
+++ b/tests/JsonApi/Serializer/CollectionNormalizerTest.php
@@ -36,6 +36,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new \ArrayObject(), CollectionNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization([], 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \ArrayObject(), 'xml'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalizePaginator()

--- a/tests/JsonApi/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ConstraintViolationNormalizerTest.php
@@ -39,6 +39,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new ConstraintViolationList(), ConstraintViolationListNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new ConstraintViolationList(), 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), ConstraintViolationListNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/JsonApi/Serializer/EntrypointNormalizerTest.php
+++ b/tests/JsonApi/Serializer/EntrypointNormalizerTest.php
@@ -45,6 +45,7 @@ class EntrypointNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($entrypoint, EntrypointNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization($entrypoint, 'json'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), EntrypointNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/JsonApi/Serializer/ErrorNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ErrorNormalizerTest.php
@@ -34,6 +34,7 @@ class ErrorNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new FlattenException(), ErrorNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new FlattenException(), 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), ErrorNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     /**

--- a/tests/JsonApi/Serializer/ItemNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ItemNormalizerTest.php
@@ -58,6 +58,7 @@ class ItemNormalizerTest extends TestCase
 
         $this->assertTrue($normalizer->supportsDenormalization(null, Dummy::class, ItemNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsDenormalization(null, \stdClass::class, ItemNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testSupportNormalization()

--- a/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
@@ -34,6 +34,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new ConstraintViolationList(), ConstraintViolationListNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new ConstraintViolationList(), 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), ConstraintViolationListNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Problem/Serializer/ErrorNormalizerTest.php
+++ b/tests/Problem/Serializer/ErrorNormalizerTest.php
@@ -34,6 +34,7 @@ class ErrorNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new FlattenException(), ErrorNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsNormalization(new FlattenException(), 'xml'));
         $this->assertFalse($normalizer->supportsNormalization(new \stdClass(), ErrorNormalizer::FORMAT));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -67,6 +67,7 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization($std));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -60,6 +60,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Swagger/Serializer/ApiGatewayNormalizerTest.php
+++ b/tests/Swagger/Serializer/ApiGatewayNormalizerTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Tests\Swagger\Serializer;
 use ApiPlatform\Core\Swagger\Serializer\ApiGatewayNormalizer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,6 +42,8 @@ final class ApiGatewayNormalizerTest extends TestCase
     protected function setUp()
     {
         $this->documentationNormalizerMock = $this->prophesize(NormalizerInterface::class);
+        $this->documentationNormalizerMock->willImplement(CacheableSupportsMethodInterface::class);
+        $this->documentationNormalizerMock->hasCacheableSupportsMethod()->willReturn(true);
         $this->objectMock = $this->prophesize(\stdClass::class);
         $this->normalizer = new ApiGatewayNormalizer($this->documentationNormalizerMock->reveal());
     }
@@ -49,6 +52,7 @@ final class ApiGatewayNormalizerTest extends TestCase
     {
         $this->documentationNormalizerMock->supportsNormalization('foo', 'bar')->willReturn(true)->shouldBeCalledTimes(1);
         $this->assertTrue($this->normalizer->supportsNormalization('foo', 'bar'));
+        $this->assertTrue($this->normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalizeWithoutApiGateway()

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -1304,6 +1304,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($documentation, 'json'));
         $this->assertFalse($normalizer->supportsNormalization($documentation));
         $this->assertFalse($normalizer->supportsNormalization(new Dummy(), 'json'));
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNoOperations()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

It should improve dramatically the performance (benchmarking in progress).
It also means that we drop support for the Serializer Component <4.1, and as a direct consequence of PHP 7.0.