### PR TITLE
Deactivate ItemNormalizer when not in ApiPlatform context

### DIFF
--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -32,7 +32,7 @@ class ItemNormalizer extends AbstractItemNormalizer
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         // Avoid issues with proxies if we populated the object
-        if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
+        if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE]) && isset($context['resource_class'])) {
             if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {
                 throw new InvalidArgumentException('Update is not allowed for this operation.');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

We use the serializer to save / load some json encoded data into our database, so we do something like this : 

```
$this->serializer->deserialize($encoded, MyObject::class . '[]', 'json');
```

However we recently added some validation on this object and use api platform to do it, so we needed to add a fake id parameter (not sure if it's still useful ?)

When doing this previous code was not working because when using this serializer it's trying to use the iri convertion tool which is really not need in our case.

Not sure if this is the right fix but for us it works.
