### PR TITLE
Hal Item Normalizer: add a local cache for classMetadataFactory

### DIFF
--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -30,6 +30,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
     const FORMAT = 'jsonhal';
 
     private $componentsCache = [];
+    private $attributesMetadataCache = [];
 
     /**
      * {@inheritdoc}
@@ -169,7 +170,10 @@ final class ItemNormalizer extends AbstractItemNormalizer
     private function populateRelation(array $data, $object, string $format = null, array $context, array $components, string $type): array
     {
         $class = \get_class($object);
-        $attributesMetadata = $this->classMetadataFactory ? $this->classMetadataFactory->getMetadataFor($object)->getAttributesMetadata() : null;
+
+        $attributesMetadata = \array_key_exists($class, $this->attributesMetadataCache) ?
+            $this->attributesMetadataCache[$class] :
+            $this->attributesMetadataCache[$class] = $this->classMetadataFactory ? $this->classMetadataFactory->getMetadataFor($object)->getAttributesMetadata() : null;
 
         $key = '_'.$type;
         foreach ($components[$type] as $relation) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

here: https://github.com/api-platform/core/pull/1971 i accidentally created a performance issue.

I didn't spot this because the (prod) cached metadata factory does not have a local lookup:
https://github.com/symfony/symfony/blob/1b2bd8f41971f7903fd04d898801a1874a0427dc/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php#L46

while the (dev) uncached one does:
https://github.com/symfony/symfony/blob/1b2bd8f41971f7903fd04d898801a1874a0427dc/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php#L44-L48

This means that in prod mode, many many cache lookups are done, which is pretty slow.
This PR adds a local cache to fix that excessive lookups.