### PR TITLE
FilterEagerLoadingExtension accepts joins with class name as join value

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -135,6 +135,9 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
             /** @var Join $joinPart */
             $joinString = str_replace($aliases, $replacements, $joinPart->getJoin());
             $pos = strpos($joinString, '.');
+            if (false === $pos) {
+                continue;
+            }
             $alias = substr($joinString, 0, $pos);
             $association = substr($joinString, $pos + 1);
             $condition = str_replace($aliases, $replacements, $joinPart->getCondition());

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
@@ -302,6 +302,7 @@ SQL;
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(CompositeRelation::class)->willReturn(new ResourceMetadata(CompositeRelation::class));
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class));
 
         $classMetadata = new ClassMetadataInfo(CompositeRelation::class);
         $classMetadata->isIdentifierComposite = true;
@@ -322,6 +323,7 @@ SQL;
             ->innerJoin('o.compositeItem', 'item')
             ->innerJoin('o.compositeLabel', 'label')
             ->leftJoin('o.foo', 'foo', 'WITH', 'o.bar = item.foo')
+            ->leftJoin(DummyCar::class, 'car', 'WITH', 'car.id = o.car')
             ->where('item.field1 = :foo')
             ->setParameter('foo', 1);
 
@@ -331,6 +333,7 @@ SQL;
         $queryNameGenerator->generateJoinAlias('o')->shouldBeCalled()->willReturn('o_2');
 
         $queryNameGenerator->generateJoinAlias('foo')->shouldBeCalled()->willReturn('foo_2');
+        $queryNameGenerator->generateJoinAlias(DummyCar::class)->shouldNotBeCalled();
 
         $filterEagerLoadingExtension = new FilterEagerLoadingExtension($resourceMetadataFactoryProphecy->reveal(), false);
         $filterEagerLoadingExtension->applyToCollection($qb, $queryNameGenerator->reveal(), CompositeRelation::class, 'get');
@@ -341,6 +344,7 @@ FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeRelation o
 INNER JOIN o.compositeItem item
 INNER JOIN o.compositeLabel label
 LEFT JOIN o.foo foo WITH o.bar = item.foo
+LEFT JOIN ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar car WITH car.id = o.car
 WHERE o.item IN(
     SELECT IDENTITY(o_2.item) FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeRelation o_2
     INNER JOIN o_2.compositeItem item_2


### PR DESCRIPTION
Hello,

The cause is explained in #2012.

I have two doubts/things i am not proud of:

- the optimisation is skipped for related joins
- i am not sure of the behaviour of this fix with composite relations.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2012 
| License       | MIT
| Doc PR        | None

(It is a reedition of the PR #2013, due to my mistake, sorry for the duplicate).