### PR TITLE
fix issue #1717 - Support Subresources MaxDepth for yaml and xml

### DIFF
--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -122,6 +122,7 @@ final class XmlExtractor extends AbstractExtractor
                 'subresource' => $property->subresource ? [
                     'collection' => $this->phpize($property->subresource, 'collection', 'bool'),
                     'resourceClass' => $this->phpize($property->subresource, 'resourceClass', 'string'),
+                    'maxDepth' => $this->phpize($property->subresource, 'maxDepth', 'integer'),
                 ] : null,
             ];
         }
@@ -143,6 +144,8 @@ final class XmlExtractor extends AbstractExtractor
         switch ($type) {
             case 'string':
                 return (string) $array[$key];
+            case 'integer':
+                return (integer) $array[$key];
             case 'bool':
                 return (bool) XmlUtils::phpize($array[$key]);
         }

--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -146,13 +146,15 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
         if (null !== $type) {
             $isCollection = $type->isCollection();
             $resourceClass = $isCollection ? $type->getCollectionValueType()->getClassName() : $type->getClassName();
+            $maxDepth = null; // for Type we can't configure maxDepth, maxDepth is always null
         } elseif (isset($subresource['resourceClass'])) {
             $resourceClass = $subresource['resourceClass'];
             $isCollection = $subresource['collection'] ?? true;
+            $maxDepth = $subresource['maxDepth'] ?? null;
         } else {
             return null;
         }
 
-        return new SubresourceMetadata($resourceClass, $isCollection);
+        return new SubresourceMetadata($resourceClass, $isCollection, $maxDepth);
     }
 }

--- a/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
@@ -130,7 +130,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     }
 
     /**
-     * @dataProvider decoratedPropertyMetadataProvider
+     * @dataProvider typedPropertyMetadataProvider
      */
     public function testCreateWithCollectionTypedParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata)
     {
@@ -161,7 +161,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     }
 
     /**
-     * @dataProvider decoratedPropertyMetadataProvider
+     * @dataProvider typedPropertyMetadataProvider
      */
     public function testCreateWithTypedParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata)
     {

--- a/tests/Metadata/Property/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Property/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -38,7 +38,7 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
                 'bar' => [['Bar'], 'baz' => 'Baz'],
                 'baz' => 'Baz',
             ],
-            'subresource' => new SubresourceMetadata('Foo', true),
+            'subresource' => new SubresourceMetadata('Foo', true, 1),
         ];
 
         return [[$this->getPropertyMetadata($metadata)]];
@@ -46,6 +46,24 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
 
     public function decoratedPropertyMetadataProvider()
     {
+        $metadata = [
+            'description' => 'The dummy foo',
+            'readable' => true,
+            'writable' => true,
+            'readableLink' => true,
+            'writableLink' => false,
+            'required' => true,
+            'identifier' => false,
+            'attributes' => ['Foo'],
+            'subresource' => new SubresourceMetadata('Foo', true, 1),
+        ];
+
+        return [[$this->getPropertyMetadata($metadata)]];
+    }
+
+    public function typedPropertyMetadataProvider()
+    {
+        // for Type we can't configure maxDepth, maxDepth is always null
         $metadata = [
             'description' => 'The dummy foo',
             'readable' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1717 
| License       | MIT
| Doc PR        | -

I found it needed more integration in Extractor and Property Factory in order to use Subresources MaxDepth.

I have update related test cases.

Question about Type class which is used in ExtractorPropertyMetadataFactory:
`$type = $propertyMetadata->getType();`

It uses the built-in symfony Type class and we can't retrieve maxDepth info. So I set maxDepth to null in this case. If you have better idea.
