### PR TITLE
added an --output option to the api:swagger:export

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -56,7 +56,8 @@ final class SwaggerCommand extends Command
         $this
             ->setName('api:swagger:export')
             ->setDescription('Dump the Swagger 2.0 (OpenAPI) documentation')
-            ->addOption('yaml', 'y', InputOption::VALUE_NONE, 'Dump the documentation in YAML');
+            ->addOption('yaml', 'y', InputOption::VALUE_NONE, 'Dump the documentation in YAML')
+            ->addOption('output', 'o', InputOption::VALUE_OPTIONAL, 'Write output to file');
     }
 
     /**
@@ -67,6 +68,14 @@ final class SwaggerCommand extends Command
         $documentation = new Documentation($this->resourceNameCollectionFactory->create(), $this->apiTitle, $this->apiDescription, $this->apiVersion, $this->apiFormats);
         $data = $this->documentationNormalizer->normalize($documentation);
         $content = $input->getOption('yaml') ? Yaml::dump($data) : json_encode($data, JSON_PRETTY_PRINT);
-        $output->writeln($content);
+
+        if (!empty($input->getOption('output'))) {
+            file_put_contents($input->getOption('output'), $content);
+            $output->writeln(
+                sprintf('Data written to %s', $input->getOption('output'))
+            );
+        } else {
+            $output->writeln($content);
+        }
     }
 }

--- a/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
+++ b/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
@@ -54,6 +54,16 @@ class SwaggerCommandTest extends KernelTestCase
         $this->assertYaml($this->tester->getDisplay());
     }
 
+    public function testWriteToFile()
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'test_write_to_file');
+
+        $this->tester->run(['command' => 'api:swagger:export', '--output' => $tmpFile]);
+
+        $this->assertJson(file_get_contents($tmpFile));
+        @unlink($tmpFile);
+    }
+
     /**
      * @param string $data
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2023
| License       | MIT
| Doc PR        | api-platform/doc#506

Option to specify file to write generate contents instead of stdout.
