### PR TITLE
RFC: enforce void return

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -69,6 +69,7 @@ return PhpCsFixer\Config::create()
         'strict_comparison' => true,
         'strict_param' => true,
         'ternary_to_null_coalescing' => true,
+        'void_return' => true,
     ])
     ->setFinder($finder)
 ;

--- a/features/bootstrap/CoverageContext.php
+++ b/features/bootstrap/CoverageContext.php
@@ -34,7 +34,7 @@ final class CoverageContext implements Context
     /**
      * @BeforeSuite
      */
-    public static function setup()
+    public static function setup(): void
     {
         $filter = new Filter();
         $filter->addDirectoryToWhitelist(__DIR__.'/../../src');
@@ -44,7 +44,7 @@ final class CoverageContext implements Context
     /**
      * @AfterSuite
      */
-    public static function tearDown()
+    public static function tearDown(): void
     {
         $feature = getenv('FEATURE') ?: 'behat';
         (new PHP())->process(self::$coverage, __DIR__."/../../build/cov/coverage-$feature.cov");
@@ -53,7 +53,7 @@ final class CoverageContext implements Context
     /**
      * @BeforeScenario
      */
-    public function startCoverage(BeforeScenarioScope $scope)
+    public function startCoverage(BeforeScenarioScope $scope): void
     {
         self::$coverage->start("{$scope->getFeature()->getTitle()}::{$scope->getScenario()->getTitle()}");
     }
@@ -61,7 +61,7 @@ final class CoverageContext implements Context
     /**
      * @AfterScenario
      */
-    public function stopCoverage()
+    public function stopCoverage(): void
     {
         self::$coverage->stop();
     }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -90,7 +90,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      *
      * @AfterStep
      */
-    public function removeAcceptHeaderAfterRequest(AfterStepScope $event)
+    public function removeAcceptHeaderAfterRequest(AfterStepScope $event): void
     {
         if (preg_match('/^I send a "[A-Z]+" request to ".+"/', $event->getStep()->getText())) {
             $this->request->setHttpHeader('Accept', null);
@@ -102,7 +102,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      *
      * @BeforeScenario
      */
-    public function removeAcceptHeaderBeforeScenario()
+    public function removeAcceptHeaderBeforeScenario(): void
     {
         $this->request->setHttpHeader('Accept', null);
     }
@@ -110,7 +110,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @BeforeScenario @createSchema
      */
-    public function createDatabase()
+    public function createDatabase(): void
     {
         $this->schemaTool->dropSchema($this->classes);
         $this->doctrine->getManager()->clear();
@@ -120,7 +120,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects
      */
-    public function thereAreDummyObjects(int $nb)
+    public function thereAreDummyObjects(int $nb): void
     {
         $descriptions = ['Smart dummy.', 'Not so smart dummy.'];
 
@@ -140,7 +140,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb foo objects with fake names
      */
-    public function thereAreFooObjectsWithFakeNames(int $nb)
+    public function thereAreFooObjectsWithFakeNames(int $nb): void
     {
         $names = ['Hawsepipe', 'Sthenelus', 'Ephesian', 'Separativeness', 'Balbo'];
         $bars = ['Lorem', 'Ipsum', 'Dolor', 'Sit', 'Amet'];
@@ -159,7 +159,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb fooDummy objects with fake names
      */
-    public function thereAreFooDummyObjectsWithFakeNames($nb)
+    public function thereAreFooDummyObjectsWithFakeNames($nb): void
     {
         $names = ['Hawsepipe', 'Ephesian', 'Sthenelus', 'Separativeness', 'Balbo'];
         $dummies = ['Lorem', 'Ipsum', 'Dolor', 'Sit', 'Amet'];
@@ -181,7 +181,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy group objects
      */
-    public function thereAreDummyGroupObjects(int $nb)
+    public function thereAreDummyGroupObjects(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $dummyGroup = new DummyGroup();
@@ -199,7 +199,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy property objects
      */
-    public function thereAreDummyPropertyObjects(int $nb)
+    public function thereAreDummyPropertyObjects(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $dummyProperty = new DummyProperty();
@@ -221,7 +221,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy property objects with :nb2 groups
      */
-    public function thereAreDummyPropertyObjectsWithGroups(int $nb, int $nb2)
+    public function thereAreDummyPropertyObjectsWithGroups(int $nb, int $nb2): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $dummyProperty = new DummyProperty();
@@ -254,7 +254,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb embedded dummy objects
      */
-    public function thereAreEmbeddedDummyObjects(int $nb)
+    public function thereAreEmbeddedDummyObjects(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $dummy = new EmbeddedDummy();
@@ -273,7 +273,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects with relatedDummy
      */
-    public function thereAreDummyObjectsWithRelatedDummy(int $nb)
+    public function thereAreDummyObjectsWithRelatedDummy(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $relatedDummy = new RelatedDummy();
@@ -294,7 +294,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects with JSON and array data
      */
-    public function thereAreDummyObjectsWithJsonData(int $nb)
+    public function thereAreDummyObjectsWithJsonData(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $dummy = new Dummy();
@@ -313,7 +313,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      * @Given there are :nb dummy objects with relatedDummy and its thirdLevel
      * @Given there is :nb dummy object with relatedDummy and its thirdLevel
      */
-    public function thereAreDummyObjectsWithRelatedDummyAndItsThirdLevel(int $nb)
+    public function thereAreDummyObjectsWithRelatedDummyAndItsThirdLevel(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $thirdLevel = new ThirdLevel();
@@ -338,7 +338,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects with embeddedDummy
      */
-    public function thereAreDummyObjectsWithEmbeddedDummy(int $nb)
+    public function thereAreDummyObjectsWithEmbeddedDummy(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $embeddableDummy = new EmbeddableDummy();
@@ -357,7 +357,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects having each :nbrelated relatedDummies
      */
-    public function thereAreDummyObjectsWithRelatedDummies(int $nb, int $nbrelated)
+    public function thereAreDummyObjectsWithRelatedDummies(int $nb, int $nbrelated): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $dummy = new Dummy();
@@ -383,7 +383,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      * @Given there are :nb dummy objects with dummyDate
      * @Given there is :nb dummy object with dummyDate
      */
-    public function thereAreDummyObjectsWithDummyDate(int $nb)
+    public function thereAreDummyObjectsWithDummyDate(int $nb): void
     {
         $descriptions = ['Smart dummy.', 'Not so smart dummy.'];
 
@@ -409,7 +409,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects with dummyDate and dummyBoolean :bool
      */
-    public function thereAreDummyObjectsWithDummyDateAndDummyBoolean(int $nb, string $bool)
+    public function thereAreDummyObjectsWithDummyDateAndDummyBoolean(int $nb, string $bool): void
     {
         $descriptions = ['Smart dummy.', 'Not so smart dummy.'];
 
@@ -445,7 +445,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects with dummyDate and relatedDummy
      */
-    public function thereAreDummyObjectsWithDummyDateAndRelatedDummy(int $nb)
+    public function thereAreDummyObjectsWithDummyDateAndRelatedDummy(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $date = new \DateTime(sprintf('2015-04-%d', $i), new \DateTimeZone('UTC'));
@@ -473,7 +473,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb embedded dummy objects with dummyDate and embeddedDummy
      */
-    public function thereAreDummyObjectsWithDummyDateAndEmbeddedDummy(int $nb)
+    public function thereAreDummyObjectsWithDummyDateAndEmbeddedDummy(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $date = new \DateTime(sprintf('2015-04-%d', $i), new \DateTimeZone('UTC'));
@@ -499,7 +499,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummy objects with dummyPrice
      */
-    public function thereAreDummyObjectsWithDummyPrice(int $nb)
+    public function thereAreDummyObjectsWithDummyPrice(int $nb): void
     {
         $descriptions = ['Smart dummy.', 'Not so smart dummy.'];
         $prices = ['9.99', '12.99', '15.99', '19.99'];
@@ -521,7 +521,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      * @Given there are :nb dummy objects with dummyBoolean :bool
      * @Given there is :nb dummy object with dummyBoolean :bool
      */
-    public function thereAreDummyObjectsWithDummyBoolean(int $nb, string $bool)
+    public function thereAreDummyObjectsWithDummyBoolean(int $nb, string $bool): void
     {
         if (\in_array($bool, ['true', '1', 1], true)) {
             $bool = true;
@@ -549,7 +549,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb embedded dummy objects with embeddedDummy.dummyBoolean :bool
      */
-    public function thereAreDummyObjectsWithEmbeddedDummyBoolean(int $nb, string $bool)
+    public function thereAreDummyObjectsWithEmbeddedDummyBoolean(int $nb, string $bool): void
     {
         if (\in_array($bool, ['true', '1', 1], true)) {
             $bool = true;
@@ -576,7 +576,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb embedded dummy objects with relatedDummy.embeddedDummy.dummyBoolean :bool
      */
-    public function thereAreDummyObjectsWithRelationEmbeddedDummyBoolean(int $nb, string $bool)
+    public function thereAreDummyObjectsWithRelationEmbeddedDummyBoolean(int $nb, string $bool): void
     {
         if (\in_array($bool, ['true', '1', 1], true)) {
             $bool = true;
@@ -609,7 +609,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb SecuredDummy objects
      */
-    public function thereAreSecuredDummyObjects(int $nb)
+    public function thereAreSecuredDummyObjects(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $securedDummy = new SecuredDummy();
@@ -626,7 +626,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is a RelationEmbedder object
      */
-    public function thereIsARelationEmbedderObject()
+    public function thereIsARelationEmbedderObject(): void
     {
         $relationEmbedder = new RelationEmbedder();
 
@@ -637,7 +637,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is a Dummy Object mapped by UUID
      */
-    public function thereIsADummyObjectMappedByUUID()
+    public function thereIsADummyObjectMappedByUUID(): void
     {
         $dummy = new UuidIdentifierDummy();
         $dummy->setName('My Dummy');
@@ -650,7 +650,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are Composite identifier objects
      */
-    public function thereIsACompositeIdentifierObject()
+    public function thereIsACompositeIdentifierObject(): void
     {
         $item = new CompositeItem();
         $item->setField1('foobar');
@@ -679,7 +679,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are composite primitive identifiers objects
      */
-    public function thereAreCompositePrimitiveIdentifiersObjects()
+    public function thereAreCompositePrimitiveIdentifiersObjects(): void
     {
         $foo = new CompositePrimitiveItem('Foo', 2016);
         $foo->setDescription('This is foo.');
@@ -696,7 +696,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is a FileConfigDummy object
      */
-    public function thereIsAFileConfigDummyObject()
+    public function thereIsAFileConfigDummyObject(): void
     {
         $fileConfigDummy = new FileConfigDummy();
         $fileConfigDummy->setName('ConfigDummy');
@@ -709,7 +709,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is a DummyCar entity with related colors
      */
-    public function thereIsAFooEntityWithRelatedBars()
+    public function thereIsAFooEntityWithRelatedBars(): void
     {
         $foo = new DummyCar();
         $foo->setName('mustli');
@@ -736,7 +736,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is a RelatedDummy with :nb friends
      */
-    public function thereIsARelatedDummyWithFriends(int $nb)
+    public function thereIsARelatedDummyWithFriends(int $nb): void
     {
         $relatedDummy = new RelatedDummy();
         $relatedDummy->setName('RelatedDummy with friends');
@@ -772,7 +772,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is an answer :answer to the question :question
      */
-    public function thereIsAnAnswerToTheQuestion(string $a, string $q)
+    public function thereIsAnAnswerToTheQuestion(string $a, string $q): void
     {
         $answer = new Answer();
         $answer->setContent($a);
@@ -791,7 +791,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb nodes in a container :uuid
      */
-    public function thereAreNodesInAContainer(int $nb, string $uuid)
+    public function thereAreNodesInAContainer(int $nb, string $uuid): void
     {
         $container = new Container();
         $container->setId($uuid);
@@ -810,7 +810,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Then the password :password for user :user should be hashed
      */
-    public function thePasswordForUserShouldBeHashed(string $password, string $user)
+    public function thePasswordForUserShouldBeHashed(string $password, string $user): void
     {
         $user = $this->doctrine->getRepository(User::class)->find($user);
 
@@ -822,7 +822,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given I have a product with offers
      */
-    public function createProductWithOffers()
+    public function createProductWithOffers(): void
     {
         $offer = new DummyOffer();
         $offer->setValue(2);
@@ -848,7 +848,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are people having pets
      */
-    public function createPeopleWithPets()
+    public function createPeopleWithPets(): void
     {
         $personToPet = new PersonToPet();
 
@@ -877,7 +877,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      * @Given there are :nb dummydate objects with dummyDate
      * @Given there is :nb dummydate object with dummyDate
      */
-    public function thereAreDummyDateObjectsWithDummyDate(int $nb)
+    public function thereAreDummyDateObjectsWithDummyDate(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $date = new \DateTime(sprintf('2015-04-%d', $i), new \DateTimeZone('UTC'));
@@ -894,7 +894,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there are :nb dummyimmutabledate objects with dummyDate
      */
-    public function thereAreDummyImmutableDateObjectsWithDummyDate(int $nb)
+    public function thereAreDummyImmutableDateObjectsWithDummyDate(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $date = new \DateTimeImmutable(sprintf('2015-04-%d', $i), new \DateTimeZone('UTC'));
@@ -910,7 +910,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is a ramsey identified resource with uuid :uuid
      */
-    public function thereIsARamseyIdentifiedResource(string $uuid)
+    public function thereIsARamseyIdentifiedResource(string $uuid): void
     {
         $dummy = new RamseyUuidDummy();
         $dummy->setId($uuid);
@@ -922,7 +922,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * @Given there is a dummy object with a fourth level relation
      */
-    public function thereIsADummyObjectWithAFourthLevelRelation()
+    public function thereIsADummyObjectWithAFourthLevelRelation(): void
     {
         $fourthLevel = new FourthLevel();
         $fourthLevel->setLevel(4);

--- a/features/bootstrap/GraphqlContext.php
+++ b/features/bootstrap/GraphqlContext.php
@@ -54,7 +54,7 @@ final class GraphqlContext implements Context
      *
      * @BeforeScenario
      */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         /** @var InitializedContextEnvironment $environment */
         $environment = $scope->getEnvironment();
@@ -64,7 +64,7 @@ final class GraphqlContext implements Context
     /**
      * @When I have the following GraphQL request:
      */
-    public function IHaveTheFollowingGraphqlRequest(PyStringNode $request)
+    public function IHaveTheFollowingGraphqlRequest(PyStringNode $request): void
     {
         $this->graphqlRequest = ['query' => $request->getRaw()];
         $this->graphqlLine = $request->getLine();
@@ -73,7 +73,7 @@ final class GraphqlContext implements Context
     /**
      * @When I send the following GraphQL request:
      */
-    public function ISendTheFollowingGraphqlRequest(PyStringNode $request)
+    public function ISendTheFollowingGraphqlRequest(PyStringNode $request): void
     {
         $this->IHaveTheFollowingGraphqlRequest($request);
         $this->sendGraphqlRequest();
@@ -82,7 +82,7 @@ final class GraphqlContext implements Context
     /**
      * @When I send the GraphQL request with variables:
      */
-    public function ISendTheGraphqlRequestWithVariables(PyStringNode $variables)
+    public function ISendTheGraphqlRequestWithVariables(PyStringNode $variables): void
     {
         $this->graphqlRequest['variables'] = $variables->getRaw();
         $this->sendGraphqlRequest();
@@ -91,7 +91,7 @@ final class GraphqlContext implements Context
     /**
      * @When I send the GraphQL request with operation :operation
      */
-    public function ISendTheGraphqlRequestWithOperation(string $operation)
+    public function ISendTheGraphqlRequestWithOperation(string $operation): void
     {
         $this->graphqlRequest['operation'] = $operation;
         $this->sendGraphqlRequest();
@@ -100,7 +100,7 @@ final class GraphqlContext implements Context
     /**
      * @When I send the query to introspect the schema
      */
-    public function ISendTheQueryToIntrospectTheSchema()
+    public function ISendTheQueryToIntrospectTheSchema(): void
     {
         $this->graphqlRequest = ['query' => Introspection::getIntrospectionQuery()];
         $this->sendGraphqlRequest();
@@ -109,7 +109,7 @@ final class GraphqlContext implements Context
     /**
      * @Then the GraphQL field :fieldName is deprecated for the reason :reason
      */
-    public function theGraphQLFieldIsDeprecatedForTheReason(string $fieldName, string $reason)
+    public function theGraphQLFieldIsDeprecatedForTheReason(string $fieldName, string $reason): void
     {
         foreach (json_decode($this->request->getContent(), true)['data']['__type']['fields'] as $field) {
             if ($fieldName === $field['name'] && $field['isDeprecated'] && $reason === $field['deprecationReason']) {
@@ -120,7 +120,7 @@ final class GraphqlContext implements Context
         throw new ExpectationFailedException(sprintf('The field "%s" is not deprecated.', $fieldName));
     }
 
-    private function sendGraphqlRequest()
+    private function sendGraphqlRequest(): void
     {
         $this->request->setHttpHeader('Accept', null);
         $this->restContext->iSendARequestTo('GET', '/graphql?'.http_build_query($this->graphqlRequest));

--- a/features/bootstrap/HttpCacheContext.php
+++ b/features/bootstrap/HttpCacheContext.php
@@ -25,7 +25,7 @@ final class HttpCacheContext implements KernelAwareContext
      */
     private $kernel;
 
-    public function setKernel(KernelInterface $kernel)
+    public function setKernel(KernelInterface $kernel): void
     {
         $this->kernel = $kernel;
     }
@@ -33,7 +33,7 @@ final class HttpCacheContext implements KernelAwareContext
     /**
      * @Then :iris IRIs should be purged
      */
-    public function irisShouldBePurged(string $iris)
+    public function irisShouldBePurged(string $iris): void
     {
         $purger = $this->kernel->getContainer()->get('test.api_platform.http_cache.purger');
 

--- a/features/bootstrap/HydraContext.php
+++ b/features/bootstrap/HydraContext.php
@@ -37,7 +37,7 @@ final class HydraContext implements Context
      *
      * @BeforeScenario
      */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         /** @var InitializedContextEnvironment $environment */
         $environment = $scope->getEnvironment();
@@ -47,7 +47,7 @@ final class HydraContext implements Context
     /**
      * @Then the Hydra class :class exists
      */
-    public function assertTheHydraClassExist(string $className)
+    public function assertTheHydraClassExist(string $className): void
     {
         try {
             $this->getClassInfo($className);
@@ -59,7 +59,7 @@ final class HydraContext implements Context
     /**
      * @Then the Hydra class :class doesn't exist
      */
-    public function assertTheHydraClassNotExist(string $className)
+    public function assertTheHydraClassNotExist(string $className): void
     {
         try {
             $this->getClassInfo($className);
@@ -73,7 +73,7 @@ final class HydraContext implements Context
     /**
      * @Then the boolean value of the node :node of the Hydra class :class is true
      */
-    public function assertBooleanNodeValueIs(string $nodeName, string $className)
+    public function assertBooleanNodeValueIs(string $nodeName, string $className): void
     {
         Assert::assertTrue($this->propertyAccessor->getValue($this->getClassInfo($className), $nodeName));
     }
@@ -81,7 +81,7 @@ final class HydraContext implements Context
     /**
      * @Then the value of the node :node of the Hydra class :class is :value
      */
-    public function assertNodeValueIs(string $nodeName, string $className, string $value)
+    public function assertNodeValueIs(string $nodeName, string $className, string $value): void
     {
         Assert::assertEquals(
             $this->propertyAccessor->getValue($this->getClassInfo($className), $nodeName),
@@ -92,7 +92,7 @@ final class HydraContext implements Context
     /**
      * @Then the boolean value of the node :node of the property :prop of the Hydra class :class is true
      */
-    public function assertPropertyNodeValueIsTrue(string $nodeName, string $propertyName, string $className)
+    public function assertPropertyNodeValueIsTrue(string $nodeName, string $propertyName, string $className): void
     {
         Assert::assertTrue($this->propertyAccessor->getValue($this->getPropertyInfo($propertyName, $className), $nodeName));
     }
@@ -100,7 +100,7 @@ final class HydraContext implements Context
     /**
      * @Then the value of the node :node of the property :prop of the Hydra class :class is :value
      */
-    public function assertPropertyNodeValueIs(string $nodeName, string $propertyName, string $className, string $value)
+    public function assertPropertyNodeValueIs(string $nodeName, string $propertyName, string $className, string $value): void
     {
         Assert::assertEquals(
             $this->propertyAccessor->getValue($this->getPropertyInfo($propertyName, $className), $nodeName),
@@ -111,7 +111,7 @@ final class HydraContext implements Context
     /**
      * @Then the boolean value of the node :node of the operation :operation of the Hydra class :class is true
      */
-    public function assertOperationNodeBooleanValueIs(string $nodeName, string $operationMethod, string $className)
+    public function assertOperationNodeBooleanValueIs(string $nodeName, string $operationMethod, string $className): void
     {
         Assert::assertTrue($this->propertyAccessor->getValue($this->getOperation($operationMethod, $className), $nodeName));
     }
@@ -119,7 +119,7 @@ final class HydraContext implements Context
     /**
      * @Then the value of the node :node of the operation :operation of the Hydra class :class is :value
      */
-    public function assertOperationNodeValueIs(string $nodeName, string $operationMethod, string $className, string $value)
+    public function assertOperationNodeValueIs(string $nodeName, string $operationMethod, string $className, string $value): void
     {
         Assert::assertEquals(
             $this->propertyAccessor->getValue($this->getOperation($operationMethod, $className), $nodeName),
@@ -130,7 +130,7 @@ final class HydraContext implements Context
     /**
      * @Then the value of the node :node of the operation :operation of the Hydra class :class contains :value
      */
-    public function assertOperationNodeValueContains(string $nodeName, string $operationMethod, string $className, string $value)
+    public function assertOperationNodeValueContains(string $nodeName, string $operationMethod, string $className, string $value): void
     {
         $property = $this->getOperation($operationMethod, $className);
 
@@ -140,7 +140,7 @@ final class HydraContext implements Context
     /**
      * @Then :nb operations are available for Hydra class :class
      */
-    public function assertNbOperationsExist(int $nb, string $className)
+    public function assertNbOperationsExist(int $nb, string $className): void
     {
         Assert::assertEquals($nb, \count($this->getOperations($className)));
     }
@@ -148,7 +148,7 @@ final class HydraContext implements Context
     /**
      * @Then :nb properties are available for Hydra class :class
      */
-    public function assertNbPropertiesExist(int $nb, string $className)
+    public function assertNbPropertiesExist(int $nb, string $className): void
     {
         Assert::assertEquals($nb, \count($this->getProperties($className)));
     }
@@ -156,7 +156,7 @@ final class HydraContext implements Context
     /**
      * @Then :prop property doesn't exist for the Hydra class :class
      */
-    public function assertPropertyNotExist(string $propertyName, string $className)
+    public function assertPropertyNotExist(string $propertyName, string $className): void
     {
         try {
             $this->getPropertyInfo($propertyName, $className);
@@ -170,7 +170,7 @@ final class HydraContext implements Context
     /**
      * @Then :prop property is readable for Hydra class :class
      */
-    public function assertPropertyIsReadable(string $propertyName, string $className)
+    public function assertPropertyIsReadable(string $propertyName, string $className): void
     {
         if (!$this->getPropertyInfo($propertyName, $className)->{'hydra:readable'}) {
             throw new ExpectationFailedException(sprintf('Property "%s" of class "%s" is not readable', $propertyName, $className));
@@ -180,7 +180,7 @@ final class HydraContext implements Context
     /**
      * @Then :prop property is not readable for Hydra class :class
      */
-    public function assertPropertyIsNotReadable(string $propertyName, string $className)
+    public function assertPropertyIsNotReadable(string $propertyName, string $className): void
     {
         if ($this->getPropertyInfo($propertyName, $className)->{'hydra:readable'}) {
             throw new ExpectationFailedException(sprintf('Property "%s" of class "%s" is readable', $propertyName, $className));
@@ -190,7 +190,7 @@ final class HydraContext implements Context
     /**
      * @Then :prop property is writable for Hydra class :class
      */
-    public function assertPropertyIsWritable(string $propertyName, string $className)
+    public function assertPropertyIsWritable(string $propertyName, string $className): void
     {
         if (!$this->getPropertyInfo($propertyName, $className)->{'hydra:writable'}) {
             throw new ExpectationFailedException(sprintf('Property "%s" of class "%s" is not writable', $propertyName, $className));
@@ -200,7 +200,7 @@ final class HydraContext implements Context
     /**
      * @Then :prop property is required for Hydra class :class
      */
-    public function assertPropertyIsRequired(string $propertyName, string $className)
+    public function assertPropertyIsRequired(string $propertyName, string $className): void
     {
         if (!$this->getPropertyInfo($propertyName, $className)->{'hydra:required'}) {
             throw new ExpectationFailedException(sprintf('Property "%s" of class "%s" is not required', $propertyName, $className));
@@ -210,7 +210,7 @@ final class HydraContext implements Context
     /**
      * @Then :prop property is not required for Hydra class :class
      */
-    public function assertPropertyIsNotRequired(string $propertyName, string $className)
+    public function assertPropertyIsNotRequired(string $propertyName, string $className): void
     {
         if ($this->getPropertyInfo($propertyName, $className)->{'hydra:required'}) {
             throw new ExpectationFailedException(sprintf('Property "%s" of class "%s" is required', $propertyName, $className));

--- a/features/bootstrap/JsonApiContext.php
+++ b/features/bootstrap/JsonApiContext.php
@@ -52,7 +52,7 @@ final class JsonApiContext implements Context
      *
      * @BeforeScenario
      */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         /** @var InitializedContextEnvironment $environment */
         $environment = $scope->getEnvironment();
@@ -62,7 +62,7 @@ final class JsonApiContext implements Context
     /**
      * @Then the JSON should be valid according to the JSON API schema
      */
-    public function theJsonShouldBeValidAccordingToTheJsonApiSchema()
+    public function theJsonShouldBeValidAccordingToTheJsonApiSchema(): void
     {
         $json = $this->getJson()->getContent();
         $this->validator->validate($json, (object) ['$ref' => 'file://'.__DIR__.'/../../'.$this->jsonApiSchemaFile]);
@@ -75,7 +75,7 @@ final class JsonApiContext implements Context
     /**
      * @Then the JSON node :node should be an empty array
      */
-    public function theJsonNodeShouldBeAnEmptyArray($node)
+    public function theJsonNodeShouldBeAnEmptyArray($node): void
     {
         $actual = $this->getValueOfNode($node);
         if (null !== $actual && [] !== $actual) {
@@ -86,7 +86,7 @@ final class JsonApiContext implements Context
     /**
      * @Then the JSON node :node should be a number
      */
-    public function theJsonNodeShouldBeANumber($node)
+    public function theJsonNodeShouldBeANumber($node): void
     {
         if (!is_numeric($actual = $this->getValueOfNode($node))) {
             throw new ExpectationFailedException(sprintf('The node value is `%s`', json_encode($actual)));
@@ -96,7 +96,7 @@ final class JsonApiContext implements Context
     /**
      * @Then the JSON node :node should not be an empty string
      */
-    public function theJsonNodeShouldNotBeAnEmptyString($node)
+    public function theJsonNodeShouldNotBeAnEmptyString($node): void
     {
         if ('' === $actual = $this->getValueOfNode($node)) {
             throw new ExpectationFailedException(sprintf('The node value is `%s`', json_encode($actual)));
@@ -106,7 +106,7 @@ final class JsonApiContext implements Context
     /**
      * @Given there is a RelatedDummy
      */
-    public function thereIsARelatedDummy()
+    public function thereIsARelatedDummy(): void
     {
         $relatedDummy = new RelatedDummy();
         $relatedDummy->setName('RelatedDummy with no friends');
@@ -118,7 +118,7 @@ final class JsonApiContext implements Context
     /**
      * @Given there is a DummyFriend
      */
-    public function thereIsADummyFriend()
+    public function thereIsADummyFriend(): void
     {
         $friend = new DummyFriend();
         $friend->setName('DummyFriend');
@@ -130,7 +130,7 @@ final class JsonApiContext implements Context
     /**
      * @Given there is a CircularReference
      */
-    public function thereIsACircularReference()
+    public function thereIsACircularReference(): void
     {
         $circularReference = new CircularReference();
         $circularReference->parent = $circularReference;

--- a/features/bootstrap/JsonContext.php
+++ b/features/bootstrap/JsonContext.php
@@ -48,7 +48,7 @@ final class JsonContext extends BaseJsonContext
     /**
      * @Then /^the JSON should be deep equal to:$/
      */
-    public function theJsonShouldBeDeepEqualTo(PyStringNode $content)
+    public function theJsonShouldBeDeepEqualTo(PyStringNode $content): void
     {
         $actual = $this->getJson();
         try {
@@ -70,7 +70,7 @@ final class JsonContext extends BaseJsonContext
     /**
      * @Then /^the JSON should be a superset of:$/
      */
-    public function theJsonIsASupersetOf(PyStringNode $content)
+    public function theJsonIsASupersetOf(PyStringNode $content): void
     {
         $actual = json_decode($this->httpCallResultPool->getResult()->getValue(), true);
         Assert::assertArraySubset(json_decode($content->getRaw(), true), $actual);

--- a/features/bootstrap/JsonHalContext.php
+++ b/features/bootstrap/JsonHalContext.php
@@ -43,7 +43,7 @@ final class JsonHalContext implements Context
      *
      * @BeforeScenario
      */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         /** @var InitializedContextEnvironment $environment */
         $environment = $scope->getEnvironment();
@@ -53,7 +53,7 @@ final class JsonHalContext implements Context
     /**
      * @Then the JSON should be valid according to the JSON HAL schema
      */
-    public function theJsonShouldBeValidAccordingToTheJsonHALSchema()
+    public function theJsonShouldBeValidAccordingToTheJsonHALSchema(): void
     {
         $json = $this->getJson()->getContent();
         $this->validator->validate($json, (object) ['$ref' => 'file://'.__DIR__.'/../../'.$this->schemaFile]);

--- a/features/bootstrap/SwaggerContext.php
+++ b/features/bootstrap/SwaggerContext.php
@@ -30,7 +30,7 @@ final class SwaggerContext implements Context
      *
      * @BeforeScenario
      */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         /** @var InitializedContextEnvironment $environment */
         $environment = $scope->getEnvironment();
@@ -40,7 +40,7 @@ final class SwaggerContext implements Context
     /**
      * @Then the Swagger class :class exists
      */
-    public function assertTheSwaggerClassExist(string $className)
+    public function assertTheSwaggerClassExist(string $className): void
     {
         try {
             $this->getClassInfo($className);
@@ -52,7 +52,7 @@ final class SwaggerContext implements Context
     /**
      * @Then the Swagger class :class doesn't exist
      */
-    public function assertTheSwaggerClassNotExist(string $className)
+    public function assertTheSwaggerClassNotExist(string $className): void
     {
         try {
             $this->getClassInfo($className);
@@ -66,7 +66,7 @@ final class SwaggerContext implements Context
     /**
      * @Then the Swagger path :arg1 exists
      */
-    public function assertThePathExist(string $path)
+    public function assertThePathExist(string $path): void
     {
         $json = $this->getLastJsonResponse();
 
@@ -76,7 +76,7 @@ final class SwaggerContext implements Context
     /**
      * @Then :prop property exists for the Swagger class :class
      */
-    public function assertPropertyExist(string $propertyName, string $className)
+    public function assertPropertyExist(string $propertyName, string $className): void
     {
         try {
             $this->getPropertyInfo($propertyName, $className);
@@ -88,7 +88,7 @@ final class SwaggerContext implements Context
     /**
      * @Then :prop property is required for Swagger class :class
      */
-    public function assertPropertyIsRequired(string $propertyName, string $className)
+    public function assertPropertyIsRequired(string $propertyName, string $className): void
     {
         if (!\in_array($propertyName, $this->getClassInfo($className)->required, true)) {
             throw new ExpectationFailedException(sprintf('Property "%s" of class "%s" should be required', $propertyName, $className));

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -42,7 +42,7 @@ trait AttributesHydratorTrait
     /**
      * @throws InvalidArgumentException
      */
-    private function hydrateAttributes(array $values)
+    private function hydrateAttributes(array $values): void
     {
         if (isset($values['attributes'])) {
             $this->attributes = $values['attributes'];

--- a/src/Api/FilterLocatorTrait.php
+++ b/src/Api/FilterLocatorTrait.php
@@ -33,7 +33,7 @@ trait FilterLocatorTrait
      * @param ContainerInterface|FilterCollection|null $filterLocator
      * @param bool                                     $allowNull
      */
-    private function setFilterLocator($filterLocator = null, bool $allowNull = false)
+    private function setFilterLocator($filterLocator = null, bool $allowNull = false): void
     {
         if ($filterLocator instanceof ContainerInterface || $filterLocator instanceof FilterCollection || (null === $filterLocator && $allowNull)) {
             if ($filterLocator instanceof FilterCollection) {

--- a/src/Bridge/Doctrine/Common/DataPersister.php
+++ b/src/Bridge/Doctrine/Common/DataPersister.php
@@ -64,7 +64,7 @@ final class DataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function remove($data)
+    public function remove($data): void
     {
         if (!$manager = $this->getManager($data)) {
             return;

--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -52,7 +52,7 @@ final class PurgeHttpCacheListener
     /**
      * Collects tags from the previous and the current version of the updated entities to purge related documents.
      */
-    public function preUpdate(PreUpdateEventArgs $eventArgs)
+    public function preUpdate(PreUpdateEventArgs $eventArgs): void
     {
         $object = $eventArgs->getObject();
         $this->gatherResourceAndItemTags($object, true);
@@ -73,7 +73,7 @@ final class PurgeHttpCacheListener
     /**
      * Collects tags from inserted and deleted entities, including relations.
      */
-    public function onFlush(OnFlushEventArgs $eventArgs)
+    public function onFlush(OnFlushEventArgs $eventArgs): void
     {
         $em = $eventArgs->getEntityManager();
         $uow = $em->getUnitOfWork();
@@ -97,13 +97,13 @@ final class PurgeHttpCacheListener
     /**
      * Purges tags collected during this request, and clears the tag list.
      */
-    public function postFlush()
+    public function postFlush(): void
     {
         $this->purger->purge($this->tags);
         $this->tags = [];
     }
 
-    private function gatherResourceAndItemTags($entity, bool $purgeItem)
+    private function gatherResourceAndItemTags($entity, bool $purgeItem): void
     {
         try {
             $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
@@ -119,7 +119,7 @@ final class PurgeHttpCacheListener
         }
     }
 
-    private function gatherRelationTags(EntityManagerInterface $em, $entity)
+    private function gatherRelationTags(EntityManagerInterface $em, $entity): void
     {
         $associationMappings = $em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
         foreach (array_keys($associationMappings) as $property) {
@@ -127,7 +127,7 @@ final class PurgeHttpCacheListener
         }
     }
 
-    private function addTagsFor($value)
+    private function addTagsFor($value): void
     {
         if (!$value) {
             return;
@@ -148,7 +148,7 @@ final class PurgeHttpCacheListener
         }
     }
 
-    private function addTagForItem($value)
+    private function addTagForItem($value): void
     {
         try {
             $iri = $this->iriConverter->getIriFromItem($value);

--- a/src/Bridge/Doctrine/EventListener/WriteListener.php
+++ b/src/Bridge/Doctrine/EventListener/WriteListener.php
@@ -39,7 +39,7 @@ final class WriteListener
      *
      * @param GetResponseForControllerResultEvent $event
      */
-    public function onKernelView(GetResponseForControllerResultEvent $event)
+    public function onKernelView(GetResponseForControllerResultEvent $event): void
     {
         $request = $event->getRequest();
         if ($request->isMethodSafe(false)) {

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -75,7 +75,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = []): void
     {
         $this->apply(true, $queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
     }
@@ -83,12 +83,12 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
     /**
      * The context may contain serialization groups which helps defining joined entities that are readable.
      */
-    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null, array $context = [])
+    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null, array $context = []): void
     {
         $this->apply(false, $queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
     }
 
-    private function apply(bool $collection, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context)
+    private function apply(bool $collection, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context): void
     {
         if (null === $resourceClass) {
             throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');
@@ -123,7 +123,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
      *
      * @throws RuntimeException when the max number of joins has been reached
      */
-    private function joinRelations(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, bool $forceEager, bool $fetchPartial, string $parentAlias, array $options = [], array $normalizationContext = [], bool $wasLeftJoin = false, int &$joinCount = 0, int $currentDepth = null)
+    private function joinRelations(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, bool $forceEager, bool $fetchPartial, string $parentAlias, array $options = [], array $normalizationContext = [], bool $wasLeftJoin = false, int &$joinCount = 0, int $currentDepth = null): void
     {
         if ($joinCount > $this->maxJoins) {
             throw new RuntimeException('The total number of joined relations has exceeded the specified maximum. Raise the limit if necessary, or use the "max_depth" option of the Symfony serializer.');
@@ -234,7 +234,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
         }
     }
 
-    private function addSelect(QueryBuilder $queryBuilder, string $entity, string $associationAlias, array $propertyMetadataOptions)
+    private function addSelect(QueryBuilder $queryBuilder, string $entity, string $associationAlias, array $propertyMetadataOptions): void
     {
         $select = [];
         $entityManager = $queryBuilder->getEntityManager();

--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -38,7 +38,7 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = []): void
     {
         if (null === $resourceClass) {
             throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');

--- a/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
@@ -47,7 +47,7 @@ final class FilterExtension implements ContextAwareQueryCollectionExtensionInter
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = []): void
     {
         if (null === $resourceClass) {
             throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');

--- a/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
@@ -40,7 +40,7 @@ final class OrderExtension implements ContextAwareQueryCollectionExtensionInterf
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = []): void
     {
         if (null === $resourceClass) {
             throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');

--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -70,7 +70,7 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
     /**
      * {@inheritdoc}
      */
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = [])
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass = null, string $operationName = null, array $context = []): void
     {
         if (null === $resourceClass) {
             throw new InvalidArgumentException('The "$resourceClass" parameter must not be null');

--- a/src/Bridge/Doctrine/Orm/Filter/AbstractContextAwareFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractContextAwareFilter.php
@@ -21,7 +21,7 @@ abstract class AbstractContextAwareFilter extends AbstractFilter implements Cont
     /**
      * {@inheritdoc}
      */
-    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = []): void
     {
         if (!isset($context['filters']) || !\is_array($context['filters'])) {
             parent::apply($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);

--- a/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
@@ -59,7 +59,7 @@ abstract class AbstractFilter implements FilterInterface
     /**
      * {@inheritdoc}
      */
-    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null/*, array $context = []*/)
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null/*, array $context = []*/): void
     {
         @trigger_error(sprintf('Using "%s::apply()" is deprecated since 2.2. Use "%s::apply()" with the "filters" context key instead.', __CLASS__, AbstractContextAwareFilter::class), E_USER_DEPRECATED);
 

--- a/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
@@ -62,7 +62,7 @@ class BooleanFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
         if (
             !$this->isPropertyEnabled($property, $resourceClass) ||

--- a/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
@@ -74,7 +74,7 @@ class DateFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
         // Expect $values to be an array having the period as keys and the date value as values
         if (
@@ -165,7 +165,7 @@ class DateFilter extends AbstractContextAwareFilter
      * @param string|null                 $nullManagement
      * @param string|Type                 $type
      */
-    protected function addWhere(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, string $operator, string $value, string $nullManagement = null, $type = null)
+    protected function addWhere(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, string $operator, string $value, string $nullManagement = null, $type = null): void
     {
         try {
             $value = false === strpos($type, '_immutable') ? new \DateTime($value) : new \DateTimeImmutable($value);

--- a/src/Bridge/Doctrine/Orm/Filter/ExistsFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/ExistsFilter.php
@@ -64,7 +64,7 @@ class ExistsFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
         if (
             !isset($value[self::QUERY_PARAMETER_KEY]) ||

--- a/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
@@ -94,7 +94,7 @@ class NumericFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
         if (
             !$this->isPropertyEnabled($property, $resourceClass) ||

--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -79,7 +79,7 @@ class OrderFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = []): void
     {
         if (isset($context['filters']) && !isset($context['filters'][$this->orderParameterName])) {
             return;
@@ -126,7 +126,7 @@ class OrderFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $direction, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $direction, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
         if (!$this->isPropertyEnabled($property, $resourceClass) || !$this->isPropertyMapped($property, $resourceClass)) {
             return;

--- a/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
@@ -60,7 +60,7 @@ class RangeFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
         if (
             !\is_array($values) ||
@@ -99,7 +99,7 @@ class RangeFilter extends AbstractContextAwareFilter
      * @param string                      $operator
      * @param string                      $value
      */
-    protected function addWhere(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, $alias, $field, $operator, $value)
+    protected function addWhere(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, $alias, $field, $operator, $value): void
     {
         $valueParameter = $queryNameGenerator->generateParameterName($field);
 

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -177,7 +177,7 @@ class SearchFilter extends AbstractContextAwareFilter
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
         if (
             null === $value ||
@@ -302,7 +302,7 @@ class SearchFilter extends AbstractContextAwareFilter
      *
      * @throws InvalidArgumentException If strategy does not exist
      */
-    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, $value, bool $caseSensitive)
+    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, $value, bool $caseSensitive): void
     {
         $wrapCase = $this->createWrapCase($caseSensitive);
         $valueParameter = $queryNameGenerator->generateParameterName($field);

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -110,7 +110,7 @@ class ItemDataProvider implements DenormalizedIdentifiersAwareItemDataProviderIn
      * @param QueryBuilder  $queryBuilder
      * @param ClassMetadata $classMetadata
      */
-    private function addWhereForIdentifiers(array $identifiers, QueryBuilder $queryBuilder, ClassMetadata $classMetadata)
+    private function addWhereForIdentifiers(array $identifiers, QueryBuilder $queryBuilder, ClassMetadata $classMetadata): void
     {
         $alias = $queryBuilder->getRootAliases()[0];
         foreach ($identifiers as $identifier => $value) {

--- a/src/Bridge/FosUser/EventListener.php
+++ b/src/Bridge/FosUser/EventListener.php
@@ -38,7 +38,7 @@ final class EventListener
      *
      * @param GetResponseForControllerResultEvent $event
      */
-    public function onKernelView(GetResponseForControllerResultEvent $event)
+    public function onKernelView(GetResponseForControllerResultEvent $event): void
     {
         $request = $event->getRequest();
         if (!RequestAttributesExtractor::extractAttributes($request)) {

--- a/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
@@ -29,7 +29,7 @@ final class ApiPlatformBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -51,7 +51,7 @@ final class SwaggerCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('api:swagger:export')
@@ -62,7 +62,7 @@ final class SwaggerCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $documentation = new Documentation($this->resourceNameCollectionFactory->create(), $this->apiTitle, $this->apiDescription, $this->apiVersion, $this->apiFormats);
         $data = $this->documentationNormalizer->normalize($documentation);

--- a/src/Bridge/Symfony/Bundle/DataCollector/RequestDataCollector.php
+++ b/src/Bridge/Symfony/Bundle/DataCollector/RequestDataCollector.php
@@ -37,7 +37,7 @@ final class RequestDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, \Exception $exception = null): void
     {
         $counters = ['ignored_filters' => 0];
         $resourceClass = $request->attributes->get('_api_resource_class');
@@ -105,7 +105,7 @@ final class RequestDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -50,7 +50,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     /**
      * {@inheritdoc}
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if (!$frameworkConfiguration = $container->getExtensionConfig('framework')) {
             return;
@@ -82,7 +82,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -154,7 +154,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $formats
      * @param array            $errorFormats
      */
-    private function handleConfig(ContainerBuilder $container, array $config, array $formats, array $errorFormats)
+    private function handleConfig(ContainerBuilder $container, array $config, array $formats, array $errorFormats): void
     {
         $container->setParameter('api_platform.enable_entrypoint', $config['enable_entrypoint']);
         $container->setParameter('api_platform.enable_docs', $config['enable_docs']);
@@ -203,7 +203,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $config
      * @param XmlFileLoader    $loader
      */
-    private function registerMetadataConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader)
+    private function registerMetadataConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         $loader->load('metadata/metadata.xml');
         $loader->load('metadata/xml.xml');
@@ -303,7 +303,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $config
      * @param XmlFileLoader    $loader
      */
-    private function registerOAuthConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader)
+    private function registerOAuthConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         if (!$config['oauth']) {
             return;
@@ -326,7 +326,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $config
      * @param XmlFileLoader    $loader
      */
-    private function registerApiKeysConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader)
+    private function registerApiKeysConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         $container->setParameter('api_platform.swagger.api_keys', $config['swagger']['api_keys']);
     }
@@ -338,7 +338,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $config
      * @param XmlFileLoader    $loader
      */
-    private function registerSwaggerConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader)
+    private function registerSwaggerConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         if (!$config['enable_swagger']) {
             return;
@@ -360,7 +360,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array         $formats
      * @param XmlFileLoader $loader
      */
-    private function registerJsonApiConfiguration(array $formats, XmlFileLoader $loader)
+    private function registerJsonApiConfiguration(array $formats, XmlFileLoader $loader): void
     {
         if (!isset($formats['jsonapi'])) {
             return;
@@ -377,7 +377,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param XmlFileLoader    $loader
      * @param bool             $docEnabled
      */
-    private function registerJsonLdConfiguration(ContainerBuilder $container, array $formats, XmlFileLoader $loader, bool $docEnabled)
+    private function registerJsonLdConfiguration(ContainerBuilder $container, array $formats, XmlFileLoader $loader, bool $docEnabled): void
     {
         if (!isset($formats['jsonld'])) {
             return;
@@ -397,7 +397,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array         $formats
      * @param XmlFileLoader $loader
      */
-    private function registerJsonHalConfiguration(array $formats, XmlFileLoader $loader)
+    private function registerJsonHalConfiguration(array $formats, XmlFileLoader $loader): void
     {
         if (!isset($formats['jsonhal'])) {
             return;
@@ -412,7 +412,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array         $errorFormats
      * @param XmlFileLoader $loader
      */
-    private function registerJsonProblemConfiguration(array $errorFormats, XmlFileLoader $loader)
+    private function registerJsonProblemConfiguration(array $errorFormats, XmlFileLoader $loader): void
     {
         if (!isset($errorFormats['jsonproblem'])) {
             return;
@@ -428,7 +428,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $config
      * @param XmlFileLoader    $loader
      */
-    private function registerGraphqlConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader)
+    private function registerGraphqlConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         if (!$config['graphql']) {
             return;
@@ -448,7 +448,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param XmlFileLoader $loader
      * @param bool          $useDoctrine
      */
-    private function registerBundlesConfiguration(array $bundles, array $config, XmlFileLoader $loader, bool $useDoctrine)
+    private function registerBundlesConfiguration(array $bundles, array $config, XmlFileLoader $loader, bool $useDoctrine): void
     {
         // Doctrine ORM support
         if ($useDoctrine) {
@@ -471,7 +471,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      *
      * @param ContainerBuilder $container
      */
-    private function registerCacheConfiguration(ContainerBuilder $container)
+    private function registerCacheConfiguration(ContainerBuilder $container): void
     {
         // Don't use system cache pool in dev
         if ($container->hasParameter('api_platform.metadata_cache') ? $container->getParameter('api_platform.metadata_cache') : !$container->getParameter('kernel.debug')) {
@@ -492,7 +492,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $config
      * @param bool             $useDoctrine
      */
-    private function registerDoctrineExtensionConfiguration(ContainerBuilder $container, array $config, bool $useDoctrine)
+    private function registerDoctrineExtensionConfiguration(ContainerBuilder $container, array $config, bool $useDoctrine): void
     {
         if (!$useDoctrine || $config['eager_loading']['enabled']) {
             return;
@@ -504,7 +504,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->removeDefinition('api_platform.doctrine.orm.query_extension.filter_eager_loading');
     }
 
-    private function registerHttpCache(ContainerBuilder $container, array $config, XmlFileLoader $loader, bool $useDoctrine)
+    private function registerHttpCache(ContainerBuilder $container, array $config, XmlFileLoader $loader, bool $useDoctrine): void
     {
         $loader->load('http_cache.xml');
 
@@ -556,7 +556,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      * @param array            $config
      * @param XmlFileLoader    $loader
      */
-    private function registerValidatorConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader)
+    private function registerValidatorConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         if (!$config['validator']) {
             return;
@@ -568,7 +568,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     /**
      * Registers the DataCollector configuration.
      */
-    private function registerDataCollector(ContainerBuilder $container, array $config, XmlFileLoader $loader)
+    private function registerDataCollector(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         if (!$config['enable_profiler']) {
             return;

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPass.php
@@ -36,7 +36,7 @@ final class AnnotationFilterPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $resourceClassDirectories = $container->getParameter('api_platform.resource_class_directories');
         $reader = $container->get('annotation_reader');
@@ -46,7 +46,7 @@ final class AnnotationFilterPass implements CompilerPassInterface
         }
     }
 
-    private function createFilterDefinitions(\ReflectionClass $reflectionClass, Reader $reader, ContainerBuilder $container)
+    private function createFilterDefinitions(\ReflectionClass $reflectionClass, Reader $reader, ContainerBuilder $container): void
     {
         foreach ($this->readFilterAnnotations($reflectionClass, $reader) as $id => list($arguments, $filterClass)) {
             if ($container->hasDefinition($id)) {

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -32,14 +32,14 @@ final class DataProviderPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         foreach (OperationType::TYPES as $type) {
             $this->addSerializerLocator($container, $type);
         }
     }
 
-    private function addSerializerLocator(ContainerBuilder $container, string $type)
+    private function addSerializerLocator(ContainerBuilder $container, string $type): void
     {
         $services = $container->findTaggedServiceIds("api_platform.{$type}_data_provider", true);
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPass.php
@@ -32,7 +32,7 @@ final class FilterPass implements CompilerPassInterface
      *
      * @throws RuntimeException
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $filters = [];
         foreach ($container->findTaggedServiceIds('api_platform.filter', true) as $serviceId => $tags) {

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -241,7 +241,7 @@ final class Configuration implements ConfigurationInterface
      *
      * @throws InvalidConfigurationException
      */
-    private function addExceptionToStatusSection(ArrayNodeDefinition $rootNode)
+    private function addExceptionToStatusSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()
@@ -296,7 +296,7 @@ final class Configuration implements ConfigurationInterface
      * @param string              $key
      * @param array               $defaultValue
      */
-    private function addFormatSection(ArrayNodeDefinition $rootNode, string $key, array $defaultValue)
+    private function addFormatSection(ArrayNodeDefinition $rootNode, string $key, array $defaultValue): void
     {
         $rootNode
             ->children()

--- a/src/Bridge/Symfony/Bundle/EventListener/SwaggerUiListener.php
+++ b/src/Bridge/Symfony/Bundle/EventListener/SwaggerUiListener.php
@@ -22,7 +22,7 @@ final class SwaggerUiListener
      *
      * @param $event GetResponseEvent
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
         if (

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -155,7 +155,7 @@ final class ApiLoader extends Loader
      *
      * @param RouteCollection $routeCollection
      */
-    private function loadExternalFiles(RouteCollection $routeCollection)
+    private function loadExternalFiles(RouteCollection $routeCollection): void
     {
         if ($this->entrypointEnabled) {
             $routeCollection->addCollection($this->fileLoader->load('api.xml'));
@@ -181,7 +181,7 @@ final class ApiLoader extends Loader
      *
      * @throws RuntimeException
      */
-    private function addRoute(RouteCollection $routeCollection, string $resourceClass, string $operationName, array $operation, ResourceMetadata $resourceMetadata, string $operationType)
+    private function addRoute(RouteCollection $routeCollection, string $resourceClass, string $operationName, array $operation, ResourceMetadata $resourceMetadata, string $operationType): void
     {
         $resourceShortName = $resourceMetadata->getShortName();
 

--- a/src/Bridge/Symfony/Routing/Router.php
+++ b/src/Bridge/Symfony/Routing/Router.php
@@ -42,7 +42,7 @@ final class Router implements RouterInterface, UrlGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function setContext(RequestContext $context)
+    public function setContext(RequestContext $context): void
     {
         $this->router->setContext($context);
     }

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -50,7 +50,7 @@ final class ValidateListener
      *
      * @throws ValidationException
      */
-    public function onKernelView(GetResponseForControllerResultEvent $event)
+    public function onKernelView(GetResponseForControllerResultEvent $event): void
     {
         $request = $event->getRequest();
         if (

--- a/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -40,7 +40,7 @@ final class ValidationExceptionListener
      *
      * @param GetResponseForExceptionEvent $event
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(GetResponseForExceptionEvent $event): void
     {
         $exception = $event->getException();
         if (!$exception instanceof ValidationException) {

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -37,7 +37,7 @@ class Validator implements ValidatorInterface
     /**
      * {@inheritdoc}
      */
-    public function validate($data, array $context = [])
+    public function validate($data, array $context = []): void
     {
         if (null !== $validationGroups = $context['groups'] ?? null) {
             if (

--- a/src/DataPersister/ChainDataPersister.php
+++ b/src/DataPersister/ChainDataPersister.php
@@ -59,7 +59,7 @@ final class ChainDataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function remove($data)
+    public function remove($data): void
     {
         foreach ($this->persisters as $persister) {
             if ($persister->supports($data)) {

--- a/src/DataProvider/SerializerAwareDataProviderTrait.php
+++ b/src/DataProvider/SerializerAwareDataProviderTrait.php
@@ -30,7 +30,7 @@ trait SerializerAwareDataProviderTrait
      */
     private $serializerLocator;
 
-    public function setSerializerLocator(ContainerInterface $serializerLocator)
+    public function setSerializerLocator(ContainerInterface $serializerLocator): void
     {
         $this->serializerLocator = $serializerLocator;
     }

--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -61,7 +61,7 @@ final class AddFormatListener
      * @throws NotFoundHttpException
      * @throws NotAcceptableHttpException
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
         if (!$request->attributes->has('_api_resource_class') && !$request->attributes->has('_api_respond') && !$request->attributes->has('_graphql')) {
@@ -122,7 +122,7 @@ final class AddFormatListener
      * @param Request $request
      * @param array   $formats
      */
-    private function addRequestFormats(Request $request, array $formats)
+    private function addRequestFormats(Request $request, array $formats): void
     {
         foreach ($formats as $format => $mimeTypes) {
             $request->setFormat($format, $mimeTypes);
@@ -132,7 +132,7 @@ final class AddFormatListener
     /**
      * Populates the $mimeTypes property.
      */
-    private function populateMimeTypes()
+    private function populateMimeTypes(): void
     {
         if (null !== $this->mimeTypes) {
             return;

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -60,7 +60,7 @@ final class DeserializeListener
      *
      * @param GetResponseEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
         $method = $request->getMethod();

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\EventListener\ExceptionListener as BaseExceptio
  */
 final class ExceptionListener extends BaseExceptionListener
 {
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(GetResponseForExceptionEvent $event): void
     {
         $request = $event->getRequest();
         // Normalize exceptions only for routes managed by API Platform

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -54,7 +54,7 @@ final class ReadListener
      *
      * @throws NotFoundHttpException
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
         if (

--- a/src/EventListener/RespondListener.php
+++ b/src/EventListener/RespondListener.php
@@ -33,7 +33,7 @@ final class RespondListener
      *
      * @param GetResponseForControllerResultEvent $event
      */
-    public function onKernelView(GetResponseForControllerResultEvent $event)
+    public function onKernelView(GetResponseForControllerResultEvent $event): void
     {
         $controllerResult = $event->getControllerResult();
         $request = $event->getRequest();

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -44,7 +44,7 @@ final class SerializeListener
      *
      * @param GetResponseForControllerResultEvent $event
      */
-    public function onKernelView(GetResponseForControllerResultEvent $event)
+    public function onKernelView(GetResponseForControllerResultEvent $event): void
     {
         $controllerResult = $event->getControllerResult();
         $request = $event->getRequest();
@@ -82,7 +82,7 @@ final class SerializeListener
      *
      * @throws RuntimeException
      */
-    private function serializeRawData(GetResponseForControllerResultEvent $event, Request $request, $controllerResult)
+    private function serializeRawData(GetResponseForControllerResultEvent $event, Request $request, $controllerResult): void
     {
         if (!$request->attributes->get('_api_respond')) {
             return;

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -34,7 +34,7 @@ class WriteListener
     /**
      * Persists, updates or delete data return by the controller if applicable.
      */
-    public function onKernelView(GetResponseForControllerResultEvent $event)
+    public function onKernelView(GetResponseForControllerResultEvent $event): void
     {
         $request = $event->getRequest();
         if ($request->isMethodSafe(false) || !$request->attributes->has('_api_resource_class')) {

--- a/src/Filter/QueryParameterValidateListener.php
+++ b/src/Filter/QueryParameterValidateListener.php
@@ -37,7 +37,7 @@ final class QueryParameterValidateListener
         $this->setFilterLocator($filterLocator);
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
         if (

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -118,7 +118,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
      *
      * @throws Error
      */
-    private function validate($item, ResolveInfo $info, ResourceMetadata $resourceMetadata, string $operationName = null)
+    private function validate($item, ResolveInfo $info, ResourceMetadata $resourceMetadata, string $operationName = null): void
     {
         if (null === $this->validator) {
             return;

--- a/src/GraphQl/Resolver/ResourceAccessCheckerTrait.php
+++ b/src/GraphQl/Resolver/ResourceAccessCheckerTrait.php
@@ -41,7 +41,7 @@ trait ResourceAccessCheckerTrait
      *
      * @throws Error
      */
-    public function canAccess(ResourceAccessCheckerInterface $resourceAccessChecker = null, ResourceMetadata $resourceMetadata, string $resourceClass, ResolveInfo $info, $object = null, string $operationName = null)
+    public function canAccess(ResourceAccessCheckerInterface $resourceAccessChecker = null, ResourceMetadata $resourceMetadata, string $resourceClass, ResolveInfo $info, $object = null, string $operationName = null): void
     {
         if (null === $resourceAccessChecker) {
             return;

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -88,7 +88,7 @@ final class ItemNormalizer extends BaseItemNormalizer
     /**
      * {@inheritdoc}
      */
-    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = [])
+    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = []): void
     {
         if ('_id' === $attribute) {
             $attribute = 'id';

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -237,7 +237,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
                         }
 
                         parse_str($key, $parsed);
-                        array_walk_recursive($parsed, function (&$value) use ($graphqlFilterType) {
+                        array_walk_recursive($parsed, function (&$value) use ($graphqlFilterType): void {
                             $value = $graphqlFilterType;
                         });
                         $args = $this->mergeFilterArgs($args, $parsed, $resourceMetadata, $key);

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -79,7 +79,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      *
      * @throws RuntimeException
      */
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): void
     {
         throw new RuntimeException(sprintf('%s is a read-only format.', self::FORMAT));
     }

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -40,7 +40,7 @@ final class AddHeadersListener
         $this->public = $public;
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(FilterResponseEvent $event): void
     {
         $request = $event->getRequest();
         if (!$request->isMethodCacheable() || !RequestAttributesExtractor::extractAttributes($request)) {

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -42,7 +42,7 @@ final class AddTagsListener
      *
      * @param FilterResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(FilterResponseEvent $event): void
     {
         $request = $event->getRequest();
         $response = $event->getResponse();

--- a/src/HttpCache/VarnishPurger.php
+++ b/src/HttpCache/VarnishPurger.php
@@ -37,7 +37,7 @@ final class VarnishPurger implements PurgerInterface
     /**
      * {@inheritdoc}
      */
-    public function purge(array $iris)
+    public function purge(array $iris): void
     {
         if (!$iris) {
             return;

--- a/src/Hydra/EventListener/AddLinkHeaderListener.php
+++ b/src/Hydra/EventListener/AddLinkHeaderListener.php
@@ -36,7 +36,7 @@ final class AddLinkHeaderListener
      *
      * @param FilterResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(FilterResponseEvent $event): void
     {
         $event->getResponse()->headers->set('Link', sprintf(
             '<%s>; rel="%sapiDocumentation"',

--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -110,7 +110,7 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
     /**
      * {@inheritdoc}
      */
-    public function setNormalizer(NormalizerInterface $normalizer)
+    public function setNormalizer(NormalizerInterface $normalizer): void
     {
         if ($this->collectionNormalizer instanceof NormalizerAwareInterface) {
             $this->collectionNormalizer->setNormalizer($normalizer);

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -91,7 +91,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
      * @param string           $prefixedShortName
      * @param array            $entrypointProperties
      */
-    private function populateEntrypointProperties(string $resourceClass, ResourceMetadata $resourceMetadata, string $shortName, string $prefixedShortName, array &$entrypointProperties)
+    private function populateEntrypointProperties(string $resourceClass, ResourceMetadata $resourceMetadata, string $shortName, string $prefixedShortName, array &$entrypointProperties): void
     {
         $hydraCollectionOperations = $this->getHydraOperations($resourceClass, $resourceMetadata, $prefixedShortName, true);
         if (empty($hydraCollectionOperations)) {

--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -111,7 +111,7 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Norm
     /**
      * {@inheritdoc}
      */
-    public function setNormalizer(NormalizerInterface $normalizer)
+    public function setNormalizer(NormalizerInterface $normalizer): void
     {
         if ($this->collectionNormalizer instanceof NormalizerAwareInterface) {
             $this->collectionNormalizer->setNormalizer($normalizer);

--- a/src/JsonApi/EventListener/TransformFieldsetsParametersListener.php
+++ b/src/JsonApi/EventListener/TransformFieldsetsParametersListener.php
@@ -31,7 +31,7 @@ final class TransformFieldsetsParametersListener
         $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/src/JsonApi/EventListener/TransformFilteringParametersListener.php
+++ b/src/JsonApi/EventListener/TransformFilteringParametersListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 final class TransformFilteringParametersListener
 {
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
         if (

--- a/src/JsonApi/EventListener/TransformPaginationParametersListener.php
+++ b/src/JsonApi/EventListener/TransformPaginationParametersListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 final class TransformPaginationParametersListener
 {
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/src/JsonApi/EventListener/TransformSortingParametersListener.php
+++ b/src/JsonApi/EventListener/TransformSortingParametersListener.php
@@ -31,7 +31,7 @@ final class TransformSortingParametersListener
         $this->orderParameterName = $orderParameterName;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -153,7 +153,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
     /**
      * {@inheritdoc}
      */
-    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = [])
+    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = []): void
     {
         parent::setAttributeValue($object, $attribute, \is_array($value) && array_key_exists('data', $value) ? $value['data'] : $value, $format, $context);
     }

--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -30,7 +30,7 @@ final class XmlExtractor extends AbstractExtractor
     /**
      * {@inheritdoc}
      */
-    protected function extractPath(string $path)
+    protected function extractPath(string $path): void
     {
         try {
             $xml = simplexml_import_dom(XmlUtils::loadFile($path, self::RESOURCE_SCHEMA));

--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -29,7 +29,7 @@ final class YamlExtractor extends AbstractExtractor
     /**
      * {@inheritdoc}
      */
-    protected function extractPath(string $path)
+    protected function extractPath(string $path): void
     {
         try {
             $resourcesYaml = Yaml::parse(file_get_contents($path), Yaml::PARSE_CONSTANT);
@@ -50,7 +50,7 @@ final class YamlExtractor extends AbstractExtractor
         $this->extractResources($resourcesYaml, $path);
     }
 
-    private function extractResources(array $resourcesYaml, string $path)
+    private function extractResources(array $resourcesYaml, string $path): void
     {
         foreach ($resourcesYaml as $resourceName => $resourceYaml) {
             if (null === $resourceYaml) {
@@ -86,7 +86,7 @@ final class YamlExtractor extends AbstractExtractor
         }
     }
 
-    private function extractProperties(array $resourceYaml, string $resourceName, string $path)
+    private function extractProperties(array $resourceYaml, string $resourceName, string $path): void
     {
         foreach ($resourceYaml['properties'] as $propertyName => $propertyValues) {
             if (null === $propertyValues) {

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -63,7 +63,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
      * @param int    $depth             the number of visited
      * @param int    $maxDepth
      */
-    private function computeSubresourceOperations(string $resourceClass, array &$tree, string $rootResourceClass = null, array $parentOperation = null, array $visited = [], int $depth = 0, int $maxDepth = null)
+    private function computeSubresourceOperations(string $resourceClass, array &$tree, string $rootResourceClass = null, array $parentOperation = null, array $visited = [], int $depth = 0, int $maxDepth = null): void
     {
         if (null === $rootResourceClass) {
             $rootResourceClass = $resourceClass;

--- a/src/Security/EventListener/DenyAccessListener.php
+++ b/src/Security/EventListener/DenyAccessListener.php
@@ -56,7 +56,7 @@ final class DenyAccessListener
      *
      * @throws AccessDeniedException
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
         if (!$attributes = RequestAttributesExtractor::extractAttributes($request)) {

--- a/src/Security/ExpressionLanguage.php
+++ b/src/Security/ExpressionLanguage.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\Authorization\ExpressionLanguage as BaseExpr
  */
 class ExpressionLanguage extends BaseExpressionLanguage
 {
-    protected function registerFunctions()
+    protected function registerFunctions(): void
     {
         parent::registerFunctions();
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -165,7 +165,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = [])
+    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = []): void
     {
         if (!\is_string($attribute)) {
             throw new InvalidValueException('Invalid value provided (invalid IRI?).');
@@ -225,7 +225,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      *
      * @throws InvalidArgumentException
      */
-    protected function validateType(string $attribute, Type $type, $value, string $format = null)
+    protected function validateType(string $attribute, Type $type, $value, string $format = null): void
     {
         $builtinType = $type->getBuiltinType();
         if (Type::BUILTIN_TYPE_FLOAT === $builtinType && null !== $format && false !== strpos($format, 'json')) {
@@ -351,7 +351,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      * @param string $attributeName
      * @param mixed  $value
      */
-    private function setValue($object, string $attributeName, $value)
+    private function setValue($object, string $attributeName, $value): void
     {
         try {
             $this->propertyAccessor->setValue($object, $attributeName, $value);

--- a/src/Serializer/Filter/GroupFilter.php
+++ b/src/Serializer/Filter/GroupFilter.php
@@ -37,7 +37,7 @@ final class GroupFilter implements FilterInterface
     /**
      * {@inheritdoc}
      */
-    public function apply(Request $request, bool $normalization, array $attributes, array &$context)
+    public function apply(Request $request, bool $normalization, array $attributes, array &$context): void
     {
         if (array_key_exists($this->parameterName, $commonAttribute = $request->attributes->get('_api_filters', []))) {
             $groups = $commonAttribute[$this->parameterName];

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -37,7 +37,7 @@ final class PropertyFilter implements FilterInterface
     /**
      * {@inheritdoc}
      */
-    public function apply(Request $request, bool $normalization, array $attributes, array &$context)
+    public function apply(Request $request, bool $normalization, array $attributes, array &$context): void
     {
         if (null !== $propertyAttribute = $request->attributes->get('_api_filter_property')) {
             $properties = $propertyAttribute;

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -43,7 +43,7 @@ class ItemNormalizer extends AbstractItemNormalizer
         return parent::denormalize($data, $class, $format, $context);
     }
 
-    private function updateObjectToPopulate(array $data, array &$context)
+    private function updateObjectToPopulate(array $data, array &$context): void
     {
         try {
             $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getItemFromIri((string) $data['id'], $context + ['fetch_data' => true]);

--- a/src/Serializer/ResourceList.php
+++ b/src/Serializer/ResourceList.php
@@ -18,7 +18,7 @@ namespace ApiPlatform\Core\Serializer;
  */
 class ResourceList extends \ArrayObject
 {
-    public function serialize()
+    public function serialize(): void
     {
     }
 }

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -184,7 +184,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
      * @param array            $mimeTypes
      * @param string           $operationType
      */
-    private function addPaths(\ArrayObject $paths, \ArrayObject $definitions, string $resourceClass, string $resourceShortName, ResourceMetadata $resourceMetadata, array $mimeTypes, string $operationType)
+    private function addPaths(\ArrayObject $paths, \ArrayObject $definitions, string $resourceClass, string $resourceShortName, ResourceMetadata $resourceMetadata, array $mimeTypes, string $operationType): void
     {
         if (null === $operations = OperationType::COLLECTION === $operationType ? $resourceMetadata->getCollectionOperations() : $resourceMetadata->getItemOperations()) {
             return;

--- a/src/Test/DoctrineOrmFilterTestCase.php
+++ b/src/Test/DoctrineOrmFilterTestCase.php
@@ -53,7 +53,7 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
      */
     protected $filterClass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
 
@@ -65,7 +65,7 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
     /**
      * @dataProvider provideApplyTestData
      */
-    public function testApply(array $properties = null, array $filterParameters, string $expectedDql, array $expectedParameters = null, callable $factory = null)
+    public function testApply(array $properties = null, array $filterParameters, string $expectedDql, array $expectedParameters = null, callable $factory = null): void
     {
         $this->doTestApply(false, $properties, $filterParameters, $expectedDql, $expectedParameters, $factory);
     }
@@ -74,12 +74,12 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
      * @group legacy
      * @dataProvider provideApplyTestData
      */
-    public function testApplyRequest(array $properties = null, array $filterParameters, string $expectedDql, array $expectedParameters = null, callable $factory = null)
+    public function testApplyRequest(array $properties = null, array $filterParameters, string $expectedDql, array $expectedParameters = null, callable $factory = null): void
     {
         $this->doTestApply(true, $properties, $filterParameters, $expectedDql, $expectedParameters, $factory);
     }
 
-    protected function doTestApply(bool $request, array $properties = null, array $filterParameters, string $expectedDql, array $expectedParameters = null, callable $filterFactory = null)
+    protected function doTestApply(bool $request, array $properties = null, array $filterParameters, string $expectedDql, array $expectedParameters = null, callable $filterFactory = null): void
     {
         if (null === $filterFactory) {
             $filterFactory = function (ManagerRegistry $managerRegistry, RequestStack $requestStack = null, array $properties = null): FilterInterface {

--- a/src/Validator/EventListener/ValidateListener.php
+++ b/src/Validator/EventListener/ValidateListener.php
@@ -40,7 +40,7 @@ final class ValidateListener
      *
      * @throws ValidationException
      */
-    public function onKernelView(GetResponseForControllerResultEvent $event)
+    public function onKernelView(GetResponseForControllerResultEvent $event): void
     {
         $request = $event->getRequest();
         if (

--- a/tests/Action/EntrypointActionTest.php
+++ b/tests/Action/EntrypointActionTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EntrypointActionTest extends TestCase
 {
-    public function testGetEntrypoint()
+    public function testGetEntrypoint(): void
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection(['dummies']));

--- a/tests/Action/ExceptionActionTest.php
+++ b/tests/Action/ExceptionActionTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class ExceptionActionTest extends TestCase
 {
-    public function testActionWithCatchableException()
+    public function testActionWithCatchableException(): void
     {
         $serializerException = $this->prophesize(ExceptionInterface::class);
         $serializerException->willExtend(\Exception::class);
@@ -52,7 +52,7 @@ class ExceptionActionTest extends TestCase
         $this->assertEquals($expected, $exceptionAction($flattenException, $request));
     }
 
-    public function testActionWithUncatchableException()
+    public function testActionWithUncatchableException(): void
     {
         $serializerException = $this->prophesize(ExceptionInterface::class);
         $serializerException->willExtend(\Exception::class);

--- a/tests/Action/PlaceholderActionTest.php
+++ b/tests/Action/PlaceholderActionTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PlaceholderActionTest extends TestCase
 {
-    public function testAction()
+    public function testAction(): void
     {
         $action = new PlaceholderAction();
 

--- a/tests/Annotation/ApiFilterTest.php
+++ b/tests/Annotation/ApiFilterTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ApiFilterTest extends TestCase
 {
-    public function testInvalidConstructor()
+    public function testInvalidConstructor(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('This annotation needs a value representing the filter class.');
@@ -31,7 +31,7 @@ class ApiFilterTest extends TestCase
         $resource = new ApiFilter();
     }
 
-    public function testInvalidFilter()
+    public function testInvalidFilter(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The filter class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy" does not implement "ApiPlatform\\Core\\Api\\FilterInterface".');
@@ -39,7 +39,7 @@ class ApiFilterTest extends TestCase
         $resource = new ApiFilter(['value' => Dummy::class]);
     }
 
-    public function testInvalidProperty()
+    public function testInvalidProperty(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Property "foo" does not exist on the ApiFilter annotation.');
@@ -47,7 +47,7 @@ class ApiFilterTest extends TestCase
         $resource = new ApiFilter(['value' => DummyFilter::class, 'foo' => 'bar']);
     }
 
-    public function testAssignation()
+    public function testAssignation(): void
     {
         $resource = new ApiFilter(['value' => DummyFilter::class, 'strategy' => 'test', 'properties' => ['one', 'two'], 'arguments' => ['args']]);
 

--- a/tests/Annotation/ApiPropertyTest.php
+++ b/tests/Annotation/ApiPropertyTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ApiPropertyTest extends TestCase
 {
-    public function testAssignation()
+    public function testAssignation(): void
     {
         $property = new ApiProperty();
         $property->description = 'description';
@@ -45,7 +45,7 @@ class ApiPropertyTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $property->attributes);
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $property = new ApiProperty([
             'deprecationReason' => 'this field is deprecated',

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ApiResourceTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $resource = new ApiResource([
             'accessControl' => 'has_role("ROLE_FOO")',
@@ -87,7 +87,7 @@ class ApiResourceTest extends TestCase
         ], $resource->attributes);
     }
 
-    public function testApiResourceAnnotation()
+    public function testApiResourceAnnotation(): void
     {
         $reader = new AnnotationReader();
         $resource = $reader->getClassAnnotation(new \ReflectionClass(AnnotatedClass::class), ApiResource::class);
@@ -105,7 +105,7 @@ class ApiResourceTest extends TestCase
         ], $resource->attributes);
     }
 
-    public function testConstructWithInvalidAttribute()
+    public function testConstructWithInvalidAttribute(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown property "invalidAttribute" on annotation "ApiPlatform\\Core\\Annotation\\ApiResource".');

--- a/tests/Api/CachedIdentifiersExtractorTest.php
+++ b/tests/Api/CachedIdentifiersExtractorTest.php
@@ -43,7 +43,7 @@ class CachedIdentifiersExtractorTest extends TestCase
     /**
      * @dataProvider itemProvider
      */
-    public function testFirstPass($item, $expected)
+    public function testFirstPass($item, $expected): void
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
 
@@ -73,7 +73,7 @@ class CachedIdentifiersExtractorTest extends TestCase
     /**
      * @dataProvider itemProvider
      */
-    public function testSecondPass($item, $expected)
+    public function testSecondPass($item, $expected): void
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
 
@@ -126,7 +126,7 @@ class CachedIdentifiersExtractorTest extends TestCase
     /**
      * @dataProvider identifiersRelatedProvider
      */
-    public function testFirstPassWithRelated($item, $expected)
+    public function testFirstPassWithRelated($item, $expected): void
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
         $keyRelated = 'iri_identifiers'.md5(RelatedDummy::class);
@@ -154,7 +154,7 @@ class CachedIdentifiersExtractorTest extends TestCase
     /**
      * @dataProvider identifiersRelatedProvider
      */
-    public function testSecondPassWithRelated($item, $expected)
+    public function testSecondPassWithRelated($item, $expected): void
     {
         $key = 'iri_identifiers'.md5(Dummy::class);
         $keyRelated = 'iri_identifiers'.md5(RelatedDummy::class);
@@ -184,7 +184,7 @@ class CachedIdentifiersExtractorTest extends TestCase
      * @group legacy
      * @expectedDeprecation Not injecting ApiPlatform\Core\Api\ResourceClassResolverInterface in the CachedIdentifiersExtractor might introduce cache issues with object identifiers.
      */
-    public function testDeprecationResourceClassResolver()
+    public function testDeprecationResourceClassResolver(): void
     {
         $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
         $decoration = $this->prophesize(IdentifiersExtractorInterface::class);

--- a/tests/Api/EntrypointTest.php
+++ b/tests/Api/EntrypointTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EntrypointTest extends TestCase
 {
-    public function testGetResourceNameCollection()
+    public function testGetResourceNameCollection(): void
     {
         $resourceNameCollection = new ResourceNameCollection([Dummy::class]);
         $entrypoint = new Entrypoint($resourceNameCollection);

--- a/tests/Api/FilterCollectionFactoryTest.php
+++ b/tests/Api/FilterCollectionFactoryTest.php
@@ -28,7 +28,7 @@ class FilterCollectionFactoryTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testCreateFilterCollectionFromLocator()
+    public function testCreateFilterCollectionFromLocator(): void
     {
         $filter = $this->prophesize(FilterInterface::class)->reveal();
 

--- a/tests/Api/FilterCollectionTest.php
+++ b/tests/Api/FilterCollectionTest.php
@@ -25,7 +25,7 @@ class FilterCollectionTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testIsArrayObject()
+    public function testIsArrayObject(): void
     {
         $filterCollection = new FilterCollection();
         $this->assertInstanceOf(\ArrayObject::class, $filterCollection);

--- a/tests/Api/FilterLocatorTraitTest.php
+++ b/tests/Api/FilterLocatorTraitTest.php
@@ -24,7 +24,7 @@ use Psr\Container\ContainerInterface;
  */
 class FilterLocatorTraitTest extends TestCase
 {
-    public function testSetFilterLocator()
+    public function testSetFilterLocator(): void
     {
         $filterLocator = $this->prophesize(ContainerInterface::class)->reveal();
 
@@ -38,7 +38,7 @@ class FilterLocatorTraitTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testSetFilterLocatorWithDeprecatedFilterCollection()
+    public function testSetFilterLocatorWithDeprecatedFilterCollection(): void
     {
         $filterCollection = new FilterCollection();
 
@@ -48,7 +48,7 @@ class FilterLocatorTraitTest extends TestCase
         $this->assertEquals($filterCollection, $filterLocatorTraitImpl->getFilterLocator());
     }
 
-    public function testSetFilterLocatorWithNullAndNullAllowed()
+    public function testSetFilterLocatorWithNullAndNullAllowed(): void
     {
         $filterLocatorTraitImpl = $this->getFilterLocatorTraitImpl();
         $filterLocatorTraitImpl->setFilterLocator(null, true);
@@ -59,7 +59,7 @@ class FilterLocatorTraitTest extends TestCase
     /**
      * @group legacy
      */
-    public function testSetFilterLocatorWithNullAndNullNotAllowed()
+    public function testSetFilterLocatorWithNullAndNullNotAllowed(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$filterLocator" argument is expected to be an implementation of the "Psr\\Container\\ContainerInterface" interface.');
@@ -71,7 +71,7 @@ class FilterLocatorTraitTest extends TestCase
     /**
      * @group legacy
      */
-    public function testSetFilterLocatorWithInvalidFilterLocator()
+    public function testSetFilterLocatorWithInvalidFilterLocator(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$filterLocator" argument is expected to be an implementation of the "Psr\\Container\\ContainerInterface" interface or null.');
@@ -80,7 +80,7 @@ class FilterLocatorTraitTest extends TestCase
         $filterLocatorTraitImpl->setFilterLocator(new \ArrayObject(), true);
     }
 
-    public function testGetFilter()
+    public function testGetFilter(): void
     {
         $filter = $this->prophesize(FilterInterface::class)->reveal();
 
@@ -97,7 +97,7 @@ class FilterLocatorTraitTest extends TestCase
         $this->assertEquals($filter, $returnedFilter);
     }
 
-    public function testGetFilterWithNonexistentFilterId()
+    public function testGetFilterWithNonexistentFilterId(): void
     {
         $filterLocatorProphecy = $this->prophesize(ContainerInterface::class);
         $filterLocatorProphecy->has('foo')->willReturn(false)->shouldBeCalled();
@@ -114,7 +114,7 @@ class FilterLocatorTraitTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testGetFilterWithDeprecatedFilterCollection()
+    public function testGetFilterWithDeprecatedFilterCollection(): void
     {
         $filter = $this->prophesize(FilterInterface::class)->reveal();
 
@@ -131,7 +131,7 @@ class FilterLocatorTraitTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testGetFilterWithNonexistentFilterIdAndDeprecatedFilterCollection()
+    public function testGetFilterWithNonexistentFilterIdAndDeprecatedFilterCollection(): void
     {
         $filterLocatorTraitImpl = $this->getFilterLocatorTraitImpl();
         $filterLocatorTraitImpl->setFilterLocator(new FilterCollection());

--- a/tests/Api/FormatsProviderTest.php
+++ b/tests/Api/FormatsProviderTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FormatsProviderTest extends TestCase
 {
-    public function testNoResourceClass()
+    public function testNoResourceClass(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create()->shouldNotBeCalled();
@@ -33,7 +33,7 @@ class FormatsProviderTest extends TestCase
         $this->assertSame(['jsonld' => 'application/ld+json'], $formatProvider->getFormatsFromAttributes([]));
     }
 
-    public function testResourceClassWithoutFormatsAttributes()
+    public function testResourceClassWithoutFormatsAttributes(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata())->shouldBeCalled();
@@ -43,7 +43,7 @@ class FormatsProviderTest extends TestCase
         $this->assertSame(['jsonld' => ['application/ld+json']], $formatProvider->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'get']));
     }
 
-    public function testResourceClassWithFormatsAttributes()
+    public function testResourceClassWithFormatsAttributes(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['formats' => ['jsonld']]);
@@ -54,7 +54,7 @@ class FormatsProviderTest extends TestCase
         $this->assertSame(['jsonld' => ['application/ld+json']], $formatProvider->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'get']));
     }
 
-    public function testResourceClassWithFormatsAttributesOverRiddingMimeTypes()
+    public function testResourceClassWithFormatsAttributesOverRiddingMimeTypes(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['formats' => ['jsonld' => ['application/foo'], 'bar' => ['application/bar', 'application/baz'], 'buz' => 'application/fuz']]);
@@ -65,7 +65,7 @@ class FormatsProviderTest extends TestCase
         $this->assertSame(['jsonld' => ['application/foo'], 'bar' => ['application/bar', 'application/baz'], 'buz' => ['application/fuz']], $formatProvider->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'get']));
     }
 
-    public function testBadFormatsShortDeclaration()
+    public function testBadFormatsShortDeclaration(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('You either need to add the format \'foo\' to your project configuration or declare a mime type for it in your annotation.');
@@ -79,7 +79,7 @@ class FormatsProviderTest extends TestCase
         $formatProvider->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'get']);
     }
 
-    public function testInvalidFormatsShortDeclaration()
+    public function testInvalidFormatsShortDeclaration(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The \'formats\' attributes value must be a string when trying to include an already configured format, array given.');
@@ -93,7 +93,7 @@ class FormatsProviderTest extends TestCase
         $this->assertSame(['jsonld' => ['application/ld+json']], $formatProvider->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'get']));
     }
 
-    public function testInvalidFormatsDeclaration()
+    public function testInvalidFormatsDeclaration(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The \'formats\' attributes must be an array, string given for resource class \'Foo\'.');

--- a/tests/Api/IdentifiersExtractorTest.php
+++ b/tests/Api/IdentifiersExtractorTest.php
@@ -52,7 +52,7 @@ class IdentifiersExtractorTest extends TestCase
         return [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy];
     }
 
-    public function testGetIdentifiersFromResourceClass()
+    public function testGetIdentifiersFromResourceClass(): void
     {
         list($propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy) = $this->getMetadataFactoryProphecies(Dummy::class, ['id']);
 
@@ -61,7 +61,7 @@ class IdentifiersExtractorTest extends TestCase
         $this->assertSame(['id'], $identifiersExtractor->getIdentifiersFromResourceClass(Dummy::class));
     }
 
-    public function testGetCompositeIdentifiersFromResourceClass()
+    public function testGetCompositeIdentifiersFromResourceClass(): void
     {
         list($propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy) = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'name']);
 
@@ -85,7 +85,7 @@ class IdentifiersExtractorTest extends TestCase
     /**
      * @dataProvider itemProvider
      */
-    public function testGetIdentifiersFromItem($item, $expected)
+    public function testGetIdentifiersFromItem($item, $expected): void
     {
         list($propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy) = $this->getMetadataFactoryProphecies(Dummy::class, ['id']);
 
@@ -110,7 +110,7 @@ class IdentifiersExtractorTest extends TestCase
     /**
      * @dataProvider itemProviderComposite
      */
-    public function testGetCompositeIdentifiersFromItem($item, $expected)
+    public function testGetCompositeIdentifiersFromItem($item, $expected): void
     {
         list($propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy) = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'name']);
 
@@ -143,7 +143,7 @@ class IdentifiersExtractorTest extends TestCase
     /**
      * @dataProvider itemProviderRelated
      */
-    public function testGetRelatedIdentifiersFromItem($item, $expected)
+    public function testGetRelatedIdentifiersFromItem($item, $expected): void
     {
         $prophecies = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'relatedDummy']);
         list($propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy) = $this->getMetadataFactoryProphecies(RelatedDummy::class, ['id'], $prophecies);
@@ -153,7 +153,7 @@ class IdentifiersExtractorTest extends TestCase
         $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
     }
 
-    public function testThrowNoIdentifierFromItem()
+    public function testThrowNoIdentifierFromItem(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No identifier found in "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\RelatedDummy" through relation "relatedDummy" of "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy" used as identifier');
@@ -191,7 +191,7 @@ class IdentifiersExtractorTest extends TestCase
      * @group legacy
      * @expectedDeprecation Not injecting ApiPlatform\Core\Api\ResourceClassResolverInterface in the CachedIdentifiersExtractor might introduce cache issues with object identifiers.
      */
-    public function testLegacyGetIdentifiersFromItem()
+    public function testLegacyGetIdentifiersFromItem(): void
     {
         list($propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy) = $this->getMetadataFactoryProphecies(Dummy::class, ['id']);
 

--- a/tests/Api/ResourceClassResolverTest.php
+++ b/tests/Api/ResourceClassResolverTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ResourceClassResolverTest extends TestCase
 {
-    public function testGetResourceClassWithIntendedClassName()
+    public function testGetResourceClassWithIntendedClassName(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Smail');
@@ -41,7 +41,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertEquals($resourceClass, Dummy::class);
     }
 
-    public function testGetResourceClassWithOtherClassName()
+    public function testGetResourceClassWithOtherClassName(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Smail');
@@ -53,7 +53,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertEquals($resourceClass, Dummy::class);
     }
 
-    public function testGetResourceClassWithNoClassName()
+    public function testGetResourceClassWithNoClassName(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Smail');
@@ -65,7 +65,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertEquals($resourceClass, Dummy::class);
     }
 
-    public function testGetResourceClassWithTraversableAsValue()
+    public function testGetResourceClassWithTraversableAsValue(): void
     {
         $dummy = new Dummy();
         $dummy->setName('JLM');
@@ -81,7 +81,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertEquals($resourceClass, Dummy::class);
     }
 
-    public function testGetResourceClassWithPaginatorInterfaceAsValue()
+    public function testGetResourceClassWithPaginatorInterfaceAsValue(): void
     {
         $paginatorProphecy = $this->prophesize(PaginatorInterface::class);
 
@@ -94,7 +94,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertEquals($resourceClass, Dummy::class);
     }
 
-    public function testGetResourceClassWithWrongClassName()
+    public function testGetResourceClassWithWrongClassName(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No resource class found for object of type "stdClass".');
@@ -106,7 +106,7 @@ class ResourceClassResolverTest extends TestCase
         $resourceClassResolver->getResourceClass(new \stdClass(), null);
     }
 
-    public function testGetResourceClassWithNoResourceClassName()
+    public function testGetResourceClassWithNoResourceClassName(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No resource class found.');
@@ -117,7 +117,7 @@ class ResourceClassResolverTest extends TestCase
         $resourceClassResolver->getResourceClass(new \ArrayIterator([]), null);
     }
 
-    public function testIsResourceClassWithIntendedClassName()
+    public function testIsResourceClassWithIntendedClassName(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Smail');
@@ -129,7 +129,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertTrue($resourceClass);
     }
 
-    public function testIsResourceClassWithWrongClassName()
+    public function testIsResourceClassWithWrongClassName(): void
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([\ArrayIterator::class]))->shouldBeCalled();
@@ -139,7 +139,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertFalse($resourceClass);
     }
 
-    public function testGetResourceClassWithNoResourceClassNameAndNoObject()
+    public function testGetResourceClassWithNoResourceClassNameAndNoObject(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No resource class found.');
@@ -150,7 +150,7 @@ class ResourceClassResolverTest extends TestCase
         $resourceClassResolver->getResourceClass(false, null);
     }
 
-    public function testGetResourceClassWithResourceClassNameAndNoObject()
+    public function testGetResourceClassWithResourceClassNameAndNoObject(): void
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
@@ -159,7 +159,7 @@ class ResourceClassResolverTest extends TestCase
         $this->assertEquals($resourceClassResolver->getResourceClass(false, Dummy::class), Dummy::class);
     }
 
-    public function testGetResourceClassWithChildResource()
+    public function testGetResourceClassWithChildResource(): void
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([DummyTableInheritance::class]))->shouldBeCalled();

--- a/tests/Bridge/Doctrine/Common/DataPersisterTest.php
+++ b/tests/Bridge/Doctrine/Common/DataPersisterTest.php
@@ -25,12 +25,12 @@ use PHPUnit\Framework\TestCase;
  */
 class DataPersisterTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertInstanceOf(DataPersisterInterface::class, new DataPersister($this->prophesize(ManagerRegistry::class)->reveal()));
     }
 
-    public function testSupports()
+    public function testSupports(): void
     {
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($this->prophesize(ObjectManager::class)->reveal())->shouldBeCalled();
@@ -38,12 +38,12 @@ class DataPersisterTest extends TestCase
         $this->assertTrue((new DataPersister($managerRegistryProphecy->reveal()))->supports(new Dummy()));
     }
 
-    public function testDoesNotSupport()
+    public function testDoesNotSupport(): void
     {
         $this->assertFalse((new DataPersister($this->prophesize(ManagerRegistry::class)->reveal()))->supports('dummy'));
     }
 
-    public function testPersist()
+    public function testPersist(): void
     {
         $dummy = new Dummy();
 
@@ -60,7 +60,7 @@ class DataPersisterTest extends TestCase
         $this->assertSame($dummy, $result);
     }
 
-    public function testPersistIfEntityAlreadyManaged()
+    public function testPersistIfEntityAlreadyManaged(): void
     {
         $dummy = new Dummy();
 
@@ -77,7 +77,7 @@ class DataPersisterTest extends TestCase
         $this->assertSame($dummy, $result);
     }
 
-    public function testPersistWithNullManager()
+    public function testPersistWithNullManager(): void
     {
         $dummy = new Dummy();
 
@@ -88,7 +88,7 @@ class DataPersisterTest extends TestCase
         $this->assertSame($dummy, $result);
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $dummy = new Dummy();
 
@@ -102,7 +102,7 @@ class DataPersisterTest extends TestCase
         (new DataPersister($managerRegistryProphecy->reveal()))->remove($dummy);
     }
 
-    public function testRemoveWithNullManager()
+    public function testRemoveWithNullManager(): void
     {
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn(null)->shouldBeCalled();

--- a/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -32,7 +32,7 @@ use Prophecy\Argument;
  */
 class PurgeHttpCacheListenerTest extends TestCase
 {
-    public function testOnFlush()
+    public function testOnFlush(): void
     {
         $toInsert1 = new Dummy();
         $toInsert2 = new Dummy();
@@ -75,7 +75,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $listener->postFlush();
     }
 
-    public function testPreUpdate()
+    public function testPreUpdate(): void
     {
         $oldRelatedDummy = new RelatedDummy();
         $oldRelatedDummy->setId(1);

--- a/tests/Bridge/Doctrine/EventListener/WriteListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/WriteListenerTest.php
@@ -32,7 +32,7 @@ class WriteListenerTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener class is deprecated since version 2.2 and will be removed in 3.0. Use the ApiPlatform\Core\EventListener\WriteListener class instead.
      */
-    public function testOnKernelViewWithControllerResultAndPostMethod()
+    public function testOnKernelViewWithControllerResultAndPostMethod(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -57,7 +57,7 @@ class WriteListenerTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener class is deprecated since version 2.2 and will be removed in 3.0. Use the ApiPlatform\Core\EventListener\WriteListener class instead.
      */
-    public function testOnKernelViewWithControllerResultAndDeleteMethod()
+    public function testOnKernelViewWithControllerResultAndDeleteMethod(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -83,7 +83,7 @@ class WriteListenerTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener class is deprecated since version 2.2 and will be removed in 3.0. Use the ApiPlatform\Core\EventListener\WriteListener class instead.
      */
-    public function testOnKernelViewWithSafeMethod()
+    public function testOnKernelViewWithSafeMethod(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -103,7 +103,7 @@ class WriteListenerTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener class is deprecated since version 2.2 and will be removed in 3.0. Use the ApiPlatform\Core\EventListener\WriteListener class instead.
      */
-    public function testOnKernelViewWithNoResourceClass()
+    public function testOnKernelViewWithNoResourceClass(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -123,7 +123,7 @@ class WriteListenerTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener class is deprecated since version 2.2 and will be removed in 3.0. Use the ApiPlatform\Core\EventListener\WriteListener class instead.
      */
-    public function testOnKernelViewWithNoManager()
+    public function testOnKernelViewWithNoManager(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');

--- a/tests/Bridge/Doctrine/Orm/CollectionDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/CollectionDataProviderTest.php
@@ -33,7 +33,7 @@ use Prophecy\Argument;
  */
 class CollectionDataProviderTest extends TestCase
 {
-    public function testGetCollection()
+    public function testGetCollection(): void
     {
         $queryProphecy = $this->prophesize(AbstractQuery::class);
         $queryProphecy->getResult()->willReturn([])->shouldBeCalled();
@@ -58,7 +58,7 @@ class CollectionDataProviderTest extends TestCase
         $this->assertEquals([], $dataProvider->getCollection(Dummy::class, 'foo'));
     }
 
-    public function testQueryResultExtension()
+    public function testQueryResultExtension(): void
     {
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilder = $queryBuilderProphecy->reveal();
@@ -81,7 +81,7 @@ class CollectionDataProviderTest extends TestCase
         $this->assertEquals([], $dataProvider->getCollection(Dummy::class, 'foo'));
     }
 
-    public function testCannotCreateQueryBuilder()
+    public function testCannotCreateQueryBuilder(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The repository class must have a "createQueryBuilder" method.');
@@ -98,7 +98,7 @@ class CollectionDataProviderTest extends TestCase
         $this->assertEquals([], $dataProvider->getCollection(Dummy::class, 'foo'));
     }
 
-    public function testUnsupportedClass()
+    public function testUnsupportedClass(): void
     {
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn(null)->shouldBeCalled();

--- a/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -50,7 +50,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  */
 class EagerLoadingExtensionTest extends TestCase
 {
-    public function testApplyToCollection()
+    public function testApplyToCollection(): void
     {
         $context = ['groups' => ['foo']];
         $callContext = ['serializer_groups' => ['foo']];
@@ -127,7 +127,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class, null, $context);
     }
 
-    public function testApplyToItem()
+    public function testApplyToItem(): void
     {
         $context = ['groups' => ['foo']];
         $callContext = ['serializer_groups' => ['foo']];
@@ -234,7 +234,7 @@ class EagerLoadingExtensionTest extends TestCase
         $orderExtensionTest->applyToItem($queryBuilder, new QueryNameGenerator(), Dummy::class, [], null, $context);
     }
 
-    public function testCreateItemWithOperationName()
+    public function testCreateItemWithOperationName(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
@@ -258,7 +258,7 @@ class EagerLoadingExtensionTest extends TestCase
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, [], 'item_operation', ['groups' => ['foo']]);
     }
 
-    public function testCreateCollectionWithOperationName()
+    public function testCreateCollectionWithOperationName(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
@@ -282,7 +282,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, 'collection_operation', ['groups' => ['foo']]);
     }
 
-    public function testDenormalizeItemWithCorrectResourceClass()
+    public function testDenormalizeItemWithCorrectResourceClass(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         //Dummy is the correct class for the denormalization context serialization groups, and we're fetching RelatedDummy
@@ -305,7 +305,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), RelatedDummy::class, ['id' => 1], 'item_operation', ['resource_class' => Dummy::class]);
     }
 
-    public function testDenormalizeItemWithExistingGroups()
+    public function testDenormalizeItemWithExistingGroups(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         //groups exist from the context, we don't need to compute them again
@@ -327,7 +327,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), RelatedDummy::class, ['id' => 1], 'item_operation', [AbstractNormalizer::GROUPS => 'some_groups']);
     }
 
-    public function testMaxJoinsReached()
+    public function testMaxJoinsReached(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The total number of joined relations has exceeded the specified maximum. Raise the limit if necessary, or use the "max_depth" option of the Symfony serializer.');
@@ -379,7 +379,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, null, ['groups' => ['foo']]);
     }
 
-    public function testMaxDepth()
+    public function testMaxDepth(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadata = new ResourceMetadata();
@@ -447,7 +447,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testForceEager()
+    public function testForceEager(): void
     {
         $resourceMetadata = new ResourceMetadata();
         $resourceMetadata = $resourceMetadata->withAttributes(['normalization_context' => [AbstractNormalizer::GROUPS => 'foobar']]);
@@ -491,7 +491,7 @@ class EagerLoadingExtensionTest extends TestCase
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
     }
 
-    public function testExtraLazy()
+    public function testExtraLazy(): void
     {
         $resourceMetadata = new ResourceMetadata();
         $resourceMetadata = $resourceMetadata->withAttributes(['normalization_context' => [AbstractNormalizer::GROUPS => 'foobar']]);
@@ -527,7 +527,7 @@ class EagerLoadingExtensionTest extends TestCase
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
     }
 
-    public function testResourceClassNotFoundException()
+    public function testResourceClassNotFoundException(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata())->withAttributes(['normalization_context' => ['groups' => ['foo']]]));
@@ -551,7 +551,7 @@ class EagerLoadingExtensionTest extends TestCase
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, [], null);
     }
 
-    public function testPropertyNotFoundException()
+    public function testPropertyNotFoundException(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata())->withAttributes(['normalization_context' => ['groups' => ['foo']]]));
@@ -575,7 +575,7 @@ class EagerLoadingExtensionTest extends TestCase
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
     }
 
-    public function testResourceClassNotFoundExceptionPropertyNameCollection()
+    public function testResourceClassNotFoundExceptionPropertyNameCollection(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata())->withAttributes(['normalization_context' => ['groups' => ['foo']]]));
@@ -604,7 +604,7 @@ class EagerLoadingExtensionTest extends TestCase
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
     }
 
-    public function testApplyToCollectionWithSerializerContextBuilder()
+    public function testApplyToCollectionWithSerializerContextBuilder(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
@@ -668,7 +668,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testAttributes()
+    public function testAttributes(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
@@ -732,7 +732,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testNotInAttributes()
+    public function testNotInAttributes(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
@@ -773,7 +773,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionNoPartial()
+    public function testApplyToCollectionNoPartial(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata())->withAttributes(['normalization_context' => ['groups' => ['foo']]]));
@@ -814,7 +814,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionWithANonRedableButFetchEagerProperty()
+    public function testApplyToCollectionWithANonRedableButFetchEagerProperty(): void
     {
         $this->doTestApplyToCollectionWithANonRedableButFetchEagerProperty(false);
     }
@@ -822,12 +822,12 @@ class EagerLoadingExtensionTest extends TestCase
     /**
      * @group legacy
      */
-    public function testLegacyApplyToCollectionWithANonRedableButFetchEagerProperty()
+    public function testLegacyApplyToCollectionWithANonRedableButFetchEagerProperty(): void
     {
         $this->doTestApplyToCollectionWithANonRedableButFetchEagerProperty(true);
     }
 
-    private function doTestApplyToCollectionWithANonRedableButFetchEagerProperty(bool $legacy)
+    private function doTestApplyToCollectionWithANonRedableButFetchEagerProperty(bool $legacy): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata())->withAttributes(['normalization_context' => ['groups' => ['foo']]]));
@@ -870,7 +870,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionWithARedableButNotFetchEagerProperty()
+    public function testApplyToCollectionWithARedableButNotFetchEagerProperty(): void
     {
         $this->doTestApplyToCollectionWithARedableButNotFetchEagerProperty(false);
     }
@@ -878,12 +878,12 @@ class EagerLoadingExtensionTest extends TestCase
     /**
      * @group legacy
      */
-    public function testLeacyApplyToCollectionWithARedableButNotFetchEagerProperty()
+    public function testLeacyApplyToCollectionWithARedableButNotFetchEagerProperty(): void
     {
         $this->doTestApplyToCollectionWithARedableButNotFetchEagerProperty(true);
     }
 
-    private function doTestApplyToCollectionWithARedableButNotFetchEagerProperty(bool $legacy)
+    private function doTestApplyToCollectionWithARedableButNotFetchEagerProperty(bool $legacy): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata())->withAttributes(['normalization_context' => ['groups' => ['foo']]]));

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FilterEagerLoadingExtensionTest extends TestCase
 {
-    public function testIsNoForceEagerCollectionAttributes()
+    public function testIsNoForceEagerCollectionAttributes(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class, null, null, null, [
@@ -54,7 +54,7 @@ class FilterEagerLoadingExtensionTest extends TestCase
         $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
     }
 
-    public function testIsNoForceEagerResource()
+    public function testIsNoForceEagerResource(): void
     {
         $em = $this->prophesize(EntityManager::class);
         $em->getClassMetadata(DummyCar::class)->shouldBeCalled()->willReturn(new ClassMetadataInfo(DummyCar::class));
@@ -74,7 +74,7 @@ class FilterEagerLoadingExtensionTest extends TestCase
         $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, null);
     }
 
-    public function testIsForceEagerConfig()
+    public function testIsForceEagerConfig(): void
     {
         $em = $this->prophesize(EntityManager::class);
         $em->getClassMetadata(DummyCar::class)->shouldBeCalled()->willReturn(new ClassMetadataInfo(DummyCar::class));
@@ -94,7 +94,7 @@ class FilterEagerLoadingExtensionTest extends TestCase
         $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
     }
 
-    public function testHasNoWherePart()
+    public function testHasNoWherePart(): void
     {
         $em = $this->prophesize(EntityManager::class);
         $em->getClassMetadata(DummyCar::class)->shouldBeCalled()->willReturn(new ClassMetadataInfo(DummyCar::class));
@@ -112,7 +112,7 @@ class FilterEagerLoadingExtensionTest extends TestCase
         $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
     }
 
-    public function testHasNoJoinPart()
+    public function testHasNoJoinPart(): void
     {
         $em = $this->prophesize(EntityManager::class);
         $em->getClassMetadata(DummyCar::class)->shouldBeCalled()->willReturn(new ClassMetadataInfo(DummyCar::class));
@@ -132,7 +132,7 @@ class FilterEagerLoadingExtensionTest extends TestCase
         $filterEagerLoadingExtension->applyToCollection($qb->reveal(), $queryNameGenerator->reveal(), DummyCar::class, 'get');
     }
 
-    public function testApplyCollection()
+    public function testApplyCollection(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class));
@@ -162,7 +162,7 @@ class FilterEagerLoadingExtensionTest extends TestCase
     /**
      * https://github.com/api-platform/core/issues/1021.
      */
-    public function testHiddenOrderBy()
+    public function testHiddenOrderBy(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class));
@@ -200,7 +200,7 @@ SQL;
         $this->assertEquals($this->toDQLString($expected), $qb->getDQL());
     }
 
-    public function testGroupBy()
+    public function testGroupBy(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata(DummyCar::class));
@@ -242,7 +242,7 @@ SQL;
         $this->assertEquals($this->toDQLString($expected), $qb->getDQL());
     }
 
-    public function testCompositeIdentifiers()
+    public function testCompositeIdentifiers(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(CompositeRelation::class)->willReturn(new ResourceMetadata(CompositeRelation::class));
@@ -298,7 +298,7 @@ SQL;
         $this->assertEquals($this->toDQLString($expected), $qb->getDQL());
     }
 
-    public function testFetchEagerWithNoForceEager()
+    public function testFetchEagerWithNoForceEager(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(CompositeRelation::class)->willReturn(new ResourceMetadata(CompositeRelation::class));
@@ -359,7 +359,7 @@ DQL;
         $this->assertEquals($this->toDQLString($expected), $qb->getDQL());
     }
 
-    public function testCompositeIdentifiersWithAssociation()
+    public function testCompositeIdentifiersWithAssociation(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(CompositeRelation::class)->willReturn(new ResourceMetadata(CompositeRelation::class));
@@ -417,7 +417,7 @@ SQL;
         $this->assertEquals($this->toDQLString($expected), $qb->getDQL());
     }
 
-    public function testCompositeIdentifiersWithoutAssociation()
+    public function testCompositeIdentifiersWithoutAssociation(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(CompositeRelation::class)->willReturn(new ResourceMetadata(CompositeRelation::class));

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterExtensionTest.php
@@ -31,7 +31,7 @@ use Psr\Container\ContainerInterface;
  */
 class FilterExtensionTest extends TestCase
 {
-    public function testApplyToCollectionWithValidFilters()
+    public function testApplyToCollectionWithValidFilters(): void
     {
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
@@ -60,7 +60,7 @@ class FilterExtensionTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testApplyToCollectionWithValidFiltersAndDeprecatedFilterCollection()
+    public function testApplyToCollectionWithValidFiltersAndDeprecatedFilterCollection(): void
     {
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
@@ -80,7 +80,7 @@ class FilterExtensionTest extends TestCase
     /**
      * @group legacy
      */
-    public function testConstructWithInvalidFilterLocator()
+    public function testConstructWithInvalidFilterLocator(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$filterLocator" argument is expected to be an implementation of the "Psr\\Container\\ContainerInterface" interface.');
@@ -88,7 +88,7 @@ class FilterExtensionTest extends TestCase
         new FilterExtension($this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(), new \ArrayObject());
     }
 
-    public function testApplyToCollectionWithoutFilters()
+    public function testApplyToCollectionWithoutFilters(): void
     {
         $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST'], 'custom' => ['method' => 'GET', 'path' => '/foo'], 'custom2' => ['method' => 'POST', 'path' => '/foo']]);
 

--- a/tests/Bridge/Doctrine/Orm/Extension/OrderExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/OrderExtensionTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
  */
 class OrderExtensionTest extends TestCase
 {
-    public function testApplyToCollectionWithValidOrder()
+    public function testApplyToCollectionWithValidOrder(): void
     {
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
@@ -49,7 +49,7 @@ class OrderExtensionTest extends TestCase
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionWithWrongOrder()
+    public function testApplyToCollectionWithWrongOrder(): void
     {
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
@@ -69,7 +69,7 @@ class OrderExtensionTest extends TestCase
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionWithOrderOverridden()
+    public function testApplyToCollectionWithOrderOverridden(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
@@ -92,7 +92,7 @@ class OrderExtensionTest extends TestCase
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionWithOrderOverriddenWithNoDirection()
+    public function testApplyToCollectionWithOrderOverriddenWithNoDirection(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
@@ -116,7 +116,7 @@ class OrderExtensionTest extends TestCase
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionWithOrderOverriddenWithAssociation()
+    public function testApplyToCollectionWithOrderOverriddenWithAssociation(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
@@ -141,7 +141,7 @@ class OrderExtensionTest extends TestCase
         $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class);
     }
 
-    public function testApplyToCollectionWithOrderOverriddenWithEmbeddedAssociation()
+    public function testApplyToCollectionWithOrderOverriddenWithEmbeddedAssociation(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);

--- a/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -36,7 +36,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class PaginationExtensionTest extends TestCase
 {
-    public function testApplyToCollection()
+    public function testApplyToCollection(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['pagination' => true, 'itemsPerPage' => 20, '_page' => 2]));
@@ -68,7 +68,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionWithItemPerPageZero()
+    public function testApplyToCollectionWithItemPerPageZero(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['pagination' => true, 'itemsPerPage' => 0, '_page' => 1]));
@@ -100,7 +100,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionWithItemPerPageZeroAndPage2()
+    public function testApplyToCollectionWithItemPerPageZeroAndPage2(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Page should not be greater than 1 if itemsPerPage is equal to 0');
@@ -135,7 +135,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionWithItemPerPageLessThen0()
+    public function testApplyToCollectionWithItemPerPageLessThen0(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Item per page parameter should not be less than 0');
@@ -170,7 +170,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionWithItemPerPageTooHigh()
+    public function testApplyToCollectionWithItemPerPageTooHigh(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['pagination' => true, 'itemsPerPage' => 301, '_page' => 2]));
@@ -205,7 +205,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionWithGraphql()
+    public function testApplyToCollectionWithGraphql(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['pagination' => true], [], [
@@ -239,7 +239,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionNoRequest()
+    public function testApplyToCollectionNoRequest(): void
     {
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilderProphecy->setFirstResult(Argument::any())->shouldNotBeCalled();
@@ -254,7 +254,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionEmptyRequest()
+    public function testApplyToCollectionEmptyRequest(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
@@ -276,7 +276,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionPaginationDisabled()
+    public function testApplyToCollectionPaginationDisabled(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
@@ -299,7 +299,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testApplyToCollectionWithMaximumItemsPerPage()
+    public function testApplyToCollectionWithMaximumItemsPerPage(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['pagination' => true, 'itemsPerPage' => 80, 'page' => 1]));
@@ -334,7 +334,7 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($queryBuilder, new QueryNameGenerator(), 'Foo', 'op');
     }
 
-    public function testSupportsResult()
+    public function testSupportsResult(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
@@ -351,7 +351,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertTrue($extension->supportsResult('Foo', 'op'));
     }
 
-    public function testSupportsResultNoRequest()
+    public function testSupportsResultNoRequest(): void
     {
         $extension = new PaginationExtension(
             $this->prophesize(ManagerRegistry::class)->reveal(),
@@ -361,7 +361,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertFalse($extension->supportsResult('Foo', 'op'));
     }
 
-    public function testSupportsResultEmptyRequest()
+    public function testSupportsResultEmptyRequest(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
@@ -378,7 +378,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertTrue($extension->supportsResult('Foo', 'op'));
     }
 
-    public function testSupportsResultClientNotAllowedToPaginate()
+    public function testSupportsResultClientNotAllowedToPaginate(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['pagination' => true]));
@@ -397,7 +397,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertFalse($extension->supportsResult('Foo', 'op'));
     }
 
-    public function testSupportsResultPaginationDisabled()
+    public function testSupportsResultPaginationDisabled(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
@@ -415,7 +415,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertFalse($extension->supportsResult('Foo', 'op'));
     }
 
-    public function testGetResult()
+    public function testGetResult(): void
     {
         $result = $this->getPaginationExtensionResult(false);
 
@@ -423,7 +423,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertInstanceOf(PaginatorInterface::class, $result);
     }
 
-    public function testGetResultWithoutFetchJoinCollection()
+    public function testGetResultWithoutFetchJoinCollection(): void
     {
         $result = $this->getPaginationExtensionResult(false, false, false);
 
@@ -431,7 +431,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertInstanceOf(PaginatorInterface::class, $result);
     }
 
-    public function testGetResultWithPartial()
+    public function testGetResultWithPartial(): void
     {
         $result = $this->getPaginationExtensionResult(true);
 
@@ -439,7 +439,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertNotInstanceOf(PaginatorInterface::class, $result);
     }
 
-    public function testSimpleGetResult()
+    public function testSimpleGetResult(): void
     {
         $result = $this->getPaginationExtensionResult(false, true);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/BooleanFilterTest.php
@@ -24,7 +24,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = BooleanFilter::class;
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $filter = new BooleanFilter($this->managerRegistry, null, null, [
             'id' => null,
@@ -42,7 +42,7 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function testGetDescriptionDefaultFields()
+    public function testGetDescriptionDefaultFields(): void
     {
         $filter = new BooleanFilter($this->managerRegistry);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/CommonFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/CommonFilterTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CommonFilterTest extends TestCase
 {
-    public function testSplitPropertiesWithoutResourceClass()
+    public function testSplitPropertiesWithoutResourceClass(): void
     {
         $managerRegistry = $this->prophesize(ManagerRegistry::class);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/DateFilterTest.php
@@ -30,12 +30,12 @@ class DateFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = DateFilter::class;
 
-    public function testApplyDate()
+    public function testApplyDate(): void
     {
         $this->doTestApplyDate(false);
     }
 
-    public function testApplyDateImmutable()
+    public function testApplyDateImmutable(): void
     {
         $this->doTestApplyDateImmutable(false);
     }
@@ -43,7 +43,7 @@ class DateFilterTest extends DoctrineOrmFilterTestCase
     /**
      * @group legacy
      */
-    public function testRequestApplyDate()
+    public function testRequestApplyDate(): void
     {
         $this->doTestApplyDate(true);
     }
@@ -51,12 +51,12 @@ class DateFilterTest extends DoctrineOrmFilterTestCase
     /**
      * @group legacy
      */
-    public function testRequestApplyDateImmutable()
+    public function testRequestApplyDateImmutable(): void
     {
         $this->doTestApplyDateImmutable(true);
     }
 
-    private function doTestApplyDate(bool $request)
+    private function doTestApplyDate(bool $request): void
     {
         $filters = ['dummyDate' => ['after' => '2015-04-05']];
 
@@ -75,7 +75,7 @@ class DateFilterTest extends DoctrineOrmFilterTestCase
         $this->assertInstanceOf(\DateTime::class, $queryBuilder->getParameters()[0]->getValue());
     }
 
-    private function doTestApplyDateImmutable(bool $request)
+    private function doTestApplyDateImmutable(bool $request): void
     {
         $filters = ['dummyDate' => ['after' => '2015-04-05']];
 
@@ -94,7 +94,7 @@ class DateFilterTest extends DoctrineOrmFilterTestCase
         $this->assertInstanceOf(\DateTimeImmutable::class, $queryBuilder->getParameters()[0]->getValue());
     }
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $filter = new DateFilter($this->managerRegistry);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/ExistsFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/ExistsFilterTest.php
@@ -24,7 +24,7 @@ class ExistsFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = ExistsFilter::class;
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $filter = new ExistsFilter($this->managerRegistry, null, null, ['name' => null, 'description' => null]);
 
@@ -37,7 +37,7 @@ class ExistsFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function testGetDescriptionDefaultFields()
+    public function testGetDescriptionDefaultFields(): void
     {
         $filter = new ExistsFilter($this->managerRegistry);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
@@ -24,7 +24,7 @@ class NumericFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = NumericFilter::class;
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $filter = new NumericFilter($this->managerRegistry, null, null, [
             'id' => null,
@@ -42,7 +42,7 @@ class NumericFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function testGetDescriptionDefaultFields()
+    public function testGetDescriptionDefaultFields(): void
     {
         $filter = new NumericFilter($this->managerRegistry);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -27,7 +27,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = OrderFilter::class;
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $filter = new OrderFilter($this->managerRegistry, null, 'order', null, ['id' => null, 'name' => null, 'foo' => null]);
         $this->assertEquals([
@@ -44,7 +44,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function testGetDescriptionDefaultFields()
+    public function testGetDescriptionDefaultFields(): void
     {
         $filter = new OrderFilter($this->managerRegistry);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
@@ -24,7 +24,7 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
 {
     protected $filterClass = RangeFilter::class;
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $filter = new RangeFilter($this->managerRegistry);
 

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -55,7 +55,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         return new SearchFilter($managerRegistry, $requestStack, $iriConverter, $propertyAccessor, null, $properties);
     }
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $filter = $this->filterFactory($this->managerRegistry, null);
 
@@ -344,7 +344,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function testDoubleJoin()
+    public function testDoubleJoin(): void
     {
         $this->doTestDoubleJoin(false);
     }
@@ -352,12 +352,12 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     /**
      * @group legacy
      */
-    public function testRequestDoubleJoin()
+    public function testRequestDoubleJoin(): void
     {
         $this->doTestDoubleJoin(true);
     }
 
-    private function doTestDoubleJoin(bool $request)
+    private function doTestDoubleJoin(bool $request): void
     {
         $filters = ['relatedDummy.symfony' => 'foo'];
 
@@ -378,7 +378,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         $this->assertEquals($actual, $expected);
     }
 
-    public function testTripleJoin()
+    public function testTripleJoin(): void
     {
         $this->doTestTripleJoin(false);
     }
@@ -386,12 +386,12 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     /**
      * @group legacy
      */
-    public function testRequestTripleJoin()
+    public function testRequestTripleJoin(): void
     {
         $this->doTestTripleJoin(true);
     }
 
-    private function doTestTripleJoin(bool $request)
+    private function doTestTripleJoin(bool $request): void
     {
         $filters = ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '2'];
 
@@ -413,7 +413,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         $this->assertEquals($actual, $expected);
     }
 
-    public function testJoinLeft()
+    public function testJoinLeft(): void
     {
         $this->doTestJoinLeft(false);
     }
@@ -421,12 +421,12 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     /**
      * @group legacy
      */
-    public function testRequestJoinLeft()
+    public function testRequestJoinLeft(): void
     {
         $this->doTestJoinLeft(true);
     }
 
-    private function doTestJoinLeft(bool $request)
+    private function doTestJoinLeft(bool $request): void
     {
         $filters = ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '3'];
 
@@ -447,7 +447,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         $this->assertEquals($actual, $expected);
     }
 
-    public function testApplyWithAnotherAlias()
+    public function testApplyWithAnotherAlias(): void
     {
         $this->doTestApplyWithAnotherAlias(false);
     }
@@ -455,12 +455,12 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     /**
      * @group legacy
      */
-    public function testRequestApplyWithAnotherAlias()
+    public function testRequestApplyWithAnotherAlias(): void
     {
         $this->doTestApplyWithAnotherAlias(true);
     }
 
-    private function doTestApplyWithAnotherAlias(bool $request)
+    private function doTestApplyWithAnotherAlias(bool $request): void
     {
         $filters = ['name' => 'exact'];
 

--- a/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
@@ -45,7 +45,7 @@ use Prophecy\Argument;
  */
 class ItemDataProviderTest extends TestCase
 {
-    public function testGetItemSingleIdentifier()
+    public function testGetItemSingleIdentifier(): void
     {
         $context = ['foo' => 'bar', 'fetch_data' => true, ChainIdentifierDenormalizer::HAS_IDENTIFIER_DENORMALIZER => true];
         $queryProphecy = $this->prophesize(AbstractQuery::class);
@@ -83,7 +83,7 @@ class ItemDataProviderTest extends TestCase
         $this->assertEquals([], $dataProvider->getItem(Dummy::class, ['id' => 1], 'foo', $context));
     }
 
-    public function testGetItemDoubleIdentifier()
+    public function testGetItemDoubleIdentifier(): void
     {
         $queryProphecy = $this->prophesize(AbstractQuery::class);
         $queryProphecy->getOneOrNullResult()->willReturn([])->shouldBeCalled();
@@ -131,7 +131,7 @@ class ItemDataProviderTest extends TestCase
     /**
      * @group legacy
      */
-    public function testGetItemWrongCompositeIdentifier()
+    public function testGetItemWrongCompositeIdentifier(): void
     {
         $this->expectException(PropertyNotFoundException::class);
 
@@ -152,7 +152,7 @@ class ItemDataProviderTest extends TestCase
         $dataProvider->getItem(Dummy::class, 'ida=1;', 'foo');
     }
 
-    public function testQueryResultExtension()
+    public function testQueryResultExtension(): void
     {
         $comparisonProphecy = $this->prophesize(Comparison::class);
         $comparison = $comparisonProphecy->reveal();
@@ -188,7 +188,7 @@ class ItemDataProviderTest extends TestCase
         $this->assertEquals([], $dataProvider->getItem(Dummy::class, ['id' => 1], 'foo', $context));
     }
 
-    public function testUnsupportedClass()
+    public function testUnsupportedClass(): void
     {
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn(null)->shouldBeCalled();
@@ -203,7 +203,7 @@ class ItemDataProviderTest extends TestCase
         $this->assertFalse($dataProvider->supports(Dummy::class, 'foo'));
     }
 
-    public function testCannotCreateQueryBuilder()
+    public function testCannotCreateQueryBuilder(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The repository class must have a "createQueryBuilder" method.');

--- a/tests/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactoryTest.php
+++ b/tests/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactoryTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DoctrineOrmPropertyMetadataFactoryTest extends TestCase
 {
-    public function testCreateNoManager()
+    public function testCreateNoManager(): void
     {
         $propertyMetadata = new PropertyMetadata();
         $propertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
@@ -42,7 +42,7 @@ class DoctrineOrmPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($doctrineOrmPropertyMetadataFactory->create(Dummy::class, 'id', []), $propertyMetadata);
     }
 
-    public function testCreateNoClassMetadata()
+    public function testCreateNoClassMetadata(): void
     {
         $propertyMetadata = new PropertyMetadata();
         $propertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
@@ -59,7 +59,7 @@ class DoctrineOrmPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($doctrineOrmPropertyMetadataFactory->create(Dummy::class, 'id', []), $propertyMetadata);
     }
 
-    public function testCreateIsIdentifier()
+    public function testCreateIsIdentifier(): void
     {
         $propertyMetadata = new PropertyMetadata();
         $propertyMetadata = $propertyMetadata->withIdentifier(true);
@@ -80,7 +80,7 @@ class DoctrineOrmPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($doctrineOrmPropertyMetadataFactory->create(Dummy::class, 'id', []), $propertyMetadata);
     }
 
-    public function testCreateIsWritable()
+    public function testCreateIsWritable(): void
     {
         $propertyMetadata = new PropertyMetadata();
         $propertyMetadata = $propertyMetadata->withWritable(false);
@@ -105,7 +105,7 @@ class DoctrineOrmPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($doctrinePropertyMetadata->isWritable(), false);
     }
 
-    public function testCreateClassMetadataInfo()
+    public function testCreateClassMetadataInfo(): void
     {
         $propertyMetadata = new PropertyMetadata();
 
@@ -130,7 +130,7 @@ class DoctrineOrmPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($doctrinePropertyMetadata->isWritable(), true);
     }
 
-    public function testCreateClassMetadata()
+    public function testCreateClassMetadata(): void
     {
         $propertyMetadata = new PropertyMetadata();
 

--- a/tests/Bridge/Doctrine/Orm/PaginatorTest.php
+++ b/tests/Bridge/Doctrine/Orm/PaginatorTest.php
@@ -24,7 +24,7 @@ class PaginatorTest extends TestCase
     /**
      * @dataProvider initializeProvider
      */
-    public function testInitialize($firstResult, $maxResults, $totalItems, $currentPage, $lastPage)
+    public function testInitialize($firstResult, $maxResults, $totalItems, $currentPage, $lastPage): void
     {
         $paginator = $this->getPaginator($firstResult, $maxResults, $totalItems);
 
@@ -33,7 +33,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($maxResults, $paginator->getItemsPerPage());
     }
 
-    public function testInitializeWithQueryFirstResultNotApplied()
+    public function testInitializeWithQueryFirstResultNotApplied(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('"Doctrine\\ORM\\Query::setFirstResult()" or/and "Doctrine\\ORM\\Query::setMaxResults()" was/were not applied to the query.');
@@ -41,7 +41,7 @@ class PaginatorTest extends TestCase
         $this->getPaginatorWithMalformedQuery(false);
     }
 
-    public function testInitializeWithQueryMaxResultsNotApplied()
+    public function testInitializeWithQueryMaxResultsNotApplied(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('"Doctrine\\ORM\\Query::setFirstResult()" or/and "Doctrine\\ORM\\Query::setMaxResults()" was/were not applied to the query.');
@@ -49,7 +49,7 @@ class PaginatorTest extends TestCase
         $this->getPaginatorWithMalformedQuery(true);
     }
 
-    public function testGetIterator()
+    public function testGetIterator(): void
     {
         $paginator = $this->getPaginator();
 
@@ -74,7 +74,7 @@ class PaginatorTest extends TestCase
         return new Paginator($doctrinePaginator->reveal());
     }
 
-    private function getPaginatorWithMalformedQuery($maxResults = false)
+    private function getPaginatorWithMalformedQuery($maxResults = false): void
     {
         $query = $this->prophesize(Query::class);
         $query->getFirstResult()->willReturn($maxResults ? 42 : null)->shouldBeCalled();

--- a/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
@@ -46,7 +46,7 @@ use Prophecy\Argument;
  */
 class SubresourceDataProviderTest extends TestCase
 {
-    private function assertIdentifierManagerMethodCalls($managerProphecy)
+    private function assertIdentifierManagerMethodCalls($managerProphecy): void
     {
         $platformProphecy = $this->prophesize(AbstractPlatform::class);
 
@@ -99,7 +99,7 @@ class SubresourceDataProviderTest extends TestCase
         return $managerRegistryProphecy->reveal();
     }
 
-    public function testNotASubresource()
+    public function testNotASubresource(): void
     {
         $this->expectException(ResourceClassNotSupportedException::class);
         $this->expectExceptionMessage('The given resource class is not a subresource.');
@@ -114,7 +114,7 @@ class SubresourceDataProviderTest extends TestCase
         $dataProvider->getSubresource(Dummy::class, ['id' => 1], []);
     }
 
-    public function testGetSubresource()
+    public function testGetSubresource(): void
     {
         $dql = 'SELECT relatedDummies_a2 FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy id_a1 INNER JOIN id_a1.relatedDummies relatedDummies_a2 WHERE id_a1.id = :id_p1';
 
@@ -171,7 +171,7 @@ class SubresourceDataProviderTest extends TestCase
         $this->assertEquals([], $dataProvider->getSubresource(RelatedDummy::class, ['id' => ['id' => 1]], $context));
     }
 
-    public function testGetSubSubresourceItem()
+    public function testGetSubSubresourceItem(): void
     {
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $identifiers = ['id'];
@@ -263,7 +263,7 @@ class SubresourceDataProviderTest extends TestCase
         $this->assertEquals($result, $dataProvider->getSubresource(ThirdLevel::class, ['id' => ['id' => 1], 'relatedDummies' => ['id' => 1]], $context));
     }
 
-    public function testQueryResultExtension()
+    public function testQueryResultExtension(): void
     {
         $dql = 'SELECT relatedDummies_a2 FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy id_a1 INNER JOIN id_a1.relatedDummies relatedDummies_a2 WHERE id_a1.id = :id_p1';
 
@@ -322,7 +322,7 @@ class SubresourceDataProviderTest extends TestCase
         $this->assertEquals([], $dataProvider->getSubresource(RelatedDummy::class, ['id' => ['id' => 1]], $context));
     }
 
-    public function testCannotCreateQueryBuilder()
+    public function testCannotCreateQueryBuilder(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The repository class must have a "createQueryBuilder" method.');
@@ -342,7 +342,7 @@ class SubresourceDataProviderTest extends TestCase
         $dataProvider->getSubresource(Dummy::class, ['id' => 1], []);
     }
 
-    public function testThrowResourceClassNotSupportedException()
+    public function testThrowResourceClassNotSupportedException(): void
     {
         $this->expectException(ResourceClassNotSupportedException::class);
 
@@ -359,7 +359,7 @@ class SubresourceDataProviderTest extends TestCase
     /**
      * @group legacy
      */
-    public function testGetSubSubresourceItemLegacy()
+    public function testGetSubSubresourceItemLegacy(): void
     {
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $identifiers = ['id'];
@@ -455,7 +455,7 @@ class SubresourceDataProviderTest extends TestCase
         $this->assertEquals($result, $dataProvider->getSubresource(ThirdLevel::class, ['id' => 1, 'relatedDummies' => 1], $context));
     }
 
-    public function testGetSubresourceCollectionItem()
+    public function testGetSubresourceCollectionItem(): void
     {
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $identifiers = ['id'];

--- a/tests/Bridge/Doctrine/Orm/Util/IdentifierManagerTraitTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/IdentifierManagerTraitTest.php
@@ -48,7 +48,7 @@ class IdentifierManagerTraitTest extends TestCase
     /**
      * @group legacy
      */
-    public function testSingleIdentifier()
+    public function testSingleIdentifier(): void
     {
         list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataFactories(Dummy::class, [
             'id',
@@ -67,7 +67,7 @@ class IdentifierManagerTraitTest extends TestCase
     /**
      * @group legacy
      */
-    public function testCompositeIdentifier()
+    public function testCompositeIdentifier(): void
     {
         list($propertyNameCollectionFactory, $propertyMetadataFactory) = $this->getMetadataFactories(Dummy::class, [
             'ida',
@@ -90,7 +90,7 @@ class IdentifierManagerTraitTest extends TestCase
     /**
      * @group legacy
      */
-    public function testInvalidIdentifier()
+    public function testInvalidIdentifier(): void
     {
         $this->expectException(PropertyNotFoundException::class);
         $this->expectExceptionMessage('Invalid identifier "idbad=1;idb=2", "ida" was not found.');

--- a/tests/Bridge/Doctrine/Orm/Util/QueryBuilderHelperTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryBuilderHelperTest.php
@@ -26,7 +26,7 @@ class QueryBuilderHelperTest extends TestCase
      *
      * @param string|null $originAlias
      */
-    public function testAddJoinOnce(string $originAliasForJoinOnce = null, string $expectedAlias)
+    public function testAddJoinOnce(string $originAliasForJoinOnce = null, string $expectedAlias): void
     {
         $queryBuilder = new QueryBuilder($this->prophesize(EntityManagerInterface::class)->reveal());
         $queryBuilder->from('foo', 'f');

--- a/tests/Bridge/Doctrine/Orm/Util/QueryCheckerTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryCheckerTest.php
@@ -25,35 +25,35 @@ use PHPUnit\Framework\TestCase;
 
 class QueryCheckerTest extends TestCase
 {
-    public function testHasHavingClauseWithHavingClause()
+    public function testHasHavingClauseWithHavingClause(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getDQLPart('having')->willReturn(['having' => 'toto']);
         $this->assertTrue(QueryChecker::hasHavingClause($queryBuilder->reveal()));
     }
 
-    public function testHasHavingClauseWithEmptyHavingClause()
+    public function testHasHavingClauseWithEmptyHavingClause(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getDQLPart('having')->willReturn([]);
         $this->assertFalse(QueryChecker::hasHavingClause($queryBuilder->reveal()));
     }
 
-    public function testHasMaxResult()
+    public function testHasMaxResult(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getMaxResults()->willReturn(10);
         $this->assertTrue(QueryChecker::hasMaxResults($queryBuilder->reveal()));
     }
 
-    public function testHasMaxResultWithNoMaxResult()
+    public function testHasMaxResultWithNoMaxResult(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getMaxResults()->willReturn(null);
         $this->assertFalse(QueryChecker::hasMaxResults($queryBuilder->reveal()));
     }
 
-    public function testHasRootEntityWithCompositeIdentifier()
+    public function testHasRootEntityWithCompositeIdentifier(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -67,7 +67,7 @@ class QueryCheckerTest extends TestCase
         $this->assertTrue(QueryChecker::hasRootEntityWithCompositeIdentifier($queryBuilder->reveal(), $managerRegistry->reveal()));
     }
 
-    public function testHasRootEntityWithNoCompositeIdentifier()
+    public function testHasRootEntityWithNoCompositeIdentifier(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -81,7 +81,7 @@ class QueryCheckerTest extends TestCase
         $this->assertFalse(QueryChecker::hasRootEntityWithCompositeIdentifier($queryBuilder->reveal(), $managerRegistry->reveal()));
     }
 
-    public function testHasRootEntityWithForeignKeyIdentifier()
+    public function testHasRootEntityWithForeignKeyIdentifier(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -95,7 +95,7 @@ class QueryCheckerTest extends TestCase
         $this->assertTrue(QueryChecker::hasRootEntityWithForeignKeyIdentifier($queryBuilder->reveal(), $managerRegistry->reveal()));
     }
 
-    public function testHasRootEntityWithNoForeignKeyIdentifier()
+    public function testHasRootEntityWithNoForeignKeyIdentifier(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -108,7 +108,7 @@ class QueryCheckerTest extends TestCase
         $this->assertFalse(QueryChecker::hasRootEntityWithForeignKeyIdentifier($queryBuilder->reveal(), $managerRegistry->reveal()));
     }
 
-    public function testHasOrderByOnToManyJoinWithoutJoin()
+    public function testHasOrderByOnToManyJoinWithoutJoin(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -124,7 +124,7 @@ class QueryCheckerTest extends TestCase
         $this->assertFalse(QueryChecker::hasOrderByOnToManyJoin($queryBuilder->reveal(), $managerRegistry->reveal()));
     }
 
-    public function testHasOrderByOnToManyJoinWithoutOrderBy()
+    public function testHasOrderByOnToManyJoinWithoutOrderBy(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -140,7 +140,7 @@ class QueryCheckerTest extends TestCase
         $this->assertFalse(QueryChecker::hasOrderByOnToManyJoin($queryBuilder->reveal(), $managerRegistry->reveal()));
     }
 
-    public function testHasOrderByOnToManyJoinWithoutJoinAndWithoutOrderBy()
+    public function testHasOrderByOnToManyJoinWithoutJoinAndWithoutOrderBy(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -156,7 +156,7 @@ class QueryCheckerTest extends TestCase
         $this->assertFalse(QueryChecker::hasOrderByOnToManyJoin($queryBuilder->reveal(), $managerRegistry->reveal()));
     }
 
-    public function testHasOrderByOnToManyJoinWithClassLeftJoin()
+    public function testHasOrderByOnToManyJoinWithClassLeftJoin(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -180,7 +180,7 @@ class QueryCheckerTest extends TestCase
     /**
      * Adds a test on the fix referenced in https://github.com/api-platform/core/pull/1449.
      */
-    public function testOrderByOnToManyWithRelationAsBasis()
+    public function testOrderByOnToManyWithRelationAsBasis(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);

--- a/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
@@ -28,7 +28,7 @@ class QueryJoinParserTest extends TestCase
 {
     use PHPMock;
 
-    public function testGetClassMetadataFromJoinAlias()
+    public function testGetClassMetadataFromJoinAlias(): void
     {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
@@ -43,19 +43,19 @@ class QueryJoinParserTest extends TestCase
         $this->assertEquals($metadata, $classMetadata->reveal());
     }
 
-    public function testGetJoinRelationshipWithJoin()
+    public function testGetJoinRelationshipWithJoin(): void
     {
         $join = new Join('INNER_JOIN', 'a_1.relatedDummy', 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals('a_1.relatedDummy', QueryJoinParser::getJoinRelationship($join));
     }
 
-    public function testGetJoinRelationshipWithClassJoin()
+    public function testGetJoinRelationshipWithClassJoin(): void
     {
         $join = new Join('INNER_JOIN', RelatedDummy::class, 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals(RelatedDummy::class, QueryJoinParser::getJoinRelationship($join));
     }
 
-    public function testGetJoinRelationshipWithReflection()
+    public function testGetJoinRelationshipWithReflection(): void
     {
         $methodExist = $this->getFunctionMock('ApiPlatform\Core\Bridge\Doctrine\Orm\Util', 'method_exists');
         $methodExist->expects($this->any())->with(Join::class, 'getJoin')->willReturn('false');
@@ -63,19 +63,19 @@ class QueryJoinParserTest extends TestCase
         $this->assertEquals('a_1.relatedDummy', QueryJoinParser::getJoinRelationship($join));
     }
 
-    public function testGetJoinAliasWithJoin()
+    public function testGetJoinAliasWithJoin(): void
     {
         $join = new Join('INNER_JOIN', 'relatedDummy', 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals('a_1', QueryJoinParser::getJoinAlias($join));
     }
 
-    public function testGetJoinAliasWithClassJoin()
+    public function testGetJoinAliasWithClassJoin(): void
     {
         $join = new Join('LEFT_JOIN', RelatedDummy::class, 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals('a_1', QueryJoinParser::getJoinAlias($join));
     }
 
-    public function testGetJoinAliasWithReflection()
+    public function testGetJoinAliasWithReflection(): void
     {
         $methodExist = $this->getFunctionMock('ApiPlatform\Core\Bridge\Doctrine\Orm\Util', 'method_exists');
         $methodExist->expects($this->any())->with(Join::class, 'getAlias')->willReturn('false');
@@ -83,13 +83,13 @@ class QueryJoinParserTest extends TestCase
         $this->assertEquals('a_1', QueryJoinParser::getJoinAlias($join));
     }
 
-    public function testGetOrderByPartsWithOrderBy()
+    public function testGetOrderByPartsWithOrderBy(): void
     {
         $orderBy = new OrderBy('name', 'asc');
         $this->assertEquals(['name asc'], QueryJoinParser::getOrderByParts($orderBy));
     }
 
-    public function testGetOrderByPartsWithReflection()
+    public function testGetOrderByPartsWithReflection(): void
     {
         $methodExist = $this->getFunctionMock('ApiPlatform\Core\Bridge\Doctrine\Orm\Util', 'method_exists');
         $methodExist->expects($this->any())->with(OrderBy::class, 'getParts')->willReturn('false');

--- a/tests/Bridge/Doctrine/Orm/Util/QueryNameGeneratorTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryNameGeneratorTest.php
@@ -21,13 +21,13 @@ use PHPUnit\Framework\TestCase;
  */
 class QueryNameGeneratorTest extends TestCase
 {
-    public function testGenerateJoinAlias()
+    public function testGenerateJoinAlias(): void
     {
         $queryNameGenerator = new QueryNameGenerator();
         $this->assertEquals('related_a1', $queryNameGenerator->generateJoinAlias('related'));
     }
 
-    public function testGenerateParemeterName()
+    public function testGenerateParemeterName(): void
     {
         $queryNameGenerator = new QueryNameGenerator();
         $this->assertEquals('name_p1', $queryNameGenerator->generateParameterName('name'));

--- a/tests/Bridge/FosUser/EventListenerTest.php
+++ b/tests/Bridge/FosUser/EventListenerTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
  */
 class EventListenerTest extends TestCase
 {
-    public function testDelete()
+    public function testDelete(): void
     {
         $user = $this->prophesize(UserInterface::class);
 
@@ -45,7 +45,7 @@ class EventListenerTest extends TestCase
         $listener->onKernelView($event->reveal());
     }
 
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $user = $this->prophesize(UserInterface::class);
 
@@ -64,7 +64,7 @@ class EventListenerTest extends TestCase
         $listener->onKernelView($event->reveal());
     }
 
-    public function testNotApiRequest()
+    public function testNotApiRequest(): void
     {
         $request = new Request();
 
@@ -79,7 +79,7 @@ class EventListenerTest extends TestCase
         $listener->onKernelView($event->reveal());
     }
 
-    public function testNotUser()
+    public function testNotUser(): void
     {
         $request = new Request([], [], ['_api_resource_class' => User::class, '_api_item_operation_name' => 'put']);
         $request->setMethod('PUT');
@@ -96,7 +96,7 @@ class EventListenerTest extends TestCase
         $listener->onKernelView($event->reveal());
     }
 
-    public function testSafeMethod()
+    public function testSafeMethod(): void
     {
         $request = new Request([], [], ['_api_resource_class' => User::class, '_api_item_operation_name' => 'put']);
 

--- a/tests/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProviderTest.php
+++ b/tests/Bridge/NelmioApiDoc/Extractor/AnnotationsProvider/ApiPlatformProviderTest.php
@@ -42,7 +42,7 @@ class ApiPlatformProviderTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Extractor\AnnotationsProvider\ApiPlatformProvider class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $apiPlatformProvider = new ApiPlatformProvider(
             $this->prophesize(ResourceNameCollectionFactoryInterface::class)->reveal(),
@@ -58,7 +58,7 @@ class ApiPlatformProviderTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Extractor\AnnotationsProvider\ApiPlatformProvider class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testGetAnnotations()
+    public function testGetAnnotations(): void
     {
         $dummySearchFilterProphecy = $this->prophesize(FilterInterface::class);
         $dummySearchFilterProphecy->getDescription(Dummy::class)->willReturn([
@@ -81,7 +81,7 @@ class ApiPlatformProviderTest extends TestCase
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Extractor\AnnotationsProvider\ApiPlatformProvider class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testGetAnnotationsWithDeprecatedFilterCollection()
+    public function testGetAnnotationsWithDeprecatedFilterCollection(): void
     {
         $dummySearchFilterProphecy = $this->prophesize(FilterInterface::class);
         $dummySearchFilterProphecy->getDescription(Dummy::class)->willReturn([
@@ -99,7 +99,7 @@ class ApiPlatformProviderTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Extractor\AnnotationsProvider\ApiPlatformProvider class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testConstructWithInvalidFilterLocator()
+    public function testConstructWithInvalidFilterLocator(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$filterLocator" argument is expected to be an implementation of the "Psr\\Container\\ContainerInterface" interface.');
@@ -113,7 +113,7 @@ class ApiPlatformProviderTest extends TestCase
         );
     }
 
-    private function extractAnnotations($filterLocator)
+    private function extractAnnotations($filterLocator): void
     {
         $resourceNameCollection = new ResourceNameCollection([Dummy::class, RelatedDummy::class]);
 
@@ -320,7 +320,7 @@ JSON;
         return json_decode($hydraDocJson, true);
     }
 
-    public function testGetAnnotationsWithEmptyHydraDoc()
+    public function testGetAnnotationsWithEmptyHydraDoc(): void
     {
         $documentationNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
         $documentationNormalizerProphecy->normalize(new Documentation(new ResourceNameCollection([Dummy::class])))->willReturn([])->shouldBeCalled();
@@ -339,7 +339,7 @@ JSON;
         $this->assertEquals([], $apiPlatformProvider->getAnnotations());
     }
 
-    public function testGetAnnotationsWithInvalidHydraSupportedClass()
+    public function testGetAnnotationsWithInvalidHydraSupportedClass(): void
     {
         $hydraDoc = ['hydra:supportedClass' => 'not an array'];
 
@@ -360,7 +360,7 @@ JSON;
         $this->assertEquals([], $apiPlatformProvider->getAnnotations());
     }
 
-    public function testGetAnnotationsWithEmptyHydraSupportedClass()
+    public function testGetAnnotationsWithEmptyHydraSupportedClass(): void
     {
         $hydraDoc = ['hydra:supportedClass' => []];
 
@@ -381,7 +381,7 @@ JSON;
         $this->assertEquals([], $apiPlatformProvider->getAnnotations());
     }
 
-    public function testGetAnnotationsWithInvalidHydraSupportedOperation()
+    public function testGetAnnotationsWithInvalidHydraSupportedOperation(): void
     {
         $hydraDoc = ['hydra:supportedClass' => [
             ['@id' => '#Entrypoint'],
@@ -425,7 +425,7 @@ JSON;
         $this->assertEquals([$apiDoc], $apiPlatformProvider->getAnnotations());
     }
 
-    public function testGetAnnotationsWithEmptyHydraSupportedOperation()
+    public function testGetAnnotationsWithEmptyHydraSupportedOperation(): void
     {
         $hydraDoc = ['hydra:supportedClass' => [
             ['@id' => '#Entrypoint'],
@@ -469,7 +469,7 @@ JSON;
         $this->assertEquals([$apiDoc], $apiPlatformProvider->getAnnotations());
     }
 
-    public function testGetAnnotationsWithInvalidHydraSupportedProperty()
+    public function testGetAnnotationsWithInvalidHydraSupportedProperty(): void
     {
         $hydraDoc = ['hydra:supportedClass' => [
             ['@id' => '#Entrypoint', 'hydra:supportedProperty' => 'not an array'],
@@ -513,7 +513,7 @@ JSON;
         $this->assertEquals([$apiDoc], $apiPlatformProvider->getAnnotations());
     }
 
-    public function testGetAnnotationsWithEmptyHydraSupportedProperty()
+    public function testGetAnnotationsWithEmptyHydraSupportedProperty(): void
     {
         $hydraDoc = ['hydra:supportedClass' => [
             ['@id' => '#Entrypoint', 'hydra:supportedProperty' => []],

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -42,7 +42,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
@@ -61,7 +61,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testSupports()
+    public function testSupports(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
@@ -83,7 +83,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testNoOnDataFirstArray()
+    public function testNoOnDataFirstArray(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
@@ -105,7 +105,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testSupportsAttributeNormalization()
+    public function testSupportsAttributeNormalization(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Acme\CustomAttributeDummy')->willReturn(new ResourceMetadata('dummy', 'dummy', null, [
@@ -165,7 +165,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testSupportsUnknownResource()
+    public function testSupportsUnknownResource(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(UnknownDummy::class)->willThrow(ResourceClassNotFoundException::class)->shouldBeCalled();
@@ -187,7 +187,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testSupportsUnsupportedClassFormat()
+    public function testSupportsUnsupportedClassFormat(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Argument::any())->shouldNotBeCalled();
@@ -209,7 +209,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testParse()
+    public function testParse(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [
@@ -283,7 +283,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testParseDateTime()
+    public function testParseDateTime(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [], []))->shouldBeCalled();
@@ -325,7 +325,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testParseRelation()
+    public function testParseRelation(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [], []))->shouldBeCalled();
@@ -416,7 +416,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testParseWithNameConverter()
+    public function testParseWithNameConverter(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [], []))->shouldBeCalled();
@@ -461,7 +461,7 @@ class ApiPlatformParserTest extends TestCase
     /**
      * @expectedDeprecation The ApiPlatform\Core\Bridge\NelmioApiDoc\Parser\ApiPlatformParser class is deprecated since version 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testParseRecursive()
+    public function testParseRecursive(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy', 'dummy', null, [], []))->shouldBeCalled();

--- a/tests/Bridge/RamseyUuid/Normalizer/UuidNormalizerTest.php
+++ b/tests/Bridge/RamseyUuid/Normalizer/UuidNormalizerTest.php
@@ -19,7 +19,7 @@ use Ramsey\Uuid\Uuid;
 
 class UuidNormalizerTest extends TestCase
 {
-    public function testDenormalizeUuid()
+    public function testDenormalizeUuid(): void
     {
         $uuid = Uuid::uuid4();
         $normalizer = new UuidNormalizer();
@@ -27,14 +27,14 @@ class UuidNormalizerTest extends TestCase
         $this->assertEquals($uuid, $normalizer->denormalize($uuid->toString(), Uuid::class));
     }
 
-    public function testNoSupportDenormalizeUuid()
+    public function testNoSupportDenormalizeUuid(): void
     {
         $uuid = 'notanuuid';
         $normalizer = new UuidNormalizer();
         $this->assertFalse($normalizer->supportsDenormalization($uuid, ''));
     }
 
-    public function testFailDenormalizeUuid()
+    public function testFailDenormalizeUuid(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidIdentifierException::class);
 

--- a/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
+++ b/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
@@ -41,7 +41,7 @@ class SwaggerUiActionTest extends TestCase
     /**
      * @dataProvider getInvokeParameters
      */
-    public function testInvoke(Request $request, ProphecyInterface $twigProphecy)
+    public function testInvoke(Request $request, ProphecyInterface $twigProphecy): void
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection(['Foo', 'Bar']))->shouldBeCalled();
@@ -133,7 +133,7 @@ class SwaggerUiActionTest extends TestCase
     /**
      * @dataProvider getDoNotRunCurrentRequestParameters
      */
-    public function testDoNotRunCurrentRequest(Request $request)
+    public function testDoNotRunCurrentRequest(Request $request): void
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection(['Foo', 'Bar']))->shouldBeCalled();

--- a/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class ApiPlatformBundleTest extends TestCase
 {
-    public function testBuild()
+    public function testBuild(): void
     {
         $containerProphecy = $this->prophesize(ContainerBuilder::class);
         $containerProphecy->addCompilerPass(Argument::type(DataProviderPass::class))->shouldBeCalled();

--- a/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
+++ b/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
@@ -29,7 +29,7 @@ class SwaggerCommandTest extends KernelTestCase
      */
     private $tester;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
 
@@ -40,14 +40,14 @@ class SwaggerCommandTest extends KernelTestCase
         $this->tester = new ApplicationTester($application);
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->tester->run(['command' => 'api:swagger:export']);
 
         $this->assertJson($this->tester->getDisplay());
     }
 
-    public function testExecuteWithYaml()
+    public function testExecuteWithYaml(): void
     {
         $this->tester->run(['command' => 'api:swagger:export', '--yaml' => true]);
 
@@ -57,7 +57,7 @@ class SwaggerCommandTest extends KernelTestCase
     /**
      * @param string $data
      */
-    private function assertYaml($data)
+    private function assertYaml($data): void
     {
         try {
             Yaml::parse($data);

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -35,7 +35,7 @@ class RequestDataCollectorTest extends TestCase
     private $metadataFactory;
     private $filterLocator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->response = $this->createMock(Response::class);
         $this->attributes = $this->prophesize(ParameterBag::class);
@@ -49,7 +49,7 @@ class RequestDataCollectorTest extends TestCase
         $this->filterLocator = $this->prophesize(ContainerInterface::class);
     }
 
-    public function testNoResourceClass()
+    public function testNoResourceClass(): void
     {
         $this->apiResourceClassWillReturn(null);
 
@@ -71,7 +71,7 @@ class RequestDataCollectorTest extends TestCase
         $this->assertNull($dataCollector->getResourceMetadata());
     }
 
-    public function testNotCallingCollect()
+    public function testNotCallingCollect(): void
     {
         $this->request
             ->getAcceptableContentTypes()
@@ -89,7 +89,7 @@ class RequestDataCollectorTest extends TestCase
         $this->assertNull($dataCollector->getResourceMetadata());
     }
 
-    public function testWithResource()
+    public function testWithResource(): void
     {
         $this->apiResourceClassWillReturn(DummyEntity::class, ['_api_item_operation_name' => 'get', '_api_receive' => true]);
         $this->request->attributes = $this->attributes->reveal();
@@ -116,7 +116,7 @@ class RequestDataCollectorTest extends TestCase
         $this->assertSame(ResourceMetadata::class, $dataCollector->getResourceMetadata()->getType());
     }
 
-    private function apiResourceClassWillReturn($data, $context = [])
+    private function apiResourceClassWillReturn($data, $context = []): void
     {
         $this->attributes->get('_api_resource_class')->shouldBeCalled()->willReturn($data);
         $this->attributes->all()->shouldBeCalled()->willReturn([

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -96,17 +96,17 @@ class ApiPlatformExtensionTest extends TestCase
 
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extension = new ApiPlatformExtension();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->extension);
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->extension = new ApiPlatformExtension();
 
@@ -115,7 +115,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->assertInstanceOf(ConfigurationExtensionInterface::class, $this->extension);
     }
 
-    public function testNotPrependWhenNull()
+    public function testNotPrependWhenNull(): void
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn(null)->shouldBeCalled();
@@ -126,7 +126,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->prepend($containerBuilder);
     }
 
-    public function testNotPrependSerializerWhenConfigExist()
+    public function testNotPrependSerializerWhenConfigExist(): void
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([0 => ['serializer' => ['enabled' => false]]])->shouldBeCalled();
@@ -139,7 +139,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->prepend($containerBuilder);
     }
 
-    public function testNotPrependPropertyInfoWhenConfigExist()
+    public function testNotPrependPropertyInfoWhenConfigExist(): void
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([0 => ['property_info' => ['enabled' => false]]])->shouldBeCalled();
@@ -152,7 +152,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->prepend($containerBuilder);
     }
 
-    public function testPrependWhenNotConfigured()
+    public function testPrependWhenNotConfigured(): void
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([])->shouldBeCalled();
@@ -162,7 +162,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->prepend($containerBuilder);
     }
 
-    public function testPrependWhenNotEnabled()
+    public function testPrependWhenNotEnabled(): void
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([0 => ['serializer' => []]])->shouldBeCalled();
@@ -172,7 +172,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->prepend($containerBuilder);
     }
 
-    public function testPrependWhenNameConverterIsConfigured()
+    public function testPrependWhenNameConverterIsConfigured(): void
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([0 => ['serializer' => ['enabled' => true, 'name_converter' => 'foo'], 'property_info' => ['enabled' => false]]]);
@@ -181,7 +181,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->prepend($containerBuilderProphecy->reveal());
     }
 
-    public function testNotPrependWhenNameConverterIsNotConfigured()
+    public function testNotPrependWhenNameConverterIsNotConfigured(): void
     {
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([0 => ['serializer' => ['enabled' => true], 'property_info' => ['enabled' => false]]])->shouldBeCalled();
@@ -190,7 +190,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->prepend($containerBuilderProphecy->reveal());
     }
 
-    public function testLoadDefaultConfig()
+    public function testLoadDefaultConfig(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilder = $containerBuilderProphecy->reveal();
@@ -198,7 +198,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(self::DEFAULT_CONFIG, $containerBuilder);
     }
 
-    public function testSetNameConverter()
+    public function testSetNameConverter(): void
     {
         $nameConverterId = 'test.name_converter';
 
@@ -209,7 +209,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['name_converter' => $nameConverterId]]), $containerBuilder);
     }
 
-    public function testEnableFosUser()
+    public function testEnableFosUser(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
@@ -222,7 +222,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['enable_fos_user' => true]]), $containerBuilder);
     }
 
-    public function testFosUserPriority()
+    public function testFosUserPriority(): void
     {
         $builder = new ContainerBuilder();
 
@@ -245,7 +245,7 @@ class ApiPlatformExtensionTest extends TestCase
      * @group legacy
      * @expectedDeprecation Enabling the NelmioApiDocBundle integration has been deprecated in 2.2 and will be removed in 3.0. NelmioApiDocBundle 3 has native support for API Platform.
      */
-    public function testEnableNelmioApiDoc()
+    public function testEnableNelmioApiDoc(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
@@ -259,7 +259,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['enable_nelmio_api_doc' => true]]), $containerBuilder);
     }
 
-    public function testDisableGraphql()
+    public function testDisableGraphql(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setDefinition('api_platform.action.graphql_entrypoint')->shouldNotBeCalled();
@@ -277,7 +277,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['graphql' => ['enabled' => false]]]), $containerBuilder);
     }
 
-    public function testEnableSecurity()
+    public function testEnableSecurity(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
@@ -293,7 +293,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(self::DEFAULT_CONFIG, $containerBuilder);
     }
 
-    public function testAddResourceClassDirectories()
+    public function testAddResourceClassDirectories(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->getParameter('api_platform.resource_class_directories')->shouldBeCalled()->willReturn([]);
@@ -315,7 +315,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['resource_class_directories' => ['foobar']]]), $containerBuilder);
     }
 
-    public function testResourcesToWatchWithUnsupportedMappingType()
+    public function testResourcesToWatchWithUnsupportedMappingType(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageRegExp('/Unsupported mapping type in ".+", supported types are XML & Yaml\\./');
@@ -326,7 +326,7 @@ class ApiPlatformExtensionTest extends TestCase
         );
     }
 
-    public function testResourcesToWatchWithNonExistentFile()
+    public function testResourcesToWatchWithNonExistentFile(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not open file or directory "fake_file.xml".');
@@ -337,7 +337,7 @@ class ApiPlatformExtensionTest extends TestCase
         );
     }
 
-    public function testDisableEagerLoadingExtension()
+    public function testDisableEagerLoadingExtension(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setParameter('api_platform.eager_loading.enabled', false)->shouldBeCalled();
@@ -349,7 +349,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load(array_merge_recursive(self::DEFAULT_CONFIG, ['api_platform' => ['eager_loading' => ['enabled' => false]]]), $containerBuilder);
     }
 
-    public function testNotRegisterHttpCacheWhenEnabledWithNoVarnishServer()
+    public function testNotRegisterHttpCacheWhenEnabledWithNoVarnishServer(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilder = $containerBuilderProphecy->reveal();
@@ -360,7 +360,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load($config, $containerBuilder);
     }
 
-    public function testRegisterHttpCacheWhenEnabledWithNoRequestOption()
+    public function testRegisterHttpCacheWhenEnabledWithNoRequestOption(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilder = $containerBuilderProphecy->reveal();
@@ -371,7 +371,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load($config, $containerBuilder);
     }
 
-    public function testDisabledDocsRemovesAddLinkHeaderService()
+    public function testDisabledDocsRemovesAddLinkHeaderService(): void
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->removeDefinition('api_platform.hydra.listener.response.add_link_header')->shouldBeCalled();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
@@ -35,7 +35,7 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class AnnotationFilterPassTest extends TestCase
 {
-    public function testProcess()
+    public function testProcess(): void
     {
         $annotationFilterPass = new AnnotationFilterPass();
 
@@ -98,7 +98,7 @@ class AnnotationFilterPassTest extends TestCase
         $annotationFilterPass->process($containerBuilderProphecy->reveal());
     }
 
-    public function testProcessWrongFilter()
+    public function testProcessWrongFilter(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The filter class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Doctrine\\Orm\\Filter\\AnotherDummyFilter" does not implement "ApiPlatform\\Core\\Api\\FilterInterface".');
@@ -132,7 +132,7 @@ class AnnotationFilterPassTest extends TestCase
         $annotationFilterPass->process($containerBuilderProphecy->reveal());
     }
 
-    public function testProcessExistingFilter()
+    public function testProcessExistingFilter(): void
     {
         $annotationFilterPass = new AnnotationFilterPass();
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/FilterPassTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class FilterPassTest extends TestCase
 {
-    public function testProcess()
+    public function testProcess(): void
     {
         $filterPass = new FilterPass();
 
@@ -48,7 +48,7 @@ class FilterPassTest extends TestCase
         $filterPass->process($containerBuilderProphecy->reveal());
     }
 
-    public function testIdNotExist()
+    public function testIdNotExist(): void
     {
         $filterPass = new FilterPass();
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -41,13 +41,13 @@ class ConfigurationTest extends TestCase
      */
     private $processor;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->configuration = new Configuration();
         $this->processor = new Processor();
     }
 
-    public function testDefaultConfig()
+    public function testDefaultConfig(): void
     {
         $treeBuilder = $this->configuration->getConfigTreeBuilder();
         $config = $this->processor->processConfiguration($this->configuration, ['api_platform' => ['title' => 'title', 'description' => 'description', 'version' => '1.0.0']]);
@@ -151,7 +151,7 @@ class ConfigurationTest extends TestCase
      * @group legacy
      * @expectedDeprecation Using a string "HTTP_INTERNAL_SERVER_ERROR" as a constant of the "Symfony\Component\HttpFoundation\Response" class is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3. Use the Symfony's custom YAML extension for PHP constants instead (i.e. "!php/const:Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR").
      */
-    public function testLegacyExceptionToStatusConfig()
+    public function testLegacyExceptionToStatusConfig(): void
     {
         $config = $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [
@@ -173,7 +173,7 @@ class ConfigurationTest extends TestCase
      * @group legacy
      * @expectedDeprecation The use of the `default_operation_path_resolver` has been deprecated in 2.1 and will be removed in 3.0. Use `path_segment_name_generator` instead.
      */
-    public function testLegacyDefaultOperationPathResolver()
+    public function testLegacyDefaultOperationPathResolver(): void
     {
         $config = $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [
@@ -197,7 +197,7 @@ class ConfigurationTest extends TestCase
     /**
      * @dataProvider invalidHttpStatusCodeProvider
      */
-    public function testExceptionToStatusConfigWithInvalidHttpStatusCode($invalidHttpStatusCode)
+    public function testExceptionToStatusConfigWithInvalidHttpStatusCode($invalidHttpStatusCode): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessageRegExp('/The HTTP status code ".+" is not valid\\./');
@@ -226,7 +226,7 @@ class ConfigurationTest extends TestCase
     /**
      * @dataProvider invalidHttpStatusCodeValueProvider
      */
-    public function testExceptionToStatusConfigWithInvalidHttpStatusCodeValue($invalidHttpStatusCodeValue)
+    public function testExceptionToStatusConfigWithInvalidHttpStatusCodeValue($invalidHttpStatusCodeValue): void
     {
         $this->expectException(InvalidTypeException::class);
         $this->expectExceptionMessageRegExp('/Invalid type for path "api_platform\\.exception_to_status\\.Exception". Expected int, but got .+\\./');
@@ -243,7 +243,7 @@ class ConfigurationTest extends TestCase
     /**
      * Test config for api keys.
      */
-    public function testApiKeysConfig()
+    public function testApiKeysConfig(): void
     {
         $exampleConfig = [
                 'name' => 'Authorization',
@@ -265,7 +265,7 @@ class ConfigurationTest extends TestCase
     /**
      * Test config for empty title and description.
      */
-    public function testEmptyTitleDescriptionConfig()
+    public function testEmptyTitleDescriptionConfig(): void
     {
         $config = $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [],

--- a/tests/Bridge/Symfony/Bundle/EventListener/SwaggerUiListenerTest.php
+++ b/tests/Bridge/Symfony/Bundle/EventListener/SwaggerUiListenerTest.php
@@ -26,7 +26,7 @@ class SwaggerUiListenerTest extends TestCase
     /**
      * @dataProvider getParameters
      */
-    public function testOnKernelRequest(Request $request, string $controller = null)
+    public function testOnKernelRequest(Request $request, string $controller = null): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -43,7 +43,7 @@ use Symfony\Component\Routing\Route;
  */
 class ApiLoaderTest extends TestCase
 {
-    public function testApiLoader()
+    public function testApiLoader(): void
     {
         $resourceMetadata = new ResourceMetadata();
         $resourceMetadata = $resourceMetadata->withShortName('dummy');
@@ -98,7 +98,7 @@ class ApiLoaderTest extends TestCase
         );
     }
 
-    public function testApiLoaderWithPrefix()
+    public function testApiLoaderWithPrefix(): void
     {
         $resourceMetadata = new ResourceMetadata();
         $resourceMetadata = $resourceMetadata->withShortName('dummy');
@@ -127,7 +127,7 @@ class ApiLoaderTest extends TestCase
         );
     }
 
-    public function testNoMethodApiLoader()
+    public function testNoMethodApiLoader(): void
     {
         $this->expectException(\RuntimeException::class);
 
@@ -145,7 +145,7 @@ class ApiLoaderTest extends TestCase
         $this->getApiLoaderWithResourceMetadata($resourceMetadata)->load(null);
     }
 
-    public function testWrongMethodApiLoader()
+    public function testWrongMethodApiLoader(): void
     {
         $this->expectException(\RuntimeException::class);
 
@@ -163,14 +163,14 @@ class ApiLoaderTest extends TestCase
         $this->getApiLoaderWithResourceMetadata($resourceMetadata)->load(null);
     }
 
-    public function testNoShortNameApiLoader()
+    public function testNoShortNameApiLoader(): void
     {
         $this->expectException(InvalidResourceException::class);
 
         $this->getApiLoaderWithResourceMetadata(new ResourceMetadata())->load(null);
     }
 
-    public function testRecursiveSubresource()
+    public function testRecursiveSubresource(): void
     {
         $resourceMetadata = new ResourceMetadata();
         $resourceMetadata = $resourceMetadata->withShortName('dummy');

--- a/tests/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
@@ -28,7 +28,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedRouteNameResolverTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $cacheItemPoolProphecy = $this->prophesize(CacheItemPoolInterface::class);
 
@@ -39,7 +39,7 @@ class CachedRouteNameResolverTest extends TestCase
         $this->assertInstanceOf(RouteNameResolverInterface::class, $cachedRouteNameResolver);
     }
 
-    public function testGetRouteNameForItemRouteWithNoMatchingRoute()
+    public function testGetRouteNameForItemRouteWithNoMatchingRoute(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No item route associated with the type "AppBundle\\Entity\\User".');
@@ -60,7 +60,7 @@ class CachedRouteNameResolverTest extends TestCase
         $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM);
     }
 
-    public function testGetRouteNameForItemRouteOnCacheMiss()
+    public function testGetRouteNameForItemRouteOnCacheMiss(): void
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
         $cacheItemProphecy->isHit()->willReturn(false)->shouldBeCalledTimes(1);
@@ -79,7 +79,7 @@ class CachedRouteNameResolverTest extends TestCase
         $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', false), 'Trigger the local cache');
     }
 
-    public function testGetRouteNameForItemRouteOnCacheHit()
+    public function testGetRouteNameForItemRouteOnCacheHit(): void
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
         $cacheItemProphecy->isHit()->shouldBeCalledTimes(1)->willReturn(true);
@@ -98,7 +98,7 @@ class CachedRouteNameResolverTest extends TestCase
         $this->assertSame('some_item_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM), 'Trigger the local cache');
     }
 
-    public function testGetRouteNameForCollectionRouteWithNoMatchingRoute()
+    public function testGetRouteNameForCollectionRouteWithNoMatchingRoute(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No collection route associated with the type "AppBundle\\Entity\\User".');
@@ -119,7 +119,7 @@ class CachedRouteNameResolverTest extends TestCase
         $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::COLLECTION);
     }
 
-    public function testGetRouteNameForCollectionRouteOnCacheMiss()
+    public function testGetRouteNameForCollectionRouteOnCacheMiss(): void
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
         $cacheItemProphecy->isHit()->shouldBeCalledTimes(1)->willReturn(false);
@@ -138,7 +138,7 @@ class CachedRouteNameResolverTest extends TestCase
         $this->assertSame('some_collection_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', true), 'Trigger the local cache');
     }
 
-    public function testGetRouteNameForCollectionRouteOnCacheHit()
+    public function testGetRouteNameForCollectionRouteOnCacheHit(): void
     {
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
         $cacheItemProphecy->isHit()->willReturn(true)->shouldBeCalledTimes(1);
@@ -157,7 +157,7 @@ class CachedRouteNameResolverTest extends TestCase
         $this->assertSame('some_collection_route', $cachedRouteNameResolver->getRouteName('AppBundle\Entity\User', OperationType::COLLECTION), 'Trigger the local cache');
     }
 
-    public function testGetRouteNameWithCacheItemThrowsCacheException()
+    public function testGetRouteNameWithCacheItemThrowsCacheException(): void
     {
         $cacheException = $this->prophesize(CacheException::class);
         $cacheException->willExtend(\Exception::class);

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -39,7 +39,7 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class IriConverterTest extends TestCase
 {
-    public function testGetItemFromIriNoRouteException()
+    public function testGetItemFromIriNoRouteException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No route matches "/users/3".');
@@ -50,7 +50,7 @@ class IriConverterTest extends TestCase
         $converter->getItemFromIri('/users/3');
     }
 
-    public function testGetItemFromIriNoResourceException()
+    public function testGetItemFromIriNoResourceException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No resource associated to "/users/3".');
@@ -62,7 +62,7 @@ class IriConverterTest extends TestCase
         $converter->getItemFromIri('/users/3');
     }
 
-    public function testGetItemFromIriItemNotFoundException()
+    public function testGetItemFromIriItemNotFoundException(): void
     {
         $this->expectException(ItemNotFoundException::class);
         $this->expectExceptionMessage('Item not found for "/users/3".');
@@ -83,7 +83,7 @@ class IriConverterTest extends TestCase
         $converter->getItemFromIri('/users/3');
     }
 
-    public function testGetItemFromIri()
+    public function testGetItemFromIri(): void
     {
         $item = new \StdClass();
         $itemDataProviderProphecy = $this->prophesize(ItemDataProviderInterface::class);
@@ -100,7 +100,7 @@ class IriConverterTest extends TestCase
         $this->assertEquals($converter->getItemFromIri('/users/3', ['fetch_data' => true]), $item);
     }
 
-    public function testGetItemFromIriWithOperationName()
+    public function testGetItemFromIriWithOperationName(): void
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
 
@@ -124,7 +124,7 @@ class IriConverterTest extends TestCase
         $this->assertEquals($converter->getItemFromIri('/users/3', ['fetch_data' => true]), 'foo');
     }
 
-    public function testGetIriFromResourceClass()
+    public function testGetIriFromResourceClass(): void
     {
         $routeNameResolverProphecy = $this->prophesize(RouteNameResolverInterface::class);
         $routeNameResolverProphecy->getRouteName(Dummy::class, OperationType::COLLECTION)->willReturn('dummies');
@@ -136,7 +136,7 @@ class IriConverterTest extends TestCase
         $this->assertEquals($converter->getIriFromResourceClass(Dummy::class), '/dummies');
     }
 
-    public function testNotAbleToGenerateGetIriFromResourceClass()
+    public function testNotAbleToGenerateGetIriFromResourceClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to generate an IRI for "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy"');
@@ -151,7 +151,7 @@ class IriConverterTest extends TestCase
         $converter->getIriFromResourceClass(Dummy::class);
     }
 
-    public function testGetSubresourceIriFromResourceClass()
+    public function testGetSubresourceIriFromResourceClass(): void
     {
         $routeNameResolverProphecy = $this->prophesize(RouteNameResolverInterface::class);
         $routeNameResolverProphecy->getRouteName(Dummy::class, OperationType::SUBRESOURCE, Argument::type('array'))->willReturn('api_dummies_related_dummies_get_subresource');
@@ -163,7 +163,7 @@ class IriConverterTest extends TestCase
         $this->assertEquals($converter->getSubresourceIriFromResourceClass(Dummy::class, ['subresource_identifiers' => ['id' => 1], 'subresource_resources' => [RelatedDummy::class => 1]]), '/dummies/1/related_dummies');
     }
 
-    public function testNotAbleToGenerateGetSubresourceIriFromResourceClass()
+    public function testNotAbleToGenerateGetSubresourceIriFromResourceClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to generate an IRI for "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy"');
@@ -178,7 +178,7 @@ class IriConverterTest extends TestCase
         $converter->getSubresourceIriFromResourceClass(Dummy::class, ['subresource_identifiers' => ['id' => 1], 'subresource_resources' => [RelatedDummy::class => 1]]);
     }
 
-    public function testGetItemIriFromResourceClass()
+    public function testGetItemIriFromResourceClass(): void
     {
         $routeNameResolverProphecy = $this->prophesize(RouteNameResolverInterface::class);
         $routeNameResolverProphecy->getRouteName(Dummy::class, OperationType::ITEM)->willReturn('api_dummies_get_item');
@@ -190,7 +190,7 @@ class IriConverterTest extends TestCase
         $this->assertEquals($converter->getItemIriFromResourceClass(Dummy::class, ['id' => 1]), '/dummies/1');
     }
 
-    public function testNotAbleToGenerateGetItemIriFromResourceClass()
+    public function testNotAbleToGenerateGetItemIriFromResourceClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to generate an IRI for "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy"');
@@ -205,7 +205,7 @@ class IriConverterTest extends TestCase
         $converter->getItemIriFromResourceClass(Dummy::class, ['id' => 1]);
     }
 
-    public function testGetItemFromIriWithIdentifierDenormalizer()
+    public function testGetItemFromIriWithIdentifierDenormalizer(): void
     {
         $item = new \StdClass();
         $itemDataProviderProphecy = $this->prophesize(ItemDataProviderInterface::class);
@@ -223,7 +223,7 @@ class IriConverterTest extends TestCase
         $this->assertEquals($converter->getItemFromIri('/users/3', ['fetch_data' => true]), $item);
     }
 
-    public function testGetItemFromIriWithSubresourceDataProvider()
+    public function testGetItemFromIriWithSubresourceDataProvider(): void
     {
         $item = new \StdClass();
         $subresourceContext = ['identifiers' => [['id', Dummy::class, true]]];
@@ -242,7 +242,7 @@ class IriConverterTest extends TestCase
         $this->assertEquals($converter->getItemFromIri('/users/3/adresses', ['fetch_data' => true]), $item);
     }
 
-    public function testGetItemFromIriWithSubresourceDataProviderNotFound()
+    public function testGetItemFromIriWithSubresourceDataProviderNotFound(): void
     {
         $this->expectException(ItemNotFoundException::class);
         $this->expectExceptionMessage('Item not found for "/users/3/adresses".');
@@ -265,7 +265,7 @@ class IriConverterTest extends TestCase
         $converter->getItemFromIri('/users/3/adresses', ['fetch_data' => true]);
     }
 
-    public function testGetItemFromIriBadIdentifierException()
+    public function testGetItemFromIriBadIdentifierException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Item not found for "/users/3".');
@@ -290,7 +290,7 @@ class IriConverterTest extends TestCase
      * @expectedDeprecation Not injecting "ApiPlatform\Core\Api\IdentifiersExtractorInterface" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      * @expectedDeprecation Not injecting ApiPlatform\Core\Api\ResourceClassResolverInterface in the CachedIdentifiersExtractor might introduce cache issues with object identifiers.
      */
-    public function testLegacyConstructor()
+    public function testLegacyConstructor(): void
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);

--- a/tests/Bridge/Symfony/Routing/RouteNameGeneratorTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameGeneratorTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RouteNameGeneratorTest extends TestCase
 {
-    public function testGenerate()
+    public function testGenerate(): void
     {
         $this->assertEquals('api_foos_get_collection', RouteNameGenerator::generate('get', 'Foo', OperationType::COLLECTION));
         $this->assertEquals('api_bars_custom_operation_item', RouteNameGenerator::generate('custom_operation', 'Bar', OperationType::ITEM));
@@ -33,12 +33,12 @@ class RouteNameGeneratorTest extends TestCase
      * @group legacy
      * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
-    public function testLegacyGenerate()
+    public function testLegacyGenerate(): void
     {
         $this->assertEquals('api_foos_get_collection', RouteNameGenerator::generate('get', 'Foo', true));
     }
 
-    public function testGenerateWithSubresource()
+    public function testGenerateWithSubresource(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Subresource operations are not supported by the RouteNameGenerator.');

--- a/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class RouteNameResolverTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $routerProphecy = $this->prophesize(RouterInterface::class);
 
@@ -35,7 +35,7 @@ class RouteNameResolverTest extends TestCase
         $this->assertInstanceOf(RouteNameResolverInterface::class, $routeNameResolver);
     }
 
-    public function testGetRouteNameForItemRouteWithNoMatchingRoute()
+    public function testGetRouteNameForItemRouteWithNoMatchingRoute(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('No item route associated with the type "AppBundle\\Entity\\User".');
@@ -57,7 +57,7 @@ class RouteNameResolverTest extends TestCase
      * @group legacy
      * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
-    public function testGetRouteNameForItemRouteLegacy()
+    public function testGetRouteNameForItemRouteLegacy(): void
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add('some_collection_route', new Route('/some/collection/path', [
@@ -78,7 +78,7 @@ class RouteNameResolverTest extends TestCase
         $this->assertSame('some_item_route', $actual);
     }
 
-    public function testGetRouteNameForItemRoute()
+    public function testGetRouteNameForItemRoute(): void
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add('some_collection_route', new Route('/some/collection/path', [
@@ -99,7 +99,7 @@ class RouteNameResolverTest extends TestCase
         $this->assertSame('some_item_route', $actual);
     }
 
-    public function testGetRouteNameForCollectionRouteWithNoMatchingRoute()
+    public function testGetRouteNameForCollectionRouteWithNoMatchingRoute(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('No collection route associated with the type "AppBundle\\Entity\\User".');
@@ -121,7 +121,7 @@ class RouteNameResolverTest extends TestCase
      * @group legacy
      * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
-    public function testGetRouteNameForCollectionRouteLegacy()
+    public function testGetRouteNameForCollectionRouteLegacy(): void
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add('some_item_route', new Route('/some/item/path/{id}', [
@@ -142,7 +142,7 @@ class RouteNameResolverTest extends TestCase
         $this->assertSame('some_collection_route', $actual);
     }
 
-    public function testGetRouteNameForCollectionRoute()
+    public function testGetRouteNameForCollectionRoute(): void
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add('some_item_route', new Route('/some/item/path/{id}', [
@@ -163,7 +163,7 @@ class RouteNameResolverTest extends TestCase
         $this->assertSame('some_collection_route', $actual);
     }
 
-    public function testGetRouteNameForSubresourceRoute()
+    public function testGetRouteNameForSubresourceRoute(): void
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add('a_some_subresource_route', new Route('/a/some/item/path/{id}', [

--- a/tests/Bridge/Symfony/Routing/RouterOperationPathResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouterOperationPathResolverTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class RouterOperationPathResolverTest extends TestCase
 {
-    public function testResolveOperationPath()
+    public function testResolveOperationPath(): void
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add('foos', new Route('/foos'));
@@ -42,7 +42,7 @@ class RouterOperationPathResolverTest extends TestCase
         $this->assertEquals('/foos', $operationPathResolver->resolveOperationPath('Foo', ['route_name' => 'foos'], OperationType::COLLECTION, 'get'));
     }
 
-    public function testResolveOperationPathWithSubresource()
+    public function testResolveOperationPathWithSubresource(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Subresource operations are not supported by the RouterOperationPathResolver without a route name.');
@@ -54,7 +54,7 @@ class RouterOperationPathResolverTest extends TestCase
         $operationPathResolver->resolveOperationPath('Foo', ['property' => 'bar', 'collection' => true, 'resource_class' => 'Foo'], OperationType::SUBRESOURCE, 'get');
     }
 
-    public function testResolveOperationPathWithRouteNameGeneration()
+    public function testResolveOperationPathWithRouteNameGeneration(): void
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add(RouteNameGenerator::generate('get', 'Foo', OperationType::COLLECTION), new Route('/foos'));
@@ -67,7 +67,7 @@ class RouterOperationPathResolverTest extends TestCase
         $this->assertEquals('/foos', $operationPathResolver->resolveOperationPath('Foo', [], OperationType::COLLECTION, 'get'));
     }
 
-    public function testResolveOperationPathWithRouteNotFound()
+    public function testResolveOperationPathWithRouteNotFound(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The route "api_foos_get_collection" of the resource "Foo" was not found.');
@@ -84,7 +84,7 @@ class RouterOperationPathResolverTest extends TestCase
      * @expectedDeprecation Method ApiPlatform\Core\Bridge\Symfony\Routing\RouterOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
      * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
-    public function testLegacyResolveOperationPath()
+    public function testLegacyResolveOperationPath(): void
     {
         $operationPathResolverProphecy = $this->prophesize(OperationPathResolverInterface::class);
         $operationPathResolverProphecy->resolveOperationPath('Foo', [], OperationType::ITEM, null)->willReturn('/foos/{id}.{_format}')->shouldBeCalled();

--- a/tests/Bridge/Symfony/Routing/RouterTest.php
+++ b/tests/Bridge/Symfony/Routing/RouterTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class RouterTest extends TestCase
 {
-    public function testContextAccessor()
+    public function testContextAccessor(): void
     {
         $context = new RequestContext();
 
@@ -38,7 +38,7 @@ class RouterTest extends TestCase
         $this->assertSame($context, $router->getContext());
     }
 
-    public function testGetRouteCollection()
+    public function testGetRouteCollection(): void
     {
         $routeCollection = new RouteCollection();
 
@@ -49,7 +49,7 @@ class RouterTest extends TestCase
         $this->assertSame($routeCollection, $router->getRouteCollection());
     }
 
-    public function testGenerate()
+    public function testGenerate(): void
     {
         $mockedRouter = $this->prophesize('Symfony\Component\Routing\RouterInterface');
         $mockedRouter->generate('foo', [], RouterInterface::ABSOLUTE_PATH)->willReturn('/bar')->shouldBeCalled();
@@ -58,7 +58,7 @@ class RouterTest extends TestCase
         $this->assertSame('/bar', $router->generate('foo'));
     }
 
-    public function testMatch()
+    public function testMatch(): void
     {
         $context = new RequestContext('/app_dev.php', 'GET', 'localhost', 'https');
 

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
@@ -34,7 +34,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class ValidateListenerTest extends TestCase
 {
-    public function testNotAnApiPlatformRequest()
+    public function testNotAnApiPlatformRequest(): void
     {
         $validatorProphecy = $this->prophesize(ValidatorInterface::class);
         $validatorProphecy->validate()->shouldNotBeCalled();
@@ -54,7 +54,7 @@ class ValidateListenerTest extends TestCase
         $listener->onKernelView($event->reveal());
     }
 
-    public function testValidatorIsCalled()
+    public function testValidatorIsCalled(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['a', 'b', 'c'];
@@ -73,7 +73,7 @@ class ValidateListenerTest extends TestCase
         $validationViewListener->onKernelView($event);
     }
 
-    public function testGetGroupsFromCallable()
+    public function testGetGroupsFromCallable(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['a', 'b', 'c'];
@@ -93,7 +93,7 @@ class ValidateListenerTest extends TestCase
         $validationViewListener->onKernelView($event);
     }
 
-    public function testGetGroupsFromService()
+    public function testGetGroupsFromService(): void
     {
         $data = new DummyEntity();
 
@@ -118,7 +118,7 @@ class ValidateListenerTest extends TestCase
         $validationViewListener->onKernelView($event);
     }
 
-    public function testValidatorWithScalarGroup()
+    public function testValidatorWithScalarGroup(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['foo'];
@@ -136,7 +136,7 @@ class ValidateListenerTest extends TestCase
         $validationViewListener->onKernelView($event);
     }
 
-    public function testDoNotCallWhenReceiveFlagIsFalse()
+    public function testDoNotCallWhenReceiveFlagIsFalse(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['a', 'b', 'c'];
@@ -151,7 +151,7 @@ class ValidateListenerTest extends TestCase
         $validationViewListener->onKernelView($event);
     }
 
-    public function testThrowsValidationExceptionWithViolationsFound()
+    public function testThrowsValidationExceptionWithViolationsFound(): void
     {
         $this->expectException(ValidationException::class);
 

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidationExceptionListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidationExceptionListenerTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
  */
 class ValidationExceptionListenerTest extends TestCase
 {
-    public function testNotValidationException()
+    public function testNotValidationException(): void
     {
         $eventProphecy = $this->prophesize(GetResponseForExceptionEvent::class);
         $eventProphecy->getException()->willReturn(new \Exception())->shouldBeCalled();
@@ -39,7 +39,7 @@ class ValidationExceptionListenerTest extends TestCase
         $listener->onKernelException($eventProphecy->reveal());
     }
 
-    public function testValidationException()
+    public function testValidationException(): void
     {
         $list = new ConstraintViolationList([]);
 

--- a/tests/Bridge/Symfony/Validator/Exception/ValidationExceptionTest.php
+++ b/tests/Bridge/Symfony/Validator/Exception/ValidationExceptionTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
  */
 class ValidationExceptionTest extends TestCase
 {
-    public function testToString()
+    public function testToString(): void
     {
         $e = new ValidationException(new ConstraintViolationList([
             new ConstraintViolation('message 1', '', [], '', '', 'invalid'),

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -30,13 +30,13 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
 {
     private $validatorClassMetadata;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->validatorClassMetadata = new ClassMetadata(DummyValidatedEntity::class);
         (new AnnotationLoader(new AnnotationReader()))->loadClassMetadata($this->validatorClassMetadata);
     }
 
-    public function testCreateWithPropertyWithRequiredConstraints()
+    public function testCreateWithPropertyWithRequiredConstraints(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy', true, true, null, null, null, false);
         $expectedPropertyMetadata = $propertyMetadata->withRequired(true);
@@ -54,7 +54,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
     }
 
-    public function testCreateWithPropertyWithNotRequiredConstraints()
+    public function testCreateWithPropertyWithNotRequiredConstraints(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy date', true, true, null, null, null, false);
         $expectedPropertyMetadata = $propertyMetadata->withRequired(false);
@@ -72,7 +72,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
     }
 
-    public function testCreateWithPropertyWithoutConstraints()
+    public function testCreateWithPropertyWithoutConstraints(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy id', true, true, null, null, null, true);
         $expectedPropertyMetadata = $propertyMetadata->withRequired(false);
@@ -90,7 +90,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
     }
 
-    public function testCreateWithPropertyWithRightValidationGroupsAndRequiredConstraints()
+    public function testCreateWithPropertyWithRightValidationGroupsAndRequiredConstraints(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy group', true, true, null, null, null, false);
         $expectedPropertyMetadata = $propertyMetadata->withRequired(true);
@@ -108,7 +108,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
     }
 
-    public function testCreateWithPropertyWithBadValidationGroupsAndRequiredConstraints()
+    public function testCreateWithPropertyWithBadValidationGroupsAndRequiredConstraints(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy group', true, true, null, null, null, false);
         $expectedPropertyMetadata = $propertyMetadata->withRequired(false);
@@ -126,7 +126,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
     }
 
-    public function testCreateWithPropertyWithNonStringValidationGroupsAndRequiredConstraints()
+    public function testCreateWithPropertyWithNonStringValidationGroupsAndRequiredConstraints(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy group', true, true, null, null, null, false);
         $expectedPropertyMetadata = $propertyMetadata->withRequired(false);
@@ -144,7 +144,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
     }
 
-    public function testCreateWithRequiredByDecorated()
+    public function testCreateWithRequiredByDecorated(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy date', true, true, null, null, true, false);
         $expectedPropertyMetadata = clone $propertyMetadata;

--- a/tests/Bridge/Symfony/Validator/ValidatorTest.php
+++ b/tests/Bridge/Symfony/Validator/ValidatorTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface as SymfonyValidator
  */
 class ValidatorTest extends TestCase
 {
-    public function testValid()
+    public function testValid(): void
     {
         $data = new DummyEntity();
 
@@ -39,7 +39,7 @@ class ValidatorTest extends TestCase
         $validator->validate(new DummyEntity());
     }
 
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $this->expectException(ValidationException::class);
 
@@ -58,7 +58,7 @@ class ValidatorTest extends TestCase
         $validator->validate(new DummyEntity());
     }
 
-    public function testGetGroupsFromCallable()
+    public function testGetGroupsFromCallable(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['a', 'b', 'c'];
@@ -74,7 +74,7 @@ class ValidatorTest extends TestCase
         }]);
     }
 
-    public function testGetGroupsFromService()
+    public function testGetGroupsFromService(): void
     {
         $data = new DummyEntity();
 
@@ -97,7 +97,7 @@ class ValidatorTest extends TestCase
         $validator->validate(new DummyEntity(), ['groups' => 'groups_builder']);
     }
 
-    public function testValidatorWithScalarGroup()
+    public function testValidatorWithScalarGroup(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['foo'];

--- a/tests/DataPersister/ChainDataPersisterTest.php
+++ b/tests/DataPersister/ChainDataPersisterTest.php
@@ -23,12 +23,12 @@ use PHPUnit\Framework\TestCase;
  */
 class ChainDataPersisterTest extends TestCase
 {
-    public function testContruct()
+    public function testContruct(): void
     {
         $this->assertInstanceOf(DataPersisterInterface::class, new ChainDataPersister([$this->prophesize(DataPersisterInterface::class)->reveal()]));
     }
 
-    public function testSupports()
+    public function testSupports(): void
     {
         $dummy = new Dummy();
 
@@ -38,7 +38,7 @@ class ChainDataPersisterTest extends TestCase
         $this->assertTrue((new ChainDataPersister([$persisterProphecy->reveal()]))->supports($dummy));
     }
 
-    public function testDoesNotSupport()
+    public function testDoesNotSupport(): void
     {
         $dummy = new Dummy();
 
@@ -48,7 +48,7 @@ class ChainDataPersisterTest extends TestCase
         $this->assertFalse((new ChainDataPersister([$persisterProphecy->reveal()]))->supports($dummy));
     }
 
-    public function testPersist()
+    public function testPersist(): void
     {
         $dummy = new Dummy();
 
@@ -63,7 +63,7 @@ class ChainDataPersisterTest extends TestCase
         (new ChainDataPersister([$fooPersisterProphecy->reveal(), $barPersisterProphecy->reveal()]))->persist($dummy);
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $dummy = new Dummy();
 

--- a/tests/DataProvider/ChainCollectionDataProviderTest.php
+++ b/tests/DataProvider/ChainCollectionDataProviderTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ChainCollectionDataProviderTest extends TestCase
 {
-    public function testGetCollection()
+    public function testGetCollection(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Rosa');
@@ -61,7 +61,7 @@ class ChainCollectionDataProviderTest extends TestCase
         );
     }
 
-    public function testGetCollectionNotSupported()
+    public function testGetCollectionNotSupported(): void
     {
         $firstDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
@@ -77,7 +77,7 @@ class ChainCollectionDataProviderTest extends TestCase
      * @group legacy
      * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" in a data provider is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
      */
-    public function testLegacyGetCollection()
+    public function testLegacyGetCollection(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Rosa');
@@ -102,7 +102,7 @@ class ChainCollectionDataProviderTest extends TestCase
      * @group legacy
      * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" in a data provider is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
      */
-    public function testLegacyGetCollectionExceptions()
+    public function testLegacyGetCollectionExceptions(): void
     {
         $firstDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $firstDataProvider->getCollection('notfound', 'op', [])->willThrow(ResourceClassNotSupportedException::class);
@@ -113,7 +113,7 @@ class ChainCollectionDataProviderTest extends TestCase
         $this->assertEmpty($collection);
     }
 
-    public function testGetCollectionWithEmptyDataProviders()
+    public function testGetCollectionWithEmptyDataProviders(): void
     {
         $collection = (new ChainCollectionDataProvider([]))->getCollection(Dummy::class);
 

--- a/tests/DataProvider/ChainItemDataProviderTest.php
+++ b/tests/DataProvider/ChainItemDataProviderTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ChainItemDataProviderTest extends TestCase
 {
-    public function testGetItem()
+    public function testGetItem(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Lucie');
@@ -57,7 +57,7 @@ class ChainItemDataProviderTest extends TestCase
         $this->assertEquals($dummy, $chainItemDataProvider->getItem(Dummy::class, ['id' => 1]));
     }
 
-    public function testGetItemWithoutDenormalizedIdentifiers()
+    public function testGetItemWithoutDenormalizedIdentifiers(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Lucie');
@@ -85,7 +85,7 @@ class ChainItemDataProviderTest extends TestCase
         $this->assertEquals($dummy, $chainItemDataProvider->getItem(Dummy::class, ['id' => 1]));
     }
 
-    public function testGetItemExceptions()
+    public function testGetItemExceptions(): void
     {
         $firstDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $firstDataProvider->willImplement(RestrictedDataProviderInterface::class);
@@ -100,7 +100,7 @@ class ChainItemDataProviderTest extends TestCase
      * @group legacy
      * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
      */
-    public function testLegacyGetItem()
+    public function testLegacyGetItem(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Lucie');
@@ -123,7 +123,7 @@ class ChainItemDataProviderTest extends TestCase
      * @group legacy
      * @expectedDeprecation Receiving "$id" as non-array in an item data provider is deprecated in 2.3 in favor of implementing "ApiPlatform\Core\DataProvider\DenormalizedIdentifiersAwareItemDataProviderInterface".
      */
-    public function testLegacyGetItemWithoutDenormalizedIdentifiersAndCompositeIdentifier()
+    public function testLegacyGetItemWithoutDenormalizedIdentifiersAndCompositeIdentifier(): void
     {
         $dummy = new CompositePrimitiveItem('Lucie', 1984);
 
@@ -143,7 +143,7 @@ class ChainItemDataProviderTest extends TestCase
      * @group legacy
      * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
      */
-    public function testLegacyGetItemExceptions()
+    public function testLegacyGetItemExceptions(): void
     {
         $firstDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $firstDataProvider->getItem('notfound', 1, null, [])->willThrow(ResourceClassNotSupportedException::class);

--- a/tests/DataProvider/ChainSubresourcedataProviderTest.php
+++ b/tests/DataProvider/ChainSubresourcedataProviderTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ChainSubresourcedataProviderTest extends TestCase
 {
-    public function testGetSubresource()
+    public function testGetSubresource(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Rosa');
@@ -53,7 +53,7 @@ class ChainSubresourcedataProviderTest extends TestCase
         $this->assertEquals([$dummy, $dummy2], $chainSubresourceDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get'));
     }
 
-    public function testGetSubresourceExceptionsItem()
+    public function testGetSubresourceExceptionsItem(): void
     {
         $context = ['collection' => false];
         $firstDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
@@ -65,7 +65,7 @@ class ChainSubresourcedataProviderTest extends TestCase
         $this->assertNull($chainSubresourceDataProvider->getSubresource(Dummy::class, ['id' => 1], $context, 'get'));
     }
 
-    public function testGetSubresourceExceptionsCollection()
+    public function testGetSubresourceExceptionsCollection(): void
     {
         $context = ['collection' => true];
         $firstDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
@@ -81,7 +81,7 @@ class ChainSubresourcedataProviderTest extends TestCase
      * @group legacy
      * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" in a data provider is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
      */
-    public function testLegacyGetSubresource()
+    public function testLegacyGetSubresource(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Rosa');
@@ -107,7 +107,7 @@ class ChainSubresourcedataProviderTest extends TestCase
      * @group legacy
      * @expectedDeprecation Throwing a "ApiPlatform\Core\Exception\ResourceClassNotSupportedException" in a data provider is deprecated in favor of implementing "ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface"
      */
-    public function testLegacyGetCollectionExeptions()
+    public function testLegacyGetCollectionExeptions(): void
     {
         $firstDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
         $firstDataProvider->getSubresource('notfound', ['id' => 1], [], 'get')->willThrow(ResourceClassNotSupportedException::class);

--- a/tests/Documentation/Action/DocumentationActionTest.php
+++ b/tests/Documentation/Action/DocumentationActionTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class DocumentationActionTest extends TestCase
 {
-    public function testDocumentationAction()
+    public function testDocumentationAction(): void
     {
         $requestProphecy = $this->prophesize(Request::class);
         $attributesProphecy = $this->prophesize(ParameterBagInterface::class);
@@ -54,14 +54,14 @@ class DocumentationActionTest extends TestCase
      * @group legacy
      * @expectedDeprecation Using an array as formats provider is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3
      */
-    public function testDocumentationActionFormatDeprecation()
+    public function testDocumentationActionFormatDeprecation(): void
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection(['dummies']));
         new DocumentationAction($resourceNameCollectionFactoryProphecy->reveal(), '', '', '', ['formats' => ['jsonld' => 'application/ld+json']]);
     }
 
-    public function testDocumentationActionThrowsOnBadFormatArgument()
+    public function testDocumentationActionThrowsOnBadFormatArgument(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$formatsProvider" argument is expected to be an implementation of the "ApiPlatform\\Core\\Api\\FormatsProviderInterface" interface.');

--- a/tests/EventListener/AddFormatListenerTest.php
+++ b/tests/EventListener/AddFormatListenerTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class AddFormatListenerTest extends TestCase
 {
-    public function testNoResourceClass()
+    public function testNoResourceClass(): void
     {
         $request = new Request();
 
@@ -44,7 +44,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertNull($request->getFormat('application/vnd.notexist'));
     }
 
-    public function testSupportedRequestFormat()
+    public function testSupportedRequestFormat(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->setRequestFormat('xml');
@@ -63,7 +63,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertSame('text/xml', $request->getMimeType($request->getRequestFormat()));
     }
 
-    public function testRespondFlag()
+    public function testRespondFlag(): void
     {
         $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('xml');
@@ -82,7 +82,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertSame('text/xml', $request->getMimeType($request->getRequestFormat()));
     }
 
-    public function testUnsupportedRequestFormat()
+    public function testUnsupportedRequestFormat(): void
     {
         $this->expectException(NotAcceptableHttpException::class);
         $this->expectExceptionMessage('Requested format "text/xml" is not supported. Supported MIME types are "application/json".');
@@ -102,7 +102,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertSame('json', $request->getRequestFormat());
     }
 
-    public function testSupportedAcceptHeader()
+    public function testSupportedAcceptHeader(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml, application/json;q=0.9, */*;q=0.8');
@@ -120,7 +120,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertSame('json', $request->getRequestFormat());
     }
 
-    public function testAcceptAllHeader()
+    public function testAcceptAllHeader(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8');
@@ -139,7 +139,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertSame('application/octet-stream', $request->getMimeType($request->getRequestFormat()));
     }
 
-    public function testUnsupportedAcceptHeader()
+    public function testUnsupportedAcceptHeader(): void
     {
         $this->expectException(NotAcceptableHttpException::class);
         $this->expectExceptionMessage('Requested format "text/html, application/xhtml+xml, application/xml;q=0.9" is not supported. Supported MIME types are "application/octet-stream", "application/json".');
@@ -158,7 +158,7 @@ class AddFormatListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    public function testInvalidAcceptHeader()
+    public function testInvalidAcceptHeader(): void
     {
         $this->expectException(NotAcceptableHttpException::class);
         $this->expectExceptionMessage('Requested format "invalid" is not supported. Supported MIME types are "application/json".');
@@ -177,7 +177,7 @@ class AddFormatListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    public function testAcceptHeaderTakePrecedenceOverRequestFormat()
+    public function testAcceptHeaderTakePrecedenceOverRequestFormat(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo']);
         $request->headers->set('Accept', 'application/json');
@@ -196,7 +196,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertSame('json', $request->getRequestFormat());
     }
 
-    public function testInvalidRouteFormat()
+    public function testInvalidRouteFormat(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Format "invalid" is not supported');
@@ -214,7 +214,7 @@ class AddFormatListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    public function testResourceClassSupportedRequestFormat()
+    public function testResourceClassSupportedRequestFormat(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get']);
         $request->setRequestFormat('csv');
@@ -233,7 +233,7 @@ class AddFormatListenerTest extends TestCase
         $this->assertSame('text/csv', $request->getMimeType($request->getRequestFormat()));
     }
 
-    public function testBadFormatsProviderParameterThrowsException()
+    public function testBadFormatsProviderParameterThrowsException(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$formatsProvider" argument is expected to be an implementation of the "ApiPlatform\\Core\\Api\\FormatsProviderInterface" interface.');
@@ -245,7 +245,7 @@ class AddFormatListenerTest extends TestCase
      * @group legacy
      * @expectedDeprecation Using an array as formats provider is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3
      */
-    public function testLegacyFormatsParameter()
+    public function testLegacyFormatsParameter(): void
     {
         new AddFormatListener(new Negotiator(), ['xml' => ['text/xml']]);
     }

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -31,7 +31,7 @@ class DeserializeListenerTest extends TestCase
 {
     const FORMATS = ['json' => ['application/json']];
 
-    public function testDoNotCallWhenRequestMethodIsSafe()
+    public function testDoNotCallWhenRequestMethodIsSafe(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -55,7 +55,7 @@ class DeserializeListenerTest extends TestCase
     /**
      * @dataProvider allowedEmptyRequestMethodsProvider
      */
-    public function testDoNotCallWhenSendingAndEmptyRequestContent($method)
+    public function testDoNotCallWhenSendingAndEmptyRequestContent($method): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -82,7 +82,7 @@ class DeserializeListenerTest extends TestCase
         return [['PUT'], ['POST']];
     }
 
-    public function testDoNotCallWhenRequestNotManaged()
+    public function testDoNotCallWhenRequestNotManaged(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -103,7 +103,7 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testDoNotCallWhenReceiveFlagIsFalse()
+    public function testDoNotCallWhenReceiveFlagIsFalse(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -127,7 +127,7 @@ class DeserializeListenerTest extends TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function testDeserialize(string $method, bool $populateObject)
+    public function testDeserialize(string $method, bool $populateObject): void
     {
         $result = $populateObject ? new \stdClass() : null;
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -154,7 +154,7 @@ class DeserializeListenerTest extends TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function testDeserializeResourceClassSupportedFormat(string $method, bool $populateObject)
+    public function testDeserializeResourceClassSupportedFormat(string $method, bool $populateObject): void
     {
         $result = $populateObject ? new \stdClass() : null;
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -184,7 +184,7 @@ class DeserializeListenerTest extends TestCase
         return [['POST', false], ['PUT', true]];
     }
 
-    public function testContentNegotiation()
+    public function testContentNegotiation(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -211,7 +211,7 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testNotSupportedContentType()
+    public function testNotSupportedContentType(): void
     {
         $this->expectException(NotAcceptableHttpException::class);
         $this->expectExceptionMessage('The content-type "application/rdf+xml" is not supported. Supported MIME types are "application/ld+json", "text/xml".');
@@ -241,7 +241,7 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testNoContentType()
+    public function testNoContentType(): void
     {
         $this->expectException(NotAcceptableHttpException::class);
         $this->expectExceptionMessage('The "Content-Type" header must exist.');
@@ -270,7 +270,7 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testBadFormatsProviderParameterThrowsException()
+    public function testBadFormatsProviderParameterThrowsException(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$formatsProvider" argument is expected to be an implementation of the "ApiPlatform\\Core\\Api\\FormatsProviderInterface" interface.');
@@ -292,7 +292,7 @@ class DeserializeListenerTest extends TestCase
      * @group legacy
      * @expectedDeprecation Using an array as formats provider is deprecated since API Platform 2.3 and will not be possible anymore in API Platform 3
      */
-    public function testLegacyFormatsParameter()
+    public function testLegacyFormatsParameter(): void
     {
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->deserialize()->shouldNotBeCalled();

--- a/tests/EventListener/EventPrioritiesTest.php
+++ b/tests/EventListener/EventPrioritiesTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EventPrioritiesTest extends TestCase
 {
-    public function testConstants()
+    public function testConstants(): void
     {
         $this->assertEquals(5, EventPriorities::PRE_READ);
         $this->assertEquals(3, EventPriorities::POST_READ);

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -29,7 +29,7 @@ class ExceptionListenerTest extends TestCase
     /**
      * @dataProvider getRequest
      */
-    public function testOnKernelException(Request $request)
+    public function testOnKernelException(Request $request): void
     {
         $kernel = $this->prophesize(HttpKernelInterface::class);
         $kernel->handle(Argument::type(Request::class), HttpKernelInterface::SUB_REQUEST, false)->willReturn(new Response())->shouldBeCalled();
@@ -52,7 +52,7 @@ class ExceptionListenerTest extends TestCase
         ];
     }
 
-    public function testDoNothingWhenNotAnApiCall()
+    public function testDoNothingWhenNotAnApiCall(): void
     {
         $eventProphecy = $this->prophesize(GetResponseForExceptionEvent::class);
         $eventProphecy->getRequest()->willReturn(new Request())->shouldBeCalled();
@@ -61,7 +61,7 @@ class ExceptionListenerTest extends TestCase
         $listener->onKernelException($eventProphecy->reveal());
     }
 
-    public function testDoNothingWhenHtmlRequested()
+    public function testDoNothingWhenHtmlRequested(): void
     {
         $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('html');

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ReadListenerTest extends TestCase
 {
-    public function testNotAnApiPlatformRequest()
+    public function testNotAnApiPlatformRequest(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
 
@@ -54,7 +54,7 @@ class ReadListenerTest extends TestCase
     /**
      * @group legacy
      */
-    public function testLegacyConstructor()
+    public function testLegacyConstructor(): void
     {
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
         $collectionDataProvider->getCollection()->shouldNotBeCalled();
@@ -72,7 +72,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
     }
 
-    public function testDoNotCallWhenReceiveFlagIsFalse()
+    public function testDoNotCallWhenReceiveFlagIsFalse(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
 
@@ -95,7 +95,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
     }
 
-    public function testRetrieveCollectionPost()
+    public function testRetrieveCollectionPost(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
 
@@ -121,7 +121,7 @@ class ReadListenerTest extends TestCase
         $this->assertNull($request->attributes->get('data'));
     }
 
-    public function testRetrieveCollectionGet()
+    public function testRetrieveCollectionGet(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
 
@@ -146,7 +146,7 @@ class ReadListenerTest extends TestCase
         $this->assertSame([], $request->attributes->get('data'));
     }
 
-    public function testRetrieveItem()
+    public function testRetrieveItem(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
         $identifierDenormalizer->denormalize('1', 'Foo')->shouldBeCalled()->willReturn(['id' => '1']);
@@ -173,7 +173,7 @@ class ReadListenerTest extends TestCase
         $this->assertSame($data, $request->attributes->get('data'));
     }
 
-    public function testRetrieveItemNoIdentifier()
+    public function testRetrieveItemNoIdentifier(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -198,7 +198,7 @@ class ReadListenerTest extends TestCase
         $request->attributes->get('data');
     }
 
-    public function testRetrieveSubresource()
+    public function testRetrieveSubresource(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
         $identifierDenormalizer->denormalize('1', 'Bar')->shouldBeCalled()->willReturn(['id' => '1']);
@@ -225,7 +225,7 @@ class ReadListenerTest extends TestCase
         $this->assertSame($data, $request->attributes->get('data'));
     }
 
-    public function testRetrieveSubresourceNoDataProvider()
+    public function testRetrieveSubresourceNoDataProvider(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -247,7 +247,7 @@ class ReadListenerTest extends TestCase
         $request->attributes->get('data');
     }
 
-    public function testRetrieveSubresourceNotFound()
+    public function testRetrieveSubresourceNotFound(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
         $identifierDenormalizer->denormalize('1', 'Bar')->willThrow(new InvalidIdentifierException())->shouldBeCalled();
@@ -269,7 +269,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
     }
 
-    public function testRetrieveItemNotFound()
+    public function testRetrieveItemNotFound(): void
     {
         $identifierDenormalizer = $this->prophesize(ChainIdentifierDenormalizer::class);
         $identifierDenormalizer->denormalize('22', 'Foo')->shouldBeCalled()->willReturn(['id' => 22]);
@@ -292,7 +292,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
     }
 
-    public function testRetrieveBadItemNormalizedIdentifiers()
+    public function testRetrieveBadItemNormalizedIdentifiers(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -313,7 +313,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
     }
 
-    public function testRetrieveBadSubresourceNormalizedIdentifiers()
+    public function testRetrieveBadSubresourceNormalizedIdentifiers(): void
     {
         $this->expectException(NotFoundHttpException::class);
 

--- a/tests/EventListener/RespondListenerTest.php
+++ b/tests/EventListener/RespondListenerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class RespondListenerTest extends TestCase
 {
-    public function testDoNotHandleResponse()
+    public function testDoNotHandleResponse(): void
     {
         $request = new Request();
         $request->setRequestFormat('xml');
@@ -38,7 +38,7 @@ class RespondListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
-    public function testCreate200Response()
+    public function testCreate200Response(): void
     {
         $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('xml');
@@ -63,7 +63,7 @@ class RespondListenerTest extends TestCase
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
     }
 
-    public function testCreate201Response()
+    public function testCreate201Response(): void
     {
         $kernelProphecy = $this->prophesize(HttpKernelInterface::class);
 
@@ -90,7 +90,7 @@ class RespondListenerTest extends TestCase
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
     }
 
-    public function testCreate204Response()
+    public function testCreate204Response(): void
     {
         $kernelProphecy = $this->prophesize(HttpKernelInterface::class);
 

--- a/tests/EventListener/SerializeListenerTest.php
+++ b/tests/EventListener/SerializeListenerTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class SerializeListenerTest extends TestCase
 {
-    public function testDoNotSerializeResponse()
+    public function testDoNotSerializeResponse(): void
     {
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->serialize()->shouldNotBeCalled();
@@ -48,7 +48,7 @@ class SerializeListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
-    public function testDoNotSerializeWhenFormatNotSet()
+    public function testDoNotSerializeWhenFormatNotSet(): void
     {
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->serialize()->shouldNotBeCalled();
@@ -64,7 +64,7 @@ class SerializeListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
-    public function testDoNotSerializeWhenResourceClassNotSet()
+    public function testDoNotSerializeWhenResourceClassNotSet(): void
     {
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->serialize()->shouldNotBeCalled();
@@ -83,7 +83,7 @@ class SerializeListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
-    public function testDoNotSerializeWhenOperationNotSet()
+    public function testDoNotSerializeWhenOperationNotSet(): void
     {
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->serialize()->shouldNotBeCalled();
@@ -102,7 +102,7 @@ class SerializeListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
-    public function testSerializeCollectionOperation()
+    public function testSerializeCollectionOperation(): void
     {
         $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'collection_operation_name' => 'get'];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -138,7 +138,7 @@ class SerializeListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
-    public function testSerializeItemOperation()
+    public function testSerializeItemOperation(): void
     {
         $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'item_operation_name' => 'get'];
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -173,7 +173,7 @@ class SerializeListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(EncoderInterface::class);

--- a/tests/EventListener/WriteListenerTest.php
+++ b/tests/EventListener/WriteListenerTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class WriteListenerTest extends TestCase
 {
-    public function testOnKernelViewWithControllerResultAndPersist()
+    public function testOnKernelViewWithControllerResultAndPersist(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -57,7 +57,7 @@ class WriteListenerTest extends TestCase
      * @group legacy
      * @expectedDeprecation Returning void from ApiPlatform\Core\DataPersister\DataPersisterInterface::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.
      */
-    public function testOnKernelViewWithControllerResultAndPersistReturningVoid()
+    public function testOnKernelViewWithControllerResultAndPersistReturningVoid(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -87,7 +87,7 @@ class WriteListenerTest extends TestCase
     /**
      * @see https://github.com/api-platform/core/issues/1799
      */
-    public function testOnKernelViewWithControllerResultAndPersistWithImmutableResource()
+    public function testOnKernelViewWithControllerResultAndPersistWithImmutableResource(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -123,7 +123,7 @@ class WriteListenerTest extends TestCase
         }
     }
 
-    public function testOnKernelViewWithControllerResultAndRemove()
+    public function testOnKernelViewWithControllerResultAndRemove(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -146,7 +146,7 @@ class WriteListenerTest extends TestCase
         (new WriteListener($dataPersisterProphecy->reveal()))->onKernelView($event);
     }
 
-    public function testOnKernelViewWithSafeMethod()
+    public function testOnKernelViewWithSafeMethod(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -170,7 +170,7 @@ class WriteListenerTest extends TestCase
         (new WriteListener($dataPersisterProphecy->reveal()))->onKernelView($event);
     }
 
-    public function testOnKernelViewWithNoResourceClass()
+    public function testOnKernelViewWithNoResourceClass(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
@@ -193,7 +193,7 @@ class WriteListenerTest extends TestCase
         (new WriteListener($dataPersisterProphecy->reveal()))->onKernelView($event);
     }
 
-    public function testOnKernelViewWithNoDataPersisterSupport()
+    public function testOnKernelViewWithNoDataPersisterSupport(): void
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');

--- a/tests/Filter/QueryParameterValidateListenerTest.php
+++ b/tests/Filter/QueryParameterValidateListenerTest.php
@@ -32,7 +32,7 @@ class QueryParameterValidateListenerTest extends TestCase
     /**
      * unsafe method should not use filter validations.
      */
-    public function testOnKernelRequestWithUnsafeMethod()
+    public function testOnKernelRequestWithUnsafeMethod(): void
     {
         $this->setUpWithFilters();
 
@@ -50,7 +50,7 @@ class QueryParameterValidateListenerTest extends TestCase
     /**
      * If the tested filter is non-existant, then nothing should append.
      */
-    public function testOnKernelRequestWithWrongFilter()
+    public function testOnKernelRequestWithWrongFilter(): void
     {
         $this->setUpWithFilters(['some_inexistent_filter']);
 
@@ -71,7 +71,7 @@ class QueryParameterValidateListenerTest extends TestCase
     /**
      * if the required parameter is not set, throw an FilterValidationException.
      */
-    public function testOnKernelRequestWithRequiredFilterNotSet()
+    public function testOnKernelRequestWithRequiredFilterNotSet(): void
     {
         $this->setUpWithFilters(['some_filter']);
 
@@ -110,7 +110,7 @@ class QueryParameterValidateListenerTest extends TestCase
     /**
      * if the required parameter is set, no exception should be throwned.
      */
-    public function testOnKernelRequestWithRequiredFilter()
+    public function testOnKernelRequestWithRequiredFilter(): void
     {
         $this->setUpWithFilters(['some_filter']);
 
@@ -150,7 +150,7 @@ class QueryParameterValidateListenerTest extends TestCase
         );
     }
 
-    private function setUpWithFilters(array $filters = [])
+    private function setUpWithFilters(array $filters = []): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy

--- a/tests/Fixtures/DummyObjectWithoutConstructor.php
+++ b/tests/Fixtures/DummyObjectWithoutConstructor.php
@@ -25,7 +25,7 @@ class DummyObjectWithoutConstructor
         return $this->foo;
     }
 
-    public function setFoo($foo)
+    public function setFoo($foo): void
     {
         $this->foo = $foo;
     }

--- a/tests/Fixtures/NullPurger.php
+++ b/tests/Fixtures/NullPurger.php
@@ -22,7 +22,7 @@ final class NullPurger implements PurgerInterface
 {
     private $iris = [];
 
-    public function purge(array $iris)
+    public function purge(array $iris): void
     {
         $this->iris = $iris;
     }
@@ -32,7 +32,7 @@ final class NullPurger implements PurgerInterface
         return $this->iris;
     }
 
-    public function clear()
+    public function clear(): void
     {
         $this->iris = [];
     }

--- a/tests/Fixtures/Query.php
+++ b/tests/Fixtures/Query.php
@@ -20,9 +20,11 @@ class Query
 {
     public function getFirstResult()
     {
+        return null;
     }
 
     public function getMaxResults()
     {
+        return null;
     }
 }

--- a/tests/Fixtures/TestBundle/Doctrine/Orm/Filter/DummyFilter.php
+++ b/tests/Fixtures/TestBundle/Doctrine/Orm/Filter/DummyFilter.php
@@ -24,7 +24,7 @@ class DummyFilter extends AbstractFilter
         return $this->splitPropertyParts($property);
     }
 
-    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
     }
 

--- a/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
@@ -54,7 +54,7 @@ abstract class AbstractDummy
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/Answer.php
+++ b/tests/Fixtures/TestBundle/Entity/Answer.php
@@ -129,7 +129,7 @@ class Answer
         return $this->relatedQuestions;
     }
 
-    public function addRelatedQuestion(Question $question)
+    public function addRelatedQuestion(Question $question): void
     {
         $this->relatedQuestions->add($question);
     }

--- a/tests/Fixtures/TestBundle/Entity/ArrayFilterValidator.php
+++ b/tests/Fixtures/TestBundle/Entity/ArrayFilterValidator.php
@@ -54,7 +54,7 @@ class ArrayFilterValidator
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/CompositeItem.php
+++ b/tests/Fixtures/TestBundle/Entity/CompositeItem.php
@@ -69,7 +69,7 @@ class CompositeItem
      *
      * @param string|null $field1 the value to set
      */
-    public function setField1($field1 = null)
+    public function setField1($field1 = null): void
     {
         $this->field1 = $field1;
     }

--- a/tests/Fixtures/TestBundle/Entity/CompositeLabel.php
+++ b/tests/Fixtures/TestBundle/Entity/CompositeLabel.php
@@ -63,7 +63,7 @@ class CompositeLabel
      *
      * @param string|null $value the value to set
      */
-    public function setValue($value = null)
+    public function setValue($value = null): void
     {
         $this->value = $value;
     }

--- a/tests/Fixtures/TestBundle/Entity/CompositePrimitiveItem.php
+++ b/tests/Fixtures/TestBundle/Entity/CompositePrimitiveItem.php
@@ -72,7 +72,7 @@ class CompositePrimitiveItem
      *
      * @param string $description
      */
-    public function setDescription(string $description)
+    public function setDescription(string $description): void
     {
         $this->description = $description;
     }

--- a/tests/Fixtures/TestBundle/Entity/CompositeRelation.php
+++ b/tests/Fixtures/TestBundle/Entity/CompositeRelation.php
@@ -62,7 +62,7 @@ class CompositeRelation
      *
      * @param string|null $value the value to set
      */
-    public function setValue($value = null)
+    public function setValue($value = null): void
     {
         $this->value = $value;
     }
@@ -82,7 +82,7 @@ class CompositeRelation
      *
      * @param CompositeItem $compositeItem the value to set
      */
-    public function setCompositeItem(CompositeItem $compositeItem)
+    public function setCompositeItem(CompositeItem $compositeItem): void
     {
         $this->compositeItem = $compositeItem;
     }
@@ -102,7 +102,7 @@ class CompositeRelation
      *
      * @param CompositeLabel $compositeLabel the value to set
      */
-    public function setCompositeLabel(CompositeLabel $compositeLabel)
+    public function setCompositeLabel(CompositeLabel $compositeLabel): void
     {
         $this->compositeLabel = $compositeLabel;
     }

--- a/tests/Fixtures/TestBundle/Entity/ConcreteDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/ConcreteDummy.php
@@ -35,7 +35,7 @@ class ConcreteDummy extends AbstractDummy
      */
     private $instance;
 
-    public function setInstance($instance)
+    public function setInstance($instance): void
     {
         $this->instance = $instance;
     }

--- a/tests/Fixtures/TestBundle/Entity/Container.php
+++ b/tests/Fixtures/TestBundle/Entity/Container.php
@@ -53,7 +53,7 @@ class Container
         return $this->id;
     }
 
-    public function setId(string $id)
+    public function setId(string $id): void
     {
         $this->id = $id;
     }

--- a/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
@@ -61,7 +61,7 @@ class CustomActionDummy
         return $this->foo;
     }
 
-    public function setFoo(string $foo)
+    public function setFoo(string $foo): void
     {
         $this->foo = $foo;
     }

--- a/tests/Fixtures/TestBundle/Entity/CustomIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomIdentifierDummy.php
@@ -59,7 +59,7 @@ class CustomIdentifierDummy
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/CustomNormalizedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomNormalizedDummy.php
@@ -72,7 +72,7 @@ class CustomNormalizedDummy
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -96,7 +96,7 @@ class CustomNormalizedDummy
     /**
      * @param string $alias
      */
-    public function setAlias($alias)
+    public function setAlias($alias): void
     {
         $this->alias = $alias;
     }
@@ -112,7 +112,7 @@ class CustomNormalizedDummy
     /**
      * @param string $value
      */
-    public function setPersonalizedAlias($value)
+    public function setPersonalizedAlias($value): void
     {
         $this->alias = $value;
     }

--- a/tests/Fixtures/TestBundle/Entity/CustomWritableIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomWritableIdentifierDummy.php
@@ -42,7 +42,7 @@ class CustomWritableIdentifierDummy
     /**
      * @param string $slug
      */
-    public function setSlug($slug)
+    public function setSlug($slug): void
     {
         $this->slug = $slug;
     }
@@ -66,7 +66,7 @@ class CustomWritableIdentifierDummy
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -152,7 +152,7 @@ class Dummy
      */
     public $nameConverted;
 
-    public static function staticMethod()
+    public static function staticMethod(): void
     {
     }
 
@@ -168,12 +168,12 @@ class Dummy
         return $this->id;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -183,7 +183,7 @@ class Dummy
         return $this->name;
     }
 
-    public function setAlias($alias)
+    public function setAlias($alias): void
     {
         $this->alias = $alias;
     }
@@ -193,7 +193,7 @@ class Dummy
         return $this->alias;
     }
 
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
@@ -203,7 +203,7 @@ class Dummy
         return $this->description;
     }
 
-    public function hasRole($role)
+    public function hasRole($role): void
     {
     }
 
@@ -212,12 +212,12 @@ class Dummy
         return $this->foo;
     }
 
-    public function setFoo(array $foo = null)
+    public function setFoo(array $foo = null): void
     {
         $this->foo = $foo;
     }
 
-    public function setDummyDate(\DateTime $dummyDate = null)
+    public function setDummyDate(\DateTime $dummyDate = null): void
     {
         $this->dummyDate = $dummyDate;
     }
@@ -239,7 +239,7 @@ class Dummy
         return $this->dummyPrice;
     }
 
-    public function setJsonData($jsonData)
+    public function setJsonData($jsonData): void
     {
         $this->jsonData = $jsonData;
     }
@@ -249,7 +249,7 @@ class Dummy
         return $this->jsonData;
     }
 
-    public function setArrayData($arrayData)
+    public function setArrayData($arrayData): void
     {
         $this->arrayData = $arrayData;
     }
@@ -264,12 +264,12 @@ class Dummy
         return $this->relatedDummy;
     }
 
-    public function setRelatedDummy(RelatedDummy $relatedDummy)
+    public function setRelatedDummy(RelatedDummy $relatedDummy): void
     {
         $this->relatedDummy = $relatedDummy;
     }
 
-    public function addRelatedDummy(RelatedDummy $relatedDummy)
+    public function addRelatedDummy(RelatedDummy $relatedDummy): void
     {
         $this->relatedDummies->add($relatedDummy);
     }
@@ -285,12 +285,12 @@ class Dummy
     /**
      * @param bool $dummyBoolean
      */
-    public function setDummyBoolean($dummyBoolean)
+    public function setDummyBoolean($dummyBoolean): void
     {
         $this->dummyBoolean = $dummyBoolean;
     }
 
-    public function setDummy($dummy = null)
+    public function setDummy($dummy = null): void
     {
         $this->dummy = $dummy;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyAggregateOffer.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyAggregateOffer.php
@@ -70,12 +70,12 @@ class DummyAggregateOffer
         return $this->offers;
     }
 
-    public function setOffers($offers)
+    public function setOffers($offers): void
     {
         $this->offers = $offers;
     }
 
-    public function addOffer(DummyOffer $offer)
+    public function addOffer(DummyOffer $offer): void
     {
         $this->offers->add($offer);
         $offer->setAggregate($this);
@@ -91,7 +91,7 @@ class DummyAggregateOffer
         return $this->value;
     }
 
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }
@@ -101,7 +101,7 @@ class DummyAggregateOffer
         return $this->product;
     }
 
-    public function setProduct(DummyProduct $product)
+    public function setProduct(DummyProduct $product): void
     {
         $this->product = $product;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -125,7 +125,7 @@ class DummyCar
      *
      * @param string name the value to set
      */
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -145,7 +145,7 @@ class DummyCar
      *
      * @param bool canSell the value to set
      */
-    public function setCanSell(bool $canSell)
+    public function setCanSell(bool $canSell): void
     {
         $this->canSell = $canSell;
     }
@@ -165,7 +165,7 @@ class DummyCar
      *
      * @param \DateTime availableAt the value to set
      */
-    public function setAvailableAt(\DateTime $availableAt)
+    public function setAvailableAt(\DateTime $availableAt): void
     {
         $this->availableAt = $availableAt;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomFormat.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomFormat.php
@@ -45,12 +45,12 @@ class DummyCustomFormat
         return $this->id;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyEntityWithConstructor.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyEntityWithConstructor.php
@@ -105,7 +105,7 @@ class DummyEntityWithConstructor
     /**
      * @param string $baz
      */
-    public function setBaz(string $baz)
+    public function setBaz(string $baz): void
     {
         $this->baz = $baz;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyFriend.php
@@ -63,7 +63,7 @@ class DummyFriend
      *
      * @param int $id the value to set
      */
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -83,7 +83,7 @@ class DummyFriend
      *
      * @param string $name the value to set
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyOffer.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyOffer.php
@@ -60,7 +60,7 @@ class DummyOffer
         return $this->value;
     }
 
-    public function setValue(int $value)
+    public function setValue(int $value): void
     {
         $this->value = $value;
     }
@@ -70,7 +70,7 @@ class DummyOffer
         return $this->aggregate;
     }
 
-    public function setAggregate(DummyAggregateOffer $aggregate)
+    public function setAggregate(DummyAggregateOffer $aggregate): void
     {
         $this->aggregate = $aggregate;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyProduct.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyProduct.php
@@ -78,12 +78,12 @@ class DummyProduct
         return $this->offers;
     }
 
-    public function setOffers($offers)
+    public function setOffers($offers): void
     {
         $this->offers = $offers;
     }
 
-    public function addOffer(DummyAggregateOffer $offer)
+    public function addOffer(DummyAggregateOffer $offer): void
     {
         $this->offers->add($offer);
         $offer->setProduct($this);
@@ -99,7 +99,7 @@ class DummyProduct
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -109,12 +109,12 @@ class DummyProduct
         return $this->relatedProducts;
     }
 
-    public function setRelatedProducts(Collection $relatedProducts)
+    public function setRelatedProducts(Collection $relatedProducts): void
     {
         $this->relatedProducts = $relatedProducts;
     }
 
-    public function addRelatedProduct(self $relatedProduct)
+    public function addRelatedProduct(self $relatedProduct): void
     {
         $this->relatedProducts->add($relatedProduct);
         $relatedProduct->setParent($this);
@@ -125,7 +125,7 @@ class DummyProduct
         return $this->parent;
     }
 
-    public function setParent(self $product)
+    public function setParent(self $product): void
     {
         $this->parent = $product;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritance.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritance.php
@@ -59,7 +59,7 @@ class DummyTableInheritance
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceChild.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceChild.php
@@ -37,7 +37,7 @@ class DummyTableInheritanceChild extends DummyTableInheritance
         return $this->nickname;
     }
 
-    public function setNickname($nickname)
+    public function setNickname($nickname): void
     {
         $this->nickname = $nickname;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceDifferentChild.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceDifferentChild.php
@@ -37,7 +37,7 @@ class DummyTableInheritanceDifferentChild extends DummyTableInheritance
         return $this->email;
     }
 
-    public function setEmail($email)
+    public function setEmail($email): void
     {
         $this->email = $email;
     }

--- a/tests/Fixtures/TestBundle/Entity/EmbeddableDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/EmbeddableDummy.php
@@ -69,7 +69,7 @@ class EmbeddableDummy
      */
     protected $symfony;
 
-    public static function staticMethod()
+    public static function staticMethod(): void
     {
     }
 
@@ -88,7 +88,7 @@ class EmbeddableDummy
     /**
      * @param string $dummyName
      */
-    public function setDummyName(string $dummyName)
+    public function setDummyName(string $dummyName): void
     {
         $this->dummyName = $dummyName;
     }
@@ -104,7 +104,7 @@ class EmbeddableDummy
     /**
      * @param bool $dummyBoolean
      */
-    public function setDummyBoolean(bool $dummyBoolean)
+    public function setDummyBoolean(bool $dummyBoolean): void
     {
         $this->dummyBoolean = $dummyBoolean;
     }
@@ -120,7 +120,7 @@ class EmbeddableDummy
     /**
      * @param \DateTime $dummyDate
      */
-    public function setDummyDate(\DateTime $dummyDate)
+    public function setDummyDate(\DateTime $dummyDate): void
     {
         $this->dummyDate = $dummyDate;
     }
@@ -136,7 +136,7 @@ class EmbeddableDummy
     /**
      * @param string $dummyFloat
      */
-    public function setDummyFloat(string $dummyFloat)
+    public function setDummyFloat(string $dummyFloat): void
     {
         $this->dummyFloat = $dummyFloat;
     }
@@ -152,7 +152,7 @@ class EmbeddableDummy
     /**
      * @param string $dummyPrice
      */
-    public function setDummyPrice(string $dummyPrice)
+    public function setDummyPrice(string $dummyPrice): void
     {
         $this->dummyPrice = $dummyPrice;
     }
@@ -168,7 +168,7 @@ class EmbeddableDummy
     /**
      * @param mixed $symfony
      */
-    public function setSymfony($symfony)
+    public function setSymfony($symfony): void
     {
         $this->symfony = $symfony;
     }

--- a/tests/Fixtures/TestBundle/Entity/EmbeddedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/EmbeddedDummy.php
@@ -71,7 +71,7 @@ class EmbeddedDummy
      */
     public $relatedDummy;
 
-    public static function staticMethod()
+    public static function staticMethod(): void
     {
     }
 
@@ -96,7 +96,7 @@ class EmbeddedDummy
     /**
      * @param string $name
      */
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -112,7 +112,7 @@ class EmbeddedDummy
     /**
      * @param EmbeddableDummy $embeddedDummy
      */
-    public function setEmbeddedDummy(EmbeddableDummy $embeddedDummy)
+    public function setEmbeddedDummy(EmbeddableDummy $embeddedDummy): void
     {
         $this->embeddedDummy = $embeddedDummy;
     }
@@ -128,7 +128,7 @@ class EmbeddedDummy
     /**
      * @param \DateTime $dummyDate
      */
-    public function setDummyDate(\DateTime $dummyDate)
+    public function setDummyDate(\DateTime $dummyDate): void
     {
         $this->dummyDate = $dummyDate;
     }
@@ -144,7 +144,7 @@ class EmbeddedDummy
     /**
      * @param RelatedDummy $relatedDummy
      */
-    public function setRelatedDummy(RelatedDummy $relatedDummy)
+    public function setRelatedDummy(RelatedDummy $relatedDummy): void
     {
         $this->relatedDummy = $relatedDummy;
     }

--- a/tests/Fixtures/TestBundle/Entity/FileConfigDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/FileConfigDummy.php
@@ -52,7 +52,7 @@ class FileConfigDummy
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -62,7 +62,7 @@ class FileConfigDummy
         return $this->name;
     }
 
-    public function setFoo($foo)
+    public function setFoo($foo): void
     {
         $this->foo = $foo;
     }

--- a/tests/Fixtures/TestBundle/Entity/FilterValidator.php
+++ b/tests/Fixtures/TestBundle/Entity/FilterValidator.php
@@ -54,7 +54,7 @@ class FilterValidator
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/Foo.php
+++ b/tests/Fixtures/TestBundle/Entity/Foo.php
@@ -56,7 +56,7 @@ class Foo
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -71,7 +71,7 @@ class Foo
         return $this->bar;
     }
 
-    public function setBar($bar)
+    public function setBar($bar): void
     {
         $this->bar = $bar;
     }

--- a/tests/Fixtures/TestBundle/Entity/FooDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/FooDummy.php
@@ -56,7 +56,7 @@ class FooDummy
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -71,7 +71,7 @@ class FooDummy
         return $this->dummy;
     }
 
-    public function setDummy(Dummy $dummy)
+    public function setDummy(Dummy $dummy): void
     {
         $this->dummy = $dummy;
     }

--- a/tests/Fixtures/TestBundle/Entity/FourthLevel.php
+++ b/tests/Fixtures/TestBundle/Entity/FourthLevel.php
@@ -63,7 +63,7 @@ class FourthLevel
     /**
      * @param int $level
      */
-    public function setLevel($level)
+    public function setLevel($level): void
     {
         $this->level = $level;
     }

--- a/tests/Fixtures/TestBundle/Entity/JsonldContextDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/JsonldContextDummy.php
@@ -56,7 +56,7 @@ class JsonldContextDummy
         return $this->id;
     }
 
-    public function setPerson($person)
+    public function setPerson($person): void
     {
         $this->person = $person;
     }

--- a/tests/Fixtures/TestBundle/Entity/Node.php
+++ b/tests/Fixtures/TestBundle/Entity/Node.php
@@ -40,7 +40,7 @@ class Node
      */
     private $container;
 
-    public function setContainer(Container $container)
+    public function setContainer(Container $container): void
     {
         $this->container = $container;
     }
@@ -50,7 +50,7 @@ class Node
         return $this->container;
     }
 
-    public function setSerial(int $serial)
+    public function setSerial(int $serial): void
     {
         $this->serial = $serial;
     }

--- a/tests/Fixtures/TestBundle/Entity/OverriddenOperationDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/OverriddenOperationDummy.php
@@ -106,7 +106,7 @@ class OverriddenOperationDummy
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -116,7 +116,7 @@ class OverriddenOperationDummy
         return $this->name;
     }
 
-    public function setAlias($alias)
+    public function setAlias($alias): void
     {
         $this->alias = $alias;
     }
@@ -126,7 +126,7 @@ class OverriddenOperationDummy
         return $this->alias;
     }
 
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }

--- a/tests/Fixtures/TestBundle/Entity/RamseyUuidDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RamseyUuidDummy.php
@@ -37,7 +37,7 @@ class RamseyUuidDummy
         return $this->id;
     }
 
-    public function setId(string $uuid)
+    public function setId(string $uuid): void
     {
         $this->id = Uuid::fromString($uuid);
     }

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -102,12 +102,12 @@ class RelatedDummy extends ParentDummy
         return $this->id;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -122,12 +122,12 @@ class RelatedDummy extends ParentDummy
         return $this->symfony;
     }
 
-    public function setSymfony($symfony)
+    public function setSymfony($symfony): void
     {
         $this->symfony = $symfony;
     }
 
-    public function setDummyDate(\DateTime $dummyDate)
+    public function setDummyDate(\DateTime $dummyDate): void
     {
         $this->dummyDate = $dummyDate;
     }
@@ -148,7 +148,7 @@ class RelatedDummy extends ParentDummy
     /**
      * @param bool $dummyBoolean
      */
-    public function setDummyBoolean($dummyBoolean)
+    public function setDummyBoolean($dummyBoolean): void
     {
         $this->dummyBoolean = $dummyBoolean;
     }
@@ -164,7 +164,7 @@ class RelatedDummy extends ParentDummy
     /**
      * @param ThirdLevel|null $thirdLevel
      */
-    public function setThirdLevel(ThirdLevel $thirdLevel = null)
+    public function setThirdLevel(ThirdLevel $thirdLevel = null): void
     {
         $this->thirdLevel = $thirdLevel;
     }
@@ -184,7 +184,7 @@ class RelatedDummy extends ParentDummy
      *
      * @param RelatedToDummyFriend $relatedToDummyFriend the value to set
      */
-    public function addRelatedToDummyFriend(RelatedToDummyFriend $relatedToDummyFriend)
+    public function addRelatedToDummyFriend(RelatedToDummyFriend $relatedToDummyFriend): void
     {
         $this->relatedToDummyFriend->add($relatedToDummyFriend);
     }
@@ -200,7 +200,7 @@ class RelatedDummy extends ParentDummy
     /**
      * @param EmbeddableDummy $embeddedDummy
      */
-    public function setEmbeddedDummy(EmbeddableDummy $embeddedDummy)
+    public function setEmbeddedDummy(EmbeddableDummy $embeddedDummy): void
     {
         $this->embeddedDummy = $embeddedDummy;
     }

--- a/tests/Fixtures/TestBundle/Entity/RelatedNormalizedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedNormalizedDummy.php
@@ -74,7 +74,7 @@ class RelatedNormalizedDummy
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -95,7 +95,7 @@ class RelatedNormalizedDummy
     /**
      * @param ArrayCollection $customNormalizedDummy
      */
-    public function setCustomNormalizedDummy($customNormalizedDummy)
+    public function setCustomNormalizedDummy($customNormalizedDummy): void
     {
         $this->customNormalizedDummy = $customNormalizedDummy;
     }

--- a/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedToDummyFriend.php
@@ -62,7 +62,7 @@ class RelatedToDummyFriend
      */
     private $relatedDummy;
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -83,7 +83,7 @@ class RelatedToDummyFriend
     /**
      * @param null|string $description
      */
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
@@ -103,7 +103,7 @@ class RelatedToDummyFriend
      *
      * @param DummyFriend $dummyFriend the value to set
      */
-    public function setDummyFriend(DummyFriend $dummyFriend)
+    public function setDummyFriend(DummyFriend $dummyFriend): void
     {
         $this->dummyFriend = $dummyFriend;
     }
@@ -123,7 +123,7 @@ class RelatedToDummyFriend
      *
      * @param RelatedDummy $relatedDummy the value to set
      */
-    public function setRelatedDummy(RelatedDummy $relatedDummy)
+    public function setRelatedDummy(RelatedDummy $relatedDummy): void
     {
         $this->relatedDummy = $relatedDummy;
     }

--- a/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
+++ b/tests/Fixtures/TestBundle/Entity/RelationEmbedder.php
@@ -77,7 +77,7 @@ class RelationEmbedder
         return $this->related;
     }
 
-    public function setRelated(RelatedDummy $relatedDummy)
+    public function setRelated(RelatedDummy $relatedDummy): void
     {
         $this->related = $relatedDummy;
     }

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -87,7 +87,7 @@ class SecuredDummy
         return $this->title;
     }
 
-    public function setTitle(string $title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
@@ -97,7 +97,7 @@ class SecuredDummy
         return $this->description;
     }
 
-    public function setDescription(string $description)
+    public function setDescription(string $description): void
     {
         $this->description = $description;
     }
@@ -107,7 +107,7 @@ class SecuredDummy
         return $this->owner;
     }
 
-    public function setOwner(string $owner)
+    public function setOwner(string $owner): void
     {
         $this->owner = $owner;
     }

--- a/tests/Fixtures/TestBundle/Entity/SingleFileConfigDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SingleFileConfigDummy.php
@@ -43,7 +43,7 @@ class SingleFileConfigDummy
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/ThirdLevel.php
+++ b/tests/Fixtures/TestBundle/Entity/ThirdLevel.php
@@ -78,7 +78,7 @@ class ThirdLevel
     /**
      * @param int $level
      */
-    public function setLevel($level)
+    public function setLevel($level): void
     {
         $this->level = $level;
     }
@@ -94,7 +94,7 @@ class ThirdLevel
     /**
      * @param bool $test
      */
-    public function setTest($test)
+    public function setTest($test): void
     {
         $this->test = $test;
     }
@@ -110,7 +110,7 @@ class ThirdLevel
     /**
      * @param FourthLevel|null $fourthLevel
      */
-    public function setFourthLevel(FourthLevel $fourthLevel = null)
+    public function setFourthLevel(FourthLevel $fourthLevel = null): void
     {
         $this->fourthLevel = $fourthLevel;
     }

--- a/tests/Fixtures/TestBundle/Entity/UpperCaseIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/UpperCaseIdentifierDummy.php
@@ -46,7 +46,7 @@ class UpperCaseIdentifierDummy
         return $this->Uuid;
     }
 
-    public function setUuid(string $Uuid)
+    public function setUuid(string $Uuid): void
     {
         $this->Uuid = $Uuid;
     }
@@ -56,7 +56,7 @@ class UpperCaseIdentifierDummy
         return $this->name;
     }
 
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Entity/UuidIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/UuidIdentifierDummy.php
@@ -44,7 +44,7 @@ class UuidIdentifierDummy
         return $this->uuid;
     }
 
-    public function setUuid(string $uuid)
+    public function setUuid(string $uuid): void
     {
         $this->uuid = $uuid;
     }
@@ -54,7 +54,7 @@ class UuidIdentifierDummy
         return $this->name;
     }
 
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/TestBundle/Filter/ArrayRequiredFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/ArrayRequiredFilter.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\QueryBuilder;
 
 final class ArrayRequiredFilter extends AbstractFilter
 {
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
     }
 

--- a/tests/Fixtures/TestBundle/Filter/RequiredFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/RequiredFilter.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\QueryBuilder;
 
 final class RequiredFilter extends AbstractFilter
 {
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
     {
     }
 

--- a/tests/Fixtures/TestBundle/Manager/UserManager.php
+++ b/tests/Fixtures/TestBundle/Manager/UserManager.php
@@ -24,7 +24,7 @@ class UserManager extends BaseUserManager
     /**
      * {@inheritdoc}
      */
-    public function updateUser(UserInterface $user, $andFlush = true)
+    public function updateUser(UserInterface $user, $andFlush = true): void
     {
         // Extract email part before the `@` character to use it as username is username not set
         if (null === $user->getUsername()) {

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -65,7 +65,7 @@ class AppKernel extends Kernel
         return $bundles;
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
         $routes->import('config/routing.yml');
 
@@ -74,7 +74,7 @@ class AppKernel extends Kernel
         }
     }
 
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
     {
         $c->setParameter('kernel.project_dir', __DIR__);
 

--- a/tests/Fixtures/app/config/parameters_mysql.yml
+++ b/tests/Fixtures/app/config/parameters_mysql.yml
@@ -1,5 +1,5 @@
 parameters:
     dbname:   'api_platform_test'
-    user:     'travis'
+    user:     'root'
     password: ''
     host:     'localhost'

--- a/tests/GraphQl/Action/EntrypointActionTest.php
+++ b/tests/GraphQl/Action/EntrypointActionTest.php
@@ -31,14 +31,14 @@ class EntrypointActionTest extends TestCase
     /**
      * Hack to avoid transient failing test because of Date header.
      */
-    private function assertEqualsWithoutDateHeader(JsonResponse $expected, JsonResponse $actual)
+    private function assertEqualsWithoutDateHeader(JsonResponse $expected, JsonResponse $actual): void
     {
         $expected->headers->remove('Date');
         $actual->headers->remove('Date');
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetAction()
+    public function testGetAction(): void
     {
         $request = new Request(['query' => 'graphqlQuery', 'variables' => '["graphqlVariable"]', 'operation' => 'graphqlOperationName']);
         $request->setRequestFormat('json');
@@ -47,7 +47,7 @@ class EntrypointActionTest extends TestCase
         $this->assertEqualsWithoutDateHeader(new JsonResponse(['GraphQL']), $mockedEntrypoint($request));
     }
 
-    public function testPostRawAction()
+    public function testPostRawAction(): void
     {
         $request = new Request(['variables' => '["graphqlVariable"]', 'operation' => 'graphqlOperationName'], [], [], [], [], [], 'graphqlQuery');
         $request->setMethod('POST');
@@ -57,7 +57,7 @@ class EntrypointActionTest extends TestCase
         $this->assertEqualsWithoutDateHeader(new JsonResponse(['GraphQL']), $mockedEntrypoint($request));
     }
 
-    public function testPostJsonAction()
+    public function testPostJsonAction(): void
     {
         $request = new Request([], [], [], [], [], [], '{"query": "graphqlQuery", "variables": "[\"graphqlVariable\"]", "operation": "graphqlOperationName"}');
         $request->setMethod('POST');
@@ -67,7 +67,7 @@ class EntrypointActionTest extends TestCase
         $this->assertEqualsWithoutDateHeader(new JsonResponse(['GraphQL']), $mockedEntrypoint($request));
     }
 
-    public function testBadContentTypePostAction()
+    public function testBadContentTypePostAction(): void
     {
         $request = new Request();
         $request->setMethod('POST');
@@ -78,7 +78,7 @@ class EntrypointActionTest extends TestCase
         $this->assertEquals('{"errors":[{"message":"GraphQL query is not valid","category":"graphql"}]}', $mockedEntrypoint($request)->getContent());
     }
 
-    public function testBadMethodAction()
+    public function testBadMethodAction(): void
     {
         $request = new Request();
         $request->setMethod('PUT');
@@ -88,7 +88,7 @@ class EntrypointActionTest extends TestCase
         $this->assertEquals('{"errors":[{"message":"GraphQL query is not valid","category":"graphql"}]}', $mockedEntrypoint($request)->getContent());
     }
 
-    public function testBadVariablesAction()
+    public function testBadVariablesAction(): void
     {
         $request = new Request(['query' => 'graphqlQuery', 'variables' => 'graphqlVariable', 'operation' => 'graphqlOperationName']);
         $request->setRequestFormat('json');

--- a/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -39,7 +39,7 @@ class CollectionResolverFactoryTest extends TestCase
     /**
      * @dataProvider paginationProvider
      */
-    public function testCreateCollectionResolverNoCollection(bool $paginationEnabled, array $expected)
+    public function testCreateCollectionResolverNoCollection(bool $paginationEnabled, array $expected): void
     {
         $factory = $this->createCollectionResolverFactory([], [], ['id' => 1], $paginationEnabled);
         $resolver = $factory(RelatedDummy::class, Dummy::class, 'operationName');
@@ -59,7 +59,7 @@ class CollectionResolverFactoryTest extends TestCase
         ];
     }
 
-    public function testCreateCollectionResolverNoPagination()
+    public function testCreateCollectionResolverNoPagination(): void
     {
         $factory = $this->createCollectionResolverFactory([
             'Object1',
@@ -78,7 +78,7 @@ class CollectionResolverFactoryTest extends TestCase
     /**
      * @dataProvider subresourceProvider
      */
-    public function testCreateSubresourceCollectionResolverNoPagination(array $subcollection, array $expected)
+    public function testCreateSubresourceCollectionResolverNoPagination(array $subcollection, array $expected): void
     {
         $factory = $this->createCollectionResolverFactory([
             'Object1',
@@ -113,7 +113,7 @@ class CollectionResolverFactoryTest extends TestCase
     /**
      * @dataProvider cursorProvider
      */
-    public function testCreateCollectionResolver(string $cursor, array $expectedCursors)
+    public function testCreateCollectionResolver(string $cursor, array $expectedCursors): void
     {
         $factory = $this->createCollectionResolverFactory([
             'Object1',
@@ -148,7 +148,7 @@ class CollectionResolverFactoryTest extends TestCase
         ];
     }
 
-    public function testCreatePaginatorCollectionResolver()
+    public function testCreatePaginatorCollectionResolver(): void
     {
         $collectionPaginatorProphecy = $this->prophesize(PaginatorInterface::class);
         $collectionPaginatorProphecy->rewind()->shouldBeCalled();

--- a/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class ItemMutationResolverFactoryTest extends TestCase
 {
-    public function testCreateItemMutationResolverNoItem()
+    public function testCreateItemMutationResolverNoItem(): void
     {
         $this->expectException(Error::class);
 
@@ -50,7 +50,7 @@ class ItemMutationResolverFactoryTest extends TestCase
         $resolver(null, ['input' => ['id' => '/dummies/3', 'clientMutationId' => '1936']], null, $resolveInfo);
     }
 
-    public function testCreateItemDeleteMutationResolver()
+    public function testCreateItemDeleteMutationResolver(): void
     {
         $dummy = new Dummy();
 

--- a/tests/GraphQl/Resolver/ItemResolverTest.php
+++ b/tests/GraphQl/Resolver/ItemResolverTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class ItemResolverTest extends TestCase
 {
-    public function testCreateItemResolverNoItem()
+    public function testCreateItemResolverNoItem(): void
     {
         $resolver = $this->createItemResolver(null);
 
@@ -42,7 +42,7 @@ class ItemResolverTest extends TestCase
         $this->assertNull($resolver(null, ['id' => '/related_dummies/3'], null, $resolveInfo));
     }
 
-    public function testCreateItemResolver()
+    public function testCreateItemResolver(): void
     {
         $resolver = $this->createItemResolver(new RelatedDummy());
 
@@ -56,7 +56,7 @@ class ItemResolverTest extends TestCase
     /**
      * @dataProvider subresourceProvider
      */
-    public function testCreateSubresourceItemResolver($normalizedSubresource)
+    public function testCreateSubresourceItemResolver($normalizedSubresource): void
     {
         $resolver = $this->createItemResolver(new Dummy());
 

--- a/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
+++ b/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 
 class ResourceFieldResolverTest extends TestCase
 {
-    public function testId()
+    public function testId(): void
     {
         $dummy = new Dummy();
 
@@ -37,7 +37,7 @@ class ResourceFieldResolverTest extends TestCase
         $this->assertEquals('/dummies/1', $resolver([ItemNormalizer::ITEM_KEY => serialize($dummy)], [], [], $resolveInfo));
     }
 
-    public function testOriginalId()
+    public function testOriginalId(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -49,7 +49,7 @@ class ResourceFieldResolverTest extends TestCase
         $this->assertEquals(1, $resolver(['id' => 1], [], [], $resolveInfo));
     }
 
-    public function testDirectAccess()
+    public function testDirectAccess(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 

--- a/tests/GraphQl/Serializer/ItemNormalizerTest.php
+++ b/tests/GraphQl/Serializer/ItemNormalizerTest.php
@@ -32,7 +32,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class ItemNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $std = new \stdClass();
         $dummy = new Dummy();
@@ -62,7 +62,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class, ItemNormalizer::FORMAT));
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $dummy = new Dummy();
         $dummy->setName('hello');
@@ -96,7 +96,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertEquals(['name' => 'hello', ItemNormalizer::ITEM_KEY => serialize($dummy)], $normalizer->normalize($dummy, ItemNormalizer::FORMAT, ['resources' => []]));
     }
 
-    public function testDenormalize()
+    public function testDenormalize(): void
     {
         $context = ['resource_class' => Dummy::class, 'api_allow_update' => true];
 

--- a/tests/GraphQl/Type/Definition/IterableTypeTest.php
+++ b/tests/GraphQl/Type/Definition/IterableTypeTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class IterableTypeTest extends TestCase
 {
-    public function testSerialize()
+    public function testSerialize(): void
     {
         $iterableType = new IterableType();
 
@@ -43,7 +43,7 @@ class IterableTypeTest extends TestCase
         $this->assertEquals(['foo'], $iterableType->serialize(['foo']));
     }
 
-    public function testParseValue()
+    public function testParseValue(): void
     {
         $iterableType = new IterableType();
 
@@ -55,7 +55,7 @@ class IterableTypeTest extends TestCase
         $this->assertEquals(['foo'], $iterableType->parseValue(['foo']));
     }
 
-    public function testParseLiteral()
+    public function testParseLiteral(): void
     {
         $iterableType = new IterableType();
 

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -36,7 +36,7 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class SchemaBuilderTest extends TestCase
 {
-    public function testGetSchemaAllFields()
+    public function testGetSchemaAllFields(): void
     {
         $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
             return new PropertyMetadata(
@@ -67,7 +67,7 @@ class SchemaBuilderTest extends TestCase
         ], array_keys($mockedSchemaBuilder->getSchema()->getConfig()->getQuery()->getFields()));
     }
 
-    public function testGetSchemaResourceClassNotFound()
+    public function testGetSchemaResourceClassNotFound(): void
     {
         $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
             return new PropertyMetadata(
@@ -98,7 +98,7 @@ class SchemaBuilderTest extends TestCase
     /**
      * @dataProvider paginationProvider
      */
-    public function testGetSchema(bool $paginationEnabled)
+    public function testGetSchema(bool $paginationEnabled): void
     {
         $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
             return new PropertyMetadata(
@@ -230,8 +230,8 @@ class SchemaBuilderTest extends TestCase
         $resourceNameCollection = new ResourceNameCollection($resourceClassNames);
         $resourceNameCollectionFactoryProphecy->create()->willReturn($resourceNameCollection);
 
-        $collectionResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {});
-        $itemMutationResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {});
+        $collectionResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function (): void {});
+        $itemMutationResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function (): void {});
 
         return new SchemaBuilder(
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -240,8 +240,8 @@ class SchemaBuilderTest extends TestCase
             $resourceMetadataFactoryProphecy->reveal(),
             $collectionResolverFactoryProphecy->reveal(),
             $itemMutationResolverFactoryProphecy->reveal(),
-            function () {},
-            function () {},
+            function (): void {},
+            function (): void {},
             null,
             $paginationEnabled
         );

--- a/tests/Hal/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hal/Serializer/CollectionNormalizerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class CollectionNormalizerTest extends TestCase
 {
-    public function testSupportsNormalize()
+    public function testSupportsNormalize(): void
     {
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page');
@@ -37,7 +37,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalizeApiSubLevel()
+    public function testNormalizeApiSubLevel(): void
     {
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass()->shouldNotBeCalled();
@@ -51,7 +51,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertEquals(['foo' => 22], $normalizer->normalize(['foo' => 'bar'], null, ['api_sub_level' => true]));
     }
 
-    public function testNormalizePaginator()
+    public function testNormalizePaginator(): void
     {
         $this->assertEquals(
             [
@@ -82,7 +82,7 @@ class CollectionNormalizerTest extends TestCase
         );
     }
 
-    public function testNormalizePartialPaginator()
+    public function testNormalizePartialPaginator(): void
     {
         $this->assertEquals(
             [

--- a/tests/Hal/Serializer/EntrypointNormalizerTest.php
+++ b/tests/Hal/Serializer/EntrypointNormalizerTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EntrypointNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $collection = new ResourceNameCollection();
         $entrypoint = new Entrypoint($collection);
@@ -45,7 +45,7 @@ class EntrypointNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $collection = new ResourceNameCollection([Dummy::class]);
         $entrypoint = new Entrypoint($collection);

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -41,7 +41,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class ItemNormalizerTest extends TestCase
 {
-    public function testDoesNotSupportDenormalization()
+    public function testDoesNotSupportDenormalization(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -64,7 +64,7 @@ class ItemNormalizerTest extends TestCase
         $normalizer->denormalize(['foo'], 'Foo');
     }
 
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $std = new \stdClass();
         $dummy = new Dummy();
@@ -95,7 +95,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $relatedDummy = new RelatedDummy();
         $dummy = new Dummy();
@@ -155,7 +155,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($dummy));
     }
 
-    public function testNormalizeWithoutCache()
+    public function testNormalizeWithoutCache(): void
     {
         $relatedDummy = new RelatedDummy();
         $dummy = new Dummy();
@@ -212,12 +212,12 @@ class ItemNormalizerTest extends TestCase
             ],
             'name' => 'hello',
         ];
-        $this->assertEquals($expected, $normalizer->normalize($dummy, null, ['not_serializable' => function () {}]));
+        $this->assertEquals($expected, $normalizer->normalize($dummy, null, ['not_serializable' => function (): void {}]));
     }
 
-    public function testMaxDepth()
+    public function testMaxDepth(): void
     {
-        $setId = function (MaxDepthDummy $dummy, int $id) {
+        $setId = function (MaxDepthDummy $dummy, int $id): void {
             $prop = new \ReflectionProperty($dummy, 'id');
             $prop->setAccessible(true);
             $prop->setValue($dummy, $id);

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  */
 class AddHeadersListenerTest extends TestCase
 {
-    public function testDoNotSetHeaderWhenMethodNotCacheable()
+    public function testDoNotSetHeaderWhenMethodNotCacheable(): void
     {
         $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
         $request->setMethod('PUT');
@@ -42,7 +42,7 @@ class AddHeadersListenerTest extends TestCase
         $this->assertNull($response->getEtag());
     }
 
-    public function testDoNotSetHeaderWhenNotAnApiOperation()
+    public function testDoNotSetHeaderWhenNotAnApiOperation(): void
     {
         $request = new Request();
         $response = new Response();
@@ -57,7 +57,7 @@ class AddHeadersListenerTest extends TestCase
         $this->assertNull($response->getEtag());
     }
 
-    public function testDoNotSetHeaderWhenNoContent()
+    public function testDoNotSetHeaderWhenNoContent(): void
     {
         $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
         $response = new Response();
@@ -72,7 +72,7 @@ class AddHeadersListenerTest extends TestCase
         $this->assertNull($response->getEtag());
     }
 
-    public function testAddHeaders()
+    public function testAddHeaders(): void
     {
         $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
         $response = new Response('some content', 200, ['Vary' => ['Accept', 'Cookie']]);

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  */
 class AddTagsListenerTest extends TestCase
 {
-    public function testDoNotSetHeaderWhenMethodNotCacheable()
+    public function testDoNotSetHeaderWhenMethodNotCacheable(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -47,7 +47,7 @@ class AddTagsListenerTest extends TestCase
         $this->assertFalse($response->headers->has('Cache-Tags'));
     }
 
-    public function testDoNotSetHeaderWhenResponseNotCacheable()
+    public function testDoNotSetHeaderWhenResponseNotCacheable(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -65,7 +65,7 @@ class AddTagsListenerTest extends TestCase
         $this->assertFalse($response->headers->has('Cache-Tags'));
     }
 
-    public function testDoNotSetHeaderWhenNotAnApiOperation()
+    public function testDoNotSetHeaderWhenNotAnApiOperation(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -85,7 +85,7 @@ class AddTagsListenerTest extends TestCase
         $this->assertFalse($response->headers->has('Cache-Tags'));
     }
 
-    public function testDoNotSetHeaderWhenEmptyTagList()
+    public function testDoNotSetHeaderWhenEmptyTagList(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -105,7 +105,7 @@ class AddTagsListenerTest extends TestCase
         $this->assertFalse($response->headers->has('Cache-Tags'));
     }
 
-    public function testAddTags()
+    public function testAddTags(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -125,7 +125,7 @@ class AddTagsListenerTest extends TestCase
         $this->assertSame('/foo,/bar', $response->headers->get('Cache-Tags'));
     }
 
-    public function testAddCollectionIri()
+    public function testAddCollectionIri(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
@@ -146,7 +146,7 @@ class AddTagsListenerTest extends TestCase
         $this->assertSame('/foo,/bar,/dummies', $response->headers->get('Cache-Tags'));
     }
 
-    public function testAddCollectionIriWhenCollectionIsEmpty()
+    public function testAddCollectionIriWhenCollectionIsEmpty(): void
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();

--- a/tests/HttpCache/VarnishPurgerTest.php
+++ b/tests/HttpCache/VarnishPurgerTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class VarnishPurgerTest extends TestCase
 {
-    public function testPurge()
+    public function testPurge(): void
     {
         $clientProphecy1 = $this->prophesize(ClientInterface::class);
         $clientProphecy1->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => '(^|\,)/foo($|\,)']])->willReturn(new Response())->shouldBeCalled();
@@ -38,7 +38,7 @@ class VarnishPurgerTest extends TestCase
         $purger->purge(['/foo' => '/foo', '/bar' => '/bar']);
     }
 
-    public function testEmptyTags()
+    public function testEmptyTags(): void
     {
         $clientProphecy1 = $this->prophesize(ClientInterface::class);
         $clientProphecy1->request()->shouldNotBeCalled();

--- a/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class CollectionFiltersNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $decoratedProphecy = $this->prophesize(NormalizerInterface::class);
         $decoratedProphecy->willImplement(CacheableSupportsMethodInterface::class);
@@ -49,7 +49,7 @@ class CollectionFiltersNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testDoNothingIfSubLevel()
+    public function testDoNothingIfSubLevel(): void
     {
         $dummy = new Dummy();
 
@@ -69,7 +69,7 @@ class CollectionFiltersNormalizerTest extends TestCase
         $this->assertEquals(['name' => 'foo'], $normalizer->normalize($dummy, null, ['api_sub_level' => true]));
     }
 
-    public function testDoNothingIfNoFilter()
+    public function testDoNothingIfNoFilter(): void
     {
         $dummy = new Dummy();
 
@@ -92,7 +92,7 @@ class CollectionFiltersNormalizerTest extends TestCase
         $this->assertEquals(['name' => 'foo'], $normalizer->normalize($dummy, null, ['collection_operation_name' => 'get']));
     }
 
-    public function testDoNothingIfNoRequestUri()
+    public function testDoNothingIfNoRequestUri(): void
     {
         $dummy = new Dummy();
 
@@ -115,7 +115,7 @@ class CollectionFiltersNormalizerTest extends TestCase
         $this->assertEquals(['name' => 'foo'], $normalizer->normalize($dummy, null, []));
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $filterProphecy = $this->prophesize(FilterInterface::class);
         $filterProphecy->getDescription(Dummy::class)->willReturn(['a' => ['property' => 'name', 'required' => true]])->shouldBeCalled();
@@ -131,7 +131,7 @@ class CollectionFiltersNormalizerTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testNormalizeWithDeprecatedFilterCollection()
+    public function testNormalizeWithDeprecatedFilterCollection(): void
     {
         $filterProphecy = $this->prophesize(FilterInterface::class);
         $filterProphecy->getDescription(Dummy::class)->willReturn(['a' => ['property' => 'name', 'required' => true]])->shouldBeCalled();
@@ -142,7 +142,7 @@ class CollectionFiltersNormalizerTest extends TestCase
     /**
      * @group legacy
      */
-    public function testConstructWithInvalidFilterLocator()
+    public function testConstructWithInvalidFilterLocator(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$filterLocator" argument is expected to be an implementation of the "Psr\\Container\\ContainerInterface" interface.');
@@ -155,7 +155,7 @@ class CollectionFiltersNormalizerTest extends TestCase
         );
     }
 
-    private function normalize($filterLocator)
+    private function normalize($filterLocator): void
     {
         $dummy = new Dummy();
 

--- a/tests/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionNormalizerTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class CollectionNormalizerTest extends TestCase
 {
-    public function testSupportsNormalize()
+    public function testSupportsNormalize(): void
     {
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $iriConvert = $this->prophesize(IriConverterInterface::class);
@@ -47,7 +47,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalizeApiSubLevel()
+    public function testNormalizeApiSubLevel(): void
     {
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass(['foo' => 'bar'], null, true)->willReturn('Foo')->shouldBeCalled();
@@ -65,7 +65,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertEquals(['@context' => '/contexts/Foo', '@id' => '/foo/1', '@type' => 'hydra:Collection', 'hydra:member' => [0 => '22'], 'hydra:totalItems' => 1], $normalizer->normalize(['foo' => 'bar'], null));
     }
 
-    public function testNormalizePaginator()
+    public function testNormalizePaginator(): void
     {
         $this->assertEquals(
             [
@@ -84,7 +84,7 @@ class CollectionNormalizerTest extends TestCase
         );
     }
 
-    public function testNormalizePartialPaginator()
+    public function testNormalizePartialPaginator(): void
     {
         $this->assertEquals(
             [

--- a/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
  */
 class ConstraintViolationNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
         $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
@@ -40,7 +40,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
         $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -37,7 +37,7 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class DocumentationNormalizerTest extends TestCase
 {
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $title = 'Test Api';
         $desc = 'test ApiGerard';

--- a/tests/Hydra/Serializer/EntrypointNormalizerTest.php
+++ b/tests/Hydra/Serializer/EntrypointNormalizerTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EntrypointNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $collection = new ResourceNameCollection();
         $entrypoint = new Entrypoint($collection);
@@ -45,7 +45,7 @@ class EntrypointNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $collection = new ResourceNameCollection([Dummy::class]);
         $entrypoint = new Entrypoint($collection);

--- a/tests/Hydra/Serializer/ErrorNormalizerTest.php
+++ b/tests/Hydra/Serializer/ErrorNormalizerTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ErrorNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
 
@@ -47,7 +47,7 @@ class ErrorNormalizerTest extends TestCase
      * @param string $originalMessage original message of the Exception
      * @param bool   $debug           simulates kernel debug variable
      */
-    public function testErrorServerNormalize(int $status, string $originalMessage, bool $debug)
+    public function testErrorServerNormalize(int $status, string $originalMessage, bool $debug): void
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
         $urlGeneratorProphecy->generate('api_jsonld_context', ['shortName' => 'Error'])->willReturn('/context/foo')->shouldBeCalled();
@@ -81,7 +81,7 @@ class ErrorNormalizerTest extends TestCase
         ];
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
         $urlGeneratorProphecy->generate('api_jsonld_context', ['shortName' => 'Error'])->willReturn('/context/foo')->shouldBeCalled();

--- a/tests/Hydra/Serializer/ItemNormalizerTest.php
+++ b/tests/Hydra/Serializer/ItemNormalizerTest.php
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class ItemNormalizerTest extends TestCase
 {
-    public function testDontSupportDenormalization()
+    public function testDontSupportDenormalization(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -51,7 +51,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $std = new \stdClass();
         $dummy = new Dummy();
@@ -82,7 +82,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $dummy = new Dummy();
         $dummy->setName('hello');

--- a/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
+++ b/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class PartialCollectionViewNormalizerTest extends TestCase
 {
-    public function testNormalizeDoesNotChangeSubLevel()
+    public function testNormalizeDoesNotChangeSubLevel(): void
     {
         $decoratedNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
         $decoratedNormalizerProphecy->normalize(Argument::any(), null, ['jsonld_sub_level' => true])->willReturn(['foo' => 'bar'])->shouldBeCalled();
@@ -36,7 +36,7 @@ class PartialCollectionViewNormalizerTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $normalizer->normalize(new \stdClass(), null, ['jsonld_sub_level' => true]));
     }
 
-    public function testNormalizeDoesNotChangeWhenNoFilterNorPagination()
+    public function testNormalizeDoesNotChangeWhenNoFilterNorPagination(): void
     {
         $decoratedNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
         $decoratedNormalizerProphecy->normalize(Argument::any(), null, Argument::type('array'))->willReturn(['foo' => 'bar'])->shouldBeCalled();
@@ -45,7 +45,7 @@ class PartialCollectionViewNormalizerTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $normalizer->normalize(new \stdClass(), null, ['request_uri' => '/?page=1&pagination=1']));
     }
 
-    public function testNormalizePaginator()
+    public function testNormalizePaginator(): void
     {
         $this->assertEquals(
             [
@@ -64,7 +64,7 @@ class PartialCollectionViewNormalizerTest extends TestCase
         );
     }
 
-    public function testNormalizePartialaginator()
+    public function testNormalizePartialaginator(): void
     {
         $this->assertEquals(
             [
@@ -103,7 +103,7 @@ class PartialCollectionViewNormalizerTest extends TestCase
         return $normalizer->normalize($paginatorProphecy->reveal());
     }
 
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $decoratedNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
         $decoratedNormalizerProphecy->willImplement(CacheableSupportsMethodInterface::class);
@@ -115,7 +115,7 @@ class PartialCollectionViewNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testSetNormalizer()
+    public function testSetNormalizer(): void
     {
         $injectedNormalizer = $this->prophesize(NormalizerInterface::class)->reveal();
 

--- a/tests/Identifier/CompositeIdentifierParserTest.php
+++ b/tests/Identifier/CompositeIdentifierParserTest.php
@@ -21,7 +21,7 @@ class CompositeIdentifierParserTest extends TestCase
     /**
      * @dataProvider variousIdentifiers
      */
-    public function testNormalizeCompositeCorrectly(array $identifiers)
+    public function testNormalizeCompositeCorrectly(array $identifiers): void
     {
         foreach ($identifiers as $string => $expected) {
             $this->assertEquals(CompositeIdentifierParser::parse($string), $expected);

--- a/tests/Identifier/Normalizer/ChainIdentifierDenormalizerTest.php
+++ b/tests/Identifier/Normalizer/ChainIdentifierDenormalizerTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class ChainIdentifierDenormalizerTest extends TestCase
 {
-    public function testCompositeIdentifier()
+    public function testCompositeIdentifier(): void
     {
         $identifier = 'a=1;c=2;d=2015-04-05';
         $class = 'Dummy';
@@ -53,7 +53,7 @@ class ChainIdentifierDenormalizerTest extends TestCase
         $this->assertSame(1, $result['a']);
     }
 
-    public function testSingleDateIdentifier()
+    public function testSingleDateIdentifier(): void
     {
         $identifier = '2015-04-05';
         $class = 'Dummy';
@@ -72,7 +72,7 @@ class ChainIdentifierDenormalizerTest extends TestCase
         $this->assertEquals($identifierDenormalizer->denormalize($identifier, $class), ['funkyid' => new \DateTime('2015-04-05')]);
     }
 
-    public function testIntegerIdentifier()
+    public function testIntegerIdentifier(): void
     {
         $identifier = '42';
         $class = 'Dummy';

--- a/tests/Identifier/Normalizer/DateTimeIdentifierNormalizerTest.php
+++ b/tests/Identifier/Normalizer/DateTimeIdentifierNormalizerTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DateTimeIdentifierNormalizerTest extends TestCase
 {
-    public function testDenormalize()
+    public function testDenormalize(): void
     {
         $this->expectException(\ApiPlatform\Core\Exception\InvalidIdentifierException::class);
 
@@ -29,7 +29,7 @@ class DateTimeIdentifierNormalizerTest extends TestCase
         $normalizer->denormalize('not valid', \DateTimeImmutable::class);
     }
 
-    public function testHasCacheableSupportsMethod()
+    public function testHasCacheableSupportsMethod(): void
     {
         $this->assertTrue((new DateTimeIdentifierDenormalizer())->hasCacheableSupportsMethod());
     }

--- a/tests/Identifier/Normalizer/IntegerDenormalizerTest.php
+++ b/tests/Identifier/Normalizer/IntegerDenormalizerTest.php
@@ -21,12 +21,12 @@ use PHPUnit\Framework\TestCase;
  */
 class IntegerDenormalizerTest extends TestCase
 {
-    public function testDenormalize()
+    public function testDenormalize(): void
     {
         $this->assertSame(2, (new IntegerDenormalizer())->denormalize('2', 'int'));
     }
 
-    public function testSupportsDenormalization()
+    public function testSupportsDenormalization(): void
     {
         $normalizer = new IntegerDenormalizer();
         $this->assertTrue($normalizer->supportsDenormalization('1', 'int'));

--- a/tests/JsonApi/EventListener/TransformFieldsetsParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformFieldsetsParametersListenerTest.php
@@ -25,7 +25,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy'));
@@ -33,7 +33,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
         $this->listener = new TransformFieldsetsParametersListener($resourceMetadataFactoryProphecy->reveal());
     }
 
-    public function testOnKernelRequestWithInvalidFormat()
+    public function testOnKernelRequestWithInvalidFormat(): void
     {
         $expectedRequest = new Request();
         $expectedRequest->setRequestFormat('badformat');
@@ -48,7 +48,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequestWithInvalidFilter()
+    public function testOnKernelRequestWithInvalidFilter(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -70,7 +70,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequest()
+    public function testOnKernelRequest(): void
     {
         $request = new Request(
             ['fields' => ['dummy' => 'id,name,dummyFloat', 'relatedDummy' => 'id,name'], 'include' => 'relatedDummy,foo'],
@@ -98,7 +98,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequestWithIncludeWithoutFields()
+    public function testOnKernelRequestWithIncludeWithoutFields(): void
     {
         $request = new Request(
             ['include' => 'relatedDummy,foo'],
@@ -125,7 +125,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequestWithWrongParametersTypesDoesnTAffectRequestAttributes()
+    public function testOnKernelRequestWithWrongParametersTypesDoesnTAffectRequestAttributes(): void
     {
         $request = new Request(
             ['fields' => 'foo', 'include' => ['relatedDummy,foo']],

--- a/tests/JsonApi/EventListener/TransformFilteringParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformFilteringParametersListenerTest.php
@@ -25,12 +25,12 @@ class TransformFilteringParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new TransformFilteringParametersListener();
     }
 
-    public function testOnKernelRequestWithInvalidFormat()
+    public function testOnKernelRequestWithInvalidFormat(): void
     {
         $expectedRequest = new Request();
         $expectedRequest->setRequestFormat('badformat');
@@ -45,7 +45,7 @@ class TransformFilteringParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequestWithInvalidFilter()
+    public function testOnKernelRequestWithInvalidFilter(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -67,7 +67,7 @@ class TransformFilteringParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequest()
+    public function testOnKernelRequest(): void
     {
         $request = new Request(['filter' => ['foo' => 'bar', 'baz' => 'qux']]);
         $request->setRequestFormat('jsonapi');

--- a/tests/JsonApi/EventListener/TransformPaginationParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformPaginationParametersListenerTest.php
@@ -25,12 +25,12 @@ class TransformPaginationParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new TransformPaginationParametersListener();
     }
 
-    public function testOnKernelRequestWithInvalidFormat()
+    public function testOnKernelRequestWithInvalidFormat(): void
     {
         $expectedRequest = new Request();
         $expectedRequest->setRequestFormat('badformat');
@@ -45,7 +45,7 @@ class TransformPaginationParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequestWithInvalidPage()
+    public function testOnKernelRequestWithInvalidPage(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -67,7 +67,7 @@ class TransformPaginationParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequest()
+    public function testOnKernelRequest(): void
     {
         $request = new Request(['page' => ['size' => 5, 'number' => 3, 'error' => -1]]);
         $request->setRequestFormat('jsonapi');

--- a/tests/JsonApi/EventListener/TransformSortingParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformSortingParametersListenerTest.php
@@ -25,12 +25,12 @@ class TransformSortingParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new TransformSortingParametersListener();
     }
 
-    public function testOnKernelRequestWithInvalidFormat()
+    public function testOnKernelRequestWithInvalidFormat(): void
     {
         $expectedRequest = new Request();
         $expectedRequest->setRequestFormat('badformat');
@@ -45,7 +45,7 @@ class TransformSortingParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequestWithInvalidFilter()
+    public function testOnKernelRequestWithInvalidFilter(): void
     {
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
 
@@ -67,7 +67,7 @@ class TransformSortingParametersListenerTest extends TestCase
         $this->assertEquals($expectedRequest, $request);
     }
 
-    public function testOnKernelRequest()
+    public function testOnKernelRequest(): void
     {
         $request = new Request(['sort' => 'foo,-bar,-baz,qux']);
         $request->setRequestFormat('jsonapi');

--- a/tests/JsonApi/Serializer/CollectionNormalizerTest.php
+++ b/tests/JsonApi/Serializer/CollectionNormalizerTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class CollectionNormalizerTest extends TestCase
 {
-    public function testSupportsNormalize()
+    public function testSupportsNormalize(): void
     {
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
 
@@ -39,7 +39,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalizePaginator()
+    public function testNormalizePaginator(): void
     {
         $paginatorProphecy = $this->prophesize(PaginatorInterface::class);
         $paginatorProphecy->getCurrentPage()->willReturn(3.)->shouldBeCalled();
@@ -109,7 +109,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($paginator, CollectionNormalizer::FORMAT, ['request_uri' => '/foos?page=3']));
     }
 
-    public function testNormalizePartialPaginator()
+    public function testNormalizePartialPaginator(): void
     {
         $paginatorProphecy = $this->prophesize(PartialPaginatorInterface::class);
         $paginatorProphecy->getCurrentPage()->willReturn(3.)->shouldBeCalled();
@@ -175,7 +175,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($paginator, CollectionNormalizer::FORMAT, ['request_uri' => '/foos?page=3']));
     }
 
-    public function testNormalizeArray()
+    public function testNormalizeArray(): void
     {
         $data = ['foo'];
 
@@ -225,7 +225,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($data, CollectionNormalizer::FORMAT, ['request_uri' => '/foos']));
     }
 
-    public function testNormalizeIncludedData()
+    public function testNormalizeIncludedData(): void
     {
         $data = ['foo'];
 
@@ -295,7 +295,7 @@ class CollectionNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($data, CollectionNormalizer::FORMAT, ['request_uri' => '/foos']));
     }
 
-    public function testNormalizeWithoutDataKey()
+    public function testNormalizeWithoutDataKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The JSON API document must contain a "data" key.');

--- a/tests/JsonApi/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ConstraintViolationNormalizerTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
  */
 class ConstraintViolationNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $nameConverterInterface = $this->prophesize(NameConverterInterface::class);
@@ -42,7 +42,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy')->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class)))->shouldBeCalled(1);

--- a/tests/JsonApi/Serializer/EntrypointNormalizerTest.php
+++ b/tests/JsonApi/Serializer/EntrypointNormalizerTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EntrypointNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $collection = new ResourceNameCollection();
         $entrypoint = new Entrypoint($collection);
@@ -48,7 +48,7 @@ class EntrypointNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $collection = new ResourceNameCollection([Dummy::class, RelatedDummy::class, DummyCar::class]);
         $entrypoint = new Entrypoint($collection);

--- a/tests/JsonApi/Serializer/ErrorNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ErrorNormalizerTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ErrorNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $normalizer = new ErrorNormalizer();
 
@@ -44,7 +44,7 @@ class ErrorNormalizerTest extends TestCase
      * @param string $originalMessage original message of the Exception
      * @param bool   $debug           simulates kernel debug variable
      */
-    public function testNormalize($status, $originalMessage, $debug)
+    public function testNormalize($status, $originalMessage, $debug): void
     {
         $normalizer = new ErrorNormalizer($debug);
         $exception = FlattenException::create(new \Exception($originalMessage), $status);

--- a/tests/JsonApi/Serializer/ItemNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ItemNormalizerTest.php
@@ -41,7 +41,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class ItemNormalizerTest extends TestCase
 {
-    public function testSupportDenormalization()
+    public function testSupportDenormalization(): void
     {
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true)->shouldBeCalled();
@@ -62,7 +62,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $std = new \stdClass();
         $dummy = new Dummy();
@@ -86,7 +86,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization($std, ItemNormalizer::FORMAT));
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $dummy = new Dummy();
         $dummy->setId(10);
@@ -149,7 +149,7 @@ class ItemNormalizerTest extends TestCase
         );
     }
 
-    public function testNormalizeIsNotAnArray()
+    public function testNormalizeIsNotAnArray(): void
     {
         $object = new \stdClass();
         $object->object = $object;
@@ -178,12 +178,12 @@ class ItemNormalizerTest extends TestCase
             ItemNormalizer::FORMAT,
             [
                 'circular_reference_limit' => [spl_object_hash($object) => 2],
-                'cache_error' => function () {},
+                'cache_error' => function (): void {},
             ]
         ));
     }
 
-    public function testNormalizeThrowsNoSuchPropertyException()
+    public function testNormalizeThrowsNoSuchPropertyException(): void
     {
         $this->expectException(NoSuchPropertyException::class);
 
@@ -214,7 +214,7 @@ class ItemNormalizerTest extends TestCase
         $normalizer->normalize($foo, ItemNormalizer::FORMAT);
     }
 
-    public function testDenormalize()
+    public function testDenormalize(): void
     {
         $relatedDummy1 = new RelatedDummy();
         $relatedDummy1->setId(1);
@@ -325,7 +325,7 @@ class ItemNormalizerTest extends TestCase
         );
     }
 
-    public function testDenormalizeUpdateOperationNotAllowed()
+    public function testDenormalizeUpdateOperationNotAllowed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Update is not allowed for this operation.');
@@ -355,7 +355,7 @@ class ItemNormalizerTest extends TestCase
         );
     }
 
-    public function testDenormalizeCollectionIsNotArray()
+    public function testDenormalizeCollectionIsNotArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The type of the "relatedDummies" attribute must be "array", "string" given.');
@@ -407,7 +407,7 @@ class ItemNormalizerTest extends TestCase
         );
     }
 
-    public function testDenormalizeCollectionWithInvalidKey()
+    public function testDenormalizeCollectionWithInvalidKey(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The type of the key "0" must be "string", "integer" given.');
@@ -464,7 +464,7 @@ class ItemNormalizerTest extends TestCase
         );
     }
 
-    public function testDenormalizeRelationIsNotResourceLinkage()
+    public function testDenormalizeRelationIsNotResourceLinkage(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Only resource linkage supported currently, see: http://jsonapi.org/format/#document-resource-object-linkage.');

--- a/tests/JsonApi/Serializer/ReservedAttributeNameConverterTest.php
+++ b/tests/JsonApi/Serializer/ReservedAttributeNameConverterTest.php
@@ -24,7 +24,7 @@ class ReservedAttributeNameConverterTest extends TestCase
 {
     private $reservedAttributeNameConverter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->reservedAttributeNameConverter = new ReservedAttributeNameConverter(new CustomConverter());
     }
@@ -52,7 +52,7 @@ class ReservedAttributeNameConverterTest extends TestCase
      * @param string $propertyName
      * @param string $expectedPropertyName
      */
-    public function testNormalize($propertyName, $expectedPropertyName)
+    public function testNormalize($propertyName, $expectedPropertyName): void
     {
         $this->assertEquals($expectedPropertyName, $this->reservedAttributeNameConverter->normalize($propertyName));
     }
@@ -63,7 +63,7 @@ class ReservedAttributeNameConverterTest extends TestCase
      * @param string $expectedPropertyName
      * @param string $propertyName
      */
-    public function testDenormalize($expectedPropertyName, $propertyName)
+    public function testDenormalize($expectedPropertyName, $propertyName): void
     {
         $this->assertEquals($expectedPropertyName, $this->reservedAttributeNameConverter->denormalize($propertyName));
     }

--- a/tests/JsonLd/Action/ContextActionTest.php
+++ b/tests/JsonLd/Action/ContextActionTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ContextActionTest extends TestCase
 {
-    public function testContextActionWithEntrypoint()
+    public function testContextActionWithEntrypoint(): void
     {
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
@@ -38,7 +38,7 @@ class ContextActionTest extends TestCase
         $this->assertEquals(['@context' => ['/entrypoints']], $contextAction('Entrypoint'));
     }
 
-    public function testContextActionWithContexts()
+    public function testContextActionWithContexts(): void
     {
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
@@ -49,7 +49,7 @@ class ContextActionTest extends TestCase
         $this->assertEquals(['@context' => ['/contexts']], $contextAction('Error'));
     }
 
-    public function testContextActionWithResourceClass()
+    public function testContextActionWithResourceClass(): void
     {
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
@@ -64,7 +64,7 @@ class ContextActionTest extends TestCase
         $this->assertEquals(['@context' => ['/dummies']], $contextAction('dummy'));
     }
 
-    public function testContextActionWithThrown()
+    public function testContextActionWithThrown(): void
     {
         $this->expectException(NotFoundHttpException::class);
 

--- a/tests/JsonLd/ContextBuilderTest.php
+++ b/tests/JsonLd/ContextBuilderTest.php
@@ -38,7 +38,7 @@ class ContextBuilderTest extends TestCase
     private $propertyMetadataFactoryProphecy;
     private $urlGeneratorProphecy;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->entityClass = '\Dummy\DummyEntity';
         $this->resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
@@ -48,7 +48,7 @@ class ContextBuilderTest extends TestCase
         $this->urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
     }
 
-    public function testResourceContext()
+    public function testResourceContext(): void
     {
         $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity'));
         $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
@@ -65,7 +65,7 @@ class ContextBuilderTest extends TestCase
         $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
     }
 
-    public function testResourceContextWithJsonldContext()
+    public function testResourceContextWithJsonldContext(): void
     {
         $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity'));
         $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
@@ -86,7 +86,7 @@ class ContextBuilderTest extends TestCase
         $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
     }
 
-    public function testGetEntryPointContext()
+    public function testGetEntryPointContext(): void
     {
         $this->resourceMetadataFactoryProphecy->create('dummyPropertyA')->willReturn(new ResourceMetadata('DummyEntity'));
         $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
@@ -107,7 +107,7 @@ class ContextBuilderTest extends TestCase
         $this->assertEquals($expected, $contextBuilder->getEntrypointContext());
     }
 
-    public function testResourceContextWithReverse()
+    public function testResourceContextWithReverse(): void
     {
         $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity'));
         $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));

--- a/tests/Metadata/Extractor/XmlExtractorTest.php
+++ b/tests/Metadata/Extractor/XmlExtractorTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class XmlExtractorTest extends TestCase
 {
-    public function testEmptyOperation()
+    public function testEmptyOperation(): void
     {
         $resources = (new XmlExtractor([__DIR__.'/../../Fixtures/FileConfigurations/empty-operation.xml']))->getResources();
 

--- a/tests/Metadata/Extractor/YamlExtractorTest.php
+++ b/tests/Metadata/Extractor/YamlExtractorTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class YamlExtractorTest extends TestCase
 {
-    public function testInvalidProperty()
+    public function testInvalidProperty(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The property "shortName" must be a "string", "integer" given.');
@@ -30,7 +30,7 @@ class YamlExtractorTest extends TestCase
         (new YamlExtractor([__DIR__.'/../../Fixtures/FileConfigurations/badpropertytype.yml']))->getResources();
     }
 
-    public function testParseException()
+    public function testParseException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/Unable to parse in ".+\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/parse_exception.yml"/');
@@ -38,7 +38,7 @@ class YamlExtractorTest extends TestCase
         (new YamlExtractor([__DIR__.'/../../Fixtures/FileConfigurations/parse_exception.yml']))->getResources();
     }
 
-    public function testEmptyResources()
+    public function testEmptyResources(): void
     {
         $resources = (new YamlExtractor([__DIR__.'/../../Fixtures/FileConfigurations/resources_empty.yml']))->getResources();
 

--- a/tests/Metadata/Property/Factory/AnnotationPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/AnnotationPropertyMetadataFactoryTest.php
@@ -32,7 +32,7 @@ class AnnotationPropertyMetadataFactoryTest extends TestCase
     /**
      * @dataProvider getDependencies
      */
-    public function testCreateProperty(ProphecyInterface $reader, ProphecyInterface $decorated = null, string $description)
+    public function testCreateProperty(ProphecyInterface $reader, ProphecyInterface $decorated = null, string $description): void
     {
         $factory = new AnnotationPropertyMetadataFactory($reader->reveal(), $decorated ? $decorated->reveal() : null);
         $metadata = $factory->create(Dummy::class, 'name');
@@ -87,7 +87,7 @@ class AnnotationPropertyMetadataFactoryTest extends TestCase
         ];
     }
 
-    public function testClassNotFound()
+    public function testClassNotFound(): void
     {
         $this->expectException(PropertyNotFoundException::class);
         $this->expectExceptionMessage('Property "foo" of class "\\DoNotExist" not found.');
@@ -96,7 +96,7 @@ class AnnotationPropertyMetadataFactoryTest extends TestCase
         $factory->create('\DoNotExist', 'foo');
     }
 
-    public function testClassNotFoundButParentFound()
+    public function testClassNotFoundButParentFound(): void
     {
         $propertyMetadata = new PropertyMetadata();
 

--- a/tests/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/AnnotationPropertyNameCollectionFactoryTest.php
@@ -33,7 +33,7 @@ class AnnotationPropertyNameCollectionFactoryTest extends TestCase
     /**
      * @dataProvider getDependencies
      */
-    public function testCreate(PropertyNameCollectionFactoryInterface $decorated = null, array $results)
+    public function testCreate(PropertyNameCollectionFactoryInterface $decorated = null, array $results): void
     {
         $reader = $this->prophesize(Reader::class);
         $reader->getPropertyAnnotation(new \ReflectionProperty(Dummy::class, 'name'), ApiProperty::class)->willReturn(new ApiProperty())->shouldBeCalled();
@@ -67,7 +67,7 @@ class AnnotationPropertyNameCollectionFactoryTest extends TestCase
     /**
      * @dataProvider getUpperCaseDependencies
      */
-    public function testUpperCaseCreate(ObjectProphecy $decorated = null, array $results)
+    public function testUpperCaseCreate(ObjectProphecy $decorated = null, array $results): void
     {
         $reader = $this->prophesize(Reader::class);
         $reader->getPropertyAnnotation(new \ReflectionProperty(UpperCaseIdentifierDummy::class, 'name'), ApiProperty::class)->willReturn(new ApiProperty())->shouldBeCalled();
@@ -94,7 +94,7 @@ class AnnotationPropertyNameCollectionFactoryTest extends TestCase
         ];
     }
 
-    public function testClassDoesNotExist()
+    public function testClassDoesNotExist(): void
     {
         $this->expectException(ResourceClassNotFoundException::class);
         $this->expectExceptionMessage('The resource class "\\DoNotExist" does not exist.');

--- a/tests/Metadata/Property/Factory/CachedPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/CachedPropertyMetadataFactoryTest.php
@@ -27,7 +27,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedPropertyMetadataFactoryTest extends TestCase
 {
-    public function testCreateWithItemHit()
+    public function testCreateWithItemHit(): void
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()->willReturn(true)->shouldBeCalled();
@@ -47,7 +47,7 @@ class CachedPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy'), 'Trigger the local cache');
     }
 
-    public function testCreateWithItemNotHit()
+    public function testCreateWithItemNotHit(): void
     {
         $propertyMetadata = new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false);
 
@@ -71,7 +71,7 @@ class CachedPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedPropertyMetadataFactory->create(Dummy::class, 'dummy'), 'Trigger the local cache');
     }
 
-    public function testCreateWithGetCacheItemThrowsCacheException()
+    public function testCreateWithGetCacheItemThrowsCacheException(): void
     {
         $decoratedPropertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $decoratedPropertyMetadataFactory->create(Dummy::class, 'dummy', [])->willReturn(new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false))->shouldBeCalled();

--- a/tests/Metadata/Property/Factory/CachedPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/CachedPropertyNameCollectionFactoryTest.php
@@ -27,7 +27,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedPropertyNameCollectionFactoryTest extends TestCase
 {
-    public function testCreateWithItemHit()
+    public function testCreateWithItemHit(): void
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()->willReturn(true)->shouldBeCalled();
@@ -48,7 +48,7 @@ class CachedPropertyNameCollectionFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedPropertyNameCollectionFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
-    public function testCreateWithItemNotHit()
+    public function testCreateWithItemNotHit(): void
     {
         $resourceNameCollection = new PropertyNameCollection(['id', 'name', 'description', 'dummy']);
 
@@ -73,7 +73,7 @@ class CachedPropertyNameCollectionFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedPropertyNameCollectionFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
-    public function testCreateWithGetCacheItemThrowsCacheException()
+    public function testCreateWithGetCacheItemThrowsCacheException(): void
     {
         $decoratedPropertyNameCollectionFactory = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $decoratedPropertyNameCollectionFactory->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['id', 'name', 'description', 'dummy']))->shouldBeCalled();

--- a/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
@@ -34,7 +34,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider propertyMetadataProvider
      */
-    public function testCreateXml(PropertyMetadata $expectedPropertyMetadata)
+    public function testCreateXml(PropertyMetadata $expectedPropertyMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
 
@@ -48,7 +48,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider decoratedPropertyMetadataProvider
      */
-    public function testCreateWithParentPropertyMetadataFactoryXml(PropertyMetadata $expectedPropertyMetadata)
+    public function testCreateWithParentPropertyMetadataFactoryXml(PropertyMetadata $expectedPropertyMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
 
@@ -65,7 +65,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedPropertyMetadata, $propertyMetadata);
     }
 
-    public function testCreateWithNonexistentResourceXml()
+    public function testCreateWithNonexistentResourceXml(): void
     {
         $this->expectException(PropertyNotFoundException::class);
         $this->expectExceptionMessage('Property "foo" of the resource class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" not found.');
@@ -75,7 +75,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorPropertyMetadataFactory(new XmlExtractor([$configPath])))->create('ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ThisDoesNotExist', 'foo');
     }
 
-    public function testCreateWithNonexistentPropertyXml()
+    public function testCreateWithNonexistentPropertyXml(): void
     {
         $this->expectException(PropertyNotFoundException::class);
         $this->expectExceptionMessage('Property "bar" of the resource class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\FileConfigDummy" not found.');
@@ -85,7 +85,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorPropertyMetadataFactory(new XmlExtractor([$configPath])))->create(FileConfigDummy::class, 'bar');
     }
 
-    public function testCreateWithInvalidXml()
+    public function testCreateWithInvalidXml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('#.+Element \'\\{https://api-platform.com/schema/metadata\\}foo\': This element is not expected\\..+#');
@@ -98,7 +98,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider propertyMetadataProvider
      */
-    public function testCreateYaml(PropertyMetadata $expectedPropertyMetadata)
+    public function testCreateYaml(PropertyMetadata $expectedPropertyMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -112,7 +112,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider decoratedPropertyMetadataProvider
      */
-    public function testCreateWithParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata)
+    public function testCreateWithParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -132,7 +132,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider decoratedPropertyMetadataProvider
      */
-    public function testCreateWithCollectionTypedParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata)
+    public function testCreateWithCollectionTypedParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -163,7 +163,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider decoratedPropertyMetadataProvider
      */
-    public function testCreateWithTypedParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata)
+    public function testCreateWithTypedParentPropertyMetadataFactoryYaml(PropertyMetadata $expectedPropertyMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -185,7 +185,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedPropertyMetadata, $propertyMetadata);
     }
 
-    public function testCreateWithNonexistentResourceYaml()
+    public function testCreateWithNonexistentResourceYaml(): void
     {
         $this->expectException(PropertyNotFoundException::class);
         $this->expectExceptionMessage('Property "foo" of the resource class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" not found.');
@@ -195,7 +195,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorPropertyMetadataFactory(new YamlExtractor([$configPath])))->create('ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ThisDoesNotExist', 'foo');
     }
 
-    public function testCreateWithNonexistentPropertyYaml()
+    public function testCreateWithNonexistentPropertyYaml(): void
     {
         $this->expectException(PropertyNotFoundException::class);
         $this->expectExceptionMessage('Property "bar" of the resource class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\FileConfigDummy" not found.');
@@ -205,7 +205,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorPropertyMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class, 'bar');
     }
 
-    public function testCreateWithMalformedResourcesSettingYaml()
+    public function testCreateWithMalformedResourcesSettingYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/"resources" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/resourcesinvalid\\.yml"\\./');
@@ -215,7 +215,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorPropertyMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class, 'foo');
     }
 
-    public function testCreateWithMalformedPropertiesSettingYaml()
+    public function testCreateWithMalformedPropertiesSettingYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/"properties" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertiesinvalid\\.yml"\\./');
@@ -225,7 +225,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorPropertyMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class, 'foo');
     }
 
-    public function testCreateWithMalformedPropertySettingYaml()
+    public function testCreateWithMalformedPropertySettingYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/"foo" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertyinvalid\\.yml"\\./');
@@ -235,7 +235,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorPropertyMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class, 'foo');
     }
 
-    public function testCreateWithMalformedYaml()
+    public function testCreateWithMalformedYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactoryTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ExtractorPropertyNameCollectionFactoryTest extends TestCase
 {
-    public function testCreateXml()
+    public function testCreateXml(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
 
@@ -38,7 +38,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         );
     }
 
-    public function testCreateWithParentPropertyNameCollectionFactoryXml()
+    public function testCreateWithParentPropertyNameCollectionFactoryXml(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
 
@@ -54,7 +54,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         );
     }
 
-    public function testCreateWithNonexistentResourceXml()
+    public function testCreateWithNonexistentResourceXml(): void
     {
         $this->expectException(ResourceClassNotFoundException::class);
         $this->expectExceptionMessage('The resource class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" does not exist.');
@@ -64,7 +64,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         (new ExtractorPropertyNameCollectionFactory(new XmlExtractor([$configPath])))->create('ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ThisDoesNotExist');
     }
 
-    public function testCreateWithInvalidXml()
+    public function testCreateWithInvalidXml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('#.+Element \'\\{https://api-platform.com/schema/metadata\\}foo\': This element is not expected\\..+#');
@@ -74,7 +74,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         (new ExtractorPropertyNameCollectionFactory(new XmlExtractor([$configPath])))->create(FileConfigDummy::class);
     }
 
-    public function testCreateYaml()
+    public function testCreateYaml(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -84,7 +84,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         );
     }
 
-    public function testCreateWithParentPropertyMetadataFactoryYaml()
+    public function testCreateWithParentPropertyMetadataFactoryYaml(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -100,7 +100,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         );
     }
 
-    public function testCreateWithNonexistentResourceYaml()
+    public function testCreateWithNonexistentResourceYaml(): void
     {
         $this->expectException(ResourceClassNotFoundException::class);
         $this->expectExceptionMessage('The resource class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" does not exist.');
@@ -110,7 +110,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         (new ExtractorPropertyNameCollectionFactory(new YamlExtractor([$configPath])))->create('ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ThisDoesNotExist');
     }
 
-    public function testCreateWithMalformedResourcesSettingYaml()
+    public function testCreateWithMalformedResourcesSettingYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/"resources" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/resourcesinvalid\\.yml"\\./');
@@ -120,7 +120,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         (new ExtractorPropertyNameCollectionFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class);
     }
 
-    public function testCreateWithMalformedPropertiesSettingYaml()
+    public function testCreateWithMalformedPropertiesSettingYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/"properties" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertiesinvalid\\.yml"\\./');
@@ -130,7 +130,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         (new ExtractorPropertyNameCollectionFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class);
     }
 
-    public function testCreateWithMalformedPropertySettingYaml()
+    public function testCreateWithMalformedPropertySettingYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/"foo" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertyinvalid\\.yml"\\./');
@@ -140,7 +140,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
         (new ExtractorPropertyNameCollectionFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class);
     }
 
-    public function testCreateWithMalformedYaml()
+    public function testCreateWithMalformedYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Metadata/Property/Factory/InheritedPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/InheritedPropertyMetadataFactoryTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class InheritedPropertyMetadataFactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreate(): void
     {
         $resourceNameCollectionFactory = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactory->create()->willReturn(new ResourceNameCollection([DummyTableInheritance::class, DummyTableInheritanceChild::class]))->shouldBeCalled();

--- a/tests/Metadata/Property/Factory/InheritedPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/InheritedPropertyNameCollectionFactoryTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
  */
 class InheritedPropertyNameCollectionFactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreate(): void
     {
         $resourceNameCollectionFactory = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactory->create()->willReturn(new ResourceNameCollection([DummyTableInheritance::class, DummyTableInheritanceChild::class]))->shouldBeCalled();

--- a/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  */
 class SerializerPropertyMetadataFactoryTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
@@ -50,7 +50,7 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $this->assertInstanceOf(PropertyMetadataFactoryInterface::class, $serializerPropertyMetadataFactory);
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $dummyResourceMetadata = (new ResourceMetadata())
@@ -125,7 +125,7 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $this->assertFalse($actual[2]->isWritable());
     }
 
-    public function testCreateInherited()
+    public function testCreateInherited(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyTableInheritanceChild::class)->willReturn(new ResourceMetadata())->shouldBeCalled();

--- a/tests/Metadata/Property/PropertyMetadataTest.php
+++ b/tests/Metadata/Property/PropertyMetadataTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class PropertyMetadataTest extends TestCase
 {
-    public function testValueObject()
+    public function testValueObject(): void
     {
         $type = new Type(Type::BUILTIN_TYPE_STRING);
         $metadata = new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'desc', true, true, false, false, true, false, 'http://example.com/foo', null, ['foo' => 'bar']);
@@ -84,7 +84,7 @@ class PropertyMetadataTest extends TestCase
         $this->assertTrue($newMetadata->isInitializable());
     }
 
-    public function testShouldReturnRequiredFalseWhenRequiredTrueIsSetButMaskedByWritableFalse()
+    public function testShouldReturnRequiredFalseWhenRequiredTrueIsSetButMaskedByWritableFalse(): void
     {
         $metadata = new PropertyMetadata();
 
@@ -94,7 +94,7 @@ class PropertyMetadataTest extends TestCase
         $this->assertFalse($metadata->isRequired());
     }
 
-    public function testShouldReturnPreviouslySetRequiredTrueWhenWritableFalseUnmasked()
+    public function testShouldReturnPreviouslySetRequiredTrueWhenWritableFalseUnmasked(): void
     {
         $metadata = new PropertyMetadata();
 

--- a/tests/Metadata/Property/PropertyNameCollectionTest.php
+++ b/tests/Metadata/Property/PropertyNameCollectionTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PropertyNameCollectionTest extends TestCase
 {
-    public function testValueObject()
+    public function testValueObject(): void
     {
         $collection = new PropertyNameCollection(['foo', 'bar']);
         $this->assertInstanceOf(\Countable::class, $collection);

--- a/tests/Metadata/Resource/Factory/AnnotationResourceFilterMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceFilterMetadataFactoryTest.php
@@ -28,7 +28,7 @@ use Prophecy\Argument;
  */
 class AnnotationResourceFilterMetadataFactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreate(): void
     {
         $decorated = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decorated->create(Dummy::class)->willReturn(new ResourceMetadata('hello', 'blabla'))->shouldBeCalled();

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -32,7 +32,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
     /**
      * @dataProvider getCreateDependencies
      */
-    public function testCreate(ProphecyInterface $reader, ProphecyInterface $decorated = null, string $expectedShortName, string $expectedDescription)
+    public function testCreate(ProphecyInterface $reader, ProphecyInterface $decorated = null, string $expectedShortName, string $expectedDescription): void
     {
         $factory = new AnnotationResourceMetadataFactory($reader->reveal(), $decorated ? $decorated->reveal() : null);
         $metadata = $factory->create(Dummy::class);

--- a/tests/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactoryTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AnnotationResourceNameCollectionFactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreate(): void
     {
         $decorated = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $decorated->create()->willReturn(new ResourceNameCollection(['foo', 'bar']))->shouldBeCalled();

--- a/tests/Metadata/Resource/Factory/CachedResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/CachedResourceMetadataFactoryTest.php
@@ -27,7 +27,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedResourceMetadataFactoryTest extends TestCase
 {
-    public function testCreateWithItemHit()
+    public function testCreateWithItemHit(): void
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()->willReturn(true)->shouldBeCalled();
@@ -45,7 +45,7 @@ class CachedResourceMetadataFactoryTest extends TestCase
         $this->assertEquals(new ResourceMetadata(null, 'Dummy.'), $resultedResourceMetadata);
     }
 
-    public function testCreateWithItemNotHit()
+    public function testCreateWithItemNotHit(): void
     {
         $propertyMetadata = new ResourceMetadata(null, 'Dummy.');
 
@@ -70,7 +70,7 @@ class CachedResourceMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedResourceMetadataFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
-    public function testCreateWithGetCacheItemThrowsCacheException()
+    public function testCreateWithGetCacheItemThrowsCacheException(): void
     {
         $decoratedResourceMetadataFactory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedResourceMetadataFactory->create(Dummy::class)->willReturn(new ResourceMetadata(null, 'Dummy.'))->shouldBeCalled();

--- a/tests/Metadata/Resource/Factory/CachedResourceNameCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/CachedResourceNameCollectionFactoryTest.php
@@ -27,7 +27,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedResourceNameCollectionFactoryTest extends TestCase
 {
-    public function testCreateWithItemHit()
+    public function testCreateWithItemHit(): void
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()->willReturn(true)->shouldBeCalled();
@@ -48,7 +48,7 @@ class CachedResourceNameCollectionFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedResourceNameCollectionFactory->create(), 'Trigger the local cache');
     }
 
-    public function testCreateWithItemNotHit()
+    public function testCreateWithItemNotHit(): void
     {
         $resourceNameCollection = new ResourceNameCollection([Dummy::class]);
 
@@ -73,7 +73,7 @@ class CachedResourceNameCollectionFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedResourceNameCollectionFactory->create(), 'Trigger the local cache');
     }
 
-    public function testCreateWithGetCacheItemThrowsCacheException()
+    public function testCreateWithGetCacheItemThrowsCacheException(): void
     {
         $decoratedResourceNameCollectionFactory = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $decoratedResourceNameCollectionFactory->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -34,7 +34,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider resourceMetadataProvider
      */
-    public function testXmlCreateResourceMetadata($expectedResourceMetadata)
+    public function testXmlCreateResourceMetadata($expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
 
@@ -45,7 +45,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
     }
 
-    public function testXmlDoesNotExistMetadataFactory()
+    public function testXmlDoesNotExistMetadataFactory(): void
     {
         $this->expectException(ResourceClassNotFoundException::class);
         $this->expectExceptionMessage('Resource "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" not found.');
@@ -62,7 +62,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider optionalResourceMetadataProvider
      */
-    public function testXmlOptionalResourceMetadata($expectedResourceMetadata)
+    public function testXmlOptionalResourceMetadata($expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesoptional.xml';
 
@@ -79,7 +79,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
      * @group legacy
      * @dataProvider legacyOperationsResourceMetadataProvider
      */
-    public function testLegacyOperationsResourceMetadata($expectedResourceMetadata)
+    public function testLegacyOperationsResourceMetadata($expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/legacyoperations.xml';
 
@@ -94,7 +94,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider noCollectionOperationsResourceMetadataProvider
      */
-    public function testXmlNoCollectionOperationsResourceMetadata($expectedResourceMetadata)
+    public function testXmlNoCollectionOperationsResourceMetadata($expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/nocollectionoperations.xml';
 
@@ -109,7 +109,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider noItemOperationsResourceMetadataProvider
      */
-    public function testXmlNoItemOperationsResourceMetadata($expectedResourceMetadata)
+    public function testXmlNoItemOperationsResourceMetadata($expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/noitemoperations.xml';
 
@@ -121,7 +121,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
     }
 
-    public function testInvalidXmlResourceMetadataFactory()
+    public function testInvalidXmlResourceMetadataFactory(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -134,7 +134,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider optionalResourceMetadataProvider
      */
-    public function testXmlParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata)
+    public function testXmlParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesoptional.xml';
 
@@ -152,7 +152,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider resourceMetadataProvider
      */
-    public function testXmlExistingParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata)
+    public function testXmlExistingParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
 
@@ -169,7 +169,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider resourceMetadataProvider
      */
-    public function testYamlCreateResourceMetadata(ResourceMetadata $expectedResourceMetadata)
+    public function testYamlCreateResourceMetadata(ResourceMetadata $expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -180,7 +180,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
     }
 
-    public function testYamlDoesNotExistMetadataFactory()
+    public function testYamlDoesNotExistMetadataFactory(): void
     {
         $this->expectException(ResourceClassNotFoundException::class);
         $this->expectExceptionMessage('Resource "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" not found.');
@@ -197,7 +197,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider optionalResourceMetadataProvider
      */
-    public function testYamlOptionalResourceMetadata($expectedResourceMetadata)
+    public function testYamlOptionalResourceMetadata($expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesoptional.yml';
 
@@ -211,7 +211,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider resourceMetadataProvider
      */
-    public function testYamlSingleResourceMetadata(ResourceMetadata $expectedResourceMetadata)
+    public function testYamlSingleResourceMetadata(ResourceMetadata $expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/single_resource.yml';
 
@@ -225,7 +225,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider optionalResourceMetadataProvider
      */
-    public function testYamlParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata)
+    public function testYamlParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesoptional.yml';
 
@@ -243,7 +243,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     /**
      * @dataProvider resourceMetadataProvider
      */
-    public function testYamlExistingParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata)
+    public function testYamlExistingParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
 
@@ -257,7 +257,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
     }
 
-    public function testCreateWithMalformedYaml()
+    public function testCreateWithMalformedYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -266,7 +266,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorResourceMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class);
     }
 
-    public function testCreateWithBadDeclaration()
+    public function testCreateWithBadDeclaration(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('/"ApiPlatform\\\\Core\\\\Tests\\\\Fixtures\\\\TestBundle\\\\Entity\\\\Dummy" setting is expected to be null or an array, string given in ".+\\/Fixtures\\/FileConfigurations\\/bad_declaration\\.yml"\\./');
@@ -276,7 +276,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         (new ExtractorResourceMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class);
     }
 
-    public function testCreateShortNameResourceMetadataForClassWithoutNamespace()
+    public function testCreateShortNameResourceMetadataForClassWithoutNamespace(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourceswithoutnamespace.yml';
 

--- a/tests/Metadata/Resource/Factory/ExtractorResourceNameCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceNameCollectionFactoryTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ExtractorResourceNameCollectionFactoryTest extends TestCase
 {
-    public function testXmlResourceName()
+    public function testXmlResourceName(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
         $factory = new ExtractorResourceNameCollectionFactory(new XmlExtractor([$configPath]));
@@ -40,7 +40,7 @@ class ExtractorResourceNameCollectionFactoryTest extends TestCase
         ]));
     }
 
-    public function testInvalidExtractorResourceNameCollectionFactory()
+    public function testInvalidExtractorResourceNameCollectionFactory(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -49,7 +49,7 @@ class ExtractorResourceNameCollectionFactoryTest extends TestCase
         $factory->create();
     }
 
-    public function testYamlResourceName()
+    public function testYamlResourceName(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
         $factory = new ExtractorResourceNameCollectionFactory(new YamlExtractor([$configPath]));
@@ -60,7 +60,7 @@ class ExtractorResourceNameCollectionFactoryTest extends TestCase
         ]));
     }
 
-    public function testYamlSingleResourceName()
+    public function testYamlSingleResourceName(): void
     {
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/single_resource.yml';
         $factory = new ExtractorResourceNameCollectionFactory(new YamlExtractor([$configPath]));
@@ -68,7 +68,7 @@ class ExtractorResourceNameCollectionFactoryTest extends TestCase
         $this->assertEquals($factory->create(), new ResourceNameCollection([FileConfigDummy::class]));
     }
 
-    public function testCreateWithMalformedYaml()
+    public function testCreateWithMalformedYaml(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
@@ -27,7 +27,7 @@ class OperationResourceMetadataFactoryTest extends TestCase
     /**
      * @dataProvider getMetadata
      */
-    public function testCreateOperation(ResourceMetadata $before, ResourceMetadata $after, array $formats = [])
+    public function testCreateOperation(ResourceMetadata $before, ResourceMetadata $after, array $formats = []): void
     {
         $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedProphecy->create(Dummy::class)->shouldBeCalled()->willReturn($before);

--- a/tests/Metadata/Resource/Factory/PhpDocResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/PhpDocResourceMetadataFactoryTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhpDocResourceMetadataFactoryTest extends TestCase
 {
-    public function testExistingDescription()
+    public function testExistingDescription(): void
     {
         $resourceMetadata = new ResourceMetadata(null, 'My desc');
         $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
@@ -33,7 +33,7 @@ class PhpDocResourceMetadataFactoryTest extends TestCase
         $this->assertSame($resourceMetadata, $factory->create('Foo'));
     }
 
-    public function testNoDocBlock()
+    public function testNoDocBlock(): void
     {
         $resourceMetadata = new ResourceMetadata();
         $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
@@ -44,7 +44,7 @@ class PhpDocResourceMetadataFactoryTest extends TestCase
         $this->assertSame($resourceMetadata, $factory->create(ClassWithNoDocBlock::class));
     }
 
-    public function testExtractDescription()
+    public function testExtractDescription(): void
     {
         $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedProphecy->create(DummyEntity::class)->willReturn(new ResourceMetadata())->shouldBeCalled();

--- a/tests/Metadata/Resource/ResourceMetadataTest.php
+++ b/tests/Metadata/Resource/ResourceMetadataTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ResourceMetadataTest extends TestCase
 {
-    public function testValueObject()
+    public function testValueObject(): void
     {
         $metadata = new ResourceMetadata('shortName', 'desc', 'http://example.com/foo', ['iop1' => ['foo' => 'a'], 'iop2' => ['bar' => 'b']], ['cop1' => ['foo' => 'c'], 'cop2' => ['bar' => 'd']], ['baz' => 'bar'], ['sop1' => ['sub' => 'bus']], ['query' => ['foo' => 'graphql']]);
         $this->assertSame('shortName', $metadata->getShortName());
@@ -74,7 +74,7 @@ class ResourceMetadataTest extends TestCase
     /**
      * @dataProvider getWithMethods
      */
-    public function testWithMethods(string $name, $value)
+    public function testWithMethods(string $name, $value): void
     {
         $metadata = new ResourceMetadata();
         $newMetadata = \call_user_func([$metadata, "with$name"], $value);
@@ -82,13 +82,13 @@ class ResourceMetadataTest extends TestCase
         $this->assertSame($value, \call_user_func([$newMetadata, "get$name"]));
     }
 
-    public function testGetOperationAttributeFallback()
+    public function testGetOperationAttributeFallback(): void
     {
         $metadata = new ResourceMetadata();
         $this->assertSame('okay', $metadata->getOperationAttribute([], 'doh', 'okay'));
     }
 
-    public function testGetOperationAttributeFallbackToResourceAttribute()
+    public function testGetOperationAttributeFallbackToResourceAttribute(): void
     {
         $metadata = new ResourceMetadata(null, null, null, null, null, ['doh' => 'nuts']);
         $this->assertSame('nuts', $metadata->getOperationAttribute([], 'doh', 'okay', true));

--- a/tests/Metadata/Resource/ResourceNameCollectionTest.php
+++ b/tests/Metadata/Resource/ResourceNameCollectionTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ResourceNameCollectionTest extends TestCase
 {
-    public function testValueObject()
+    public function testValueObject(): void
     {
         $collection = new ResourceNameCollection(['foo', 'bar']);
         $this->assertInstanceOf(\Countable::class, $collection);

--- a/tests/Mock/FosUser/MailerMock.php
+++ b/tests/Mock/FosUser/MailerMock.php
@@ -26,7 +26,7 @@ class MailerMock implements MailerInterface
      *
      * @param UserInterface $user
      */
-    public function sendConfirmationEmailMessage(UserInterface $user)
+    public function sendConfirmationEmailMessage(UserInterface $user): void
     {
     }
 
@@ -35,7 +35,7 @@ class MailerMock implements MailerInterface
      *
      * @param UserInterface $user
      */
-    public function sendResettingEmailMessage(UserInterface $user)
+    public function sendResettingEmailMessage(UserInterface $user): void
     {
     }
 }

--- a/tests/Operation/Factory/CachedSubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/CachedSubresourceOperationFactoryTest.php
@@ -26,7 +26,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedSubresourceOperationFactoryTest extends TestCase
 {
-    public function testCreateWithItemHit()
+    public function testCreateWithItemHit(): void
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()->willReturn(true)->shouldBeCalledTimes(1);
@@ -45,7 +45,7 @@ class CachedSubresourceOperationFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
-    public function testCreateWithItemNotHit()
+    public function testCreateWithItemNotHit(): void
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()->willReturn(false)->shouldBeCalledTimes(1);
@@ -65,7 +65,7 @@ class CachedSubresourceOperationFactoryTest extends TestCase
         $this->assertEquals($expectedResult, $cachedSubresourceOperationFactory->create(Dummy::class), 'Trigger the local cache');
     }
 
-    public function testCreateWithGetCacheItemThrowsCacheException()
+    public function testCreateWithGetCacheItemThrowsCacheException(): void
     {
         $cacheException = $this->prophesize(CacheException::class);
         $cacheException->willExtend(\Exception::class);

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SubresourceOperationFactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreate(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
@@ -142,7 +142,7 @@ class SubresourceOperationFactoryTest extends TestCase
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
 
-    public function testCreateByOverriding()
+    public function testCreateByOverriding(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
@@ -260,7 +260,7 @@ class SubresourceOperationFactoryTest extends TestCase
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
 
-    public function testCreateWithMaxDepth()
+    public function testCreateWithMaxDepth(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
@@ -305,7 +305,7 @@ class SubresourceOperationFactoryTest extends TestCase
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
 
-    public function testCreateWithEnd()
+    public function testCreateWithEnd(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
@@ -363,7 +363,7 @@ class SubresourceOperationFactoryTest extends TestCase
         ], $result);
     }
 
-    public function testCreateWithEndButNoCollection()
+    public function testCreateWithEndButNoCollection(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));

--- a/tests/PathResolver/CustomOperationPathResolverTest.php
+++ b/tests/PathResolver/CustomOperationPathResolverTest.php
@@ -23,14 +23,14 @@ use PHPUnit\Framework\TestCase;
  */
 class CustomOperationPathResolverTest extends TestCase
 {
-    public function testResolveOperationPath()
+    public function testResolveOperationPath(): void
     {
         $operationPathResolver = new CustomOperationPathResolver($this->prophesize(OperationPathResolverInterface::class)->reveal());
 
         $this->assertEquals('/foos.{_format}', $operationPathResolver->resolveOperationPath('Foo', ['path' => '/foos.{_format}'], OperationType::COLLECTION, 'get'));
     }
 
-    public function testResolveOperationPathWithDeferred()
+    public function testResolveOperationPathWithDeferred(): void
     {
         $operationPathResolverProphecy = $this->prophesize(OperationPathResolverInterface::class);
         $operationPathResolverProphecy->resolveOperationPath('Foo', [], OperationType::ITEM, 'get')->willReturn('/foos/{id}.{_format}')->shouldBeCalled();
@@ -44,7 +44,7 @@ class CustomOperationPathResolverTest extends TestCase
      * @group legacy
      * @expectedDeprecation Method ApiPlatform\Core\PathResolver\CustomOperationPathResolver::resolveOperationPath() will have a 4th `string $operationName` argument in version 3.0. Not defining it is deprecated since 2.1.
      */
-    public function testLegacyResolveOperationPath()
+    public function testLegacyResolveOperationPath(): void
     {
         $operationPathResolver = new CustomOperationPathResolver($this->prophesize(OperationPathResolverInterface::class)->reveal());
 

--- a/tests/PathResolver/DashOperationPathResolverTest.php
+++ b/tests/PathResolver/DashOperationPathResolverTest.php
@@ -28,7 +28,7 @@ class DashOperationPathResolverTest extends TestCase
     /**
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
      */
-    public function testResolveCollectionOperationPath()
+    public function testResolveCollectionOperationPath(): void
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
 
@@ -38,7 +38,7 @@ class DashOperationPathResolverTest extends TestCase
     /**
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
      */
-    public function testResolveItemOperationPath()
+    public function testResolveItemOperationPath(): void
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
 
@@ -48,7 +48,7 @@ class DashOperationPathResolverTest extends TestCase
     /**
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
      */
-    public function testResolveSubresourceOperationPath()
+    public function testResolveSubresourceOperationPath(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Subresource operations are not supported by the OperationPathResolver.');
@@ -62,7 +62,7 @@ class DashOperationPathResolverTest extends TestCase
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\DashOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator instead.
      * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
-    public function testLegacyResolveOperationPath()
+    public function testLegacyResolveOperationPath(): void
     {
         $dashOperationPathResolver = new DashOperationPathResolver();
 

--- a/tests/PathResolver/UnderscoreOperationPathResolverTest.php
+++ b/tests/PathResolver/UnderscoreOperationPathResolverTest.php
@@ -28,7 +28,7 @@ class UnderscoreOperationPathResolverTest extends TestCase
     /**
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
      */
-    public function testResolveCollectionOperationPath()
+    public function testResolveCollectionOperationPath(): void
     {
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
 
@@ -38,7 +38,7 @@ class UnderscoreOperationPathResolverTest extends TestCase
     /**
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
      */
-    public function testResolveItemOperationPath()
+    public function testResolveItemOperationPath(): void
     {
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
 
@@ -48,7 +48,7 @@ class UnderscoreOperationPathResolverTest extends TestCase
     /**
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
      */
-    public function testResolveSubresourceOperationPath()
+    public function testResolveSubresourceOperationPath(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Subresource operations are not supported by the OperationPathResolver.');
@@ -62,7 +62,7 @@ class UnderscoreOperationPathResolverTest extends TestCase
      * @expectedDeprecation The use of ApiPlatform\Core\PathResolver\UnderscoreOperationPathResolver is deprecated since 2.1. Please use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator instead.
      * @expectedDeprecation Using a boolean for the Operation Type is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3
      */
-    public function testLegacyResolveOperationPath()
+    public function testLegacyResolveOperationPath(): void
     {
         $underscoreOperationPathResolver = new UnderscoreOperationPathResolver();
 

--- a/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
  */
 class ConstraintViolationNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
         $normalizer = new ConstraintViolationListNormalizer([], $nameConverterProphecy->reveal());
@@ -37,7 +37,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
         $normalizer = new ConstraintViolationListNormalizer(['severity', 'anotherField1'], $nameConverterProphecy->reveal());

--- a/tests/Problem/Serializer/ErrorNormalizerTest.php
+++ b/tests/Problem/Serializer/ErrorNormalizerTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ErrorNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $normalizer = new ErrorNormalizer();
 
@@ -37,7 +37,7 @@ class ErrorNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $normalizer = new ErrorNormalizer();
 
@@ -66,7 +66,7 @@ class ErrorNormalizerTest extends TestCase
      * @param string $originalMessage original message of the Exception
      * @param bool   $debug           simulates kernel debug variable
      */
-    public function testErrorServerNormalize(int $status, string $originalMessage, bool $debug)
+    public function testErrorServerNormalize(int $status, string $originalMessage, bool $debug): void
     {
         $normalizer = new ErrorNormalizer($debug);
         $exception = FlattenException::create(new \Exception($originalMessage), $status);
@@ -96,7 +96,7 @@ class ErrorNormalizerTest extends TestCase
         ];
     }
 
-    public function testErrorServerNormalizeContextStatus()
+    public function testErrorServerNormalizeContextStatus(): void
     {
         $normalizer = new ErrorNormalizer(false);
         $exception = FlattenException::create(new \Exception(''), 500);

--- a/tests/Security/EventListener/DenyAccessListenerTest.php
+++ b/tests/Security/EventListener/DenyAccessListenerTest.php
@@ -34,7 +34,7 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
  */
 class DenyAccessListenerTest extends TestCase
 {
-    public function testNoResourceClass()
+    public function testNoResourceClass(): void
     {
         $request = new Request();
 
@@ -50,7 +50,7 @@ class DenyAccessListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    public function testNoIsGrantedAttribute()
+    public function testNoIsGrantedAttribute(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get']);
 
@@ -67,7 +67,7 @@ class DenyAccessListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    public function testIsGranted()
+    public function testIsGranted(): void
     {
         $data = new \stdClass();
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get', 'data' => $data]);
@@ -88,7 +88,7 @@ class DenyAccessListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    public function testIsNotGranted()
+    public function testIsNotGranted(): void
     {
         $this->expectException(AccessDeniedException::class);
 
@@ -110,7 +110,7 @@ class DenyAccessListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    public function testAccessControlMessage()
+    public function testAccessControlMessage(): void
     {
         $this->expectException(AccessDeniedException::class);
         $this->expectExceptionMessage('You are not admin.');
@@ -136,7 +136,7 @@ class DenyAccessListenerTest extends TestCase
     /**
      * @group legacy
      */
-    public function testIsGrantedLegacy()
+    public function testIsGrantedLegacy(): void
     {
         $data = new \stdClass();
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get', 'data' => $data]);
@@ -160,7 +160,7 @@ class DenyAccessListenerTest extends TestCase
     /**
      * @group legacy
      */
-    public function testIsNotGrantedLegacy()
+    public function testIsNotGrantedLegacy(): void
     {
         $this->expectException(AccessDeniedException::class);
 
@@ -185,7 +185,7 @@ class DenyAccessListenerTest extends TestCase
     /**
      * @group legacy
      */
-    public function testSecurityComponentNotAvailable()
+    public function testSecurityComponentNotAvailable(): void
     {
         $this->expectException(\LogicException::class);
 
@@ -207,7 +207,7 @@ class DenyAccessListenerTest extends TestCase
     /**
      * @group legacy
      */
-    public function testExpressionLanguageNotInstalled()
+    public function testExpressionLanguageNotInstalled(): void
     {
         $this->expectException(\LogicException::class);
 
@@ -233,7 +233,7 @@ class DenyAccessListenerTest extends TestCase
     /**
      * @group legacy
      */
-    public function testNotBehindAFirewall()
+    public function testNotBehindAFirewall(): void
     {
         $this->expectException(\LogicException::class);
 

--- a/tests/Security/ResourceAccessCheckerTest.php
+++ b/tests/Security/ResourceAccessCheckerTest.php
@@ -30,7 +30,7 @@ class ResourceAccessCheckerTest extends TestCase
     /**
      * @dataProvider getGranted
      */
-    public function testIsGranted(bool $granted)
+    public function testIsGranted(bool $granted): void
     {
         $expressionLanguageProphecy = $this->prophesize(ExpressionLanguage::class);
         $expressionLanguageProphecy->evaluate('has_role("ROLE_ADMIN")', Argument::type('array'))->willReturn($granted)->shouldBeCalled();
@@ -54,7 +54,7 @@ class ResourceAccessCheckerTest extends TestCase
         return [[true], [false]];
     }
 
-    public function testSecurityComponentNotAvailable()
+    public function testSecurityComponentNotAvailable(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The "symfony/security" library must be installed to use the "access_control" attribute.');
@@ -63,7 +63,7 @@ class ResourceAccessCheckerTest extends TestCase
         $checker->isGranted(Dummy::class, 'has_role("ROLE_ADMIN")');
     }
 
-    public function testExpressionLanguageNotInstalled()
+    public function testExpressionLanguageNotInstalled(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The "symfony/expression-language" library must be installed to use the "access_control".');
@@ -76,7 +76,7 @@ class ResourceAccessCheckerTest extends TestCase
         $checker->isGranted(Dummy::class, 'has_role("ROLE_ADMIN")');
     }
 
-    public function testNotBehindAFirewall()
+    public function testNotBehindAFirewall(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The current token must be set to use the "access_control" attribute (is the URL behind a firewall?).');

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -42,7 +42,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class AbstractItemNormalizerTest extends TestCase
 {
-    public function testSupportNormalizationAndSupportDenormalization()
+    public function testSupportNormalizationAndSupportDenormalization(): void
     {
         $std = new \stdClass();
         $dummy = new Dummy();
@@ -71,7 +71,7 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $relatedDummy = new RelatedDummy();
 
@@ -149,7 +149,7 @@ class AbstractItemNormalizerTest extends TestCase
         ], $normalizer->normalize($dummy, null, ['resources' => []]));
     }
 
-    public function testNormalizeReadableLinks()
+    public function testNormalizeReadableLinks(): void
     {
         $relatedDummy = new RelatedDummy();
 
@@ -215,7 +215,7 @@ class AbstractItemNormalizerTest extends TestCase
         ], $normalizer->normalize($dummy, null, ['resources' => []]));
     }
 
-    public function testDenormalize()
+    public function testDenormalize(): void
     {
         $relatedDummy1 = new RelatedDummy();
         $relatedDummy2 = new RelatedDummy();
@@ -286,7 +286,7 @@ class AbstractItemNormalizerTest extends TestCase
         ], Dummy::class);
     }
 
-    public function testDenormalizeWritableLinks()
+    public function testDenormalizeWritableLinks(): void
     {
         $relatedDummy1 = new RelatedDummy();
         $relatedDummy2 = new RelatedDummy();
@@ -358,7 +358,7 @@ class AbstractItemNormalizerTest extends TestCase
         ], Dummy::class);
     }
 
-    public function testBadRelationType()
+    public function testBadRelationType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected IRI or nested document for attribute "relatedDummy", "integer" given.');
@@ -401,7 +401,7 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->denormalize(['relatedDummy' => 22], Dummy::class);
     }
 
-    public function testInnerDocumentNotAllowed()
+    public function testInnerDocumentNotAllowed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Nested documents for attribute "relatedDummy" are not allowed. Use IRIs instead.');
@@ -444,7 +444,7 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->denormalize(['relatedDummy' => ['foo' => 'bar']], Dummy::class);
     }
 
-    public function testBadType()
+    public function testBadType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The type of the "foo" attribute must be "float", "integer" given.');
@@ -478,7 +478,7 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->denormalize(['foo' => 42], Dummy::class);
     }
 
-    public function testJsonAllowIntAsFloat()
+    public function testJsonAllowIntAsFloat(): void
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
@@ -510,7 +510,7 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->denormalize(['foo' => 42], Dummy::class, 'jsonfoo');
     }
 
-    public function testDenormalizeBadKeyType()
+    public function testDenormalizeBadKeyType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The type of the key "a" must be "int", "string" given.');
@@ -563,7 +563,7 @@ class AbstractItemNormalizerTest extends TestCase
         ], Dummy::class);
     }
 
-    public function testNullable()
+    public function testNullable(): void
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
@@ -594,7 +594,7 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->denormalize(['name' => null], Dummy::class);
     }
 
-    public function testChildInheritedProperty()
+    public function testChildInheritedProperty(): void
     {
         $dummy = new DummyTableInheritance();
         $dummy->setName('foo');
@@ -642,7 +642,7 @@ class AbstractItemNormalizerTest extends TestCase
         ], $normalizer->normalize($dummy, null, ['resource_class' => DummyTableInheritance::class, 'resources' => []]));
     }
 
-    public function testDenormalizeRelationWithPlainId()
+    public function testDenormalizeRelationWithPlainId(): void
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
@@ -689,7 +689,7 @@ class AbstractItemNormalizerTest extends TestCase
         $normalizer->denormalize(['relatedDummy' => 1], Dummy::class, 'jsonld');
     }
 
-    public function testDoNotDenormalizeRelationWithPlainIdWhenPlainIdentifiersAreNotAllowed()
+    public function testDoNotDenormalizeRelationWithPlainIdWhenPlainIdentifiersAreNotAllowed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected IRI or nested document for attribute "relatedDummy", "integer" given.');

--- a/tests/Serializer/Filter/GroupFilterTest.php
+++ b/tests/Serializer/Filter/GroupFilterTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  */
 class GroupFilterTest extends TestCase
 {
-    public function testApply()
+    public function testApply(): void
     {
         $request = new Request(['groups' => ['foo', 'bar', 'baz']]);
         $context = [AbstractNormalizer::GROUPS => ['foo', 'qux']];
@@ -35,7 +35,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals([AbstractNormalizer::GROUPS => ['foo', 'qux', 'foo', 'bar', 'baz']], $context);
     }
 
-    public function testApplyWithOverriding()
+    public function testApplyWithOverriding(): void
     {
         $request = new Request(['custom_groups' => ['foo', 'bar', 'baz']]);
         $context = [AbstractNormalizer::GROUPS => ['foo', 'qux']];
@@ -46,7 +46,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals([AbstractNormalizer::GROUPS => ['foo', 'bar', 'baz']], $context);
     }
 
-    public function testApplyWithoutGroupsInRequest()
+    public function testApplyWithoutGroupsInRequest(): void
     {
         $context = [AbstractNormalizer::GROUPS => ['foo', 'bar']];
 
@@ -56,7 +56,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals([AbstractNormalizer::GROUPS => ['foo', 'bar']], $context);
     }
 
-    public function testApplyWithGroupsWhitelist()
+    public function testApplyWithGroupsWhitelist(): void
     {
         $request = new Request(['groups' => ['foo', 'bar', 'baz']]);
         $context = [AbstractNormalizer::GROUPS => 'qux'];
@@ -67,7 +67,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals([AbstractNormalizer::GROUPS => ['qux', 'foo', 'baz']], $context);
     }
 
-    public function testApplyWithGroupsWhitelistWithOverriding()
+    public function testApplyWithGroupsWhitelistWithOverriding(): void
     {
         $request = new Request(['groups' => ['foo', 'bar', 'baz']]);
         $context = [AbstractNormalizer::GROUPS => 'qux'];
@@ -78,7 +78,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals([AbstractNormalizer::GROUPS => ['foo', 'baz']], $context);
     }
 
-    public function testApplyWithGroupsInFilterAttribute()
+    public function testApplyWithGroupsInFilterAttribute(): void
     {
         $request = new Request(['groups' => ['foo', 'bar', 'baz']], [], ['_api_filters' => ['groups' => ['fooz']]]);
         $context = ['groups' => ['foo', 'qux']];
@@ -89,7 +89,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals(['groups' => ['foo', 'qux', 'fooz']], $context);
     }
 
-    public function testApplyWithInvalidGroupsInRequest()
+    public function testApplyWithInvalidGroupsInRequest(): void
     {
         $request = new Request(['groups' => 'foo,bar,baz']);
         $context = [AbstractNormalizer::GROUPS => ['foo', 'bar']];
@@ -100,7 +100,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals([AbstractNormalizer::GROUPS => ['foo', 'bar']], $context);
     }
 
-    public function testApplyWithInvalidGroupsInContext()
+    public function testApplyWithInvalidGroupsInContext(): void
     {
         $request = new Request(['custom_groups' => ['foo', 'bar', 'baz']]);
         $context = [AbstractNormalizer::GROUPS => 'qux'];
@@ -111,7 +111,7 @@ class GroupFilterTest extends TestCase
         $this->assertEquals([AbstractNormalizer::GROUPS => ['qux', 'foo', 'bar', 'baz']], $context);
     }
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $groupFilter = new GroupFilter('custom_groups');
         $expectedDescription = [

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class PropertyFilterTest extends TestCase
 {
-    public function testApply()
+    public function testApply(): void
     {
         $request = new Request(['properties' => ['foo', 'bar', 'baz']]);
         $context = ['attributes' => ['foo', 'qux']];
@@ -34,7 +34,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['foo', 'qux', 'foo', 'bar', 'baz']], $context);
     }
 
-    public function testApplyWithOverriding()
+    public function testApplyWithOverriding(): void
     {
         $request = new Request(['custom_properties' => ['foo', 'bar', 'baz']]);
         $context = ['attributes' => ['foo', 'qux']];
@@ -45,7 +45,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['foo', 'bar', 'baz']], $context);
     }
 
-    public function testApplyWithoutPropertiesInRequest()
+    public function testApplyWithoutPropertiesInRequest(): void
     {
         $context = ['attributes' => ['foo', 'bar']];
 
@@ -55,7 +55,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['foo', 'bar']], $context);
     }
 
-    public function testApplyWithPropertiesWhitelist()
+    public function testApplyWithPropertiesWhitelist(): void
     {
         $request = new Request(['properties' => ['foo', 'bar', 'baz']]);
         $context = ['attributes' => ['qux']];
@@ -66,7 +66,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['qux', 'foo', 'bar']], $context);
     }
 
-    public function testApplyWithPropertiesWhitelistWithNestedProperty()
+    public function testApplyWithPropertiesWhitelistWithNestedProperty(): void
     {
         $request = new Request(['properties' => ['foo', 'bar', 'group' => ['baz' => ['baz', 'qux'], 'qux']]]);
         $context = ['attributes' => ['qux']];
@@ -77,7 +77,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['qux', 'foo', 'group' => ['baz' => ['qux']]]], $context);
     }
 
-    public function testApplyWithPropertiesWhitelistNotMatchingAnyProperty()
+    public function testApplyWithPropertiesWhitelistNotMatchingAnyProperty(): void
     {
         $request = new Request(['properties' => ['foo', 'bar', 'group' => ['baz' => ['baz', 'qux'], 'qux']]]);
         $context = ['attributes' => ['qux']];
@@ -88,7 +88,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['qux']], $context);
     }
 
-    public function testApplyWithoutPropertiesWhitelistWithOverriding()
+    public function testApplyWithoutPropertiesWhitelistWithOverriding(): void
     {
         $request = new Request(['properties' => ['foo', 'bar', 'baz']]);
         $context = ['attributes' => ['qux']];
@@ -99,7 +99,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['foo', 'baz']], $context);
     }
 
-    public function testApplyWithPropertiesInPropertyFilterAttribute()
+    public function testApplyWithPropertiesInPropertyFilterAttribute(): void
     {
         $request = new Request(['properties' => ['foo', 'bar', 'baz']], [], ['_api_filters' => ['properties' => ['fooz']]]);
         $context = ['attributes' => ['foo', 'qux']];
@@ -110,7 +110,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['foo', 'qux', 'fooz']], $context);
     }
 
-    public function testApplyWithInvalidPropertiesInRequest()
+    public function testApplyWithInvalidPropertiesInRequest(): void
     {
         $request = new Request(['properties' => 'foo,bar,baz']);
         $context = ['attributes' => ['foo', 'bar']];
@@ -121,7 +121,7 @@ class PropertyFilterTest extends TestCase
         $this->assertEquals(['attributes' => ['foo', 'bar']], $context);
     }
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $propertyFilter = new PropertyFilter('custom_properties');
         $expectedDescription = [

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class ItemNormalizerTest extends TestCase
 {
-    public function testSupportNormalization()
+    public function testSupportNormalization(): void
     {
         $std = new \stdClass();
         $dummy = new Dummy();
@@ -64,7 +64,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $dummy = new Dummy();
         $dummy->setName('hello');
@@ -98,7 +98,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertEquals(['name' => 'hello'], $normalizer->normalize($dummy, null, ['resources' => []]));
     }
 
-    public function testDenormalize()
+    public function testDenormalize(): void
     {
         $context = ['resource_class' => Dummy::class, 'api_allow_update' => true];
 
@@ -128,7 +128,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $normalizer->denormalize(['name' => 'hello'], Dummy::class, null, $context));
     }
 
-    public function testDenormalizeWithIri()
+    public function testDenormalizeWithIri(): void
     {
         $context = ['resource_class' => Dummy::class, 'api_allow_update' => true];
 
@@ -159,7 +159,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $normalizer->denormalize(['id' => '/dummies/12', 'name' => 'hello'], Dummy::class, null, $context));
     }
 
-    public function testDenormalizeWithIdAndUpdateNotAllowed()
+    public function testDenormalizeWithIdAndUpdateNotAllowed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Update is not allowed for this operation.');

--- a/tests/Serializer/JsonEncoderTest.php
+++ b/tests/Serializer/JsonEncoderTest.php
@@ -26,31 +26,31 @@ class JsonEncoderTest extends TestCase
      */
     private $encoder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->encoder = new JsonEncoder('json');
     }
 
-    public function testSupportEncoding()
+    public function testSupportEncoding(): void
     {
         $this->assertTrue($this->encoder->supportsEncoding('json'));
         $this->assertFalse($this->encoder->supportsEncoding('csv'));
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $data = ['foo' => 'bar'];
 
         $this->assertEquals('{"foo":"bar"}', $this->encoder->encode($data, 'json'));
     }
 
-    public function testSupportDecoding()
+    public function testSupportDecoding(): void
     {
         $this->assertTrue($this->encoder->supportsDecoding('json'));
         $this->assertFalse($this->encoder->supportsDecoding('csv'));
     }
 
-    public function testDecode()
+    public function testDecode(): void
     {
         $this->assertEquals(['foo' => 'bar'], $this->encoder->decode('{"foo":"bar"}', 'json'));
     }

--- a/tests/Serializer/ResourceListTest.php
+++ b/tests/Serializer/ResourceListTest.php
@@ -23,17 +23,17 @@ class ResourceListTest extends TestCase
      */
     private $resourceList;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->resourceList = new ResourceList();
     }
 
-    public function testImplementsArrayObject()
+    public function testImplementsArrayObject(): void
     {
         $this->assertInstanceOf(\ArrayObject::class, $this->resourceList);
     }
 
-    public function testSerialize()
+    public function testSerialize(): void
     {
         $this->resourceList['foo'] = 'bar';
 

--- a/tests/Serializer/SerializerContextBuilderTest.php
+++ b/tests/Serializer/SerializerContextBuilderTest.php
@@ -31,7 +31,7 @@ class SerializerContextBuilderTest extends TestCase
      */
     private $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $resourceMetadata = new ResourceMetadata(
             null,
@@ -51,7 +51,7 @@ class SerializerContextBuilderTest extends TestCase
         $this->builder = new SerializerContextBuilder($resourceMetadataFactoryProphecy->reveal());
     }
 
-    public function testCreateFromRequest()
+    public function testCreateFromRequest(): void
     {
         $request = Request::create('/foos/1');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
@@ -84,14 +84,14 @@ class SerializerContextBuilderTest extends TestCase
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
     }
 
-    public function testThrowExceptionOnInvalidRequest()
+    public function testThrowExceptionOnInvalidRequest(): void
     {
         $this->expectException(RuntimeException::class);
 
         $this->builder->createFromRequest(new Request(), false);
     }
 
-    public function testReuseExistingAttributes()
+    public function testReuseExistingAttributes(): void
     {
         $expected = ['bar' => 'baz', 'item_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1'];
         $this->assertEquals($expected, $this->builder->createFromRequest(Request::create('/foos/1'), false, ['resource_class' => 'Foo', 'item_operation_name' => 'get']));

--- a/tests/Serializer/SerializerFilterContextBuilderTest.php
+++ b/tests/Serializer/SerializerFilterContextBuilderTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class SerializerFilterContextBuilderTest extends TestCase
 {
-    public function testCreateFromRequestWithCollectionOperation()
+    public function testCreateFromRequestWithCollectionOperation(): void
     {
         $request = new Request();
 
@@ -71,7 +71,7 @@ class SerializerFilterContextBuilderTest extends TestCase
         $this->assertInternalType('array', $context);
     }
 
-    public function testCreateFromRequestWithItemOperation()
+    public function testCreateFromRequestWithItemOperation(): void
     {
         $request = new Request();
 
@@ -112,7 +112,7 @@ class SerializerFilterContextBuilderTest extends TestCase
         $this->assertInternalType('array', $context);
     }
 
-    public function testCreateFromRequestWithoutFilters()
+    public function testCreateFromRequestWithoutFilters(): void
     {
         $request = new Request();
 
@@ -143,7 +143,7 @@ class SerializerFilterContextBuilderTest extends TestCase
         $this->assertInternalType('array', $context);
     }
 
-    public function testCreateFromRequestWithoutAttributes()
+    public function testCreateFromRequestWithoutAttributes(): void
     {
         $request = new Request([], [], [
             '_api_resource_class' => DummyGroup::class,
@@ -188,7 +188,7 @@ class SerializerFilterContextBuilderTest extends TestCase
         $this->assertInternalType('array', $context);
     }
 
-    public function testCreateFromRequestThrowsExceptionWithoutAttributesAndRequestAttributes()
+    public function testCreateFromRequestThrowsExceptionWithoutAttributesAndRequestAttributes(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Request attributes are not valid.');

--- a/tests/Swagger/Serializer/ApiGatewayNormalizerTest.php
+++ b/tests/Swagger/Serializer/ApiGatewayNormalizerTest.php
@@ -39,7 +39,7 @@ final class ApiGatewayNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->documentationNormalizerMock = $this->prophesize(NormalizerInterface::class);
         $this->documentationNormalizerMock->willImplement(CacheableSupportsMethodInterface::class);
@@ -48,14 +48,14 @@ final class ApiGatewayNormalizerTest extends TestCase
         $this->normalizer = new ApiGatewayNormalizer($this->documentationNormalizerMock->reveal());
     }
 
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $this->documentationNormalizerMock->supportsNormalization('foo', 'bar')->willReturn(true)->shouldBeCalledTimes(1);
         $this->assertTrue($this->normalizer->supportsNormalization('foo', 'bar'));
         $this->assertTrue($this->normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNormalizeWithoutApiGateway()
+    public function testNormalizeWithoutApiGateway(): void
     {
         $this->documentationNormalizerMock->normalize($this->objectMock, 'jsonld', [])
             ->willReturn(['basePath' => ''])
@@ -63,7 +63,7 @@ final class ApiGatewayNormalizerTest extends TestCase
         $this->assertEquals(['basePath' => '/'], $this->normalizer->normalize($this->objectMock->reveal(), 'jsonld'));
     }
 
-    public function testNormalizeWithApiGateway()
+    public function testNormalizeWithApiGateway(): void
     {
         $this->documentationNormalizerMock->normalize($this->objectMock, 'jsonld', ['api_gateway' => true])
             ->willReturn([

--- a/tests/Swagger/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerTest.php
@@ -59,7 +59,7 @@ class DocumentationNormalizerTest extends TestCase
      * @group legacy
      * @expectedDeprecation Passing an instance of ApiPlatform\Core\Api\UrlGeneratorInterface to ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer::__construct() is deprecated since version 2.1 and will be removed in 3.0.
      */
-    public function testLegacyConstruct()
+    public function testLegacyConstruct(): void
     {
         $normalizer = new DocumentationNormalizer(
             $this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(),
@@ -74,7 +74,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertInstanceOf(DocumentationNormalizer::class, $normalizer);
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
 
@@ -307,7 +307,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
     }
 
-    public function testNormalizeWithNameConverter()
+    public function testNormalizeWithNameConverter(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Dummy API', 'This is a dummy API', '1.2.3', ['jsonld' => ['application/ld+json']]);
 
@@ -418,7 +418,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testNormalizeWithApiKeysEnabled()
+    public function testNormalizeWithApiKeysEnabled(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
 
@@ -539,7 +539,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
     }
 
-    public function testNormalizeWithOnlyNormalizationGroups()
+    public function testNormalizeWithOnlyNormalizationGroups(): void
     {
         $title = 'Test API';
         $description = 'This is a test API.';
@@ -733,7 +733,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testNormalizeWithSwaggerDefinitionName()
+    public function testNormalizeWithSwaggerDefinitionName(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
 
@@ -827,7 +827,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
     }
 
-    public function testNormalizeWithOnlyDenormalizationGroups()
+    public function testNormalizeWithOnlyDenormalizationGroups(): void
     {
         $title = 'Test API';
         $description = 'This is a test API.';
@@ -1018,7 +1018,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testNormalizeWithNormalizationAndDenormalizationGroups()
+    public function testNormalizeWithNormalizationAndDenormalizationGroups(): void
     {
         $title = 'Test API';
         $description = 'This is a test API.';
@@ -1212,7 +1212,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testFilters()
+    public function testFilters(): void
     {
         $filterLocatorProphecy = $this->prophesize(ContainerInterface::class);
         $filters = [
@@ -1245,7 +1245,7 @@ class DocumentationNormalizerTest extends TestCase
      * @group legacy
      * @expectedDeprecation The ApiPlatform\Core\Api\FilterCollection class is deprecated since version 2.1 and will be removed in 3.0. Provide an implementation of Psr\Container\ContainerInterface instead.
      */
-    public function testFiltersWithDeprecatedFilterCollection()
+    public function testFiltersWithDeprecatedFilterCollection(): void
     {
         $this->normalizeWithFilters(new FilterCollection([
             'f1' => new DummyFilter(['name' => [
@@ -1264,7 +1264,7 @@ class DocumentationNormalizerTest extends TestCase
         ]));
     }
 
-    public function testConstructWithInvalidFilterLocator()
+    public function testConstructWithInvalidFilterLocator(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$filterLocator" argument is expected to be an implementation of the "Psr\\Container\\ContainerInterface" interface or null.');
@@ -1281,7 +1281,7 @@ class DocumentationNormalizerTest extends TestCase
         );
     }
 
-    public function testSupports()
+    public function testSupports(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -1307,7 +1307,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
-    public function testNoOperations()
+    public function testNoOperations(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), '', '', '0.0.0', ['jsonld' => ['application/ld+json']]);
 
@@ -1358,7 +1358,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testWithCustomMethod()
+    public function testWithCustomMethod(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), '', '', '0.0.0', ['jsonld' => ['application/ld+json']]);
 
@@ -1414,7 +1414,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testNormalizeWithNestedNormalizationGroups()
+    public function testNormalizeWithNestedNormalizationGroups(): void
     {
         $title = 'Test API';
         $description = 'This is a test API.';
@@ -1639,7 +1639,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    private function normalizeWithFilters($filterLocator)
+    private function normalizeWithFilters($filterLocator): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), '', '', '0.0.0', ['jsonld' => ['application/ld+json']]);
 
@@ -1744,7 +1744,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testNormalizeWithSubResource()
+    public function testNormalizeWithSubResource(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Question::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
 
@@ -1883,7 +1883,7 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->normalize($documentation));
     }
 
-    public function testNormalizeWithPropertySwaggerContext()
+    public function testNormalizeWithPropertySwaggerContext(): void
     {
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3', ['jsonld' => ['application/ld+json']]);
 

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -29,13 +29,13 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
 {
     private $extractor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
         $this->extractor = new AnnotationFilterExtractor(self::$kernel->getContainer()->get('test.annotation_reader'));
     }
 
-    public function testReadAnnotations()
+    public function testReadAnnotations(): void
     {
         $reflectionClass = new \ReflectionClass(DummyCar::class);
         $readerProphecy = $this->prophesize(Reader::class);
@@ -69,7 +69,7 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
         ]);
     }
 
-    public function testReadOrderAnnotations()
+    public function testReadOrderAnnotations(): void
     {
         $reflectionClass = new \ReflectionClass(DummyEntityFilterAnnotated::class);
         $readerProphecy = $this->prophesize(Reader::class);

--- a/tests/Util/ErrorFormatGuesserTest.php
+++ b/tests/Util/ErrorFormatGuesserTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ErrorFormatGuesserTest extends TestCase
 {
-    public function testGuessErrorFormat()
+    public function testGuessErrorFormat(): void
     {
         $request = new Request();
         $request->setRequestFormat('jsonld');
@@ -32,14 +32,14 @@ class ErrorFormatGuesserTest extends TestCase
         $this->assertEquals('application/ld+json', $format['value'][0]);
     }
 
-    public function testFallback()
+    public function testFallback(): void
     {
         $format = ErrorFormatGuesser::guessErrorFormat(new Request(), ['xml' => ['text/xml'], 'jsonld' => ['application/ld+json', 'application/json']]);
         $this->assertEquals('xml', $format['key']);
         $this->assertEquals('text/xml', $format['value'][0]);
     }
 
-    public function testFallbackWhenNotSupported()
+    public function testFallbackWhenNotSupported(): void
     {
         $request = new Request();
         $request->setRequestFormat('html');
@@ -49,7 +49,7 @@ class ErrorFormatGuesserTest extends TestCase
         $this->assertEquals('text/xml', $format['value'][0]);
     }
 
-    public function testGuessCustomErrorFormat()
+    public function testGuessCustomErrorFormat(): void
     {
         $request = new Request();
         $request->setRequestFormat('custom_json_format');

--- a/tests/Util/IriHelperTest.php
+++ b/tests/Util/IriHelperTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class IriHelperTest extends TestCase
 {
-    public function testHelpers()
+    public function testHelpers(): void
     {
         $parsed = [
             'parts' => [
@@ -39,7 +39,7 @@ class IriHelperTest extends TestCase
         $this->assertEquals('/hello.json?foo=bar&bar=3&page=2', IriHelper::createIri($parsed['parts'], $parsed['parameters'], 'page', 2.));
     }
 
-    public function testHelpersWithAbsoluteUrl()
+    public function testHelpersWithAbsoluteUrl(): void
     {
         $parsed = [
             'parts' => [
@@ -70,7 +70,7 @@ class IriHelperTest extends TestCase
         $this->assertEquals('https://foo:bar@localhost:443/hello.json?foo=bar&bar=3&page=2#foo', IriHelper::createIri($parsed['parts'], $parsed['parameters'], 'page', 2., true));
     }
 
-    public function testParseIriWithInvalidUrl()
+    public function testParseIriWithInvalidUrl(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The request URI "http:///" is malformed.');

--- a/tests/Util/ReflectionTest.php
+++ b/tests/Util/ReflectionTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ReflectionTest extends TestCase
 {
-    public function testWithGoodMethodName()
+    public function testWithGoodMethodName(): void
     {
         $methodName = 'addGerard';
         $reflection = new Reflection();
@@ -29,7 +29,7 @@ class ReflectionTest extends TestCase
         $this->assertEquals($return, 'Gerard');
     }
 
-    public function testWithBadMethodName()
+    public function testWithBadMethodName(): void
     {
         $methodName = 'delGerard';
         $reflection = new Reflection();

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class RequestAttributesExtractorTest extends TestCase
 {
-    public function testExtractCollectionAttributes()
+    public function testExtractCollectionAttributes(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post']);
 
@@ -32,7 +32,7 @@ class RequestAttributesExtractorTest extends TestCase
         );
     }
 
-    public function testExtractItemAttributes()
+    public function testExtractItemAttributes(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
 
@@ -42,7 +42,7 @@ class RequestAttributesExtractorTest extends TestCase
         );
     }
 
-    public function testExtractReceive()
+    public function testExtractReceive(): void
     {
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_receive' => '0']);
 
@@ -66,12 +66,12 @@ class RequestAttributesExtractorTest extends TestCase
         );
     }
 
-    public function testResourceClassNotSet()
+    public function testResourceClassNotSet(): void
     {
         $this->assertEmpty(RequestAttributesExtractor::extractAttributes(new Request([], [], ['_api_item_operation_name' => 'get'])));
     }
 
-    public function testOperationNotSet()
+    public function testOperationNotSet(): void
     {
         $this->assertEmpty(RequestAttributesExtractor::extractAttributes(new Request([], [], ['_api_resource_class' => 'Foo'])));
     }

--- a/tests/Util/RequestParserTest.php
+++ b/tests/Util/RequestParserTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class RequestParserTest extends TestCase
 {
-    public function testParseAndDupplicateRequest()
+    public function testParseAndDupplicateRequest(): void
     {
         $request = new Request(['toto=tata'], [], [], [], [], [], '{"gerard":"toto"}');
         $value = RequestParser::parseAndDuplicateRequest($request);
@@ -32,7 +32,7 @@ class RequestParserTest extends TestCase
     /**
      * @dataProvider parseRequestParamsProvider
      */
-    public function testParseRequestParams($source, $expected)
+    public function testParseRequestParams($source, $expected): void
     {
         $actual = RequestParser::parseRequestParams($source);
         $this->assertEquals($expected, $actual);

--- a/tests/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Validator/EventListener/ValidateListenerTest.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class ValidateListenerTest extends TestCase
 {
-    public function testNotAnApiPlatformRequest()
+    public function testNotAnApiPlatformRequest(): void
     {
         $validatorProphecy = $this->prophesize(ValidatorInterface::class);
         $validatorProphecy->validate()->shouldNotBeCalled();
@@ -52,7 +52,7 @@ class ValidateListenerTest extends TestCase
         $listener->onKernelView($event->reveal());
     }
 
-    public function testValidatorIsCalled()
+    public function testValidatorIsCalled(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['a', 'b', 'c'];
@@ -67,7 +67,7 @@ class ValidateListenerTest extends TestCase
         $validationViewListener->onKernelView($event);
     }
 
-    public function testDoNotCallWhenReceiveFlagIsFalse()
+    public function testDoNotCallWhenReceiveFlagIsFalse(): void
     {
         $data = new DummyEntity();
         $expectedValidationGroups = ['a', 'b', 'c'];
@@ -82,7 +82,7 @@ class ValidateListenerTest extends TestCase
         $validationViewListener->onKernelView($event);
     }
 
-    public function testThrowsValidationExceptionWithViolationsFound()
+    public function testThrowsValidationExceptionWithViolationsFound(): void
     {
         $this->expectException(ValidationException::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

We can add this fixer to master as it enforces php 7.1. thoughts?

further work would be adding nullable types.
