### PR TITLE
Fix test since last Symfony Release

### DIFF
--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -74,6 +74,9 @@ final class AddHeadersListener
             $this->public ? $response->setPublic() : $response->setPrivate();
         }
 
-        $response->headers->set(SessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '');
+        if(\defined(SessionListener::class.'::NO_AUTO_CACHE_CONTROL_HEADER')){
+            $response->headers->set(SessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '');
+        }
+
     }
 }

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\HttpCache\EventListener;
 
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
 
 /**
  * Configures cache HTTP headers for the current response.
@@ -72,5 +73,7 @@ final class AddHeadersListener
         if (null !== $this->public) {
             $this->public ? $response->setPublic() : $response->setPrivate();
         }
+
+        $response->headers->set(SessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '');
     }
 }

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\HttpCache\EventListener;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
 
 /**
  * Sets the list of resources' IRIs included in this response in the "Cache-Tags" HTTP header.
@@ -67,5 +68,6 @@ final class AddTagsListener
         }
 
         $event->getResponse()->headers->set('Cache-Tags', implode(',', $resources));
+        $event->getResponse()->headers->set(SessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '');
     }
 }

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -68,6 +68,8 @@ final class AddTagsListener
         }
 
         $event->getResponse()->headers->set('Cache-Tags', implode(',', $resources));
-        $event->getResponse()->headers->set(SessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '');
+        if(\defined(SessionListener::class.'::NO_AUTO_CACHE_CONTROL_HEADER')){
+            $response->headers->set(SessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | **no**
| Fixed tickets | 
| License       | MIT

Fail since 4.1.1 : for this commi : https://github.com/symfony/symfony/commit/146e01cb4442fbcb3b05dd8ae2569d9894374044

The test don't work for PHP 7.0 and Symfony before 3 month ago. ( because NO_AUTO_CACHE_CONTROL_HEADER is implemented on March 2018)
I don't know if this is a bug which need to be fix on Symfony