### PR TITLE
WhereFilter - Allow to build complex search query

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter.php
@@ -57,11 +57,11 @@ final class WhereFilter implements ContextAwareFilterInterface
             switch ($type) {
                 case AndCondition::TYPE:
                     $conditions = $this->buildWhereFromArray($alias, $conditionArray)->getConditions();
-                    $where->addCondition(new AndCondition(...$conditions));
+                    $where->addCondition(new AndCondition($conditions));
                     break;
                 case OrCondition::TYPE:
                     $conditions = $this->buildWhereFromArray($alias, $conditionArray)->getConditions();
-                    $where->addCondition(new OrCondition(...$conditions));
+                    $where->addCondition(new OrCondition($conditions));
                     break;
                 case EqCondition::TYPE:
                     $where->addCondition(new EqCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Where;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpFoundation\RequestStack;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\AndCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\ConditionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\EqCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\GtCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\GteCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\LtCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\LteCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\NeqCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\OrCondition;
+
+class WhereFilter implements FilterInterface
+{
+    private const QUERY_STRING_WHERE = 'where';
+
+    protected $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+        if (null === $request = $this->requestStack->getCurrentRequest()) {
+            return;
+        }
+
+        if (null === $whereData = $request->query->get(self::QUERY_STRING_WHERE)) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $where = $this->buildWhereFromArray($rootAlias, $whereData);
+
+        $where->apply($queryBuilder);
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        return []; // TODO
+    }
+
+    public function buildWhereFromArray(string $alias, array $whereArray): Where
+    {
+        $where = new Where();
+        foreach ($whereArray as $conditionType => $conditionArray) {
+            $type = array_keys($conditionArray)[0];
+
+            switch (true) {
+                case $conditionType === AndCondition::TYPE:
+                    $conditions = $this->buildWhereFromArray($alias, $conditionArray)->getConditions();
+                    $where->addCondition(new AndCondition(...$conditions));
+                    break;
+                case $conditionType === OrCondition::TYPE:
+                    $conditions = $this->buildWhereFromArray($alias, $conditionArray)->getConditions();
+                    $where->addCondition(new OrCondition(...$conditions));
+                    break;
+                case $type === EqCondition::TYPE:
+                    $where->addCondition(new EqCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
+                    break;
+                case $type === NeqCondition::TYPE:
+                    $where->addCondition(new NeqCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
+                    break;
+                case $type === GtCondition::TYPE:
+                    $where->addCondition(new GtCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
+                    break;
+                case $type === GteCondition::TYPE:
+                    $where->addCondition(new GteCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
+                    break;
+                case $type === LtCondition::TYPE:
+                    $where->addCondition(new LtCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
+                    break;
+                case $type === LteCondition::TYPE:
+                    $where->addCondition(new LteCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
+                    break;
+            }
+        }
+
+        return $where;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter.php
@@ -1,13 +1,19 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter;
 
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Where;
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use Doctrine\ORM\QueryBuilder;
-use Symfony\Component\HttpFoundation\RequestStack;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\AndCondition;
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\ConditionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\EqCondition;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\GtCondition;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\GteCondition;
@@ -15,25 +21,19 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\LtConditio
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\LteCondition;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\NeqCondition;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\OrCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Where;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
 
-class WhereFilter implements FilterInterface
+final class WhereFilter implements ContextAwareFilterInterface
 {
-    private const QUERY_STRING_WHERE = 'where';
-
-    protected $requestStack;
-
-    public function __construct(RequestStack $requestStack)
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
     {
-        $this->requestStack = $requestStack;
-    }
-
-    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
-    {
-        if (null === $request = $this->requestStack->getCurrentRequest()) {
+        if (null === $filters = $context['filters']) {
             return;
         }
 
-        if (null === $whereData = $request->query->get(self::QUERY_STRING_WHERE)) {
+        if (null === $whereData = $filters['where']) {
             return;
         }
 
@@ -54,31 +54,31 @@ class WhereFilter implements FilterInterface
         foreach ($whereArray as $conditionType => $conditionArray) {
             $type = array_keys($conditionArray)[0];
 
-            switch (true) {
-                case $conditionType === AndCondition::TYPE:
+            switch ($type) {
+                case AndCondition::TYPE:
                     $conditions = $this->buildWhereFromArray($alias, $conditionArray)->getConditions();
                     $where->addCondition(new AndCondition(...$conditions));
                     break;
-                case $conditionType === OrCondition::TYPE:
+                case OrCondition::TYPE:
                     $conditions = $this->buildWhereFromArray($alias, $conditionArray)->getConditions();
                     $where->addCondition(new OrCondition(...$conditions));
                     break;
-                case $type === EqCondition::TYPE:
+                case EqCondition::TYPE:
                     $where->addCondition(new EqCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
                     break;
-                case $type === NeqCondition::TYPE:
+                case NeqCondition::TYPE:
                     $where->addCondition(new NeqCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
                     break;
-                case $type === GtCondition::TYPE:
+                case GtCondition::TYPE:
                     $where->addCondition(new GtCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
                     break;
-                case $type === GteCondition::TYPE:
+                case GteCondition::TYPE:
                     $where->addCondition(new GteCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
                     break;
-                case $type === LtCondition::TYPE:
+                case LtCondition::TYPE:
                     $where->addCondition(new LtCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
                     break;
-                case $type === LteCondition::TYPE:
+                case LteCondition::TYPE:
                     $where->addCondition(new LteCondition($alias.'.'.$conditionType, (array) $conditionArray[$type]));
                     break;
             }

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/AndCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/AndCondition.php
@@ -1,10 +1,22 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class AndCondition implements ConditionInterface
+final class AndCondition implements ConditionInterface
 {
     public const TYPE = 'and';
 
@@ -23,12 +35,12 @@ class AndCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $and = $expr->andX();
+        $and = $queryBuilder->expr()->andX();
 
         foreach ($this->conditions as $condition) {
-            $and->add($condition->apply($expr));
+            $and->add($condition->apply($queryBuilder));
         }
 
         return $and;

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/AndCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/AndCondition.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class AndCondition implements ConditionInterface
+{
+    public const TYPE = 'and';
+
+    /**
+     * @var ConditionInterface[]
+     */
+    protected $conditions;
+
+    public function __construct(ConditionInterface ...$conditions)
+    {
+        $this->conditions = $conditions ?? [];
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $and = $expr->andX();
+
+        foreach ($this->conditions as $condition) {
+            $and->add($condition->apply($expr));
+        }
+
+        return $and;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/AndCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/AndCondition.php
@@ -23,11 +23,11 @@ final class AndCondition implements ConditionInterface
     /**
      * @var ConditionInterface[]
      */
-    protected $conditions;
+    private $conditions;
 
-    public function __construct(ConditionInterface ...$conditions)
+    public function __construct(array $conditions)
     {
-        $this->conditions = $conditions ?? [];
+        $this->conditions = $conditions;
     }
 
     public function getType(): string

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/ConditionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/ConditionInterface.php
@@ -1,12 +1,24 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
-use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\Expr\Composite;
+use Doctrine\ORM\QueryBuilder;
 
 interface ConditionInterface
 {
     public function getType(): string;
 
-    public function apply(Expr $expr);
+    public function apply(QueryBuilder $queryBuilder): Composite;
 }

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/ConditionInterface.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/ConditionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+interface ConditionInterface
+{
+    public function getType(): string;
+
+    public function apply(Expr $expr);
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/EqCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/EqCondition.php
@@ -20,9 +20,9 @@ final class EqCondition implements ConditionInterface
 {
     public const TYPE = 'eq';
 
-    protected $key;
+    private $key;
 
-    protected $values;
+    private $values;
 
     public function __construct(string $key, array $values)
     {

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/EqCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/EqCondition.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class EqCondition implements ConditionInterface
+{
+    public const TYPE = 'eq';
+
+    protected $key;
+
+    protected $values;
+
+    public function __construct(string $key, array $values)
+    {
+        $this->key = $key;
+        $this->values = $values;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $or = $expr->orX();
+        foreach ($this->values as $value) {
+            $or->add(
+                $expr->eq($this->key, $expr->literal($value))
+            );
+        }
+
+        return $or;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/EqCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/EqCondition.php
@@ -1,10 +1,22 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class EqCondition implements ConditionInterface
+final class EqCondition implements ConditionInterface
 {
     public const TYPE = 'eq';
 
@@ -23,12 +35,12 @@ class EqCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $or = $expr->orX();
+        $or = $queryBuilder->expr()->orX();
         foreach ($this->values as $value) {
             $or->add(
-                $expr->eq($this->key, $expr->literal($value))
+                $queryBuilder->expr()->eq($this->key, $queryBuilder->expr()->literal($value))
             );
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GtCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GtCondition.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class GtCondition implements ConditionInterface
+{
+    public const TYPE = 'gt';
+
+    protected $key;
+
+    protected $values;
+
+    public function __construct(string $key, array $values)
+    {
+        $this->key = $key;
+        $this->values = $values;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $or = $expr->orX();
+        foreach ($this->values as $value) {
+            $or->add(
+                $expr->gt($this->key, $expr->literal($value))
+            );
+        }
+
+        return $or;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GtCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GtCondition.php
@@ -1,16 +1,28 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class GtCondition implements ConditionInterface
+final class GtCondition implements ConditionInterface
 {
     public const TYPE = 'gt';
 
-    protected $key;
+    private $key;
 
-    protected $values;
+    private $values;
 
     public function __construct(string $key, array $values)
     {
@@ -23,12 +35,12 @@ class GtCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $or = $expr->orX();
+        $or = $queryBuilder->expr()->orX();
         foreach ($this->values as $value) {
             $or->add(
-                $expr->gt($this->key, $expr->literal($value))
+                $queryBuilder->expr()->gt($this->key, $queryBuilder->expr()->literal($value))
             );
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GteCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GteCondition.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class GteCondition implements ConditionInterface
+{
+    public const TYPE = 'gte';
+
+    protected $key;
+
+    protected $values;
+
+    public function __construct(string $key, array $values)
+    {
+        $this->key = $key;
+        $this->values = $values;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $or = $expr->orX();
+        foreach ($this->values as $value) {
+            $or->add(
+                $expr->gte($this->key, $expr->literal($value))
+            );
+        }
+
+        return $or;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GteCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/GteCondition.php
@@ -1,16 +1,28 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class GteCondition implements ConditionInterface
+final class GteCondition implements ConditionInterface
 {
     public const TYPE = 'gte';
 
-    protected $key;
+    private $key;
 
-    protected $values;
+    private $values;
 
     public function __construct(string $key, array $values)
     {
@@ -23,12 +35,12 @@ class GteCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $or = $expr->orX();
+        $or = $queryBuilder->expr()->orX();
         foreach ($this->values as $value) {
             $or->add(
-                $expr->gte($this->key, $expr->literal($value))
+                $queryBuilder->expr()->gte($this->key, $queryBuilder->expr()->literal($value))
             );
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LtCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LtCondition.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class LtCondition implements ConditionInterface
+{
+    public const TYPE = 'lt';
+
+    protected $key;
+
+    protected $values;
+
+    public function __construct(string $key, array $values)
+    {
+        $this->key = $key;
+        $this->values = $values;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $or = $expr->orX();
+        foreach ($this->values as $value) {
+            $or->add(
+                $expr->lt($this->key, $expr->literal($value))
+            );
+        }
+
+        return $or;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LtCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LtCondition.php
@@ -1,16 +1,28 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class LtCondition implements ConditionInterface
+final class LtCondition implements ConditionInterface
 {
     public const TYPE = 'lt';
 
-    protected $key;
+    private $key;
 
-    protected $values;
+    private $values;
 
     public function __construct(string $key, array $values)
     {
@@ -23,12 +35,12 @@ class LtCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $or = $expr->orX();
+        $or = $queryBuilder->expr()->orX();
         foreach ($this->values as $value) {
             $or->add(
-                $expr->lt($this->key, $expr->literal($value))
+                $queryBuilder->expr()->lt($this->key, $queryBuilder->expr()->literal($value))
             );
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LteCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LteCondition.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class LteCondition implements ConditionInterface
+{
+    public const TYPE = 'lte';
+
+    protected $key;
+
+    protected $values;
+
+    public function __construct(string $key, array $values)
+    {
+        $this->key = $key;
+        $this->values = $values;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $or = $expr->orX();
+        foreach ($this->values as $value) {
+            $or->add(
+                $expr->lte($this->key, $expr->literal($value))
+            );
+        }
+
+        return $or;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LteCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/LteCondition.php
@@ -1,16 +1,28 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class LteCondition implements ConditionInterface
+final class LteCondition implements ConditionInterface
 {
     public const TYPE = 'lte';
 
-    protected $key;
+    private $key;
 
-    protected $values;
+    private $values;
 
     public function __construct(string $key, array $values)
     {
@@ -23,12 +35,12 @@ class LteCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $or = $expr->orX();
+        $or = $queryBuilder->expr()->orX();
         foreach ($this->values as $value) {
             $or->add(
-                $expr->lte($this->key, $expr->literal($value))
+                $queryBuilder->expr()->lte($this->key, $queryBuilder->expr()->literal($value))
             );
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/NeqCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/NeqCondition.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class NeqCondition implements ConditionInterface
+{
+    public const TYPE = 'neq';
+
+    protected $key;
+
+    protected $values;
+
+    public function __construct(string $key, array $values)
+    {
+        $this->key = $key;
+        $this->values = $values;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $or = $expr->orX();
+        foreach ($this->values as $value) {
+            $or->add(
+                $expr->neq($this->key, $expr->literal($value))
+            );
+        }
+
+        return $or;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/NeqCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/NeqCondition.php
@@ -1,16 +1,28 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class NeqCondition implements ConditionInterface
+final class NeqCondition implements ConditionInterface
 {
     public const TYPE = 'neq';
 
-    protected $key;
+    private $key;
 
-    protected $values;
+    private $values;
 
     public function __construct(string $key, array $values)
     {
@@ -23,12 +35,12 @@ class NeqCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $or = $expr->orX();
+        $or = $queryBuilder->expr()->orX();
         foreach ($this->values as $value) {
             $or->add(
-                $expr->neq($this->key, $expr->literal($value))
+                $queryBuilder->expr()->neq($this->key, $queryBuilder->expr()->literal($value))
             );
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/OrCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/OrCondition.php
@@ -25,9 +25,9 @@ final class OrCondition implements ConditionInterface
      */
     private $conditions;
 
-    public function __construct(ConditionInterface ...$conditions)
+    public function __construct(array $conditions)
     {
-        $this->conditions = $conditions ?? [];
+        $this->conditions = $conditions;
     }
 
     public function getType(): string

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/OrCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/OrCondition.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
+
+use Doctrine\ORM\Query\Expr;
+
+class OrCondition implements ConditionInterface
+{
+    public const TYPE = 'or';
+
+    /**
+     * @var ConditionInterface[]
+     */
+    protected $conditions;
+
+    public function __construct(ConditionInterface ...$conditions)
+    {
+        $this->conditions = $conditions ?? [];
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function apply(Expr $expr)
+    {
+        $or = $expr->orX();
+
+        foreach ($this->conditions as $condition) {
+            $or->add($condition->apply($expr));
+        }
+
+        return $or;
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/OrCondition.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Condition/OrCondition.php
@@ -1,17 +1,29 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition;
 
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
 
-class OrCondition implements ConditionInterface
+final class OrCondition implements ConditionInterface
 {
     public const TYPE = 'or';
 
     /**
      * @var ConditionInterface[]
      */
-    protected $conditions;
+    private $conditions;
 
     public function __construct(ConditionInterface ...$conditions)
     {
@@ -23,12 +35,11 @@ class OrCondition implements ConditionInterface
         return self::TYPE;
     }
 
-    public function apply(Expr $expr)
+    public function apply(QueryBuilder $queryBuilder): Expr\Composite
     {
-        $or = $expr->orX();
-
+        $or = $queryBuilder->expr()->orX();
         foreach ($this->conditions as $condition) {
-            $or->add($condition->apply($expr));
+            $or->add($condition->apply($queryBuilder));
         }
 
         return $or;

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Where.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Where.php
@@ -1,12 +1,23 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\AndCondition;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\ConditionInterface;
 use Doctrine\ORM\QueryBuilder;
 
-class Where
+final class Where
 {
     /**
      * @var ConditionInterface[]

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Where.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Where.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\AndCondition;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\WhereFilter\Condition\ConditionInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class Where
+{
+    /**
+     * @var ConditionInterface[]
+     */
+    protected $conditions;
+
+    public function __construct(?ConditionInterface ...$conditions)
+    {
+        $this->conditions = $conditions ?? [];
+    }
+
+    /**
+     * @return ConditionInterface[]
+     */
+    public function getConditions(): array
+    {
+        return array_values($this->conditions);
+    }
+
+    public function addCondition(ConditionInterface $condition): void
+    {
+        if (isset($this->conditions[$condition->getType()])) {
+            $currentCondition = $this->conditions[$condition->getType()];
+            unset($this->conditions[$condition->getType()]);
+            $condition = new AndCondition($currentCondition, $condition);
+        }
+
+        $this->conditions[$condition->getType()] = $condition;
+    }
+
+    public function apply(QueryBuilder $queryBuilder)
+    {
+        foreach ($this->conditions as $condition) {
+            $expr = $queryBuilder->expr();
+            $queryBuilder->andWhere($condition->apply($expr));
+        }
+    }
+}

--- a/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Where.php
+++ b/src/Bridge/Doctrine/Orm/Filter/WhereFilter/Where.php
@@ -22,12 +22,7 @@ final class Where
     /**
      * @var ConditionInterface[]
      */
-    protected $conditions;
-
-    public function __construct(?ConditionInterface ...$conditions)
-    {
-        $this->conditions = $conditions ?? [];
-    }
+    private $conditions = [];
 
     /**
      * @return ConditionInterface[]
@@ -42,7 +37,7 @@ final class Where
         if (isset($this->conditions[$condition->getType()])) {
             $currentCondition = $this->conditions[$condition->getType()];
             unset($this->conditions[$condition->getType()]);
-            $condition = new AndCondition($currentCondition, $condition);
+            $condition = new AndCondition([$currentCondition, $condition]);
         }
 
         $this->conditions[$condition->getType()] = $condition;
@@ -51,8 +46,7 @@ final class Where
     public function apply(QueryBuilder $queryBuilder)
     {
         foreach ($this->conditions as $condition) {
-            $expr = $queryBuilder->expr();
-            $queryBuilder->andWhere($condition->apply($expr));
+            $queryBuilder->andWhere($condition->apply($queryBuilder));
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not tested yet
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hi,
I open this PR to start discuss about implementing a filter like provided in Loopback (http://loopback.io/doc/en/lb3/Where-filter.html).

The idea is to allow building complex query from client side like following examples:
```
http://localhost:8080/greetings?where[name][eq]=toto
```
```
http://localhost:8080/greetings?where[or][name][eq]=test&where[or][name][eq]=test
```
```
http://localhost:8080/greetings?where[and][name][eq]=test&where[and][id][lt]=10
```

TO-DO:
- [ ] Make allowed fields configurable
- [ ] Allow usage of sub resource fields
- [ ] Write tests
- [ ] Write documentation

I provide a first shoot implementation, wait for your comments !