### PR TITLE
fix skipped data persisters on persist

### DIFF
--- a/src/DataPersister/ChainDataPersister.php
+++ b/src/DataPersister/ChainDataPersister.php
@@ -51,9 +51,11 @@ final class ChainDataPersister implements DataPersisterInterface
     {
         foreach ($this->persisters as $persister) {
             if ($persister->supports($data)) {
-                return $persister->persist($data) ?? $data;
+                $data = $persister->persist($data) ?? $data;
             }
         }
+
+        return $data;
     }
 
     /**

--- a/tests/DataPersister/ChainDataPersisterTest.php
+++ b/tests/DataPersister/ChainDataPersisterTest.php
@@ -60,7 +60,15 @@ class ChainDataPersisterTest extends TestCase
         $barPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
         $barPersisterProphecy->persist($dummy)->shouldBeCalled();
 
-        (new ChainDataPersister([$fooPersisterProphecy->reveal(), $barPersisterProphecy->reveal()]))->persist($dummy);
+        $bazPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
+        $bazPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
+        $bazPersisterProphecy->persist($dummy)->shouldBeCalled();
+
+        (new ChainDataPersister([
+            $fooPersisterProphecy->reveal(),
+            $barPersisterProphecy->reveal(),
+            $bazPersisterProphecy->reveal(),
+        ]))->persist($dummy);
     }
 
     public function testRemove()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | (fix one)
| Deprecations? | no
| Tests pass?   | this features tests are green
| Fixed tickets | https://github.com/api-platform/core/pull/1967#discussion_r199755449
| License       | MIT

fixes https://github.com/api-platform/core/pull/1967#discussion_r199755449

Fix a unwanted behavior when multiple DataPersisters support an item, the first supporting one was called, other were skipped.

This PR, fix this.