### PR TITLE
[graphql] Add graphql filter with multiple values

### DIFF
--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -161,7 +161,7 @@ Feature: Collections filtering
     When  I send the following GraphQL request:
     """
     {
-      dummies(arrayrelatedDummy_name: ["RelatedDummy #1", "RelatedDummy #2"]) {
+      dummies(relatedDummy_name_list: ["RelatedDummy #1", "RelatedDummy #2"]) {
         edges {
           node {
             id

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -156,19 +156,26 @@ Feature: Collections filtering
     And the JSON node "data.dummies.edges[1].node.name" should be equal to "Dummy #1"
 
   @createSchema
-  Scenario: Retrieve a collection filtered using the related search filter with two values
-    Given there are 10 dummy objects
+  Scenario: Retrieve a collection filtered using the related search filter with two values and exact strategy
+    Given there are 3 dummy objects with relatedDummy
     When  I send the following GraphQL request:
     """
     {
-      dummies(name: ["#2", "#3"]) {
+      dummies(arrayrelatedDummy_name: ["RelatedDummy #1", "RelatedDummy #2"]) {
         edges {
           node {
             id
             name
+            relatedDummy {
+              name
+            }
           }
         }
       }
     }
     """
-    Then the JSON node "data.dummies.edges" should have 2 element
+    Then the response status code should be 200
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummies.edges" should have 2 element
+    And the JSON node "data.dummies.edges[0].node.relatedDummy.name" should be equal to "RelatedDummy #1"
+    And the JSON node "data.dummies.edges[1].node.relatedDummy.name" should be equal to "RelatedDummy #2"

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -154,3 +154,21 @@ Feature: Collections filtering
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.dummies.edges[0].node.name" should be equal to "Dummy #2"
     And the JSON node "data.dummies.edges[1].node.name" should be equal to "Dummy #1"
+
+  @createSchema
+  Scenario: Retrieve a collection filtered using the related search filter with two values
+    Given there are 10 dummy objects
+    When  I send the following GraphQL request:
+    """
+    {
+      dummies(name: ["#2", "#3"]) {
+        edges {
+          node {
+            id
+            name
+          }
+        }
+      }
+    }
+    """
+    Then the JSON node "data.dummies.edges" should have 2 element

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -164,11 +164,14 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
         $filters = $args;
         foreach ($filters as $name => $value) {
             if (\is_array($value)) {
+                if (0 === strpos($name, 'array')) {
+                    unset($filters[$name]);
+                    $name = substr($name, \strlen('array'));
+                }
                 $filters[$name] = $this->getNormalizedFilters($value);
-                continue;
             }
 
-            if (strpos($name, '_')) {
+            if (\is_string($name) && strpos($name, '_')) {
                 // Gives a chance to relations/nested fields.
                 $filters[str_replace('_', '.', $name)] = $value;
             }

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -162,11 +162,11 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
     private function getNormalizedFilters(array $args): array
     {
         $filters = $args;
+
         foreach ($filters as $name => $value) {
             if (\is_array($value)) {
-                if (0 === strpos($name, 'array')) {
-                    unset($filters[$name]);
-                    $name = substr($name, \strlen('array'));
+                if (strpos($name, '_list')) {
+                    $name = substr($name, 0, \strlen($name) - \strlen('_list'));
                 }
                 $filters[$name] = $this->getNormalizedFilters($value);
             }

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -231,12 +231,15 @@ final class SchemaBuilder implements SchemaBuilderInterface
                         $filterType = \in_array($value['type'], Type::$builtinTypes, true) ? new Type($value['type'], $nullable) : new Type('object', $nullable, $value['type']);
                         $graphqlFilterType = $this->convertType($filterType, false, null, $depth);
 
-                        if ('[]' === $newKey = substr($key, -2)) {
-                            $key = $newKey;
+                        if ('[]' === substr($key, -2)) {
                             $graphqlFilterType = GraphQLType::listOf($graphqlFilterType);
+                            $key = 'array'.substr($key, 0, -2);
                         }
 
                         parse_str($key, $parsed);
+                        if (array_key_exists($key, $parsed) && \is_array($parsed[$key])) {
+                            $parsed = [$key => ''];
+                        }
                         array_walk_recursive($parsed, function (&$value) use ($graphqlFilterType) {
                             $value = $graphqlFilterType;
                         });

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -233,7 +233,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
 
                         if ('[]' === substr($key, -2)) {
                             $graphqlFilterType = GraphQLType::listOf($graphqlFilterType);
-                            $key = 'array'.substr($key, 0, -2);
+                            $key = substr($key, 0, -2).'_list';
                         }
 
                         parse_str($key, $parsed);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/524

Using the SearchFilter with multiple values was not possible with graphql.

Using the same synthax than the query filter (`foo[]=bar`) was not possible because characters `[` and `]` in a graphql query are invalid and it seems that it's not possible to use the same key for both single value filter and multi values filter.

The idea is to prefix the field name with a special keyword to make the distinction between single and multiple values.