### PR TITLE
New "_api_persist" request attribute to skip the WriteListener

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -37,7 +37,7 @@ final class WriteListener
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
         $request = $event->getRequest();
-        if ($request->isMethodSafe(false) || !$request->attributes->has('_api_resource_class')) {
+        if ($request->isMethodSafe(false) || !$request->attributes->has('_api_resource_class') || !$request->attributes->getBoolean('_api_persist', true)) {
             return;
         }
 

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -58,11 +58,10 @@ final class AttributesExtractor
             return [];
         }
 
-        if (null === $apiRequest = $attributes['_api_receive'] ?? null) {
-            $result['receive'] = true;
-        } else {
-            $result['receive'] = (bool) $apiRequest;
-        }
+        $result += [
+            'receive' => (bool) ($attributes['_api_receive'] ?? true),
+            'persist' => (bool) ($attributes['_api_persist'] ?? true),
+        ];
 
         return $result;
     }

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -107,7 +107,7 @@ class RequestDataCollectorTest extends TestCase
             $this->response
         );
 
-        $this->assertSame(['resource_class' => DummyEntity::class,  'item_operation_name' => 'get', 'receive' => true], $dataCollector->getRequestAttributes());
+        $this->assertSame(['resource_class' => DummyEntity::class,  'item_operation_name' => 'get', 'receive' => true, 'persist' => true], $dataCollector->getRequestAttributes());
         $this->assertSame(['foo', 'bar'], $dataCollector->getAcceptableContentTypes());
         $this->assertSame(DummyEntity::class, $dataCollector->getResourceClass());
         $this->assertSame(['foo' => null, 'a_filter' => \stdClass::class], $dataCollector->getFilters());

--- a/tests/EventListener/AddFormatListenerTest.php
+++ b/tests/EventListener/AddFormatListenerTest.php
@@ -224,7 +224,7 @@ class AddFormatListenerTest extends TestCase
         $event = $eventProphecy->reveal();
 
         $formatsProviderProphecy = $this->prophesize(FormatsProviderInterface::class);
-        $formatsProviderProphecy->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'get', 'receive' => true])->willReturn(['csv' => ['text/csv']])->shouldBeCalled();
+        $formatsProviderProphecy->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'get', 'receive' => true, 'persist' => true])->willReturn(['csv' => ['text/csv']])->shouldBeCalled();
 
         $listener = new AddFormatListener(new Negotiator(), $formatsProviderProphecy->reveal());
         $listener->onKernelRequest($event);

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -172,7 +172,7 @@ class DeserializeListenerTest extends TestCase
         $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->willReturn([])->shouldBeCalled();
 
         $formatsProviderProphecy = $this->prophesize(FormatsProviderInterface::class);
-        $formatsProviderProphecy->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'post', 'receive' => true])->willReturn(self::FORMATS)->shouldBeCalled();
+        $formatsProviderProphecy->getFormatsFromAttributes(['resource_class' => 'Foo', 'collection_operation_name' => 'post', 'receive' => true, 'persist' => true])->willReturn(self::FORMATS)->shouldBeCalled();
 
         $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), $formatsProviderProphecy->reveal());
 

--- a/tests/EventListener/WriteListenerTest.php
+++ b/tests/EventListener/WriteListenerTest.php
@@ -170,6 +170,31 @@ class WriteListenerTest extends TestCase
         (new WriteListener($dataPersisterProphecy->reveal()))->onKernelView($event);
     }
 
+    public function testOnKernelViewWithPersistFlagOff()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('Dummyrino');
+
+        $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
+        $dataPersisterProphecy->supports($dummy)->shouldNotBeCalled();
+        $dataPersisterProphecy->persist($dummy)->shouldNotBeCalled();
+        $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
+
+        $request = new Request();
+        $request->setMethod('HEAD');
+        $request->attributes->set('_api_resource_class', Dummy::class);
+        $request->attributes->set('_api_persist', false);
+
+        $event = new GetResponseForControllerResultEvent(
+            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $dummy
+        );
+
+        (new WriteListener($dataPersisterProphecy->reveal()))->onKernelView($event);
+    }
+
     public function testOnKernelViewWithNoResourceClass()
     {
         $dummy = new Dummy();

--- a/tests/Serializer/SerializerFilterContextBuilderTest.php
+++ b/tests/Serializer/SerializerFilterContextBuilderTest.php
@@ -154,6 +154,7 @@ class SerializerFilterContextBuilderTest extends TestCase
             'resource_class' => DummyGroup::class,
             'collection_operation_name' => 'get',
             'receive' => true,
+            'persist' => true,
         ];
 
         $resourceMetadata = new ResourceMetadata(

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -27,7 +27,7 @@ class RequestAttributesExtractorTest extends TestCase
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'collection_operation_name' => 'post', 'receive' => true],
+            ['resource_class' => 'Foo', 'collection_operation_name' => 'post', 'receive' => true, 'persist' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
     }
@@ -37,7 +37,7 @@ class RequestAttributesExtractorTest extends TestCase
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true, 'persist' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
     }
@@ -47,21 +47,45 @@ class RequestAttributesExtractorTest extends TestCase
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_receive' => '0']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => false],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => false, 'persist' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_receive' => '1']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true, 'persist' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
 
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
 
         $this->assertEquals(
-            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true],
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true, 'persist' => true],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+    }
+
+    public function testExtractPersist()
+    {
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_persist' => '0']);
+
+        $this->assertEquals(
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true, 'persist' => false],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_persist' => '1']);
+
+        $this->assertEquals(
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true, 'persist' => true],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
+
+        $this->assertEquals(
+            ['resource_class' => 'Foo', 'item_operation_name' => 'get', 'receive' => true, 'persist' => true],
             RequestAttributesExtractor::extractAttributes($request)
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | api-platform/docs#523

Add a new `_api_persist` flag to skip the `WriteListener`. See also https://stackoverflow.com/q/51147945/1352334 for the use case. 