### PR TITLE
Unset the filter (with a dot character), in case of a relation, once it has been sanitized

### DIFF
--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -300,6 +300,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
             if (strpos($key, '.')) {
                 // Declare relations/nested fields in a GraphQL compatible syntax.
                 $args[str_replace('.', '_', $key)] = $value;
+                unset($args[$key]);
             }
         }
 

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -95,6 +95,32 @@ class SchemaBuilderTest extends TestCase
         $this->assertArrayNotHasKey('objectProperty', $type->getFields());
     }
 
+    public function testConvertFilterArgsToTypes()
+    {
+        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
+            return new PropertyMetadata();
+        };
+        $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, false);
+
+        $reflectionClass = new \ReflectionClass(SchemaBuilder::class);
+        $method = $reflectionClass->getMethod('convertFilterArgsToTypes');
+        $method->setAccessible(true);
+        $filterArgs = [
+            'aField' => 'string',
+            'GraphqlRelatedResource.nestedFieldA' => 'string',
+            'GraphqlRelatedResource.nestedFieldB' => 'string',
+        ];
+
+        $this->assertSame(
+            [
+                'aField' => 'string',
+                'GraphqlRelatedResource_nestedFieldA' => 'string',
+                'GraphqlRelatedResource_nestedFieldB' => 'string',
+            ],
+            $method->invoke($mockedSchemaBuilder, $filterArgs)
+        );
+    }
+
     /**
      * @dataProvider paginationProvider
      */
@@ -230,8 +256,10 @@ class SchemaBuilderTest extends TestCase
         $resourceNameCollection = new ResourceNameCollection($resourceClassNames);
         $resourceNameCollectionFactoryProphecy->create()->willReturn($resourceNameCollection);
 
-        $collectionResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {});
-        $itemMutationResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {});
+        $collectionResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {
+        });
+        $itemMutationResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {
+        });
 
         return new SchemaBuilder(
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -240,8 +268,10 @@ class SchemaBuilderTest extends TestCase
             $resourceMetadataFactoryProphecy->reveal(),
             $collectionResolverFactoryProphecy->reveal(),
             $itemMutationResolverFactoryProphecy->reveal(),
-            function () {},
-            function () {},
+            function () {
+            },
+            function () {
+            },
             null,
             $paginationEnabled
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2082
| License       | MIT
| Doc PR        | 

Against some graphql client implementation (like apollo for ios), the presence of a relation/nested property with the `.` (dot character) in the schema is not supported.
So, the array of filter definitions should be cleaned by removing the nested property once it has been sanitized (the `.` character is replaced by the `_` charceter)
