### PR TITLE
Ignore property that does not exist for interfaces (identifiers for interfaces)

### DIFF
--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -327,3 +327,38 @@ Feature: Table inheritance
        "required": ["hydra:member"]
      }
      """
+
+  Scenario: Get an interface resource item
+    When I send a "GET" request to "/resource_interfaces/some-id"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "context": {
+          "type": "string",
+          "pattern": "ResourceInterface$"
+        },
+        "@id": {
+          "type": "string",
+          "pattern": "resource_interfaces$"
+        },
+        "@type": {
+          "type": "string",
+          "pattern": "^ResourceInterface$"
+        },
+        "foo": {
+          "type": "string",
+          "required": "true"
+        },
+        "fooz": {
+          "type": "string",
+          "required": "true",
+          "pattern": "fooz"
+        }
+      }
+    }
+    """

--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -307,15 +307,11 @@ Feature: Table inheritance
            "items": {
              "type": "object",
              "properties": {
-               "@type": {
-                 "type": "string",
-                 "pattern": "^ResourceInterface$"
-               },
-               "@id": {
-                 "type": "string",
-                 "pattern": "^_:"
-               },
                "foo": {
+                 "type": "string",
+                 "required": "true"
+               },
+               "fooz": {
                  "type": "string",
                  "required": "true"
                }
@@ -341,14 +337,6 @@ Feature: Table inheritance
         "context": {
           "type": "string",
           "pattern": "ResourceInterface$"
-        },
-        "@id": {
-          "type": "string",
-          "pattern": "resource_interfaces$"
-        },
-        "@type": {
-          "type": "string",
-          "pattern": "^ResourceInterface$"
         },
         "foo": {
           "type": "string",

--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -48,9 +48,11 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
             }
         }
 
+        $isInterface = interface_exists($resourceClass);
+
         if (
-            !property_exists($resourceClass, $property) ||
-            !$propertyMetadata = $this->extractor->getResources()[$resourceClass]['properties'][$property] ?? false
+            !property_exists($resourceClass, $property) && !$isInterface ||
+            null === ($propertyMetadata = $this->extractor->getResources()[$resourceClass]['properties'][$property] ?? null)
         ) {
             return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
         }

--- a/tests/Fixtures/FileConfigurations/interface_resource.yml
+++ b/tests/Fixtures/FileConfigurations/interface_resource.yml
@@ -1,2 +1,8 @@
 resources:
-    'ApiPlatform\Core\Tests\Fixtures\DummyResourceInterface': ~
+    'ApiPlatform\Core\Tests\Fixtures\DummyResourceInterface':
+        properties:
+            something:
+                identifier: true
+            somethingElse:
+                writable: false
+                readable: true

--- a/tests/Fixtures/TestBundle/DataProvider/ResourceInterfaceImplementationDataProvider.php
+++ b/tests/Fixtures/TestBundle/DataProvider/ResourceInterfaceImplementationDataProvider.php
@@ -28,7 +28,11 @@ class ResourceInterfaceImplementationDataProvider implements ItemDataProviderInt
 
     public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
     {
-        return (new ResourceInterfaceImplementation())->setFoo('single item');
+        if ('some-id' === $id) {
+            return (new ResourceInterfaceImplementation())->setFoo('single item');
+        }
+
+        return null;
     }
 
     public function getCollection(string $resourceClass, string $operationName = null)

--- a/tests/Fixtures/TestBundle/OtherResources/ResourceInterface.php
+++ b/tests/Fixtures/TestBundle/OtherResources/ResourceInterface.php
@@ -16,4 +16,6 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\OtherResources;
 interface ResourceInterface
 {
     public function getFoo(): string;
+
+    public function getFooz(): string;
 }

--- a/tests/Fixtures/TestBundle/OtherResources/ResourceInterfaceImplementation.php
+++ b/tests/Fixtures/TestBundle/OtherResources/ResourceInterfaceImplementation.php
@@ -51,4 +51,9 @@ class ResourceInterfaceImplementation implements ResourceInterface, ResourceBarI
     {
         return $this->bar;
     }
+
+    public function getFooz(): string
+    {
+        return 'fooz';
+    }
 }

--- a/tests/Fixtures/TestBundle/Resources/config/api_resources.yml
+++ b/tests/Fixtures/TestBundle/Resources/config/api_resources.yml
@@ -7,3 +7,7 @@ resources:
         collectionOperations:
             get:
                 method: 'GET'
+
+        properties:
+            foo:
+                identifier: true

--- a/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\ExtractorPropertyMetadataFactory;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Property\SubresourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\DummyResourceInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -236,5 +237,19 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/parse_exception.yml';
 
         (new ExtractorPropertyMetadataFactory(new YamlExtractor([$configPath])))->create(FileConfigDummy::class, 'foo');
+    }
+
+    public function testItExtractPropertiesFromInterfaceResources()
+    {
+        $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/interface_resource.yml';
+
+        $propertyMetadataFactory = new ExtractorPropertyMetadataFactory(new YamlExtractor([$configPath]));
+        $metadataSomething = $propertyMetadataFactory->create(DummyResourceInterface::class, 'something');
+        $metadataSomethingElse = $propertyMetadataFactory->create(DummyResourceInterface::class, 'somethingElse');
+
+        $this->assertInstanceOf(PropertyMetadata::class, $metadataSomething);
+        $this->assertInstanceOf(PropertyMetadata::class, $metadataSomethingElse);
+        $this->assertTrue($metadataSomething->isIdentifier());
+        $this->assertFalse($metadataSomethingElse->isWritable());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Related to https://github.com/api-platform/core/issues/1574
| License       | MIT
| Doc PR        | N/A

### Motivations

TL;DR: Before: no "item" route working because we can't define an identifier. After: we can define a property for an interface and it will not be considered as "not found property".


1. It makes no sense to check if an interface exists in case it's an interface ;
2. If the property is not recognized as one and there is no identifier, then API Platform will not be able to call the DataProvider for a given item and interface as a resource is an incomplete feature.

### Usage

```yaml
Me\InterfaceAsAResource:
    properties:
         # Will work even if foo is not defined in the interface!
         foo:
             identifier: true
```

### What's next?

If you like this kind of features, I will probably work on "virtual properties" next. I see something like

```yaml
Me\InterfaceAsAResource:
    properties:
         foo:
             identifier: true
             proxy_method: 'customMethodToGetFoo'
```

What do you think? Maybe you want a separate RFC issue to discuss it?