### PR TITLE
Fix tests doctrine deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,6 @@
     ],
     "require": {
         "php": ">=7.1",
-
-        "doctrine/inflector": "^1.0",
         "psr/cache": "^1.0",
         "psr/container": "^1.0",
         "symfony/http-foundation": "^3.1 || ^4.0",

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Annotation;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Hydrates attributes from annotation's parameters.

--- a/src/Bridge/Symfony/Routing/RouteNameGenerator.php
+++ b/src/Bridge/Symfony/Routing/RouteNameGenerator.php
@@ -16,7 +16,7 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\OperationTypeDeprecationHelper;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generates the Symfony route name associated with an operation name and a resource short name.

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Util\ClassInfoTrait;
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Inflector\Inflector;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;

--- a/src/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Operation/DashPathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generate a path name with a dash separator according to a string and whether it's a collection or not.

--- a/src/Operation/UnderscorePathSegmentNameGenerator.php
+++ b/src/Operation/UnderscorePathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generate a path name with an underscore separator according to a string and whether it's a collection or not.


### PR DESCRIPTION
@dunglas I think that the ClassLoader is used by symfony in https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php#L56 if that's not the case I don't get it (see DoctrineOrmFilterTestCase).

I'm really not sure how we can fix those deprecations right now.