### PR TITLE
Fix JSON API inlcude form when remove duplicate data

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -245,6 +245,32 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given there are :nb dummy property objects with different number of related groups
+     */
+    public function thereAreDummyPropertyObjectsWithADifferentNumberRelatedGroups(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $dummyGroup = new DummyGroup();
+            $dummyProperty = new DummyProperty();
+
+            foreach (['foo', 'bar', 'baz'] as $property) {
+                $dummyProperty->$property = $dummyGroup->$property = ucfirst($property).' #'.$i;
+            }
+
+            $this->manager->persist($dummyGroup);
+            $dummyGroups[$i] = $dummyGroup;
+
+            for ($j = 1; $j <= $i; ++$j) {
+                $dummyProperty->groups[] = $dummyGroups[$j];
+            }
+
+            $this->manager->persist($dummyProperty);
+        }
+
+        $this->manager->flush();
+    }
+
+    /**
      * @Given there are :nb dummy property objects with :nb2 groups
      */
     public function thereAreDummyPropertyObjectsWithGroups(int $nb, int $nb2)

--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -584,3 +584,81 @@ Feature: JSON API Inclusion of Related Resources
         ]
     }
   """
+
+  @createSchema
+  Scenario: Request inclusion of a related resources on collection should not duplicated included object
+    Given there are 2 dummy property objects with different number of related groups
+    When I send a "GET" request to "/dummy_properties?include=groups"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+    {
+        "links": {
+            "self": "/dummy_properties?include=groups"
+        },
+        "meta": {
+            "totalItems": 2,
+            "itemsPerPage": 3,
+            "currentPage": 1
+        },
+        "data": [{
+            "id": "/dummy_properties/1",
+            "type": "DummyProperty",
+            "attributes": {
+                "_id": 1,
+                "foo": "Foo #1",
+                "bar": "Bar #1",
+                "baz": "Baz #1"
+            },
+            "relationships": {
+                "groups": {
+                    "data": [{
+                        "type": "DummyGroup",
+                        "id": "/dummy_groups/1"
+                    }]
+                }
+            }
+        }, {
+            "id": "/dummy_properties/2",
+            "type": "DummyProperty",
+            "attributes": {
+                "_id": 2,
+                "foo": "Foo #2",
+                "bar": "Bar #2",
+                "baz": "Baz #2"
+            },
+            "relationships": {
+                "groups": {
+                    "data": [{
+                        "type": "DummyGroup",
+                        "id": "/dummy_groups/1"
+                    }, {
+                        "type": "DummyGroup",
+                        "id": "/dummy_groups/2"
+                    }]
+                }
+            }
+        }],
+        "included": [{
+            "id": "/dummy_groups/1",
+            "type": "DummyGroup",
+            "attributes": {
+                "_id": 1,
+                "foo": "Foo #1",
+                "bar": "Bar #1",
+                "baz": "Baz #1"
+            }
+        }, {
+            "id": "/dummy_groups/2",
+            "type": "DummyGroup",
+            "attributes": {
+                "_id": 2,
+                "foo": "Foo #2",
+                "bar": "Bar #2",
+                "baz": "Baz #2"
+            }
+        }]
+    }
+    """

--- a/src/JsonApi/Serializer/CollectionNormalizer.php
+++ b/src/JsonApi/Serializer/CollectionNormalizer.php
@@ -90,7 +90,7 @@ final class CollectionNormalizer extends AbstractCollectionNormalizer
             $data['data'][] = $item['data'];
 
             if (isset($item['included'])) {
-                $data['included'] = array_unique(array_merge($data['included'] ?? [], $item['included']), SORT_REGULAR);
+                $data['included'] = array_values(array_unique(array_merge($data['included'] ?? [], $item['included']), SORT_REGULAR));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In `src/JsonApi/Serializer/CollectionNormalizer.php`  must reindex array cause `array_unique` preserve keys and after that `json_encode`  [ parse php array to JSON  array not to JSON object](https://stackoverflow.com/questions/11195692/json-encode-sparse-php-array-as-json-array-not-json-object).