### PR TITLE
fix #2115 SwaggerCommand with --yaml now properly serializes nested objects

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -67,7 +67,7 @@ final class SwaggerCommand extends Command
     {
         $documentation = new Documentation($this->resourceNameCollectionFactory->create(), $this->apiTitle, $this->apiDescription, $this->apiVersion, $this->apiFormats);
         $data = $this->documentationNormalizer->normalize($documentation);
-        $content = $input->getOption('yaml') ? Yaml::dump($data) : json_encode($data, JSON_PRETTY_PRINT);
+        $content = $input->getOption('yaml') ? Yaml::dump($data, Yaml::DUMP_OBJECT_AS_MAP) : json_encode($data, JSON_PRETTY_PRINT);
 
         if (!empty($input->getOption('output'))) {
             file_put_contents($input->getOption('output'), $content);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2115 
| License       | MIT

