### PR TITLE
Remove sensio/framework-extra-bundle from the dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.7",
         "ramsey/uuid-doctrine": "^1.4",
-        "sensio/framework-extra-bundle": "^3.0.11 || ^4.0 || ^5.0",
         "symfony/asset": "^3.3 || ^4.0",
         "symfony/cache": "^3.3 || ^4.0",
         "symfony/config": "^3.4 || ^4.0",

--- a/tests/Fixtures/TestBundle/Controller/CustomActionController.php
+++ b/tests/Fixtures/TestBundle/Controller/CustomActionController.php
@@ -31,11 +31,11 @@ class CustomActionController extends Controller
      *     defaults={"_api_resource_class"=CustomActionDummy::class, "_api_item_operation_name"="custom_normalization"}
      * )
      */
-    public function customNormalizationAction(CustomActionDummy $_data)
+    public function customNormalizationAction(CustomActionDummy $data)
     {
-        $_data->setFoo('foo');
+        $data->setFoo('foo');
 
-        return $this->json($_data);
+        return $this->json($data);
     }
 
     /**

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -17,7 +17,6 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\TestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use FOS\UserBundle\FOSUserBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
-use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
@@ -51,7 +50,6 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new TwigBundle(),
             new DoctrineBundle(),
-            new SensioFrameworkExtraBundle(),
             new ApiPlatformBundle(),
             new SecurityBundle(),
             new FOSUserBundle(),

--- a/tests/Fixtures/app/config/config_test.yml
+++ b/tests/Fixtures/app/config/config_test.yml
@@ -26,10 +26,6 @@ doctrine:
 twig:
     strict_variables: '%kernel.debug%'
 
-sensio_framework_extra:
-    router:
-        annotations: false
-
 api_platform:
     title:                             'My Dummy API'
     description:                       'This is a test API.'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

We forgot to remove `sensio/framework-extra-bundle` from the dev dependencies in #2108.