### PR TITLE
QueryChecker changes

### DIFF
--- a/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
@@ -84,7 +84,7 @@ final class QueryChecker
                 ->getManagerForClass($rootEntity)
                 ->getClassMetadata($rootEntity);
 
-            if ($rootMetadata instanceof ClassMetadata && ($isForeign ? $rootMetadata->isIdentifierComposite : $rootMetadata->containsForeignIdentifier)) {
+            if ($rootMetadata instanceof ClassMetadata && ($isForeign ? $rootMetadata->containsForeignIdentifier: $rootMetadata->isIdentifierComposite)) {
                 return true;
             }
         }

--- a/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
@@ -84,7 +84,7 @@ final class QueryChecker
                 ->getManagerForClass($rootEntity)
                 ->getClassMetadata($rootEntity);
 
-            if ($rootMetadata instanceof ClassMetadata && ($isForeign ? $rootMetadata->containsForeignIdentifier: $rootMetadata->isIdentifierComposite)) {
+            if ($rootMetadata instanceof ClassMetadata && ($isForeign ? $rootMetadata->containsForeignIdentifier : $rootMetadata->isIdentifierComposite)) {
                 return true;
             }
         }

--- a/tests/Bridge/Doctrine/Orm/Util/QueryCheckerTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryCheckerTest.php
@@ -59,7 +59,8 @@ class QueryCheckerTest extends TestCase
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
         $queryBuilder->getRootAliases()->willReturn(['d']);
         $classMetadata = new ClassMetadata('Dummy');
-        $classMetadata->containsForeignIdentifier = true;
+        $classMetadata->containsForeignIdentifier = false;
+        $classMetadata->isIdentifierComposite = true;
         $objectManager = $this->prophesize(ObjectManager::class);
         $objectManager->getClassMetadata('Dummy')->willReturn($classMetadata);
         $managerRegistry = $this->prophesize(ManagerRegistry::class);
@@ -73,7 +74,8 @@ class QueryCheckerTest extends TestCase
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
         $queryBuilder->getRootAliases()->willReturn(['d']);
         $classMetadata = new ClassMetadata('Dummy');
-        $classMetadata->containsForeignIdentifier = false;
+        $classMetadata->containsForeignIdentifier = true;
+        $classMetadata->isIdentifierComposite = false;
         $objectManager = $this->prophesize(ObjectManager::class);
         $objectManager->getClassMetadata('Dummy')->willReturn($classMetadata);
         $managerRegistry = $this->prophesize(ManagerRegistry::class);
@@ -88,6 +90,8 @@ class QueryCheckerTest extends TestCase
         $queryBuilder->getRootAliases()->willReturn(['d']);
         $classMetadata = new ClassMetadata('Dummy');
         $classMetadata->setIdentifier(['id', 'name']);
+        $classMetadata->containsForeignIdentifier = true;
+        $classMetadata->isIdentifierComposite = false;
         $objectManager = $this->prophesize(ObjectManager::class);
         $objectManager->getClassMetadata('Dummy')->willReturn($classMetadata);
         $managerRegistry = $this->prophesize(ManagerRegistry::class);
@@ -101,6 +105,8 @@ class QueryCheckerTest extends TestCase
         $queryBuilder->getRootEntities()->willReturn(['Dummy']);
         $queryBuilder->getRootAliases()->willReturn(['d']);
         $classMetadata = new ClassMetadata('Dummy');
+        $classMetadata->containsForeignIdentifier = false;
+        $classMetadata->isIdentifierComposite = true;
         $objectManager = $this->prophesize(ObjectManager::class);
         $objectManager->getClassMetadata('Dummy')->willReturn($classMetadata);
         $managerRegistry = $this->prophesize(ManagerRegistry::class);


### PR DESCRIPTION
changed QueryChecker hasRootEntityWithForeignKeyIdentifier() and hasRootEntityWithCompositeIdentifier() to operate as method names imply. updated unit tests.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2136 
| License       | MIT
| Doc PR        | N/A

*Please update this template with something that matches your PR*
