### PR TITLE
Sort Annotation Resource Names

### DIFF
--- a/src/Util/ReflectionClassRecursiveIterator.php
+++ b/src/Util/ReflectionClassRecursiveIterator.php
@@ -52,6 +52,7 @@ final class ReflectionClassRecursiveIterator
         }
 
         $declared = get_declared_classes();
+        sort($declared);
         foreach ($declared as $className) {
             $reflectionClass = new \ReflectionClass($className);
             $sourceFile = $reflectionClass->getFileName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe?
| New feature?  | Not sure
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When viewing resources in the React Admin, I noticed that the resources aren't actually sorted alphabetically as one would expect. This isn't an issue on smaller API's, but if you have any larger number of resources, it gets very difficult to try and find the resource you want to view since the order isn't alphabetical.

I tracked the issue down to the way the RecursiveDirectoryIterator in php iterates the fs and yields files. Figured this would be the cleanest/least impactful way to mitigate that issue.

Also, thank you guys so much for the amazing work on this project, it's incredible!