### PR TITLE
Fix reset on maxDepth

### DIFF
--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -88,6 +88,8 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             // Handle maxDepth
             if ($rootResourceClass === $resourceClass) {
                 $maxDepth = $subresource->getMaxDepth();
+                // reset depth when we return to rootResourceClass
+                $depth = 0;
             }
 
             if (null !== $maxDepth && $depth >= $maxDepth) {
@@ -95,11 +97,6 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             }
             if (isset($visited[$visiting])) {
                 continue;
-            }
-
-            if ($rootResourceClass === $resourceClass) {
-                // reset depth when we return to rootResourceClass
-                $depth = 0;
             }
 
             $rootResourceMetadata = $this->resourceMetadataFactory->create($rootResourceClass);

--- a/tests/Fixtures/DummyEntityFilterAnnotated.php
+++ b/tests/Fixtures/DummyEntityFilterAnnotated.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /*
  * This file is part of the API Platform project.
  *

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -462,7 +462,7 @@ class SubresourceOperationFactoryTest extends TestCase
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
 
-    public function testCreateWithMaxDepthSelfReferencingSubresources()
+    public function testCreateSelfReferencingSubresources()
     {
         /**
          * DummyEntity -subresource-> DummyEntity -subresource-> DummyEntity ...

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -23,7 +23,6 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Operation\Factory\SubresourceOperationFactory;
 use ApiPlatform\Core\Operation\PathSegmentNameGeneratorInterface;
 use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
-use ApiPlatform\Core\Tests\Fixtures\DummyEntityFilterAnnotated;
 use ApiPlatform\Core\Tests\Fixtures\DummyValidatedEntity;
 use ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity;
 use PHPUnit\Framework\TestCase;
@@ -397,7 +396,6 @@ class SubresourceOperationFactoryTest extends TestCase
      */
     public function testCreateWithMaxDepthMultipleSubresourcesSameMaxDepth()
     {
-
         /**
          * DummyEntity -subresource (maxDepth=1)-> RelatedDummyEntity -anotherSubresource-> DummyEntity
          * DummyEntity -secondSubresource (maxDepth=1)-> dummyValidatedEntity -moreSubresource-> RelatedDummyEntity.
@@ -406,7 +404,6 @@ class SubresourceOperationFactoryTest extends TestCase
         $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('dummyEntity'));
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
         $resourceMetadataFactoryProphecy->create(DummyValidatedEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('dummyValidatedEntity'));
-
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection(['subresource', 'secondSubresource']));
@@ -439,29 +436,29 @@ class SubresourceOperationFactoryTest extends TestCase
 
         $this->assertEquals([
             'api_dummy_entities_subresource_get_subresource' => [
-                    'property' => 'subresource',
-                    'collection' => false,
-                    'resource_class' => RelatedDummyEntity::class,
-                    'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
-                    'identifiers' => [
-                        ['id', DummyEntity::class, true],
-                    ],
-                    'route_name' => 'api_dummy_entities_subresource_get_subresource',
-                    'path' => '/dummy_entities/{id}/subresources.{_format}',
-                    'operation_name' => 'subresource_get_subresource',
-                ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+                'property' => 'subresource',
+                'collection' => false,
+                'resource_class' => RelatedDummyEntity::class,
+                'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/subresources.{_format}',
+                'operation_name' => 'subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
             'api_dummy_entities_second_subresource_get_subresource' => [
-                    'property' => 'secondSubresource',
-                    'collection' => false,
-                    'resource_class' => DummyValidatedEntity::class,
-                    'shortNames' => ['dummyValidatedEntity', 'dummyEntity'],
-                    'identifiers' => [
-                        ['id', DummyEntity::class, true],
-                    ],
-                    'route_name' => 'api_dummy_entities_second_subresource_get_subresource',
-                    'path' => '/dummy_entities/{id}/second_subresources.{_format}',
-                    'operation_name' => 'second_subresource_get_subresource',
-                ] + SubresourceOperationFactory::ROUTE_OPTIONS
+                'property' => 'secondSubresource',
+                'collection' => false,
+                'resource_class' => DummyValidatedEntity::class,
+                'shortNames' => ['dummyValidatedEntity', 'dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_second_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/second_subresources.{_format}',
+                'operation_name' => 'second_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1711, #2103
| License       | MIT
| Doc PR        | -

Seems to be we have an issue with the reset of Subresource maxDepth.

We need to reset the $depth if we return to the $rootResourceClass and this before the maxDepth Check... If not, only the maxDepth of the FIRST subresource of the rootResourceClass is generating...

But I have one fear on this: the case of a self-referencing subresource. DummyEntity -subRe-> DummyEntity. Because the maxDepth will be always reset to 0.

I think I will try to create a test for this special case and How is it handle without maxDepht btw?

ping @soyuka We already have this discussion in my first PR:
![image](https://user-images.githubusercontent.com/4228646/44332093-897e1e80-a46b-11e8-8dc2-28e3af7348d4.png)

What do you think of this?

Cheers!

