### PR TITLE
[GraphQL] Fix subresource context

### DIFF
--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -448,9 +448,15 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 continue;
             }
 
-            if ($fieldConfiguration = $this->getResourceFieldConfiguration($resourceClass, $resourceMetadata, $propertyMetadata->getDescription(), $propertyMetadata->getAttribute('deprecation_reason', ''), $propertyType, $resourceClass, $input, $mutationName, ++$depth)) {
+            $rootResource = $resourceClass;
+            if (null !== $propertyMetadata->getSubresource()) {
+                $resourceClass = $propertyMetadata->getSubresource()->getResourceClass();
+                $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+            }
+            if ($fieldConfiguration = $this->getResourceFieldConfiguration($resourceClass, $resourceMetadata, $propertyMetadata->getDescription(), $propertyMetadata->getAttribute('deprecation_reason', ''), $propertyType, $rootResource, $input, $mutationName, ++$depth)) {
                 $fields['id' === $property ? '_id' : $property] = $fieldConfiguration;
             }
+            $resourceClass = $rootResource;
         }
 
         if (null !== $mutationName) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2149
| License       | MIT
| Doc PR        |

When a property was corresponding to a subresource, the context given to `getResourceFieldConfiguration` was wrong.
It was creating issues like the one referenced, because the generated arguments for the collection were the parent's ones.
The following test was working because the parent entity (`Dummy`) has a search filter for its `name` field:
https://github.com/api-platform/core/blob/ebe842f3cc8d22f90f3099484b615bb183e9f8f5/features/graphql/filters.feature#L87-L113