### PR TITLE
[GraphQL] Only exposes the mutations if any

### DIFF
--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -92,16 +92,21 @@ final class SchemaBuilder implements SchemaBuilderInterface
             }
         }
 
-        return new Schema([
+        $schema = [
             'query' => new ObjectType([
                 'name' => 'Query',
                 'fields' => $queryFields,
             ]),
-            'mutation' => new ObjectType([
+        ];
+
+        if ($mutationFields) {
+            $schema['mutation'] = new ObjectType([
                 'name' => 'Mutation',
                 'fields' => $mutationFields,
-            ]),
-        ]);
+            ]);
+        }
+
+        return new Schema($schema);
     }
 
     private function getNodeInterface(): InterfaceType


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

Otherwise, GraphiQL gives this lovely message:
> Mutation fields must be an object with field names as keys or a function which returns [...]