### PR TITLE
Fix duplicate data in Eager loads relations

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -232,7 +232,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
 
             $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $fetchPartial, $associationAlias, $options, $normalizationContext, 'leftJoin' === $method, $joinCount, $currentDepth);
         }
-        
+
         // result is discarded (this is just re-hydrating the collections) see http://ocramius.github.io/blog/doctrine-orm-optimization-hydration/
         $queryBuilder->getQuery()->getResult();
     }

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -232,7 +232,8 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
 
             $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $fetchPartial, $associationAlias, $options, $normalizationContext, 'leftJoin' === $method, $joinCount, $currentDepth);
         }
-
+        
+        // result is discarded (this is just re-hydrating the collections) see http://ocramius.github.io/blog/doctrine-orm-optimization-hydration/
         $queryBuilder->getQuery()->getResult();
     }
 

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -232,6 +232,8 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
 
             $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $fetchPartial, $associationAlias, $options, $normalizationContext, 'leftJoin' === $method, $joinCount, $currentDepth);
         }
+
+        $queryBuilder->getQuery()->getResult();
     }
 
     private function addSelect(QueryBuilder $queryBuilder, string $entity, string $associationAlias, array $propertyMetadataOptions)

--- a/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddableDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\UnknownDummy;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -121,6 +122,9 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'relatedDummy2_a2')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('partial relatedDummy_a1.{id,name,embeddedDummy.name}')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('partial relatedDummy2_a2.{id,name,embeddedDummy.name}')->shouldBeCalled(1);
+
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(3);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, null, null, true);
@@ -228,6 +232,9 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->addSelect('partial relatedDummy4_a5.{id}')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('singleInheritanceRelation_a6')->shouldBeCalled(1);
 
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(7);
+
         $queryBuilder = $queryBuilderProphecy->reveal();
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, null, null, true);
 
@@ -253,6 +260,8 @@ class EagerLoadingExtensionTest extends TestCase
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, null, null, true);
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, [], 'item_operation', ['groups' => ['foo']]);
@@ -277,6 +286,8 @@ class EagerLoadingExtensionTest extends TestCase
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, null, null, true);
         $eagerExtensionTest->applyToCollection($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, 'collection_operation', ['groups' => ['foo']]);
@@ -300,6 +311,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, null, null, true);
         $eagerExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), RelatedDummy::class, ['id' => 1], 'item_operation', ['resource_class' => Dummy::class]);
@@ -322,6 +335,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, null, null, true);
         $eagerExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), RelatedDummy::class, ['id' => 1], 'item_operation', [AbstractNormalizer::GROUPS => 'some_groups']);
@@ -442,6 +457,8 @@ class EagerLoadingExtensionTest extends TestCase
 
         $queryBuilderProphecy->innerJoin(Argument::type('string'), Argument::type('string'))->shouldBeCalledTimes(2);
         $queryBuilderProphecy->addSelect(Argument::type('string'))->shouldBeCalled();
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(3);
 
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, false, null, null, true, $classMetadataFactoryProphecy->reveal());
         $eagerExtensionTest->applyToCollection($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class);
@@ -487,6 +504,9 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
 
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(2);
+
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, true, null, null, true);
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
     }
@@ -523,6 +543,9 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
 
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
+
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, true, null, null, true);
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
     }
@@ -546,6 +569,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, true, null, null, true);
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, [], null);
@@ -570,6 +595,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, true, null, null, true);
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
@@ -599,6 +626,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
         $queryBuilderProphecy->innerJoin('o.relation', 'relation_a1')->shouldBeCalled(1);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $orderExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30, true, null, null, true);
         $orderExtensionTest->applyToItem($queryBuilderProphecy->reveal(), new QueryNameGenerator(), Dummy::class, []);
@@ -654,6 +683,8 @@ class EagerLoadingExtensionTest extends TestCase
 
         $queryBuilderProphecy->leftJoin('o.relatedDummy', 'relatedDummy_a1')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('partial relatedDummy_a1.{id,name}')->shouldBeCalled(1);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(2);
 
         $request = Request::create('/api/dummies', 'GET', []);
 
@@ -718,6 +749,8 @@ class EagerLoadingExtensionTest extends TestCase
 
         $queryBuilderProphecy->leftJoin('o.relatedDummy', 'relatedDummy_a1')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('partial relatedDummy_a1.{id,name}')->shouldBeCalled(1);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(2);
 
         $request = Request::create('/api/dummies', 'GET', []);
 
@@ -759,6 +792,8 @@ class EagerLoadingExtensionTest extends TestCase
 
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $request = Request::create('/api/dummies', 'GET', []);
 
@@ -808,6 +843,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'relatedDummy2_a2')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('relatedDummy_a1')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('relatedDummy2_a2')->shouldBeCalled(1);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(3);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30);
@@ -864,6 +901,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'relatedDummy2_a2')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('relatedDummy_a1')->shouldBeCalled(1);
         $queryBuilderProphecy->addSelect('relatedDummy2_a2')->shouldBeCalled(1);
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(3);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30);
@@ -918,6 +957,8 @@ class EagerLoadingExtensionTest extends TestCase
         $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'relatedDummy2_a2')->shouldNotBeCalled();
         $queryBuilderProphecy->addSelect('relatedDummy_a1')->shouldNotBeCalled();
         $queryBuilderProphecy->addSelect('relatedDummy2_a2')->shouldNotBeCalled();
+        $queryAbstractProphecy = $this->prophesize(AbstractQuery::class);
+        $queryBuilderProphecy->getQuery()->willReturn($queryAbstractProphecy)->shouldBeCalledTimes(1);
 
         $queryBuilder = $queryBuilderProphecy->reveal();
         $eagerExtensionTest = new EagerLoadingExtension($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), 30);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR is related to reported bug in [api-platform/api-platform](https://github.com/api-platform/api-platform/issues/799) project.

So problem is caused because the same tables is joined multiple times **ON same condition** but with different aliases. 

I find useful article by Marco Pivetta about [Doctrine hydration](http://ocramius.github.io/blog/doctrine-orm-optimization-hydration/) where they said about coding multi-step hydration, that is used in PR.
