### PR TITLE
[GraphQL] Allow non-writeable fields in mutation response

### DIFF
--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -304,11 +304,10 @@ Feature: GraphQL introspection support
     And the JSON node "data.typeCreateInput.inputFields[0].name" should be equal to "bar"
     And the JSON node "data.typeCreateInput.inputFields[1].name" should be equal to "baz"
     And the JSON node "data.typeCreateInput.inputFields[2].name" should be equal to "clientMutationId"
-    And the JSON node "data.typeCreatePayload.fields" should have 4 elements
+    And the JSON node "data.typeCreatePayload.fields" should have 3 elements
     And the JSON node "data.typeCreatePayload.fields[0].name" should be equal to "id"
     And the JSON node "data.typeCreatePayload.fields[1].name" should be equal to "bar"
-    And the JSON node "data.typeCreatePayload.fields[2].name" should be equal to "baz"
-    And the JSON node "data.typeCreatePayload.fields[3].name" should be equal to "clientMutationId"
+    And the JSON node "data.typeCreatePayload.fields[2].name" should be equal to "clientMutationId"
 
   Scenario: Retrieve an item through a GraphQL query
     Given there are 4 dummy objects with relatedDummy

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -40,6 +40,7 @@ Feature: GraphQL mutation support
     mutation {
       createFoo(input: {name: "A new one", bar: "new", clientMutationId: "myId"}) {
         id
+        _id
         name
         bar
         clientMutationId
@@ -50,6 +51,7 @@ Feature: GraphQL mutation support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.createFoo.id" should be equal to "/foos/1"
+    And the JSON node "data.createFoo._id" should be equal to 1
     And the JSON node "data.createFoo.name" should be equal to "A new one"
     And the JSON node "data.createFoo.bar" should be equal to "new"
     And the JSON node "data.createFoo.clientMutationId" should be equal to "myId"
@@ -272,7 +274,6 @@ Feature: GraphQL mutation support
       createDummyGroup(input: {bar: "Bar", baz: "Baz", clientMutationId: "myId"}) {
         id
         bar
-        baz
         clientMutationId
       }
     }
@@ -282,7 +283,6 @@ Feature: GraphQL mutation support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.createDummyGroup.id" should be equal to "/dummy_groups/2"
     And the JSON node "data.createDummyGroup.bar" should be equal to "Bar"
-    And the JSON node "data.createDummyGroup.baz" should be null
     And the JSON node "data.createDummyGroup.clientMutationId" should be equal to "myId"
 
   Scenario: Trigger a validation error

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -459,8 +459,8 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['graphql_operation_name' => $mutationName ?? 'query']);
                 if (
                     null === ($propertyType = $propertyMetadata->getType())
-                    || (!$input && null === $mutationName && false === $propertyMetadata->isReadable())
-                    || (null !== $mutationName && false === $propertyMetadata->isWritable())
+                    || (!$input && false === $propertyMetadata->isReadable())
+                    || ($input && null !== $mutationName && false === $propertyMetadata->isWritable())
                 ) {
                     continue;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

It makes sense for non-writeable fields to be excluded from the GraphQL **input** types, but they should surely be accessible in the payload data read back from a mutation.

To give a simple example, `Person._id` is non-writeable, as my IDs are auto generated by the server, but I still want to be able to see the generated ID after calling `createPerson`.

```graphql
  mutation CreatePersonMutation {
    createPerson(input: {name: "Alice"}) {
      _id
      name
    }
  }
```

The above query would previously have failed (`_id` not found in `createPersonPayload`) -- this PR corrects that.