### PR TITLE
Sligthly improved code - removed unnecessary step

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -111,12 +111,11 @@ final class PurgeHttpCacheListener
             return;
         }
 
-        $iri = $this->iriConverter->getIriFromResourceClass($resourceClass);
+        $iri = $purgeItem
+	        ? $this->iriConverter->getIriFromItem($entity)
+	        : $this->iriConverter->getIriFromResourceClass($resourceClass);
+
         $this->tags[$iri] = $iri;
-        if ($purgeItem) {
-            $iri = $this->iriConverter->getIriFromItem($entity);
-            $this->tags[$iri] = $iri;
-        }
     }
 
     private function gatherRelationTags(EntityManagerInterface $em, $entity)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | didn't test

Just slight improvement - in a case if `$purgeItem === true` your code invoked `$this->tags[$iri]` twice.