### PR TITLE
Fix: max depth not working when fetch eager is disabled

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -35,6 +35,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FooDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FourthLevel;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Greeting;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Node;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Person;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\PersonToPet;
@@ -1023,5 +1024,23 @@ final class FeatureContext implements Context, SnippetAcceptingContext
 
         $this->manager->flush();
         $this->manager->clear();
+    }
+
+    /**
+     * @Given there is a max depth dummy with :level level of descendants
+     */
+    public function thereIsAMaxDepthDummyWithLevelOfDescendants(int $level)
+    {
+        $maxDepthDummy = new MaxDepthDummy();
+        $maxDepthDummy->name = "level $level";
+        $this->manager->persist($maxDepthDummy);
+
+        for ($i = 1; $i <= $level; ++$i) {
+            $maxDepthDummy = $maxDepthDummy->child = new MaxDepthDummy();
+            $maxDepthDummy->name = 'level '.($i + 1);
+            $this->manager->persist($maxDepthDummy);
+        }
+
+        $this->manager->flush();
     }
 }

--- a/features/hal/max_depth.feature
+++ b/features/hal/max_depth.feature
@@ -7,7 +7,7 @@ Feature: Max depth handling
   Scenario: Create a resource with 1 level of descendants
     When I add "Accept" header equal to "application/hal+json"
     And I add "Content-Type" header equal to "application/json"
-    And I send a "POST" request to "/max_depth_dummies" with body:
+    And I send a "POST" request to "/max_depth_eager_dummies" with body:
     """
     {
       "name": "level 1",
@@ -24,17 +24,62 @@ Feature: Max depth handling
     {
       "_links": {
         "self": {
-          "href": "\/max_depth_dummies\/1"
+          "href": "\/max_depth_eager_dummies\/1"
         },
         "child": {
-          "href": "\/max_depth_dummies\/2"
+          "href": "\/max_depth_eager_dummies\/2"
         }
       },
       "_embedded": {
         "child": {
           "_links": {
             "self": {
-              "href": "\/max_depth_dummies\/2"
+              "href": "\/max_depth_eager_dummies\/2"
+            }
+          },
+          "id": 2,
+          "name": "level 2"
+        }
+      },
+      "id": 1,
+      "name": "level 1"
+    }
+    """
+
+  Scenario: Add a 2nd level of descendants
+    When I add "Accept" header equal to "application/hal+json"
+    And I add "Content-Type" header equal to "application/json"
+    And I send a "PUT" request to "max_depth_eager_dummies/1" with body:
+    """
+    {
+      "id": "/max_depth_eager_dummies/1",
+      "child": {
+        "id": "/max_depth_eager_dummies/2",
+        "child": {
+          "name": "level 3"
+        }
+      }
+    }
+    """
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/hal+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "_links": {
+        "self": {
+          "href": "\/max_depth_eager_dummies\/1"
+        },
+        "child": {
+          "href": "\/max_depth_eager_dummies\/2"
+        }
+      },
+      "_embedded": {
+        "child": {
+          "_links": {
+            "self": {
+              "href": "\/max_depth_eager_dummies\/2"
             }
           },
           "id": 2,
@@ -47,7 +92,8 @@ Feature: Max depth handling
     """
 
   @dropSchema
-  Scenario: Add a 2nd level of descendants
+  Scenario: Add a 2nd level of descendants when eager fetching is disabled
+    Given there is a max depth dummy with 1 level of descendants
     When I add "Accept" header equal to "application/hal+json"
     And I add "Content-Type" header equal to "application/json"
     And I send a "PUT" request to "max_depth_dummies/1" with body:
@@ -62,7 +108,7 @@ Feature: Max depth handling
       }
     }
     """
-    And the response status code should be 200
+    Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/hal+json; charset=utf-8"
     And the JSON should be equal to:

--- a/features/jsonld/max_depth.feature
+++ b/features/jsonld/max_depth.feature
@@ -6,7 +6,7 @@ Feature: Max depth handling
   @createSchema
   Scenario: Create a resource with 1 level of descendants
     When I add "Content-Type" header equal to "application/ld+json"
-    And I send a "POST" request to "/max_depth_dummies" with body:
+    And I send a "POST" request to "/max_depth_eager_dummies" with body:
     """
     {
       "name": "level 1",
@@ -21,14 +21,14 @@ Feature: Max depth handling
     And the JSON should be equal to:
     """
     {
-      "@context": "/contexts/MaxDepthDummy",
-      "@id": "/max_depth_dummies/1",
-      "@type": "MaxDepthDummy",
+      "@context": "/contexts/MaxDepthEagerDummy",
+      "@id": "/max_depth_eager_dummies/1",
+      "@type": "MaxDepthEagerDummy",
       "id": 1,
       "name": "level 1",
       "child": {
-        "@id": "/max_depth_dummies/2",
-        "@type": "MaxDepthDummy",
+        "@id": "/max_depth_eager_dummies/2",
+        "@type": "MaxDepthEagerDummy",
         "id": 2,
         "name": "level 2"
       }
@@ -38,12 +38,12 @@ Feature: Max depth handling
   @dropSchema
   Scenario: Add a 2nd level of descendants
     When I add "Content-Type" header equal to "application/ld+json"
-    And I send a "PUT" request to "max_depth_dummies/1" with body:
+    And I send a "PUT" request to "max_depth_eager_dummies/1" with body:
     """
     {
-      "@id": "/max_depth_dummies/1",
+      "@id": "/max_depth_eager_dummies/1",
       "child": {
-        "@id": "/max_depth_dummies/2",
+        "@id": "/max_depth_eager_dummies/2",
         "child": {
           "name": "level 3"
         }
@@ -56,14 +56,14 @@ Feature: Max depth handling
     And the JSON should be equal to:
     """
     {
-      "@context": "/contexts/MaxDepthDummy",
-      "@id": "/max_depth_dummies/1",
-      "@type": "MaxDepthDummy",
+      "@context": "/contexts/MaxDepthEagerDummy",
+      "@id": "/max_depth_eager_dummies/1",
+      "@type": "MaxDepthEagerDummy",
       "id": 1,
       "name": "level 1",
       "child": {
-        "@id": "/max_depth_dummies/2",
-        "@type": "MaxDepthDummy",
+        "@id": "/max_depth_eager_dummies/2",
+        "@type": "MaxDepthEagerDummy",
         "id": 2,
         "name": "level 2"
       }

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Hal\Serializer;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
 use ApiPlatform\Core\Serializer\ContextTrait;
+use ApiPlatform\Core\Util\ClassInfoTrait;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 
 /**
@@ -26,6 +27,7 @@ use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 final class ItemNormalizer extends AbstractItemNormalizer
 {
     use ContextTrait;
+    use ClassInfoTrait;
 
     const FORMAT = 'jsonhal';
 
@@ -102,7 +104,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     private function getComponents($object, string $format = null, array $context)
     {
-        $cacheKey = \get_class($object).'-'.$context['cache_key'];
+        $cacheKey = $this->getObjectClass($object).'-'.$context['cache_key'];
 
         if (isset($this->componentsCache[$cacheKey])) {
             return $this->componentsCache[$cacheKey];
@@ -160,7 +162,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     private function populateRelation(array $data, $object, string $format = null, array $context, array $components, string $type): array
     {
-        $class = \get_class($object);
+        $class = $this->getObjectClass($object);
 
         $attributesMetadata = \array_key_exists($class, $this->attributesMetadataCache) ?
             $this->attributesMetadataCache[$class] :

--- a/tests/Fixtures/TestBundle/Entity/MaxDepthEagerDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/MaxDepthEagerDummy.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -28,7 +27,7 @@ use Symfony\Component\Serializer\Annotation\MaxDepth;
  *
  * @author Brian Fox <brian@brianfox.fr>
  */
-class MaxDepthDummy
+class MaxDepthEagerDummy
 {
     /**
      * @ORM\Column(type="integer")
@@ -45,8 +44,7 @@ class MaxDepthDummy
     public $name;
 
     /**
-     * @ORM\ManyToOne(targetEntity="MaxDepthDummy", cascade={"persist"})
-     * @ApiProperty(attributes={"fetch_eager"=false})
+     * @ORM\ManyToOne(targetEntity="MaxDepthEagerDummy", cascade={"persist"})
      * @Groups({"default"})
      * @MaxDepth(1)
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Max depth annotation was not working in HAL when fetch eager was disabled.