### PR TITLE
[2.3] Throw an InvalidArgument when trying to get Item from a collection route

### DIFF
--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -374,6 +374,35 @@ Feature: Search filter on collections
     }
     """
 
+  @sqlite
+  Scenario: Search for entities with an existing collection route name
+    When I send a "GET" request to "/dummies?relatedDummies=dummy_cars"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?relatedDummies=dummy_cars"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
   @createSchema
   Scenario: Search related collection by name
     Given there are 3 dummy objects having each 3 relatedDummies

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -79,6 +79,10 @@ final class IriConverter implements IriConverterInterface
             throw new InvalidArgumentException(sprintf('No resource associated to "%s".', $iri));
         }
 
+        if (isset($parameters['_api_collection_operation_name'])) {
+            throw new InvalidArgumentException(sprintf('The iri "%s" references a collection not an item.', $iri));
+        }
+
         $attributes = AttributesExtractor::extractAttributes($parameters);
 
         try {

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -62,6 +62,21 @@ class IriConverterTest extends TestCase
         $converter->getItemFromIri('/users/3');
     }
 
+    public function testGetItemFromIriCollectionRouteException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The iri "/users" references a collection not an item.');
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->match('/users')->willReturn([
+            '_api_resource_class' => Dummy::class,
+            '_api_collection_operation_name' => 'get',
+        ])->shouldBeCalledTimes(1);
+
+        $converter = $this->getIriConverter($routerProphecy);
+        $converter->getItemFromIri('/users');
+    }
+
     public function testGetItemFromIriItemNotFoundException()
     {
         $this->expectException(ItemNotFoundException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When using the search filter on an exact association for example, if the obviously bad value is a matching collection url, the filter IriConverter will throw `Either \"item_operation_name\" or \"collection_operation_name\" must be defined, unless the \"_api_receive\" request attribute is set to false.`

This is because `getItemFromIri()` will get a match on the router but won't match the expected the attributes.

an easy way to reproduce this on the demo is to try to filter `/reviews?book=foo` versus `/reviews?book=parchments` or `/reviews?book=book`
