### PR TITLE
Fixed join condition replacement with new aliases.

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -138,10 +138,11 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
             }
             $alias = substr($joinString, 0, $pos);
             $association = substr($joinString, $pos + 1);
-            $condition = str_replace($aliases, $replacements, $joinPart->getCondition());
-            $newAlias = QueryBuilderHelper::addJoinOnce($queryBuilderClone, $queryNameGenerator, $alias, $association, $joinPart->getJoinType(), $joinPart->getConditionType(), $condition, $originAlias);
+            $newAlias = $queryNameGenerator->generateJoinAlias($association);
             $aliases[] = "{$joinPart->getAlias()}.";
             $replacements[] = "$newAlias.";
+            $condition = str_replace($aliases, $replacements, $joinPart->getCondition());
+            QueryBuilderHelper::addJoinOnce($queryBuilderClone, $queryNameGenerator, $alias, $association, $joinPart->getJoinType(), $joinPart->getConditionType(), $condition, $originAlias, $newAlias);
         }
 
         $queryBuilderClone->add('where', str_replace($aliases, $replacements, (string) $wherePart));

--- a/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
@@ -30,7 +30,7 @@ final class QueryBuilderHelper
     /**
      * Adds a join to the queryBuilder if none exists.
      */
-    public static function addJoinOnce(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $association, string $joinType = null, string $conditionType = null, string $condition = null, string $originAlias = null): string
+    public static function addJoinOnce(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $association, string $joinType = null, string $conditionType = null, string $condition = null, string $originAlias = null, string $newAlias = null): string
     {
         $join = self::getExistingJoin($queryBuilder, $alias, $association, $originAlias);
 
@@ -38,7 +38,7 @@ final class QueryBuilderHelper
             return $join->getAlias();
         }
 
-        $associationAlias = $queryNameGenerator->generateJoinAlias($association);
+        $associationAlias = $newAlias ?: $queryNameGenerator->generateJoinAlias($association);
         $query = "$alias.$association";
 
         if (Join::LEFT_JOIN === $joinType || QueryChecker::hasLeftJoin($queryBuilder)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

FilterEagerLoadingExtension didn't work properly with join conditions. As a result, the reference to the old alias remained in the condition.