### PR TITLE
fixed Bidirectional ONE_TO_ONE mapping

### DIFF
--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -28,6 +28,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInte
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\QueryBuilder;
 
 /**
@@ -175,6 +176,17 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
                     $qb->select($alias)
                         ->from($identifierResourceClass, $alias);
                     break;
+                // ONE_TO_ONE relation can be Unidirectional or Bidirectional. For Bidirectional mappedBy attribute is used.
+                case ClassMetadataInfo::ONE_TO_ONE:
+                    try {
+                        $mappedBy = $classMetadata->getAssociationMapping($previousAssociationProperty)['mappedBy'];
+                        $previousAlias = "$previousAlias.$mappedBy";
+
+                        $qb->select($alias)
+                            ->from($identifierResourceClass, $alias);
+                        break;
+                    } catch (MappingException $e) {
+                    }
                 default:
                     $qb->select("IDENTITY($alias.$previousAssociationProperty)")
                         ->from($identifierResourceClass, $alias);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1801
| License       | MIT
| Doc PR        | 

Background:
For Doctrine ONE_TO_ONE mapping there is possible to define Unidirectional and Bidirectional relations. [ref](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#one-to-many-bidirectional). For unidirectional case everything works properly, but for bidirectional an exception
```
Type error: Argument 1 passed to
Doctrine\ORM\Mapping\DefaultQuoteStrategy::getJoinColumnName() must be of the type array, boolean given, 
called in vendor\doctrine\orm\lib\Doctrine\ORM\Query\AST\Functions\IdentityFunction.php on line 89
```
is returned. The reason for that is that for this scenario syntax:
```
     * @OneToOne(targetEntity="SubEntity", mappedBy="entity")
````

My fix solves the problem by checking if there is a `mappedBy` attribute for an entity. If no, then it's processed as it used to be, and if yes, then additional query is being built.

@soyuka @alanpoulain @dunglas please take a look.