### PR TITLE
Allow multiple order filters in entity.

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterExtension.php
@@ -61,14 +61,14 @@ final class FilterExtension implements ContextAwareQueryCollectionExtensionInter
             return;
         }
 
-        $orderFilter = null;
+        $orderFilters = [];
 
         foreach ($resourceFilters as $filterId) {
             $filter = $this->getFilter($filterId);
             if ($filter instanceof FilterInterface) {
                 // Apply the OrderFilter after every other filter to avoid an edge case where OrderFilter would do a LEFT JOIN instead of an INNER JOIN
                 if ($filter instanceof OrderFilter) {
-                    $orderFilter = $filter;
+                    $orderFilters[] = $filter;
                     continue;
                 }
 
@@ -77,7 +77,7 @@ final class FilterExtension implements ContextAwareQueryCollectionExtensionInter
             }
         }
 
-        if (null !== $orderFilter) {
+        foreach ($orderFilters as $orderFilter) {
             $context['filters'] = $context['filters'] ?? [];
             $orderFilter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This improvement allows to have several orderFilters in one entity.
I faced a problem when I created my own custom Order Filter. As a result in the same class I use 2 different order  filters: default and my custom (which extends default). But Api-Platform can't handle several order filters - only last one wins. This commit fixes this issue.