### PR TITLE
GraphQL: fix a bug when the class name isn't provided

### DIFF
--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -366,6 +366,10 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 }
 
                 $resourceClass = $this->isCollection($type) ? $type->getCollectionValueType()->getClassName() : $type->getClassName();
+                if (null === $resourceClass) {
+                    return null;
+                }
+
                 try {
                     $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
                     if ([] === $resourceMetadata->getGraphql() ?? []) {

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -209,6 +209,37 @@ class SchemaBuilderTest extends TestCase
         );
     }
 
+    /**
+     * Tests that the GraphQL SchemaBuilder supports an edge case where a property is typed as an Type::BUILTIN_TYPE_OBJECT but has no class related.
+     */
+    public function testObjectTypeWithoutClass()
+    {
+        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
+            return new PropertyMetadata(
+                new Type(
+                    $builtinType
+                ),
+                "{$builtinType}Description",
+                true,
+                true,
+                null,
+                null,
+                null
+            );
+        };
+
+        $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, false);
+        $this->assertEquals([
+            'node',
+            'shortName1',
+            'shortName1s',
+            'shortName2',
+            'shortName2s',
+            'shortName3',
+            'shortName3s',
+        ], array_keys($mockedSchemaBuilder->getSchema()->getConfig()->getQuery()->getFields()));
+    }
+
     public function paginationProvider(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Mandatory for GraphQL support in Sylius.