### PR TITLE
Improve the ExistsFilter behavior (to cohabit with the SearchFilter)

### DIFF
--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -404,7 +404,7 @@ Feature: Date filter on collections
       },
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],relatedDummy[exists],dummyFloat,dummyFloat[],dummyPrice,dummyPrice[],order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,relatedDummy.thirdLevel.level,relatedDummy.thirdLevel.level[],relatedDummy.thirdLevel.fourthLevel.level,relatedDummy.thirdLevel.fourthLevel.level[],relatedDummy.thirdLevel.badFourthLevel.level,relatedDummy.thirdLevel.badFourthLevel.level[],relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level,relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level[],properties[]}",
+        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],exists[alias],exists[description],exists[relatedDummy.name],exists[dummyBoolean],exists[relatedDummy],dummyFloat,dummyFloat[],dummyPrice,dummyPrice[],order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,relatedDummy.thirdLevel.level,relatedDummy.thirdLevel.level[],relatedDummy.thirdLevel.fourthLevel.level,relatedDummy.thirdLevel.fourthLevel.level[],relatedDummy.thirdLevel.badFourthLevel.level,relatedDummy.thirdLevel.badFourthLevel.level[],relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level,relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level[],properties[]}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -469,25 +469,31 @@ Feature: Date filter on collections
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "description[exists]",
+            "variable": "exists[alias]",
+            "property": "alias",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "exists[description]",
             "property": "description",
             "required": false
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "relatedDummy.name[exists]",
+            "variable": "exists[relatedDummy.name]",
             "property": "relatedDummy.name",
             "required": false
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "dummyBoolean[exists]",
+            "variable": "exists[dummyBoolean]",
             "property": "dummyBoolean",
             "required": false
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "relatedDummy[exists]",
+            "variable": "exists[relatedDummy]",
             "property": "relatedDummy",
             "required": false
           },
@@ -831,7 +837,7 @@ Feature: Date filter on collections
           },
           "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "/dummies{?dummyBoolean,dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],relatedDummy[exists],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
+              "hydra:template": "/dummies{?dummyBoolean,dummyDate[before],dummyDate[after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],exists[description],exists[relatedDummy.name],exists[dummyBoolean],exists[relatedDummy],dummyFloat,dummyPrice,order[id],order[name],order[relatedDummy.symfony],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -890,25 +896,25 @@ Feature: Date filter on collections
                   },
                   {
                       "@type": "IriTemplateMapping",
-                      "variable": "description[exists]",
+                      "variable": "exists[description]",
                       "property": "description",
                       "required": false
                   },
                   {
                       "@type": "IriTemplateMapping",
-                      "variable": "relatedDummy.name[exists]",
+                      "variable": "exists[relatedDummy.name]",
                       "property": "relatedDummy.name",
                       "required": false
                   },
                   {
                     "@type": "IriTemplateMapping",
-                    "variable": "relatedDummy[exists]",
+                    "variable": "exists[relatedDummy]",
                     "property": "relatedDummy",
                     "required": false
                   },
                   {
                       "@type": "IriTemplateMapping",
-                      "variable": "dummyBoolean[exists]",
+                      "variable": "exists[dummyBoolean]",
                       "property": "dummyBoolean",
                       "required": false
                   },

--- a/features/doctrine/exists_filter.feature
+++ b/features/doctrine/exists_filter.feature
@@ -6,7 +6,7 @@ Feature: Exists filter on collections
   @createSchema
   Scenario: Get collection where exists does not exist
     Given there are 15 dummy objects with dummyBoolean true
-    When I send a "GET" request to "/dummies?dummyBoolean[exists]=0"
+    When I send a "GET" request to "/dummies?exists[dummyBoolean]=0"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
@@ -26,7 +26,7 @@ Feature: Exists filter on collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?dummyBoolean%5Bexists%5D=0$"},
+            "@id": {"pattern": "^/dummies\\?exists%5BdummyBoolean%5D=0$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }
@@ -35,7 +35,7 @@ Feature: Exists filter on collections
     """
 
   Scenario: Get collection where exists does exist
-    When I send a "GET" request to "/dummies?dummyBoolean[exists]=1"
+    When I send a "GET" request to "/dummies?exists[dummyBoolean]=1"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
@@ -55,7 +55,7 @@ Feature: Exists filter on collections
         "hydra:view": {
           "type": "object",
           "properties": {
-            "@id": {"pattern": "^/dummies\\?dummyBoolean%5Bexists%5D=1&page=1$"},
+            "@id": {"pattern": "^/dummies\\?exists%5BdummyBoolean%5D=1&page=1$"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -30,7 +30,7 @@ Feature: Collections filtering
     When I send the following GraphQL request:
     """
     {
-      dummies(relatedDummy: {exists: true}) {
+      dummies(exists: {relatedDummy: true}) {
         edges {
           node {
             id

--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -137,7 +137,7 @@ Feature: Create-Retrieve-Update-Delete
       "hydra:totalItems": 1,
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],relatedDummy[exists],dummyFloat,dummyFloat[],dummyPrice,dummyPrice[],order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,relatedDummy.thirdLevel.level,relatedDummy.thirdLevel.level[],relatedDummy.thirdLevel.fourthLevel.level,relatedDummy.thirdLevel.fourthLevel.level[],relatedDummy.thirdLevel.badFourthLevel.level,relatedDummy.thirdLevel.badFourthLevel.level[],relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level,relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level[],properties[]}",
+        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],exists[alias],exists[description],exists[relatedDummy.name],exists[dummyBoolean],exists[relatedDummy],dummyFloat,dummyFloat[],dummyPrice,dummyPrice[],order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,relatedDummy.thirdLevel.level,relatedDummy.thirdLevel.level[],relatedDummy.thirdLevel.fourthLevel.level,relatedDummy.thirdLevel.fourthLevel.level[],relatedDummy.thirdLevel.badFourthLevel.level,relatedDummy.thirdLevel.badFourthLevel.level[],relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level,relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level[],properties[]}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -202,25 +202,31 @@ Feature: Create-Retrieve-Update-Delete
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "description[exists]",
+            "variable": "exists[alias]",
+            "property": "alias",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "exists[description]",
             "property": "description",
             "required": false
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "relatedDummy.name[exists]",
+            "variable": "exists[relatedDummy.name]",
             "property": "relatedDummy.name",
             "required": false
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "dummyBoolean[exists]",
+            "variable": "exists[dummyBoolean]",
             "property": "dummyBoolean",
             "required": false
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "relatedDummy[exists]",
+            "variable": "exists[relatedDummy]",
             "property": "relatedDummy",
             "required": false
           },

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -168,6 +168,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.eager_loading.max_joins', $config['eager_loading']['max_joins']);
         $container->setParameter('api_platform.eager_loading.fetch_partial', $config['eager_loading']['fetch_partial']);
         $container->setParameter('api_platform.eager_loading.force_eager', $config['eager_loading']['force_eager']);
+        $container->setParameter('api_platform.collection.exists_parameter_name', $config['collection']['exists_parameter_name']);
         $container->setParameter('api_platform.collection.order', $config['collection']['order']);
         $container->setParameter('api_platform.collection.order_parameter_name', $config['collection']['order_parameter_name']);
         $container->setParameter('api_platform.collection.pagination.enabled', $config['collection']['pagination']['enabled']);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -167,6 +167,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->scalarNode('exists_parameter_name')->defaultValue('exists')->cannotBeEmpty()->info('The name of the query parameter to filter on nullable field values.')->end()
                         ->scalarNode('order')->defaultValue('ASC')->info('The default order of results.')->end() // Default ORDER is required for postgresql and mysql >= 5.7 when using LIMIT/OFFSET request
                         ->scalarNode('order_parameter_name')->defaultValue('order')->cannotBeEmpty()->info('The name of the query parameter to order results.')->end()
                         ->arrayNode('pagination')

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
@@ -84,6 +84,7 @@
         <service id="api_platform.doctrine_mongodb.odm.exists_filter" class="ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\ExistsFilter" public="false" abstract="true">
             <argument type="service" id="doctrine_mongodb" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <argument>%api_platform.collection.exists_parameter_name%</argument>
         </service>
         <service id="ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\ExistsFilter" alias="api_platform.doctrine_mongodb.odm.exists_filter" />
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -98,6 +98,7 @@
             <argument type="service" id="doctrine" />
             <argument>null</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
+            <argument>%api_platform.collection.exists_parameter_name%</argument>
         </service>
         <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter" alias="api_platform.doctrine.orm.exists_filter" />
 

--- a/tests/Bridge/Doctrine/Common/Filter/ExistsFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/ExistsFilterTestTrait.php
@@ -23,7 +23,7 @@ trait ExistsFilterTestTrait
         $filter = $filter = $this->buildFilter(['name' => null, 'description' => null]);
 
         $this->assertEquals([
-            'description[exists]' => [
+            'exists[description]' => [
                 'property' => 'description',
                 'type' => 'bool',
                 'required' => false,
@@ -39,8 +39,8 @@ trait ExistsFilterTestTrait
                     'description' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => 'true',
+                    'exists' => [
+                        'description' => 'true',
                     ],
                 ],
             ],
@@ -50,8 +50,8 @@ trait ExistsFilterTestTrait
                     'description' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '',
+                    'exists' => [
+                        'description' => '',
                     ],
                 ],
             ],
@@ -61,8 +61,8 @@ trait ExistsFilterTestTrait
                     'description' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '1',
+                    'exists' => [
+                        'description' => '1',
                     ],
                 ],
             ],
@@ -72,8 +72,8 @@ trait ExistsFilterTestTrait
                     'description' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => 'invalid',
+                    'exists' => [
+                        'description' => 'invalid',
                     ],
                 ],
             ],
@@ -83,8 +83,8 @@ trait ExistsFilterTestTrait
                     'description' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => 'false',
+                    'exists' => [
+                        'description' => 'false',
                     ],
                 ],
             ],
@@ -94,8 +94,62 @@ trait ExistsFilterTestTrait
                     'description' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '0',
+                    'exists' => [
+                        'description' => '0',
+                    ],
+                ],
+            ],
+
+            'multiple values (true and true)' => [
+                [
+                    'alias' => null,
+                    'description' => null,
+                ],
+                [
+                    'exists' => [
+                        'alias' => 'true',
+                        'description' => 'true',
+                    ],
+                ],
+            ],
+
+            'multiple values (1 and 0)' => [
+                [
+                    'alias' => null,
+                    'description' => null,
+                ],
+                [
+                    'exists' => [
+                        'alias' => '1',
+                        'description' => '0',
+                    ],
+                ],
+            ],
+
+            'multiple values (false and 0)' => [
+                [
+                    'alias' => null,
+                    'description' => null,
+                ],
+                [
+                    'exists' => [
+                        'alias' => 'false',
+                        'description' => '0',
+                    ],
+                ],
+            ],
+
+            'custom exists parameter name' => [
+                [
+                    'alias' => null,
+                    'description' => null,
+                ],
+                [
+                    'exists' => [
+                        'alias' => 'true',
+                    ],
+                    'customExists' => [
+                        'description' => 'true',
                     ],
                 ],
             ],
@@ -106,11 +160,9 @@ trait ExistsFilterTestTrait
                     'relatedDummy.name' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '1',
-                    ],
-                    'relatedDummy.name' => [
-                        'exists' => '1',
+                    'exists' => [
+                        'description' => '1',
+                        'relatedDummy.name' => '1',
                     ],
                 ],
             ],
@@ -121,11 +173,9 @@ trait ExistsFilterTestTrait
                     'name' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '1',
-                    ],
-                    'name' => [
-                        'exists' => '0',
+                    'exists' => [
+                        'description' => '1',
+                        'name' => '0',
                     ],
                 ],
             ],
@@ -136,11 +186,9 @@ trait ExistsFilterTestTrait
                     'relatedDummies' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '1',
-                    ],
-                    'relatedDummies' => [
-                        'exists' => '1',
+                    'exists' => [
+                        'description' => '1',
+                        'relatedDummies' => '1',
                     ],
                 ],
             ],
@@ -151,11 +199,9 @@ trait ExistsFilterTestTrait
                     'relatedDummies' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '1',
-                    ],
-                    'relatedDummies' => [
-                        'exists' => '0',
+                    'exists' => [
+                        'description' => '1',
+                        'relatedDummies' => '0',
                     ],
                 ],
             ],
@@ -166,11 +212,9 @@ trait ExistsFilterTestTrait
                     'relatedDummy' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '1',
-                    ],
-                    'relatedDummy' => [
-                        'exists' => '1',
+                    'exists' => [
+                        'description' => '1',
+                        'relatedDummy' => '1',
                     ],
                 ],
             ],
@@ -181,11 +225,9 @@ trait ExistsFilterTestTrait
                     'relatedDummy' => null,
                 ],
                 [
-                    'description' => [
-                        'exists' => '1',
-                    ],
-                    'relatedDummy' => [
-                        'exists' => '0',
+                    'exists' => [
+                        'description' => '1',
+                        'relatedDummy' => '0',
                     ],
                 ],
             ],
@@ -195,8 +237,8 @@ trait ExistsFilterTestTrait
                     'relatedOwnedDummy' => null,
                 ],
                 [
-                    'relatedOwnedDummy' => [
-                        'exists' => '0',
+                    'exists' => [
+                        'relatedOwnedDummy' => '0',
                     ],
                 ],
             ],
@@ -206,8 +248,8 @@ trait ExistsFilterTestTrait
                     'relatedOwnedDummy' => null,
                 ],
                 [
-                    'relatedOwnedDummy' => [
-                        'exists' => '1',
+                    'exists' => [
+                        'relatedOwnedDummy' => '1',
                     ],
                 ],
             ],
@@ -217,8 +259,8 @@ trait ExistsFilterTestTrait
                     'relatedOwningDummy' => null,
                 ],
                 [
-                    'relatedOwningDummy' => [
-                        'exists' => '0',
+                    'exists' => [
+                        'relatedOwningDummy' => '0',
                     ],
                 ],
             ],
@@ -228,8 +270,8 @@ trait ExistsFilterTestTrait
                     'relatedOwningDummy' => null,
                 ],
                 [
-                    'relatedOwningDummy' => [
-                        'exists' => '1',
+                    'exists' => [
+                        'relatedOwningDummy' => '1',
                     ],
                 ],
             ],

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/ExistsFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/ExistsFilterTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Doctrine\MongoDbOdm\Filter;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\ExistsFilter;
 use ApiPlatform\Core\Test\DoctrineMongoDbOdmFilterTestCase;
 use ApiPlatform\Core\Tests\Bridge\Doctrine\Common\Filter\ExistsFilterTestTrait;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * @author Alan Poulain <contact@alanpoulain.eu>
@@ -31,77 +32,77 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
         $filter = $this->buildFilter();
 
         $this->assertEquals([
-            'id[exists]' => [
+            'exists[id]' => [
                 'property' => 'id',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'alias[exists]' => [
+            'exists[alias]' => [
                 'property' => 'alias',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'description[exists]' => [
+            'exists[description]' => [
                 'property' => 'description',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummy[exists]' => [
+            'exists[dummy]' => [
                 'property' => 'dummy',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyDate[exists]' => [
+            'exists[dummyDate]' => [
                 'property' => 'dummyDate',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyFloat[exists]' => [
+            'exists[dummyFloat]' => [
                 'property' => 'dummyFloat',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyPrice[exists]' => [
+            'exists[dummyPrice]' => [
                 'property' => 'dummyPrice',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'jsonData[exists]' => [
+            'exists[jsonData]' => [
                 'property' => 'jsonData',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'arrayData[exists]' => [
+            'exists[arrayData]' => [
                 'property' => 'arrayData',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'nameConverted[exists]' => [
+            'exists[nameConverted]' => [
                 'property' => 'nameConverted',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyBoolean[exists]' => [
+            'exists[dummyBoolean]' => [
                 'property' => 'dummyBoolean',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'relatedDummy[exists]' => [
+            'exists[relatedDummy]' => [
                 'property' => 'relatedDummy',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'relatedDummies[exists]' => [
+            'exists[relatedDummies]' => [
                 'property' => 'relatedDummies',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'relatedOwnedDummy[exists]' => [
+            'exists[relatedOwnedDummy]' => [
                 'property' => 'relatedOwnedDummy',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'relatedOwningDummy[exists]' => [
+            'exists[relatedOwningDummy]' => [
                 'property' => 'relatedOwningDummy',
                 'type' => 'bool',
                 'required' => false,
@@ -111,6 +112,13 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
 
     public function provideApplyTestData(): array
     {
+        $existsFilterFactory = function (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter {
+            return new ExistsFilter($managerRegistry, null, 'exists', $properties);
+        };
+        $customExistsFilterFactory = function (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter {
+            return new ExistsFilter($managerRegistry, null, 'customExists', $properties);
+        };
+
         return array_merge_recursive(
             $this->provideApplyTestArguments(),
             [
@@ -124,6 +132,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'valid values (empty for true)' => [
@@ -136,6 +145,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'valid values (1 for true)' => [
@@ -148,10 +158,12 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'invalid values' => [
                     [],
+                    $existsFilterFactory,
                 ],
 
                 'negative values' => [
@@ -162,6 +174,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'negative values (0)' => [
@@ -172,6 +185,74 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
+                ],
+
+                'multiple values (true and true)' => [
+                    [
+                        [
+                            '$match' => [
+                                'alias' => [
+                                    '$ne' => null,
+                                ],
+                            ],
+                        ],
+                        [
+                            '$match' => [
+                                'description' => [
+                                    '$ne' => null,
+                                ],
+                            ],
+                        ],
+                    ],
+                    $existsFilterFactory,
+                ],
+
+                'multiple values (1 and 0)' => [
+                    [
+                        [
+                            '$match' => [
+                                'alias' => [
+                                    '$ne' => null,
+                                ],
+                            ],
+                        ],
+                        [
+                            '$match' => [
+                                'description' => null,
+                            ],
+                        ],
+                    ],
+                    $existsFilterFactory,
+                ],
+
+                'multiple values (false and 0)' => [
+                    [
+                        [
+                            '$match' => [
+                                'alias' => null,
+                            ],
+                        ],
+                        [
+                            '$match' => [
+                                'description' => null,
+                            ],
+                        ],
+                    ],
+                    $existsFilterFactory,
+                ],
+
+                'custom exists parameter name' => [
+                    [
+                        [
+                            '$match' => [
+                                'description' => [
+                                    '$ne' => null,
+                                ],
+                            ],
+                        ],
+                    ],
+                    $customExistsFilterFactory,
                 ],
 
                 'related values' => [
@@ -202,6 +283,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'not nullable values' => [
@@ -214,6 +296,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related collection not empty' => [
@@ -233,6 +316,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related collection empty' => [
@@ -250,6 +334,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related association exists' => [
@@ -269,6 +354,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related association does not exist' => [
@@ -286,6 +372,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related owned association does not exist' => [
@@ -296,6 +383,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related owned association exists' => [
@@ -308,6 +396,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related owning association does not exist' => [
@@ -318,6 +407,7 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
 
                 'related owning association exists' => [
@@ -330,8 +420,46 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                    $existsFilterFactory,
                 ],
             ]
         );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The ExistsFilter syntax "description[exists]=true/false" is deprecated since 2.5. Use the syntax "exists[description]=true/false" instead.
+     */
+    public function testLegacyExistsAfterSyntax()
+    {
+        $args = [
+            [
+                'description' => null,
+            ],
+            [
+                'description' => [
+                    'exists' => 'true',
+                ],
+            ],
+            [
+                [
+                    '$match' => [
+                        'description' => [
+                            '$ne' => null,
+                        ],
+                    ],
+                ],
+            ],
+            function (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter {
+                return new ExistsFilter($managerRegistry, null, 'exists', $properties);
+            },
+        ];
+
+        $this->testApply(...$args);
+    }
+
+    protected function buildFilter(?array $properties = null)
+    {
+        return new $this->filterClass($this->managerRegistry, null, 'exists', $properties);
     }
 }

--- a/tests/Bridge/Doctrine/Orm/Filter/ExistsFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/ExistsFilterTest.php
@@ -17,6 +17,8 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter;
 use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Bridge\Doctrine\Common\Filter\ExistsFilterTestTrait;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
@@ -32,57 +34,57 @@ class ExistsFilterTest extends DoctrineOrmFilterTestCase
         $filter = $this->buildFilter();
 
         $this->assertEquals([
-            'id[exists]' => [
+            'exists[id]' => [
                 'property' => 'id',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'alias[exists]' => [
+            'exists[alias]' => [
                 'property' => 'alias',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'description[exists]' => [
+            'exists[description]' => [
                 'property' => 'description',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummy[exists]' => [
+            'exists[dummy]' => [
                 'property' => 'dummy',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyDate[exists]' => [
+            'exists[dummyDate]' => [
                 'property' => 'dummyDate',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyFloat[exists]' => [
+            'exists[dummyFloat]' => [
                 'property' => 'dummyFloat',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyPrice[exists]' => [
+            'exists[dummyPrice]' => [
                 'property' => 'dummyPrice',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'jsonData[exists]' => [
+            'exists[jsonData]' => [
                 'property' => 'jsonData',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'arrayData[exists]' => [
+            'exists[arrayData]' => [
                 'property' => 'arrayData',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'nameConverted[exists]' => [
+            'exists[nameConverted]' => [
                 'property' => 'nameConverted',
                 'type' => 'bool',
                 'required' => false,
             ],
-            'dummyBoolean[exists]' => [
+            'exists[dummyBoolean]' => [
                 'property' => 'dummyBoolean',
                 'type' => 'bool',
                 'required' => false,
@@ -92,73 +94,194 @@ class ExistsFilterTest extends DoctrineOrmFilterTestCase
 
     public function provideApplyTestData(): array
     {
+        $existsFilterFactory = function (ManagerRegistry $managerRegistry, array $properties = null, RequestStack $requestStack = null): ExistsFilter {
+            return new ExistsFilter($managerRegistry, $requestStack, null, 'exists', $properties);
+        };
+        $customExistsFilterFactory = function (ManagerRegistry $managerRegistry, array $properties = null, RequestStack $requestStack = null): ExistsFilter {
+            return new ExistsFilter($managerRegistry, $requestStack, null, 'customExists', $properties);
+        };
+
         return array_merge_recursive(
             $this->provideApplyTestArguments(),
             [
                 'valid values' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'valid values (empty for true)' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'valid values (1 for true)' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'invalid values' => [
                     sprintf('SELECT o FROM %s o', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'negative values' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'negative values (0)' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
+                ],
+
+                'multiple values (true and true)' => [
+                    sprintf('SELECT o FROM %s o WHERE o.alias IS NOT NULL AND o.description IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
+                ],
+
+                'multiple values (1 and 0)' => [
+                    sprintf('SELECT o FROM %s o WHERE o.alias IS NOT NULL AND o.description IS NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
+                ],
+
+                'multiple values (false and 0)' => [
+                    sprintf('SELECT o FROM %s o WHERE o.alias IS NULL AND o.description IS NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
+                ],
+
+                'custom exists parameter name' => [
+                    sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),
+                    null,
+                    $customExistsFilterFactory,
                 ],
 
                 'related values' => [
                     sprintf('SELECT o FROM %s o INNER JOIN o.relatedDummy relatedDummy_a1 WHERE o.description IS NOT NULL AND relatedDummy_a1.name IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'not nullable values' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related collection not empty' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL AND o.relatedDummies IS NOT EMPTY', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related collection empty' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL AND o.relatedDummies IS EMPTY', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related association exists' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL AND o.relatedDummy IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related association does not exist' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL AND o.relatedDummy IS NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related owned association does not exist' => [
                     sprintf('SELECT o FROM %s o LEFT JOIN o.relatedOwnedDummy relatedOwnedDummy_a1 WHERE relatedOwnedDummy_a1 IS NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related owned association exists' => [
                     sprintf('SELECT o FROM %s o LEFT JOIN o.relatedOwnedDummy relatedOwnedDummy_a1 WHERE relatedOwnedDummy_a1 IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related owning association does not exist' => [
                     sprintf('SELECT o FROM %s o WHERE o.relatedOwningDummy IS NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
 
                 'related owning association exists' => [
                     sprintf('SELECT o FROM %s o WHERE o.relatedOwningDummy IS NOT NULL', Dummy::class),
+                    null,
+                    $existsFilterFactory,
                 ],
             ]
         );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The ExistsFilter syntax "description[exists]=true/false" is deprecated since 2.5. Use the syntax "exists[description]=true/false" instead.
+     */
+    public function testLegacyExistsAfterSyntax()
+    {
+        $args = [
+            [
+                'description' => null,
+            ],
+            [
+                'description' => [
+                    'exists' => 'true',
+                ],
+            ],
+            sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),
+            null,
+            function (ManagerRegistry $managerRegistry, array $properties = null, RequestStack $requestStack = null): ExistsFilter {
+                return new ExistsFilter($managerRegistry, $requestStack, null, 'exists', $properties);
+            },
+        ];
+
+        $this->testApply(...$args);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an instance of "Symfony\Component\HttpFoundation\RequestStack" is deprecated since 2.2. Use "filters" context key instead.
+     * @expectedDeprecation Using "ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter::apply()" is deprecated since 2.2. Use "ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter::apply()" with the "filters" context key instead.
+     * @expectedDeprecation The use of "ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter::extractProperties()" is deprecated since 2.2. Use the "filters" key of the context instead.
+     * @expectedDeprecation The ExistsFilter syntax "description[exists]=true/false" is deprecated since 2.5. Use the syntax "exists[description]=true/false" instead.
+     */
+    public function testLegacyRequest()
+    {
+        $args = [
+            [
+                'description' => null,
+            ],
+            [
+                'description' => [
+                    'exists' => 'true',
+                ],
+            ],
+            sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),
+            null,
+            function (ManagerRegistry $managerRegistry, array $properties = null, RequestStack $requestStack = null): ExistsFilter {
+                return new ExistsFilter($managerRegistry, $requestStack, null, 'exists', $properties);
+            },
+        ];
+
+        $this->testApplyRequest(...$args);
+    }
+
+    protected function buildFilter(?array $properties = null)
+    {
+        return new $this->filterClass($this->managerRegistry, null, null, 'exists', $properties);
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -653,6 +653,7 @@ class ApiPlatformExtensionTest extends TestCase
         })->shouldBeCalled();
 
         $parameters = [
+            'api_platform.collection.exists_parameter_name' => 'exists',
             'api_platform.collection.order' => 'ASC',
             'api_platform.collection.order_parameter_name' => 'order',
             'api_platform.description' => 'description',

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -120,6 +120,7 @@ class ConfigurationTest extends TestCase
                 'fetch_partial' => false,
             ],
             'collection' => [
+                'exists_parameter_name' => 'exists',
                 'order' => 'ASC',
                 'order_parameter_name' => 'order',
                 'pagination' => [

--- a/tests/Fixtures/app/config/config_orm.yml
+++ b/tests/Fixtures/app/config/config_orm.yml
@@ -45,7 +45,7 @@ services:
 
     app.my_dummy_resource.exists_filter:
         parent:    'api_platform.doctrine.orm.exists_filter'
-        arguments: [ { 'description': ~, 'relatedDummy.name': ~, 'dummyBoolean': ~, 'relatedDummy': ~ } ]
+        arguments: [ { 'alias': ~, 'description': ~, 'relatedDummy.name': ~, 'dummyBoolean': ~, 'relatedDummy': ~ } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.exists' } ]
 
     app.related_dummy_resource.search_filter:

--- a/tests/Fixtures/app/config/config_services_mongodb.yml
+++ b/tests/Fixtures/app/config/config_services_mongodb.yml
@@ -12,7 +12,7 @@ services:
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.mongodb.date' } ]
     app.my_dummy_resource.mongodb.exists_filter:
         parent:    'api_platform.doctrine_mongodb.odm.exists_filter'
-        arguments: [ { 'description': ~, 'relatedDummy.name': ~, 'dummyBoolean': ~, 'relatedDummy': ~ } ]
+        arguments: [ { 'alias': ~, 'description': ~, 'relatedDummy.name': ~, 'dummyBoolean': ~, 'relatedDummy': ~ } ]
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.mongodb.exists' } ]
     app.my_dummy_resource.mongodb.numeric_filter:
         parent:    'api_platform.doctrine_mongodb.odm.numeric_filter'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (for GraphQL)
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #2231
| License       | MIT
| Doc PR        | api-platform/docs#613

Improve the behavior of the `ExistsFilter` filter to be declared according to the following syntax:
- on a REST collection endpoints: `/dummies?exists[<property>]=true/false`
- on the GraphQL endpoint: `dummies(exists: {<property>: "true/false"}) { ... }`

The name of the query parameter is controlled via the bundle configuration:
```yaml
api_platform:
  collection:
    exists_parameter_name: 'not_null'
``` 

It allows to use an `ExistsFilter` and a `SearchFilter` on the same property via the GraphQL endpoint.
 
- [x] Improve ExistsFilter
- [x] PHPUnit
- [x] Behat
- [x] Documentation