### PR TITLE
Arachnophobia mode

### DIFF
--- a/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -40,6 +40,7 @@ final class SwaggerUiAction
     private $title;
     private $description;
     private $version;
+    private $showWebby;
     private $formats = [];
     private $oauthEnabled;
     private $oauthClientId;
@@ -54,7 +55,7 @@ final class SwaggerUiAction
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, \Twig_Environment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', /* FormatsProviderInterface */ $formatsProvider = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [])
+    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, \Twig_Environment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', bool $showWebby = true, /* FormatsProviderInterface */ $formatsProvider = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [])
     {
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -62,6 +63,7 @@ final class SwaggerUiAction
         $this->twig = $twig;
         $this->urlGenerator = $urlGenerator;
         $this->title = $title;
+        $this->showWebby = $showWebby;
         $this->description = $description;
         $this->version = $version;
         $this->oauthEnabled = $oauthEnabled;
@@ -110,6 +112,7 @@ final class SwaggerUiAction
             'title' => $this->title,
             'description' => $this->description,
             'formats' => $this->formats,
+            'showWebby' => $this->showWebby,
         ];
 
         $swaggerData = [

--- a/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -55,7 +55,7 @@ final class SwaggerUiAction
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, \Twig_Environment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', bool $showWebby = true, /* FormatsProviderInterface */ $formatsProvider = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [])
+    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, \Twig_Environment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', /* FormatsProviderInterface */ $formatsProvider = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [], bool $showWebby = true)
     {
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -156,6 +156,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.title', $config['title']);
         $container->setParameter('api_platform.description', $config['description']);
         $container->setParameter('api_platform.version', $config['version']);
+        $container->setParameter('api_platform.show_webby', $config['show_webby']);
         $container->setParameter('api_platform.exception_to_status', $config['exception_to_status']);
         $container->setParameter('api_platform.formats', $formats);
         $container->setParameter('api_platform.error_formats', $errorFormats);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ final class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                     ->defaultValue('0.0.0')
                 ->end()
+                ->booleanNode('show_webby')->defaultTrue()->info('If true, show Webby on the documentation page')->end()
                 ->scalarNode('default_operation_path_resolver')
                     ->defaultValue('api_platform.operation_path_resolver.underscore')
                     ->setDeprecated('The use of the `default_operation_path_resolver` has been deprecated in 2.1 and will be removed in 3.0. Use `path_segment_name_generator` instead.')

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -60,6 +60,7 @@
             <argument>%api_platform.title%</argument>
             <argument>%api_platform.description%</argument>
             <argument>%api_platform.version%</argument>
+            <argument>%api_platform.show_webby%</argument>
             <argument type="service" id="api_platform.formats_provider" />
             <argument>%api_platform.oauth.enabled%</argument>
             <argument>%api_platform.oauth.clientId%</argument>

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -60,7 +60,6 @@
             <argument>%api_platform.title%</argument>
             <argument>%api_platform.description%</argument>
             <argument>%api_platform.version%</argument>
-            <argument>%api_platform.show_webby%</argument>
             <argument type="service" id="api_platform.formats_provider" />
             <argument>%api_platform.oauth.enabled%</argument>
             <argument>%api_platform.oauth.clientId%</argument>
@@ -70,6 +69,7 @@
             <argument>%api_platform.oauth.tokenUrl%</argument>
             <argument>%api_platform.oauth.authorizationUrl%</argument>
             <argument>%api_platform.oauth.scopes%</argument>
+            <argument>%api_platform.show_webby%</argument>
         </service>
 
     </services>

--- a/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -133,14 +133,9 @@ window.onload = () => {
 };
 
 function manageWebbyDisplay() {
-    const webbyClass = document.getElementsByClassName('webby');
+    const webby = document.getElementsByClassName('webby')[0];
+    if(!webby) return;
 
-    // First, check if Webby is present
-    if (webbyClass.length === 0) {
-        return;
-    }
-
-    const webby = webbyClass[0];
     const web = document.getElementsByClassName('web')[0];
     webby.classList.add('calm');
     web.classList.add('calm');

--- a/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -1,21 +1,26 @@
 'use strict';
 
 window.onload = () => {
-    const webby = document.getElementsByClassName('webby')[0];
-    const web = document.getElementsByClassName('web')[0];
-    webby.classList.add('calm');
-    web.classList.add('calm');
-    webby.addEventListener('click', () => {
-        if (webby.classList.contains('frighten')) {
-            return;
-        }
-        webby.classList.replace('calm', 'frighten');
-        web.classList.replace('calm', 'frighten');
-        setTimeout(() => {
-            webby.classList.replace('frighten', 'calm');
-            web.classList.replace('frighten', 'calm');
-        }, 10000);
-    });
+    const webbyClass = document.getElementsByClassName('webby');
+
+    // First, check if Webby is present
+    if(webbyClass.length > 0) {
+        const webby = webbyClass[0];
+        const web = document.getElementsByClassName('web')[0];
+        webby.classList.add('calm');
+        web.classList.add('calm');
+        webby.addEventListener('click', () => {
+            if (webby.classList.contains('frighten')) {
+                return;
+            }
+            webby.classList.replace('calm', 'frighten');
+            web.classList.replace('calm', 'frighten');
+            setTimeout(() => {
+                webby.classList.replace('frighten', 'calm');
+                web.classList.replace('frighten', 'calm');
+            }, 10000);
+        });
+    }
 
     const data = JSON.parse(document.getElementById('swagger-data').innerText);
     const ui = SwaggerUIBundle({

--- a/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -134,7 +134,7 @@ window.onload = () => {
 
 function manageWebbyDisplay() {
     const webby = document.getElementsByClassName('webby')[0];
-    if(!webby) return;
+    if (!webby) return;
 
     const web = document.getElementsByClassName('web')[0];
     webby.classList.add('calm');

--- a/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -1,26 +1,7 @@
 'use strict';
 
 window.onload = () => {
-    const webbyClass = document.getElementsByClassName('webby');
-
-    // First, check if Webby is present
-    if(webbyClass.length > 0) {
-        const webby = webbyClass[0];
-        const web = document.getElementsByClassName('web')[0];
-        webby.classList.add('calm');
-        web.classList.add('calm');
-        webby.addEventListener('click', () => {
-            if (webby.classList.contains('frighten')) {
-                return;
-            }
-            webby.classList.replace('calm', 'frighten');
-            web.classList.replace('calm', 'frighten');
-            setTimeout(() => {
-                webby.classList.replace('frighten', 'calm');
-                web.classList.replace('frighten', 'calm');
-            }, 10000);
-        });
-    }
+    manageWebbyDisplay();
 
     const data = JSON.parse(document.getElementById('swagger-data').innerText);
     const ui = SwaggerUIBundle({
@@ -150,3 +131,28 @@ window.onload = () => {
         }
     }
 };
+
+function manageWebbyDisplay() {
+    const webbyClass = document.getElementsByClassName('webby');
+
+    // First, check if Webby is present
+    if (webbyClass.length === 0) {
+        return;
+    }
+
+    const webby = webbyClass[0];
+    const web = document.getElementsByClassName('web')[0];
+    webby.classList.add('calm');
+    web.classList.add('calm');
+    webby.addEventListener('click', () => {
+        if (webby.classList.contains('frighten')) {
+            return;
+        }
+        webby.classList.replace('calm', 'frighten');
+        web.classList.replace('calm', 'frighten');
+        setTimeout(() => {
+            webby.classList.replace('frighten', 'calm');
+            web.classList.replace('frighten', 'calm');
+        }, 10000);
+    });
+}

--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -51,8 +51,8 @@
 </header>
 
 {% if showWebby %}
-<div class="web"><img src="{{ asset('bundles/apiplatform/web.png') }}"></div>
-<div class="webby"><img src="{{ asset('bundles/apiplatform/webby.png') }}"></div>
+    <div class="web"><img src="{{ asset('bundles/apiplatform/web.png') }}"></div>
+    <div class="webby"><img src="{{ asset('bundles/apiplatform/webby.png') }}"></div>
 {% endif %}
 
 <div id="swagger-ui" class="api-platform"></div>

--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -50,8 +50,10 @@
     <a id="logo" href="https://api-platform.com"><img src="{{ asset('bundles/apiplatform/logo-header.svg') }}" alt="API Platform"></a>
 </header>
 
+{% if showWebby %}
 <div class="web"><img src="{{ asset('bundles/apiplatform/web.png') }}"></div>
 <div class="webby"><img src="{{ asset('bundles/apiplatform/webby.png') }}"></div>
+{% endif %}
 
 <div id="swagger-ui" class="api-platform"></div>
 

--- a/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
+++ b/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
@@ -75,6 +75,7 @@ class SwaggerUiActionTest extends TestCase
             'title' => '',
             'description' => '',
             'formats' => [],
+            'showWebby' => true,
             'swagger_data' => [
                 'url' => '/url',
                 'spec' => self::SPEC,
@@ -102,6 +103,7 @@ class SwaggerUiActionTest extends TestCase
             'title' => '',
             'description' => '',
             'formats' => [],
+            'showWebby' => true,
             'swagger_data' => [
                 'url' => '/url',
                 'spec' => self::SPEC,
@@ -148,6 +150,7 @@ class SwaggerUiActionTest extends TestCase
             'title' => '',
             'description' => '',
             'formats' => [],
+            'showWebby' => true,
             'swagger_data' => [
                 'url' => '/url',
                 'spec' => self::SPEC,

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -458,6 +458,7 @@ class ApiPlatformExtensionTest extends TestCase
             ],
             'api_platform.title' => 'title',
             'api_platform.version' => 'version',
+            'api_platform.show_webby' => true,
             'api_platform.allow_plain_identifiers' => false,
             'api_platform.eager_loading.enabled' => Argument::type('bool'),
             'api_platform.eager_loading.max_joins' => 30,

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -58,6 +58,7 @@ class ConfigurationTest extends TestCase
             'title' => 'title',
             'description' => 'description',
             'version' => '1.0.0',
+            'show_webby' => true,
             'formats' => [
                 'jsonld' => ['mime_types' => ['application/ld+json']],
                 'json' => ['mime_types' => ['application/json']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | WTFPL
| Doc PR        | api-platform/doc#612

One of the greatest bugs in the Human software is their fear of spiders. In some cases, the simple seeing of something big go down the screen makes them feel bad for some seconds, before realizing it's just Webby.

Problem is, the Human software is closed-source, so this PR tries to manage that issue by providing a way to disable displaying Webby on the Swagger UI pages. Of course, Webby remains visible by default.

To disable Webby's display, just add this to API Platform's config:
```yaml
# /config/api_platform.yaml
api_platform:
    show_webby: false # defaults to true
```