### PR TITLE
fix deserialize relation bug

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -371,7 +371,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if (
             !$this->resourceClassResolver->isResourceClass($className) ||
-            $propertyMetadata->isWritableLink()
+            ($propertyMetadata->isWritableLink() && is_array($value))
         ) {
             $context['resource_class'] = $className;
             $context['api_allow_update'] = true;


### PR DESCRIPTION
at the deserializeRelation method if the resource is managed by api-platform and it is writable, it should be array.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
