### PR TITLE
Use context builder for DocumentationNormalizer and SerializerPropertyMetadataFactory

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.operation_method_resolver" />
             <argument type="service" id="api_platform.router" />
+            <argument type="service" id="api_platform.serializer.context_builder" />
             <argument type="service" id="api_platform.subresource_operation_factory" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
@@ -67,6 +67,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.serializer.inner" />
+            <argument type="service" id="api_platform.serializer.context_builder" />
         </service>
 
         <service id="api_platform.metadata.property.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="-10" public="false">

--- a/src/Serializer/SerializerContextBuilderInterface.php
+++ b/src/Serializer/SerializerContextBuilderInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Serializer;
 
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -30,4 +31,23 @@ interface SerializerContextBuilderInterface
      * @throws RuntimeException
      */
     public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null): array;
+
+    /**
+     * Gets the effective serializer groups used in normalization/denormalization.
+     *
+     * Groups are extracted in the following order:
+     *
+     * - From the "serializer_groups" key of the $options array.
+     * - From metadata of the given operation ("collection_operation_name" and "item_operation_name" keys).
+     * - From metadata of the current resource.
+     *
+     *
+     * @return (string[]|null)[]
+     */
+    public function createFromResourceClass(array $options, string $resourceClass): array;
+
+    /**
+     * Gets the context for the property name factory.
+     */
+    public function getPropertyNameCollectionFactoryContext(ResourceMetadata $resourceMetadata): array;
 }

--- a/src/Serializer/SerializerFilterContextBuilder.php
+++ b/src/Serializer/SerializerFilterContextBuilder.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Serializer;
 
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Serializer\Filter\FilterInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Psr\Container\ContainerInterface;
@@ -63,5 +64,21 @@ final class SerializerFilterContextBuilder implements SerializerContextBuilderIn
         }
 
         return $context;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createFromResourceClass(array $options, string $resourceClass): array
+    {
+        return $this->decorated->createFromResourceClass($options, $resourceClass);
+    }
+
+    /**
+     * Gets the context for the property name factory.
+     */
+    public function getPropertyNameCollectionFactoryContext(ResourceMetadata $resourceMetadata): array
+    {
+        return $this->decorated->getPropertyNameCollectionFactoryContext($resourceMetadata);
     }
 }


### PR DESCRIPTION
While setting up react admin I noticed that dynamic context building is not available for `/docs.jsonld` endpoint. This is an attempt to fix this.
If this code is something worth looking at then I would update tests.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | https://github.com/api-platform/api-platform/issues/866
| License       | MIT

