### PR TITLE
Bump PHPStan version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - *update-project-dependencies
       - run:
           name: Install PHPStan
-          command: composer global require phpstan/phpstan:0.10.1
+          command: composer global require phpstan/phpstan:0.10.5
       - *save-composer-cache-by-revision
       - *save-composer-cache-by-branch
       - run:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - echo extension=php_pdo_sqlite.dll >> php.ini
   - echo memory_limit=3G >> php.ini
   - cd %APPVEYOR_BUILD_FOLDER%
-  - composer install --no-interaction --no-progress
+  - composer install --no-interaction --no-progress --no-suggest
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/features/security/README.md
+++ b/features/security/README.md
@@ -60,7 +60,7 @@ one of the most popular framework validation in the world.
 
 The sending of security headers is ensured by [our "send security headers" functional test suite](send_security_headers.feature)
 and the unit tests of the [`RespondListener`](../../tests/EventListener/RespondListenerTest.php), [`ExceptionAction`](../../tests/Action/ExceptionActionTest.php)
-and [`ValidationExceptionListener`](../../tests/Bridge/Symfony/Validation/EventListener/ValidationExceptionListenerTest.php).
+and [`ValidationExceptionListener`](../../tests/Bridge/Symfony/Validator/EventListener/ValidationExceptionListenerTest.php).
 
 ### JSON encoding
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
     ignoreErrors:
         # Real problems, hard to fix
         - '#Parameter \#2 \$dqlPart of method Doctrine\\ORM\\QueryBuilder::add\(\) expects array\|object, string given\.#'
+        - '#Call to function method_exists\(\) with .Doctrine.+ and .get(Join|Alias|Parts). will always evaluate to false\.#'
 
         # False positives
         - '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy::\$[a-zA-Z0-9_]+#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,6 @@ parameters:
     ignoreErrors:
         # Real problems, hard to fix
         - '#Parameter \#2 \$dqlPart of method Doctrine\\ORM\\QueryBuilder::add\(\) expects array\|object, string given\.#'
-        - '#Call to function method_exists\(\) with .Doctrine.+ and .get(Join|Alias|Parts). will always evaluate to false\.#'
 
         # False positives
         - '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy::\$[a-zA-Z0-9_]+#'

--- a/src/Bridge/Doctrine/Orm/Util/QueryJoinParser.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryJoinParser.php
@@ -100,17 +100,7 @@ final class QueryJoinParser
      */
     public static function getJoinRelationship(Join $join): string
     {
-        static $relationshipProperty = null;
-        static $initialized = false;
-
-        if (!$initialized && !method_exists(Join::class, 'getJoin')) {
-            $relationshipProperty = new \ReflectionProperty(Join::class, '_join');
-            $relationshipProperty->setAccessible(true);
-
-            $initialized = true;
-        }
-
-        return (null === $relationshipProperty) ? $join->getJoin() : $relationshipProperty->getValue($join);
+        return $join->getJoin();
     }
 
     /**
@@ -118,17 +108,7 @@ final class QueryJoinParser
      */
     public static function getJoinAlias(Join $join): string
     {
-        static $aliasProperty = null;
-        static $initialized = false;
-
-        if (!$initialized && !method_exists(Join::class, 'getAlias')) {
-            $aliasProperty = new \ReflectionProperty(Join::class, '_alias');
-            $aliasProperty->setAccessible(true);
-
-            $initialized = true;
-        }
-
-        return (null === $aliasProperty) ? $join->getAlias() : $aliasProperty->getValue($join);
+        return $join->getAlias();
     }
 
     /**
@@ -139,16 +119,6 @@ final class QueryJoinParser
      */
     public static function getOrderByParts(OrderBy $orderBy): array
     {
-        static $partsProperty = null;
-        static $initialized = false;
-
-        if (!$initialized && !method_exists(OrderBy::class, 'getParts')) {
-            $partsProperty = new \ReflectionProperty(OrderBy::class, '_parts');
-            $partsProperty->setAccessible(true);
-
-            $initialized = true;
-        }
-
-        return (null === $partsProperty) ? $orderBy->getParts() : $partsProperty->getValue($orderBy);
+        return $orderBy->getParts();
     }
 }

--- a/src/DataProvider/SubresourceDataProviderInterface.php
+++ b/src/DataProvider/SubresourceDataProviderInterface.php
@@ -32,7 +32,7 @@ interface SubresourceDataProviderInterface
      *
      * @throws ResourceClassNotSupportedException
      *
-     * @return object|null
+     * @return array|object|null
      */
     public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null);
 }

--- a/src/GraphQl/Type/Definition/IterableType.php
+++ b/src/GraphQl/Type/Definition/IterableType.php
@@ -20,6 +20,7 @@ use GraphQL\Language\AST\IntValueNode;
 use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\ObjectValueNode;
 use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Language\AST\ValueNode;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\Utils;
 
@@ -80,7 +81,7 @@ final class IterableType extends ScalarType
     }
 
     /**
-     * @param StringValueNode|BooleanValueNode|IntValueNode|FloatValueNode|ObjectValueNode|ListValueNode $valueNode
+     * @param StringValueNode|BooleanValueNode|IntValueNode|FloatValueNode|ObjectValueNode|ListValueNode|ValueNode $valueNode
      */
     private function parseIterableLiteral($valueNode)
     {

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -263,10 +263,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
                     ],
                 ],
             ];
-
-            if (!isset($pathOperation['parameters']) && $parameters = $this->getFiltersParameters($resourceClass, $operationName, $resourceMetadata, $definitions, $serializerContext)) {
-                $pathOperation['parameters'] = $parameters;
-            }
+            $pathOperation['parameters'] ?? $pathOperation['parameters'] = $this->getFiltersParameters($resourceClass, $operationName, $resourceMetadata, $definitions, $serializerContext);
 
             if ($this->paginationEnabled && $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_enabled', true, true)) {
                 $pathOperation['parameters'][] = $this->getPaginationParameters();

--- a/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
@@ -55,14 +55,6 @@ class QueryJoinParserTest extends TestCase
         $this->assertEquals(RelatedDummy::class, QueryJoinParser::getJoinRelationship($join));
     }
 
-    public function testGetJoinRelationshipWithReflection()
-    {
-        $methodExist = $this->getFunctionMock('ApiPlatform\Core\Bridge\Doctrine\Orm\Util', 'method_exists');
-        $methodExist->expects($this->any())->with(Join::class, 'getJoin')->willReturn('false');
-        $join = new Join('INNER_JOIN', 'a_1.relatedDummy', 'a_1', null, 'a_1.name = r.name');
-        $this->assertEquals('a_1.relatedDummy', QueryJoinParser::getJoinRelationship($join));
-    }
-
     public function testGetJoinAliasWithJoin()
     {
         $join = new Join('INNER_JOIN', 'relatedDummy', 'a_1', null, 'a_1.name = r.name');
@@ -75,25 +67,9 @@ class QueryJoinParserTest extends TestCase
         $this->assertEquals('a_1', QueryJoinParser::getJoinAlias($join));
     }
 
-    public function testGetJoinAliasWithReflection()
-    {
-        $methodExist = $this->getFunctionMock('ApiPlatform\Core\Bridge\Doctrine\Orm\Util', 'method_exists');
-        $methodExist->expects($this->any())->with(Join::class, 'getAlias')->willReturn('false');
-        $join = new Join('INNER_JOIN', 'relatedDummy', 'a_1', null, 'a_1.name = r.name');
-        $this->assertEquals('a_1', QueryJoinParser::getJoinAlias($join));
-    }
-
     public function testGetOrderByPartsWithOrderBy()
     {
         $orderBy = new OrderBy('name', 'asc');
         $this->assertEquals(['name asc'], QueryJoinParser::getOrderByParts($orderBy));
-    }
-
-    public function testGetOrderByPartsWithReflection()
-    {
-        $methodExist = $this->getFunctionMock('ApiPlatform\Core\Bridge\Doctrine\Orm\Util', 'method_exists');
-        $methodExist->expects($this->any())->with(OrderBy::class, 'getParts')->willReturn('false');
-        $orderBy = new OrderBy('name', 'desc');
-        $this->assertEquals(['name desc'], QueryJoinParser::getOrderByParts($orderBy));
     }
 }

--- a/tests/Metadata/Property/Factory/InheritedPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/InheritedPropertyNameCollectionFactoryTest.php
@@ -34,7 +34,7 @@ class InheritedPropertyNameCollectionFactoryTest extends TestCase
 
         $propertyNameCollectionFactory = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactory->create(DummyTableInheritance::class, [])->willReturn(new PropertyNameCollection(['name']))->shouldBeCalled();
-        $propertyNameCollectionFactory->create(DummyTableInheritanceChild::class, [])->willReturn(new PropertyNameCollection(['nickname', 169]))->shouldBeCalled();
+        $propertyNameCollectionFactory->create(DummyTableInheritanceChild::class, [])->willReturn(new PropertyNameCollection(['nickname', '169']))->shouldBeCalled();
 
         $factory = new InheritedPropertyNameCollectionFactory($resourceNameCollectionFactory->reveal(), $propertyNameCollectionFactory->reveal());
         $metadata = $factory->create(DummyTableInheritance::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

and fix a mistake in a readme

Instead of adding a new exclude rule, I would rather drop [this code](https://github.com/api-platform/core/blob/master/src/Bridge/Doctrine/Orm/Util/QueryJoinParser.php#L103-L111) and in other places in the QueryJoinParser. Those are public method that didn't moved since 6 years and are still there in the next 3.0, I fail to understand what it is trying to fix and why if the method is to be removed at some point, we expect the internal property to still be there.
let me know if it is ok