### PR TITLE
fix OneToOne bidirectional + unitTest WIP

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1018,6 +1018,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
         $this->manager->persist($relatedOwnedDummy);
 
         $dummy = new Dummy();
+        $dummy->setName('plop');
         $dummy->setRelatedOwnedDummy($relatedOwnedDummy);
         $this->manager->persist($dummy);
 
@@ -1030,6 +1031,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     public function thereIsARelatedOwningDummy()
     {
         $dummy = new Dummy();
+        $dummy->setName('plop');
         $this->manager->persist($dummy);
 
         $relatedOwningDummy = new RelatedOwningDummy();

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1029,7 +1029,6 @@ final class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function thereIsARelatedOwningDummy()
     {
-
         $dummy = new Dummy();
         $this->manager->persist($dummy);
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1018,7 +1018,7 @@ final class FeatureContext implements Context, SnippetAcceptingContext
         $this->manager->persist($relatedOwnedDummy);
 
         $dummy = new Dummy();
-        $dummy->setOwnedDummy($relatedOwnedDummy);
+        $dummy->setRelatedOwnedDummy($relatedOwnedDummy);
         $this->manager->persist($dummy);
 
         $this->manager->flush();

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1010,15 +1010,31 @@ final class FeatureContext implements Context, SnippetAcceptingContext
     }
 
     /**
-     * @Given there is a RelatedOwnedDummy and a RelatedOwningDummy object with OneToOne bidirectional relation
+     * @Given there is a RelatedOwnedDummy object with OneToOne relation
      */
-    public function thereIsARelatedOwnedDummyAndARelatedOwningDummy()
+    public function thereIsARelatedOwnedDummy()
     {
         $relatedOwnedDummy = new RelatedOwnedDummy();
         $this->manager->persist($relatedOwnedDummy);
 
+        $dummy = new Dummy();
+        $dummy->setOwnedDummy($relatedOwnedDummy);
+        $this->manager->persist($dummy);
+
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is a RelatedOwningDummy object with OneToOne relation
+     */
+    public function thereIsARelatedOwningDummy()
+    {
+
+        $dummy = new Dummy();
+        $this->manager->persist($dummy);
+
         $relatedOwningDummy = new RelatedOwningDummy();
-        $relatedOwningDummy->setOwnedDummy($relatedOwnedDummy);
+        $relatedOwningDummy->setOwnedDummy($dummy);
         $this->manager->persist($relatedOwningDummy);
 
         $this->manager->flush();

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -43,6 +43,8 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Pet;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Question;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RamseyUuidDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedOwnedDummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedOwningDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedToDummyFriend;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelationEmbedder;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\SecuredDummy;
@@ -1003,6 +1005,21 @@ final class FeatureContext implements Context, SnippetAcceptingContext
         $dummy->addRelatedDummy($namedRelatedDummy);
         $dummy->addRelatedDummy($relatedDummy);
         $this->manager->persist($dummy);
+
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is a RelatedOwnedDummy and a RelatedOwningDummy object with OneToOne bidirectional relation
+     */
+    public function thereIsARelatedOwnedDummyAndARelatedOwningDummy()
+    {
+        $relatedOwnedDummy = new RelatedOwnedDummy();
+        $this->manager->persist($relatedOwnedDummy);
+
+        $relatedOwningDummy = new RelatedOwningDummy();
+        $relatedOwningDummy->setOwnedDummy($relatedOwnedDummy);
+        $this->manager->persist($relatedOwningDummy);
 
         $this->manager->flush();
     }

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -342,6 +342,40 @@ Feature: Subresource support
     }
     """
 
+
+  Scenario: The OneToOne subresource should be accessible from owned side
+    Given there is a RelatedOwnedDummy object with OneToOne relation
+    When I send a "GET" request to "/related_owned_dummies/1/owning_dummy"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
+      "id": 1
+    }
+    """
+
+
+  Scenario: The OneToOne subresource should be accessible from owning side
+    Given there is a RelatedOwningDummy object with OneToOne relation
+    When I send a "GET" request to "/related_owning_dummies/1/owned_dummy"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
+      "id": 1
+    }
+    """
+
   @dropSchema
   Scenario: Recursive resource
     When I send a "GET" request to "/dummy_products/2"
@@ -366,36 +400,3 @@ Feature: Subresource support
     }
     """
 
-  @dropSchema
-  Scenario: The OneToOne subresource should be accessible from owned side
-    @Given there is a RelatedOwnedDummy object with OneToOne relation
-    When I send a "GET" request to "/related_owned_dummies/1/owning_dummy"
-    And the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/Dummy",
-      "@id": "/dummies/1",
-      "@type": "Dummy",
-      "id": 1
-    }
-    """
-
-  @dropSchema
-  Scenario: The OneToOne subresource should be accessible from owning side
-    Given there is a RelatedOwningDummy object with OneToOne relation
-    When I send a "GET" request to "/related_owning_dummies/1/owned_dummy"
-    And the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/Dummy",
-      "@id": "/dummies/1",
-      "@type": "Dummy",
-      "id": 1
-    }
-    """

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -368,34 +368,34 @@ Feature: Subresource support
 
   @dropSchema
   Scenario: The OneToOne subresource should be accessible from owned side
-    Given there is a RelatedOwnedDummy and a RelatedOwningDummy object with OneToOne bidirectional relation
-    When I send a "GET" request to "/related_owned_dummies/1/related_owning_dummy"
+    @Given there is a RelatedOwnedDummy object with OneToOne relation
+    When I send a "GET" request to "/related_owned_dummies/1/owning_dummy"
     And the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be equal to:
     """
     {
-      "@context": "/contexts/RelatedOwningDummy",
-      "@id": "/related_owning_dummies/1",
-      "@type": "RelatedOwningDummy",
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
       "id": 1
     }
     """
 
   @dropSchema
   Scenario: The OneToOne subresource should be accessible from owning side
-    Given there is a RelatedOwnedDummy and a RelatedOwningDummy object with OneToOne bidirectional relation
-    When I send a "GET" request to "/related_owning_dummies/1/related_owned_dummy"
+    Given there is a RelatedOwningDummy object with OneToOne relation
+    When I send a "GET" request to "/related_owning_dummies/1/owned_dummy"
     And the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be equal to:
     """
     {
-      "@context": "/contexts/RelatedOwnedDummy",
-      "@id": "/related_owned_dummies/1",
-      "@type": "RelatedOwnedDummy",
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
       "id": 1
     }
     """

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -350,7 +350,7 @@ Feature: Subresource support
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be equal to:
     """
-    {
+    {+
       "@context": "/contexts/DummyProduct",
       "@id": "/dummy_products/2",
       "@type": "DummyProduct",
@@ -363,5 +363,39 @@ Feature: Subresource support
         "/dummy_products/1"
       ],
       "parent": null
+    }
+    """
+
+  @dropSchema
+  Scenario: The OneToOne subresource should be accessible from owned side
+    Given there is a RelatedOwnedDummy and a RelatedOwningDummy object with OneToOne bidirectional relation
+    When I send a "GET" request to "/related_owned_dummies/1/related_owning_dummy"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedOwningDummy",
+      "@id": "/related_owning_dummies/1",
+      "@type": "RelatedOwningDummy",
+      "id": 1
+    }
+    """
+
+  @dropSchema
+  Scenario: The OneToOne subresource should be accessible from owning side
+    Given there is a RelatedOwnedDummy and a RelatedOwningDummy object with OneToOne bidirectional relation
+    When I send a "GET" request to "/related_owning_dummies/1/related_owned_dummy"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedOwnedDummy",
+      "@id": "/related_owned_dummies/1",
+      "@type": "RelatedOwnedDummy",
+      "id": 1
     }
     """

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -355,7 +355,8 @@ Feature: Subresource support
       "@context": "/contexts/Dummy",
       "@id": "/dummies/1",
       "@type": "Dummy",
-      "id": 1
+      "id": 1,
+      "name": "plop"
     }
     """
 
@@ -372,7 +373,8 @@ Feature: Subresource support
       "@context": "/contexts/Dummy",
       "@id": "/dummies/1",
       "@type": "Dummy",
-      "id": 1
+      "id": 1,
+      "name": "plop"
     }
     """
 

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -352,8 +352,8 @@ Feature: Subresource support
     And the JSON should be equal to:
     """
     {
-      "@context": "\/contexts\/Dummy",
-      "@id": "\/dummies\/3",
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/3",
       "@type": "Dummy",
       "description": null,
       "dummy": null,
@@ -366,7 +366,7 @@ Feature: Subresource support
       "jsonData": [],
       "arrayData": [],
       "name_converted": null,
-      "relatedOwnedDummy": "\/related_owned_dummies\/1",
+      "relatedOwnedDummy": "/related_owned_dummies/1",
       "relatedOwningDummy": null,
       "id": 3,
       "name": "plop",
@@ -385,8 +385,8 @@ Feature: Subresource support
     And the JSON should be equal to:
     """
     {
-      "@context": "\/contexts\/Dummy",
-      "@id": "\/dummies\/4",
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/4",
       "@type": "Dummy",
       "description": null,
       "dummy": null,
@@ -400,7 +400,7 @@ Feature: Subresource support
       "arrayData": [],
       "name_converted": null,
       "relatedOwnedDummy": null,
-      "relatedOwningDummy": "\/related_owning_dummies\/1",
+      "relatedOwningDummy": "/related_owning_dummies/1",
       "id": 4,
       "name": "plop",
       "alias": null,
@@ -431,4 +431,3 @@ Feature: Subresource support
       "parent": null
     }
     """
-

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -416,7 +416,7 @@ Feature: Subresource support
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be equal to:
     """
-    {+
+    {
       "@context": "/contexts/DummyProduct",
       "@id": "/dummy_products/2",
       "@type": "DummyProduct",

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -352,11 +352,26 @@ Feature: Subresource support
     And the JSON should be equal to:
     """
     {
-      "@context": "/contexts/Dummy",
-      "@id": "/dummies/1",
+      "@context": "\/contexts\/Dummy",
+      "@id": "\/dummies\/3",
       "@type": "Dummy",
-      "id": 1,
-      "name": "plop"
+      "description": null,
+      "dummy": null,
+      "dummyBoolean": null,
+      "dummyDate": null,
+      "dummyFloat": null,
+      "dummyPrice": null,
+      "relatedDummy": null,
+      "relatedDummies": [],
+      "jsonData": [],
+      "arrayData": [],
+      "name_converted": null,
+      "relatedOwnedDummy": "\/related_owned_dummies\/1",
+      "relatedOwningDummy": null,
+      "id": 3,
+      "name": "plop",
+      "alias": null,
+      "foo": null
     }
     """
 
@@ -370,11 +385,26 @@ Feature: Subresource support
     And the JSON should be equal to:
     """
     {
-      "@context": "/contexts/Dummy",
-      "@id": "/dummies/1",
+      "@context": "\/contexts\/Dummy",
+      "@id": "\/dummies\/4",
       "@type": "Dummy",
-      "id": 1,
-      "name": "plop"
+      "description": null,
+      "dummy": null,
+      "dummyBoolean": null,
+      "dummyDate": null,
+      "dummyFloat": null,
+      "dummyPrice": null,
+      "relatedDummy": null,
+      "relatedDummies": [],
+      "jsonData": [],
+      "arrayData": [],
+      "name_converted": null,
+      "relatedOwnedDummy": null,
+      "relatedOwningDummy": "\/related_owning_dummies\/1",
+      "id": 4,
+      "name": "plop",
+      "alias": null,
+      "foo": null
     }
     """
 

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -346,7 +346,7 @@ Feature: Subresource support
   Scenario: The OneToOne subresource should be accessible from owned side
     Given there is a RelatedOwnedDummy object with OneToOne relation
     When I send a "GET" request to "/related_owned_dummies/1/owning_dummy"
-    And the response status code should be 200
+    Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be equal to:
@@ -375,11 +375,10 @@ Feature: Subresource support
     }
     """
 
-
   Scenario: The OneToOne subresource should be accessible from owning side
     Given there is a RelatedOwningDummy object with OneToOne relation
     When I send a "GET" request to "/related_owning_dummies/1/owned_dummy"
-    And the response status code should be 200
+    Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be equal to:

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -181,7 +181,9 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
                 case ClassMetadataInfo::ONE_TO_ONE:
                     $association = $classMetadata->getAssociationMapping($previousAssociationProperty);
                     if (!isset($association['mappedBy'])) {
-                        goto def;
+                        $qb->select("IDENTITY($alias.$previousAssociationProperty)")
+                            ->from($identifierResourceClass, $alias);
+                        break;
                     }
                     $mappedBy = $association['mappedBy'];
                     $previousAlias = "$previousAlias.$mappedBy";
@@ -190,7 +192,6 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
                         ->from($identifierResourceClass, $alias);
                     break;
                 default:
-                    def:
                     $qb->select("IDENTITY($alias.$previousAssociationProperty)")
                         ->from($identifierResourceClass, $alias);
             }

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -178,7 +178,19 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
                     $qb->select($alias)
                         ->from($identifierResourceClass, $alias);
                     break;
+                case ClassMetadataInfo::ONE_TO_ONE:
+                    $association = $classMetadata->getAssociationMapping($previousAssociationProperty);
+                    if (!isset($association['mappedBy'])) {
+                        goto def;
+                    }
+                    $mappedBy = $association['mappedBy'];
+                    $previousAlias = "$previousAlias.$mappedBy";
+
+                    $qb->select($alias)
+                        ->from($identifierResourceClass, $alias);
+                    break;
                 default:
+                    def:
                     $qb->select("IDENTITY($alias.$previousAssociationProperty)")
                         ->from($identifierResourceClass, $alias);
             }

--- a/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
@@ -281,9 +281,7 @@ class SubresourceDataProviderTest extends TestCase
         $queryBuilder->setParameter('id_p1', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
         $funcProphecy = $this->prophesize(Func::class);
         $func = $funcProphecy->reveal();
-
         $queryBuilder->andWhere($func)->shouldBeCalled()->willReturn($queryBuilder);
-
         $queryBuilder->getQuery()->shouldBeCalled()->willReturn($queryProphecy->reveal());
 
         $repositoryProphecy = $this->prophesize(EntityRepository::class);

--- a/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
@@ -326,8 +326,6 @@ class SubresourceDataProviderTest extends TestCase
 
         $context = ['property' => 'ownedDummy', 'identifiers' => [['id', RelatedOwningDummy::class], ['ownedDummy', RelatedOwnedDummy::class]], 'collection' => false, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
 
-
-
         $this->assertEquals($result, $dataProvider->getSubresource(RelatedOwnedDummy::class, ['id' => ['id' => 1], 'ownedDummy' => ['id' => 1]], $context));
     }
 

--- a/tests/Fixtures/TestBundle/Entity/RelatedOwnedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedOwnedDummy.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -45,6 +46,7 @@ class RelatedOwnedDummy
      *
      * @ORM\OneToOne(targetEntity="Dummy", cascade={"persist"}, inversedBy="relatedOwnedDummy")
      * @ORM\JoinColumn(nullable=false)
+     * @ApiSubresource
      */
     public $owningDummy;
 

--- a/tests/Fixtures/TestBundle/Entity/RelatedOwningDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedOwningDummy.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -44,6 +45,7 @@ class RelatedOwningDummy
      * @var Dummy
      *
      * @ORM\OneToOne(targetEntity="Dummy", cascade={"persist"}, mappedBy="relatedOwningDummy")
+     * @ApiSubresource
      */
     public $ownedDummy;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1801
| License       | MIT
| Doc PR        | 

This is a rework for this PR https://github.com/api-platform/core/pull/2228

@soyuka I'm struggling with UnitTest right now I don't now why prophecy contradicted itself... When I mock getClassMetadata and getRepository it says only getClassMetadata is called and when I remove getRepository it says only getRepository is called... Any help or clue on this could be appreciated.

Another question, it could be great to add a test with behat in subresource.feature to test OneToOne subresource in both way but I think there is no context for subresources and relation. Any clue on this?

Thanks in advance! Hope we can test this and merge this fix today =)
