### PR TITLE
Deprecate dead code in QueryJoinParser and remove internal usage

### DIFF
--- a/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryChecker.php
@@ -95,7 +95,7 @@ final class QueryChecker
 
         $orderByAliases = [];
         foreach ($orderByParts as $orderBy) {
-            $parts = QueryJoinParser::getOrderByParts($orderBy);
+            $parts = $orderBy->getParts();
 
             foreach ($parts as $part) {
                 $pos = strpos($part, '.');
@@ -111,12 +111,12 @@ final class QueryChecker
 
         foreach ($joinParts as $joins) {
             foreach ($joins as $join) {
-                $alias = QueryJoinParser::getJoinAlias($join);
+                $alias = $join->getAlias();
 
                 if (!isset($orderByAliases[$alias])) {
                     continue;
                 }
-                $relationship = QueryJoinParser::getJoinRelationship($join);
+                $relationship = $join->getJoin();
 
                 if (false !== strpos($relationship, '.')) {
                     /*

--- a/src/Bridge/Doctrine/Orm/Util/QueryJoinParser.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryJoinParser.php
@@ -48,8 +48,8 @@ final class QueryJoinParser
             $aliasMap[$rootAlias] = 'root';
 
             foreach ($joins as $join) {
-                $alias = self::getJoinAlias($join);
-                $relationship = self::getJoinRelationship($join);
+                $alias = $join->getAlias();
+                $relationship = $join->getJoin();
 
                 $pos = strpos($relationship, '.');
 
@@ -100,6 +100,8 @@ final class QueryJoinParser
      */
     public static function getJoinRelationship(Join $join): string
     {
+        @trigger_error(sprintf('The use of "%s::getJoinRelationship()" is deprecated since 2.3 and will be removed in 3.0. Use "%s::getJoin()" directly instead.', __CLASS__, Join::class), E_USER_DEPRECATED);
+
         return $join->getJoin();
     }
 
@@ -108,17 +110,20 @@ final class QueryJoinParser
      */
     public static function getJoinAlias(Join $join): string
     {
+        @trigger_error(sprintf('The use of "%s::getJoinAlias()" is deprecated since 2.3 and will be removed in 3.0. Use "%s::getAlias()" directly instead.', __CLASS__, Join::class), E_USER_DEPRECATED);
+
         return $join->getAlias();
     }
 
     /**
      * Gets the parts from an OrderBy expression.
      *
-     *
      * @return string[]
      */
     public static function getOrderByParts(OrderBy $orderBy): array
     {
+        @trigger_error(sprintf('The use of "%s::getOrderByParts()" is deprecated since 2.3 and will be removed in 3.0. Use "%s::getParts()" directly instead.', __CLASS__, OrderBy::class), E_USER_DEPRECATED);
+
         return $orderBy->getParts();
     }
 }

--- a/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
+++ b/tests/Bridge/Doctrine/Orm/Util/QueryJoinParserTest.php
@@ -43,30 +43,50 @@ class QueryJoinParserTest extends TestCase
         $this->assertEquals($metadata, $classMetadata->reveal());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The use of "ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryJoinParser::getJoinRelationship()" is deprecated since 2.3 and will be removed in 3.0. Use "Doctrine\ORM\Query\Expr\Join::getJoin()" directly instead.
+     */
     public function testGetJoinRelationshipWithJoin()
     {
         $join = new Join('INNER_JOIN', 'a_1.relatedDummy', 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals('a_1.relatedDummy', QueryJoinParser::getJoinRelationship($join));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The use of "ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryJoinParser::getJoinRelationship()" is deprecated since 2.3 and will be removed in 3.0. Use "Doctrine\ORM\Query\Expr\Join::getJoin()" directly instead.
+     */
     public function testGetJoinRelationshipWithClassJoin()
     {
         $join = new Join('INNER_JOIN', RelatedDummy::class, 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals(RelatedDummy::class, QueryJoinParser::getJoinRelationship($join));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The use of "ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryJoinParser::getJoinAlias()" is deprecated since 2.3 and will be removed in 3.0. Use "Doctrine\ORM\Query\Expr\Join::getAlias()" directly instead.
+     */
     public function testGetJoinAliasWithJoin()
     {
         $join = new Join('INNER_JOIN', 'relatedDummy', 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals('a_1', QueryJoinParser::getJoinAlias($join));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The use of "ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryJoinParser::getJoinAlias()" is deprecated since 2.3 and will be removed in 3.0. Use "Doctrine\ORM\Query\Expr\Join::getAlias()" directly instead.
+     */
     public function testGetJoinAliasWithClassJoin()
     {
         $join = new Join('LEFT_JOIN', RelatedDummy::class, 'a_1', null, 'a_1.name = r.name');
         $this->assertEquals('a_1', QueryJoinParser::getJoinAlias($join));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The use of "ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryJoinParser::getOrderByParts()" is deprecated since 2.3 and will be removed in 3.0. Use "Doctrine\ORM\Query\Expr\OrderBy::getParts()" directly instead.
+     */
     public function testGetOrderByPartsWithOrderBy()
     {
         $orderBy = new OrderBy('name', 'asc');


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Follows https://github.com/api-platform/core/pull/2267