### PR TITLE
allow to use multiple values with NumericFilter

### DIFF
--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -404,7 +404,7 @@ Feature: Date filter on collections
       },
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],relatedDummy[exists],dummyFloat,dummyPrice,order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,properties[]}",
+        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],relatedDummy[exists],dummyFloat,dummyFloat[],dummyPrice,dummyPrice[],order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,properties[]}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -499,7 +499,19 @@ Feature: Date filter on collections
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "dummyFloat[]",
+            "property": "dummyFloat",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "dummyPrice",
+            "property": "dummyPrice",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "dummyPrice[]",
             "property": "dummyPrice",
             "required": false
           },

--- a/features/doctrine/numeric_filter.feature
+++ b/features/doctrine/numeric_filter.feature
@@ -47,6 +47,51 @@ Feature: Numeric filter on collections
     }
     """
 
+  @createSchema
+  Scenario: Get collection by multiple dummyPrice
+    Given there are 10 dummy objects with dummyPrice
+    When I send a "GET" request to "/dummies?dummyPrice[]=9.99&dummyPrice[]=12.99"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And print last JSON response
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/1$"},
+                  {"pattern": "^/dummies/2$"},
+                  {"pattern": "^/dummies/5$"}
+                ]
+              }
+            }
+          },
+          "maxItems": 3,
+          "uniqueItems": true
+        },
+        "hydra:totalItems": {"pattern": "^6$"},
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5B%5D=9.99&dummyPrice%5B%5D=12.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
   Scenario: Get collection by non-numeric dummyPrice=marty
     Given there are 10 dummy objects with dummyPrice
     When I send a "GET" request to "/dummies?dummyPrice=marty"

--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -135,7 +135,7 @@ Feature: Create-Retrieve-Update-Delete
       "hydra:totalItems": 1,
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],relatedDummy[exists],dummyFloat,dummyPrice,order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,properties[]}",
+        "hydra:template": "/dummies{?dummyBoolean,relatedDummy.embeddedDummy.dummyBoolean,dummyDate[before],dummyDate[strictly_before],dummyDate[after],dummyDate[strictly_after],relatedDummy.dummyDate[before],relatedDummy.dummyDate[strictly_before],relatedDummy.dummyDate[after],relatedDummy.dummyDate[strictly_after],description[exists],relatedDummy.name[exists],dummyBoolean[exists],relatedDummy[exists],dummyFloat,dummyFloat[],dummyPrice,dummyPrice[],order[id],order[name],order[description],order[relatedDummy.name],order[relatedDummy.symfony],order[dummyDate],dummyFloat[between],dummyFloat[gt],dummyFloat[gte],dummyFloat[lt],dummyFloat[lte],dummyPrice[between],dummyPrice[gt],dummyPrice[gte],dummyPrice[lt],dummyPrice[lte],id,id[],name,alias,description,relatedDummy.name,relatedDummy.name[],relatedDummies,relatedDummies[],dummy,relatedDummies.name,properties[]}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
           {
@@ -230,7 +230,19 @@ Feature: Create-Retrieve-Update-Delete
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "dummyFloat[]",
+            "property": "dummyFloat",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "dummyPrice",
+            "property": "dummyPrice",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "dummyPrice[]",
             "property": "dummyPrice",
             "required": false
           },

--- a/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
@@ -61,11 +61,16 @@ class NumericFilter extends AbstractContextAwareFilter
                 continue;
             }
 
-            $description[$property] = [
-                'property' => $property,
-                'type' => $this->getType((string) $this->getDoctrineFieldType($property, $resourceClass)),
-                'required' => false,
-            ];
+            $filterParameterNames = [$property, $property.'[]'];
+
+            foreach ($filterParameterNames as $filterParameterName) {
+                $description[$filterParameterName] = [
+                    'property' => $property,
+                    'type' => $this->getType((string) $this->getDoctrineFieldType($property, $resourceClass)),
+                    'required' => false,
+                    'is_collection' => '[]' === substr($filterParameterName, -2),
+                ];
+            }
         }
 
         return $description;
@@ -99,9 +104,19 @@ class NumericFilter extends AbstractContextAwareFilter
             return;
         }
 
-        if (!is_numeric($value)) {
+        if (!is_numeric($value) && (!\is_array($value) || !$this->isNumericArray($value))) {
             $this->logger->notice('Invalid filter ignored', [
                 'exception' => new InvalidArgumentException(sprintf('Invalid numeric value for "%s::%s" property', $resourceClass, $property)),
+            ]);
+
+            return;
+        }
+
+        $values = $this->normalizeValues((array) $value);
+
+        if (empty($values)) {
+            $this->logger->notice('Invalid filter ignored', [
+                'exception' => new InvalidArgumentException(sprintf('At least one value is required, multiple values should be in "%1$s[]=firstvalue&%1$s[]=secondvalue" format', $property)),
             ]);
 
             return;
@@ -124,9 +139,15 @@ class NumericFilter extends AbstractContextAwareFilter
 
         $valueParameter = $queryNameGenerator->generateParameterName($field);
 
-        $queryBuilder
-            ->andWhere(sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
-            ->setParameter($valueParameter, $value, (string) $this->getDoctrineFieldType($property, $resourceClass));
+        if (1 === \count($values)) {
+            $queryBuilder
+                ->andWhere(sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
+                ->setParameter($valueParameter, $values[0], (string) $this->getDoctrineFieldType($property, $resourceClass));
+        } else {
+            $queryBuilder
+                ->andWhere(sprintf('%s.%s IN (:%s)', $alias, $field, $valueParameter))
+                ->setParameter($valueParameter, $values);
+        }
     }
 
     /**
@@ -138,5 +159,27 @@ class NumericFilter extends AbstractContextAwareFilter
         $metadata = $this->getNestedMetadata($resourceClass, $propertyParts['associations']);
 
         return isset(self::DOCTRINE_NUMERIC_TYPES[(string) $metadata->getTypeOfField($propertyParts['field'])]);
+    }
+
+    protected function isNumericArray(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (!is_numeric($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function normalizeValues(array $values): array
+    {
+        foreach ($values as $key => $value) {
+            if (!\is_int($key)) {
+                unset($values[$key]);
+            }
+        }
+
+        return array_values($values);
     }
 }

--- a/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/NumericFilterTest.php
@@ -38,6 +38,13 @@ class NumericFilterTest extends DoctrineOrmFilterTestCase
                 'property' => 'id',
                 'type' => 'int',
                 'required' => false,
+                'is_collection' => false,
+            ],
+            'id[]' => [
+                'property' => 'id',
+                'type' => 'int',
+                'required' => false,
+                'is_collection' => true,
             ],
         ], $filter->getDescription($this->resourceClass));
     }
@@ -51,16 +58,37 @@ class NumericFilterTest extends DoctrineOrmFilterTestCase
                 'property' => 'id',
                 'type' => 'int',
                 'required' => false,
+                'is_collection' => false,
+            ],
+            'id[]' => [
+                'property' => 'id',
+                'type' => 'int',
+                'required' => false,
+                'is_collection' => true,
             ],
             'dummyFloat' => [
                 'property' => 'dummyFloat',
                 'type' => 'float',
                 'required' => false,
+                'is_collection' => false,
+            ],
+            'dummyFloat[]' => [
+                'property' => 'dummyFloat',
+                'type' => 'float',
+                'required' => false,
+                'is_collection' => true,
             ],
             'dummyPrice' => [
                 'property' => 'dummyPrice',
                 'type' => 'string',
                 'required' => false,
+                'is_collection' => false,
+            ],
+            'dummyPrice[]' => [
+                'property' => 'dummyPrice',
+                'type' => 'string',
+                'required' => false,
+                'is_collection' => true,
             ],
         ], $filter->getDescription($this->resourceClass));
     }
@@ -78,6 +106,50 @@ class NumericFilterTest extends DoctrineOrmFilterTestCase
                     'dummyPrice' => '21',
                 ],
                 sprintf('SELECT o FROM %s o WHERE o.dummyPrice = :dummyPrice_p1', Dummy::class),
+            ],
+            'multiple numeric string (positive integer)' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                    'dummyPrice' => null,
+                ],
+                [
+                    'dummyPrice' => ['21', '22'],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyPrice IN (:dummyPrice_p1)', Dummy::class),
+            ],
+            'multiple numeric string with one invalid property key' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                    'dummyPrice' => null,
+                ],
+                [
+                    'dummyPrice' => ['invalid' => '21', '22'],
+                ],
+                sprintf('SELECT o FROM %s o WHERE o.dummyPrice = :dummyPrice_p1', Dummy::class),
+            ],
+            'multiple numeric string with invalid value keys' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                    'dummyPrice' => null,
+                ],
+                [
+                    'dummyPrice' => ['invalid' => '21', 'invalid2' => '22'],
+                ],
+                sprintf('SELECT o FROM %s o', Dummy::class),
+            ],
+            'multiple non-numeric' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                    'dummyPrice' => null,
+                ],
+                [
+                    'dummyPrice' => ['test', 'invalid'],
+                ],
+                sprintf('SELECT o FROM %s o', Dummy::class),
             ],
             'numeric string (negative integer)' => [
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  #2190
| License       | MIT
| Doc PR        | TODO

This PR allow to use the numeric filter with multiple values
The values with non-numerical keys are removed in the `normalizeValues` function to avoid collision between this filter and the `RangeFilter`