### PR TITLE
Validation to only validate properties submitted if not a posting a new entity

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -8,7 +8,7 @@
         <service id="api_platform.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Validator">
             <argument type="service" id="validator" />
             <argument type="service" id="service_container" />
-            <argument type="service" id="serializer" />
+            <argument type="service" id="Symfony\Component\Serializer\Normalizer\DenormalizerInterface" />
         </service>
         <service id="ApiPlatform\Core\Validator\ValidatorInterface" alias="api_platform.validator" />
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -8,6 +8,7 @@
         <service id="api_platform.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Validator">
             <argument type="service" id="validator" />
             <argument type="service" id="service_container" />
+            <argument type="service" id="Symfony\Component\Serializer\Encoder\DecoderInterface" />
         </service>
         <service id="ApiPlatform\Core\Validator\ValidatorInterface" alias="api_platform.validator" />
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -8,7 +8,7 @@
         <service id="api_platform.validator" class="ApiPlatform\Core\Bridge\Symfony\Validator\Validator">
             <argument type="service" id="validator" />
             <argument type="service" id="service_container" />
-            <argument type="service" id="Symfony\Component\Serializer\Encoder\DecoderInterface" />
+            <argument type="service" id="serializer" />
         </service>
         <service id="ApiPlatform\Core\Validator\ValidatorInterface" alias="api_platform.validator" />
 

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -77,9 +77,9 @@ class Validator implements ValidatorInterface
             $requestStack = $this->container->get('request_stack');
             $request = $requestStack->getCurrentRequest();
 
-            if ($request && !$request->attributes->get('_graphql') && 'post' !== strtolower($request->getMethod())) {
+            if ($request && ('' !== $requestContent = $request->getContent()) && !$request->attributes->get('_graphql') && 'post' !== strtolower($request->getMethod())) {
                 $ctx = $this->validator->startContext();
-                $decoded = $this->decoder->decode($request->getContent(), $request->getRequestFormat());
+                $decoded = $this->decoder->decode($requestContent, $request->getRequestFormat());
 
                 foreach ($decoded as $postKey => $postValue) {
                     $ctx->validateProperty($data, $postKey, $validationGroups);

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -77,7 +77,7 @@ class Validator implements ValidatorInterface
             $requestStack = $this->container->get('request_stack');
             $request = $requestStack->getCurrentRequest();
 
-            if ($request && 'post' !== strtolower($request->getMethod())) {
+            if ($request && !$request->attributes->get('_graphql') && 'post' !== strtolower($request->getMethod())) {
                 $ctx = $this->validator->startContext();
                 $decoded = $this->decoder->decode($request->getContent(), $request->getRequestFormat());
 

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -77,7 +77,12 @@ class Validator implements ValidatorInterface
             $requestStack = $this->container->get('request_stack');
             $request = $requestStack->getCurrentRequest();
 
-            if ($request && ('' !== $requestContent = $request->getContent()) && !$request->attributes->get('_graphql') && 'POST' !== $request->getMethod()) {
+            if (
+                $request &&
+                ('' !== $requestContent = $request->getContent()) &&
+                !$request->attributes->get('_graphql') &&
+                'POST' !== $request->getMethod()
+            ) {
                 $ctx = $this->validator->startContext();
                 $decoded = $this->decoder->decode($requestContent, $request->getRequestFormat());
 

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -77,7 +77,7 @@ class Validator implements ValidatorInterface
             $requestStack = $this->container->get('request_stack');
             $request = $requestStack->getCurrentRequest();
 
-            if ($request && ('' !== $requestContent = $request->getContent()) && !$request->attributes->get('_graphql') && 'post' !== strtolower($request->getMethod())) {
+            if ($request && ('' !== $requestContent = $request->getContent()) && !$request->attributes->get('_graphql') && 'POST' !== $request->getMethod()) {
                 $ctx = $this->validator->startContext();
                 $decoded = $this->decoder->decode($requestContent, $request->getRequestFormat());
 

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -77,11 +77,11 @@ class Validator implements ValidatorInterface
             $requestStack = $this->container->get('request_stack');
             $request = $requestStack->getCurrentRequest();
 
-            if ($request && strtolower($request->getMethod()) !== 'post') {
+            if ($request && 'post' !== strtolower($request->getMethod())) {
                 $ctx = $this->validator->startContext();
                 $decoded = $this->decoder->decode($request->getContent(), $request->getRequestFormat());
 
-                foreach ($decoded as $postKey=>$postValue) {
+                foreach ($decoded as $postKey => $postValue) {
                     $ctx->validateProperty($data, $postKey, $validationGroups);
                 }
 

--- a/tests/Bridge/Symfony/Validator/ValidatorTest.php
+++ b/tests/Bridge/Symfony/Validator/ValidatorTest.php
@@ -138,11 +138,10 @@ class ValidatorTest extends TestCase
         $requestProphecy->getMethod()->willReturn('put')->shouldBeCalled();
         $requestProphecy->getContent()->willReturn('{}')->shouldBeCalled();
         $requestProphecy->getRequestFormat()->willReturn('json')->shouldBeCalled();
-        $request = $requestProphecy->reveal();
-        $request->attributes = new ParameterBag(['_graphql' => false]);
+        $requestProphecy->attributes = new ParameterBag(['_graphql' => false]);
 
         $requestStackProphecy = $this->prophesize(RequestStack::class);
-        $requestStackProphecy->getCurrentRequest()->willReturn($request)->shouldBeCalled();
+        $requestStackProphecy->getCurrentRequest()->willReturn($requestProphecy->reveal())->shouldBeCalled();
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->get('request_stack')->willReturn($requestStackProphecy->reveal())->shouldBeCalled();

--- a/tests/Bridge/Symfony/Validator/ValidatorTest.php
+++ b/tests/Bridge/Symfony/Validator/ValidatorTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Bridge\Symfony\Validator\Validator;
 use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
@@ -137,9 +138,11 @@ class ValidatorTest extends TestCase
         $requestProphecy->getMethod()->willReturn('put')->shouldBeCalled();
         $requestProphecy->getContent()->willReturn('{}')->shouldBeCalled();
         $requestProphecy->getRequestFormat()->willReturn('json')->shouldBeCalled();
+        $request = $requestProphecy->reveal();
+        $request->attributes = new ParameterBag(['_graphql' => false]);
 
         $requestStackProphecy = $this->prophesize(RequestStack::class);
-        $requestStackProphecy->getCurrentRequest()->willReturn($requestProphecy->reveal())->shouldBeCalled();
+        $requestStackProphecy->getCurrentRequest()->willReturn($request)->shouldBeCalled();
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->get('request_stack')->willReturn($requestStackProphecy->reveal())->shouldBeCalled();


### PR DESCRIPTION
During a put/patch request - it doesn't seem applicable to validate fields that have not been submitted for change. In my case it was definitely not desired. When filling in a form, I'm looking to update each field as a user progresses through the form. Currently, this will send back violations for every field that failed validation and therefore not update the entity. Thoughts?

~~The Nelmio Behat test is now failing with a 500 error but I haven't traced the cause for this yet and am not sure whether it is related to this PR.~~
_Edit: Must have just been on my local machine and an unrelated issue. Tests pass fine on the automated tools_

I added a PHPUnit test for this functionality.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a
