### PR TITLE
iri based on value from persister

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -59,7 +59,8 @@ final class WriteListener
                     @trigger_error(sprintf('Returning void from %s::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.', DataPersisterInterface::class), E_USER_DEPRECATED);
                 }
 
-                $event->setControllerResult($persistResult ?? $controllerResult);
+                $controllerResult = $persistResult ?? $controllerResult;
+                $event->setControllerResult($controllerResult);
 
                 if (null !== $this->iriConverter) {
                     $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When using custom data persister, we don't pass id, but we want to somehow retrieve it. Unfortunately, returned object (with set id, is not taking under consideration when iri is set).

Example data persister: 
```
public function persist($data)
    {
        $core = $this->transformer->toCore($data);

        $this->entityManager->persist($core);
        $this->entityManager->flush();

        return $this->transformer->toHttp($core);
    }
```