### PR TITLE
Force Yaml::dump to dump empty array as actual empty array

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -67,7 +67,7 @@ final class SwaggerCommand extends Command
     {
         $documentation = new Documentation($this->resourceNameCollectionFactory->create(), $this->apiTitle, $this->apiDescription, $this->apiVersion, $this->apiFormats);
         $data = $this->documentationNormalizer->normalize($documentation);
-        $content = $input->getOption('yaml') ? Yaml::dump($data, 6, 4, Yaml::DUMP_OBJECT_AS_MAP) : json_encode($data, JSON_PRETTY_PRINT);
+        $content = $input->getOption('yaml') ? Yaml::dump($data, 6, 4, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE) : json_encode($data, JSON_PRETTY_PRINT);
         if (!empty($input->getOption('output'))) {
             file_put_contents($input->getOption('output'), $content);
             $output->writeln(


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | #2285 
| License       | MIT
| Doc PR        | api-platform/doc#1234

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
