### PR TITLE
Ability to modify response headers (mainly cache related headers)

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -26,6 +26,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("accessControl", type="string"),
  *     @Attribute("accessControlMessage", type="string"),
  *     @Attribute("attributes", type="array"),
+ *     @Attribute("cacheHeaders", type="array"),
  *     @Attribute("collectionOperations", type="array"),
  *     @Attribute("denormalizationContext", type="array"),
  *     @Attribute("deprecationReason", type="string"),
@@ -53,8 +54,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("subresourceOperations", type="array"),
  *     @Attribute("sunset", type="string"),
  *     @Attribute("swaggerContext", type="array"),
- *     @Attribute("validationGroups", type="mixed"),
- *     @Attribute("cacheHeaders", type="array")
+ *     @Attribute("validationGroups", type="mixed")
  * )
  */
 final class ApiResource
@@ -109,6 +109,13 @@ final class ApiResource
      * @var string
      */
     private $accessControlMessage;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $cacheHeaders;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
@@ -256,13 +263,6 @@ final class ApiResource
      * @var string
      */
     private $sunset;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $cacheHeaders;
 
     /**
      * @throws InvalidArgumentException

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -252,13 +252,6 @@ final class ApiResource
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
-     * @var array
-     */
-    private $responseCacheHeaders;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
      * @var string
      */
     private $sunset;

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -257,6 +257,13 @@ final class ApiResource
     private $sunset;
 
     /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $cacheHeaders;
+
+    /**
      * @throws InvalidArgumentException
      */
     public function __construct(array $values = [])

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -252,6 +252,13 @@ final class ApiResource
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
+     * @var array
+     */
+    private $responseCacheHeaders;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
      * @var string
      */
     private $sunset;

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -53,7 +53,8 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("subresourceOperations", type="array"),
  *     @Attribute("sunset", type="string"),
  *     @Attribute("swaggerContext", type="array"),
- *     @Attribute("validationGroups", type="mixed")
+ *     @Attribute("validationGroups", type="mixed"),
+ *     @Attribute("cacheHeaders", type="array")
  * )
  */
 final class ApiResource

--- a/src/Bridge/Symfony/Bundle/Resources/config/http_cache.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/http_cache.xml
@@ -6,12 +6,12 @@
 
     <services>
         <service id="api_platform.http_cache.listener.response.configure" class="ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener">
-            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument>%api_platform.http_cache.etag%</argument>
             <argument>%api_platform.http_cache.max_age%</argument>
             <argument>%api_platform.http_cache.shared_max_age%</argument>
             <argument>%api_platform.http_cache.vary%</argument>
             <argument>%api_platform.http_cache.public%</argument>
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
 
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-1" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/http_cache.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/http_cache.xml
@@ -6,6 +6,7 @@
 
     <services>
         <service id="api_platform.http_cache.listener.response.configure" class="ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener">
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument>%api_platform.http_cache.etag%</argument>
             <argument>%api_platform.http_cache.max_age%</argument>
             <argument>%api_platform.http_cache.shared_max_age%</argument>

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace AV;
+namespace ApiPlatform\Core\Bridge\Symfony\Validator\EventListener;
 
 use ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Bridge\Symfony\Validator\EventListener;
+namespace AV;
 
 use ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -53,11 +53,11 @@ final class AddHeadersListener
             return;
         }
 
-        if ($this->etag) {
+        if (!$response->getEtag() && $this->etag) {
             $response->setEtag(md5($response->getContent()));
         }
 
-        if (null !== $this->maxAge) {
+        if (!$response->getMaxAge() && null !== $this->maxAge) {
             $response->setMaxAge($this->maxAge);
         }
 
@@ -65,11 +65,11 @@ final class AddHeadersListener
             $response->setVary(array_diff($this->vary, $response->getVary()), false);
         }
 
-        if (null !== $this->sharedMaxAge) {
+        if (!$response->headers->hasCacheControlDirective('s-maxage') && null !== $this->sharedMaxAge) {
             $response->setSharedMaxAge($this->sharedMaxAge);
         }
 
-        if (null !== $this->public) {
+        if (!$response->headers->hasCacheControlDirective('public') && !$response->headers->hasCacheControlDirective('private') && null !== $this->public) {
             $this->public ? $response->setPublic() : $response->setPrivate();
         }
     }

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -44,7 +44,6 @@ final class AddHeadersListener
     }
 
     /**
-     * @param FilterResponseEvent $event
      * @throws \ApiPlatform\Core\Exception\ResourceClassNotFoundException
      */
     public function onKernelResponse(FilterResponseEvent $event)

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -29,7 +29,7 @@ class ApiResourceTest extends TestCase
         $resource = new ApiResource([
             'accessControl' => 'has_role("ROLE_FOO")',
             'accessControlMessage' => 'You are not foo.',
-            'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux']],
+            'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux'], 'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0]],
             'collectionOperations' => ['bar' => ['foo']],
             'denormalizationContext' => ['groups' => ['foo']],
             'description' => 'description',
@@ -85,6 +85,7 @@ class ApiResourceTest extends TestCase
             'pagination_partial' => true,
             'route_prefix' => '/foo',
             'validation_groups' => ['baz', 'qux'],
+            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0],
             'sunset' => 'Thu, 11 Oct 2018 00:00:00 +0200',
         ], $resource->attributes);
     }
@@ -107,6 +108,7 @@ class ApiResourceTest extends TestCase
             'route_prefix' => '/whatever',
             'access_control' => "has_role('ROLE_FOO')",
             'access_control_message' => 'You are not foo.',
+            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0]
         ], $resource->attributes);
     }
 

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -108,7 +108,7 @@ class ApiResourceTest extends TestCase
             'route_prefix' => '/whatever',
             'access_control' => "has_role('ROLE_FOO')",
             'access_control_message' => 'You are not foo.',
-            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0]
+            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0],
         ], $resource->attributes);
     }
 

--- a/tests/Fixtures/AnnotatedClass.php
+++ b/tests/Fixtures/AnnotatedClass.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *     itemOperations={"foo"={"bar"}},
  *     collectionOperations={"bar"={"foo"}},
  *     graphql={"query"={"normalization_context"={"groups"={"foo", "bar"}}}},
- *     attributes={"foo"="bar", "route_prefix"="/whatever"},
+ *     attributes={"foo"="bar", "route_prefix"="/whatever", "cache_headers"={"max_age"=0, "shared_max_age"=0}},
  *     routePrefix="/foo",
  *     accessControl="has_role('ROLE_FOO')",
  *     accessControlMessage="You are not foo."

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -38,10 +38,7 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldNotBeCalled();
 
-        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldNotBeCalled();
-
-        $listener = new AddHeadersListener($factory->reveal(), true);
+        $listener = new AddHeadersListener(true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertNull($response->getEtag());
@@ -56,10 +53,7 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldNotBeCalled();
 
-        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldNotBeCalled();
-
-        $listener = new AddHeadersListener($factory->reveal(), true);
+        $listener = new AddHeadersListener(true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertNull($response->getEtag());
@@ -74,10 +68,7 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldNotBeCalled();
-
-        $listener = new AddHeadersListener($factory->reveal(), true);
+        $listener = new AddHeadersListener(true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertNull($response->getEtag());
@@ -95,7 +86,7 @@ class AddHeadersListenerTest extends TestCase
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
 
-        $listener = new AddHeadersListener($factory->reveal(), true, 100, 200, ['Accept', 'Accept-Encoding'], true);
+        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], true, $factory->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('"9893532233caff98cd083a116b013c0b"', $response->getEtag());
@@ -119,7 +110,7 @@ class AddHeadersListenerTest extends TestCase
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
 
-        $listener = new AddHeadersListener($factory->reveal(), true, 100, 200, [], true);
+        $listener = new AddHeadersListener(true, 100, 200, [], true, $factory->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('"etag"', $response->getEtag());
@@ -139,7 +130,7 @@ class AddHeadersListenerTest extends TestCase
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
 
-        $listener = new AddHeadersListener($factory->reveal(), true, 100, 200, ['Accept', 'Accept-Encoding'], true);
+        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], true, $factory->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\HttpCache\EventListener;
 
 use ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,7 +38,10 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldNotBeCalled();
 
-        $listener = new AddHeadersListener(true);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldNotBeCalled();
+
+        $listener = new AddHeadersListener($factory->reveal(), true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertNull($response->getEtag());
@@ -51,7 +56,10 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldNotBeCalled();
 
-        $listener = new AddHeadersListener(true);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldNotBeCalled();
+
+        $listener = new AddHeadersListener($factory->reveal(), true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertNull($response->getEtag());
@@ -66,7 +74,10 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddHeadersListener(true);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldNotBeCalled();
+
+        $listener = new AddHeadersListener($factory->reveal(), true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertNull($response->getEtag());
@@ -81,7 +92,10 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], true);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
+
+        $listener = new AddHeadersListener($factory->reveal(), true, 100, 200, ['Accept', 'Accept-Encoding'], true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('"9893532233caff98cd083a116b013c0b"', $response->getEtag());
@@ -92,21 +106,42 @@ class AddHeadersListenerTest extends TestCase
     public function testDoNotSetHeaderWhenAlreadySet()
     {
         $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
-        $response = new Response();
+        $response = new Response('some content', 200, ['Vary' => ['Accept', 'Cookie']]);
         $response->setEtag('etag');
-        $response->setMaxAge(0);
+        $response->setMaxAge(300);
         // This also calls setPublic
-        $response->setSharedMaxAge(0);
+        $response->setSharedMaxAge(400);
 
         $event = $this->prophesize(FilterResponseEvent::class);
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], true);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
+
+        $listener = new AddHeadersListener($factory->reveal(), true, 100, 200, [], true);
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('"etag"', $response->getEtag());
-        $this->assertSame('max-age=0, public, s-maxage=0', $response->headers->get('Cache-Control'));
-        $this->assertSame([], $response->getVary());
+        $this->assertSame('max-age=300, public, s-maxage=400', $response->headers->get('Cache-Control'));
+    }
+
+    public function testSetHeadersFromResourceMetadata()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $response = new Response('some content', 200, ['Vary' => ['Accept', 'Cookie']]);
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $metadata = new ResourceMetadata(null, null, null, null, null, ['cache_headers' => ['max_age' => 123, 'shared_max_age' => 456]]);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
+
+        $listener = new AddHeadersListener($factory->reveal(), true, 100, 200, ['Accept', 'Accept-Encoding'], true);
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));
     }
 }


### PR DESCRIPTION
The cache headers should be able to be modified and then not overwritten by the `AddHeadersListener`. Also added annotation configuration for cache header expiry times so each resource can have a different expiry time if required.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/core/issues/2207
| License       | MIT
| Doc PR        | (not created yet)
