### PR TITLE
[WIP/RFC] Use framework expression language service instead of custom one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
         "phpdocumentor/type-resolver": "^0.3 || ^0.4",
         "phpspec/prophecy": "^1.8",
-        "phpunit/phpunit": "^7.5.2",
+        "phpunit/phpunit": "^7.5.4",
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.7",
         "ramsey/uuid-doctrine": "^1.4",

--- a/src/Api/FormatsProvider.php
+++ b/src/Api/FormatsProvider.php
@@ -92,7 +92,7 @@ final class FormatsProvider implements FormatsProviderInterface, OperationAwareF
             if (!\is_string($value)) {
                 throw new InvalidArgumentException(sprintf("The 'formats' attributes value must be a string when trying to include an already configured format, %s given.", \gettype($value)));
             }
-            if (array_key_exists($value, $this->configuredFormats)) {
+            if (\array_key_exists($value, $this->configuredFormats)) {
                 $resourceFormats[$value] = $this->configuredFormats[$value];
                 continue;
             }

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/AbstractFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/AbstractFilter.php
@@ -85,6 +85,6 @@ abstract class AbstractFilter implements FilterInterface
             return !$this->isPropertyNested($property, $resourceClass);
         }
 
-        return array_key_exists($property, $this->properties);
+        return \array_key_exists($property, $this->properties);
     }
 }

--- a/src/Bridge/Doctrine/MongoDbOdm/Paginator.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Paginator.php
@@ -136,7 +136,7 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
     private function getFacetInfo(string $field): array
     {
         foreach ($this->pipeline as $indexStage => $infoStage) {
-            if (array_key_exists('$facet', $infoStage)) {
+            if (\array_key_exists('$facet', $infoStage)) {
                 if (!isset($this->pipeline[$indexStage]['$facet'][$field])) {
                     throw new InvalidArgumentException("\"$field\" facet was not applied to the aggregation pipeline.");
                 }

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -252,7 +252,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
             }
 
             // If it's an embedded property see below
-            if (!array_key_exists($property, $targetClassMetadata->embeddedClasses)) {
+            if (!\array_key_exists($property, $targetClassMetadata->embeddedClasses)) {
                 //the field test allows to add methods to a Resource which do not reflect real database fields
                 if ($targetClassMetadata->hasField($property) && (true === $propertyMetadata->getAttribute('fetchable') || $propertyMetadata->isReadable())) {
                     $select[] = $property;

--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -81,7 +81,7 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
             ];
 
             foreach ($legacyPaginationArgs as $pos => $arg) {
-                if (array_key_exists($pos, $args)) {
+                if (\array_key_exists($pos, $args)) {
                     @trigger_error(sprintf('Passing "$%s" arguments is deprecated since API Platform 2.4 and will not be possible anymore in API Platform 3. Pass an instance of "%s" as third argument instead.', implode('", "$', array_column($legacyPaginationArgs, 'arg_name')), Paginator::class), E_USER_DEPRECATED);
 
                     if (!((null === $arg['default'] && null === $args[$pos]) || \call_user_func("is_{$arg['type']}", $args[$pos]))) {
@@ -261,7 +261,7 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
     private function getPaginationParameter(Request $request, string $parameterName, $default = null)
     {
         if (null !== $paginationAttribute = $request->attributes->get('_api_pagination')) {
-            return array_key_exists($parameterName, $paginationAttribute) ? $paginationAttribute[$parameterName] : $default;
+            return \array_key_exists($parameterName, $paginationAttribute) ? $paginationAttribute[$parameterName] : $default;
         }
 
         return $request->query->get($parameterName, $default);

--- a/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
@@ -115,7 +115,7 @@ abstract class AbstractFilter implements FilterInterface
             return !$this->isPropertyNested($property, $resourceClass);
         }
 
-        return array_key_exists($property, $this->properties);
+        return \array_key_exists($property, $this->properties);
     }
 
     /**

--- a/src/Bridge/Elasticsearch/DataProvider/Paginator.php
+++ b/src/Bridge/Elasticsearch/DataProvider/Paginator.php
@@ -99,7 +99,7 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
         foreach ($this->documents['hits']['hits'] ?? [] as $document) {
             $cacheKey = isset($document['_index'], $document['_type'], $document['_id']) ? md5("${document['_index']}_${document['_type']}_${document['_id']}") : null;
 
-            if ($cacheKey && array_key_exists($cacheKey, $this->cachedDenormalizedDocuments)) {
+            if ($cacheKey && \array_key_exists($cacheKey, $this->cachedDenormalizedDocuments)) {
                 $object = $this->cachedDenormalizedDocuments[$cacheKey];
             } else {
                 $object = $this->denormalizer->denormalize(

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -38,7 +38,6 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -120,9 +119,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $bundles = $container->getParameter('kernel.bundles');
         if (isset($bundles['SecurityBundle'])) {
-            if (class_exists(ExpressionLanguage::class)) {
-                $loader->load('security_expression_language.xml');
-            }
             $loader->load('security.xml');
         }
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/security.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/security.xml
@@ -5,6 +5,8 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="api_platform.security.expression_language" alias="security.expression_language" />
+
         <service id="api_platform.security.resource_access_checker" class="ApiPlatform\Core\Security\ResourceAccessChecker" public="false">
             <argument type="service" id="api_platform.security.expression_language" on-invalid="null" />
             <argument type="service" id="security.authentication.trust_resolver" on-invalid="null" />
@@ -20,6 +22,10 @@
 
             <!-- This listener must be executed only when the current object is available -->
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="1" />
+        </service>
+
+        <service id="api_platform.security.expression_language_provider" class="ApiPlatform\Core\Security\Core\Authorization\ExpressionLanguageProvider" public="false">
+            <tag name="security.expression_language_provider" />
         </service>
     </services>
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/security_expression_language.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/security_expression_language.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" ?>
-
-<container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <services>
-        <service id="api_platform.security.expression_language" class="ApiPlatform\Core\Security\ExpressionLanguage" public="false" />
-    </services>
-</container>

--- a/src/Cache/CachedTrait.php
+++ b/src/Cache/CachedTrait.php
@@ -27,7 +27,7 @@ trait CachedTrait
 
     private function getCached(string $cacheKey, callable $getValue)
     {
-        if (array_key_exists($cacheKey, $this->localCache)) {
+        if (\array_key_exists($cacheKey, $this->localCache)) {
             return $this->localCache[$cacheKey];
         }
 

--- a/src/DataProvider/Pagination.php
+++ b/src/DataProvider/Pagination.php
@@ -185,6 +185,6 @@ final class Pagination
     {
         $filters = $context['filters'] ?? [];
 
-        return array_key_exists($parameterName, $filters) ? $filters[$parameterName] : $default;
+        return \array_key_exists($parameterName, $filters) ? $filters[$parameterName] : $default;
     }
 }

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -246,7 +246,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
                         }
 
                         parse_str($key, $parsed);
-                        if (array_key_exists($key, $parsed) && \is_array($parsed[$key])) {
+                        if (\array_key_exists($key, $parsed) && \is_array($parsed[$key])) {
                             $parsed = [$key => ''];
                         }
                         array_walk_recursive($parsed, function (&$value) use ($graphqlFilterType) {

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -164,7 +164,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
     {
         $class = $this->getObjectClass($object);
 
-        $attributesMetadata = array_key_exists($class, $this->attributesMetadataCache) ?
+        $attributesMetadata = \array_key_exists($class, $this->attributesMetadataCache) ?
             $this->attributesMetadataCache[$class] :
             $this->attributesMetadataCache[$class] = $this->classMetadataFactory ? $this->classMetadataFactory->getMetadataFor($class)->getAttributesMetadata() : null;
 

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -157,7 +157,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = [])
     {
-        parent::setAttributeValue($object, $attribute, \is_array($value) && array_key_exists('data', $value) ? $value['data'] : $value, $format, $context);
+        parent::setAttributeValue($object, $attribute, \is_array($value) && \array_key_exists('data', $value) ? $value['data'] : $value, $format, $context);
     }
 
     /**

--- a/src/Metadata/Extractor/AbstractExtractor.php
+++ b/src/Metadata/Extractor/AbstractExtractor.php
@@ -103,7 +103,7 @@ abstract class AbstractExtractor implements ExtractorInterface
                 throw new \RuntimeException(sprintf('Using "%%%s%%" is not allowed in routing configuration.', $parameter));
             }
 
-            if (array_key_exists($parameter, $this->collectedParameters)) {
+            if (\array_key_exists($parameter, $this->collectedParameters)) {
                 return $this->collectedParameters[$parameter];
             }
 

--- a/src/Security/Core/Authorization/ExpressionLanguageProvider.php
+++ b/src/Security/Core/Authorization/ExpressionLanguageProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Security\Core\Authorization;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * Registers API Platform's Expression Language functions.
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+final class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction('is_granted', function ($attributes, $object = 'null') {
+                return sprintf('$auth_checker->isGranted(%s, %s)', $attributes, $object);
+            }, function (array $variables, $attributes, $object = null) {
+                return $variables['auth_checker']->isGranted($attributes, $object);
+            }),
+        ];
+    }
+}

--- a/src/Security/ExpressionLanguage.php
+++ b/src/Security/ExpressionLanguage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Security;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage as BaseExpressionLanguage;
 
 /**
@@ -25,6 +26,16 @@ use Symfony\Component\Security\Core\Authorization\ExpressionLanguage as BaseExpr
  */
 class ExpressionLanguage extends BaseExpressionLanguage
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(CacheItemPoolInterface $cache = null, array $providers = [])
+    {
+        @trigger_error('Using the ExpressionLanguage class directly is deprecated since API Platform 2.4 and will not be possible anymore in API Platform 3. Use the "api_platform.security.expression_language" service instead.', E_USER_DEPRECATED);
+
+        parent::__construct($cache, $providers);
+    }
+
     protected function registerFunctions()
     {
         parent::registerFunctions();

--- a/src/Security/ResourceAccessChecker.php
+++ b/src/Security/ResourceAccessChecker.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Security;
 
 use ApiPlatform\Core\Util\ClassInfoTrait;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -177,14 +177,14 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 $allowed = false === $allowedAttributes || (\is_array($allowedAttributes) && \in_array($paramName, $allowedAttributes, true));
                 $ignored = !$this->isAllowedAttribute($class, $paramName, $format, $context);
                 if ($constructorParameter->isVariadic()) {
-                    if ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
+                    if ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {
                         if (!\is_array($data[$paramName])) {
                             throw new RuntimeException(sprintf('Cannot create an instance of %s from serialized data because the variadic parameter %s can only accept an array.', $class, $constructorParameter->name));
                         }
 
                         $params = array_merge($params, $data[$paramName]);
                     }
-                } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
+                } elseif ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {
                     $params[] = $this->createConstructorArgument($data[$key], $key, $constructorParameter, $context, $format);
 
                     // Don't run set for a parameter passed to the constructor

--- a/src/Serializer/Filter/GroupFilter.php
+++ b/src/Serializer/Filter/GroupFilter.php
@@ -39,7 +39,7 @@ final class GroupFilter implements FilterInterface
      */
     public function apply(Request $request, bool $normalization, array $attributes, array &$context)
     {
-        if (array_key_exists($this->parameterName, $commonAttribute = $request->attributes->get('_api_filters', []))) {
+        if (\array_key_exists($this->parameterName, $commonAttribute = $request->attributes->get('_api_filters', []))) {
             $groups = $commonAttribute[$this->parameterName];
         } else {
             $groups = $request->query->get($this->parameterName);

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -41,7 +41,7 @@ final class PropertyFilter implements FilterInterface
     {
         if (null !== $propertyAttribute = $request->attributes->get('_api_filter_property')) {
             $properties = $propertyAttribute;
-        } elseif (array_key_exists($this->parameterName, $commonAttribute = $request->attributes->get('_api_filters', []))) {
+        } elseif (\array_key_exists($this->parameterName, $commonAttribute = $request->attributes->get('_api_filters', []))) {
             $properties = $commonAttribute[$this->parameterName];
         } else {
             $properties = $request->query->get($this->parameterName);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -164,7 +164,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([0 => ['serializer' => ['enabled' => false]]])->shouldBeCalled();
         $containerBuilderProphecy->prependExtensionConfig('framework', Argument::any())->willReturn(null)->shouldBeCalled();
         $containerBuilderProphecy->prependExtensionConfig('framework', Argument::that(function (array $config) {
-            return array_key_exists('serializer', $config);
+            return \array_key_exists('serializer', $config);
         }))->shouldNotBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
@@ -177,7 +177,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([0 => ['property_info' => ['enabled' => false]]])->shouldBeCalled();
         $containerBuilderProphecy->prependExtensionConfig('framework', Argument::any())->willReturn(null)->shouldBeCalled();
         $containerBuilderProphecy->prependExtensionConfig('framework', Argument::that(function (array $config) {
-            return array_key_exists('property_info', $config);
+            return \array_key_exists('property_info', $config);
         }))->shouldNotBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -78,6 +78,7 @@ use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -355,6 +356,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setAlias(ResourceAccessCheckerInterface::class, 'api_platform.security.resource_access_checker')->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.security.listener.request.deny_access', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.security.expression_language_provider', Argument::type(Definition::class))->shouldBeCalled();
+        $containerBuilderProphecy->setAlias('api_platform.security.expression_language', Argument::type(Alias::class))->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $this->extension->load(self::DEFAULT_CONFIG, $containerBuilder);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -354,7 +354,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.security.resource_access_checker', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setAlias(ResourceAccessCheckerInterface::class, 'api_platform.security.resource_access_checker')->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.security.listener.request.deny_access', Argument::type(Definition::class))->shouldBeCalled();
-        $containerBuilderProphecy->setDefinition('api_platform.security.expression_language', Argument::type(Definition::class))->shouldBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.security.expression_language_provider', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $this->extension->load(self::DEFAULT_CONFIG, $containerBuilder);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2265
| License       | MIT
| Doc PR        | 

Using the framework `security.expression_language` service rather than our own one allows us to extend the expression language with our own functions easily. Symfony already provides an easy way to register custom functions in `AddExpressionLanguageProvidersPass`. ApiPlatform currently does not. But I figured instead of providing our own compiler pass we can just use the built-in `security.expression_language`, extend that with our `is_granted()` function and thus at the same time also allow developers to add even more functions. Wdyt?
