### PR TITLE
bugfix: throw InvalidArgument on matching something that looks like an url

### DIFF
--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -476,6 +476,7 @@ Feature: Create-Retrieve-Update-Delete
     {
       "@id": "/dummies/1",
       "name": "A nice dummy",
+      "dummyDate": "2018-12-01 13:12",
       "jsonData": [{
           "key": "value1"
         },
@@ -498,7 +499,7 @@ Feature: Create-Retrieve-Update-Delete
       "description": null,
       "dummy": null,
       "dummyBoolean": null,
-      "dummyDate": "2015-03-01T10:00:00+00:00",
+      "dummyDate": "2018-12-01T13:12:00+00:00",
       "dummyFloat": null,
       "dummyPrice": null,
       "relatedDummy": null,
@@ -538,7 +539,7 @@ Feature: Create-Retrieve-Update-Delete
       "description": null,
       "dummy": null,
       "dummyBoolean": null,
-      "dummyDate": "2015-03-01T10:00:00+00:00",
+      "dummyDate": "2018-12-01T13:12:00+00:00",
       "dummyFloat": null,
       "dummyPrice": null,
       "relatedDummy": null,

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -30,6 +30,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Util\AttributesExtractor;
 use ApiPlatform\Core\Util\ClassInfoTrait;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;
@@ -72,6 +73,8 @@ final class IriConverter implements IriConverterInterface
         try {
             $parameters = $this->router->match($iri);
         } catch (RoutingExceptionInterface $e) {
+            throw new InvalidArgumentException(sprintf('No route matches "%s".', $iri), $e->getCode(), $e);
+        } catch (RequestExceptionInterface $e) {
             throw new InvalidArgumentException(sprintf('No route matches "%s".', $iri), $e->getCode(), $e);
         }
 

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -96,6 +97,20 @@ class IriConverterTest extends TestCase
 
         $converter = $this->getIriConverter($routerProphecy, null, $itemDataProviderProphecy);
         $converter->getItemFromIri('/users/3');
+    }
+
+    public function testGetItemFromIriWithDateLooksLikeUrl()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No route matches "28-01-2018 10:10".');
+
+        $itemDataProviderProphecy = $this->prophesize(ItemDataProviderInterface::class);
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->match('28-01-2018 10:10')->willThrow(new SuspiciousOperationException())->shouldBeCalledTimes(1);
+
+        $converter = $this->getIriConverter($routerProphecy, null, $itemDataProviderProphecy);
+        $converter->getItemFromIri('28-01-2018 10:10');
     }
 
     public function testGetItemFromIri()


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | 

If you want to reproduce here is a little insight on how to do it: 

Let's say you have this resource:

```yaml
MyNameSpace\Duration:
    shortName: 'Duration'
    itemOperations:
        get:
            method: 'GET'
            path: "/duration"
    collectionOperations:
        post:
            method: 'POST'
            path: "/duration"
            controller: 'MyDomaine/DurationAPIController'
            denormalization_context:
                dateinterval_format: 'P%dDT%hH%iM'
            normalization_context:
                dateinterval_format: 'P%dDT%hH%iM'

    properties:
        id:
            identifier: true
```

The duration is a VO that contains 3 fields.
The controller just use a librarie to calculate a start date + an interval to get an end date.

so we are sending this: 
```json
{"startDate":"28-01-2018 10:10","interval":"P0DT0H167M","business":true}
```
API-Platform tries to do `getItemFromIri` on each field that has a string, so startDate and interval, 
when the startDate is set to `28-01-2018 10:00` it does work properly and returns:

```json
{
    "interval": "P0DT0H167M",
    "id": "180128",
    "startDate": "2018-01-28T10:10:00+01:00",
    "endDate": "2018-01-29T11:47:00+01:00",
    "business": true
}
```

When adding 10 minutes to it, it does break with an `SuspiciousOperationException` since it does looks like an host from Symfony point of view.

