### PR TITLE
Integer denormalizer is numeric

### DIFF
--- a/src/Identifier/Normalizer/IntegerDenormalizer.php
+++ b/src/Identifier/Normalizer/IntegerDenormalizer.php
@@ -29,7 +29,7 @@ final class IntegerDenormalizer implements DenormalizerInterface, CacheableSuppo
      */
     public function supportsDenormalization($data, $type, $format = null): bool
     {
-        return Type::BUILTIN_TYPE_INT === $type && \is_string($data);
+        return Type::BUILTIN_TYPE_INT === $type && \ctype_digit($data);
     }
 
     /**

--- a/tests/Identifier/Normalizer/IntegerDenormalizerTest.php
+++ b/tests/Identifier/Normalizer/IntegerDenormalizerTest.php
@@ -31,6 +31,8 @@ class IntegerDenormalizerTest extends TestCase
         $normalizer = new IntegerDenormalizer();
         $this->assertTrue($normalizer->supportsDenormalization('1', 'int'));
         $this->assertFalse($normalizer->supportsDenormalization([], 'int'));
+        $this->assertFalse($normalizer->supportsDenormalization('kdunglas', 'int'));
+        $this->assertFalse($normalizer->supportsDenormalization('7.2', 'int'));
         $this->assertFalse($normalizer->supportsDenormalization('1', 'foo'));
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2116 (cc @blesenechal, please confirm)
| License       | MIT
| Doc PR        | N/A

Concrete case:

```php
final class ServerDataProvider implements ItemDataProviderInterface, RestrictedDataProviderInterface
{
    /**
     * @var EntityManagerInterface
     */
    private $entityManager;

    public function __construct(EntityManagerInterface $entityManager)
    {
        $this->entityManager = $entityManager;
    }

    /**
     * {@inheritdoc}
     */
    public function getItem(string $resourceClass, $id, ?string $operationName = null, array $context = []): ?Server
    {
        $serverRepository = $this->entityManager->getRepository(Server::class);
        $server = $serverRepository->find($id);

        if (null === $server) {
            $server = $serverRepository->findOneBy([
                'name' => $id,
            ]);
        }

        return $server;
    }

    /**
     * {@inheritdoc}
     */
    public function supports(string $resourceClass, ?string $operationName = null, array $context = []): bool
    {
        return Server::class === $resourceClass;
    }
}
```

This permit to try find a server by it's name if nothing is found with the id.

But in the current stable version, the string value will always be `0` because it's converted into string by the denormalizer.

Current workaround with a decorated service:

```php
/**
 * @see https://github.com/api-platform/core/issues/2116#issuecomment-437909022
 * @see https://github.com/api-platform/core/pull/2323
 */
final class IntegerDenormalizer implements DenormalizerInterface, CacheableSupportsMethodInterface
{
    /**
     * @var \ApiPlatform\Core\Identifier\Normalizer\IntegerDenormalizer
     */
    private $decorated;

    public function __construct(\ApiPlatform\Core\Identifier\Normalizer\IntegerDenormalizer $decorated)
    {
        $this->decorated = $decorated;
    }

    /**
     * {@inheritdoc}
     */
    public function denormalize($data, $class, $format = null, array $context = array())
    {
        return $this->decorated->denormalize($data, $class, $format, $context);
    }

    /**
     * {@inheritdoc}
     */
    public function supportsDenormalization($data, $type, $format = null)
    {
        return $this->decorated->supportsDenormalization($data, $type, $format) && \is_numeric($data);
    }

    public function hasCacheableSupportsMethod(): bool
    {
        return $this->decorated->hasCacheableSupportsMethod();
    }
}
```