### PR TITLE
Do not try do retrieve object in ItemNormalizer $context['resource_class'] is not defined

### DIFF
--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -32,7 +32,7 @@ class ItemNormalizer extends AbstractItemNormalizer
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         // Avoid issues with proxies if we populated the object
-        if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
+        if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE]) && isset($context['resource_class'])) {
             if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {
                 throw new InvalidArgumentException('Update is not allowed for this operation.');
             }

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -13,7 +13,17 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Serializer;
 
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Generic item normalizer.
@@ -24,6 +34,15 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  */
 class ItemNormalizer extends AbstractItemNormalizer
 {
+    private $logger;
+
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, LoggerInterface $logger = null)
+    {
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $itemDataProvider, $allowPlainIdentifiers);
+
+        $this->logger = $logger ?: new NullLogger();
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -32,12 +51,19 @@ class ItemNormalizer extends AbstractItemNormalizer
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         // Avoid issues with proxies if we populated the object
-        if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE]) && isset($context['resource_class'])) {
+        if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
             if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {
                 throw new InvalidArgumentException('Update is not allowed for this operation.');
             }
 
-            $this->updateObjectToPopulate($data, $context);
+            if (isset($context['resource_class'])) {
+                $this->updateObjectToPopulate($data, $context);
+            } else {
+                // See https://github.com/api-platform/core/pull/2326 to understand this message.
+                $this->logger->warning('The "resource_class" key is missing from the context.', [
+                    'context' => $context,
+                ]);
+            }
         }
 
         return parent::denormalize($data, $class, $format, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

We store some document in Elasticsearch and we hydrate them with the Serializer.
But the `ItemNormalizer` raise an error because the `resource_class` is not defined.
