### PR TITLE
(Very small improvement) Improves exception handling in ReadListener

### DIFF
--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -101,7 +101,7 @@ final class ReadListener
                 $data = $this->getSubresourceData($identifiers, $attributes, $context);
             }
         } catch (InvalidIdentifierException $e) {
-            $data = null;
+            throw new NotFoundHttpException('Not found, because of an invalid identifier configuration', $e);
         }
 
         if (null === $data) {


### PR DESCRIPTION
This PR improves exception handling to throw also previous Exception. I spent a lot of time, to figure out what's happening there: ReadListener should not mute Exceptions. It should also pass previously caught Exception (in line 104 like this commit or in line 108). I also improved NotFoundHttpException's message.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | hopefully
| Fixed tickets | no ticket for this
| License       | MIT
| Doc PR        | no doc needed

branch/version: 2.3 (because in 2.2 we are catching an even more common exception)