### PR TITLE
Add a default context in concerned normalizers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,6 @@
         "symfony/routing": "^3.3 || ^4.0",
         "symfony/security": "^3.0 || ^4.0",
         "symfony/security-bundle": "^3.4 || ^4.0",
-        "symfony/serializer": "^4.2@beta",
         "symfony/twig-bundle": "^3.4 || ^4.0",
         "symfony/validator": "^3.3 || ^4.0",
         "symfony/web-profiler-bundle": "^3.3 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "symfony/routing": "^3.3 || ^4.0",
         "symfony/security": "^3.0 || ^4.0",
         "symfony/security-bundle": "^3.4 || ^4.0",
+        "symfony/serializer": "^4.2@beta",
         "symfony/twig-bundle": "^3.4 || ^4.0",
         "symfony/validator": "^3.3 || ^4.0",
         "symfony/web-profiler-bundle": "^3.3 || ^4.0",

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -242,14 +242,14 @@ final class ItemNormalizer extends AbstractItemNormalizer
     private function isMaxDepthReached(array $attributesMetadata, string $class, string $attribute, array &$context): bool
     {
         if (
-            !($context[static::ENABLE_MAX_DEPTH] ?? false) ||
+            !($context[self::ENABLE_MAX_DEPTH] ?? false) ||
             !isset($attributesMetadata[$attribute]) ||
             null === $maxDepth = $attributesMetadata[$attribute]->getMaxDepth()
         ) {
             return false;
         }
 
-        $key = sprintf(static::DEPTH_KEY_PATTERN, $class, $attribute);
+        $key = sprintf(self::DEPTH_KEY_PATTERN, $class, $attribute);
         if (!isset($context[$key])) {
             $context[$key] = 1;
 

--- a/src/Hydra/Serializer/ErrorNormalizer.php
+++ b/src/Hydra/Serializer/ErrorNormalizer.php
@@ -27,17 +27,20 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
-    const FORMAT = 'jsonld';
-
     use ErrorNormalizerTrait;
+
+    const FORMAT = 'jsonld';
+    const TITLE = 'title';
 
     private $urlGenerator;
     private $debug;
+    private $defaultContext = [self::TITLE => 'An error occurred'];
 
-    public function __construct(UrlGeneratorInterface $urlGenerator, bool $debug = false)
+    public function __construct(UrlGeneratorInterface $urlGenerator, bool $debug = false, array $defaultContext = [])
     {
         $this->urlGenerator = $urlGenerator;
         $this->debug = $debug;
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     /**
@@ -48,7 +51,7 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
         $data = [
             '@context' => $this->urlGenerator->generate('api_jsonld_context', ['shortName' => 'Error']),
             '@type' => 'hydra:Error',
-            'hydra:title' => $context['title'] ?? 'An error occurred',
+            'hydra:title' => $context[self::TITLE] ?? $this->defaultContext[self::TITLE],
             'hydra:description' => $this->getErrorMessage($object, $context, $this->debug),
         ];
 

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -28,18 +28,23 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
     use ErrorNormalizerTrait;
 
     const FORMAT = 'jsonapi';
+    const TITLE = 'title';
 
     private $debug;
+    private $defaultContext = [
+        self::TITLE => 'An error occurred',
+    ];
 
-    public function __construct(bool $debug = false)
+    public function __construct(bool $debug = false, array $defaultContext = [])
     {
         $this->debug = $debug;
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     public function normalize($object, $format = null, array $context = [])
     {
         $data = [
-            'title' => $context['title'] ?? 'An error occurred',
+            'title' => $context[self::TITLE] ?? $this->defaultContext[self::TITLE],
             'description' => $this->getErrorMessage($object, $context, $this->debug),
         ];
 

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -42,9 +42,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
     private $componentsCache = [];
     private $resourceMetadataFactory;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ResourceMetadataFactoryInterface $resourceMetadataFactory)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ResourceMetadataFactoryInterface $resourceMetadataFactory, array $defaultContext = [])
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, null, null, false, $defaultContext);
 
         $this->resourceMetadataFactory = $resourceMetadataFactory;
     }

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -41,9 +41,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
     private $resourceMetadataFactory;
     private $contextBuilder;
 
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, ContextBuilderInterface $contextBuilder, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null)
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, ContextBuilderInterface $contextBuilder, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [])
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, null, false, $defaultContext);
 
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->contextBuilder = $contextBuilder;

--- a/src/Problem/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Problem/Serializer/ConstraintViolationListNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Problem\Serializer;
 
 use ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Converts {@see \Symfony\Component\Validator\ConstraintViolationListInterface} the API Problem spec (RFC 7807).
@@ -25,6 +26,20 @@ use ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer;
 final class ConstraintViolationListNormalizer extends AbstractConstraintViolationListNormalizer
 {
     const FORMAT = 'jsonproblem';
+    const TYPE = 'type';
+    const TITLE = 'title';
+
+    private $defaultContext = [
+        self::TYPE => 'https://tools.ietf.org/html/rfc2616#section-10',
+        self::TITLE => 'An error occurred',
+    ];
+
+    public function __construct(array $serializePayloadFields = null, NameConverterInterface $nameConverter = null, array $defaultContext = [])
+    {
+        parent::__construct($serializePayloadFields, $nameConverter);
+
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
+    }
 
     /**
      * {@inheritdoc}
@@ -34,8 +49,8 @@ final class ConstraintViolationListNormalizer extends AbstractConstraintViolatio
         list($messages, $violations) = $this->getMessagesAndViolations($object);
 
         return [
-            'type' => $context['type'] ?? 'https://tools.ietf.org/html/rfc2616#section-10',
-            'title' => $context['title'] ?? 'An error occurred',
+            'type' => $context[self::TYPE] ?? $this->defaultContext[self::TYPE],
+            'title' => $context[self::TITLE] ?? $this->defaultContext[self::TITLE],
             'detail' => $messages ? implode("\n", $messages) : (string) $object,
             'violations' => $violations,
         ];

--- a/src/Problem/Serializer/ErrorNormalizer.php
+++ b/src/Problem/Serializer/ErrorNormalizer.php
@@ -27,14 +27,21 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     const FORMAT = 'jsonproblem';
+    const TYPE = 'type';
+    const TITLE = 'title';
 
     use ErrorNormalizerTrait;
 
     private $debug;
+    private $defaultContext = [
+        self::TYPE => 'https://tools.ietf.org/html/rfc2616#section-10',
+        self::TITLE => 'An error occurred',
+    ];
 
-    public function __construct(bool $debug = false)
+    public function __construct(bool $debug = false, array $defaultContext = [])
     {
         $this->debug = $debug;
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     /**
@@ -43,8 +50,8 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
     public function normalize($object, $format = null, array $context = [])
     {
         $data = [
-            'type' => $context['type'] ?? 'https://tools.ietf.org/html/rfc2616#section-10',
-            'title' => $context['title'] ?? 'An error occurred',
+            'type' => $context[self::TYPE] ?? $this->defaultContext[self::TYPE],
+            'title' => $context[self::TITLE] ?? $this->defaultContext[self::TITLE],
             'detail' => $this->getErrorMessage($object, $context, $this->debug),
         ];
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -57,7 +57,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, array $defaultContext = [])
     {
-        if (!isset($defaultContext[self::CIRCULAR_REFERENCE_HANDLER])) {
+        if (!isset($defaultContext['circular_reference_handler'])) {
             $defaultContext['circular_reference_handler'] = function ($object) {
                 return $this->iriConverter->getIriFromItem($object);
             };

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -55,12 +55,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     protected $itemDataProvider;
     protected $allowPlainIdentifiers;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, array $defaultContext = [])
     {
-        $defaultContext = ['circular_reference_handler' => function ($object) {
-            return $this->iriConverter->getIriFromItem($object);
-        }];
-
+        if (!isset($defaultContext[self::CIRCULAR_REFERENCE_HANDLER])) {
+            $defaultContext['circular_reference_handler'] = function ($object) {
+                return $this->iriConverter->getIriFromItem($object);
+            };
+        }
         if (!interface_exists(AdvancedNameConverterInterface::class)) {
             $this->setCircularReferenceHandler($defaultContext['circular_reference_handler']);
         }

--- a/src/Swagger/Serializer/ApiGatewayNormalizer.php
+++ b/src/Swagger/Serializer/ApiGatewayNormalizer.php
@@ -27,11 +27,15 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 final class ApiGatewayNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
-    private $documentationNormalizer;
+    const API_GATEWAY = 'api_gateway';
 
-    public function __construct(NormalizerInterface $documentationNormalizer)
+    private $documentationNormalizer;
+    private $defaultContext = [self::API_GATEWAY => false];
+
+    public function __construct(NormalizerInterface $documentationNormalizer, $defaultContext = [])
     {
         $this->documentationNormalizer = $documentationNormalizer;
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     /**
@@ -44,7 +48,7 @@ final class ApiGatewayNormalizer implements NormalizerInterface, CacheableSuppor
             $data['basePath'] = '/';
         }
 
-        if (!($context['api_gateway'] ?? false)) {
+        if (!($context[self::API_GATEWAY] ?? $this->defaultContext[self::API_GATEWAY])) {
             return $data;
         }
 

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -49,6 +49,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     const SWAGGER_VERSION = '2.0';
     const FORMAT = 'json';
     const SWAGGER_DEFINITION_NAME = 'swagger_definition_name';
+    const BASE_URL = 'base_url';
 
     private $resourceMetadataFactory;
     private $propertyNameCollectionFactory;
@@ -72,11 +73,12 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     private $paginationClientEnabled;
     private $paginationClientEnabledParameterName;
     private $formatsProvider;
+    private $defaultContext = [self::BASE_URL => '/'];
 
     /**
      * @param ContainerInterface|FilterCollection|null $filterLocator The new filter locator or the deprecated filter collection
      */
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, OperationMethodResolverInterface $operationMethodResolver, OperationPathResolverInterface $operationPathResolver, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, $oauthEnabled = false, $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', array $oauthScopes = [], array $apiKeys = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, $paginationEnabled = true, $paginationPageParameterName = 'page', $clientItemsPerPage = false, $itemsPerPageParameterName = 'itemsPerPage', OperationAwareFormatsProviderInterface $formatsProvider = null, $paginationClientEnabled = false, $paginationClientEnabledParameterName = 'pagination')
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, OperationMethodResolverInterface $operationMethodResolver, OperationPathResolverInterface $operationPathResolver, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, $oauthEnabled = false, $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', array $oauthScopes = [], array $apiKeys = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, $paginationEnabled = true, $paginationPageParameterName = 'page', $clientItemsPerPage = false, $itemsPerPageParameterName = 'itemsPerPage', OperationAwareFormatsProviderInterface $formatsProvider = null, $paginationClientEnabled = false, $paginationClientEnabledParameterName = 'pagination', array $defaultContext = [])
     {
         if ($urlGenerator) {
             @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.1 and will be removed in 3.0.', UrlGeneratorInterface::class, __METHOD__), E_USER_DEPRECATED);
@@ -106,6 +108,8 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $this->formatsProvider = $formatsProvider;
         $this->paginationClientEnabled = $paginationClientEnabled;
         $this->paginationClientEnabledParameterName = $paginationClientEnabledParameterName;
+
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     /**
@@ -543,7 +547,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     {
         $doc = [
             'swagger' => self::SWAGGER_VERSION,
-            'basePath' => $context['base_url'] ?? '/',
+            'basePath' => $context[self::BASE_URL] ?? $this->defaultContext[self::BASE_URL],
             'info' => [
                 'title' => $documentation->getTitle(),
                 'version' => $documentation->getVersion(),


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Introduces a default context for all our normalizers, similarly to the one introduced in Symfony 4.2 (symfony/symfony#28709).
Will allow to also use the new config option (https://github.com/symfony/symfony/pull/28927) with API Platform.