### PR TITLE
Allow strings for single serialization groups

### DIFF
--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -136,13 +136,14 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
      * - From metadata of the given operation ("collection_operation_name" and "item_operation_name" keys).
      * - From metadata of the current resource.
      *
-     *
      * @return (string[]|null)[]
      */
     private function getEffectiveSerializerGroups(array $options, string $resourceClass): array
     {
         if (isset($options['serializer_groups'])) {
-            return [$options['serializer_groups'], $options['serializer_groups']];
+            $groups = (array) $options['serializer_groups'];
+
+            return [$groups, $groups];
         }
 
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
@@ -160,12 +161,14 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
             $denormalizationContext = $resourceMetadata->getAttribute('denormalization_context');
         }
 
-        return [$normalizationContext['groups'] ?? null, $denormalizationContext['groups'] ?? null];
+        return [
+            isset($normalizationContext['groups']) ? (array) $normalizationContext['groups'] : null,
+            isset($denormalizationContext['groups']) ? (array) $denormalizationContext['groups'] : null,
+        ];
     }
 
     /**
      * Gets the serializer groups defined on a property.
-     *
      *
      * @return string[]
      */
@@ -185,7 +188,6 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
     /**
      * Gets the serializer groups defined in a resource.
      *
-     *
      * @return string[]
      */
     private function getResourceSerializerGroups(string $resourceClass): array
@@ -193,11 +195,10 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
         $serializerClassMetadata = $this->serializerClassMetadataFactory->getMetadataFor($resourceClass);
 
         $groups = [];
-
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            $groups = array_merge($groups, $serializerAttributeMetadata->getGroups());
+            $groups += array_flip($serializerAttributeMetadata->getGroups());
         }
 
-        return array_unique($groups);
+        return array_keys($groups);
     }
 }

--- a/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
@@ -50,16 +50,19 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $this->assertInstanceOf(PropertyMetadataFactoryInterface::class, $serializerPropertyMetadataFactory);
     }
 
-    public function testCreate()
+    /**
+     * @dataProvider groupsProvider
+     */
+    public function testCreate($readGroups, $writeGroups)
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $dummyResourceMetadata = (new ResourceMetadata())
             ->withAttributes([
                 'normalization_context' => [
-                    AbstractNormalizer::GROUPS => ['dummy_read'],
+                    AbstractNormalizer::GROUPS => $readGroups,
                 ],
                 'denormalization_context' => [
-                    AbstractNormalizer::GROUPS => ['dummy_write'],
+                    AbstractNormalizer::GROUPS => $writeGroups,
                 ],
             ]);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($dummyResourceMetadata)->shouldBeCalled();
@@ -123,6 +126,14 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $this->assertInstanceOf(PropertyMetadata::class, $actual[2]);
         $this->assertFalse($actual[2]->isReadable());
         $this->assertFalse($actual[2]->isWritable());
+    }
+
+    public function groupsProvider(): array
+    {
+        return [
+            [['dummy_read'], ['dummy_write']],
+            ['dummy_read', 'dummy_write'],
+        ];
     }
 
     public function testCreateInherited()


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Prevent an error when using the following configuration (using strings in this case is supported in Symfony Serializer since the latest version):

```php
/**
 * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
 * @ApiResource(
 *     normalizationContext={"groups": "user:read"}
 * )
 */
```

This PR fixes a performance warning thrown by PHP Inspections.