### PR TITLE
Graphql: item normalizer improvement

### DIFF
--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -93,7 +93,7 @@ final class ItemNormalizer extends BaseItemNormalizer
 	 * Return object of passed type with all empty fields except id.
 	 * Necessary to speed up serialization/deserialization on Webonyx side.
 	 *
-	 * @param $originalObject
+	 * @param object $originalObject
 	 *
 	 * @return object
 	 */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When I explored why Graphql is so slow in my project, I noticed that normalizer has significant problem - it is serializing passed object to string here:
https://github.com/api-platform/core/blob/822c78c946db1fc037eaf6e11a2b2faaa023b72b/src/GraphQl/Serializer/ItemNormalizer.php#L43
It's a very expensive operation in real systems because object graph can be very big. Especially this is expensive when the object must be deserialized from this field later. Also I noticed, that api-platform really doesn't need full object deserialized from this field - it needs only class and identifier.

So my PR fixes this problem - I do minimal copy of object. In my project it speed up system in many times.