### PR TITLE
Correctly expose properties[] as a collection parameter

### DIFF
--- a/src/Serializer/Filter/GroupFilter.php
+++ b/src/Serializer/Filter/GroupFilter.php
@@ -69,6 +69,7 @@ final class GroupFilter implements FilterInterface
             "$this->parameterName[]" => [
                 'property' => null,
                 'type' => 'string',
+                'is_collection' => true,
                 'required' => false,
             ],
         ];

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -71,6 +71,7 @@ final class PropertyFilter implements FilterInterface
             "$this->parameterName[]" => [
                 'property' => null,
                 'type' => 'string',
+                'is_collection' => true,
                 'required' => false,
             ],
         ];

--- a/tests/Serializer/Filter/GroupFilterTest.php
+++ b/tests/Serializer/Filter/GroupFilterTest.php
@@ -118,6 +118,7 @@ class GroupFilterTest extends TestCase
             'custom_groups[]' => [
                 'property' => null,
                 'type' => 'string',
+                'is_collection' => true,
                 'required' => false,
             ],
         ];

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -128,6 +128,7 @@ class PropertyFilterTest extends TestCase
             'custom_properties[]' => [
                 'property' => null,
                 'type' => 'string',
+                'is_collection' => true,
                 'required' => false,
             ],
         ];


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2370
| License       | MIT

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

This fixes #2370 in which properties[] is not documented as an array of strings as expected.