### PR TITLE
Temporary fix for swagger-ui executing query too fast

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -60,8 +60,11 @@ window.onload = () => {
                 }
             }
 
-            op.querySelector('.execute').click();
-            op.scrollIntoView();
+            // Wait input values to be populated before executing the query
+            setTimeout(function(){
+                op.querySelector('.execute').click();
+                op.scrollIntoView();
+            }, 500);
         });
 
         tryOutObserver.observe(document, {childList: true, subtree: true});


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

When you access your resource in swagger with an id the execute action is triggered too fast.
We get an error because the input value isn't already updated.

For example, if you try a query like this one:
http://localhost/{entityName}/{id}

You will get an error in your input.

This fix is only intended to be a workaround.
To fix this we should maybe have a better way to handle with the onComplete in swagger ui which should be fired up when all the ajax calls are done.

We could use MutationObservers too but we don't know when we should fire up the execute click.

Feel free to reply if you have another idea.
Thank you

#SymfonyConHackday2018