### PR TITLE
Use default value of PHP properties to Swagger doc

### DIFF
--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -77,12 +77,12 @@ final class ApiProperty
     public $identifier;
 
     /**
-     * @var string
+     * @var mixed
      */
     public $default;
 
     /**
-     * @var string
+     * @var mixed
      */
     public $example;
 

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -77,6 +77,16 @@ final class ApiProperty
     public $identifier;
 
     /**
+     * @var string
+     */
+    public $default;
+
+    /**
+     * @var string
+     */
+    public $example;
+
+    /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var string

--- a/src/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
+++ b/src/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
@@ -76,6 +76,13 @@ final class DoctrineOrmPropertyMetadataFactory implements PropertyMetadataFactor
             $propertyMetadata = $propertyMetadata->withIdentifier(false);
         }
 
+        if ($doctrineClassMetadata instanceof ClassMetadataInfo && \in_array($property, $doctrineClassMetadata->getFieldNames(), true)) {
+            $fieldMapping = $doctrineClassMetadata->getFieldMapping($property);
+            if (\array_key_exists('options', $fieldMapping) && \array_key_exists('default', $fieldMapping['options'])) {
+                $propertyMetadata = $propertyMetadata->withDefault($fieldMapping['options']['default']);
+            }
+        }
+
         return $propertyMetadata;
     }
 }

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
@@ -74,6 +74,10 @@
             <argument type="service" id="api_platform.metadata.property.metadata_factory.cached.inner" />
         </service>
 
+        <service id="api_platform.metadata.property.metadata_factory.default_property" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="30" class="ApiPlatform\Core\Metadata\Property\Factory\DefaultPropertyMetadataFactory" public="false">
+            <argument type="service" id="api_platform.metadata.property.metadata_factory.default_property.inner" />
+        </service>
+
         <service id="ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface" alias="api_platform.metadata.property.metadata_factory" />
 
         <!-- Cache -->

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -176,6 +176,18 @@ final class SchemaFactory implements SchemaFactoryInterface
             $propertySchema['externalDocs'] = ['url' => $iri];
         }
 
+        if (!isset($propertySchema['default']) && null !== $default = $propertyMetadata->getDefault()) {
+            $propertySchema['default'] = $default;
+        }
+
+        if (!isset($propertySchema['example']) && null !== $example = $propertyMetadata->getExample()) {
+            $propertySchema['example'] = $example;
+        }
+
+        if (!isset($propertySchema['example']) && isset($propertySchema['default'])) {
+            $propertySchema['example'] = $propertySchema['default'];
+        }
+
         $valueSchema = [];
         if (null !== $type = $propertyMetadata->getType()) {
             $isCollection = $type->isCollection();

--- a/src/Metadata/Property/Factory/AnnotationPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationPropertyMetadataFactory.php
@@ -112,12 +112,16 @@ final class AnnotationPropertyMetadataFactory implements PropertyMetadataFactory
                 $annotation->identifier,
                 $annotation->iri,
                 null,
-                $annotation->attributes
+                $annotation->attributes,
+                null,
+                null,
+                $annotation->default,
+                $annotation->example
             );
         }
 
         $propertyMetadata = $parentPropertyMetadata;
-        foreach ([['get', 'description'], ['is', 'readable'], ['is', 'writable'], ['is', 'readableLink'], ['is', 'writableLink'], ['is', 'required'], ['get', 'iri'], ['is', 'identifier'], ['get', 'attributes']] as $property) {
+        foreach ([['get', 'description'], ['is', 'readable'], ['is', 'writable'], ['is', 'readableLink'], ['is', 'writableLink'], ['is', 'required'], ['get', 'iri'], ['is', 'identifier'], ['get', 'attributes'], ['get', 'default'], ['get', 'example']] as $property) {
             if (null !== $value = $annotation->{$property[1]}) {
                 $propertyMetadata = $this->createWith($propertyMetadata, $property, $value);
             }

--- a/src/Metadata/Property/Factory/DefaultPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/DefaultPropertyMetadataFactory.php
@@ -48,7 +48,7 @@ final class DefaultPropertyMetadataFactory implements PropertyMetadataFactoryInt
 
         $defaultProperties = $reflectionClass->getDefaultProperties();
 
-        if (!array_key_exists($property, $defaultProperties) || null === ($defaultProperty = $defaultProperties[$property])) {
+        if (!\array_key_exists($property, $defaultProperties) || null === ($defaultProperty = $defaultProperties[$property])) {
             return $propertyMetadata;
         }
 

--- a/src/Metadata/Property/Factory/DefaultPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/DefaultPropertyMetadataFactory.php
@@ -16,7 +16,10 @@ namespace ApiPlatform\Core\Metadata\Property\Factory;
 use ApiPlatform\Core\Exception\PropertyNotFoundException;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 
-class DefaultPropertyMetadataFactory implements PropertyMetadataFactoryInterface
+/**
+ * Populates defaults values of the ressource properties using the default PHP values of properties.
+ */
+final class DefaultPropertyMetadataFactory implements PropertyMetadataFactoryInterface
 {
     private $decorated;
 
@@ -45,16 +48,10 @@ class DefaultPropertyMetadataFactory implements PropertyMetadataFactoryInterface
 
         $defaultProperties = $reflectionClass->getDefaultProperties();
 
-        if (array_key_exists($property, $defaultProperties) && null !== ($defaultProperty = $defaultProperties[$property])) {
-            $attributes = $propertyMetadata->getAttributes() ?? [];
-            $attributes['swagger_context']['default'] = $defaultProperty;
-            if (!isset($attributes['swagger_context']['example'])) {
-                $attributes['swagger_context']['example'] = $defaultProperty;
-            }
-
-            return $propertyMetadata->withAttributes($attributes);
+        if (!array_key_exists($property, $defaultProperties) || null === ($defaultProperty = $defaultProperties[$property])) {
+            return $propertyMetadata;
         }
 
-        return $propertyMetadata;
+        return $propertyMetadata->withDefault($defaultProperty);
     }
 }

--- a/src/Metadata/Property/Factory/DefaultPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/DefaultPropertyMetadataFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\Property\Factory;
+
+use ApiPlatform\Core\Exception\PropertyNotFoundException;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+
+class DefaultPropertyMetadataFactory implements PropertyMetadataFactoryInterface
+{
+    private $decorated;
+
+    public function __construct(PropertyMetadataFactoryInterface $decorated = null)
+    {
+        $this->decorated = $decorated;
+    }
+
+    public function create(string $resourceClass, string $property, array $options = []): PropertyMetadata
+    {
+        if (null === $this->decorated) {
+            $propertyMetadata = new PropertyMetadata();
+        } else {
+            try {
+                $propertyMetadata = $this->decorated->create($resourceClass, $property, $options);
+            } catch (PropertyNotFoundException $propertyNotFoundException) {
+                $propertyMetadata = new PropertyMetadata();
+            }
+        }
+
+        try {
+            $reflectionClass = new \ReflectionClass($resourceClass);
+        } catch (\ReflectionException $reflectionException) {
+            return $propertyMetadata;
+        }
+
+        $defaultProperties = $reflectionClass->getDefaultProperties();
+
+        if (array_key_exists($property, $defaultProperties) && null !== ($defaultProperty = $defaultProperties[$property])) {
+            $attributes = $propertyMetadata->getAttributes() ?? [];
+            $attributes['swagger_context']['default'] = $defaultProperty;
+            if (!isset($attributes['swagger_context']['example'])) {
+                $attributes['swagger_context']['example'] = $defaultProperty;
+            }
+
+            return $propertyMetadata->withAttributes($attributes);
+        }
+
+        return $propertyMetadata;
+    }
+}

--- a/src/Metadata/Property/PropertyMetadata.php
+++ b/src/Metadata/Property/PropertyMetadata.php
@@ -38,8 +38,16 @@ final class PropertyMetadata
     private $attributes;
     private $subresource;
     private $initializable;
+    /**
+     * @var null
+     */
+    private $default;
+    /**
+     * @var null
+     */
+    private $example;
 
-    public function __construct(Type $type = null, string $description = null, bool $readable = null, bool $writable = null, bool $readableLink = null, bool $writableLink = null, bool $required = null, bool $identifier = null, string $iri = null, $childInherited = null, array $attributes = null, SubresourceMetadata $subresource = null, bool $initializable = null)
+    public function __construct(Type $type = null, string $description = null, bool $readable = null, bool $writable = null, bool $readableLink = null, bool $writableLink = null, bool $required = null, bool $identifier = null, string $iri = null, $childInherited = null, array $attributes = null, SubresourceMetadata $subresource = null, bool $initializable = null, $default = null, $example = null)
     {
         $this->type = $type;
         $this->description = $description;
@@ -57,6 +65,8 @@ final class PropertyMetadata
         $this->attributes = $attributes;
         $this->subresource = $subresource;
         $this->initializable = $initializable;
+        $this->default = $default;
+        $this->example = $example;
     }
 
     /**
@@ -346,6 +356,44 @@ final class PropertyMetadata
     {
         $metadata = clone $this;
         $metadata->initializable = $initializable;
+
+        return $metadata;
+    }
+
+    /**
+     * Returns the default value of the property or NULL if the property doesn't have a default value.
+     */
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    /**
+     * Returns a new instance with the given default value for the property.
+     */
+    public function withDefault($default): self
+    {
+        $metadata = clone $this;
+        $metadata->default = $default;
+
+        return $metadata;
+    }
+
+    /**
+     * Returns an example of the value of the property.
+     */
+    public function getExample()
+    {
+        return $this->example;
+    }
+
+    /**
+     * Returns a new instance with the given example.
+     */
+    public function withExample($example): self
+    {
+        $metadata = clone $this;
+        $metadata->example = $example;
 
         return $metadata;
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -936,6 +936,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.resource.metadata_factory.xml',
             'api_platform.metadata.resource.name_collection_factory.cached',
             'api_platform.metadata.resource.name_collection_factory.xml',
+            'api_platform.metadata.property.metadata_factory.default_property',
             'api_platform.negotiator',
             'api_platform.operation_method_resolver',
             'api_platform.operation_path_resolver.custom',

--- a/tests/Fixtures/TestBundle/Entity/DummyPropertyWithDefaultValue.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyPropertyWithDefaultValue.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * DummyPropertyWithDefaultValue.
+ *
+ * @ORM\Entity
+ *
+ * @ApiResource(attributes={
+ *     "normalization_context"={"groups"={"dummy_read"}},
+ *     "denormalization_context"={"groups"={"dummy_write"}}
+ * })
+ */
+class DummyPropertyWithDefaultValue
+{
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @Groups("dummy_read")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(nullable=true)
+     *
+     * @Groups({"dummy_read", "dummy_write"})
+     */
+    public $foo = 'foo';
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyPropertyWithDefaultValue.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyPropertyWithDefaultValue.php
@@ -50,6 +50,13 @@ class DummyPropertyWithDefaultValue
     public $foo = 'foo';
 
     /**
+     * @var string A dummy with a Doctrine default options
+     *
+     * @ORM\Column(options={"default"="default value"})
+     */
+    public $dummyDefaultOption;
+
+    /**
      * @return int
      */
     public function getId()

--- a/tests/Metadata/Property/Factory/DefaultPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/DefaultPropertyMetadataFactoryTest.php
@@ -27,36 +27,7 @@ class DefaultPropertyMetadataFactoryTest extends TestCase
         $factory = new DefaultPropertyMetadataFactory();
         $metadata = $factory->create(DummyPropertyWithDefaultValue::class, 'foo');
 
-        $shouldBe = [
-            'swagger_context' => [
-                'default' => 'foo',
-                'example' => 'foo',
-            ],
-        ];
-        $this->assertEquals($metadata->getAttributes(), $shouldBe);
-    }
-
-    public function testCreateShouldNotOverrideExampleIfAlreadyPresent()
-    {
-        $decoratedReturnProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $decoratedReturnProphecy->create(DummyPropertyWithDefaultValue::class, 'foo', [])
-            ->willReturn(new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false, null, null, [
-                'swagger_context' => [
-                    'example' => 'foo example',
-                ],
-            ]))
-            ->shouldBeCalled();
-
-        $factory = new DefaultPropertyMetadataFactory($decoratedReturnProphecy->reveal());
-        $metadata = $factory->create(DummyPropertyWithDefaultValue::class, 'foo');
-
-        $shouldBe = [
-            'swagger_context' => [
-                'default' => 'foo',
-                'example' => 'foo example',
-            ],
-        ];
-        $this->assertEquals($metadata->getAttributes(), $shouldBe);
+        $this->assertEquals($metadata->getDefault(), 'foo');
     }
 
     public function testClassDoesNotExist()

--- a/tests/Metadata/Property/Factory/DefaultPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/DefaultPropertyMetadataFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Property\Factory;
+
+use ApiPlatform\Core\Exception\PropertyNotFoundException;
+use ApiPlatform\Core\Metadata\Property\Factory\DefaultPropertyMetadataFactory;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyPropertyWithDefaultValue;
+use PHPUnit\Framework\TestCase;
+
+class DefaultPropertyMetadataFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $factory = new DefaultPropertyMetadataFactory();
+        $metadata = $factory->create(DummyPropertyWithDefaultValue::class, 'foo');
+
+        $shouldBe = [
+            'swagger_context' => [
+                'default' => 'foo',
+                'example' => 'foo',
+            ],
+        ];
+        $this->assertEquals($metadata->getAttributes(), $shouldBe);
+    }
+
+    public function testCreateShouldNotOverrideExampleIfAlreadyPresent()
+    {
+        $decoratedReturnProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $decoratedReturnProphecy->create(DummyPropertyWithDefaultValue::class, 'foo', [])
+            ->willReturn(new PropertyMetadata(null, 'A dummy', true, true, null, null, false, false, null, null, [
+                'swagger_context' => [
+                    'example' => 'foo example',
+                ],
+            ]))
+            ->shouldBeCalled();
+
+        $factory = new DefaultPropertyMetadataFactory($decoratedReturnProphecy->reveal());
+        $metadata = $factory->create(DummyPropertyWithDefaultValue::class, 'foo');
+
+        $shouldBe = [
+            'swagger_context' => [
+                'default' => 'foo',
+                'example' => 'foo example',
+            ],
+        ];
+        $this->assertEquals($metadata->getAttributes(), $shouldBe);
+    }
+
+    public function testClassDoesNotExist()
+    {
+        $factory = new DefaultPropertyMetadataFactory();
+        $metadata = $factory->create('\DoNotExist', 'foo');
+
+        $this->assertEquals(new PropertyMetadata(), $metadata);
+    }
+
+    public function testPropertyDoesNotExist()
+    {
+        $decoratedProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $decoratedProphecy->create(DummyPropertyWithDefaultValue::class, 'doNotExist', [])->willThrow(new PropertyNotFoundException());
+
+        $factory = new DefaultPropertyMetadataFactory($decoratedProphecy->reveal());
+        $metadata = $factory->create(DummyPropertyWithDefaultValue::class, 'doNotExist');
+
+        $this->assertEquals(new PropertyMetadata(), $metadata);
+    }
+}

--- a/tests/Metadata/Property/PropertyMetadataTest.php
+++ b/tests/Metadata/Property/PropertyMetadataTest.php
@@ -82,6 +82,14 @@ class PropertyMetadataTest extends TestCase
         $newMetadata = $metadata->withInitializable(true);
         $this->assertNotSame($metadata, $newMetadata);
         $this->assertTrue($newMetadata->isInitializable());
+
+        $newMetadata = $metadata->withDefault('foobar');
+        $this->assertNotSame($metadata, $newMetadata);
+        $this->assertEquals('foobar', $newMetadata->getDefault());
+
+        $newMetadata = $metadata->withExample('foobarexample');
+        $this->assertNotSame($metadata, $newMetadata);
+        $this->assertEquals('foobarexample', $newMetadata->getExample());
     }
 
     public function testShouldReturnRequiredFalseWhenRequiredTrueIsSetButMaskedByWritableFalse()

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -2966,6 +2966,7 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $result = $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT);
 
+        $this->assertIsArray($result);
         $this->assertEquals($expectedDefault, $result['definitions']['DummyPropertyWithDefaultValue']['properties']['foo']['default']);
         $this->assertEquals($expectedExample, $result['definitions']['DummyPropertyWithDefaultValue']['properties']['foo']['example']);
     }

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -2952,11 +2952,6 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(DummyPropertyWithDefaultValue::class, 'foo')->shouldBeCalled()->willReturn($propertyMetadata);
-        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->isResourceClass(DummyPropertyWithDefaultValue::class)->willReturn(true);
-
-        $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
-        $operationMethodResolverProphecy->getItemOperationMethod(DummyPropertyWithDefaultValue::class, 'get')->shouldBeCalled()->willReturn('GET');
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
@@ -2964,8 +2959,8 @@ class DocumentationNormalizerV2Test extends TestCase
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $resourceClassResolverProphecy->reveal(),
-            $operationMethodResolverProphecy->reveal(),
+            null,
+            null,
             $operationPathResolver
         );
 

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -45,6 +45,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\InputDto;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\OutputDto;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Answer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyPropertyWithDefaultValue;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Question;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use PHPUnit\Framework\TestCase;
@@ -2933,5 +2934,70 @@ class DocumentationNormalizerV2Test extends TestCase
         ];
 
         $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
+    }
+
+    /**
+     * @dataProvider propertyWithDefaultProvider
+     */
+    public function testNormalizeWithDefaultProperty($expectedDefault, $expectedExample, PropertyMetadata $propertyMetadata)
+    {
+        $documentation = new Documentation(new ResourceNameCollection([DummyPropertyWithDefaultValue::class]));
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(DummyPropertyWithDefaultValue::class, [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['foo']));
+
+        $dummyMetadata = new ResourceMetadata('DummyPropertyWithDefaultValue', null, null, ['get' => ['method' => 'GET']]);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyPropertyWithDefaultValue::class)->shouldBeCalled()->willReturn($dummyMetadata);
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(DummyPropertyWithDefaultValue::class, 'foo')->shouldBeCalled()->willReturn($propertyMetadata);
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(DummyPropertyWithDefaultValue::class)->willReturn(true);
+
+        $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
+        $operationMethodResolverProphecy->getItemOperationMethod(DummyPropertyWithDefaultValue::class, 'get')->shouldBeCalled()->willReturn('GET');
+
+        $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
+
+        $normalizer = new DocumentationNormalizer(
+            $resourceMetadataFactoryProphecy->reveal(),
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $operationMethodResolverProphecy->reveal(),
+            $operationPathResolver
+        );
+
+        $result = $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT);
+
+        $this->assertEquals($expectedDefault, $result['definitions']['DummyPropertyWithDefaultValue']['properties']['foo']['default']);
+        $this->assertEquals($expectedExample, $result['definitions']['DummyPropertyWithDefaultValue']['properties']['foo']['example']);
+    }
+
+    public function propertyWithDefaultProvider()
+    {
+        yield 'default should be use for the example if it is not defined' => [
+            'default name',
+            'default name',
+            $this->createStringPropertyMetada('default name'),
+        ];
+
+        yield 'should use default and example if they are defined' => [
+            'default name',
+            'example name',
+            $this->createStringPropertyMetada('default name', 'example name'),
+        ];
+
+        yield 'should use default and example from swagger context if they are defined' => [
+            'swagger default',
+            'swagger example',
+            $this->createStringPropertyMetada('default name', 'example name', ['swagger_context' => ['default' => 'swagger default', 'example' => 'swagger example']]),
+        ];
+    }
+
+    protected function createStringPropertyMetada($default = null, $example = null, $attributes = []): PropertyMetadata
+    {
+        return new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), null, true, true, true, true, false, false, null, null, $attributes, null, null, $default, $example);
     }
 }


### PR DESCRIPTION

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2363
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

Add default and example information to swagger context if php properties
have default values so the exemple documentation section use these values.

With a class

```
<?php

namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiProperty;
use ApiPlatform\Core\Annotation\ApiResource;
use Doctrine\ORM\Mapping as ORM;
use Ramsey\Uuid\UuidInterface;
use Symfony\Component\Serializer\Annotation\Groups;

/**
 * @ORM\Entity
 * @ApiResource(
 *     normalizationContext={"groups": {"person:read"}}
 * )
 * @ApiResource
 */
class Person
{
    /**
     * @var UuidInterface
     *
     * @ApiProperty(identifier=true)
     * @Groups({"person:read"})
     *
     * @ORM\Id
     * @ORM\Column(type="uuid", unique=true)
     * @ORM\GeneratedValue(strategy="CUSTOM")
     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
     */
    public $code;

    /**
     * @var bool
     *
     * @Groups({"person:read", "person:write"})
     *
     * @ORM\Column(type="boolean", options={"default" : false})
     */
    public $isActive = true;

    /**
     * @var integer
     *
     * @Groups({"person:read", "person:write"})
     *
     * @ORM\Column(type="integer", nullable=true)
     */
    public $int = 100;

    /**
     * @var array
     *
     * @Groups({"person:read", "person:write"})
     *
     * @ORM\Column(type="json_array", nullable=true)
     */
    public $array = ['aa', 'bb'];

    /**
     * @var string
     *
     * @ApiProperty(
     *     attributes={
     *         "swagger_context"={
     *             "example"="example string"
     *         }
     *     }
     * )
     *
     * @Groups({"person:read", "person:write"})
     *
     * @ORM\Column(nullable=true)
     */
    public $string = 'aaaaaa';
}
```

The swagger documentation displays

![api_platform_default_value](https://user-images.githubusercontent.com/163941/50059801-c7761f80-018b-11e9-8dc3-26860121a461.png)


