### PR TITLE
Fix exclude app cache path for PHP-CS-Fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ HEADER;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude('tests/Fixtures/app/cache')
+    ->exclude('tests/Fixtures/app/var')
 ;
 
 return PhpCsFixer\Config::create()


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

We don't notice the problem in our CI, because the PHP-CS-Fixer job is always separate.