### PR TITLE
Added swagger description to property filter

### DIFF
--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -67,12 +67,26 @@ final class PropertyFilter implements FilterInterface
      */
     public function getDescription(string $resourceClass): array
     {
+        $swaggerExample = sprintf('%s[]={propertyName}&%s[]={anotherPropertyName}&%s[{nestedPropertyParent}][]={nestedProperty}',
+            $this->parameterName,
+            $this->parameterName,
+            $this->parameterName
+        );
+
         return [
             "$this->parameterName[]" => [
                 'property' => null,
                 'type' => 'string',
                 'is_collection' => true,
                 'required' => false,
+                'swagger' => [
+                    'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$swaggerExample,
+                    'name' => $this->parameterName,
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                    ],
+                ],
             ],
         ];
     }

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -130,6 +130,14 @@ class PropertyFilterTest extends TestCase
                 'type' => 'string',
                 'is_collection' => true,
                 'required' => false,
+                'swagger' => [
+                    'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
+                    'name' => 'custom_properties',
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I think this qualifies as a bugfix because the only thing it really only does is add some swagger docs to the `PropertyFilter`. That's not really something that has to wait for a new minor release imho 😄 