### PR TITLE
Fix Doctrine DataPersister priority

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -12,7 +12,7 @@
         <service id="api_platform.doctrine.orm.data_persister" class="ApiPlatform\Core\Bridge\Doctrine\Common\DataPersister" public="false">
             <argument type="service" id="doctrine" />
 
-            <tag name="api_platform.data_persister" />
+            <tag name="api_platform.data_persister" priority="-1000" />
         </service>
 
         <service id="api_platform.doctrine.orm.collection_data_provider" public="false" abstract="true">


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        |n/a

This allows to leverage the `autoconfigure` flag when creating custom data providers. Without this explicit priority, the default provider can be registered before custom ones, which is counter-intuitive and annoying.

This is a potential (tiny) BC break (it's why I not targeted 2.3), but I think it is worth it.