### PR TITLE
Allow to disable input and output class

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -37,14 +37,14 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("filters", type="string[]"),
  *     @Attribute("graphql", type="array"),
  *     @Attribute("hydraContext", type="array"),
- *     @Attribute("inputClass", type="string"),
+ *     @Attribute("inputClass", type="mixed"),
  *     @Attribute("iri", type="string"),
  *     @Attribute("itemOperations", type="array"),
  *     @Attribute("maximumItemsPerPage", type="int"),
  *     @Attribute("mercure", type="mixed"),
  *     @Attribute("normalizationContext", type="array"),
  *     @Attribute("order", type="array"),
- *     @Attribute("outputClass", type="string"),
+ *     @Attribute("outputClass", type="mixed"),
  *     @Attribute("paginationClientEnabled", type="bool"),
  *     @Attribute("paginationClientItemsPerPage", type="bool"),
  *     @Attribute("paginationClientPartial", type="bool"),
@@ -277,14 +277,14 @@ final class ApiResource
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
-     * @var string
+     * @var string|false
      */
     private $inputClass;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
-     * @var string
+     * @var string|false
      */
     private $outputClass;
 

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -66,6 +66,7 @@ final class DeserializeListener
             $request->isMethodSafe(false)
             || 'DELETE' === $method
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
+            || false === ($attributes['input_class'] ?? null)
             || !$attributes['receive']
             || (
                     '' === ($requestContent = $request->getContent())

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -124,6 +124,27 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
+    public function testDoNotCallWhenInputClassDisabled()
+    {
+        $eventProphecy = $this->prophesize(GetResponseEvent::class);
+
+        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_input_class' => false]);
+        $request->setMethod('POST');
+        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->deserialize()->shouldNotBeCalled();
+
+        $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
+        $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->shouldNotBeCalled();
+
+        $formatsProviderProphecy = $this->prophesize(FormatsProviderInterface::class);
+        $formatsProviderProphecy->getFormatsFromAttributes(Argument::type('array'))->shouldNotBeCalled();
+
+        $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), $formatsProviderProphecy->reveal());
+        $listener->onKernelRequest($eventProphecy->reveal());
+    }
+
     /**
      * @dataProvider methodProvider
      */

--- a/tests/EventListener/SerializeListenerTest.php
+++ b/tests/EventListener/SerializeListenerTest.php
@@ -138,6 +138,26 @@ class SerializeListenerTest extends TestCase
         $listener->onKernelView($eventProphecy->reveal());
     }
 
+    public function testSerializeCollectionOperationWithOutputClassDisabled()
+    {
+        $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'collection_operation_name' => 'post', 'output_class' => false];
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get', '_api_output_class' => false]);
+        $request->setRequestFormat('xml');
+
+        $eventProphecy = $this->prophesize(GetResponseForControllerResultEvent::class);
+        $eventProphecy->getControllerResult()->willReturn(new \stdClass())->shouldBeCalled();
+        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
+        $eventProphecy->setControllerResult('')->shouldBeCalled();
+
+        $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
+        $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), true, Argument::type('array'))->willReturn($expectedContext)->shouldBeCalled();
+
+        $listener = new SerializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal());
+        $listener->onKernelView($eventProphecy->reveal());
+    }
+
     public function testSerializeItemOperation()
     {
         $expectedContext = ['request_uri' => '', 'resource_class' => 'Foo', 'item_operation_name' => 'get'];


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

This PR allows to set the new `input_class` and `output_class` attributes to `false`. It hints API Platform that the corresponding operation(s) will respectively expect an empty input, or will return nothing.

This is especially convenient when creating an endpoint that will return nothing. My use case: I create have a `POST /reset-password` endpoint that sends a token by mail. This endpoint returns `202 Accepted` and nothing else.

The next step will be to support `input_class` and `output_class` (including this new option) in the documentation normalizers.