### PR TITLE
Allow to set the status code through an attribute

### DIFF
--- a/src/EventListener/RespondListener.php
+++ b/src/EventListener/RespondListener.php
@@ -64,16 +64,20 @@ final class RespondListener
             }
         }
 
+        $status = null;
         if ($this->resourceMetadataFactory && $attributes = RequestAttributesExtractor::extractAttributes($request)) {
             $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
+
             if ($sunset = $resourceMetadata->getOperationAttribute($attributes, 'sunset', null, true)) {
                 $headers['Sunset'] = (new \DateTimeImmutable($sunset))->format(\DateTime::RFC1123);
             }
+
+            $status = $resourceMetadata->getOperationAttribute($attributes, 'status');
         }
 
         $event->setResponse(new Response(
             $controllerResult,
-            self::METHOD_TO_CODE[$request->getMethod()] ?? Response::HTTP_OK,
+            $status ?? self::METHOD_TO_CODE[$request->getMethod()] ?? Response::HTTP_OK,
             $headers
         ));
     }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

This patch allows to set the status code returned by an operation using a new attribute. Exemple:

```php
/**
 * @ApiResource(
 *     collectionOperations={
 *         "post"={"status"=202}
 *     },
 *     itemOperations={},
 *     outputClass=false
 * )
 *
 * @author Kévin Dunglas <dunglas@gmail.com>
 */
class ResetPasswordRequest
{
// ...
}
```

Will return a 202 Accepted instead of 201 Created.