### PR TITLE
fix #2158 - denormalize items without context and no Iri

### DIFF
--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -31,6 +31,10 @@ class ItemNormalizer extends AbstractItemNormalizer
      */
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!isset($context['resource_class'])) {
+            $context['resource_class'] = $class;
+        }
+
         // Avoid issues with proxies if we populated the object
         if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
             if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2158 
| License       | MIT
| Doc PR        |  - 

This PR fix an issue when `context` does not contain the `resource_class` key.

It's the same behaviour of the `AbstractItemNormalizer` that _inherit_ that option from the `$class` parameter before calling the `parent::denormalize` method. It actually has to be applied before try to update the object with `updateObjectToPopulate` method otherwise, if we are not using an IRI @id but only the object identifier, we got an 
```
[ErrorException]
  Notice: Undefined index: resource_class
```

This is very useful using *Symfony Messenger* with Api-platform since otherwise Entity normalizer fails to denormalize object and we are not able to consume messages.