### PR TITLE
Fix a small BC break

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -65,7 +65,7 @@ final class WriteListener
                 // Controller result must be immutable for _api_write_item_iri
                 // if it's class changed compared to the base class let's avoid calling the IriConverter
                 // especially that the Output class could be a DTO that's not referencing any route
-                if (null !== $this->iriConverter && (false !== $attributes['output_class'] ?? null) && \get_class($controllerResult) === \get_class($event->getControllerResult())) {
+                if (null !== $this->iriConverter && (false !== $attributes['output_class'] ?? null) && $attributes['resource_class'] === ($class = \get_class($controllerResult)) && $class === \get_class($event->getControllerResult())) {
                     $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
                 }
                 break;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In our app we use table inheritance like `File`  and `FooFile` extending `File`
In 2.3 we can update a FooFile even if it not an ApiResource by send a PUT request on File.

it is not possible anymore as the iriConverter will throw on `getIriFromItem`.

So basically at this point in the listener, `$controllerResult` would be a `FooFile`, `api_resource` and `output_class` attributes would be equal to `File`

I'm really unsure that this is the correct fix. ping @soyuka 