### PR TITLE
Allow to pass a single value for the groups opt

### DIFF
--- a/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
+++ b/src/Bridge/NelmioApiDoc/Parser/ApiPlatformParser.php
@@ -136,7 +136,7 @@ final class ApiPlatformParser implements ParserInterface
 
         return [
             $groupsContext => [
-                AbstractNormalizer::GROUPS => array_merge($itemOperationAttribute ?? [], $collectionOperationAttribute ?? []),
+                AbstractNormalizer::GROUPS => array_merge((array) ($itemOperationAttribute ?? []), (array) ($collectionOperationAttribute ?? [])),
             ],
         ];
     }

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -156,18 +156,22 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $context = [];
 
         if (isset($attributes['normalization_context'][AbstractNormalizer::GROUPS])) {
-            $context['serializer_groups'] = $attributes['normalization_context'][AbstractNormalizer::GROUPS];
+            $context['serializer_groups'] = (array) $attributes['normalization_context'][AbstractNormalizer::GROUPS];
         }
 
-        if (isset($attributes['denormalization_context'][AbstractNormalizer::GROUPS])) {
-            if (isset($context['serializer_groups'])) {
-                foreach ($attributes['denormalization_context'][AbstractNormalizer::GROUPS] as $groupName) {
-                    $context['serializer_groups'][] = $groupName;
-                }
-            } else {
-                $context['serializer_groups'] = $attributes['denormalization_context'][AbstractNormalizer::GROUPS];
-            }
+        if (!isset($attributes['denormalization_context'][AbstractNormalizer::GROUPS])) {
+            return $context;
         }
+
+        if (isset($context['serializer_groups'])) {
+            foreach ((array) $attributes['denormalization_context'][AbstractNormalizer::GROUPS] as $groupName) {
+                $context['serializer_groups'][] = $groupName;
+            }
+
+            return $context;
+        }
+
+        $context['serializer_groups'] = (array) $attributes['denormalization_context'][AbstractNormalizer::GROUPS];
 
         return $context;
     }

--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -141,7 +141,7 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
     private function getEffectiveSerializerGroups(array $options, string $resourceClass): array
     {
         if (isset($options['serializer_groups'])) {
-            return [$options['serializer_groups'], $options['serializer_groups']];
+            return [(array) $options['serializer_groups'], (array) $options['serializer_groups']];
         }
 
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
@@ -159,7 +159,10 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
             $denormalizationContext = $resourceMetadata->getAttribute('denormalization_context');
         }
 
-        return [$normalizationContext['groups'] ?? null, $denormalizationContext['groups'] ?? null];
+        return [
+            isset($normalizationContext['groups']) ? (array) $normalizationContext['groups'] : null,
+            isset($denormalizationContext['groups']) ? (array) $denormalizationContext['groups'] : null,
+        ];
     }
 
     /**

--- a/tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -28,7 +28,7 @@ use Symfony\Component\Serializer\Annotation as Serializer;
  * @ApiResource(
  *     itemOperations={"get"={"swagger_context"={"tags"={}}}, "put", "delete"},
  *     attributes={
- *         "normalization_context"={"groups"={"colors"}}
+ *         "normalization_context"={"groups"="colors"}
  *     }
  * )
  * @ORM\Entity


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Allows to use the short syntax for serialization groups introduced in https://github.com/symfony/symfony/pull/27503 with API Platform.