### PR TITLE
Add support for input and output classes to Hydra

### DIFF
--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -352,4 +352,302 @@ class DocumentationNormalizerTest extends TestCase
         $this->assertFalse($documentationNormalizer->supportsNormalization($documentation, 'hal'));
         $this->assertTrue($documentationNormalizer->hasCacheableSupportsMethod());
     }
+
+    public function testNormalizeInputOutputClass()
+    {
+        $title = 'Test Api';
+        $desc = 'test ApiGerard';
+        $version = '0.0.0';
+        $documentation = new Documentation(new ResourceNameCollection(['dummy' => 'dummy']), $title, $desc, $version, []);
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create('inputClass', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['a', 'b']));
+        $propertyNameCollectionFactoryProphecy->create('outputClass', [])->shouldBeCalled()->willReturn(new PropertyNameCollection(['c', 'd']));
+
+        $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => [], 'put' => ['input_class' => false]], ['get' => [], 'post' => ['output_class' => false]], ['input_class' => 'inputClass', 'output_class' => 'outputClass']);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn($dummyMetadata);
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create('inputClass', 'a')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'a', true, true, true, true, false, false, null, null, []));
+        $propertyMetadataFactoryProphecy->create('inputClass', 'b')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'b', true, true, true, true, false, false, null, null, []));
+        $propertyMetadataFactoryProphecy->create('outputClass', 'c')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'c', true, true, true, true, false, false, null, null, []));
+        $propertyMetadataFactoryProphecy->create('outputClass', 'd')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'd', true, true, true, true, false, false, null, null, []));
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(Argument::type('string'))->willReturn(true);
+
+        $operationMethodResolverProphecy = $this->prophesize(OperationMethodResolverInterface::class);
+        $operationMethodResolverProphecy->getItemOperationMethod('dummy', 'get')->shouldBeCalled()->willReturn('GET');
+        $operationMethodResolverProphecy->getItemOperationMethod('dummy', 'put')->shouldBeCalled()->willReturn('PUT');
+        $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'get')->shouldBeCalled()->willReturn('GET');
+        $operationMethodResolverProphecy->getCollectionOperationMethod('dummy', 'post')->shouldBeCalled()->willReturn('POST');
+
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGenerator->generate('api_entrypoint')->willReturn('/')->shouldBeCalled(1);
+        $urlGenerator->generate('api_doc', ['_format' => 'jsonld'])->willReturn('/doc')->shouldBeCalled(1);
+        $urlGenerator->generate('api_doc', ['_format' => 'jsonld'], 0)->willReturn('/doc')->shouldBeCalled(1);
+
+        $documentationNormalizer = new DocumentationNormalizer(
+            $resourceMetadataFactoryProphecy->reveal(),
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $operationMethodResolverProphecy->reveal(),
+            $urlGenerator->reveal()
+        );
+
+        $expected = [
+            '@context' => [
+                '@vocab' => '/doc#',
+                'hydra' => 'http://www.w3.org/ns/hydra/core#',
+                'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+                'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+                'xmls' => 'http://www.w3.org/2001/XMLSchema#',
+                'owl' => 'http://www.w3.org/2002/07/owl#',
+                'schema' => 'http://schema.org/',
+                'domain' => [
+                    '@id' => 'rdfs:domain',
+                    '@type' => '@id',
+                ],
+                'range' => [
+                    '@id' => 'rdfs:range',
+                    '@type' => '@id',
+                ],
+                'subClassOf' => [
+                    '@id' => 'rdfs:subClassOf',
+                    '@type' => '@id',
+                ],
+                'expects' => [
+                    '@id' => 'hydra:expects',
+                    '@type' => '@id',
+                ],
+                'returns' => [
+                    '@id' => 'hydra:returns',
+                    '@type' => '@id',
+                ],
+            ],
+            '@id' => '/doc',
+            '@type' => 'hydra:ApiDocumentation',
+            'hydra:title' => 'Test Api',
+            'hydra:description' => 'test ApiGerard',
+            'hydra:entrypoint' => '/',
+            'hydra:supportedClass' => [
+                [
+                    '@id' => '#dummy',
+                    '@type' => 'hydra:Class',
+                    'rdfs:label' => 'dummy',
+                    'hydra:title' => 'dummy',
+                    'hydra:supportedProperty' => [
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#dummy/a',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'a',
+                                'domain' => '#dummy',
+                                'range' => 'xmls:string',
+                            ],
+                            'hydra:title' => 'a',
+                            'hydra:required' => false,
+                            'hydra:readable' => true,
+                            'hydra:writable' => true,
+                            'hydra:description' => 'a',
+                        ],
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#dummy/b',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'b',
+                                'domain' => '#dummy',
+                                'range' => 'xmls:string',
+                            ],
+                            'hydra:title' => 'b',
+                            'hydra:required' => false,
+                            'hydra:readable' => true,
+                            'hydra:writable' => true,
+                            'hydra:description' => 'b',
+                        ],
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#dummy/c',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'c',
+                                'domain' => '#dummy',
+                                'range' => 'xmls:string',
+                            ],
+                            'hydra:title' => 'c',
+                            'hydra:required' => false,
+                            'hydra:readable' => true,
+                            'hydra:writable' => true,
+                            'hydra:description' => 'c',
+                        ],
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#dummy/d',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'd',
+                                'domain' => '#dummy',
+                                'range' => 'xmls:string',
+                            ],
+                            'hydra:title' => 'd',
+                            'hydra:required' => false,
+                            'hydra:readable' => true,
+                            'hydra:writable' => true,
+                            'hydra:description' => 'd',
+                        ],
+                    ],
+                    'hydra:supportedOperation' => [
+                        [
+                            '@type' => [
+                                'hydra:Operation',
+                                'schema:FindAction',
+                            ],
+                            'hydra:method' => 'GET',
+                            'hydra:title' => 'Retrieves dummy resource.',
+                            'rdfs:label' => 'Retrieves dummy resource.',
+                            'returns' => '#dummy',
+                        ],
+                        [
+                            '@type' => [
+                                'hydra:Operation',
+                                'schema:ReplaceAction',
+                            ],
+                            'expects' => 'owl:Nothing',
+                            'hydra:method' => 'PUT',
+                            'hydra:title' => 'Replaces the dummy resource.',
+                            'rdfs:label' => 'Replaces the dummy resource.',
+                            'returns' => '#dummy',
+                        ],
+                    ],
+                    'hydra:description' => 'dummy',
+                ],
+                [
+                    '@id' => '#Entrypoint',
+                    '@type' => 'hydra:Class',
+                    'hydra:title' => 'The API entrypoint',
+                    'hydra:supportedProperty' => [
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#Entrypoint/dummy',
+                                '@type' => 'hydra:Link',
+                                'domain' => '#Entrypoint',
+                                'rdfs:label' => 'The collection of dummy resources',
+                                'rdfs:range' => [
+                                    [
+                                        '@id' => 'hydra:Collection',
+                                    ],
+                                    [
+                                        'owl:equivalentClass' => [
+                                            'owl:onProperty' => [
+                                                '@id' => 'hydra:member',
+                                            ],
+                                            'owl:allValuesFrom' => [
+                                                '@id' => '#dummy',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                'hydra:supportedOperation' => [
+                                    [
+                                        '@type' => [
+                                            'hydra:Operation',
+                                            'schema:FindAction',
+                                        ],
+                                        'hydra:method' => 'GET',
+                                        'hydra:title' => 'Retrieves the collection of dummy resources.',
+                                        'rdfs:label' => 'Retrieves the collection of dummy resources.',
+                                        'returns' => 'hydra:Collection',
+                                    ],
+                                    [
+                                        '@type' => [
+                                            'hydra:Operation',
+                                            'schema:CreateAction',
+                                        ],
+                                        'expects' => '#dummy',
+                                        'hydra:method' => 'POST',
+                                        'hydra:title' => 'Creates a dummy resource.',
+                                        'rdfs:label' => 'Creates a dummy resource.',
+                                        'returns' => 'owl:Nothing',
+                                    ],
+                                ],
+                            ],
+                            'hydra:title' => 'The collection of dummy resources',
+                            'hydra:readable' => true,
+                            'hydra:writable' => false,
+                        ],
+                    ],
+                    'hydra:supportedOperation' => [
+                        '@type' => 'hydra:Operation',
+                        'hydra:method' => 'GET',
+                        'rdfs:label' => 'The API entrypoint.',
+                        'returns' => '#EntryPoint',
+                    ],
+                ],
+                2 => [
+                    '@id' => '#ConstraintViolation',
+                    '@type' => 'hydra:Class',
+                    'hydra:title' => 'A constraint violation',
+                    'hydra:supportedProperty' => [
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#ConstraintViolation/propertyPath',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'propertyPath',
+                                'domain' => '#ConstraintViolation',
+                                'range' => 'xmls:string',
+                            ],
+                            'hydra:title' => 'propertyPath',
+                            'hydra:description' => 'The property path of the violation',
+                            'hydra:readable' => true,
+                            'hydra:writable' => false,
+                        ],
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#ConstraintViolation/message',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'message',
+                                'domain' => '#ConstraintViolation',
+                                'range' => 'xmls:string',
+                            ],
+                            'hydra:title' => 'message',
+                            'hydra:description' => 'The message associated with the violation',
+                            'hydra:readable' => true,
+                            'hydra:writable' => false,
+                        ],
+                    ],
+                ],
+                [
+                    '@id' => '#ConstraintViolationList',
+                    '@type' => 'hydra:Class',
+                    'subClassOf' => 'hydra:Error',
+                    'hydra:title' => 'A constraint violation list',
+                    'hydra:supportedProperty' => [
+                        [
+                            '@type' => 'hydra:SupportedProperty',
+                            'hydra:property' => [
+                                '@id' => '#ConstraintViolationList/violations',
+                                '@type' => 'rdf:Property',
+                                'rdfs:label' => 'violations',
+                                'domain' => '#ConstraintViolationList',
+                                'range' => '#ConstraintViolation',
+                            ],
+                            'hydra:title' => 'violations',
+                            'hydra:description' => 'The violations',
+                            'hydra:readable' => true,
+                            'hydra:writable' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $documentationNormalizer->normalize($documentation));
+    }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Adds the support for the `input_class` and `output_class` attributes in the Hydra documentation normalizer.
