### PR TITLE
[WIP] Allow POST/DELETE on an ApiSubresource

### DIFF
--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -269,6 +269,273 @@ Feature: Subresource support
     }
     """
 
+  @createSchema
+  Scenario: Create an entry on a subresource collection
+    Given there is a dummy object with a fourth level relation
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummies/1/related_dummies" with body:
+    """
+    {
+      "name": "New related dummy"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    Then I send a "GET" request to "/dummies/1/related_dummies"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedDummy",
+      "@id": "/dummies/1/related_dummies",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/related_dummies/1",
+          "@type": "https://schema.org/Product",
+          "id": 1,
+          "name": "Hello",
+          "symfony": "symfony",
+          "dummyDate": null,
+          "thirdLevel": {
+            "@id": "/third_levels/1",
+            "@type": "ThirdLevel",
+            "fourthLevel": "/fourth_levels/1"
+          },
+          "relatedToDummyFriend": [],
+          "dummyBoolean": null,
+          "embeddedDummy": [],
+          "age": null
+        },
+        {
+          "@id": "/related_dummies/2",
+          "@type": "https://schema.org/Product",
+          "id": 2,
+          "name": null,
+          "symfony": "symfony",
+          "dummyDate": null,
+          "thirdLevel": {
+            "@id": "/third_levels/1",
+            "@type": "ThirdLevel",
+            "fourthLevel": "/fourth_levels/1"
+          },
+          "relatedToDummyFriend": [],
+          "dummyBoolean": null,
+          "embeddedDummy": [],
+          "age": null
+        },
+        {
+          "@id": "/related_dummies/3",
+          "@type": "https://schema.org/Product",
+          "id": 3,
+          "name": "New related dummy",
+          "symfony": "symfony",
+          "dummyDate": null,
+          "thirdLevel": null,
+          "relatedToDummyFriend": [],
+          "dummyBoolean": null,
+          "embeddedDummy": [],
+          "age": null
+        }
+      ],
+      "hydra:totalItems": 3,
+      "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "/dummies/1/related_dummies{?relatedToDummyFriend.dummyFriend,relatedToDummyFriend.dummyFriend[],name}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedToDummyFriend.dummyFriend",
+            "property": "relatedToDummyFriend.dummyFriend",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedToDummyFriend.dummyFriend[]",
+            "property": "relatedToDummyFriend.dummyFriend",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "name",
+            "property": "name",
+            "required": false
+          }
+        ]
+      }
+    }
+    """
+
+  @createSchema
+  Scenario: Add an existing entry on a subresource collection
+    Given there is a dummy object with a fourth level relation
+    And there is a RelatedDummy with 0 friends
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummies/1/related_dummies" with body:
+    """
+    {
+      "@id": "/related_dummies/3"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    Then I send a "GET" request to "/dummies/1/related_dummies"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedDummy",
+      "@id": "/dummies/1/related_dummies",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/related_dummies/1",
+          "@type": "https://schema.org/Product",
+          "id": 1,
+          "name": "Hello",
+          "symfony": "symfony",
+          "dummyDate": null,
+          "thirdLevel": {
+            "@id": "/third_levels/1",
+            "@type": "ThirdLevel",
+            "fourthLevel": "/fourth_levels/1"
+          },
+          "relatedToDummyFriend": [],
+          "dummyBoolean": null,
+          "embeddedDummy": [],
+          "age": null
+        },
+        {
+          "@id": "/related_dummies/2",
+          "@type": "https://schema.org/Product",
+          "id": 2,
+          "name": null,
+          "symfony": "symfony",
+          "dummyDate": null,
+          "thirdLevel": {
+            "@id": "/third_levels/1",
+            "@type": "ThirdLevel",
+            "fourthLevel": "/fourth_levels/1"
+          },
+          "relatedToDummyFriend": [],
+          "dummyBoolean": null,
+          "embeddedDummy": [],
+          "age": null
+        },
+        {
+          "@id": "/related_dummies/3",
+          "@type": "https://schema.org/Product",
+          "id": 3,
+          "name": "RelatedDummy with friends",
+          "symfony": "symfony",
+          "dummyDate": null,
+          "thirdLevel": null,
+          "relatedToDummyFriend": [],
+          "dummyBoolean": null,
+          "embeddedDummy": [],
+          "age": null
+        }
+      ],
+      "hydra:totalItems": 3,
+      "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "/dummies/1/related_dummies{?relatedToDummyFriend.dummyFriend,relatedToDummyFriend.dummyFriend[],name}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedToDummyFriend.dummyFriend",
+            "property": "relatedToDummyFriend.dummyFriend",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedToDummyFriend.dummyFriend[]",
+            "property": "relatedToDummyFriend.dummyFriend",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "name",
+            "property": "name",
+            "required": false
+          }
+        ]
+      }
+    }
+    """
+
+  @createSchema
+  Scenario: Delete an entry on a subresource collection
+    Given there is a dummy object with a fourth level relation
+    When I send a "DELETE" request to "/dummies/1/related_dummies/2"
+    Then the response status code should be 204
+    And the response should be empty
+    And I send a "GET" request to "/dummies/1/related_dummies"
+    And the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedDummy",
+      "@id": "/dummies/1/related_dummies",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/related_dummies/1",
+          "@type": "https://schema.org/Product",
+          "id": 1,
+          "name": "Hello",
+          "symfony": "symfony",
+          "dummyDate": null,
+          "thirdLevel": {
+            "@id": "/third_levels/1",
+            "@type": "ThirdLevel",
+            "fourthLevel": "/fourth_levels/1"
+          },
+          "relatedToDummyFriend": [],
+          "dummyBoolean": null,
+          "embeddedDummy": [],
+          "age": null
+        }
+      ],
+      "hydra:totalItems": 1,
+      "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "/dummies/1/related_dummies{?relatedToDummyFriend.dummyFriend,relatedToDummyFriend.dummyFriend[],name}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedToDummyFriend.dummyFriend",
+            "property": "relatedToDummyFriend.dummyFriend",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "relatedToDummyFriend.dummyFriend[]",
+            "property": "relatedToDummyFriend.dummyFriend",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "name",
+            "property": "name",
+            "required": false
+          }
+        ]
+      }
+    }
+    """
+
   Scenario: Get offers subresource from aggregate offers subresource
     Given I have a product with offers
     When I send a "GET" request to "/dummy_products/2/offers/1/offers"

--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -20,6 +20,11 @@ namespace ApiPlatform\Core\Annotation;
  *
  * @Annotation
  * @Target({"METHOD", "PROPERTY"})
+ * @Attributes(
+ *     @Attribute("maxDepth", type="int"),
+ *     @Attribute("postEnabled", type="bool"),
+ *     @Attribute("deleteEnabled", type="bool")
+ * )
  */
 final class ApiSubresource
 {
@@ -27,4 +32,14 @@ final class ApiSubresource
      * @var int
      */
     public $maxDepth;
+
+    /**
+     * @var bool
+     */
+    public $postEnabled = true;
+
+    /**
+     * @var bool
+     */
+    public $deleteEnabled = true;
 }

--- a/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
+++ b/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
@@ -67,6 +67,16 @@ final class TraceableChainDataPersister implements ContextAwareDataPersisterInte
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function removeElementFromCollection($data, array $context = [])
+    {
+        if ($match = $this->tracePersisters($data, $context)) {
+            return $match->removeElementFromCollection($data, $context);
+        }
+    }
+
     private function tracePersisters($data, array $context = [])
     {
         $match = null;

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -236,6 +236,8 @@
         <service id="api_platform.action.put_item" alias="api_platform.action.placeholder" public="true" />
         <service id="api_platform.action.delete_item" alias="api_platform.action.placeholder" public="true" />
         <service id="api_platform.action.get_subresource" alias="api_platform.action.placeholder" public="true" />
+        <service id="api_platform.action.post_subresource" alias="api_platform.action.placeholder" public="true" />
+        <service id="api_platform.action.delete_subresource" alias="api_platform.action.placeholder" public="true" />
 
         <service id="api_platform.action.entrypoint" class="ApiPlatform\Core\Action\EntrypointAction" public="true">
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />

--- a/src/Bridge/Symfony/Messenger/DataPersister.php
+++ b/src/Bridge/Symfony/Messenger/DataPersister.php
@@ -90,4 +90,12 @@ final class DataPersister implements ContextAwareDataPersisterInterface
     {
         $this->messageBus->dispatch(new Envelope($data, new RemoveStamp()));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeElementFromCollection($data, array $context = [])
+    {
+        $this->messageBus->dispatch(new Envelope($data, new RemoveStamp()));
+    }
 }

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -135,7 +135,7 @@ final class ApiLoader extends Loader
                     $operation['options'] ?? [],
                     $operation['host'] ?? '',
                     $operation['schemes'] ?? [],
-                    ['GET'],
+                    [$operation['method'] ?? 'GET'],
                     $operation['condition'] ?? ''
                 ));
             }

--- a/src/DataPersister/ChainDataPersister.php
+++ b/src/DataPersister/ChainDataPersister.php
@@ -70,4 +70,18 @@ final class ChainDataPersister implements ContextAwareDataPersisterInterface
             }
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeElementFromCollection($data, array $context = [])
+    {
+        foreach ($this->persisters as $persister) {
+            if ($persister->supports($data, $context)) {
+                $persister->removeElementFromCollection($data, $context);
+
+                return;
+            }
+        }
+    }
 }

--- a/src/DataPersister/ContextAwareDataPersisterInterface.php
+++ b/src/DataPersister/ContextAwareDataPersisterInterface.php
@@ -34,4 +34,9 @@ interface ContextAwareDataPersisterInterface extends DataPersisterInterface
      * {@inheritdoc}
      */
     public function remove($data, array $context = []);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeElementFromCollection($data, array $context = []);
 }

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -94,12 +94,14 @@ final class DeserializeListener
             $context[AbstractNormalizer::OBJECT_TO_POPULATE] = $data;
         }
 
+        $context['api_allow_update'] = \array_key_exists('subresource_context', $attributes);
         $request->attributes->set(
             'data',
             $this->serializer->deserialize(
                 $requestContent, $context['resource_class'], $format, $context
             )
         );
+        $a = 'b';
     }
 
     /**

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -97,6 +97,13 @@ final class ReadListener
                 }
 
                 $data = $this->getSubresourceData($identifiers, $attributes, $context);
+
+                \array_pop($identifiers);
+                $parentData = $this->itemDataProvider->getItem($attributes['subresource_context']['identifiers'][0][1], $identifiers, null, $context);
+                if (null === $parentData) {
+                    throw new NotFoundHttpException('Not Found');
+                }
+                $request->attributes->set('parentData', $parentData);
             }
         } catch (InvalidIdentifierException $e) {
             throw new NotFoundHttpException('Not found, because of an invalid identifier configuration', $e);

--- a/src/Metadata/Property/Factory/AnnotationSubresourceMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AnnotationSubresourceMetadataFactory.php
@@ -86,13 +86,12 @@ final class AnnotationSubresourceMetadataFactory implements PropertyMetadataFact
         }
         $isCollection = $type->isCollection();
         $resourceClass = $isCollection && ($collectionValueType = $type->getCollectionValueType()) ? $collectionValueType->getClassName() : $type->getClassName();
-        $maxDepth = $annotation->maxDepth;
         // @ApiSubresource is on the class identifier (/collection/{id}/subcollection/{subcollectionId})
         if (null === $resourceClass) {
             $resourceClass = $originResourceClass;
             $isCollection = false;
         }
 
-        return $propertyMetadata->withSubresource(new SubresourceMetadata($resourceClass, $isCollection, $maxDepth));
+        return $propertyMetadata->withSubresource(new SubresourceMetadata($resourceClass, $isCollection, $annotation->maxDepth, $annotation->postEnabled, $annotation->deleteEnabled));
     }
 }

--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -133,7 +133,6 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
         }
 
         $type = $propertyMetadata->getType();
-        $maxDepth = \is_array($subresource) ? $subresource['maxDepth'] ?? null : null;
 
         if (null !== $type) {
             $isCollection = $type->isCollection();
@@ -145,6 +144,12 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
             return null;
         }
 
-        return new SubresourceMetadata($resourceClass, $isCollection, $maxDepth);
+        return new SubresourceMetadata(
+            $resourceClass,
+            $isCollection,
+            \is_array($subresource) ? $subresource['maxDepth'] ?? null : null,
+            \is_array($subresource) ? $subresource['postEnabled'] ?? true : true,
+            \is_array($subresource) ? $subresource['deleteEnabled'] ?? true : true
+        );
     }
 }

--- a/src/Metadata/Property/SubresourceMetadata.php
+++ b/src/Metadata/Property/SubresourceMetadata.php
@@ -23,12 +23,16 @@ final class SubresourceMetadata
     private $resourceClass;
     private $collection;
     private $maxDepth;
+    private $postEnabled;
+    private $deleteEnabled;
 
-    public function __construct(string $resourceClass, bool $collection = false, int $maxDepth = null)
+    public function __construct(string $resourceClass, bool $collection = false, int $maxDepth = null, bool $postEnabled = true, bool $deleteEnabled = true)
     {
         $this->resourceClass = $resourceClass;
         $this->collection = $collection;
         $this->maxDepth = $maxDepth;
+        $this->postEnabled = $postEnabled;
+        $this->deleteEnabled = $deleteEnabled;
     }
 
     public function getResourceClass(): string
@@ -60,5 +64,15 @@ final class SubresourceMetadata
     public function getMaxDepth(): ?int
     {
         return $this->maxDepth;
+    }
+
+    public function isPostEnabled(): bool
+    {
+        return $this->postEnabled;
+    }
+
+    public function isDeleteEnabled(): bool
+    {
+        return $this->deleteEnabled;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -289,6 +289,11 @@ class Dummy
         $this->relatedDummies->add($relatedDummy);
     }
 
+    public function removeRelatedDummy(RelatedDummy $relatedDummy)
+    {
+        $this->relatedDummies->removeElement($relatedDummy);
+    }
+
     public function getRelatedOwnedDummy()
     {
         return $this->relatedOwnedDummy;

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -43,7 +43,7 @@ class RelatedDummy extends ParentDummy
      * @var string A name
      *
      * @ORM\Column(nullable=true)
-     * @Groups({"friends"})
+     * @Groups({"barcelona", "chicago", "friends"})
      */
     public $name;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1628
| License       | MIT
| Doc PR        | TODO
| Dependencies | https://github.com/api-platform/core/issues/2706

- [x] Update routing to add `POST` & `DELETE` methods
- [ ] In `POST` request, add data to root object collection (ie: `$rootData->addRelatedDummy($data)`)
- [ ] In `DELETE` request, remove data from root object collection (ie: `$rootData->removeRelatedDummy($data)`)
- [x] Add ApiSubresource annotation option to enable/disable POST/DELETE operations
- [x] Add Behat tests
- [ ] Add PHPUnit tests
- [ ] Add documentation PR (if the workflow of this one is validated by the core team)