### PR TITLE
Allow strict matching for operation names

### DIFF
--- a/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -153,9 +153,9 @@ final class SwaggerUiAction
             $swaggerData['shortName'] = $metadata->getShortName();
 
             if (null !== $collectionOperationName = $request->attributes->get('_api_collection_operation_name')) {
-                $swaggerData['operationId'] = sprintf('%s%sCollection', $collectionOperationName, $swaggerData['shortName']);
+                $swaggerData['operationId'] = sprintf('%s%sCollection', $collectionOperationName, ucfirst($swaggerData['shortName']));
             } elseif (null !== $itemOperationName = $request->attributes->get('_api_item_operation_name')) {
-                $swaggerData['operationId'] = sprintf('%s%sItem', $itemOperationName, $swaggerData['shortName']);
+                $swaggerData['operationId'] = sprintf('%s%sItem', $itemOperationName, ucfirst($swaggerData['shortName']));
             } elseif (null !== $subresourceOperationContext = $request->attributes->get('_api_subresource_context')) {
                 $swaggerData['operationId'] = $subresourceOperationContext['operationId'];
             }


### PR DESCRIPTION
When falling back to SwaggerUiAction, correctly case Operation ID
to enable correct matching.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
