### PR TITLE
[GraphQL] Check item resource class in mutation

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -122,6 +122,21 @@ Feature: GraphQL mutation support
     And the JSON node "data.deleteFoo.id" should be equal to "/foos/1"
     And the JSON node "data.deleteFoo.clientMutationId" should be equal to "anotherId"
 
+  Scenario: Trigger an error trying to delete item of different resource
+    When I send the following GraphQL request:
+    """
+    mutation {
+      deleteFoo(input: {id: "/dummies/1", clientMutationId: "myId"}) {
+        id
+        clientMutationId
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "errors[0].message" should be equal to 'Item "/dummies/1" did not match expected type "ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo".'
+
   Scenario: Delete an item with composite identifiers through a mutation
     Given there are Composite identifier objects
     When I send the following GraphQL request:

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -23,6 +23,7 @@ use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Security\ResourceAccessCheckerInterface;
+use ApiPlatform\Core\Util\ClassInfoTrait;
 use ApiPlatform\Core\Validator\Exception\ValidationException;
 use ApiPlatform\Core\Validator\ValidatorInterface;
 use GraphQL\Error\Error;
@@ -39,6 +40,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 final class ItemMutationResolverFactory implements ResolverFactoryInterface
 {
+    use ClassInfoTrait;
     use FieldsToAttributesTrait;
     use ResourceAccessCheckerTrait;
 
@@ -82,6 +84,10 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                     $item = $this->iriConverter->getItemFromIri($args['input']['id'], $normalizationContext);
                 } catch (ItemNotFoundException $e) {
                     throw Error::createLocatedError(sprintf('Item "%s" not found.', $args['input']['id']), $info->fieldNodes, $info->path);
+                }
+
+                if ($resourceClass !== $this->getObjectClass($item)) {
+                    throw Error::createLocatedError(sprintf('Item "%s" did not match expected type "%s".', $args['input']['id'], $resourceClass), $info->fieldNodes, $info->path);
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2364 
| License       | MIT
| Doc PR        | 

This prevents passing IRIs belonging to different resource classes, which would bypass access control in some instances (see #2364).