### PR TITLE
[GraphQL] Add custom mutations

### DIFF
--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy as DummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyAggregateOffer as DummyAggregateOfferDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCar as DummyCarDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCarColor as DummyCarColorDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomMutation as DummyCustomMutationDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDate as DummyDateDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDtoCustom as DummyDtoCustomDocument;
@@ -61,6 +62,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyAggregateOffer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCarColor;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomMutation;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDate;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDtoCustom;
@@ -424,6 +426,21 @@ final class DoctrineContext implements Context
             $dummyCustomQuery = $this->buildDummyCustomQuery();
 
             $this->manager->persist($dummyCustomQuery);
+        }
+
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there are :nb dummyCustomMutation objects
+     */
+    public function thereAreDummyCustomMutationObjects(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $customMutationDummy = $this->buildDummyCustomMutation();
+            $customMutationDummy->setOperandA(3);
+
+            $this->manager->persist($customMutationDummy);
         }
 
         $this->manager->flush();
@@ -1353,6 +1370,14 @@ final class DoctrineContext implements Context
     private function buildDummyCustomQuery()
     {
         return $this->isOrm() ? new DummyCustomQuery() : new DummyCustomQueryDocument();
+    }
+
+    /**
+     * @return DummyCustomMutation|DummyCustomMutationDocument
+     */
+    private function buildDummyCustomMutation()
+    {
+        return $this->isOrm() ? new DummyCustomMutation() : new DummyCustomMutationDocument();
     }
 
     /**

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -435,3 +435,38 @@ Feature: GraphQL mutation support
       }
     }
     """
+
+  Scenario: Execute a custom mutation
+    Given there are 1 dummyCustomMutation objects
+    When I send the following GraphQL request:
+    """
+    mutation {
+      sumDummyCustomMutation(input: {id: "/dummy_custom_mutations/1", operandB: 5}) {
+        dummyCustomMutation {
+          id
+          result
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.sumDummyCustomMutation.dummyCustomMutation.result" should be equal to "8"
+
+  Scenario: Execute a not persisted custom mutation
+    When I send the following GraphQL request:
+    """
+    mutation {
+      sumNotPersistedDummyCustomMutation(input: {id: "/dummy_custom_mutations/1", operandB: 5}) {
+        dummyCustomMutation {
+          id
+          result
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.sumNotPersistedDummyCustomMutation.dummyCustomMutation" should be null

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -45,9 +45,6 @@ parameters:
 			message: '#Parameter \#9 \$nameConverter of class ApiPlatform\\Core\\Swagger\\Serializer\\DocumentationNormalizer constructor expects Symfony\\Component\\Serializer\\NameConverter\\NameConverterInterface\|null, object given\.#'
 			path: %currentWorkingDirectory%/tests/Swagger/Serializer/DocumentationNormalizer*Test.php
 		-
-			message: '#Parameter \#3 \$normalizer of class ApiPlatform\\Core\\GraphQl\\Resolver\\Factory\\ItemMutationResolverFactory constructor expects Symfony\\Component\\Serializer\\Normalizer\\NormalizerInterface, object given\.#'
-			path: %currentWorkingDirectory%/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
-		-
 			message: '#Parameter \#1 \$resource of method ApiPlatform\\Core\\Metadata\\Extractor\\XmlExtractor::getAttributes\(\) expects SimpleXMLElement, object given\.#'
 			path: %currentWorkingDirectory%/src/Metadata/Extractor/XmlExtractor.php
 		-

--- a/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\Annotati
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlMutationResolverPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolverPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
@@ -43,6 +44,7 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new ElasticsearchClientPass());
         $container->addCompilerPass(new GraphQlTypePass());
         $container->addCompilerPass(new GraphQlQueryResolverPass());
+        $container->addCompilerPass(new GraphQlMutationResolverPass());
         $container->addCompilerPass(new MetadataAwareNameConverterPass());
     }
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -27,6 +27,7 @@ use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\Core\GraphQl\Type\Definition\TypeInterface as GraphQlTypeInterface;
@@ -115,6 +116,8 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             ->addTag('api_platform.graphql.query_resolver');
         $container->registerForAutoconfiguration(QueryCollectionResolverInterface::class)
             ->addTag('api_platform.graphql.query_resolver');
+        $container->registerForAutoconfiguration(MutationResolverInterface::class)
+            ->addTag('api_platform.graphql.mutation_resolver');
         $container->registerForAutoconfiguration(GraphQlTypeInterface::class)
             ->addTag('api_platform.graphql.type');
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPass.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Injects GraphQL Mutation resolvers.
+ *
+ * @internal
+ *
+ * @author Raoul Clais <raoul.clais@gmail.com>
+ */
+final class GraphQlMutationResolverPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $mutations = [];
+        foreach ($container->findTaggedServiceIds('api_platform.graphql.mutation_resolver', true) as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $mutations[$tag['id'] ?? $serviceId] = new Reference($serviceId);
+            }
+        }
+
+        $container->getDefinition('api_platform.graphql.mutation_resolver_locator')->addArgument($mutations);
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -31,6 +31,7 @@
         <service id="api_platform.graphql.resolver.factory.item_mutation" class="ApiPlatform\Core\GraphQl\Resolver\Factory\ItemMutationResolverFactory" public="false">
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.data_persister" />
+            <argument type="service" id="api_platform.graphql.mutation_resolver_locator" />
             <argument type="service" id="serializer" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="null" />
@@ -42,6 +43,10 @@
         </service>
 
         <service id="api_platform.graphql.query_resolver_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
+            <tag name="container.service_locator" />
+        </service>
+
+        <service id="api_platform.graphql.mutation_resolver_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
             <tag name="container.service_locator" />
         </service>
 
@@ -132,6 +137,7 @@
             <argument type="service" id="api_platform.graphql.schema_builder" />
             <tag name="console.command" />
         </service>
+
     </services>
 
 </container>

--- a/src/GraphQl/Resolver/MutationResolverInterface.php
+++ b/src/GraphQl/Resolver/MutationResolverInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Resolver;
+
+/**
+ * A function resolving a GraphQL mutation.
+ *
+ * @experimental
+ *
+ * @author Raoul Clais <raoul.clais@gmail.com>
+ */
+interface MutationResolverInterface
+{
+    /**
+     * @param object|null $item
+     *
+     * @return object|null The mutated item
+     */
+    public function __invoke($item, array $context);
+}

--- a/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\Annotati
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlMutationResolverPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolverPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
@@ -39,6 +40,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(ElasticsearchClientPass::class))->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(GraphQlTypePass::class))->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(GraphQlQueryResolverPass::class))->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(GraphQlMutationResolverPass::class))->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(MetadataAwareNameConverterPass::class))->shouldBeCalled();
 
         $bundle = new ApiPlatformBundle();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -59,6 +59,7 @@ use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Exception\FilterValidationException;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\Core\GraphQl\Type\Definition\TypeInterface as GraphQlTypeInterface;
@@ -646,6 +647,10 @@ class ApiPlatformExtensionTest extends TestCase
             ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
         $this->childDefinitionProphecy->addTag('api_platform.graphql.query_resolver')->shouldBeCalledTimes(2);
 
+        $containerBuilderProphecy->registerForAutoconfiguration(MutationResolverInterface::class)
+            ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
+        $this->childDefinitionProphecy->addTag('api_platform.graphql.mutation_resolver')->shouldBeCalledTimes(1);
+
         $containerBuilderProphecy->getParameter('kernel.bundles')->willReturn([
             'DoctrineBundle' => DoctrineBundle::class,
         ])->shouldBeCalled();
@@ -970,6 +975,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.type_locator',
             'api_platform.graphql.types_factory',
             'api_platform.graphql.query_resolver_locator',
+            'api_platform.graphql.mutation_resolver_locator',
             'api_platform.graphql.normalizer.item',
             'api_platform.graphql.normalizer.item.non_resource',
             'api_platform.graphql.command.export_command',

--- a/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * Dummy with a custom GraphQL mutation resolver.
+ *
+ * @ODM\Document
+ * @ApiResource(graphql={
+ *     "sum"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}}
+ *     },
+ *     "sumNotPersisted"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_not_persisted",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}}
+ *     }
+ * })
+ *
+ * @author Raoul Clais <raoul.clais@gmail.com>
+ */
+class DummyCustomMutation
+{
+    /**
+     * @var int
+     *
+     * @ODM\Id(strategy="INCREMENT", type="integer")
+     */
+    private $id;
+
+    /**
+     * @var int
+     *
+     * @ODM\Field(type="integer")
+     */
+    private $operandA;
+
+    /**
+     * @var int
+     *
+     * @Groups({"sum"})
+     * @ODM\Field(type="integer", nullable=true)
+     */
+    private $operandB;
+
+    /**
+     * @var int
+     *
+     * @Groups({"result"})
+     * @ODM\Field(type="integer", nullable=true)
+     */
+    private $result;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getOperandA(): int
+    {
+        return $this->operandA;
+    }
+
+    public function setOperandA(int $operandA): void
+    {
+        $this->operandA = $operandA;
+    }
+
+    public function getOperandB(): int
+    {
+        return $this->operandB;
+    }
+
+    public function setOperandB(int $operandB): void
+    {
+        $this->operandB = $operandB;
+    }
+
+    public function getResult(): int
+    {
+        return $this->result;
+    }
+
+    public function setResult(int $result): void
+    {
+        $this->result = $result;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * Dummy with a custom GraphQL mutation resolver.
+ *
+ * @ORM\Entity
+ * @ApiResource(graphql={
+ *     "sum"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}}
+ *     },
+ *     "sumNotPersisted"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_not_persisted",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}}
+ *     }
+ * })
+ *
+ * @author Raoul Clais <raoul.clais@gmail.com>
+ */
+class DummyCustomMutation
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     */
+    private $operandA;
+
+    /**
+     * @var int
+     *
+     * @Groups({"sum"})
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $operandB;
+
+    /**
+     * @var int
+     *
+     * @Groups({"result"})
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $result;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getOperandA(): int
+    {
+        return $this->operandA;
+    }
+
+    public function setOperandA(int $operandA): void
+    {
+        $this->operandA = $operandA;
+    }
+
+    public function getOperandB(): int
+    {
+        return $this->operandB;
+    }
+
+    public function setOperandB(int $operandB): void
+    {
+        $this->operandB = $operandB;
+    }
+
+    public function getResult(): int
+    {
+        return $this->result;
+    }
+
+    public function setResult(int $result): void
+    {
+        $this->result = $result;
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryCollectionResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryCollectionResolver.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver;
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryItemResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryItemResolver.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver;
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
@@ -22,7 +22,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
  *
  * @author Lukas Lücke <lukas@luecke.me>
  */
-class DummyCustomQueryNotRetrievedItemDocumentResolver implements QueryItemResolverInterface
+class DummyCustomQueryItemResolver implements QueryItemResolverInterface
 {
     /**
      * @param DummyCustomQuery|DummyCustomQueryDocument|null $item
@@ -31,12 +31,7 @@ class DummyCustomQueryNotRetrievedItemDocumentResolver implements QueryItemResol
      */
     public function __invoke($item, array $context)
     {
-        if (null === $item) {
-            $item = new DummyCustomQueryDocument();
-            $item->message = 'Success (not retrieved)!';
-
-            return $item;
-        }
+        $item->message = 'Success!';
 
         return $item;
     }

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNotRetrievedItemDocumentResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNotRetrievedItemDocumentResolver.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver;
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
@@ -22,7 +22,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
  *
  * @author Lukas Lücke <lukas@luecke.me>
  */
-class DummyCustomQueryItemResolver implements QueryItemResolverInterface
+class DummyCustomQueryNotRetrievedItemDocumentResolver implements QueryItemResolverInterface
 {
     /**
      * @param DummyCustomQuery|DummyCustomQueryDocument|null $item
@@ -31,7 +31,12 @@ class DummyCustomQueryItemResolver implements QueryItemResolverInterface
      */
     public function __invoke($item, array $context)
     {
-        $item->message = 'Success!';
+        if (null === $item) {
+            $item = new DummyCustomQueryDocument();
+            $item->message = 'Success (not retrieved)!';
+
+            return $item;
+        }
 
         return $item;
     }

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNotRetrievedItemResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNotRetrievedItemResolver.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver;
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/SumMutationResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/SumMutationResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomMutation as DummyCustomMutationDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomMutation;
+
+/**
+ * Resolver for custom mutation.
+ *
+ * @author Raoul Clais <raoul.clais@gmail.com>
+ */
+class SumMutationResolver implements MutationResolverInterface
+{
+    /**
+     * @param DummyCustomMutation|DummyCustomMutationDocument|null $item
+     *
+     * @return DummyCustomMutation|DummyCustomMutationDocument
+     */
+    public function __invoke($item, array $context)
+    {
+        $item->setResult($item->getOperandA() + $item->getOperandB());
+
+        return $item;
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/SumNotPersistedMutationResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/SumNotPersistedMutationResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomMutation as DummyCustomMutationDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomMutation;
+
+/**
+ * Resolver for custom mutation (item not persisted).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class SumNotPersistedMutationResolver implements MutationResolverInterface
+{
+    /**
+     * @param DummyCustomMutation|DummyCustomMutationDocument|null $item
+     */
+    public function __invoke($item, array $context)
+    {
+        // Side-effect.
+
+        return null;
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -254,13 +254,25 @@ services:
             -  { name: 'messenger.message_handler' }
 
     app.graphql.query_resolver.dummy_custom_item:
-        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver\DummyCustomQueryItemResolver'
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryItemResolver'
         public: false
         tags:
             - { name: 'api_platform.graphql.query_resolver' }
 
     app.graphql.query_resolver.dummy_custom_collection:
-        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver\DummyCustomQueryCollectionResolver'
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryCollectionResolver'
         public: false
         tags:
             - { name: 'api_platform.graphql.query_resolver' }
+
+    app.graphql.mutation_resolver.dummy_custom:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumMutationResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.mutation_resolver' }
+
+    app.graphql.mutation_resolver.dummy_custom_not_persisted:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumNotPersistedMutationResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.mutation_resolver' }

--- a/tests/Fixtures/app/config/config_orm.yml
+++ b/tests/Fixtures/app/config/config_orm.yml
@@ -73,7 +73,7 @@ services:
             -  { name: 'api_platform.data_persister' }
 
     app.graphql.query_resolver.dummy_custom_not_retrieved_item:
-        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver\DummyCustomQueryNotRetrievedItemResolver'
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryNotRetrievedItemResolver'
         public: false
         tags:
             - { name: 'api_platform.graphql.query_resolver' }

--- a/tests/Fixtures/app/config/config_services_mongodb.yml
+++ b/tests/Fixtures/app/config/config_services_mongodb.yml
@@ -58,7 +58,7 @@ services:
             -  { name: 'api_platform.data_persister' }
 
     app.graphql.query_resolver.dummy_custom_not_retrieved_item_document:
-        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Resolver\DummyCustomQueryNotRetrievedItemDocumentResolver'
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryNotRetrievedItemDocumentResolver'
         public: false
         tags:
             - { name: 'api_platform.graphql.query_resolver' }

--- a/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
@@ -88,7 +88,7 @@ class ItemResolverFactoryTest extends TestCase
 
         $resolveInfo = new ResolveInfo('name', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 
-        $this->expectExceptionMessage('Resolver only handles items of class ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy but retrieved item is of class ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy');
+        $this->expectExceptionMessage('Resolver only handles items of class RelatedDummy but retrieved item is of class Dummy.');
 
         $this->assertEquals('normalizedItem', ($this->itemResolverFactory)(RelatedDummy::class)(null, ['id' => '/dummies/3'], null, $resolveInfo));
     }
@@ -107,7 +107,7 @@ class ItemResolverFactoryTest extends TestCase
             return new Dummy();
         });
 
-        $this->expectExceptionMessage('Custom query resolver "query_resolver_id" has to return an item of class ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy but returned an item of class ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy');
+        $this->expectExceptionMessage('Custom query resolver "query_resolver_id" has to return an item of class RelatedDummy but returned an item of class Dummy.');
 
         ($this->itemResolverFactory)(null, null, 'custom_query')(null, ['id' => '/related_dummies/3'], null, $resolveInfo);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Introduce a new `MutationResolverInterface` interface.

Create a service which implements this interface and declare your custom mutation on your entity:
```
@ApiResource(graphql={
    "create",
    "update",
    "increment"={"mutation"=IncrementMutation::class}
})
```

If `null` is returned from the resolver, the item will not be persisted.