### PR TITLE
[JSONAPI] Add support for nested resource inclusion

### DIFF
--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -662,3 +662,301 @@ Feature: JSON API Inclusion of Related Resources
         }]
     }
     """
+
+  @createSchema
+  Scenario: Request inclusion of nested resource on an item
+    Given there are 1 dummy objects with relatedDummy and its thirdLevel
+    When I send a "GET" request to "/dummies/1?include=relatedDummy.thirdLevel"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And print last JSON response
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+        {
+            "data": {
+                "id": "/dummies/1",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 1,
+                    "name": "Dummy #1",
+                    "alias": "Alias #0",
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedDummy": {
+                        "data": {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/1"
+                        }
+                    }
+                }
+            },
+            "included": [
+                {
+                  "id": "/third_levels/1",
+                  "type": "ThirdLevel",
+                  "attributes": {
+                      "_id": 1,
+                      "level": 3,
+                      "test": true
+                  }
+                },
+                {
+                    "id": "/related_dummies/1",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #1",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 1,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "id": "/third_levels/1",
+                                "type": "ThirdLevel"
+                            }
+                        }
+                    }
+                }
+            ]
+       }
+    """
+
+  @createSchema
+  Scenario: Request inclusion of nested resource on a collection
+    Given there are 3 dummy objects with relatedDummy and its thirdLevel
+    When I send a "GET" request to "/dummies?include=relatedDummy.thirdLevel"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And print last JSON response
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+        {
+          "links": {
+              "self": "/dummies?include=relatedDummy.thirdLevel"
+          },
+          "meta": {
+              "totalItems": 3,
+              "itemsPerPage": 3,
+              "currentPage": 1
+          },
+          "data": [
+            {
+              "id": "/dummies/1",
+              "type": "Dummy",
+              "attributes": {
+                  "description": null,
+                  "dummy": null,
+                  "dummyBoolean": null,
+                  "dummyDate": null,
+                  "dummyFloat": null,
+                  "dummyPrice": null,
+                  "jsonData": [],
+                  "arrayData": [],
+                  "name_converted": null,
+                  "_id": 1,
+                  "name": "Dummy #1",
+                  "alias": "Alias #2",
+                  "foo": null
+              },
+              "relationships": {
+                  "relatedDummy": {
+                      "data": {
+                          "type": "RelatedDummy",
+                          "id": "/related_dummies/1"
+                      }
+                  }
+              }
+            },
+            {
+              "id": "/dummies/2",
+              "type": "Dummy",
+              "attributes": {
+                  "description": null,
+                  "dummy": null,
+                  "dummyBoolean": null,
+                  "dummyDate": null,
+                  "dummyFloat": null,
+                  "dummyPrice": null,
+                  "jsonData": [],
+                  "arrayData": [],
+                  "name_converted": null,
+                  "_id": 2,
+                  "name": "Dummy #2",
+                  "alias": "Alias #1",
+                  "foo": null
+              },
+              "relationships": {
+                  "relatedDummy": {
+                      "data": {
+                          "type": "RelatedDummy",
+                          "id": "/related_dummies/2"
+                      }
+                  }
+              }
+            },
+            {
+              "id": "/dummies/3",
+              "type": "Dummy",
+              "attributes": {
+                  "description": null,
+                  "dummy": null,
+                  "dummyBoolean": null,
+                  "dummyDate": null,
+                  "dummyFloat": null,
+                  "dummyPrice": null,
+                  "jsonData": [],
+                  "arrayData": [],
+                  "name_converted": null,
+                  "_id": 3,
+                  "name": "Dummy #3",
+                  "alias": "Alias #0",
+                  "foo": null
+              },
+              "relationships": {
+                  "relatedDummy": {
+                      "data": {
+                          "type": "RelatedDummy",
+                          "id": "/related_dummies/3"
+                      }
+                  }
+              }
+            }
+          ],
+          "included": [
+              {
+                "id": "/third_levels/1",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 1,
+                    "level": 3,
+                    "test": true
+                }
+              },
+              {
+                  "id": "/related_dummies/1",
+                  "type": "RelatedDummy",
+                  "attributes": {
+                      "name": "RelatedDummy #1",
+                      "dummyDate": null,
+                      "dummyBoolean": null,
+                      "embeddedDummy": {
+                          "dummyName": null,
+                          "dummyBoolean": null,
+                          "dummyDate": null,
+                          "dummyFloat": null,
+                          "dummyPrice": null,
+                          "symfony": null
+                      },
+                      "_id": 1,
+                      "symfony": "symfony",
+                      "age": null
+                  },
+                  "relationships": {
+                      "thirdLevel": {
+                          "data": {
+                              "id": "/third_levels/1",
+                              "type": "ThirdLevel"
+                          }
+                      }
+                  }
+              },
+              {
+                "id": "/third_levels/2",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 2,
+                    "level": 3,
+                    "test": true
+                }
+              },
+              {
+                  "id": "/related_dummies/2",
+                  "type": "RelatedDummy",
+                  "attributes": {
+                      "name": "RelatedDummy #2",
+                      "dummyDate": null,
+                      "dummyBoolean": null,
+                      "embeddedDummy": {
+                          "dummyName": null,
+                          "dummyBoolean": null,
+                          "dummyDate": null,
+                          "dummyFloat": null,
+                          "dummyPrice": null,
+                          "symfony": null
+                      },
+                      "_id": 2,
+                      "symfony": "symfony",
+                      "age": null
+                  },
+                  "relationships": {
+                      "thirdLevel": {
+                          "data": {
+                              "id": "/third_levels/2",
+                              "type": "ThirdLevel"
+                          }
+                      }
+                  }
+              },
+              {
+                "id": "/third_levels/3",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 3,
+                    "level": 3,
+                    "test": true
+                }
+              },
+              {
+                  "id": "/related_dummies/3",
+                  "type": "RelatedDummy",
+                  "attributes": {
+                      "name": "RelatedDummy #3",
+                      "dummyDate": null,
+                      "dummyBoolean": null,
+                      "embeddedDummy": {
+                          "dummyName": null,
+                          "dummyBoolean": null,
+                          "dummyDate": null,
+                          "dummyFloat": null,
+                          "dummyPrice": null,
+                          "symfony": null
+                      },
+                      "_id": 3,
+                      "symfony": "symfony",
+                      "age": null
+                  },
+                  "relationships": {
+                      "thirdLevel": {
+                          "data": {
+                              "id": "/third_levels/3",
+                              "type": "ThirdLevel"
+                          }
+                      }
+                  }
+              }
+          ]
+       }
+    """

--- a/src/JsonApi/EventListener/TransformFieldsetsParametersListener.php
+++ b/src/JsonApi/EventListener/TransformFieldsetsParametersListener.php
@@ -63,12 +63,13 @@ final class TransformFieldsetsParametersListener
 
         $resourceShortName = $this->resourceMetadataFactory->create($resourceClass)->getShortName();
 
+        $includedResourceTypes = explode('.', implode('.', $includeParameter));
         foreach ($fieldsParameter as $resourceType => $fields) {
             $fields = explode(',', $fields);
 
             if ($resourceShortName === $resourceType) {
                 $properties = array_merge($properties, $fields);
-            } elseif (\in_array($resourceType, $includeParameter, true)) {
+            } elseif (\in_array($resourceType, $includedResourceTypes, true)) {
                 $properties[$resourceType] = $fields;
 
                 $request->attributes->set('_api_included', array_merge($request->attributes->get('_api_included', []), [$resourceType]));

--- a/tests/JsonApi/EventListener/TransformFieldsetsParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformFieldsetsParametersListenerTest.php
@@ -101,7 +101,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
     public function testOnKernelRequestWithIncludeWithoutFields()
     {
         $request = new Request(
-            ['include' => 'relatedDummy,foo'],
+            ['include' => 'relatedDummy,foo,nested.prop'],
             [],
             ['_api_resource_class' => Dummy::class]
         );
@@ -113,11 +113,11 @@ class TransformFieldsetsParametersListenerTest extends TestCase
         $this->listener->onKernelRequest($eventProphecy->reveal());
 
         $expectedRequest = new Request(
-            ['include' => 'relatedDummy,foo'],
+            ['include' => 'relatedDummy,foo,nested.prop'],
             [],
             [
                 '_api_resource_class' => Dummy::class,
-                '_api_included' => ['relatedDummy', 'foo'],
+                '_api_included' => ['relatedDummy', 'foo', 'nested.prop'],
             ]
         );
         $expectedRequest->setRequestFormat('jsonapi');


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/core/issues/2365, https://github.com/api-platform/api-platform/issues/940
| Doc PR        | to be done

Here is a first attempt at supporting inclusion of nested resources.

I think it does not work well with [Sparse Fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets) but that's already an improvement.

@dematerializer, @RikudouSage it, would be really appreciated if you could try it and provide feedback 