### PR TITLE
Allow to push relations to the client using HTTP/2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
         "phpdocumentor/type-resolver": "^0.3 || ^0.4",
         "phpspec/prophecy": "^1.8",
-        "phpunit/phpunit": "^7.5.1",
+        "phpunit/phpunit": "^7.5.2",
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.7",
         "ramsey/uuid-doctrine": "^1.4",

--- a/features/push_relations/push.feature
+++ b/features/push_relations/push.feature
@@ -1,0 +1,17 @@
+@sqlite
+Feature: Push relations using HTTP/2
+  In order to have a fast API
+  As an API software developer
+  I need to push relations using HTTP/2
+
+  @createSchema
+  Scenario: Push the relations of a collection of items
+    Given there are 2 dummy objects with relatedDummy
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/dummies"
+    Then the header "Link" should be equal to '</related_dummies/1>; rel="preload",</related_dummies/2>; rel="preload",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
+
+  Scenario: Push the relations of a collection of items
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/dummies/1"
+    Then the header "Link" should be equal to '</related_dummies/1>; rel="preload",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'

--- a/features/push_relations/push.feature
+++ b/features/push_relations/push.feature
@@ -11,7 +11,7 @@ Feature: Push relations using HTTP/2
     And I send a "GET" request to "/dummies"
     Then the header "Link" should be equal to '</related_dummies/1>; rel="preload",</related_dummies/2>; rel="preload",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
 
-  Scenario: Push the relations of a collection of items
+  Scenario: Push the relations of an item
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/dummies/1"
     Then the header "Link" should be equal to '</related_dummies/1>; rel="preload",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -28,6 +28,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("fetchEager", type="bool"),
  *     @Attribute("openapiContext", type="array"),
  *     @Attribute("jsonldContext", type="array"),
+ *     @Attribute("push", type="bool"),
  *     @Attribute("swaggerContext", type="array")
  * )
  */
@@ -108,14 +109,21 @@ final class ApiProperty
      *
      * @var array
      */
-    private $swaggerContext;
+    private $openapiContext;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $push;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var array
      */
-    private $openapiContext;
+    private $swaggerContext;
 
     /**
      * @throws InvalidArgumentException

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -64,8 +64,8 @@ final class DeserializeListener
         $request = $event->getRequest();
         $method = $request->getMethod();
         if (
-            $request->isMethodSafe(false)
-            || 'DELETE' === $method
+            'DELETE' === $method
+            || $request->isMethodSafe(false)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || false === ($attributes['input_class'] ?? null)
             || !$attributes['receive']

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -24,7 +24,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
 
 /**
  * Serializes data.

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -92,8 +92,8 @@ final class SerializeListener
         }
 
         $linkProvider = $request->attributes->get('_links', new GenericLinkProvider());
-        foreach ($resourcesToPush as $resourcesToPush) {
-            $linkProvider = $linkProvider->withLink(new Link('preload', $resourcesToPush));
+        foreach ($resourcesToPush as $resourceToPush) {
+            $linkProvider = $linkProvider->withLink(new Link('preload', $resourceToPush));
         }
         $request->attributes->set('_links', $linkProvider);
     }

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -80,11 +80,8 @@ final class SerializeListener
         $resources = new ResourceList();
         $context['resources'] = &$resources;
 
-        $resourcesToPush = [];
-        if (class_exists(AddLinkHeaderListener::class)) {
-            $resourcesToPush = new ResourceList();
-            $context['resources_to_push'] = &$resourcesToPush;
-        }
+        $resourcesToPush = new ResourceList();
+        $context['resources_to_push'] = &$resourcesToPush;
 
         $request->attributes->set('_api_normalization_context', $context);
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -531,7 +531,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     protected function normalizeRelation(PropertyMetadata $propertyMetadata, $relatedObject, string $resourceClass, string $format = null, array $context)
     {
-        if (null === $relatedObject || $propertyMetadata->isReadableLink() || !empty($context['attributes'])) {
+        if (null === $relatedObject || !empty($context['attributes']) || $propertyMetadata->isReadableLink()) {
             if (null === $relatedObject) {
                 unset($context['resource_class']);
             } else {
@@ -547,6 +547,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $iri = $this->iriConverter->getIriFromItem($relatedObject);
         if (isset($context['resources'])) {
             $context['resources'][$iri] = $iri;
+        }
+        if (isset($context['resources_to_push']) && $propertyMetadata->getAttribute('push', false)) {
+            $context['resources_to_push'][$iri] = $iri;
         }
 
         return $iri;

--- a/tests/Annotation/ApiPropertyTest.php
+++ b/tests/Annotation/ApiPropertyTest.php
@@ -54,6 +54,7 @@ class ApiPropertyTest extends TestCase
             'jsonldContext' => ['foo' => 'bar'],
             'swaggerContext' => ['foo' => 'baz'],
             'openapiContext' => ['foo' => 'baz'],
+            'push' => true,
             'attributes' => ['unknown' => 'unknown', 'fetchable' => false],
         ]);
         $this->assertEquals([
@@ -63,6 +64,7 @@ class ApiPropertyTest extends TestCase
             'jsonld_context' => ['foo' => 'bar'],
             'swagger_context' => ['foo' => 'baz'],
             'openapi_context' => ['foo' => 'baz'],
+            'push' => true,
             'unknown' => 'unknown',
         ], $property->attributes);
     }

--- a/tests/EventListener/SerializeListenerTest.php
+++ b/tests/EventListener/SerializeListenerTest.php
@@ -113,7 +113,7 @@ class SerializeListenerTest extends TestCase
                 'xml',
                 Argument::allOf(
                     Argument::that(function (array $context) {
-                        return $context['resources'] instanceof ResourceList;
+                        return $context['resources'] instanceof ResourceList && $context['resources_to_push'] instanceof ResourceList;
                     }),
                     Argument::withEntry('request_uri', ''),
                     Argument::withEntry('resource_class', 'Foo'),
@@ -168,7 +168,7 @@ class SerializeListenerTest extends TestCase
                 'xml',
                 Argument::allOf(
                     Argument::that(function (array $context) {
-                        return $context['resources'] instanceof ResourceList;
+                        return $context['resources'] instanceof ResourceList && $context['resources_to_push'] instanceof ResourceList;
                     }),
                     Argument::withEntry('request_uri', ''),
                     Argument::withEntry('resource_class', 'Foo'),

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -120,6 +120,7 @@ class Dummy
      * @var RelatedDummy A related dummy
      *
      * @ORM\ManyToOne(targetEntity="RelatedDummy")
+     * @ApiProperty(push=true)
      */
     public $relatedDummy;
 


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/714

This new feature allows to use the web server to push relations of the current resources using HTTP/2. It's especially useful when used together with [the built-in HTTP cache invalidation system (based on Varnish)](https://api-platform.com/docs/core/performance/#enabling-the-built-in-http-cache-invalidation-system).

The usage is very easy:

```php
<?php

namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiProperty;
use ApiPlatform\Core\Annotation\ApiResource;

/**
 * @ApiResource
 */
class Book
{
    /**
     * @var Author $author
     * @ApiProperty(push=true)
     */
    public $author;
}
```

Then, the Symfony WebLink component will be used to generate the appropriate `Link` HTTP header that will be used by the web server to send the related resource(s) using a server push.