### PR TITLE
Enhance the filter annotation

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPass.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
 use ApiPlatform\Core\Util\AnnotationFilterExtractorTrait;
 use ApiPlatform\Core\Util\ReflectionClassRecursiveIterator;
 use Doctrine\Common\Annotations\Reader;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -56,8 +57,13 @@ final class AnnotationFilterPass implements CompilerPassInterface
                 continue;
             }
 
-            $definition = new Definition();
-            $definition->setClass($filterClass);
+            if ($container->has($filterClass) && $container->findDefinition($filterClass)->isAbstract()) {
+                $definition = new ChildDefinition($filterClass);
+            } else {
+                $definition = new Definition();
+                $definition->setClass($filterClass);
+            }
+
             $definition->addTag(self::TAG_FILTER_NAME);
             $definition->setAutowired(true);
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -83,8 +83,10 @@
         </service>
 
         <service id="api_platform.serializer.property_filter" class="ApiPlatform\Core\Serializer\Filter\PropertyFilter" public="false" abstract="true" />
+        <service id="ApiPlatform\Core\Serializer\Filter\PropertyFilter" alias="api_platform.serializer.property_filter" />
 
         <service id="api_platform.serializer.group_filter" class="ApiPlatform\Core\Serializer\Filter\GroupFilter" public="false" abstract="true" />
+        <service id="ApiPlatform\Core\Serializer\Filter\GroupFilter" alias="api_platform.serializer.group_filter" />
 
         <service id="api_platform.serializer.normalizer.item" class="ApiPlatform\Core\Serializer\ItemNormalizer" public="false">
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -56,6 +56,7 @@
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter" alias="api_platform.doctrine.orm.search_filter" />
 
         <service id="api_platform.doctrine.orm.order_filter" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
@@ -63,36 +64,42 @@
             <argument>%api_platform.collection.order_parameter_name%</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter" alias="api_platform.doctrine.orm.order_filter" />
 
         <service id="api_platform.doctrine.orm.range_filter" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\RangeFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
             <argument>null</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\RangeFilter" alias="api_platform.doctrine.orm.range_filter" />
 
         <service id="api_platform.doctrine.orm.date_filter" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
             <argument>null</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter" alias="api_platform.doctrine.orm.date_filter" />
 
         <service id="api_platform.doctrine.orm.boolean_filter" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
             <argument>null</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter" alias="api_platform.doctrine.orm.boolean_filter" />
 
         <service id="api_platform.doctrine.orm.numeric_filter" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\NumericFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
             <argument>null</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\NumericFilter" alias="api_platform.doctrine.orm.numeric_filter" />
 
         <service id="api_platform.doctrine.orm.exists_filter" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
             <argument>null</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter" alias="api_platform.doctrine.orm.exists_filter" />
 
         <!-- Metadata loader -->
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -119,6 +119,7 @@
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="api_platform.elasticsearch.name_converter.inner_fields" />
         </service>
+        <service id="ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\TermFilter" alias="api_platform.elasticsearch.term_filter" />
 
         <service id="api_platform.elasticsearch.order_filter" class="ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter" public="false" abstract="true">
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
@@ -127,6 +128,7 @@
             <argument type="service" id="api_platform.elasticsearch.name_converter.inner_fields" />
             <argument>%api_platform.collection.order_parameter_name%</argument>
         </service>
+        <service id="ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter" alias="api_platform.elasticsearch.order_filter" />
     </services>
 
 </container>

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -24,8 +24,17 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\OrderExtension;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\PaginationExtension;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\NumericFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\RangeFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractorInterface;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Extension\FullBodySearchCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter as ElasticsearchOrderFilter;
+use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\TermFilter;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
@@ -40,6 +49,8 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInte
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Security\ResourceAccessCheckerInterface;
+use ApiPlatform\Core\Serializer\Filter\GroupFilter;
+use ApiPlatform\Core\Serializer\Filter\PropertyFilter;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\TestBundle;
 use ApiPlatform\Core\Validator\ValidatorInterface;
@@ -467,6 +478,8 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setAlias('api_platform.elasticsearch.metadata.document.metadata_factory', 'api_platform.elasticsearch.metadata.document.metadata_factory.configured')->shouldBeCalled();
         $containerBuilderProphecy->setAlias(DocumentMetadataFactoryInterface::class, 'api_platform.elasticsearch.metadata.document.metadata_factory')->shouldBeCalled();
         $containerBuilderProphecy->setAlias(IdentifierExtractorInterface::class, 'api_platform.elasticsearch.identifier_extractor')->shouldBeCalled();
+        $containerBuilderProphecy->setAlias(TermFilter::class, 'api_platform.elasticsearch.term_filter')->shouldBeCalled();
+        $containerBuilderProphecy->setAlias(ElasticsearchOrderFilter::class, 'api_platform.elasticsearch.order_filter')->shouldBeCalled();
         $containerBuilderProphecy->registerForAutoconfiguration(FullBodySearchCollectionExtensionInterface::class)->willReturn($childDefinitionProphecy)->shouldBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.elasticsearch.host', 'http://elasticsearch:9200')->shouldBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.elasticsearch.mapping', [])->shouldBeCalled();
@@ -702,6 +715,8 @@ class ApiPlatformExtensionTest extends TestCase
             PropertyMetadataFactoryInterface::class => 'api_platform.metadata.property.metadata_factory',
             ValidatorInterface::class => 'api_platform.validator',
             ResourceClassResolverInterface::class => 'api_platform.resource_class_resolver',
+            PropertyFilter::class => 'api_platform.serializer.property_filter',
+            GroupFilter::class => 'api_platform.serializer.group_filter',
         ];
 
         foreach ($aliases as $alias => $service) {
@@ -860,6 +875,13 @@ class ApiPlatformExtensionTest extends TestCase
             PaginationExtension::class => 'api_platform.doctrine.orm.query_extension.pagination',
             OrderExtension::class => 'api_platform.doctrine.orm.query_extension.order',
             ValidatorInterface::class => 'api_platform.validator',
+            SearchFilter::class => 'api_platform.doctrine.orm.search_filter',
+            OrderFilter::class => 'api_platform.doctrine.orm.order_filter',
+            RangeFilter::class => 'api_platform.doctrine.orm.range_filter',
+            DateFilter::class => 'api_platform.doctrine.orm.date_filter',
+            BooleanFilter::class => 'api_platform.doctrine.orm.boolean_filter',
+            NumericFilter::class => 'api_platform.doctrine.orm.numeric_filter',
+            ExistsFilter::class => 'api_platform.doctrine.orm.exists_filter',
         ];
 
         foreach ($aliases as $alias => $service) {

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPassTest.php
@@ -26,6 +26,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -71,6 +72,12 @@ class AnnotationFilterPassTest extends TestCase
         $containerBuilderProphecy->hasDefinition('annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_api_platform_core_serializer_filter_group_filter')->shouldBeCalled()->willReturn(false);
         $containerBuilderProphecy->hasDefinition('annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_api_platform_core_bridge_doctrine_orm_filter_date_filter')->shouldBeCalled()->willReturn(false);
 
+        $containerBuilderProphecy->has(SearchFilter::class)->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->has(GroupFilter::class)->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->has(DateFilter::class)->willReturn(true)->shouldBeCalled();
+
+        $containerBuilderProphecy->findDefinition(DateFilter::class)->willReturn((new Definition(DateFilter::class))->setAbstract(true))->shouldBeCalled();
+
         $containerBuilderProphecy->setDefinition('annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_api_platform_core_bridge_doctrine_orm_filter_search_filter', Argument::that(function ($def) {
             $this->assertInstanceOf(Definition::class, $def);
             $this->assertEquals(SearchFilter::class, $def->getClass());
@@ -88,8 +95,8 @@ class AnnotationFilterPassTest extends TestCase
         }))->shouldBeCalled();
 
         $containerBuilderProphecy->setDefinition('annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_api_platform_core_bridge_doctrine_orm_filter_date_filter', Argument::that(function ($def) {
-            $this->assertInstanceOf(Definition::class, $def);
-            $this->assertEquals(DateFilter::class, $def->getClass());
+            $this->assertInstanceOf(ChildDefinition::class, $def);
+            $this->assertEquals(DateFilter::class, $def->getParent());
             $this->assertEquals(['$properties' => ['dummyDate' => null]], $def->getArguments());
 
             return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR allows to use the abstract definitions of filter services when using the filter annotation.
It also allows to use Elasticsearch filters with the filter annotation without issues. In fact, without this fix the passed name converter to the Elasticsearch filter constructor is `null` because of the autowiring.

WDYT?