### PR TITLE
https://github.com/api-platform/core/issues/2458

### DIFF
--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -32,7 +32,8 @@ Feature: Documentation support
     # Root properties
     And the JSON node "@id" should be equal to "/docs.jsonld"
     And the JSON node "hydra:title" should be equal to "My Dummy API"
-    And the JSON node "hydra:description" should be equal to "This is a test API."
+    And the JSON node "hydra:description" should contain "This is a test API."
+    And the JSON node "hydra:description" should contain "Made with love"
     And the JSON node "hydra:entrypoint" should be equal to "/"
     # Supported classes
     And the Hydra class "The API entrypoint" exists

--- a/features/swagger/docs.feature
+++ b/features/swagger/docs.feature
@@ -13,7 +13,8 @@ Feature: Documentation support
     And the JSON node "swagger" should be equal to "2.0"
     # Root properties
     And the JSON node "info.title" should be equal to "My Dummy API"
-    And the JSON node "info.description" should be equal to "This is a test API."
+    And the JSON node "info.description" should contain "This is a test API."
+    And the JSON node "info.description" should contain "Made with love"
     # Supported classes
     And the Swagger class "AbstractDummy" exists
     And the Swagger class "CircularReference" exists

--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -67,7 +67,7 @@ final class SwaggerCommand extends Command
     {
         $documentation = new Documentation($this->resourceNameCollectionFactory->create(), $this->apiTitle, $this->apiDescription, $this->apiVersion, $this->apiFormats);
         $data = $this->documentationNormalizer->normalize($documentation);
-        $content = $input->getOption('yaml') ? Yaml::dump($data, 6, 4, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE) : (json_encode($data, JSON_PRETTY_PRINT) ?: '');
+        $content = $input->getOption('yaml') ? Yaml::dump($data, 6, 4, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK) : (json_encode($data, JSON_PRETTY_PRINT) ?: '');
         if (!empty($filename = $input->getOption('output')) && \is_string($filename)) {
             file_put_contents($filename, $content);
             $output->writeln(

--- a/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
+++ b/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
@@ -72,6 +72,17 @@ YAML;
 YAML;
 
         $this->assertContains($expected, $result, 'arrays should be correctly formatted.');
+
+        $expected = <<<YAML
+info:
+    title: 'My Dummy API'
+    version: 0.0.0
+    description: |
+        This is a test API.
+        Made with love
+YAML;
+
+        $this->assertContains($expected, $result, 'multiline formatting must be preserved (using literal style).');
     }
 
     public function testWriteToFile()

--- a/tests/Fixtures/app/config/config_test.yml
+++ b/tests/Fixtures/app/config/config_test.yml
@@ -28,7 +28,9 @@ twig:
 
 api_platform:
     title:                             'My Dummy API'
-    description:                       'This is a test API.'
+    description: |
+        This is a test API.
+        Made with love
     allow_plain_identifiers:           true
     formats:
         jsonld:                        ['application/ld+json']


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | not sure
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/core/issues/2458
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

This PR allow to keep the original formatting, before : 

```
    # The description of the API.
    description: |
        A multiline
        description
```

would become

```
info:
    ...
    description: "A multiline\ndescription"
```

and will now be preserved.