### PR TITLE
Use api_doc to switch between SwaggerUI and ReDoc

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -67,8 +67,8 @@
             <br>
             Other API docs:
             {% set active_ui = app.request.get('ui', 'swagger_ui') %}
-            {% if swaggerUiEnabled and active_ui != 'swagger_ui' %}<a href="{{ path('api_entrypoint') }}">Swagger UI</a>{% endif %}
-            {% if reDocEnabled and active_ui != 're_doc' %}<a href="{{ path('api_entrypoint', {'ui': 're_doc'}) }}">ReDoc</a>{% endif %}
+            {% if swaggerUiEnabled and active_ui != 'swagger_ui' %}<a href="{{ path('api_doc') }}">Swagger UI</a>{% endif %}
+            {% if reDocEnabled and active_ui != 're_doc' %}<a href="{{ path('api_doc', {'ui': 're_doc'}) }}">ReDoc</a>{% endif %}
             <a href="{% if graphqlEnabled %}{{ path('api_graphql_entrypoint') }}{% else %}javascript:alert('GraphQL support is not enabled, see https://api-platform.com/docs/core/graphql/'){% endif %}">GraphiQL</a>
         </div>
     </div>


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

My `api_entrypoint`  is behind a JWT-secured firewall and therefore can't be accessed. However, I have an exception for the route `api_doc`. Since it's [the documented route](https://api-platform.com/docs/core/swagger/) to access to SwaggerUI (and now ReDoc), I think we should use this route to switch between the two UIs.