### PR TITLE
Fix version constraints for Doctrine MongoDB ODM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,10 +76,11 @@
         "webonyx/graphql-php": ">=0.13 <1.0"
     },
     "conflict": {
-        "doctrine/common": "<2.7"
+        "doctrine/common": "<2.7",
+        "doctrine/mongodb-odm": "<2.0"
     },
     "suggest": {
-        "doctrine/mongodb-odm-bundle": "To support MongoDB.",
+        "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",
         "elasticsearch/elasticsearch": "To support Elasticsearch.",
         "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge.",
         "guzzlehttp/guzzle": "To use the HTTP cache invalidation system.",


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This updates `composer.json` with a `conflict` constraint for Doctrine MongoDB ODM. Since the ODM dependency is optional, using `conflict` is the only way to enforce having 2.0 or later. Users with 1.0 will get weird errors about repositories not being of the expected type instead of a useful message that they should be using API Platform with 2.0 only.