### PR TITLE
Allow configuring input and ouput class per operation

### DIFF
--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -206,14 +206,25 @@ final class ApiLoader extends Loader
         $path = trim(trim($resourceMetadata->getAttribute('route_prefix', '')), '/');
         $path .= $this->operationPathResolver->resolveOperationPath($resourceShortName, $operation, $operationType, $operationName);
 
+        $inputClass = $resourceMetadata->getAttribute('input_class', $resourceClass);
+        $outputClass = $resourceMetadata->getAttribute('output_class', $resourceClass);
+
+        if (OperationType::ITEM === $operationType) {
+            $inputClass = $resourceMetadata->getItemOperationAttribute($operationName, 'input_class', $inputClass);
+            $outputClass = $resourceMetadata->getItemOperationAttribute($operationName, 'output_class', $outputClass);
+        } else {
+            $inputClass = $resourceMetadata->getCollectionOperationAttribute($operationName, 'input_class', $inputClass);
+            $outputClass = $resourceMetadata->getCollectionOperationAttribute($operationName, 'output_class', $outputClass);
+        }
+
         $route = new Route(
             $path,
             [
                 '_controller' => $controller,
                 '_format' => null,
                 '_api_resource_class' => $resourceClass,
-                '_api_input_class' => $resourceMetadata->getAttribute('input_class', $resourceClass),
-                '_api_output_class' => $resourceMetadata->getAttribute('output_class', $resourceClass),
+                '_api_input_class' => $inputClass,
+                '_api_output_class' => $outputClass,
                 sprintf('_api_%s_operation_name', $operationType) => $operationName,
             ] + ($operation['defaults'] ?? []),
             $operation['requirements'] ?? [],

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -206,15 +206,12 @@ final class ApiLoader extends Loader
         $path = trim(trim($resourceMetadata->getAttribute('route_prefix', '')), '/');
         $path .= $this->operationPathResolver->resolveOperationPath($resourceShortName, $operation, $operationType, $operationName);
 
-        $inputClass = $resourceMetadata->getAttribute('input_class', $resourceClass);
-        $outputClass = $resourceMetadata->getAttribute('output_class', $resourceClass);
-
         if (OperationType::ITEM === $operationType) {
-            $inputClass = $resourceMetadata->getItemOperationAttribute($operationName, 'input_class', $inputClass);
-            $outputClass = $resourceMetadata->getItemOperationAttribute($operationName, 'output_class', $outputClass);
+            $inputClass = $resourceMetadata->getItemOperationAttribute($operationName, 'input_class', $resourceClass, true);
+            $outputClass = $resourceMetadata->getItemOperationAttribute($operationName, 'output_class', $resourceClass, true);
         } else {
-            $inputClass = $resourceMetadata->getCollectionOperationAttribute($operationName, 'input_class', $inputClass);
-            $outputClass = $resourceMetadata->getCollectionOperationAttribute($operationName, 'output_class', $outputClass);
+            $inputClass = $resourceMetadata->getCollectionOperationAttribute($operationName, 'input_class', $resourceClass, true);
+            $outputClass = $resourceMetadata->getCollectionOperationAttribute($operationName, 'output_class', $resourceClass, true);
         }
 
         $route = new Route(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This allows specifying the input and output class per operation.
It is [already possibly](https://github.com/api-platform/core/blob/15103682f8600ccbdca5d119827a076da02d4172/src/Bridge/Symfony/Routing/ApiLoader.php#L126) to specify them for subresources, so I think it was an oversight for operations, which is why i'm classifying this as a bug.