### PR TITLE
Fix instantiating object with discriminator mapping

### DIFF
--- a/features/main/crud_abstract.feature
+++ b/features/main/crud_abstract.feature
@@ -80,8 +80,8 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
     """
 
   Scenario: Update a concrete resource
-      When I add "Content-Type" header equal to "application/ld+json"
-      And I send a "PUT" request to "/concrete_dummies/1" with body:
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/concrete_dummies/1" with body:
       """
       {
         "@id": "/concrete_dummies/1",
@@ -89,11 +89,11 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
         "name": "A nice dummy"
       }
       """
-      Then the response status code should be 200
-      And the response should be in JSON
-      And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-      And the header "Content-Location" should be equal to "/concrete_dummies/1"
-      And the JSON should be equal to:
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should be equal to "/concrete_dummies/1"
+    And the JSON should be equal to:
       """
       {
         "@context": "/contexts/ConcreteDummy",
@@ -102,6 +102,32 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
         "instance": "Become real",
         "id": 1,
         "name": "A nice dummy"
+      }
+      """
+
+  Scenario: Update a concrete resource using abstract resource uri
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/abstract_dummies/1" with body:
+      """
+      {
+        "@id": "/concrete_dummies/1",
+        "instance": "Become surreal",
+        "name": "A nicer dummy"
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should be equal to "/concrete_dummies/1"
+    And the JSON should be equal to:
+      """
+      {
+        "@context": "/contexts/ConcreteDummy",
+        "@id": "/concrete_dummies/1",
+        "@type": "ConcreteDummy",
+        "instance": "Become surreal",
+        "id": 1,
+        "name": "A nicer dummy"
       }
       """
 

--- a/features/main/crud_abstract.feature
+++ b/features/main/crud_abstract.feature
@@ -135,3 +135,30 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
     When I send a "DELETE" request to "/abstract_dummies/1"
     Then the response status code should be 204
     And the response should be empty
+
+  Scenario: Create a concrete resource with discriminator
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/abstract_dummies" with body:
+    """
+    {
+      "discr": "concrete",
+      "instance": "Concrete",
+      "name": "My Dummy"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should be equal to "/concrete_dummies/2"
+    And the header "Location" should be equal to "/concrete_dummies/2"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/ConcreteDummy",
+      "@id": "/concrete_dummies/2",
+      "@type": "ConcreteDummy",
+      "instance": "Concrete",
+      "id": 2,
+      "name": "My Dummy"
+    }
+    """

--- a/features/main/crud_abstract.feature
+++ b/features/main/crud_abstract.feature
@@ -136,6 +136,7 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
     Then the response status code should be 204
     And the response should be empty
 
+  @createSchema
   Scenario: Create a concrete resource with discriminator
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/abstract_dummies" with body:
@@ -149,16 +150,16 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
     Then the response status code should be 201
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the header "Content-Location" should be equal to "/concrete_dummies/2"
-    And the header "Location" should be equal to "/concrete_dummies/2"
+    And the header "Content-Location" should be equal to "/concrete_dummies/1"
+    And the header "Location" should be equal to "/concrete_dummies/1"
     And the JSON should be equal to:
     """
     {
       "@context": "/contexts/ConcreteDummy",
-      "@id": "/concrete_dummies/2",
+      "@id": "/concrete_dummies/1",
       "@type": "ConcreteDummy",
       "instance": "Concrete",
-      "id": 2,
+      "id": 1,
       "name": "My Dummy"
     }
     """

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -65,9 +65,6 @@ final class WriteListener
 
                 $event->setControllerResult($persistResult ?? $controllerResult);
 
-                // Controller result must be immutable for _api_write_item_iri
-                // if it's class changed compared to the base class let's avoid calling the IriConverter
-                // especially that the Output class could be a DTO that's not referencing any route
                 if (null === $this->iriConverter) {
                     return;
                 }
@@ -79,8 +76,7 @@ final class WriteListener
                     $hasOutput = \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'];
                 }
 
-                $class = \get_class($controllerResult);
-                if ($hasOutput && $attributes['resource_class'] === $class && $class === \get_class($event->getControllerResult())) {
+                if ($hasOutput) {
                     $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
                 }
             break;

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -185,6 +185,12 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     protected function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes, string $format = null)
     {
+        if (null !== $object = $this->extractObjectToPopulate($class, $context, static::OBJECT_TO_POPULATE)) {
+            unset($context[static::OBJECT_TO_POPULATE]);
+
+            return $object;
+        }
+
         if ($this->classDiscriminatorResolver && $mapping = $this->classDiscriminatorResolver->getMappingForClass($class)) {
             if (!isset($data[$mapping->getTypeProperty()])) {
                 throw new RuntimeException(sprintf('Type property "%s" not found for the abstract object "%s"', $mapping->getTypeProperty(), $class));
@@ -197,12 +203,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
             $class = $mappedClass;
             $reflectionClass = new \ReflectionClass($class);
-        }
-
-        if (null !== $object = $this->extractObjectToPopulate($class, $context, static::OBJECT_TO_POPULATE)) {
-            unset($context[static::OBJECT_TO_POPULATE]);
-
-            return $object;
         }
 
         $constructor = $this->getConstructor($data, $class, $context, $reflectionClass, $allowedAttributes);

--- a/tests/EventListener/WriteListenerTest.php
+++ b/tests/EventListener/WriteListenerTest.php
@@ -18,9 +18,8 @@ use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\EventListener\WriteListener;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConcreteDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
-use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritance;
-use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceChild;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
@@ -270,16 +269,16 @@ class WriteListenerTest extends TestCase
 
     public function testOnKernelViewWithParentResourceClass()
     {
-        $dummy = new DummyTableInheritanceChild();
+        $dummy = new ConcreteDummy();
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
         $dataPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
         $dataPersisterProphecy->persist($dummy)->willReturn($dummy)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1')->shouldBeCalled();
 
-        $request = new Request([], [], ['_api_resource_class' => DummyTableInheritance::class, '_api_item_operation_name' => 'put', '_api_persist' => true]);
+        $request = new Request([], [], ['_api_resource_class' => ConcreteDummy::class, '_api_item_operation_name' => 'put', '_api_persist' => true]);
         $request->setMethod('PUT');
 
         $event = new GetResponseForControllerResultEvent(

--- a/tests/Fixtures/TestBundle/Document/AbstractDummy.php
+++ b/tests/Fixtures/TestBundle/Document/AbstractDummy.php
@@ -23,11 +23,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  * @ApiResource(
- *     itemOperations={
- *         "get",
- *         "put",
- *         "delete",
- *     },
+ *     collectionOperations={"get", "post"},
+ *     itemOperations={"get", "put", "delete"},
  *     attributes={"filters"={"my_dummy.mongodb.search", "my_dummy.mongodb.order", "my_dummy.mongodb.date"}}
  * )
  * @ODM\Document

--- a/tests/Fixtures/TestBundle/Document/AbstractDummy.php
+++ b/tests/Fixtures/TestBundle/Document/AbstractDummy.php
@@ -22,8 +22,14 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Abstract Dummy.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @ApiResource(attributes={"filters"={"my_dummy.mongodb.search", "my_dummy.mongodb.order", "my_dummy.mongodb.date"}})
+ * @ApiResource(
+ *     itemOperations={
+ *         "get",
+ *         "put",
+ *         "delete",
+ *     },
+ *     attributes={"filters"={"my_dummy.mongodb.search", "my_dummy.mongodb.order", "my_dummy.mongodb.date"}}
+ * )
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField(value="discr")

--- a/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
@@ -23,7 +23,14 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
- * @ApiResource(attributes={"filters"={"my_dummy.search", "my_dummy.order", "my_dummy.date"}})
+ * @ApiResource(
+ *     itemOperations={
+ *         "get",
+ *         "put",
+ *         "delete",
+ *     },
+ *     attributes={"filters"={"my_dummy.search", "my_dummy.order", "my_dummy.date"}}
+ * )
  * @ORM\Entity
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="discr", type="string", length=16)

--- a/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/AbstractDummy.php
@@ -24,11 +24,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @ApiResource(
- *     itemOperations={
- *         "get",
- *         "put",
- *         "delete",
- *     },
+ *     collectionOperations={"get", "post"},
+ *     itemOperations={"get", "put", "delete"},
  *     attributes={"filters"={"my_dummy.search", "my_dummy.order", "my_dummy.date"}}
  * )
  * @ORM\Entity

--- a/tests/Fixtures/TestBundle/Resources/config/serialization/abstract_dummy.yml
+++ b/tests/Fixtures/TestBundle/Resources/config/serialization/abstract_dummy.yml
@@ -1,0 +1,11 @@
+ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AbstractDummy:
+  discriminator_map:
+    type_property: discr
+    mapping:
+      concrete: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConcreteDummy'
+
+ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\AbstractDummy:
+  discriminator_map:
+    type_property: discr
+    mapping:
+      concrete: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\ConcreteDummy'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The bug here is:
if you are trying to update a resource that has discriminator mapping, using a URI that is mapped on the abstract class, the class discriminator mapping resolution may fail because when updating a resource, there is no need to send the discriminator in the request.
Instead we should prioritize `OBJECT_TO_POPULATE` as it is already known which resource we have, via the Read Listener.
