### PR TITLE
More Descriptive Input/Output class names

### DIFF
--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -550,7 +550,9 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     {
         $keyPrefix = $resourceMetadata->getShortName();
         if (null !== $publicClass) {
-            $keyPrefix .= ':'.md5($publicClass);
+            $parts = explode('\\', $publicClass);
+            $shortName = end($parts);
+            $keyPrefix .= ':'.$shortName;
         }
 
         if (isset($serializerContext[self::SWAGGER_DEFINITION_NAME])) {

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -2374,7 +2374,7 @@ class DocumentationNormalizerV2Test extends TestCase
                                 'schema' => [
                                     'type' => 'array',
                                     'items' => [
-                                        '$ref' => '#/definitions/Dummy:300dcd476cef011532fb0ca7683395d7',
+                                        '$ref' => '#/definitions/Dummy:OutputDto',
                                     ],
                                 ],
                             ],
@@ -2399,7 +2399,7 @@ class DocumentationNormalizerV2Test extends TestCase
                             201 => [
                                 'description' => 'Dummy resource created',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:300dcd476cef011532fb0ca7683395d7',
+                                    '$ref' => '#/definitions/Dummy:OutputDto',
                                 ],
                             ],
                             400 => [
@@ -2415,7 +2415,7 @@ class DocumentationNormalizerV2Test extends TestCase
                                 'in' => 'body',
                                 'description' => 'The new Dummy resource',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:b4f76c1a44965bd401aa23bb37618acc',
+                                    '$ref' => '#/definitions/Dummy:InputDto',
                                 ],
                             ],
                         ],
@@ -2439,7 +2439,7 @@ class DocumentationNormalizerV2Test extends TestCase
                             200 => [
                                 'description' => 'Dummy resource response',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:300dcd476cef011532fb0ca7683395d7',
+                                    '$ref' => '#/definitions/Dummy:OutputDto',
                                 ],
                             ],
                             404 => [
@@ -2465,7 +2465,7 @@ class DocumentationNormalizerV2Test extends TestCase
                                 'in' => 'body',
                                 'description' => 'The updated Dummy resource',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:b4f76c1a44965bd401aa23bb37618acc',
+                                    '$ref' => '#/definitions/Dummy:InputDto',
                                 ],
                             ],
                         ],
@@ -2473,7 +2473,7 @@ class DocumentationNormalizerV2Test extends TestCase
                             200 => [
                                 'description' => 'Dummy resource updated',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:300dcd476cef011532fb0ca7683395d7',
+                                    '$ref' => '#/definitions/Dummy:OutputDto',
                                 ],
                             ],
                             400 => [
@@ -2487,7 +2487,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ],
             ]),
             'definitions' => new \ArrayObject([
-                'Dummy:300dcd476cef011532fb0ca7683395d7' => new \ArrayObject([
+                'Dummy:OutputDto' => new \ArrayObject([
                     'type' => 'object',
                     'description' => 'This is a dummy.',
                     'externalDocs' => [
@@ -2505,7 +2505,7 @@ class DocumentationNormalizerV2Test extends TestCase
                         ]),
                     ],
                 ]),
-                'Dummy:b4f76c1a44965bd401aa23bb37618acc' => new \ArrayObject([
+                'Dummy:InputDto' => new \ArrayObject([
                     'type' => 'object',
                     'description' => 'This is a dummy.',
                     'externalDocs' => [


### PR DESCRIPTION
- Updated the DocumentationNormalizer to give
  a more decriptive name for input/output classes
- This looks very good when you name your DTO's
  like commands: `Book:CreateBookRequest` or
  `Book:UpdateBookForm` etc etc.

Signed-off-by: RJ Garcia <rj@bighead.net>

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Ish
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
