### PR TITLE
Disable Messenger From Config

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -41,7 +41,6 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -149,11 +148,8 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerValidatorConfiguration($container, $config);
         $this->registerDataCollectorConfiguration($container, $config, $loader);
         $this->registerMercureConfiguration($container, $config, $loader, $useDoctrine);
+        $this->registerMessengerConfiguration($config, $loader);
         $this->registerElasticsearchConfiguration($container, $config, $loader);
-
-        if (interface_exists(MessageBusInterface::class) && $container->has('message_bus')) {
-            $loader->load('messenger.xml');
-        }
     }
 
     /**
@@ -578,6 +574,15 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         if ($useDoctrine) {
             $loader->load('doctrine_orm_mercure_publisher.xml');
         }
+    }
+
+    private function registerMessengerConfiguration(array $config, XmlFileLoader $loader)
+    {
+        if (!$config['messenger']['enabled']) {
+            return;
+        }
+
+        $loader->load('messenger.xml');
     }
 
     private function registerElasticsearchConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader)

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 
 /**
@@ -243,6 +244,10 @@ final class Configuration implements ConfigurationInterface
                             ->info('The URL send in the Link HTTP header. If not set, will default to the URL for the Symfony\'s bundle default hub.')
                         ->end()
                     ->end()
+                ->end()
+
+                ->arrayNode('messenger')
+                    ->{interface_exists(MessageBusInterface::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                 ->end()
 
                 ->arrayNode('elasticsearch')

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -471,6 +471,19 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load($config, $containerBuilder);
     }
 
+    public function testDisabledMessenger()
+    {
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
+        $containerBuilderProphecy->setAlias('api_platform.message_bus', 'message_bus')->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.messenger.data_persister', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilder = $containerBuilderProphecy->reveal();
+
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['messenger']['enabled'] = false;
+
+        $this->extension->load($config, $containerBuilder);
+    }
+
     public function testDisableDoctrine()
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
@@ -837,7 +850,6 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->getParameter('kernel.debug')->willReturn(false);
 
         $containerBuilderProphecy->getDefinition('api_platform.http_cache.purger.varnish')->willReturn(new Definition());
-        $containerBuilderProphecy->has('message_bus')->willReturn(true);
 
         return $containerBuilderProphecy;
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -157,6 +157,9 @@ class ConfigurationTest extends TestCase
             'doctrine_mongodb_odm' => [
                 'enabled' => true,
             ],
+            'messenger' => [
+                'enabled' => true,
+            ],
             'mercure' => [
                 'enabled' => true,
                 'hub_url' => null,


### PR DESCRIPTION
- Added ability to disable messenger from config
- Removed previous check if container has message_bus

Signed-off-by: RJ Garcia <rj@bighead.net>

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 