### PR TITLE
Fix Bug Preventing Denormalization of Input Classes with Different Fields

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -128,9 +128,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         $context['api_denormalize'] = true;
-        if (!isset($context['resource_class'])) {
-            $context['resource_class'] = $class;
-        }
+        $context['resource_class'] = $class;
 
         return parent::denormalize($data, $class, $format, $context);
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyForAdditionalFields.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyForAdditionalFields.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class DummyForAdditionalFields
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+    /** @ORM\Column */
+    private $name;
+    /** @ORM\Column */
+    private $slug;
+
+    public function __construct(string $name, string $slug)
+    {
+        $this->name = $name;
+        $this->slug = $slug;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyForAdditionalFieldsInput.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyForAdditionalFieldsInput.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+
+/**
+ * @ApiResource
+ */
+final class DummyForAdditionalFieldsInput
+{
+    private $dummyName;
+
+    public function __construct(string $dummyName)
+    {
+        $this->dummyName = $dummyName;
+    }
+
+    public function getDummyName(): string
+    {
+        return $this->dummyName;
+    }
+}


### PR DESCRIPTION
Fixes the bug where AbstractItemSerializer would use
the resource class instead of the input class to
determine allowed properties.

Enforced `$context['resource_class']` to be set to
current denormalized class to resolve issue. Figured this
should be the case since AbstractItemNormalizer only works
on resources.

Signed-off-by: RJ Garcia <rj@bighead.net>

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
