### PR TITLE
Doctrine ORM Paginator should provide possibility to get  Query object

### DIFF
--- a/src/Bridge/Doctrine/Orm/Paginator.php
+++ b/src/Bridge/Doctrine/Orm/Paginator.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm;
 
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
+use Doctrine\ORM\Query;
 
 /**
  * Decorates the Doctrine ORM paginator.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class Paginator extends AbstractPaginator implements PaginatorInterface
+final class Paginator extends AbstractPaginator implements PaginatorInterface, QueryAwareInterface
 {
     /**
      * @var int
@@ -45,5 +46,13 @@ final class Paginator extends AbstractPaginator implements PaginatorInterface
     public function getTotalItems(): float
     {
         return (float) ($this->totalItems ?? $this->totalItems = \count($this->paginator));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuery(): Query
+    {
+        return $this->paginator->getQuery();
     }
 }

--- a/src/Bridge/Doctrine/Orm/QueryAwareInterface.php
+++ b/src/Bridge/Doctrine/Orm/QueryAwareInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Orm;
+
+use Doctrine\ORM\Query;
+
+interface QueryAwareInterface
+{
+    /**
+     * Gets the Query object that will actually be executed.
+     *
+     * This should allow configuring options which could only be set on the Query
+     * object itself.
+     */
+    public function getQuery(): Query;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This pull request adds `getQuery` method to `ApiPlatform\Core\Bridge\Doctrine\Orm\AbstractPaginator`. 
Why: When making Translatable entity from Doctrine Extensions work I had to set hints for Query (https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.x/doc/translatable.md#using-orm-query-hint). The best way to do this from my point of view was to decorate pagination extension (`api_platform.doctrine.orm.query_extension.pagination`) and the only thing I was missing is a way to manipulate with a Query object. Otherwise I would have to rewrite whole Pagination Extension.

`Doctrine\ORM\Tools\Pagination\Paginator` exposes Query object so why its wrapper from Api Platform should not?
