### PR TITLE
Throw exception if no item found when denormalizing a relation using plain identifiers

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -393,7 +393,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             // repeat the code so that IRIs keep working with the json format
             if (true === $this->allowPlainIdentifiers && $this->itemDataProvider) {
                 try {
-                    return $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true]);
+                    if (null !== $item = $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true])) {
+                        return $item;
+                    }
                 } catch (ItemNotFoundException $e) {
                     throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
                 } catch (InvalidArgumentException $e) {

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -719,7 +719,7 @@ class AbstractItemNormalizerTest extends TestCase
         $serializerProphecy->willImplement(DenormalizerInterface::class);
 
         $itemDataProviderProphecy = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProviderProphecy->getItem(RelatedDummy::class, 1, null, Argument::type('array'))->shouldBeCalled();
+        $itemDataProviderProphecy->getItem(RelatedDummy::class, 1, null, Argument::type('array'))->shouldBeCalled()->willReturn(new RelatedDummy());
 
         $normalizer = $this->getMockForAbstractClass(AbstractItemNormalizer::class, [
             $propertyNameCollectionFactoryProphecy->reveal(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

Scenario: This is enabled: `allow_plain_identifiers: true`, the request is sent in `json`, and a non existing plain identifier is sent in a relationship field. 

Instead of returning a `400` error code, a `200` code is returned.

That's because `denormalizeRelation` returns an empty object instead of throwing `InvalidArgumentException`.

If this PR makes sense I'll add a test for it too.

