### PR TITLE
bugfix: throw InvalidArgument on matching something that looks like a…

### DIFF
--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -426,6 +426,7 @@ Feature: Create-Retrieve-Update-Delete
     {
       "@id": "/dummies/1",
       "name": "A nice dummy",
+      "dummyDate": "2018-12-01 13:12",
       "jsonData": [{
           "key": "value1"
         },
@@ -447,7 +448,7 @@ Feature: Create-Retrieve-Update-Delete
       "description": null,
       "dummy": null,
       "dummyBoolean": null,
-      "dummyDate": "2015-03-01T10:00:00+00:00",
+      "dummyDate": "2018-12-01T13:12:00+00:00",
       "dummyFloat": null,
       "dummyPrice": null,
       "relatedDummy": null,
@@ -486,7 +487,7 @@ Feature: Create-Retrieve-Update-Delete
       "description": null,
       "dummy": null,
       "dummyBoolean": null,
-      "dummyDate": "2015-03-01T10:00:00+00:00",
+      "dummyDate": "2018-12-01T13:12:00+00:00",
       "dummyFloat": null,
       "dummyPrice": null,
       "relatedDummy": null,

--- a/src/Bridge/Symfony/Routing/Router.php
+++ b/src/Bridge/Symfony/Routing/Router.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -72,7 +74,12 @@ final class Router implements RouterInterface, UrlGeneratorInterface
         $pathInfo = str_replace($baseContext->getBaseUrl(), '', $pathInfo);
 
         $request = Request::create($pathInfo, 'GET', [], [], [], ['HTTP_HOST' => $baseContext->getHost()]);
-        $context = (new RequestContext())->fromRequest($request);
+        try {
+            $context = (new RequestContext())->fromRequest($request);
+        } catch (RequestExceptionInterface $e) {
+            throw new RouteNotFoundException('Invalid request context.');
+        }
+
         $context->setPathInfo($pathInfo);
         $context->setScheme($baseContext->getScheme());
         $context->setHost($baseContext->getHost());

--- a/src/Bridge/Symfony/Routing/Router.php
+++ b/src/Bridge/Symfony/Routing/Router.php
@@ -16,7 +16,7 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -77,7 +77,7 @@ final class Router implements RouterInterface, UrlGeneratorInterface
         try {
             $context = (new RequestContext())->fromRequest($request);
         } catch (RequestExceptionInterface $e) {
-            throw new RouteNotFoundException('Invalid request context.');
+            throw new ResourceNotFoundException('Invalid request context.');
         }
 
         $context->setPathInfo($pathInfo);

--- a/tests/Bridge/Symfony/Routing/RouterTest.php
+++ b/tests/Bridge/Symfony/Routing/RouterTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Symfony\Routing;
 use ApiPlatform\Core\Bridge\Symfony\Routing\Router;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
@@ -71,5 +72,18 @@ class RouterTest extends TestCase
         $router = new Router($mockedRouter->reveal());
 
         $this->assertEquals(['bar'], $router->match('/app_dev.php/foo'));
+    }
+
+    public function testWithinvalidContext()
+    {
+        $this->expectException(RoutingExceptionInterface::class);
+        $this->expectExceptionMessage('Invalid request context.');
+        $context = new RequestContext('/app_dev.php', 'GET', 'localhost', 'https');
+
+        $mockedRouter = $this->prophesize('Symfony\Component\Routing\RouterInterface');
+        $mockedRouter->getContext()->willReturn($context)->shouldBeCalled();
+
+        $router = new Router($mockedRouter->reveal());
+        $router->match('28-01-2018 10:10');
     }
 }


### PR DESCRIPTION
…n url

I know that backporting is only for security fixes but this is a really old issue, maybe we can make an exception?