### PR TITLE
fix error case when denormalizing relations with plain identifiers.

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -436,13 +436,12 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         if (!\is_array($value)) {
             // repeat the code so that IRIs keep working with the json format
             if (true === $this->allowPlainIdentifiers && $this->itemDataProvider) {
-                try {
-                    return $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true]);
-                } catch (ItemNotFoundException $e) {
-                    throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
-                } catch (InvalidArgumentException $e) {
-                    // Give a chance to other normalizers (e.g.: DateTimeNormalizer)
+                $item = $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true]);
+                if (null === $item) {
+                    throw new ItemNotFoundException(sprintf('Item not found for "%s".', $value));
                 }
+
+                return $item;
             }
 
             throw new InvalidArgumentException(sprintf(


### PR DESCRIPTION
fix error case when denormalizing relations with plain identifiers. null is returned, no exceptions are thrown.

Not sure which branch to merge into. let me know!

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
