### PR TITLE
Fix Wrong call to DataTransformer::supportsTransformation for JsonApi…

### DIFF
--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -68,7 +68,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
         }
 
         $outputClass = $this->getOutputClass($this->getObjectClass($object), $context);
-        if (null !== $outputClass && null !== $this->dataTransformer && $this->dataTransformer->supportsTransformation($object, $context)) {
+        if (null !== $outputClass && null !== $this->dataTransformer && $this->dataTransformer->supportsTransformation($object, $outputClass, $context)) {
             $object = $this->dataTransformer->transform($object, $context);
         }
 


### PR DESCRIPTION
… format

Wrong call to DataTransformer::supportsTransformation in JsonApi::ItemNormalizer, missing the second string parameter before the context parameter.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2539
| License       | MIT

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
