### PR TITLE
add missing cache pool adapter override

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -450,6 +450,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->register('api_platform.cache.route_name_resolver', ArrayAdapter::class);
         $container->register('api_platform.cache.identifiers_extractor', ArrayAdapter::class);
         $container->register('api_platform.cache.subresource_operation_factory', ArrayAdapter::class);
+        $container->register('api_platform.elasticsearch.cache.metadata.document', ArrayAdapter::class);
     }
 
     /**


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Overriding the adapter for the `api_platform.elasticsearch.cache.metadata.document` cache pool was missing.