### PR TITLE
[MongoDB] Allow limit 0

### DIFF
--- a/features/hydra/collection.feature
+++ b/features/hydra/collection.feature
@@ -396,7 +396,6 @@ Feature: Collections support
     }
     """
 
-  @!mongodb
   @createSchema
   Scenario: Allow passing 0 to `itemsPerPage`
     When I send a "GET" request to "/dummies?itemsPerPage=0"

--- a/tests/Bridge/Doctrine/MongoDbOdm/PaginatorTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/PaginatorTest.php
@@ -74,6 +74,15 @@ class PaginatorTest extends TestCase
         $this->getPaginatorWithMissingStage(true, true, true, true);
     }
 
+    public function testInitializeWithLimitZeroStageApplied()
+    {
+        $paginator = $this->getPaginator(0, 5, 0, true);
+
+        $this->assertEquals(1, $paginator->getCurrentPage());
+        $this->assertEquals(1, $paginator->getLastPage());
+        $this->assertEquals(0, $paginator->getItemsPerPage());
+    }
+
     public function testInitializeWithNoCount()
     {
         $paginator = $this->getPaginatorWithNoCount();
@@ -90,7 +99,7 @@ class PaginatorTest extends TestCase
         $this->assertSame($paginator->getIterator(), $paginator->getIterator(), 'Iterator should be cached');
     }
 
-    private function getPaginator($firstResult = 1, $maxResults = 15, $totalItems = 42)
+    private function getPaginator($firstResult = 1, $maxResults = 15, $totalItems = 42, $limitZero = false)
     {
         $iterator = $this->prophesize(Iterator::class);
         $pipeline = [
@@ -98,7 +107,7 @@ class PaginatorTest extends TestCase
                 '$facet' => [
                     'results' => [
                         ['$skip' => $firstResult],
-                        ['$limit' => $maxResults],
+                        $limitZero ? ['$match' => [Paginator::LIMIT_ZERO_MARKER_FIELD => Paginator::LIMIT_ZERO_MARKER]] : ['$limit' => $maxResults],
                     ],
                     'count' => [
                         ['$count' => 'count'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

This PR allows to set a limit equals to 0 for MongoDB.
This is a little tricky since MongoDB doesn't allow it by default.
It is a requirement for this PR: https://github.com/api-platform/core/pull/2142