### PR TITLE
add missing MetadataAwareNameConverterPass registration 🐛

### DIFF
--- a/src/Bridge/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
+++ b/src/Bridge/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
@@ -36,7 +36,7 @@ final class InnerFieldsNameConverter implements AdvancedNameConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($propertyName, string $class = null, string $format = null, $context = [])
+    public function normalize($propertyName, string $class = null, string $format = null, array $context = [])
     {
         return $this->convertInnerFields($propertyName, true, $class, $format, $context);
     }
@@ -44,7 +44,7 @@ final class InnerFieldsNameConverter implements AdvancedNameConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function denormalize($propertyName, string $class = null, string $format = null, $context = [])
+    public function denormalize($propertyName, string $class = null, string $format = null, array $context = [])
     {
         return $this->convertInnerFields($propertyName, false, $class, $format, $context);
     }

--- a/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\Annotati
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -38,5 +39,6 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new AnnotationFilterPass());
         $container->addCompilerPass(new FilterPass());
         $container->addCompilerPass(new ElasticsearchClientPass());
+        $container->addCompilerPass(new MetadataAwareNameConverterPass());
     }
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
@@ -33,8 +33,16 @@ final class MetadataAwareNameConverterPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasAlias('api_platform.name_converter') && $container->hasDefinition('serializer.name_converter.metadata_aware')) {
-            $container->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware');
+        if ($container->hasAlias('api_platform.name_converter') || !$container->hasDefinition('serializer.name_converter.metadata_aware')) {
+            return;
         }
+
+        $definition = $container->getDefinition('serializer.name_converter.metadata_aware');
+
+        if (1 >= \count($definition->getArguments()) || null === $definition->getArgument(1)) {
+            return;
+        }
+
+        $container->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware');
     }
 }

--- a/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\Annotati
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -34,6 +35,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(AnnotationFilterPass::class))->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(FilterPass::class))->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(ElasticsearchClientPass::class))->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(MetadataAwareNameConverterPass::class))->shouldBeCalled();
 
         $bundle = new ApiPlatformBundle();
         $bundle->build($containerProphecy->reveal());

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPassTest.php
@@ -17,20 +17,33 @@ use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\Metadata
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
 class MetadataAwareNameConverterPassTest extends TestCase
 {
+    public function testConstruct()
+    {
+        $this->assertInstanceOf(CompilerPassInterface::class, new MetadataAwareNameConverterPass());
+    }
+
     public function testProcess()
     {
         $pass = new MetadataAwareNameConverterPass();
-        $this->assertInstanceOf(CompilerPassInterface::class, $pass);
+
+        $arguments = [new Reference('serializer.mapping.class_metadata_factory'), new Reference('app.name_converter')];
+
+        $definition = $this->prophesize(Definition::class);
+        $definition->getArguments()->willReturn($arguments)->shouldBeCalled();
+        $definition->getArgument(1)->willReturn($arguments[1])->shouldBeCalled();
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(false);
-        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn(true);
+        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->willReturn($definition)->shouldBeCalled();
         $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldBeCalled();
 
         $pass->process($containerBuilderProphecy->reveal());
@@ -39,11 +52,11 @@ class MetadataAwareNameConverterPassTest extends TestCase
     public function testProcessWithNameConverter()
     {
         $pass = new MetadataAwareNameConverterPass();
-        $this->assertInstanceOf(CompilerPassInterface::class, $pass);
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(true);
-        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->shouldNotBeCalled()->willReturn(true);
+        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->shouldNotBeCalled();
+        $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->shouldNotBeCalled();
         $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldNotBeCalled();
 
         $pass->process($containerBuilderProphecy->reveal());
@@ -52,11 +65,29 @@ class MetadataAwareNameConverterPassTest extends TestCase
     public function testProcessWithoutMetadataAwareDefinition()
     {
         $pass = new MetadataAwareNameConverterPass();
-        $this->assertInstanceOf(CompilerPassInterface::class, $pass);
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(false);
-        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn(false);
+        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldNotBeCalled();
+
+        $pass->process($containerBuilderProphecy->reveal());
+    }
+
+    public function testProcessWithMetadataAwareDefinitionSecondArgumentNull()
+    {
+        $pass = new MetadataAwareNameConverterPass();
+
+        $arguments = [new Reference('serializer.mapping.class_metadata_factory'), null];
+
+        $definition = $this->prophesize(Definition::class);
+        $definition->getArguments()->willReturn($arguments)->shouldBeCalled();
+        $definition->getArgument(1)->willReturn($arguments[1])->shouldBeCalled();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->willReturn($definition)->shouldBeCalled();
         $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldNotBeCalled();
 
         $pass->process($containerBuilderProphecy->reveal());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2523
| License       | MIT
| Doc PR        | 

the `MetadataAwareNameConverter` wasn't being registered because the compiler pass had forgotten to be added :)
