### PR TITLE
[GraphQL] Make clientMutationId nullable

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -54,6 +54,24 @@ Feature: GraphQL mutation support
     And the JSON node "data.createFoo.bar" should be equal to "new"
     And the JSON node "data.createFoo.clientMutationId" should be equal to "myId"
 
+  Scenario: Create an item without a clientMutationId
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createFoo(input: {name: "Created without mutation id", bar: "works"}) {
+        id
+        name
+        bar
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createFoo.id" should be equal to "/foos/2"
+    And the JSON node "data.createFoo.name" should be equal to "Created without mutation id"
+    And the JSON node "data.createFoo.bar" should be equal to "works"
+
   Scenario: Create an item with a subresource
     Given there are 1 dummy objects with relatedDummy
     When I send the following GraphQL request:

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -441,7 +441,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
     {
         $fields = [];
         $idField = ['type' => GraphQLType::nonNull(GraphQLType::id())];
-        $clientMutationId = GraphQLType::nonNull(GraphQLType::string());
+        $clientMutationId = GraphQLType::string();
 
         if ('delete' === $mutationName || (null !== $ioMetadata && null === $ioMetadata['class'])) {
             return [


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2570 
| License       | MIT
| Doc PR        | N/A

As a reference, the [current Relay specification](https://facebook.github.io/relay/graphql/mutations.htm#sec-Mutation-inputs) contains the following:
> In particular, all mutations must expose exactly one argument, named input. This argument’s type must be a NON_NULL wrapper around an INPUT_OBJECT. That input object type **may** contain an argument named clientMutationId. **If provided**, that argument must be a String. That argument **may** be non‐null.