### PR TITLE
Search filter should not use DbRef for association

### DIFF
--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -416,6 +416,17 @@ Feature: Search filter on collections
     And the JSON node "_embedded.item[2]._links.relatedDummies" should have 3 elements
 
   @createSchema
+  Scenario: Search by related collection id
+    Given there are 2 dummy objects having each 2 relatedDummies
+    When I add "Accept" header equal to "application/hal+json"
+    And I send a "GET" request to "/dummies?relatedDummies=3"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "totalItems" should be equal to "1"
+    And the JSON node "_links.item" should have 1 element
+    And the JSON node "_links.item[0].href" should be equal to "/dummies/2"
+
+  @createSchema
   Scenario: Get collection by id equals 9.99 which is not possible
     Given there are 30 dummy objects
     When I send a "GET" request to "/dummies?id=9.99"

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
@@ -135,7 +135,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 
         $aggregationBuilder
             ->match()
-            ->field("$matchField.\$id")
+            ->field($matchField)
             ->in($values);
     }
 

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
@@ -346,9 +346,9 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                         ],
                         [
                             '$match' => [
-                                'relatedDummy.$id' => [
+                                'relatedDummy' => [
                                     '$in' => [
-                                        'foo',
+                                        0,
                                     ],
                                 ],
                             ],
@@ -472,9 +472,9 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     [
                         [
                             '$match' => [
-                                'relatedDummy.$id' => [
+                                'relatedDummy' => [
                                     '$in' => [
-                                        'exact',
+                                        0,
                                     ],
                                 ],
                             ],
@@ -511,7 +511,7 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     [
                         [
                             '$match' => [
-                                'relatedDummy.$id' => [
+                                'relatedDummy' => [
                                     '$in' => [
                                         1,
                                         '2',
@@ -521,7 +521,7 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                         ],
                         [
                             '$match' => [
-                                'relatedDummies.$id' => [
+                                'relatedDummies' => [
                                     '$in' => [
                                         '1',
                                     ],

--- a/tests/Fixtures/TestBundle/Document/RelatedToDummyFriend.php
+++ b/tests/Fixtures/TestBundle/Document/RelatedToDummyFriend.php
@@ -51,7 +51,7 @@ class RelatedToDummyFriend
     private $description;
 
     /**
-     * @ODM\ReferenceOne(targetDocument=DummyFriend::class)
+     * @ODM\ReferenceOne(targetDocument=DummyFriend::class, storeAs="id")
      * @Groups({"fakemanytomany", "friends"})
      * @Assert\NotNull
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2574
| License       | MIT
| Doc PR        |

The search filter should not use DbRef when searching by association because lookups need raw ids.