### PR TITLE
[GraphQL] Avoid to call serialize in ItemNormalizer

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -13,7 +13,6 @@
             <argument type="service" id="api_platform.collection_data_provider" />
             <argument type="service" id="api_platform.subresource_data_provider" />
             <argument type="service" id="serializer" />
-            <argument type="service" id="api_platform.identifiers_extractor.cached" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="null" />
             <argument type="service" id="request_stack" />
@@ -85,6 +84,7 @@
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.identifiers_extractor.cached" />
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -116,23 +116,17 @@ final class IriConverter implements IriConverterInterface
     public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
         $resourceClass = $this->getObjectClass($item);
-        $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
 
         try {
-            $identifiers = $this->generateIdentifiersUrl($this->identifiersExtractor->getIdentifiersFromItem($item), $resourceClass);
-
-            return $this->router->generate($routeName, ['id' => implode(';', $identifiers)], $referenceType);
+            $identifiers = $this->identifiersExtractor->getIdentifiersFromItem($item);
         } catch (RuntimeException $e) {
             throw new InvalidArgumentException(sprintf(
                 'Unable to generate an IRI for the item of type "%s"',
                 $resourceClass
             ), $e->getCode(), $e);
-        } catch (RoutingExceptionInterface $e) {
-            throw new InvalidArgumentException(sprintf(
-                'Unable to generate an IRI for the item of type "%s"',
-                $resourceClass
-            ), $e->getCode(), $e);
         }
+
+        return $this->getItemIriFromResourceClass($resourceClass, $identifiers, $referenceType);
     }
 
     /**
@@ -152,10 +146,17 @@ final class IriConverter implements IriConverterInterface
      */
     public function getItemIriFromResourceClass(string $resourceClass, array $identifiers, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
+        $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
+
         try {
-            return $this->router->generate($this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM), $identifiers, $referenceType);
+            $identifiers = $this->generateIdentifiersUrl($identifiers, $resourceClass);
+
+            return $this->router->generate($routeName, ['id' => implode(';', $identifiers)], $referenceType);
         } catch (RoutingExceptionInterface $e) {
-            throw new InvalidArgumentException(sprintf('Unable to generate an IRI for "%s".', $resourceClass), $e->getCode(), $e);
+            throw new InvalidArgumentException(sprintf(
+                'Unable to generate an IRI for "%s".',
+                $resourceClass
+            ), $e->getCode(), $e);
         }
     }
 

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Resolver\Factory;
 
-use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
@@ -44,18 +43,16 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
     private $collectionDataProvider;
     private $subresourceDataProvider;
     private $normalizer;
-    private $identifiersExtractor;
     private $resourceAccessChecker;
     private $requestStack;
     private $paginationEnabled;
     private $resourceMetadataFactory;
 
-    public function __construct(CollectionDataProviderInterface $collectionDataProvider, SubresourceDataProviderInterface $subresourceDataProvider, NormalizerInterface $normalizer, IdentifiersExtractorInterface $identifiersExtractor, ResourceMetadataFactoryInterface $resourceMetadataFactory, ResourceAccessCheckerInterface $resourceAccessChecker = null, RequestStack $requestStack = null, bool $paginationEnabled = false)
+    public function __construct(CollectionDataProviderInterface $collectionDataProvider, SubresourceDataProviderInterface $subresourceDataProvider, NormalizerInterface $normalizer, ResourceMetadataFactoryInterface $resourceMetadataFactory, ResourceAccessCheckerInterface $resourceAccessChecker = null, RequestStack $requestStack = null, bool $paginationEnabled = false)
     {
         $this->subresourceDataProvider = $subresourceDataProvider;
         $this->collectionDataProvider = $collectionDataProvider;
         $this->normalizer = $normalizer;
-        $this->identifiersExtractor = $identifiersExtractor;
         $this->resourceAccessChecker = $resourceAccessChecker;
         $this->requestStack = $requestStack;
         $this->paginationEnabled = $paginationEnabled;
@@ -82,8 +79,8 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             $dataProviderContext['filters'] = $this->getNormalizedFilters($args);
             $dataProviderContext['graphql'] = true;
 
-            if (isset($rootClass, $source[$rootProperty = $info->fieldName], $source[ItemNormalizer::ITEM_KEY])) {
-                $rootResolvedFields = $this->identifiersExtractor->getIdentifiersFromItem(unserialize($source[ItemNormalizer::ITEM_KEY]));
+            if (isset($rootClass, $source[$rootProperty = $info->fieldName], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY])) {
+                $rootResolvedFields = $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY];
                 $subresource = $this->getSubresource($rootClass, $rootResolvedFields, array_keys($rootResolvedFields), $rootProperty, $resourceClass, true, $dataProviderContext);
                 $collection = $subresource ?? [];
             } else {

--- a/src/GraphQl/Resolver/ResourceFieldResolver.php
+++ b/src/GraphQl/Resolver/ResourceFieldResolver.php
@@ -36,8 +36,8 @@ final class ResourceFieldResolver
     public function __invoke($source, $args, $context, ResolveInfo $info)
     {
         $property = null;
-        if ('id' === $info->fieldName && isset($source[ItemNormalizer::ITEM_KEY])) {
-            return $this->iriConverter->getIriFromItem(unserialize($source[ItemNormalizer::ITEM_KEY]));
+        if ('id' === $info->fieldName && isset($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY])) {
+            return $this->iriConverter->getItemIriFromResourceClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]);
         }
 
         if ('_id' === $info->fieldName && isset($source['id'])) {

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -131,11 +131,11 @@ final class SchemaBuilder implements SchemaBuilderInterface
                 ],
             ],
             'resolveType' => function ($value) {
-                if (!isset($value[ItemNormalizer::ITEM_KEY])) {
+                if (!isset($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY])) {
                     return null;
                 }
 
-                $shortName = (new \ReflectionObject(unserialize($value[ItemNormalizer::ITEM_KEY])))->getShortName();
+                $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName();
 
                 return $this->graphqlTypes[$shortName] ?? null;
             },

--- a/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
+++ b/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
@@ -26,15 +26,13 @@ class ResourceFieldResolverTest extends TestCase
 {
     public function testId()
     {
-        $dummy = new Dummy();
-
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getItemIriFromResourceClass(Dummy::class, ['id' => 1])->willReturn('/dummies/1')->shouldBeCalled();
 
         $resolveInfo = new ResolveInfo('id', [], null, new ObjectType(['name' => '']), '', new Schema([]), null, null, null, null);
 
         $resolver = new ResourceFieldResolver($iriConverterProphecy->reveal());
-        $this->assertEquals('/dummies/1', $resolver([ItemNormalizer::ITEM_KEY => serialize($dummy)], [], [], $resolveInfo));
+        $this->assertEquals('/dummies/1', $resolver([ItemNormalizer::ITEM_RESOURCE_CLASS_KEY => Dummy::class, ItemNormalizer::ITEM_IDENTIFIERS_KEY => ['id' => 1]], [], [], $resolveInfo));
     }
 
     public function testOriginalId()

--- a/tests/GraphQl/Serializer/ItemNormalizerTest.php
+++ b/tests/GraphQl/Serializer/ItemNormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\GraphQl\Serializer;
 
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
@@ -45,6 +46,7 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true)->shouldBeCalled();
@@ -54,6 +56,7 @@ class ItemNormalizerTest extends TestCase
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             $iriConverterProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal(),
             $resourceClassResolverProphecy->reveal()
         );
 
@@ -82,6 +85,9 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromItem($dummy)->willReturn(['id' => 1])->shouldBeCalled();
+
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
 
@@ -93,6 +99,7 @@ class ItemNormalizerTest extends TestCase
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             $iriConverterProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             null,
             null,
@@ -106,7 +113,7 @@ class ItemNormalizerTest extends TestCase
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
-        $this->assertEquals(['name' => 'hello', ItemNormalizer::ITEM_KEY => serialize($dummy)], $normalizer->normalize($dummy, ItemNormalizer::FORMAT, ['resources' => []]));
+        $this->assertEquals(['name' => 'hello', ItemNormalizer::ITEM_RESOURCE_CLASS_KEY => Dummy::class, ItemNormalizer::ITEM_IDENTIFIERS_KEY => ['id' => 1]], $normalizer->normalize($dummy, ItemNormalizer::FORMAT, ['resources' => []]));
     }
 
     public function testDenormalize()
@@ -123,6 +130,8 @@ class ItemNormalizerTest extends TestCase
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -132,6 +141,7 @@ class ItemNormalizerTest extends TestCase
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             $iriConverterProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
             null,
             null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Following https://github.com/api-platform/core/pull/2358.

Replace calls to serialize with computed data in the normalizer to improve performance.

In master because there are some BC breaks (but no deprecated since it's still experimental).