### PR TITLE
Publish mercure updates on flush

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
@@ -17,7 +17,7 @@
             <argument type="service" id="mercure.hub.default.publisher" />
 
             <tag name="doctrine.event_listener" event="onFlush" />
-            <tag name="kernel.event_listener" event="kernel.terminate" method="postFlush" />
+            <tag name="doctrine.event_listener" event="postFlush" />
         </service>
 
     </services>


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

When persisting from a messenger Handler, mercure updates where not published because `kernel.terminate` is not used in that context. This will use doctrine `postFlush` instead to publish mercure updates.
