### PR TITLE
Use composition for Normalizers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-kernel": "^3.4 || ^4.0",
         "symfony/property-access": "^3.4 || ^4.0",
         "symfony/property-info": "^3.4 || ^4.0",
-        "symfony/serializer": "^4.1",
+        "symfony/serializer": "4.2.x-dev",
         "symfony/web-link": "^4.1",
         "willdurand/negotiation": "^2.0.3"
     },

--- a/src/Hal/Serializer/HalItemNormalizer.php
+++ b/src/Hal/Serializer/HalItemNormalizer.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Hal\Serializer;
+
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class HalItemNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    private $normalizer;
+
+    public function __construct(NormalizerInterface $normalizer)
+    {
+        if (!$normalizer instanceof DenormalizerInterface) {
+            throw new \TypeError('');
+        }
+
+        $this->normalizer = $normalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        return $this->normalizer->denormalize($data, $class, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $this->normalizer->supportsDenormalization($data, $type, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return $this->normalizer->normalize($object, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->normalizer->supportsNormalization($data, $format);
+    }
+}

--- a/src/JsonApi/Serializer/JsonApiItemNormalizer.php
+++ b/src/JsonApi/Serializer/JsonApiItemNormalizer.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonApi\Serializer;
+
+use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\CircularReferenceException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Exception\ExtraAttributesException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class JsonApiItemNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    private $normalizer;
+
+    public function __construct(NormalizerInterface $normalizer)
+    {
+        $this->normalizer = $normalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        // TODO: Implement hasCacheableSupportsMethod() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        // TODO: Implement denormalize() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        // TODO: Implement supportsDenormalization() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        // TODO: Implement normalize() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        // TODO: Implement supportsNormalization() method.
+    }
+}

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -20,33 +20,77 @@ use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
-use ApiPlatform\Core\Serializer\ContextTrait;
-use ApiPlatform\Core\Util\ClassInfoTrait;
+use ApiPlatform\Core\Serializer\ObjectClassResolver;
+use ApiPlatform\Core\Serializer\ResourceClassNormalizer;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Converts between objects and array including JSON-LD and Hydra metadata.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ItemNormalizer extends AbstractItemNormalizer
+final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface, SerializerAwareInterface
 {
-    use ClassInfoTrait;
-    use ContextTrait;
-    use JsonLdContextTrait;
+//    use ClassInfoTrait;
+//    use ContextTrait;
+//    use JsonLdContextTrait;
 
     const FORMAT = 'jsonld';
 
-    private $contextBuilder;
+//    private $contextBuilder;
+
+    private $objectNormalizer;
+
+    private $normalizer;
 
     public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, ContextBuilderInterface $contextBuilder, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], iterable $dataTransformers = [], bool $handleNonResource = false)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, null, false, $defaultContext, $dataTransformers, $resourceMetadataFactory, $handleNonResource);
+//        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, null, false, $defaultContext, $dataTransformers, $resourceMetadataFactory, $handleNonResource);
 
-        $this->contextBuilder = $contextBuilder;
+//        $this->contextBuilder = $contextBuilder;
+        $this->objectNormalizer = new ObjectNormalizer(
+            $classMetadataFactory,
+            $nameConverter,
+            $propertyAccessor,
+            null,
+            null,
+            new ObjectClassResolver(),
+            $defaultContext
+        );
+
+        $jsonLdItemNormalizer = new JsonLdItemNormalizer(
+            $this->objectNormalizer,
+            $iriConverter,
+            $resourceMetadataFactory,
+            $contextBuilder
+        );
+
+        $resourceClassNormalizer = new ResourceClassNormalizer(
+            $jsonLdItemNormalizer,
+            $resourceClassResolver,
+            $iriConverter
+        );
+
+        $this->normalizer = $resourceClassNormalizer;
+    }
+
+    public function setSerializer(SerializerInterface $serializer)
+    {
+        $this->objectNormalizer->setSerializer($serializer);
+    }
+
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return $this->normalizer->hasCacheableSupportsMethod();
     }
 
     /**
@@ -54,7 +98,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     public function supportsNormalization($data, $format = null, array $context = [])
     {
-        return self::FORMAT === $format && parent::supportsNormalization($data, $format, $context);
+        return $this->normalizer->supportsNormalization($data, $format, $context);
     }
 
     /**
@@ -62,37 +106,38 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        if ($this->handleNonResource && ($context['api_normalize'] ?? false) || null !== $outputClass = $this->getOutputClass($this->getObjectClass($object), $context)) {
-            if (isset($outputClass)) {
-                $object = $this->transformOutput($object, $context);
-            }
-
-            $data = $this->createJsonLdContext($this->contextBuilder, $object, $context);
-            $rawData = parent::normalize($object, $format, $context);
-            if (!\is_array($rawData)) {
-                return $rawData;
-            }
-
-            return $data + $rawData;
-        }
-
-        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
-        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-        $data = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
-
-        // Use resolved resource class instead of given resource class to support multiple inheritance child types
-        $context['resource_class'] = $resourceClass;
-        $context['iri'] = $this->iriConverter->getIriFromItem($object);
-
-        $rawData = parent::normalize($object, $format, $context);
-        if (!\is_array($rawData)) {
-            return $rawData;
-        }
-
-        $data['@id'] = $context['iri'];
-        $data['@type'] = $resourceMetadata->getIri() ?: $resourceMetadata->getShortName();
-
-        return $data + $rawData;
+        return $this->normalizer->normalize($object, $format, $context);
+//        if ($this->handleNonResource && ($context['api_normalize'] ?? false) || null !== $outputClass = $this->getOutputClass($this->getObjectClass($object), $context)) {
+//            if (isset($outputClass)) {
+//                $object = $this->transformOutput($object, $context);
+//            }
+//
+//            $data = $this->createJsonLdContext($this->contextBuilder, $object, $context);
+//            $rawData = parent::normalize($object, $format, $context);
+//            if (!\is_array($rawData)) {
+//                return $rawData;
+//            }
+//
+//            return $data + $rawData;
+//        }
+//
+//        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
+//        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+//        $data = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
+//
+//        // Use resolved resource class instead of given resource class to support multiple inheritance child types
+//        $context['resource_class'] = $resourceClass;
+//        $context['iri'] = $this->iriConverter->getIriFromItem($object);
+//
+//        $rawData = parent::normalize($object, $format, $context);
+//        if (!\is_array($rawData)) {
+//            return $rawData;
+//        }
+//
+//        $data['@id'] = $context['iri'];
+//        $data['@type'] = $resourceMetadata->getIri() ?: $resourceMetadata->getShortName();
+//
+//        return $data + $rawData;
     }
 
     /**
@@ -100,7 +145,8 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     public function supportsDenormalization($data, $type, $format = null, array $context = [])
     {
-        return self::FORMAT === $format && parent::supportsDenormalization($data, $type, $format, $context);
+        return $this->normalizer->supportsDenormalization($data, $type, $format, $context);
+//        return self::FORMAT === $format && parent::supportsDenormalization($data, $type, $format, $context);
     }
 
     /**
@@ -110,15 +156,16 @@ final class ItemNormalizer extends AbstractItemNormalizer
      */
     public function denormalize($data, $class, $format = null, array $context = [])
     {
-        // Avoid issues with proxies if we populated the object
-        if (isset($data['@id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
-            if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {
-                throw new InvalidArgumentException('Update is not allowed for this operation.');
-            }
-
-            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getItemFromIri($data['@id'], $context + ['fetch_data' => true]);
-        }
-
-        return parent::denormalize($data, $class, $format, $context);
+        return $this->normalizer->denormalize($data, $class, $format, $context);
+//        // Avoid issues with proxies if we populated the object
+//        if (isset($data['@id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
+//            if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {
+//                throw new InvalidArgumentException('Update is not allowed for this operation.');
+//            }
+//
+//            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getItemFromIri($data['@id'], $context + ['fetch_data' => true]);
+//        }
+//
+//        return parent::denormalize($data, $class, $format, $context);
     }
 }

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -89,12 +89,17 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
         $this->normalizer = $resourceClassNormalizer;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setSerializer(SerializerInterface $serializer)
     {
         $this->objectNormalizer->setSerializer($serializer);
     }
 
-
+    /**
+     * {@inheritdoc}
+     */
     public function hasCacheableSupportsMethod(): bool
     {
         return $this->normalizer->hasCacheableSupportsMethod();

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Serializer\DataTransformerNormalizer;
 use ApiPlatform\Core\Serializer\ObjectClassResolver;
 use ApiPlatform\Core\Serializer\ResourceClassNormalizer;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -66,8 +67,14 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
             $defaultContext
         );
 
-        $jsonLdItemNormalizer = new JsonLdItemNormalizer(
+        $dataTransformerNormalizer = new DataTransformerNormalizer(
             $this->objectNormalizer,
+            $resourceMetadataFactory,
+            $dataTransformers
+        );
+
+        $jsonLdItemNormalizer = new JsonLdItemNormalizer(
+            $dataTransformerNormalizer,
             $iriConverter,
             $resourceMetadataFactory,
             $contextBuilder

--- a/src/JsonLd/Serializer/JsonLdItemNormalizer.php
+++ b/src/JsonLd/Serializer/JsonLdItemNormalizer.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonLd\Serializer;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class JsonLdItemNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    use JsonLdContextTrait;
+
+    const FORMAT = 'jsonld';
+
+    private $normalizer;
+
+    private $iriConverter;
+
+    private $resourceMetadataFactory;
+
+    private $contextBuilder;
+
+    public function __construct(NormalizerInterface $normalizer, IriConverterInterface $iriConverter, ResourceMetadataFactoryInterface $resourceMetadataFactory, ContextBuilderInterface $contextBuilder)
+    {
+        $this->normalizer = $normalizer;
+        $this->iriConverter = $iriConverter;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->contextBuilder = $contextBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        return $this->normalizer->denormalize($data, $class, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null, array $context = [])
+    {
+        return self::FORMAT === $format && $this->normalizer->supportsDenormalization($data, $type, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $rawData = $this->normalizer->normalize($object, $format, $context);
+
+        if (!\is_array($rawData)) {
+            return $rawData;
+        }
+
+        $resourceClass = $context['resource_class'] ?? null;
+
+        if (!\is_string($resourceClass)) {
+            return $this->normalizer->normalize($object, $format, $context);
+        }
+
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+        $data = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
+
+        if (!isset($context['iri'])) {
+            $context['iri'] = $this->iriConverter->getIriFromItem($object);
+        }
+
+        $data['@id'] = $context['iri'];
+        $data['@type'] = $resourceMetadata->getIri() ?: $resourceMetadata->getShortName();
+
+        return array_merge($data, $rawData);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null, array $context = [])
+    {
+        return self::FORMAT === $format && $this->normalizer->supportsNormalization($data, $format, $context);
+    }
+}

--- a/src/Serializer/AddResourceClassNormalizer.php
+++ b/src/Serializer/AddResourceClassNormalizer.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace ApiPlatform\Core\Serializer;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer as ElasticsearchItemNormalizer;
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Util\ClassInfoTrait;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Add resource class to the context
+ */
+final class AddResourceClassNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    use ContextTrait;
+    use ClassInfoTrait;
+
+    /** @var DenormalizerInterface|NormalizerInterface */
+    private $normalizer;
+
+    private $resourceClassResolver;
+
+    private $iriConverter;
+
+    public function __construct(NormalizerInterface $normalizer, ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter)
+    {
+        if (!$normalizer instanceof DenormalizerInterface) {
+            throw new InvalidArgumentException('Normalizer should be an instance of '.DenormalizerInterface::class);
+        }
+
+        $this->normalizer = $normalizer;
+        $this->resourceClassResolver = $resourceClassResolver;
+        $this->iriConverter = $iriConverter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $context['api_denormalize'] = true;
+        $context['resource_class'] = $class;
+
+        return $this->normalizer->denormalize($data, $class, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if (ElasticsearchItemNormalizer::FORMAT === $format) {
+            return false;
+        }
+
+        return $this->normalizer->supportsDenormalization($data, $type, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        try {
+            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
+        } catch (InvalidArgumentException $e) {
+            $context = $this->initContext(\get_class($object), $context);
+            $context['api_normalize'] = true;
+
+            return $this->normalizer->normalize($object, $format, $context);
+        }
+
+        $context = $this->initContext($resourceClass, $context);
+        $context['api_normalize'] = true;
+
+        if (isset($context['resources'])) {
+            $resource = $context['iri'] ?? $this->iriConverter->getIriFromItem($object);
+            $context['resources'][$resource] = $resource;
+        }
+
+        return $this->normalizer->normalize($object, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        if (!\is_object($data) || $data instanceof \Traversable) {
+            return false;
+        }
+
+        return $this->normalizer->supportsNormalization($data, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        if ($this->normalizer instanceof CacheableSupportsMethodInterface) {
+            return $this->normalizer->hasCacheableSupportsMethod();
+        }
+
+        return false;
+    }
+}

--- a/src/Serializer/ApiItemNormalizer.php
+++ b/src/Serializer/ApiItemNormalizer.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ApiPlatform\Core\Serializer;
+
+final class ApiItemNormalizer extends AbstractItemNormalizer
+{
+}

--- a/src/Serializer/DataTransformerNormalizer.php
+++ b/src/Serializer/DataTransformerNormalizer.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace ApiPlatform\Core\Serializer;
+
+use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Transform data before denormalization
+ */
+class DataTransformerNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    use InputOutputMetadataTrait;
+
+    /** @var DenormalizerInterface|NormalizerInterface */
+    private $normalizer;
+
+    /**
+     * @var iterable|DataTransformerInterface[]
+     */
+    private $dataTransformers;
+
+    public function __construct(NormalizerInterface $normalizer, ResourceMetadataFactoryInterface $resourceMetadataFactory, iterable $dataTransformers = [])
+    {
+        if (!$normalizer instanceof DenormalizerInterface) {
+            throw new \TypeError('Normalizer should be an instance of '.DenormalizerInterface::class);
+        }
+
+        $this->normalizer = $normalizer;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->dataTransformers = $dataTransformers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $inputClass = $this->getInputClass($class, $context);
+
+        if (null !== $inputClass && null !== $dataTransformer = $this->getDataTransformer($data, $class, $context)) {
+            $data = $dataTransformer->transform(
+                $this->normalizer->denormalize($data, $inputClass, $format, ['resource_class' => $inputClass] + $context),
+                $class,
+                $context
+            );
+        }
+
+        return $this->normalizer->denormalize($data, $class, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $this->normalizer->supportsDenormalization($data, $type, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return $this->normalizer->normalize($object, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->normalizer->supportsNormalization($data, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        if ($this->normalizer instanceof CacheableSupportsMethodInterface) {
+            return $this->normalizer->hasCacheableSupportsMethod();
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds the first supported data transformer if any.
+     */
+    private function getDataTransformer($object, string $to, array $context = []): ?DataTransformerInterface
+    {
+        foreach ($this->dataTransformers as $dataTransformer) {
+            if ($dataTransformer->supportsTransformation($object, $to, $context)) {
+                return $dataTransformer;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Serializer/ObjectClassResolver.php
+++ b/src/Serializer/ObjectClassResolver.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ApiPlatform\Core\Serializer;
+
+use ApiPlatform\Core\Util\ClassInfoTrait;
+
+class ObjectClassResolver
+{
+    use ClassInfoTrait;
+
+    public function __invoke($object)
+    {
+        return $this->getObjectClass($object);
+    }
+}

--- a/tests/Hydra/Serializer/ItemNormalizerTest.php
+++ b/tests/Hydra/Serializer/ItemNormalizerTest.php
@@ -46,12 +46,13 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(false);
         $resourceClassResolverProphecy->getResourceClass(['dummy'], 'Dummy')->willReturn(Dummy::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['name' => 'name']));
 
         $normalizer = new ItemNormalizer($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $contextBuilderProphecy->reveal());
 
-        $this->assertFalse($normalizer->supportsDenormalization('foo', ItemNormalizer::FORMAT));
+        $this->assertFalse($normalizer->supportsDenormalization('foo',  Dummy::class, ItemNormalizer::FORMAT));
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 

--- a/tests/Hydra/Serializer/ItemNormalizerTest.php
+++ b/tests/Hydra/Serializer/ItemNormalizerTest.php
@@ -23,6 +23,7 @@ use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Serializer\ApiItemNormalizer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #2355 
| License       | MIT
| Doc PR        | /

This is a beginning for #2355 to use composition over inheritance in the various normalizer. Goal is to be decoupled from the ObjectNormalizer so someone can still use JSON LD / Hydra / Json API with a custom normalizer or a different implementation.

There is a lot of questions that i wonder, that's why it's far from being complete but it shows where i want to go.

Some questions i have: 

 * Should we have a new class instead ? (easier for depreciation)
 * Does every normalizer should use composition (like i began to do) or should we add a generic decoupling instead (not sure if it will be easier)
 * Some behavior may be not available in the sub normalizer (like object to populate) is there a way to enforce this or should we just tell the user to take care of this with documentation ?
