### PR TITLE
Add _api_parent_resource_class support

### DIFF
--- a/src/Bridge/Symfony/Routing/RouteNameResolver.php
+++ b/src/Bridge/Symfony/Routing/RouteNameResolver.php
@@ -47,10 +47,12 @@ final class RouteNameResolver implements RouteNameResolverInterface
 
         foreach ($this->router->getRouteCollection()->all() as $routeName => $route) {
             $currentResourceClass = $route->getDefault('_api_resource_class');
+            $parentResourceClass = $route->getDefault('_api_parent_resource_class');
+
             $operation = $route->getDefault(sprintf('_api_%s_operation_name', $operationType));
             $methods = $route->getMethods();
 
-            if ($resourceClass === $currentResourceClass && null !== $operation && (empty($methods) || \in_array('GET', $methods, true))) {
+            if (($resourceClass === $currentResourceClass || $resourceClass === $parentResourceClass) && null !== $operation && (empty($methods) || \in_array('GET', $methods, true))) {
                 if (OperationType::SUBRESOURCE === $operationType && false === $this->isSameSubresource($context, $route->getDefault('_api_subresource_context'))) {
                     continue;
                 }

--- a/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
@@ -99,6 +99,28 @@ class RouteNameResolverTest extends TestCase
         $this->assertSame('some_item_route', $actual);
     }
 
+    public function testGetRouteNameForItemRouteWithParentResource()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('some_collection_route', new Route('/some/collection/path', [
+            '_api_resource_class' => 'AppBundle\Entity\User',
+            '_api_collection_operation_name' => 'some_collection_op',
+        ]));
+        $routeCollection->add('some_item_route', new Route('/some/item/path/{id}', [
+            '_api_resource_class' => 'AppBundle\Entity\UserDetails',
+            '_api_parent_resource_class' => 'AppBundle\Entity\User',
+            '_api_item_operation_name' => 'some_item_op',
+        ]));
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->getRouteCollection()->willReturn($routeCollection);
+
+        $routeNameResolver = new RouteNameResolver($routerProphecy->reveal());
+        $actual = $routeNameResolver->getRouteName('AppBundle\Entity\User', OperationType::ITEM);
+
+        $this->assertSame('some_item_route', $actual);
+    }
+
     public function testGetRouteNameForCollectionRouteWithNoMatchingRoute()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR adds support for a `_api_parent_resource_class` route parameter, to be used as follows:
```php
/**
 * @ApiResource(
 *     collectionOperations={},
 *
 *     itemOperations={
 *         "get": {
 *             "path": "/employees/{id}",
 *             "defaults": {"_api_parent_resource_class": "Application\Resource\Employee" }
 *         }
 *     }
 * )
 */
class EmployeeDetails {
    // ...
}
```
This allows another resource to override (part of) the operations of a so-called parent resource class. In the above example, this would allow an `EmployeeDetails` resource to be returned when fetching an `Employee` item:

```
GET /employees -> Employee[]
GET /employees/{id} -> EmployeeDetails
```

## Real world use case
We use two dedicated resource classes for - in this example - the information we have about an employee. We have a light-weight `Employee` resource that is used in collections (including `GET /employees`) and nested references, and an `EmployeeDetails` resource that includes all details about the employee. The reasoning is that some of the employee information is redundant in 99% of all cases. Examples are an employee's auth roles, last login, recent actions etc.

Without this PR, disabling the "get" `itemOperation` on the `Employee` resource results in a `No item route associated with the type Application\Resource\Employee` exception because the `Employee` collection expects an `Employee` item for its GET item operation. With this operation disabled on the `Employee` resource itself, no matching route can be found. The `_api_resource_class` parameter is set automatically, so it is not possible to override this value.

Since there is no way to instruct the `RouteNameResolver` to use a different resource class for these operations, I have added an optional `_api_parent_resource_class` parameter that allows to override the resource class.

If the general idea of this PR is accepted then I'll submit a doc PR as well. Unit test is included.