### PR TITLE
Use ContextAware on data persister chains

### DIFF
--- a/src/Bridge/Doctrine/Common/DataPersister.php
+++ b/src/Bridge/Doctrine/Common/DataPersister.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Common;
 
-use ApiPlatform\Core\DataPersister\DataPersisterInterface;
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use ApiPlatform\Core\Util\ClassInfoTrait;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager as DoctrineObjectManager;
@@ -24,7 +24,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
-final class DataPersister implements DataPersisterInterface
+final class DataPersister implements ContextAwareDataPersisterInterface
 {
     use ClassInfoTrait;
 
@@ -38,7 +38,7 @@ final class DataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function supports($data): bool
+    public function supports($data, array $context = []): bool
     {
         return null !== $this->getManager($data);
     }
@@ -46,7 +46,7 @@ final class DataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function persist($data)
+    public function persist($data, array $context = [])
     {
         if (!$manager = $this->getManager($data)) {
             return $data;
@@ -65,7 +65,7 @@ final class DataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function remove($data)
+    public function remove($data, array $context = [])
     {
         if (!$manager = $this->getManager($data)) {
             return;

--- a/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
+++ b/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DataPersister;
 
 use ApiPlatform\Core\DataPersister\ChainDataPersister;
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 
 /**
  * @author Anthony GRASSIOT <antograssiot@free.fr>
  */
-final class TraceableChainDataPersister implements DataPersisterInterface
+final class TraceableChainDataPersister implements ContextAwareDataPersisterInterface
 {
     private $persisters = [];
     private $persistersResponse = [];
@@ -41,37 +42,37 @@ final class TraceableChainDataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function supports($data): bool
+    public function supports($data, array $context = []): bool
     {
-        return $this->decorated->supports($data);
+        return $this->decorated->supports($data, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function persist($data)
+    public function persist($data, array $context = [])
     {
-        if ($match = $this->tracePersisters($data)) {
-            return $match->persist($data) ?? $data;
+        if ($match = $this->tracePersisters($data, $context)) {
+            return $match->persist($data, $context) ?? $data;
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function remove($data)
+    public function remove($data, array $context = [])
     {
-        if ($match = $this->tracePersisters($data)) {
-            return $match->remove($data);
+        if ($match = $this->tracePersisters($data, $context)) {
+            return $match->remove($data, $context);
         }
     }
 
-    private function tracePersisters($data)
+    private function tracePersisters($data, array $context = [])
     {
         $match = null;
         foreach ($this->persisters as $persister) {
             $this->persistersResponse[\get_class($persister)] = $match ? null : false;
-            if (!$match && $persister->supports($data)) {
+            if (!$match && $persister->supports($data, $context)) {
                 $match = $persister;
                 $this->persistersResponse[\get_class($persister)] = true;
             }

--- a/src/DataPersister/ChainDataPersister.php
+++ b/src/DataPersister/ChainDataPersister.php
@@ -18,7 +18,7 @@ namespace ApiPlatform\Core\DataPersister;
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
-final class ChainDataPersister implements DataPersisterInterface
+final class ChainDataPersister implements ContextAwareDataPersisterInterface
 {
     /** @internal */
     public $persisters;
@@ -34,10 +34,10 @@ final class ChainDataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function supports($data): bool
+    public function supports($data, array $context = []): bool
     {
         foreach ($this->persisters as $persister) {
-            if ($persister->supports($data)) {
+            if ($persister->supports($data, $context)) {
                 return true;
             }
         }
@@ -48,11 +48,11 @@ final class ChainDataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function persist($data)
+    public function persist($data, array $context = [])
     {
         foreach ($this->persisters as $persister) {
-            if ($persister->supports($data)) {
-                return $persister->persist($data) ?? $data;
+            if ($persister->supports($data, $context)) {
+                return $persister->persist($data, $context) ?? $data;
             }
         }
     }
@@ -60,11 +60,11 @@ final class ChainDataPersister implements DataPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function remove($data)
+    public function remove($data, array $context = [])
     {
         foreach ($this->persisters as $persister) {
-            if ($persister->supports($data)) {
-                $persister->remove($data);
+            if ($persister->supports($data, $context)) {
+                $persister->remove($data, $context);
 
                 return;
             }

--- a/src/DataPersister/ContextAwareDataPersisterInterface.php
+++ b/src/DataPersister/ContextAwareDataPersisterInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\DataPersister;
+
+/**
+ * Manages data persistence.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+interface ContextAwareDataPersisterInterface extends DataPersisterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($data, array $context = []): bool;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persist($data, array $context = []);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($data, array $context = []);
+}

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -49,7 +49,7 @@ final class WriteListener
         }
 
         $controllerResult = $event->getControllerResult();
-        if (!$this->dataPersister->supports($controllerResult)) {
+        if (!$this->dataPersister->supports($controllerResult, $attributes)) {
             return;
         }
 
@@ -57,7 +57,7 @@ final class WriteListener
             case 'PUT':
             case 'PATCH':
             case 'POST':
-                $persistResult = $this->dataPersister->persist($controllerResult);
+                $persistResult = $this->dataPersister->persist($controllerResult, $attributes);
 
                 if (null === $persistResult) {
                     @trigger_error(sprintf('Returning void from %s::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.', DataPersisterInterface::class), E_USER_DEPRECATED);

--- a/tests/DataPersister/ChainDataPersisterTest.php
+++ b/tests/DataPersister/ChainDataPersisterTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\DataPersister\ChainDataPersister;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
@@ -33,7 +34,7 @@ class ChainDataPersisterTest extends TestCase
         $dummy = new Dummy();
 
         $persisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $persisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
+        $persisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
 
         $this->assertTrue((new ChainDataPersister([$persisterProphecy->reveal()]))->supports($dummy));
     }
@@ -43,7 +44,7 @@ class ChainDataPersisterTest extends TestCase
         $dummy = new Dummy();
 
         $persisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $persisterProphecy->supports($dummy)->willReturn(false)->shouldBeCalled();
+        $persisterProphecy->supports($dummy, Argument::type('array'))->willReturn(false)->shouldBeCalled();
 
         $this->assertFalse((new ChainDataPersister([$persisterProphecy->reveal()]))->supports($dummy));
     }
@@ -53,16 +54,16 @@ class ChainDataPersisterTest extends TestCase
         $dummy = new Dummy();
 
         $fooPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $fooPersisterProphecy->supports($dummy)->willReturn(false)->shouldBeCalled();
-        $fooPersisterProphecy->persist($dummy)->shouldNotBeCalled();
+        $fooPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(false)->shouldBeCalled();
+        $fooPersisterProphecy->persist($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $barPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $barPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
-        $barPersisterProphecy->persist($dummy)->shouldBeCalled();
+        $barPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $barPersisterProphecy->persist($dummy, Argument::type('array'))->shouldBeCalled();
 
         $foobarPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $foobarPersisterProphecy->supports($dummy)->shouldNotBeCalled();
-        $foobarPersisterProphecy->persist($dummy)->shouldNotBeCalled();
+        $foobarPersisterProphecy->supports($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $foobarPersisterProphecy->persist($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         (new ChainDataPersister([$fooPersisterProphecy->reveal(), $barPersisterProphecy->reveal(), $foobarPersisterProphecy->reveal()]))->persist($dummy);
     }
@@ -72,16 +73,16 @@ class ChainDataPersisterTest extends TestCase
         $dummy = new Dummy();
 
         $fooPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $fooPersisterProphecy->supports($dummy)->willReturn(false)->shouldBeCalled();
-        $fooPersisterProphecy->remove($dummy)->shouldNotBeCalled();
+        $fooPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(false)->shouldBeCalled();
+        $fooPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $barPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $barPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
-        $barPersisterProphecy->remove($dummy)->shouldBeCalled();
+        $barPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $barPersisterProphecy->remove($dummy, Argument::type('array'))->shouldBeCalled();
 
         $foobarPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $foobarPersisterProphecy->supports($dummy)->shouldNotBeCalled();
-        $foobarPersisterProphecy->remove($dummy)->shouldNotBeCalled();
+        $foobarPersisterProphecy->supports($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $foobarPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         (new ChainDataPersister([$fooPersisterProphecy->reveal(), $barPersisterProphecy->reveal(), $foobarPersisterProphecy->reveal()]))->remove($dummy);
     }

--- a/tests/EventListener/WriteListenerTest.php
+++ b/tests/EventListener/WriteListenerTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConcreteDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -36,8 +37,8 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
-        $dataPersisterProphecy->persist($dummy)->willReturn($dummy)->shouldBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->willReturn($dummy)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1')->shouldBeCalled();
@@ -71,8 +72,8 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
-        $dataPersisterProphecy->persist($dummy)->shouldBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => Dummy::class]);
 
@@ -104,13 +105,13 @@ class WriteListenerTest extends TestCase
         $dummy2->setName('Dummyferoce');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1')->shouldBeCalled();
 
         $dataPersisterProphecy
-            ->persist($dummy)
+            ->persist($dummy, Argument::type('array'))
             ->willReturn($dummy2) // Persist is not mutating $dummy, but return a brand new technically unrelated object instead
             ->shouldBeCalled()
         ;
@@ -141,7 +142,7 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
@@ -149,7 +150,7 @@ class WriteListenerTest extends TestCase
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['output' => ['class' => null]]));
 
-        $dataPersisterProphecy->persist($dummy)->willReturn($dummy)->shouldBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->willReturn($dummy)->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'post']);
         $request->setMethod('POST');
@@ -170,7 +171,7 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
         $dataPersisterProphecy->remove($dummy)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
@@ -195,9 +196,9 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->shouldNotBeCalled();
-        $dataPersisterProphecy->persist($dummy)->shouldNotBeCalled();
-        $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
@@ -221,9 +222,9 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->shouldNotBeCalled();
-        $dataPersisterProphecy->persist($dummy)->shouldNotBeCalled();
-        $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
@@ -247,9 +248,9 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->shouldNotBeCalled();
-        $dataPersisterProphecy->persist($dummy)->shouldNotBeCalled();
-        $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
@@ -272,8 +273,8 @@ class WriteListenerTest extends TestCase
         $dummy = new ConcreteDummy();
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->willReturn(true)->shouldBeCalled();
-        $dataPersisterProphecy->persist($dummy)->willReturn($dummy)->shouldBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->willReturn($dummy)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1')->shouldBeCalled();
@@ -297,9 +298,9 @@ class WriteListenerTest extends TestCase
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy)->willReturn(false)->shouldBeCalled();
-        $dataPersisterProphecy->persist($dummy)->shouldNotBeCalled();
-        $dataPersisterProphecy->remove($dummy)->shouldNotBeCalled();
+        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(false)->shouldBeCalled();
+        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();


### PR DESCRIPTION
Re-do https://github.com/api-platform/core/pull/2569 as I merged it too quickly

Updates the ChainDataPersisters with the context so that it gets propagated to the messenger data persister.