### PR TITLE
Attribute to allow disabling elasticsearch

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("denormalizationContext", type="array"),
  *     @Attribute("deprecationReason", type="string"),
  *     @Attribute("description", type="string"),
+ *     @Attribute("elasticsearch", type="bool"),
  *     @Attribute("fetchPartial", type="bool"),
  *     @Attribute("forceEager", type="bool"),
  *     @Attribute("formats", type="array"),
@@ -135,6 +136,13 @@ final class ApiResource
      * @var string
      */
     private $deprecationReason;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $elasticsearch;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -65,6 +65,7 @@
             <argument type="service" id="api_platform.elasticsearch.metadata.document.metadata_factory" />
             <argument type="service" id="api_platform.elasticsearch.identifier_extractor" />
             <argument type="service" id="serializer" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
 
             <tag name="api_platform.item_data_provider" priority="5" />
         </service>
@@ -75,6 +76,7 @@
             <argument type="service" id="api_platform.elasticsearch.identifier_extractor" />
             <argument type="service" id="serializer" />
             <argument type="service" id="api_platform.pagination" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="tagged" tag="api_platform.elasticsearch.request_body_search_extension.collection" />
 
             <tag name="api_platform.collection_data_provider" priority="5" />


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | todo

If you want to use Elasticsearch on top of doctrine it's currently not possible (unless you override the Elasticsearch DataProvider). 
This adds an `elasticsearch` attribute that you can use to disable elasticsearch (it's enabled y default as soon as you have a mapping). 
For example:

```
 * @ApiResource(
 *   elasticsearch=false,
 *   collectionOperations={"get",
 *     "create"={"input"=BookmarkInput::class, "output"=false, "status"=202, "method"="POST", "messenger"=true},
 *     "search"={"elasticsearch"=true, "method"="GET", "path"="/bookmarks/search.{_format}"}
 *   }
 * )
```

The Elasticsearch data provider will only be used in the `/bookmarks/search` method.