### PR TITLE
Fix messenger persister

### DIFF
--- a/src/Bridge/Symfony/Messenger/DataPersister.php
+++ b/src/Bridge/Symfony/Messenger/DataPersister.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Bridge\Symfony\Messenger;
 
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\ClassInfoTrait;
 use Symfony\Component\Messenger\Envelope;
@@ -46,7 +47,12 @@ final class DataPersister implements ContextAwareDataPersisterInterface
      */
     public function supports($data, array $context = []): bool
     {
-        $resourceMetadata = $this->resourceMetadataFactory->create($this->getObjectClass($data));
+        try {
+            $resourceMetadata = $this->resourceMetadataFactory->create($context['resource_class'] ?? $this->getObjectClass($data));
+        } catch (ResourceClassNotFoundException $e) {
+            return false;
+        }
+
         if (null !== $operationName = $context['collection_operation_name'] ?? $context['item_operation_name'] ?? null) {
             return true === $resourceMetadata->getTypedOperationAttribute(
                 $context['collection_operation_name'] ?? false ? OperationType::COLLECTION : OperationType::ITEM,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | soon

When the context is available in the Messenger Data Persister, let's use it. This also gives us the ability to send an Input to the messenger (skip the transformation see https://github.com/api-platform/core/pull/2495 discussion).
