### PR TITLE
Use separate instance of ItemNormalizer for handling non-resource

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -101,10 +101,29 @@
             <argument>null</argument>
             <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="ignore" />
+            <argument>false</argument>
+
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-923" />
+        </service>
+
+        <service id="api_platform.serializer.normalizer.item.non_resource" class="ApiPlatform\Core\Serializer\ItemNormalizer" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
+            <argument type="service" id="api_platform.item_data_provider" on-invalid="ignore" />
+            <argument>%api_platform.allow_plain_identifiers%</argument>
+            <argument>null</argument>
+            <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="ignore" />
             <argument>true</argument>
 
-              <!-- After the DataURINormalizer but before the object denormalizer -->
-            <tag name="serializer.normalizer" priority="-923" />
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-925" />
         </service>
 
         <!-- Resources Operations path resolver -->

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -56,7 +56,7 @@
             <argument type="service" id="property_info" on-invalid="ignore" />
             <argument type="service" id="serializer.mapping.class_discriminator_resolver" on-invalid="ignore" />
 
-            <!-- After the DataURINormalizer but before the object denormalizer -->
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
             <tag name="serializer.normalizer" priority="-922" />
         </service>
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -79,10 +79,29 @@
             <argument>null</argument>
             <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="ignore" />
+            <argument>false</argument>
+
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-922" />
+        </service>
+
+        <service id="api_platform.graphql.normalizer.item.non_resource" class="ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
+            <argument type="service" id="api_platform.item_data_provider" on-invalid="ignore" />
+            <argument>%api_platform.allow_plain_identifiers%</argument>
+            <argument>null</argument>
+            <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="ignore" />
             <argument>true</argument>
 
-            <!-- After the DataURINormalizer but before the object denormalizer -->
-            <tag name="serializer.normalizer" priority="-922" />
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-924" />
         </service>
     </services>
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/hal.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/hal.xml
@@ -39,10 +39,29 @@
             <argument type="collection" />
             <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="ignore" />
+            <argument>false</argument>
+
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-922" />
+        </service>
+
+        <service id="api_platform.hal.normalizer.item.non_resource" class="ApiPlatform\Core\Hal\Serializer\ItemNormalizer" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
+            <argument>null</argument>
+            <argument>false</argument>
+            <argument type="collection" />
+            <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="ignore" />
             <argument>true</argument>
 
-              <!-- After the DataURINormalizer but before the object denormalizer -->
-            <tag name="serializer.normalizer" priority="-922" />
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-924" />
         </service>
     </services>
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/jsonapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/jsonapi.xml
@@ -41,10 +41,26 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="collection" />
             <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
+            <argument>false</argument>
+
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-922" />
+        </service>
+
+        <service id="api_platform.jsonapi.normalizer.item.non_resource" class="ApiPlatform\Core\JsonApi\Serializer\ItemNormalizer" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.jsonapi.name_converter.reserved_attribute_name" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="collection" />
+            <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
             <argument>true</argument>
 
-            <!-- After the DataURINormalizer but before the object denormalizer -->
-            <tag name="serializer.normalizer" priority="-922" />
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-924" />
         </service>
 
         <service id="api_platform.jsonapi.normalizer.constraint_violation_list" class="ApiPlatform\Core\JsonApi\Serializer\ConstraintViolationListNormalizer" public="false">

--- a/src/Bridge/Symfony/Bundle/Resources/config/jsonld.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/jsonld.xml
@@ -27,10 +27,28 @@
             <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
             <argument type="collection" />
             <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
+            <argument>false</argument>
+
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-922" />
+        </service>
+
+        <service id="api_platform.jsonld.normalizer.item.non_resource" class="ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer" public="false">
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.jsonld.context_builder" />
+            <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
+            <argument type="collection" />
+            <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
             <argument>true</argument>
 
-            <!-- After the DataURINormalizer but before the object denormalizer -->
-            <tag name="serializer.normalizer" priority="-922" />
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-924" />
         </service>
 
         <service id="api_platform.jsonld.encoder" class="ApiPlatform\Core\Serializer\JsonEncoder" public="false">

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -29,9 +29,9 @@ final class ItemNormalizer extends BaseItemNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null, array $context = [])
+    public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && parent::supportsNormalization($data, $format, $context);
+        return self::FORMAT === $format && parent::supportsNormalization($data, $format);
     }
 
     /**

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -29,9 +29,9 @@ final class ItemNormalizer extends BaseItemNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = [])
     {
-        return self::FORMAT === $format && parent::supportsNormalization($data, $format);
+        return self::FORMAT === $format && parent::supportsNormalization($data, $format, $context);
     }
 
     /**
@@ -58,9 +58,9 @@ final class ItemNormalizer extends BaseItemNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null, array $context = [])
     {
-        return self::FORMAT === $format && parent::supportsDenormalization($data, $type, $format);
+        return self::FORMAT === $format && parent::supportsDenormalization($data, $type, $format, $context);
     }
 
     /**

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -38,9 +38,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null, array $context = [])
+    public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && parent::supportsNormalization($data, $format, $context);
+        return self::FORMAT === $format && parent::supportsNormalization($data, $format);
     }
 
     /**

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -49,9 +49,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null, array $context = [])
+    public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && parent::supportsNormalization($data, $format, $context);
+        return self::FORMAT === $format && parent::supportsNormalization($data, $format);
     }
 
     /**

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -52,9 +52,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null, array $context = [])
+    public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && parent::supportsNormalization($data, $format, $context);
+        return self::FORMAT === $format && parent::supportsNormalization($data, $format);
     }
 
     /**

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -15,16 +15,12 @@ namespace ApiPlatform\Core\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
-use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer as ElasticsearchItemNormalizer;
+use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\InvalidValueException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
-use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer as GraphQlItemNormalizer;
-use ApiPlatform\Core\Hal\Serializer\ItemNormalizer as HalItemNormalizer;
-use ApiPlatform\Core\JsonApi\Serializer\ItemNormalizer as JsonApiItemNormalizer;
-use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer as JsonLdItemNormalizer;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
@@ -40,7 +36,6 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
-use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -49,11 +44,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implements ContextAwareNormalizerInterface
+abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 {
-    private const FORMATS = [GraphQlItemNormalizer::FORMAT, HalItemNormalizer::FORMAT, JsonApiItemNormalizer::FORMAT, JsonLdItemNormalizer::FORMAT];
-    const USE_API_PLATFORM = 'use_api_platform';
-
     use ClassInfoTrait;
     use ContextTrait;
     use InputOutputMetadataTrait;
@@ -101,12 +93,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null, array $context = [])
+    public function supportsNormalization($data, $format = null)
     {
-        if (!(($context[static::USE_API_PLATFORM] ?? false) || \in_array($format, self::FORMATS, true))) {
-            return false;
-        }
-
         if (!\is_object($data) || $data instanceof \Traversable) {
             return false;
         }
@@ -123,7 +111,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
      */
     public function hasCacheableSupportsMethod(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -156,7 +144,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
      */
     public function supportsDenormalization($data, $type, $format = null)
     {
-        if (ElasticsearchItemNormalizer::FORMAT === $format) {
+        if (ItemNormalizer::FORMAT === $format) {
             return false;
         }
 

--- a/src/Serializer/InputOutputMetadataTrait.php
+++ b/src/Serializer/InputOutputMetadataTrait.php
@@ -14,11 +14,12 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Serializer;
 
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 
 trait InputOutputMetadataTrait
 {
     /**
-     * @var \ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface
+     * @var ResourceMetadataFactoryInterface
      */
     protected $resourceMetadataFactory;
 

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -37,9 +37,9 @@ class ItemNormalizer extends AbstractItemNormalizer
 {
     private $logger;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, LoggerInterface $logger = null, iterable $dataTransformers = [], ResourceMetadataFactoryInterface $resourceMetadataFactory = null, $allowUnmappedClass = false)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, LoggerInterface $logger = null, iterable $dataTransformers = [], ResourceMetadataFactoryInterface $resourceMetadataFactory = null, bool $handleNonResource = false)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $itemDataProvider, $allowPlainIdentifiers, [], $dataTransformers, $resourceMetadataFactory, $allowUnmappedClass);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $itemDataProvider, $allowPlainIdentifiers, [], $dataTransformers, $resourceMetadataFactory, $handleNonResource);
 
         $this->logger = $logger ?: new NullLogger();
     }

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -57,7 +57,6 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         }
 
         $context = $resourceMetadata->getTypedOperationAttribute($operationType, $attributes[$operationKey], $key, [], true);
-        $context[AbstractItemNormalizer::USE_API_PLATFORM] = true;
         $context['operation_type'] = $operationType;
         $context[$operationKey] = $attributes[$operationKey];
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -320,6 +320,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.graphql.executor')->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.schema_builder')->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.normalizer.item')->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.normalizer.item.non_resource')->shouldNotBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.graphql.enabled', true)->shouldNotBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.graphql.enabled', false)->shouldBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
@@ -780,6 +781,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.serializer.property_filter',
             'api_platform.serializer.group_filter',
             'api_platform.serializer.normalizer.item',
+            'api_platform.serializer.normalizer.item.non_resource',
             'api_platform.subresource_data_provider',
             'api_platform.subresource_operation_factory',
             'api_platform.subresource_operation_factory.cached',
@@ -897,6 +899,7 @@ class ApiPlatformExtensionTest extends TestCase
         $definitions = [
             'api_platform.data_collector.request',
             'api_platform.doctrine.listener.http_cache.purge',
+            'api_platform.doctrine.listener.mercure.publish',
             'api_platform.doctrine.metadata_factory',
             'api_platform.doctrine.orm.boolean_filter',
             'api_platform.doctrine.orm.collection_data_provider',
@@ -945,20 +948,16 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.resolver.item',
             'api_platform.graphql.resolver.resource_field',
             'api_platform.graphql.normalizer.item',
-            'api_platform.jsonld.normalizer.item',
-            'api_platform.jsonld.encoder',
-            'api_platform.jsonld.action.context',
-            'api_platform.jsonld.context_builder',
-            'api_platform.jsonld.normalizer.item',
-            'api_platform.swagger.normalizer.documentation',
-            'api_platform.swagger.normalizer.api_gateway',
-            'api_platform.swagger.command.swagger_command',
-            'api_platform.swagger.action.ui',
-            'api_platform.swagger.listener.ui',
+            'api_platform.graphql.normalizer.item.non_resource',
             'api_platform.hal.encoder',
             'api_platform.hal.normalizer.collection',
             'api_platform.hal.normalizer.entrypoint',
             'api_platform.hal.normalizer.item',
+            'api_platform.hal.normalizer.item.non_resource',
+            'api_platform.http_cache.listener.response.add_tags',
+            'api_platform.http_cache.listener.response.configure',
+            'api_platform.http_cache.purger.varnish_client',
+            'api_platform.http_cache.purger.varnish',
             'api_platform.hydra.listener.response.add_link_header',
             'api_platform.hydra.normalizer.collection',
             'api_platform.hydra.normalizer.collection_filters',
@@ -971,7 +970,9 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.jsonld.context_builder',
             'api_platform.jsonld.encoder',
             'api_platform.jsonld.normalizer.item',
-            'api_platform.jsonld.normalizer.item',
+            'api_platform.jsonld.normalizer.item.non_resource',
+            'api_platform.mercure.listener.response.add_link_header',
+            'api_platform.messenger.data_persister',
             'api_platform.metadata.extractor.yaml',
             'api_platform.metadata.property.metadata_factory.annotation',
             'api_platform.metadata.property.metadata_factory.yaml',
@@ -988,15 +989,12 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.problem.encoder',
             'api_platform.problem.normalizer.constraint_violation_list',
             'api_platform.problem.normalizer.error',
+            'api_platform.swagger.action.ui',
             'api_platform.swagger.command.swagger_command',
-            'api_platform.http_cache.listener.response.configure',
-            'api_platform.http_cache.purger.varnish',
-            'api_platform.http_cache.purger.varnish_client',
-            'api_platform.http_cache.listener.response.add_tags',
+            'api_platform.swagger.listener.ui',
+            'api_platform.swagger.normalizer.api_gateway',
+            'api_platform.swagger.normalizer.documentation',
             'api_platform.validator',
-            'api_platform.mercure.listener.response.add_link_header',
-            'api_platform.doctrine.listener.mercure.publish',
-            'api_platform.messenger.data_persister',
         ];
 
         foreach ($definitions as $definition) {

--- a/tests/GraphQl/Serializer/ItemNormalizerTest.php
+++ b/tests/GraphQl/Serializer/ItemNormalizerTest.php
@@ -34,7 +34,6 @@ class ItemNormalizerTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testSupportNormalization()
     {
@@ -75,9 +74,9 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
@@ -102,7 +101,7 @@ class ItemNormalizerTest extends TestCase
             null,
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -117,9 +116,9 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -141,7 +140,7 @@ class ItemNormalizerTest extends TestCase
             null,
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -100,7 +100,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($dummy, 'jsonhal'));
         $this->assertFalse($normalizer->supportsNormalization($dummy, 'xml'));
         $this->assertFalse($normalizer->supportsNormalization($std, 'jsonhal'));
-        $this->assertFalse($normalizer->hasCacheableSupportsMethod());
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -43,7 +43,6 @@ class ItemNormalizerTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testDoesNotSupportDenormalization()
     {
@@ -70,7 +69,6 @@ class ItemNormalizerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testSupportsNormalization()
     {
@@ -152,7 +150,7 @@ class ItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -219,7 +217,7 @@ class ItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -299,7 +297,7 @@ class ItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true
+            false
         );
         $serializer = new Serializer([$normalizer]);
         $normalizer->setSerializer($serializer);

--- a/tests/Hydra/Serializer/ItemNormalizerTest.php
+++ b/tests/Hydra/Serializer/ItemNormalizerTest.php
@@ -52,7 +52,7 @@ class ItemNormalizerTest extends TestCase
         $normalizer = new ItemNormalizer($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $contextBuilderProphecy->reveal());
 
         $this->assertFalse($normalizer->supportsDenormalization('foo', ItemNormalizer::FORMAT));
-        $this->assertFalse($normalizer->hasCacheableSupportsMethod());
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     /**
@@ -87,7 +87,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($dummy, 'jsonld'));
         $this->assertFalse($normalizer->supportsNormalization($dummy, 'xml'));
         $this->assertFalse($normalizer->supportsNormalization($std, 'jsonld'));
-        $this->assertFalse($normalizer->hasCacheableSupportsMethod());
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Hydra/Serializer/ItemNormalizerTest.php
+++ b/tests/Hydra/Serializer/ItemNormalizerTest.php
@@ -36,7 +36,6 @@ class ItemNormalizerTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testDontSupportDenormalization()
     {
@@ -57,7 +56,6 @@ class ItemNormalizerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testSupportNormalization()
     {
@@ -101,9 +99,9 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1988')->shouldBeCalled();
@@ -130,7 +128,7 @@ class ItemNormalizerTest extends TestCase
             null,
             [],
             [],
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 

--- a/tests/JsonApi/Serializer/ItemNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ItemNormalizerTest.php
@@ -45,7 +45,6 @@ class ItemNormalizerTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testSupportDenormalization()
     {
@@ -70,7 +69,6 @@ class ItemNormalizerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testSupportNormalization()
     {
@@ -141,7 +139,7 @@ class ItemNormalizerTest extends TestCase
             $resourceMetadataFactoryProphecy->reveal(),
             [],
             [],
-            true
+            false
         );
 
         $normalizer->setSerializer($serializerProphecy->reveal());
@@ -182,7 +180,7 @@ class ItemNormalizerTest extends TestCase
             $resourceMetadataFactory->reveal(),
             [],
             [],
-            true
+            false
         );
 
         $normalizer->setSerializer(new Serializer([$normalizer]));
@@ -242,7 +240,7 @@ class ItemNormalizerTest extends TestCase
             $resourceMetadataFactory->reveal(),
             [],
             [],
-            true
+            false
         );
 
         $normalizer->normalize($foo, ItemNormalizer::FORMAT);
@@ -327,7 +325,7 @@ class ItemNormalizerTest extends TestCase
             $resourceMetadataFactory->reveal(),
             [],
             [],
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -380,7 +378,7 @@ class ItemNormalizerTest extends TestCase
             $this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(),
             [],
             [],
-            true
+            false
         );
 
         $normalizer->denormalize(
@@ -437,7 +435,7 @@ class ItemNormalizerTest extends TestCase
             $resourceMetadataFactory->reveal(),
             [],
             [],
-            true
+            false
         );
 
         $normalizer->denormalize(
@@ -495,7 +493,7 @@ class ItemNormalizerTest extends TestCase
             $resourceMetadataFactory->reveal(),
             [],
             [],
-            true
+            false
         );
 
         $normalizer->denormalize(
@@ -555,7 +553,7 @@ class ItemNormalizerTest extends TestCase
             $resourceMetadataFactory->reveal(),
             [],
             [],
-            true
+            false
         );
 
         $normalizer->denormalize(

--- a/tests/JsonApi/Serializer/ItemNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ItemNormalizerTest.php
@@ -65,7 +65,7 @@ class ItemNormalizerTest extends TestCase
 
         $this->assertTrue($normalizer->supportsDenormalization(null, Dummy::class, ItemNormalizer::FORMAT));
         $this->assertFalse($normalizer->supportsDenormalization(null, \stdClass::class, ItemNormalizer::FORMAT));
-        $this->assertFalse($normalizer->hasCacheableSupportsMethod());
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     /**

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -52,7 +52,6 @@ class AbstractItemNormalizerTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testLegacySupportNormalizationAndSupportDenormalization()
     {
@@ -94,6 +93,8 @@ class AbstractItemNormalizerTest extends TestCase
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
+        $resourceClassResolverProphecy->isResourceClass(\stdClass::class)->willReturn(false);
 
         $normalizer = $this->getMockForAbstractClass(AbstractItemNormalizer::class, [
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -108,13 +109,13 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
 
         $this->assertTrue($normalizer->supportsNormalization($dummy));
-        $this->assertTrue($normalizer->supportsNormalization($std));
+        $this->assertFalse($normalizer->supportsNormalization($std));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
-        $this->assertTrue($normalizer->supportsDenormalization($std, \stdClass::class));
+        $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
@@ -192,7 +193,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -271,7 +272,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -349,7 +350,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -386,7 +387,7 @@ class AbstractItemNormalizerTest extends TestCase
             (new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', true, false))->withInitializable(true)
         );
 
-        $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $this->prophesize(IriConverterInterface::class)->reveal(), $this->prophesize(ResourceClassResolverInterface::class)->reveal(), null, null, null, null, false, [], [], null, true) extends AbstractItemNormalizer {
+        $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $this->prophesize(IriConverterInterface::class)->reveal(), $this->prophesize(ResourceClassResolverInterface::class)->reveal(), null, null, null, null, false, [], [], null, false) extends AbstractItemNormalizer {
         };
 
         /** @var DummyForAdditionalFieldsInput $res */
@@ -471,7 +472,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -526,7 +527,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -577,7 +578,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -619,7 +620,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -658,7 +659,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -698,7 +699,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -755,7 +756,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -798,7 +799,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -851,7 +852,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -908,7 +909,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1016,32 +1017,11 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [],
             null,
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
         $normalizer->denormalize(['relatedDummy' => 1], Dummy::class, 'jsonld');
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
-     */
-    public function testDisallowUnmappedClass()
-    {
-        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
-        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-
-        $this->getMockForAbstractClass(AbstractItemNormalizer::class, [
-            $propertyNameCollectionFactoryProphecy->reveal(),
-            $propertyMetadataFactoryProphecy->reveal(),
-            $iriConverterProphecy->reveal(),
-            $resourceClassResolverProphecy->reveal(),
-            $propertyAccessorProphecy->reveal(),
-        ]);
     }
 
     /**
@@ -1124,7 +1104,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             [$dataTransformerProphecy->reveal(), $secondDataTransformerProphecy->reveal()],
             $resourceMetadataFactoryProphecy->reveal(),
-            true,
+            false,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -76,11 +76,11 @@ class AbstractItemNormalizerTest extends TestCase
             $propertyAccessorProphecy->reveal(),
         ]);
 
-        $this->assertTrue($normalizer->supportsNormalization($dummy, null, [AbstractItemNormalizer::USE_API_PLATFORM => true]));
-        $this->assertFalse($normalizer->supportsNormalization($std, null, [AbstractItemNormalizer::USE_API_PLATFORM => true]));
+        $this->assertTrue($normalizer->supportsNormalization($dummy));
+        $this->assertFalse($normalizer->supportsNormalization($std));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
-        $this->assertFalse($normalizer->hasCacheableSupportsMethod());
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testSupportNormalizationAndSupportDenormalization()
@@ -111,11 +111,11 @@ class AbstractItemNormalizerTest extends TestCase
             true,
         ]);
 
-        $this->assertTrue($normalizer->supportsNormalization($dummy, null, [AbstractItemNormalizer::USE_API_PLATFORM => true]));
-        $this->assertTrue($normalizer->supportsNormalization($std, null, [AbstractItemNormalizer::USE_API_PLATFORM => true]));
+        $this->assertTrue($normalizer->supportsNormalization($dummy));
+        $this->assertTrue($normalizer->supportsNormalization($std));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertTrue($normalizer->supportsDenormalization($std, \stdClass::class));
-        $this->assertFalse($normalizer->hasCacheableSupportsMethod());
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -60,14 +60,14 @@ class ItemNormalizerTest extends TestCase
             $resourceClassResolverProphecy->reveal()
         );
 
-        $this->assertTrue($normalizer->supportsNormalization($dummy, 'jsonld'));
-        $this->assertTrue($normalizer->supportsNormalization($dummy, 'jsonld'));
-        $this->assertFalse($normalizer->supportsNormalization($std, 'jsonld'));
+        $this->assertTrue($normalizer->supportsNormalization($dummy));
+        $this->assertTrue($normalizer->supportsNormalization($dummy));
+        $this->assertFalse($normalizer->supportsNormalization($std));
 
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
-        $this->assertFalse($normalizer->hasCacheableSupportsMethod());
+        $this->assertTrue($normalizer->hasCacheableSupportsMethod());
     }
 
     public function testNormalize()

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -37,7 +37,6 @@ class ItemNormalizerTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation Passing a falsy $allowUnmappedClass flag in ApiPlatform\Core\Serializer\AbstractItemNormalizer is deprecated since version 2.4 and will default to true in 3.0.
      */
     public function testSupportNormalization()
     {
@@ -79,9 +78,9 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
@@ -106,7 +105,7 @@ class ItemNormalizerTest extends TestCase
             null,
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -121,9 +120,9 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -145,7 +144,7 @@ class ItemNormalizerTest extends TestCase
             null,
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -160,9 +159,9 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getItemFromIri('/dummies/12', ['resource_class' => Dummy::class, 'api_allow_update' => true, 'fetch_data' => true])->shouldBeCalled();
@@ -185,7 +184,7 @@ class ItemNormalizerTest extends TestCase
             null,
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -223,7 +222,7 @@ class ItemNormalizerTest extends TestCase
             null,
             [],
             null,
-            true
+            false
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
         $normalizer->denormalize(['id' => '12', 'name' => 'hello'], Dummy::class, null, $context);
@@ -237,10 +236,10 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'id', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'id', [])->willReturn($propertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
@@ -282,9 +281,9 @@ class ItemNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(OutputDto::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
 
-        $propertyMetadataFactory = new PropertyMetadata(null, null, true);
+        $propertyMetadata = new PropertyMetadata(null, null, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(OutputDto::class, 'baz', [])->willReturn($propertyMetadataFactory)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(OutputDto::class, 'baz', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 

--- a/tests/Serializer/SerializerContextBuilderTest.php
+++ b/tests/Serializer/SerializerContextBuilderTest.php
@@ -55,32 +55,32 @@ class SerializerContextBuilderTest extends TestCase
     {
         $request = Request::create('/foos/1');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['foo' => 'bar', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null, 'use_api_platform' => true];
+        $expected = ['foo' => 'bar', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, true));
 
         $request = Request::create('/foos');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'pot', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['foo' => 'bar', 'collection_operation_name' => 'pot',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'use_api_platform' => true];
+        $expected = ['foo' => 'bar', 'collection_operation_name' => 'pot',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, true));
 
         $request = Request::create('/foos/1');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null, 'use_api_platform' => true];
+        $expected = ['bar' => 'baz', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
         $request = Request::create('/foos', 'POST');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'collection_operation_name' => 'post',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => false, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'use_api_platform' => true];
+        $expected = ['bar' => 'baz', 'collection_operation_name' => 'post',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => false, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
         $request = Request::create('/foos', 'PUT');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'put', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'collection_operation_name' => 'put', 'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => true, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'use_api_platform' => true];
+        $expected = ['bar' => 'baz', 'collection_operation_name' => 'put', 'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => true, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
         $request = Request::create('/bars/1/foos');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_subresource_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'subresource_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/bars/1/foos', 'operation_type' => 'subresource', 'api_allow_update' => false, 'uri' => 'http://localhost/bars/1/foos', 'output' => null, 'input' => null, 'use_api_platform' => true];
+        $expected = ['bar' => 'baz', 'subresource_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/bars/1/foos', 'operation_type' => 'subresource', 'api_allow_update' => false, 'uri' => 'http://localhost/bars/1/foos', 'output' => null, 'input' => null];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
     }
 
@@ -93,7 +93,7 @@ class SerializerContextBuilderTest extends TestCase
 
     public function testReuseExistingAttributes()
     {
-        $expected = ['bar' => 'baz', 'item_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null, 'use_api_platform' => true];
+        $expected = ['bar' => 'baz', 'item_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null];
         $this->assertEquals($expected, $this->builder->createFromRequest(Request::create('/foos/1'), false, ['resource_class' => 'Foo', 'item_operation_name' => 'get']));
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2563, #2591, ...; alternative to #2566 (reverted here)
| License       | MIT
| Doc PR        | N/A

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

This should ensure the same caching of `supports*` methods as before for resource classes. For non-resource classes (handled by a separate instance), the `supports*` methods use the `$context`, thus not cacheable.

Not sure about the performance impact (positive or negative), but I think this is cleaner as we don't indiscriminately say yes to things we might not be able to handle (provided we're at a low enough priority). And there's no need for `use_api_platform` and/or special treatment of some formats.

Big thanks to @soyuka and @dunglas for the discussions and for bearing with me! :stuck_out_tongue_closed_eyes: