### PR TITLE
[GraphQL] Add a command for exporting a SDL schema

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,6 +2,7 @@ default:
   suites:
     default:
       contexts:
+        - 'CommandContext'
         - 'DoctrineContext':
             doctrine: '@doctrine'
         - 'HttpHeaderContext'
@@ -21,6 +22,7 @@ default:
         tags: '~@postgres&&~@mongodb&&~@elasticsearch'
     postgres:
       contexts:
+        - 'CommandContext'
         - 'DoctrineContext':
             doctrine: '@doctrine'
         - 'HttpHeaderContext'
@@ -40,6 +42,7 @@ default:
         tags: '~@sqlite&&~@mongodb&&~@elasticsearch'
     mongodb:
       contexts:
+        - 'CommandContext'
         - 'DoctrineContext':
             doctrine: '@doctrine_mongodb'
         - 'HttpHeaderContext'
@@ -89,6 +92,7 @@ coverage:
   suites:
     default:
       contexts:
+        - 'CommandContext'
         - 'DoctrineContext':
             doctrine: '@doctrine'
         - 'HttpHeaderContext'

--- a/features/bootstrap/CommandContext.php
+++ b/features/bootstrap/CommandContext.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Symfony2Extension\Context\KernelAwareContext;
+use PHPUnit\Framework\Assert;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Context for Symfony commands.
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class CommandContext implements KernelAwareContext
+{
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    /**
+     * @var CommandTester
+     */
+    private $commandTester;
+
+    /**
+     * @When I run the command :command
+     */
+    public function iRunTheCommand(string $command): void
+    {
+        $command = $this->getApplication()->find($command);
+
+        $this->getCommandTester($command)->execute([]);
+    }
+
+    /**
+     * @When I run the command :command with options:
+     */
+    public function iRunTheCommandWithOptions(string $command, TableNode $options): void
+    {
+        $command = $this->getApplication()->find($command);
+
+        $this->getCommandTester($command)->execute($options->getRowsHash());
+    }
+
+    /**
+     * @Then the command output should be:
+     */
+    public function theCommandOutputShouldBe(PyStringNode $expectedOutput): void
+    {
+        Assert::assertEquals($expectedOutput->getRaw(), $this->commandTester->getDisplay());
+    }
+
+    /**
+     * @Then the command output should contain:
+     */
+    public function theCommandOutputShouldContain(PyStringNode $expectedOutput): void
+    {
+        $expectedOutput = str_replace('###', '"""', $expectedOutput->getRaw());
+
+        Assert::assertContains($expectedOutput, $this->commandTester->getDisplay());
+    }
+
+    public function setKernel(KernelInterface $kernel): void
+    {
+        $this->kernel = $kernel;
+    }
+
+    public function getApplication(): Application
+    {
+        if (null !== $this->application) {
+            return $this->application;
+        }
+
+        $this->application = new Application($this->kernel);
+
+        return $this->application;
+    }
+
+    private function getCommandTester(Command $command): CommandTester
+    {
+        $this->commandTester = new CommandTester($command);
+
+        return $this->commandTester;
+    }
+}

--- a/features/graphql/schema.feature
+++ b/features/graphql/schema.feature
@@ -1,0 +1,77 @@
+Feature: GraphQL schema-related features
+
+  @createSchema
+  Scenario: Export the GraphQL schema in SDL
+    When I run the command "api:graphql:export"
+    Then the command output should contain:
+    """
+    ###Dummy Friend.###
+    type DummyFriend implements Node {
+      id: ID!
+
+      ###The id###
+      _id: Int!
+
+      ###The dummy name###
+      name: String!
+    }
+
+    ###Connection for DummyFriend.###
+    type DummyFriendConnection {
+      edges: [DummyFriendEdge]
+      pageInfo: DummyFriendPageInfo!
+      totalCount: Int!
+    }
+
+    ###Edge of DummyFriend.###
+    type DummyFriendEdge {
+      node: DummyFriend
+      cursor: String!
+    }
+
+    ###Information about the current page.###
+    type DummyFriendPageInfo {
+      endCursor: String
+      startCursor: String
+      hasNextPage: Boolean!
+      hasPreviousPage: Boolean!
+    }
+    """
+
+  Scenario: Export the GraphQL schema in SDL with comment descriptions
+    When I run the command "api:graphql:export" with options:
+      | --comment-descriptions | true |
+    Then the command output should contain:
+    """
+    # Dummy Friend.
+    type DummyFriend implements Node {
+      id: ID!
+
+      # The id
+      _id: Int!
+
+      # The dummy name
+      name: String!
+    }
+
+    # Connection for DummyFriend.
+    type DummyFriendConnection {
+      edges: [DummyFriendEdge]
+      pageInfo: DummyFriendPageInfo!
+      totalCount: Int!
+    }
+
+    # Edge of DummyFriend.
+    type DummyFriendEdge {
+      node: DummyFriend
+      cursor: String!
+    }
+
+    # Information about the current page.
+    type DummyFriendPageInfo {
+      endCursor: String
+      startCursor: String
+      hasNextPage: Boolean!
+      hasPreviousPage: Boolean!
+    }
+    """

--- a/src/Bridge/Symfony/Bundle/Command/GraphQlExportCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/GraphQlExportCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Command;
+
+use ApiPlatform\Core\GraphQl\Type\SchemaBuilder;
+use GraphQL\Utils\SchemaPrinter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Export the GraphQL schema in Schema Definition Language (SDL).
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class GraphQlExportCommand extends Command
+{
+    protected static $defaultName = 'api:graphql:export';
+
+    private $schemaBuilder;
+
+    public function __construct(SchemaBuilder $schemaBuilder)
+    {
+        $this->schemaBuilder = $schemaBuilder;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Export the GraphQL schema in Schema Definition Language (SDL)')
+            ->addOption('comment-descriptions', null, InputOption::VALUE_NONE, 'Use preceding comments as the description')
+            ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Write output to file')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $options = [];
+
+        if ($input->getOption('comment-descriptions')) {
+            $options['commentDescriptions'] = true;
+        }
+
+        $schemaExport = SchemaPrinter::doPrint($this->schemaBuilder->getSchema(), $options);
+
+        $filename = $input->getOption('output');
+        if (\is_string($filename)) {
+            file_put_contents($filename, $schemaExport);
+            $io->success(sprintf('Data written to %s.', $filename));
+        } else {
+            $output->writeln($schemaExport);
+        }
+
+        return 0;
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -119,6 +119,13 @@
             <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
             <tag name="serializer.normalizer" priority="-924" />
         </service>
+
+        <!-- Command -->
+
+        <service id="api_platform.graphql.command.export_command" class="ApiPlatform\Core\Bridge\Symfony\Bundle\Command\GraphQlExportCommand">
+            <argument type="service" id="api_platform.graphql.schema_builder" />
+            <tag name="console.command" />
+        </service>
     </services>
 
 </container>

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -962,6 +962,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.types_factory',
             'api_platform.graphql.normalizer.item',
             'api_platform.graphql.normalizer.item.non_resource',
+            'api_platform.graphql.command.export_command',
             'api_platform.hal.encoder',
             'api_platform.hal.normalizer.collection',
             'api_platform.hal.normalizer.entrypoint',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/759

It can be useful for some tools to have the file representing the GraphQL schema.

Can be exported in a file like this:
```shell
bin/console api:graphql:export > schema.graphql
```