### PR TITLE
Add an HTTP client dedicated to functional API testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "symfony/finder": "^3.4 || ^4.0",
         "symfony/form": "^3.4 || ^4.0",
         "symfony/framework-bundle": "^4.3",
+        "symfony/http-client": "^4.3",
         "symfony/mercure-bundle": "*",
         "symfony/messenger": "^4.3",
         "symfony/phpunit-bridge": "^4.3.1",

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -35,6 +35,7 @@ use ApiPlatform\Core\GraphQl\Type\Definition\TypeInterface as GraphQlTypeInterfa
 use Doctrine\Common\Annotations\Annotation;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
@@ -120,6 +121,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             ->addTag('api_platform.subresource_data_provider');
         $container->registerForAutoconfiguration(FilterInterface::class)
             ->addTag('api_platform.filter');
+
+        if ($container->hasParameter('test.client.parameters') && class_exists(AbstractBrowser::class)) {
+            $loader->load('test.xml');
+        }
     }
 
     private function registerCommonConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader, array $formats, array $errorFormats): void

--- a/src/Bridge/Symfony/Bundle/Resources/config/test.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="test.api_platform.client" class="ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Client" public="true">
+            <argument type="service" id="test.client" />
+        </service>
+    </services>
+
+</container>

--- a/src/Bridge/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Bridge/Symfony/Bundle/Test/ApiTestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Test;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Base class for functional API tests.
+ *
+ * @experimental
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+abstract class ApiTestCase extends KernelTestCase
+{
+    /**
+     * Creates a Client.
+     *
+     * @param array $options An array of options to pass to the createKernel method
+     */
+    protected static function createClient(array $options = []): Client
+    {
+        $kernel = static::bootKernel($options);
+
+        try {
+            /**
+             * @var Client
+             */
+            $client = $kernel->getContainer()->get('test.api_platform.client');
+        } catch (ServiceNotFoundException $e) {
+            throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit component is not available. Try running "composer require symfony/browser-kit".');
+        }
+
+        return $client;
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Test/Client.php
+++ b/src/Bridge/Symfony/Bundle/Test/Client.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Test;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpClient\HttpClientTrait;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Convenient test client that makes requests to a Kernel object.
+ *
+ * @experimental
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class Client implements HttpClientInterface
+{
+    /**
+     * @see HttpClientInterface::OPTIONS_DEFAULTS
+     */
+    public const OPTIONS_DEFAULT = [
+        'auth_basic' => null,
+        'auth_bearer' => null,
+        'query' => [],
+        'headers' => ['accept' => ['application/ld+json']],
+        'body' => '',
+        'json' => null,
+        'base_uri' => 'http://example.com',
+    ];
+
+    use HttpClientTrait;
+
+    private $kernelBrowser;
+
+    public function __construct(KernelBrowser $kernelBrowser)
+    {
+        $this->kernelBrowser = $kernelBrowser;
+        $kernelBrowser->followRedirects(false);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see Client::OPTIONS_DEFAULTS for available options
+     *
+     * @return Response
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        $basic = $options['auth_basic'] ?? null;
+        [$url, $options] = self::prepareRequest($method, $url, $options, self::OPTIONS_DEFAULT);
+        $resolvedUrl = implode('', $url);
+
+        $server = [];
+        // Convert headers to a $_SERVER-like array
+        foreach ($options['headers'] as $key => $value) {
+            if ('content-type' === $key) {
+                $server['CONTENT_TYPE'] = $value[0] ?? '';
+
+                continue;
+            }
+
+            // BrowserKit doesn't support setting several headers with the same name
+            $server['HTTP_'.strtoupper(str_replace('-', '_', $key))] = $value[0] ?? '';
+        }
+
+        if ($basic) {
+            $credentials = \is_array($basic) ? $basic : explode(':', $basic, 2);
+            $server['PHP_AUTH_USER'] = $credentials[0];
+            $server['PHP_AUTH_PW'] = $credentials[1] ?? '';
+        }
+
+        $info = [
+            'response_headers' => [],
+            'redirect_count' => 0,
+            'redirect_url' => null,
+            'start_time' => 0.0,
+            'http_method' => $method,
+            'http_code' => 0,
+            'error' => null,
+            'user_data' => $options['user_data'] ?? null,
+            'url' => $resolvedUrl,
+            'primary_port' => 'http:' === $url['scheme'] ? 80 : 443,
+        ];
+        $this->kernelBrowser->request($method, $resolvedUrl, [], [], $server, $options['body'] ?? null);
+
+        return new Response($this->kernelBrowser->getResponse(), $this->kernelBrowser->getInternalResponse(), $info);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    {
+        throw new \LogicException('Not implemented yet');
+    }
+
+    /**
+     * Gets the underlying test client.
+     */
+    public function getKernelBrowser(): KernelBrowser
+    {
+        return $this->kernelBrowser;
+    }
+
+    // The following methods are proxy methods for KernelBrowser's ones
+
+    /**
+     * Returns the container.
+     *
+     * @return ContainerInterface|null Returns null when the Kernel has been shutdown or not started yet
+     */
+    public function getContainer(): ?ContainerInterface
+    {
+        return $this->kernelBrowser->getContainer();
+    }
+
+    /**
+     * Returns the kernel.
+     */
+    public function getKernel(): KernelInterface
+    {
+        return $this->kernelBrowser->getKernel();
+    }
+
+    /**
+     * Gets the profile associated with the current Response.
+     *
+     * @return Profile|false A Profile instance
+     */
+    public function getProfile()
+    {
+        return $this->kernelBrowser->getProfile();
+    }
+
+    /**
+     * Enables the profiler for the very next request.
+     *
+     * If the profiler is not enabled, the call to this method does nothing.
+     */
+    public function enableProfiler(): void
+    {
+        $this->kernelBrowser->enableProfiler();
+    }
+
+    /**
+     * Disables kernel reboot between requests.
+     *
+     * By default, the Client reboots the Kernel for each request. This method
+     * allows to keep the same kernel across requests.
+     */
+    public function disableReboot(): void
+    {
+        $this->kernelBrowser->disableReboot();
+    }
+
+    /**
+     * Enables kernel reboot between requests.
+     */
+    public function enableReboot(): void
+    {
+        $this->kernelBrowser->enableReboot();
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Test/Response.php
+++ b/src/Bridge/Symfony/Bundle/Test/Response.php
@@ -128,10 +128,6 @@ final class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(bool $throw = true): array
     {
         if ('' === $content = $this->getContent($throw)) {

--- a/src/Bridge/Symfony/Bundle/Test/Response.php
+++ b/src/Bridge/Symfony/Bundle/Test/Response.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Test;
+
+use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
+use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\JsonException;
+use Symfony\Component\HttpClient\Exception\RedirectionException;
+use Symfony\Component\HttpClient\Exception\ServerException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * HTTP Response.
+ *
+ * @internal
+ *
+ * Partially copied from \Symfony\Component\HttpClient\Response\ResponseTrait
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class Response implements ResponseInterface
+{
+    private $httpFoundationResponse;
+    private $browserKitResponse;
+    private $headers;
+    private $info;
+    private $content;
+    private $jsonData;
+
+    public function __construct(HttpFoundationResponse $httpFoundationResponse, BrowserKitResponse $browserKitResponse, array $info)
+    {
+        $this->httpFoundationResponse = $httpFoundationResponse;
+        $this->browserKitResponse = $browserKitResponse;
+
+        $this->headers = $httpFoundationResponse->headers->all();
+
+        // Compute raw headers
+        $responseHeaders = [];
+        foreach ($this->headers as $key => $values) {
+            foreach ($values as $value) {
+                $responseHeaders[] = sprintf('%s: %s', $key, $value);
+            }
+        }
+
+        $this->content = $httpFoundationResponse->getContent();
+        $this->info = [
+            'http_code' => $httpFoundationResponse->getStatusCode(),
+            'error' => null,
+            'response_headers' => $responseHeaders,
+        ] + $info;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInfo(string $type = null)
+    {
+        if ($type) {
+            return $this->info[$type] ?? null;
+        }
+
+        return $this->info;
+    }
+
+    /**
+     * Checks the status, and try to extract message if appropriate.
+     */
+    private function checkStatusCode(): void
+    {
+        if (500 <= $this->info['http_code']) {
+            throw new ServerException($this);
+        }
+
+        if (400 <= $this->info['http_code']) {
+            throw new ClientException($this);
+        }
+
+        if (300 <= $this->info['http_code']) {
+            throw new RedirectionException($this);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContent(bool $throw = true): string
+    {
+        if ($throw) {
+            $this->checkStatusCode();
+        }
+
+        return $this->content;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatusCode(): int
+    {
+        return $this->info['http_code'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHeaders(bool $throw = true): array
+    {
+        if ($throw) {
+            $this->checkStatusCode();
+        }
+
+        return $this->headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray(bool $throw = true): array
+    {
+        if ('' === $content = $this->getContent($throw)) {
+            throw new TransportException('Response body is empty.');
+        }
+
+        if (null !== $this->jsonData) {
+            return $this->jsonData;
+        }
+
+        $contentType = $this->headers['content-type'][0] ?? 'application/json';
+
+        if (!preg_match('/\bjson\b/i', $contentType)) {
+            throw new JsonException(sprintf('Response content-type is "%s" while a JSON-compatible one was expected.', $contentType));
+        }
+
+        try {
+            $content = json_decode($content, true, 512, JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? \JSON_THROW_ON_ERROR : 0));
+        } catch (\JsonException $e) {
+            throw new JsonException($e->getMessage(), $e->getCode());
+        }
+
+        if (\PHP_VERSION_ID < 70300 && JSON_ERROR_NONE !== json_last_error()) {
+            throw new JsonException(json_last_error_msg(), json_last_error());
+        }
+
+        if (!\is_array($content)) {
+            throw new JsonException(sprintf('JSON content was expected to decode to an array, %s returned.', \gettype($content)));
+        }
+
+        return $this->jsonData = $content;
+    }
+
+    /**
+     * Returns the internal HttpKernel response.
+     */
+    public function getKernelResponse(): HttpFoundationResponse
+    {
+        return $this->httpFoundationResponse;
+    }
+
+    /**
+     * Returns the internal BrowserKit reponse.
+     */
+    public function getBrowserKitResponse(): BrowserKitResponse
+    {
+        return $this->browserKitResponse;
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function cancel(): void
+    {
+        $this->info['error'] = 'Response has been canceled.';
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1057,6 +1057,7 @@ class ApiPlatformExtensionTest extends TestCase
         foreach ($parameters as $key => $value) {
             $containerBuilderProphecy->setParameter($key, $value)->shouldBeCalled();
         }
+        $containerBuilderProphecy->hasParameter('test.client.parameters')->wilLReturn(true);
 
         foreach (['yaml', 'xml'] as $format) {
             $definitionProphecy = $this->prophesize(Definition::class);
@@ -1158,6 +1159,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.swagger.normalizer.api_gateway',
             'api_platform.swagger.normalizer.documentation',
             'api_platform.validator',
+            'test.api_platform.client',
         ];
 
         if (\in_array('odm', $doctrineIntegrationsToLoad, true)) {

--- a/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\Test;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Response;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+class ClientTest extends ApiTestCase
+{
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        /**
+         * @var EntityManagerInterface
+         */
+        $manager = self::$container->get('doctrine')->getManager();
+        $classes = $manager->getMetadataFactory()->getAllMetadata();
+        $schemaTool = new SchemaTool($manager);
+
+        $schemaTool->dropSchema($classes);
+        $schemaTool->createSchema($classes);
+    }
+
+    public function testRequest(): void
+    {
+        $client = self::createClient();
+        $client->getKernelBrowser();
+        $this->assertSame(self::$kernel->getContainer(), $client->getContainer());
+        $this->assertSame(self::$kernel, $client->getKernel());
+
+        $client->enableProfiler();
+        $response = $client->request('GET', '/');
+
+        $this->assertSame('/contexts/Entrypoint', $response->toArray()['@context']);
+        $this->assertInstanceOf(Profile::class, $client->getProfile());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $response->getKernelResponse();
+        $response->getBrowserKitResponse();
+    }
+
+    public function testCustomHeader(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+        $response = $client->request('POST', '/dummies', [
+            'headers' => [
+                'content-type' => 'application/json',
+                'accept' => 'text/xml',
+            ],
+            'body' => '{"name": "Kevin"}',
+        ]);
+        $this->assertSame('application/xml; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertContains('<name>Kevin</name>', $response->getContent());
+    }
+
+    /**
+     * @dataProvider basicProvider
+     */
+    public function testAuthBasic($basic): void
+    {
+        $client = self::createClient();
+        $client->enableReboot();
+        $response = $client->request('GET', '/secured_dummies', ['auth_basic' => $basic]);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function basicProvider(): iterable
+    {
+        yield ['dunglas:kevin'];
+        yield [['dunglas', 'kevin']];
+    }
+
+    public function testStream(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        $client = self::createClient();
+        $client->stream([]);
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
@@ -69,7 +69,7 @@ class ClientTest extends ApiTestCase
     }
 
     /**
-     * @dataProvider basicProvider
+     * @dataProvider authBasicProvider
      */
     public function testAuthBasic($basic): void
     {
@@ -79,7 +79,7 @@ class ClientTest extends ApiTestCase
         $this->assertSame(200, $response->getStatusCode());
     }
 
-    public function basicProvider(): iterable
+    public function authBasicProvider(): iterable
     {
         yield ['dunglas:kevin'];
         yield [['dunglas', 'kevin']];

--- a/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
@@ -47,10 +47,7 @@ class ClientTest extends ApiTestCase
 
         $this->assertSame('/contexts/Entrypoint', $response->toArray()['@context']);
         $this->assertInstanceOf(Profile::class, $client->getProfile());
-
         $this->assertInstanceOf(Response::class, $response);
-        $response->getKernelResponse();
-        $response->getBrowserKitResponse();
     }
 
     public function testCustomHeader(): void

--- a/tests/Bridge/Symfony/Bundle/Test/ResponseTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ResponseTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\Test;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
+use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\JsonException;
+use Symfony\Component\HttpClient\Exception\RedirectionException;
+use Symfony\Component\HttpClient\Exception\ServerException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+
+class ResponseTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $browserKitResponse = new BrowserKitResponse('', 200, ['content-type' => 'application/json']);
+        $httpFoundationResponse = new HttpFoundationResponse('', 200, ['content-type' => 'application/json']);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+
+        $this->assertSame($httpFoundationResponse, $response->getKernelResponse());
+        $this->assertSame($browserKitResponse, $response->getBrowserKitResponse());
+
+        $this->assertSame(200, $response->getInfo('http_code'));
+        $this->assertSame(200, $response->getInfo()['http_code']);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('', $response->getContent());
+    }
+
+    /**
+     * @dataProvider errorProvider
+     */
+    public function testCheckStatus(string $expectedException, int $status): void
+    {
+        $this->expectException($expectedException);
+        $browserKitResponse = new BrowserKitResponse('', $status);
+        $httpFoundationResponse = new HttpFoundationResponse('', $status);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+        $response->getContent();
+    }
+
+    public function errorProvider(): iterable
+    {
+        yield [ServerException::class, 500];
+        yield [ClientException::class, 400];
+        yield [RedirectionException::class, 300];
+    }
+
+    public function testToArray(): void
+    {
+        $browserKitResponse = new BrowserKitResponse('{"foo": "bar"}', 200, ['content-type' => 'application/ld+json']);
+        $httpFoundationResponse = new HttpFoundationResponse('{"foo": "bar"}', 200, ['content-type' => 'application/ld+json']);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+        $this->assertSame(['foo' => 'bar'], $response->toArray());
+        $this->assertSame(['foo' => 'bar'], $response->toArray()); // Trigger the cache
+    }
+
+    public function testToArrayTransportException(): void
+    {
+        $this->expectException(TransportException::class);
+
+        $response = new Response(new HttpFoundationResponse(), new BrowserKitResponse(), []);
+        $response->toArray();
+    }
+
+    public function testInvalidContentType(): void
+    {
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessage('Response content-type is "application/invalid" while a JSON-compatible one was expected.');
+
+        $browserKitResponse = new BrowserKitResponse('{"foo": "bar"}', 200, ['content-type' => 'application/invalid']);
+        $httpFoundationResponse = new HttpFoundationResponse('{"foo": "bar"}', 200, ['content-type' => 'application/invalid']);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+        $response->toArray();
+    }
+
+    public function testInvalidJson(): void
+    {
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessage('Control character error, possibly incorrectly encoded');
+
+        $browserKitResponse = new BrowserKitResponse('{"foo}', 200, ['content-type' => 'application/json']);
+        $httpFoundationResponse = new HttpFoundationResponse('{"foo}', 200, ['content-type' => 'application/json']);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+        $response->toArray();
+    }
+
+    public function testNonArrayJson(): void
+    {
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessage('JSON content was expected to decode to an array, string returned.');
+
+        $browserKitResponse = new BrowserKitResponse('"foo"', 200, ['content-type' => 'application/json']);
+        $httpFoundationResponse = new HttpFoundationResponse('"foo"', 200, ['content-type' => 'application/json']);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+        $response->toArray();
+    }
+
+    public function testCancel(): void
+    {
+        $response = new Response(new HttpFoundationResponse(), new BrowserKitResponse(), []);
+        $response->cancel();
+
+        $this->assertSame('Response has been canceled.', $response->getInfo('error'));
+    }
+}


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Currently, there are no very satisfactory solutions to write functional tests for web APIs built in PHP (API Platform and Symfony included):

* Mink/Behat/Behatch are BDD-oriented (which is completely fine, but doesn't fit with all projects/teams), are a bit complex to setup, have a high barrier to entry and are still not fully compatible with Symfony 4 (you need to rely on a dev version of Behat). They also lack of utilities, for database testing for instance.
* WebTestCase/BrowserKit are dedicated to webpage testing through web scraping (DOM Crawler, CSS selectors, simulation of browsers actions such as clicking or reloading a page...). Their API don't fit well with API testing. However, they benefit form the large ecosystem of PHPUnit, and give access to the numerous functional testing helpers provided by Symfony.
* External solutions that don't manipulate the Symfony Kernel (but are true HTTP clients) such as Postman or BlackFire Player require to setup a web server for the testing env and don't give access to the service container (for instance, to test if the database has been updated, or if a mail has been sent).

It's time to say hi to `ApiTestCase` and `Test\Client`! This new set of API testing utilities is built on top of the Symfony's `Client` test class, and implements the exact same interface than [the brand new Symfony HttpClient component](https://speakerdeck.com/fabpot/2-new-symfony-components-httpclient-and-mime).

As you'll see, it also plays very well with [Alice](https://github.com/nelmio/alice) (the fixture generator with an official Symfony recipe), that gets new power in the operation!

Let's see how it looks:

```php
namespace App\Tests;

use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
use Dunglas\UserBundle\Entity\ForgotPassword\Jti;
use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
use Lcobucci\JWT\Parser;

class UsersTest extends ApiTestCase
{
    use RefreshDatabaseTrait; // This new trait I added to HautelookAliceBundle will take care of refreshing the database content to put it in a known state between every tests

     // A simple test
    public function testCreateUser()
    {
        $client = static::createClient(); // $client implements the new Symfony's HttpClientInterface
        $response = $client->request('POST', '/api/users', ['json' => [
            'email' => 'dunglas+test@gmail.com',
            'plainPassword' => 'foo',
        ]]);
        $this->assertSame(201, $response->getStatusCode());

        $responseContent = $response->toArray();
        $this->assertStringStartsWith('/api/users/', $responseContent['@id']);

        $this->assertArraySubset([
            '@type' => 'http://schema.org/Person',
            'email' => 'dunglas+test@gmail.com',
        ], $responseContent);
        $this->assertArrayNotHasKey('password', $responseContent);
        $this->assertArrayNotHasKey('plainPassword', $responseContent);
    }

    // something more advanced, accessing the mails and the DB
    public function testChangePassword()
    {
        $client = static::createClient();
        $client->enableProfiler();
        $client->disableReboot();

        // Send the request
        $response = $client->request('POST', '/api/users/token_request', ['json' => ['username' => 'dunglas@gmail.com']]);
        $this->assertSame(202, $response->getStatusCode());

        $mailCollector = $client->getProfile()->getCollector('swiftmailer');

        // extract the JWT contained in the mail
        preg_match('#[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*#', $mailCollector->getMessages()[0]->getBody(), $matches);
        $jwt = $matches[0];
        $decodedToken = (new Parser())->parse($jwt);

        // Change the password using the provided token
        $response = $client->request('PUT', $decodedToken->getClaim('sub'), [
            'json' => ['plainPassword' => 'newPassword'],
            'auth_bearer' => $jwt,
        ]);
        $this->assertSame(200, $response->getStatusCode());

        // Checks that the user have been changed
        $user = self::$container->get('test.security.helper')->getUser();
        $encoder = self::$container->get('test.security.encoder_factory')->getEncoder($user);
        $this->assertTrue($encoder->isPasswordValid($user->getPassword(), 'newPassword', $user->getSalt()));

        // Checks that the JTI has been saved
        $this->assertNotNull(
            self::$container->get('test.doctrine')->getRepository(Jti::class)->find($decodedToken->getClaim('jti'))
        );
    }
}
```

The following fixtures are loaded automatically. The database is reseted to a known test between every test (regardless of it fails or not) using transactions for maximum performance.

```yaml
App\Entity\User:
  user_kevin:
    email: dunglas@gmail.com
    password: \$argon2i\$v=19\$m=1024,t=2,p=2\$TW9YajBjdGpUVUp4Uks1aA\$vwFQakIF9aGGoC5KjT+S3kuOYDtwtghzMuEZ/xP6FnM # maman
``` 

TODO:

* [x] Import tests
* [ ] Write docs
* [x] Add support for Basic auth
* [x] Wait for Symfony 4.3