### PR TITLE
Do not disable cache in dev

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -436,17 +436,21 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
      */
     private function registerCacheConfiguration(ContainerBuilder $container)
     {
-        // Don't use system cache pool in dev
-        if ($container->hasParameter('api_platform.metadata_cache') ? $container->getParameter('api_platform.metadata_cache') : !$container->getParameter('kernel.debug')) {
+        if (!$container->hasParameter('api_platform.metadata_cache')) {
             return;
         }
 
-        $container->register('api_platform.cache.metadata.property', ArrayAdapter::class);
-        $container->register('api_platform.cache.metadata.resource', ArrayAdapter::class);
-        $container->register('api_platform.cache.route_name_resolver', ArrayAdapter::class);
-        $container->register('api_platform.cache.identifiers_extractor', ArrayAdapter::class);
-        $container->register('api_platform.cache.subresource_operation_factory', ArrayAdapter::class);
-        $container->register('api_platform.elasticsearch.cache.metadata.document', ArrayAdapter::class);
+        @trigger_error('The "api_platform.metadata_cache" parameter is deprecated since version 2.4 and will have no effect in 3.0.', E_USER_DEPRECATED);
+
+        // BC
+        if (!$container->getParameter('api_platform.metadata_cache')) {
+            $container->register('api_platform.cache.metadata.property', ArrayAdapter::class);
+            $container->register('api_platform.cache.metadata.resource', ArrayAdapter::class);
+            $container->register('api_platform.cache.route_name_resolver', ArrayAdapter::class);
+            $container->register('api_platform.cache.identifiers_extractor', ArrayAdapter::class);
+            $container->register('api_platform.cache.subresource_operation_factory', ArrayAdapter::class);
+            $container->register('api_platform.elasticsearch.cache.metadata.document', ArrayAdapter::class);
+        }
     }
 
     /**

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1033,8 +1033,7 @@ class ApiPlatformExtensionTest extends TestCase
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
 
-        $containerBuilderProphecy->hasParameter('api_platform.metadata_cache')->willReturn(true)->shouldBeCalled();
-        $containerBuilderProphecy->getParameter('api_platform.metadata_cache')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->hasParameter('api_platform.metadata_cache')->willReturn(false);
 
         $containerBuilderProphecy->getDefinition('api_platform.mercure.listener.response.add_link_header')->willReturn(new Definition());
 

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -89,8 +89,6 @@ api_platform:
 parameters:
     container.autowiring.strict_mode: true
     container.dumper.inline_class_loader: true
-    # Enable the metadata cache to speedup the builds
-    api_platform.metadata_cache: true
 
 services:
     contain_non_resource.item_data_provider:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2593 (partially)
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/766

With the cache enabled, changing API resource metadata in `dev` still works without a manual `cache:clear`.