### PR TITLE
Create a resource with a falsy input

### DIFF
--- a/features/main/input_output.feature
+++ b/features/main/input_output.feature
@@ -242,3 +242,16 @@ Feature: DTO input and output
       }
     }
     """
+
+  @createSchema
+  Scenario: Create a resource with no input
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummy_dto_no_inputs" with body:
+    """
+    {
+      "foo": "test",
+      "bar": 1
+    }
+    """
+    Then the response status code should be 201
+    And the response should be empty

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -61,7 +61,14 @@ final class SerializeListener
 
         $context = $this->serializerContextBuilder->createFromRequest($request, true, $attributes);
 
-        if (isset($context['output']) && \array_key_exists('class', $context['output']) && null === $context['output']['class']) {
+        if (
+            (isset($context['output']) && \array_key_exists('class', $context['output']) && null === $context['output']['class'])
+            ||
+            (
+                null === $controllerResult && isset($context['input']) && \array_key_exists('class', $context['input']) &&
+                null === $context['input']['class']
+            )
+        ) {
             $event->setControllerResult('');
 
             return;

--- a/src/Validator/EventListener/ValidateListener.php
+++ b/src/Validator/EventListener/ValidateListener.php
@@ -52,10 +52,13 @@ final class ValidateListener
             return;
         }
 
-        $data = $event->getControllerResult();
         $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
-        $validationGroups = $resourceMetadata->getOperationAttribute($attributes, 'validation_groups', null, true);
+        $inputMetadata = $resourceMetadata->getOperationAttribute($attributes, 'input', [], true);
+        if (\array_key_exists('class', $inputMetadata) && null === $inputMetadata['class']) {
+            return;
+        }
 
-        $this->validator->validate($data, ['groups' => $validationGroups]);
+        $validationGroups = $resourceMetadata->getOperationAttribute($attributes, 'validation_groups', null, true);
+        $this->validator->validate($event->getControllerResult(), ['groups' => $validationGroups]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

Adds a test to write on a resource with an `input=false`. Should we throw an error if the user sent data and only accept empty data?