### PR TITLE
Don't use fetchJoinCollection on Doctrine Paginator when not needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "jangregor/phpstan-prophecy": "^0.3",
         "justinrainbow/json-schema": "^5.0",
         "nelmio/api-doc-bundle": "^2.13.3",
-        "php-mock/php-mock-phpunit": "^2.0",
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
         "phpdocumentor/type-resolver": "^0.3 || ^0.4",
         "phpspec/prophecy": "^1.8",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -67,6 +67,9 @@ parameters:
 			path: %currentWorkingDirectory%/src/Test/DoctrineMongoDbOdmFilterTestCase.php
 		- '#Method ApiPlatform\\Core\\(Serializer\\Abstract|JsonApi\\Serializer\\)ItemNormalizer::normalizeRelation\(\) should return array\|string but returns array\|bool\|float\|int\|string\.#'
 		- '#Method ApiPlatform\\Core\\Util\\RequestParser::parseRequestParams\(\) should return array but returns array\|false\.#'
+		-
+			message: '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Util\\QueryBuilderHelper::mapJoinAliases() should return array<string, array<string>\|string> but returns array<int|string, mixed>\.#'
+			path: %currentWorkingDirectory%/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
 		- "#Call to method PHPUnit\\\\Framework\\\\Assert::assertSame\\(\\) with array\\('(collection_context|item_context|subresource_context)'\\) and array<Symfony\\\\Component\\\\VarDumper\\\\Cloner\\\\Data>\\|bool\\|float\\|int\\|string\\|null will always evaluate to false\\.#"
 		# https://github.com/symfony/symfony/pull/30535
 		-

--- a/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Util;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 
@@ -28,7 +29,7 @@ final class QueryBuilderHelper
     }
 
     /**
-     * Adds a join to the queryBuilder if none exists.
+     * Adds a join to the QueryBuilder if none exists.
      */
     public static function addJoinOnce(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $association, string $joinType = null, string $conditionType = null, string $condition = null, string $originAlias = null): string
     {
@@ -51,7 +52,113 @@ final class QueryBuilderHelper
     }
 
     /**
-     * Get the existing join from queryBuilder DQL parts.
+     * Gets the entity class name by an alias used in the QueryBuilder.
+     */
+    public static function getEntityClassByAlias(string $alias, QueryBuilder $queryBuilder, ManagerRegistry $managerRegistry): string
+    {
+        if (!\in_array($alias, $queryBuilder->getAllAliases(), true)) {
+            throw new \LogicException(sprintf('The alias "%s" does not exist in the QueryBuilder.', $alias));
+        }
+
+        $rootAliasMap = self::mapRootAliases($queryBuilder->getRootAliases(), $queryBuilder->getRootEntities());
+
+        if (isset($rootAliasMap[$alias])) {
+            return $rootAliasMap[$alias];
+        }
+
+        $metadata = null;
+
+        foreach (self::traverseJoins($alias, $queryBuilder, $managerRegistry) as [$currentMetadata]) {
+            $metadata = $currentMetadata;
+        }
+
+        if (null === $metadata) {
+            throw new \LogicException(sprintf('The alias "%s" does not exist in the QueryBuilder.', $alias));
+        }
+
+        return $metadata->getName();
+    }
+
+    /**
+     * Finds the root alias for an alias used in the QueryBuilder.
+     */
+    public static function findRootAlias(string $alias, QueryBuilder $queryBuilder): string
+    {
+        if (\in_array($alias, $queryBuilder->getRootAliases(), true)) {
+            return $alias;
+        }
+
+        foreach ($queryBuilder->getDQLPart('join') as $rootAlias => $joins) {
+            foreach ($joins as $join) {
+                if ($alias === $join->getAlias()) {
+                    return $rootAlias;
+                }
+            }
+        }
+
+        throw new \LogicException(sprintf('The alias "%s" does not exist in the QueryBuilder.', $alias));
+    }
+
+    /**
+     * Traverses through the joins for an alias used in the QueryBuilder.
+     *
+     * @return \Generator<string, array>
+     */
+    public static function traverseJoins(string $alias, QueryBuilder $queryBuilder, ManagerRegistry $managerRegistry): \Generator
+    {
+        $rootAliasMap = self::mapRootAliases($queryBuilder->getRootAliases(), $queryBuilder->getRootEntities());
+
+        $joinParts = $queryBuilder->getDQLPart('join');
+        $rootAlias = self::findRootAlias($alias, $queryBuilder);
+
+        $joinAliasMap = self::mapJoinAliases($joinParts[$rootAlias]);
+
+        $aliasMap = array_merge($rootAliasMap, $joinAliasMap);
+
+        $apexEntityClass = null;
+        $associationStack = [];
+        $aliasStack = [];
+        $currentAlias = $alias;
+
+        while (null === $apexEntityClass) {
+            if (!isset($aliasMap[$currentAlias])) {
+                throw new \LogicException(sprintf('Unknown alias "%s".', $currentAlias));
+            }
+
+            if (\is_string($aliasMap[$currentAlias])) {
+                $aliasStack[] = $currentAlias;
+                $apexEntityClass = $aliasMap[$currentAlias];
+            } else {
+                [$parentAlias, $association] = $aliasMap[$currentAlias];
+
+                $associationStack[] = $association;
+                $aliasStack[] = $currentAlias;
+                $currentAlias = $parentAlias;
+            }
+        }
+
+        $entityClass = $apexEntityClass;
+
+        while (null !== ($alias = array_pop($aliasStack))) {
+            $metadata = $managerRegistry
+                ->getManagerForClass($entityClass)
+                ->getClassMetadata($entityClass);
+
+            $association = array_pop($associationStack);
+
+            yield $alias => [
+                $metadata,
+                $association,
+            ];
+
+            if (null !== $association) {
+                $entityClass = $metadata->getAssociationTargetClass($association);
+            }
+        }
+    }
+
+    /**
+     * Gets the existing join from QueryBuilder DQL parts.
      */
     private static function getExistingJoin(QueryBuilder $queryBuilder, string $alias, string $association, string $originAlias = null): ?Join
     {
@@ -70,5 +177,43 @@ final class QueryBuilderHelper
         }
 
         return null;
+    }
+
+    /**
+     * Maps the root aliases to root entity classes.
+     *
+     * @return array<string, string>
+     */
+    private static function mapRootAliases(array $rootAliases, array $rootEntities): array
+    {
+        $aliasMap = array_combine($rootAliases, $rootEntities);
+        if (false === $aliasMap) {
+            throw new \LogicException('Number of root aliases and root entities do not match.');
+        }
+
+        return $aliasMap;
+    }
+
+    /**
+     * Maps the join aliases to the parent alias and association, or the entity class.
+     *
+     * @return array<string, string[]|string>
+     */
+    private static function mapJoinAliases(iterable $joins): array
+    {
+        $aliasMap = [];
+
+        foreach ($joins as $join) {
+            $alias = $join->getAlias();
+            $relationship = $join->getJoin();
+
+            if (false !== strpos($relationship, '.')) {
+                $aliasMap[$alias] = explode('.', $relationship);
+            } else {
+                $aliasMap[$alias] = $relationship;
+            }
+        }
+
+        return $aliasMap;
     }
 }

--- a/src/Bridge/Doctrine/Orm/Util/QueryJoinParser.php
+++ b/src/Bridge/Doctrine/Orm/Util/QueryJoinParser.php
@@ -24,6 +24,10 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @internal
+ *
+ * @deprecated
  */
 final class QueryJoinParser
 {
@@ -33,70 +37,24 @@ final class QueryJoinParser
 
     /**
      * Gets the class metadata from a given join alias.
+     *
+     * @deprecated
      */
     public static function getClassMetadataFromJoinAlias(string $alias, QueryBuilder $queryBuilder, ManagerRegistry $managerRegistry): ClassMetadata
     {
-        $rootEntities = $queryBuilder->getRootEntities();
-        $rootAliases = $queryBuilder->getRootAliases();
+        @trigger_error(sprintf('The use of "%s::getClassMetadataFromJoinAlias()" is deprecated since 2.4 and will be removed in 3.0. Use "%s::getEntityClassByAlias()" instead.', __CLASS__, QueryBuilderHelper::class), E_USER_DEPRECATED);
 
-        $joinParts = $queryBuilder->getDQLPart('join');
+        $entityClass = QueryBuilderHelper::getEntityClassByAlias($alias, $queryBuilder, $managerRegistry);
 
-        $aliasMap = [];
-        $targetAlias = $alias;
-
-        foreach ($joinParts as $rootAlias => $joins) {
-            $aliasMap[$rootAlias] = 'root';
-
-            foreach ($joins as $join) {
-                $alias = $join->getAlias();
-                $relationship = $join->getJoin();
-
-                $pos = strpos($relationship, '.');
-
-                if (false !== $pos) {
-                    $aliasMap[$alias] = [
-                        'parentAlias' => substr($relationship, 0, $pos),
-                        'association' => substr($relationship, $pos + 1),
-                    ];
-                }
-            }
-        }
-
-        $associationStack = [];
-        $rootAlias = null;
-
-        while (null === $rootAlias) {
-            $mapping = $aliasMap[$targetAlias];
-
-            if ('root' === $mapping) {
-                $rootAlias = $targetAlias;
-            } else {
-                $associationStack[] = $mapping['association'];
-                $targetAlias = $mapping['parentAlias'];
-            }
-        }
-
-        $rootEntity = $rootEntities[array_search($rootAlias, $rootAliases, true)];
-
-        $rootMetadata = $managerRegistry
-            ->getManagerForClass($rootEntity)
-            ->getClassMetadata($rootEntity);
-
-        $metadata = $rootMetadata;
-
-        while (null !== ($association = array_pop($associationStack))) {
-            $associationClass = $metadata->getAssociationTargetClass($association);
-
-            $metadata = $managerRegistry
-                ->getManagerForClass($associationClass)
-                ->getClassMetadata($associationClass);
-        }
-
-        return $metadata;
+        return $managerRegistry
+            ->getManagerForClass($entityClass)
+            ->getClassMetadata($entityClass);
     }
 
     /**
      * Gets the relationship from a Join expression.
+     *
+     * @deprecated
      */
     public static function getJoinRelationship(Join $join): string
     {
@@ -107,6 +65,8 @@ final class QueryJoinParser
 
     /**
      * Gets the alias from a Join expression.
+     *
+     * @deprecated
      */
     public static function getJoinAlias(Join $join): string
     {
@@ -119,6 +79,8 @@ final class QueryJoinParser
      * Gets the parts from an OrderBy expression.
      *
      * @return string[]
+     *
+     * @deprecated
      */
     public static function getOrderByParts(OrderBy $orderBy): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes?
| New feature?  | no?
| BC breaks?    | no?
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/core/pull/2611#issuecomment-474909777, https://github.com/api-platform/core/pull/2611#issuecomment-474910906
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/771

Refactor `QueryChecker` etc.

I've removed the flawed handling of "join by class", as we simply have not enough information to do the right thing there. The main caveat (as was before) is that our checking covers the "80%":

- join by association
- no complex expression in `SELECT` / `ORDER BY` clauses

but will be confused in the remaining "20%".

For example:

🗹 Supported:

```dql
SELECT d, a_1
FROM Dummy d
LEFT JOIN d.relatedDummies a_1
ORDER BY a_1.name
```

🗷 Not supported:

```dql
SELECT d, a_1
FROM Dummy d
LEFT JOIN RelatedDummy a_1 WITH 1 = 1
ORDER BY a_1.name
```

🗷 Not supported:

```dql
SELECT d, LENGTH(a_1.name) AS HIDDEN score
FROM Dummy d
LEFT JOIN d.relatedDummies a_1
ORDER BY score
```