### PR TITLE
Fix Nested Input DTOs Resource Not Found Error

### DIFF
--- a/features/main/input_output.feature
+++ b/features/main/input_output.feature
@@ -148,6 +148,34 @@ Feature: DTO input and output
     }
     """
 
+  @createSchema
+  Scenario: Create a resource with custom input with nested dto
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummy_dto_customs" with body:
+    """
+    {
+      "foo": "test",
+      "bar": 1,
+      "nested": {
+        "baz": "baz-nested"
+      }
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/DummyDtoCustom",
+      "@id": "/dummy_dto_customs/1",
+      "@type": "DummyDtoCustom",
+      "lorem": "test",
+      "ipsum": "1",
+      "id": 1
+    }
+    """
+
   @!mongodb
   @createSchema
   Scenario: Use DTO with relations on User

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -97,7 +97,7 @@ final class DeserializeListener
         $request->attributes->set(
             'data',
             $this->serializer->deserialize(
-                $requestContent, $context['resource_class'], $format, $context
+                $requestContent, $context['input']['class'] ?? $context['resource_class'], $format, $context + ['api_denormalize' => true]
             )
         );
     }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -175,7 +175,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
 
         if (null !== $inputClass && null !== $dataTransformer = $this->getDataTransformer($data, $context['resource_class'], $context)) {
             $data = $dataTransformer->transform(
-                parent::denormalize($data, $inputClass, $format, ['input' => ['class' => null]] + $context), // ensure we don't transformData for nested relations
+                parent::denormalize($data, $inputClass, $format, ['input' => null] + $context), // ensure we don't transformData for nested relations
                 $class,
                 $context
             );

--- a/tests/Fixtures/TestBundle/Dto/CustomInputDto.php
+++ b/tests/Fixtures/TestBundle/Dto/CustomInputDto.php
@@ -24,4 +24,9 @@ class CustomInputDto
      * @var int
      */
     public $bar;
+
+    /**
+     * @var NestedDto|null
+     */
+    public $nested;
 }

--- a/tests/Fixtures/TestBundle/Dto/NestedDto.php
+++ b/tests/Fixtures/TestBundle/Dto/NestedDto.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto;
 
-class RecoverPasswordInput
+class NestedDto
 {
     /**
-     * @var \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\User
+     * @var string
      */
-    public $user;
+    public $baz;
 }


### PR DESCRIPTION
- Fixes issue where trying to use nested dto's would
  use the wrong resource class due to the input class
  being passed into the context for the child dto and
  api platform would report a Resource not found error
  accordingly
- Separated input from resource class to ensure that
  resource_class is only set if the class is ACTUALLy
  a resource class

Signed-off-by: RJ Garcia <rj@bighead.net>

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
