### PR TITLE
Ensure unsuccessful responses are not cached

### DIFF
--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -52,7 +52,7 @@ final class AddHeadersListener
 
         $response = $event->getResponse();
 
-        if (!$response->getContent()) {
+        if (!$response->getContent() || !$response->isSuccessful()) {
             return;
         }
 

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -44,6 +44,22 @@ class AddHeadersListenerTest extends TestCase
         $this->assertNull($response->getEtag());
     }
 
+    public function testDoNotSetHeaderOnUnsuccessfulResponse()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+
+        $response = new Response('{}', Response::HTTP_BAD_REQUEST);
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $listener = new AddHeadersListener(true);
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertNull($response->getEtag());
+    }
+
     public function testDoNotSetHeaderWhenNotAnApiOperation()
     {
         $request = new Request();


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

Following our conversation on Slack, this PR aims at avoiding Api-Platform to generate cache headers on 4xx / 5xx responses.