### PR TITLE
GraphQl: parse input&messenger metadata

### DIFF
--- a/features/main/input_output.feature
+++ b/features/main/input_output.feature
@@ -287,3 +287,29 @@ Feature: DTO input and output
       "data": 123
     }
     """
+
+  @!mongodb
+  Scenario: Use messenger with graphql and an input where the handler gives a synchronous result
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createMessengerWithInput(input: {var: "test"}) {
+        messengerWithInput { id, name }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be equal to:
+    """
+    {
+      "data": {
+        "createMessengerWithInput": {
+          "messengerWithInput": {
+              "id": "/messenger_with_inputs/1",
+              "name": "test"
+          }
+        }
+      }
+    }
+    """

--- a/src/Bridge/Symfony/Messenger/DataPersister.php
+++ b/src/Bridge/Symfony/Messenger/DataPersister.php
@@ -63,6 +63,10 @@ final class DataPersister implements ContextAwareDataPersisterInterface
             );
         }
 
+        if (isset($context['graphql_operation_name'])) {
+            return false !== $resourceMetadata->getGraphqlAttribute($context['graphql_operation_name'], 'messenger', false, true);
+        }
+
         return false !== $resourceMetadata->getAttribute('messenger', false);
     }
 

--- a/src/Bridge/Symfony/Messenger/DataTransformer.php
+++ b/src/Bridge/Symfony/Messenger/DataTransformer.php
@@ -55,6 +55,10 @@ final class DataTransformer implements DataTransformerInterface
 
         $metadata = $this->resourceMetadataFactory->create($context['resource_class'] ?? $to);
 
+        if (isset($context['graphql_operation_name'])) {
+            return 'input' === $metadata->getGraphqlAttribute($context['graphql_operation_name'], 'messenger', null, true);
+        }
+
         if (!isset($context['operation_type'])) {
             return 'input' === $metadata->getAttribute('messenger');
         }

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -419,8 +419,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
             return $this->graphqlTypes[$shortName];
         }
 
-        $ioMetadata = $resourceMetadata->getAttribute($input ? 'input' : 'output');
-
+        $ioMetadata = $resourceMetadata->getGraphqlAttribute(null === $mutationName ? 'query' : $mutationName, $input ? 'input' : 'output', null, true);
         if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
             $resourceClass = $ioMetadata['class'];
         }

--- a/src/Metadata/Resource/Factory/InputOutputResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/InputOutputResourceMetadataFactory.php
@@ -48,6 +48,10 @@ final class InputOutputResourceMetadataFactory implements ResourceMetadataFactor
             $resourceMetadata = $resourceMetadata->withItemOperations($this->getTransformedOperations($itemOperations, $attributes));
         }
 
+        if (null !== $graphQlAttributes = $resourceMetadata->getGraphql()) {
+            $resourceMetadata = $resourceMetadata->withGraphql($this->getTransformedOperations($graphQlAttributes, $attributes));
+        }
+
         return $resourceMetadata->withAttributes($attributes);
     }
 

--- a/tests/Bridge/Symfony/Messenger/DataPersisterTest.php
+++ b/tests/Bridge/Symfony/Messenger/DataPersisterTest.php
@@ -85,4 +85,13 @@ class DataPersisterTest extends TestCase
         $dataPersister = new DataPersister($this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(), $messageBus->reveal());
         $this->assertSame($dummy, $dataPersister->persist($dummy));
     }
+
+    public function testSupportWithGraphqlContext()
+    {
+        $metadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $metadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata(null, null, null, null, null, []))->withGraphQl(['create' => ['messenger' => 'input']]));
+
+        $dataPersister = new DataPersister($metadataFactoryProphecy->reveal(), $this->prophesize(MessageBusInterface::class)->reveal());
+        $this->assertTrue($dataPersister->supports(new DummyCar(), ['resource_class' => Dummy::class, 'graphql_operation_name' => 'create']));
+    }
 }

--- a/tests/Bridge/Symfony/Messenger/DataTransformerTest.php
+++ b/tests/Bridge/Symfony/Messenger/DataTransformerTest.php
@@ -86,4 +86,12 @@ class DataTransformerTest extends TestCase
         $dataTransformer = new DataTransformer($metadataFactoryProphecy->reveal());
         $this->assertSame($dummy, $dataTransformer->transform($dummy, Dummy::class));
     }
+
+    public function testSupportWithGraphqlContext()
+    {
+        $metadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $metadataFactoryProphecy->create(Dummy::class)->willReturn((new ResourceMetadata(null, null, null, null, null, []))->withGraphQl(['create' => ['messenger' => 'input']]));
+        $dataTransformer = new DataTransformer($metadataFactoryProphecy->reveal());
+        $this->assertTrue($dataTransformer->supportsTransformation([], Dummy::class, ['input' => ['class' => 'smth'], 'graphql_operation_name' => 'create']));
+    }
 }

--- a/tests/Fixtures/TestBundle/Entity/MessengerWithInput.php
+++ b/tests/Fixtures/TestBundle/Entity/MessengerWithInput.php
@@ -18,7 +18,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\MessengerInput;
 
 /**
- * @ApiResource(messenger="input", input=MessengerInput::class)
+ * @ApiResource(messenger="input", input=MessengerInput::class, graphql={"create"={"input"=MessengerInput::class, "messenger"="input"}})
  */
 class MessengerWithInput
 {

--- a/tests/Metadata/Resource/Factory/InputOutputResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/InputOutputResourceMetadataFactoryTest.php
@@ -24,15 +24,29 @@ class InputOutputResourceMetadataFactoryTest extends TestCase
     /**
      * @dataProvider getAttributes
      */
-    public function testExistingDescription($attributes, $expected)
+    public function testInputOutputMetadata($attributes, $expected)
     {
-        $resourceMetadata = (new ResourceMetadata(null, 'My desc'))->withAttributes($attributes);
+        $resourceMetadata = (new ResourceMetadata(null))->withAttributes($attributes);
         $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
         $decorated = $decoratedProphecy->reveal();
 
         $factory = new InputOutputResourceMetadataFactory($decorated);
         $this->assertSame($expected, $factory->create('Foo')->getAttributes()['input']);
+    }
+
+    /**
+     * @dataProvider getAttributes
+     */
+    public function testInputOutputViaGraphQlMetadata($attributes, $expected)
+    {
+        $resourceMetadata = (new ResourceMetadata(null))->withGraphQl(['create' => $attributes]);
+        $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decoratedProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new InputOutputResourceMetadataFactory($decorated);
+        $this->assertSame($expected, $factory->create('Foo')->getGraphqlAttribute('create', 'input'));
     }
 
     public function getAttributes(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

We forgot to take graphql mutations into consideration when retrieving the metadata. This now works correctly when performing a `createBookmark` mutation on my resource:

```
/**
 * @ApiResource(
 *      graphql={"create"={"input"=BookmarkInput::class, "messenger"="input"}}
 * )
 */
class Bookmark {}
``` 

It'll forward `BookmarkInput` to the messenger via the mutation :fire: :fire:  :fire:  . 

Note: for naming consistency I took the liberty of changing `graphql_operation_name` to `graphql_mutation_name` in our internal `$context` because else it's confusing.