### PR TITLE
fix: update symfony/serializer required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-kernel": "^3.4 || ^4.0",
         "symfony/property-access": "^3.4 || ^4.0",
         "symfony/property-info": "^3.4 || ^4.0",
-        "symfony/serializer": "^4.1",
+        "symfony/serializer": "^4.2",
         "symfony/web-link": "^4.1",
         "willdurand/negotiation": "^2.0.3"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -71,10 +71,6 @@ parameters:
 			message: '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Util\\QueryBuilderHelper::mapJoinAliases() should return array<string, array<string>\|string> but returns array<int|string, mixed>\.#'
 			path: %currentWorkingDirectory%/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
 		- "#Call to method PHPUnit\\\\Framework\\\\Assert::assertSame\\(\\) with array\\('(collection_context|item_context|subresource_context)'\\) and array<Symfony\\\\Component\\\\VarDumper\\\\Cloner\\\\Data>\\|bool\\|float\\|int\\|string\\|null will always evaluate to false\\.#"
-		# https://github.com/symfony/symfony/pull/30535
-		-
-			message: '#Call to method PHPUnit\\Framework\\Assert::assertNull\(\) with string will always evaluate to false\.#'
-			path: %currentWorkingDirectory%/tests/EventListener/AddFormatListenerTest.php
 		# https://github.com/doctrine/doctrine2/pull/7298/files
 		- '#Strict comparison using === between null and int will always evaluate to false\.#'
 		-


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

Currently, the required version of the symfony/serializer is ^4.1 but in api-platform/core 2.4 we use an interface that is available only since Serializer v4.2 :
`final class ReservedAttributeNameConverter implements AdvancedNameConverterInterface`

This creates a nice error like that:
```
Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the symfony-scripts event terminated with an exception                       

  [RuntimeException]                                                                                                                                                       
  An error occurred when executing the "'cache:clear --no-warmup'" command:                                                                                                
                                                                                                                                                                           
                                                                                                                                                                           
  Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 2 passed to ApiPlatform\Core\JsonApi\Serializer\ConstraintViolationLi  
  stNormalizer::__construct() must implement interface Symfony\Component\Serializer\NameConverter\NameConverterInterface or be null, instance of ApiPlatform\Core\JsonApi  
  \Serializer\ReservedAttributeNameConverter given, called in /var/www/amms-api/var/cache/dev/ContainerV9modiz/appDevDebugProjectContainer.php on line 6054 in /var/www/a  
  mms-api/vendor/api-platform/core/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php:35                                                                         
  Stack trace:                                                                                                                                                             
  #0 /var/www/amms-api/var/cache/dev/ContainerV9modiz/appDevDebugProjectContainer.php(6054): ApiPlatform\Core\JsonApi\Serializer\ConstraintViolationListNormalizer->__con  
  struct(Object(ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory), Object(ApiPlatform\Core\JsonApi\Serializer\ReservedAttributeNameConverter))     
  #1 /var/www/amms-api/var/cache/dev/ContainerV9modiz/appDevDebugProjectContainer.php(6333): Con in /var/www/amms-api/vendor/api-platform/core/src/JsonApi/Serializer/Con  
  straintViolationListNormalizer.php on line 35
```