### PR TITLE
Metadata: Attributes default value should be null not an empty array

### DIFF
--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -85,7 +85,7 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
                 $annotation->iri,
                 $annotation->itemOperations,
                 $annotation->collectionOperations,
-                $annotation->attributes,
+                $annotation->attributes ?: null,
                 $annotation->subresourceOperations,
                 $annotation->graphql
             );

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -46,6 +46,17 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $metadata->getGraphql());
     }
 
+    public function testCreateWithoutAttributes()
+    {
+        $annotation = new ApiResource([]);
+        $reader = $this->prophesize(Reader::class);
+        $reader->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotation)->shouldBeCalled();
+        $factory = new AnnotationResourceMetadataFactory($reader->reveal(), null);
+        $metadata = $factory->create(Dummy::class);
+
+        $this->assertNull($metadata->getAttributes());
+    }
+
     public function getCreateDependencies()
     {
         $annotation = new ApiResource([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

In every other metadata factory, we check if attributes is `null`. The AnnotationResourceMetadataFactory is one of the first to run and sets the attributes to an empty array. This then blocks other metadata factories, and they will not set the `attributes` value because it's not null. 
