### PR TITLE
GraphQl: Use compiler pass only when enabled

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPass.php
@@ -31,6 +31,10 @@ final class GraphQlMutationResolverPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->getParameter('api_platform.graphql.enabled')) {
+            return;
+        }
+
         $mutations = [];
         foreach ($container->findTaggedServiceIds('api_platform.graphql.mutation_resolver', true) as $serviceId => $tags) {
             foreach ($tags as $tag) {

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlQueryResolverPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlQueryResolverPass.php
@@ -31,6 +31,10 @@ final class GraphQlQueryResolverPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->getParameter('api_platform.graphql.enabled')) {
+            return;
+        }
+
         $resolvers = [];
         foreach ($container->findTaggedServiceIds('api_platform.graphql.query_resolver', true) as $serviceId => $tags) {
             foreach ($tags as $tag) {

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlTypePass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlTypePass.php
@@ -31,6 +31,10 @@ final class GraphQlTypePass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->getParameter('api_platform.graphql.enabled')) {
+            return;
+        }
+
         $types = [];
         foreach ($container->findTaggedServiceIds('api_platform.graphql.type', true) as $serviceId => $tags) {
             foreach ($tags as $tag) {

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPassTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlMutationResolverPass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class GraphQlMutationResolverPassTest extends TestCase
+{
+    public function testProcess()
+    {
+        $filterPass = new GraphQlMutationResolverPass();
+
+        $this->assertInstanceOf(CompilerPassInterface::class, $filterPass);
+
+        $typeLocatorDefinitionProphecy = $this->prophesize(Definition::class);
+        $typeLocatorDefinitionProphecy->addArgument(Argument::that(function (array $arg) {
+            return !isset($arg['foo']) && isset($arg['bar']) && $arg['bar'] instanceof Reference;
+        }))->shouldBeCalled();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('api_platform.graphql.enabled')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->findTaggedServiceIds('api_platform.graphql.mutation_resolver', true)->willReturn(['foo' => [], 'bar' => [['id' => 'bar']]])->shouldBeCalled();
+        $containerBuilderProphecy->getDefinition('api_platform.graphql.mutation_resolver_locator')->willReturn($typeLocatorDefinitionProphecy->reveal())->shouldBeCalled();
+
+        $filterPass->process($containerBuilderProphecy->reveal());
+    }
+
+    public function testDisabled()
+    {
+        $filterPass = new GraphQlMutationResolverPass();
+
+        $this->assertInstanceOf(CompilerPassInterface::class, $filterPass);
+
+        $typeLocatorDefinitionProphecy = $this->prophesize(Definition::class);
+        $typeLocatorDefinitionProphecy->addArgument(Argument::any())->shouldNotBeCalled();
+
+        $typesFactoryDefinitionProphecy = $this->prophesize(Definition::class);
+        $typesFactoryDefinitionProphecy->addArgument(['my_id'])->shouldNotBeCalled();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('api_platform.graphql.enabled')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->findTaggedServiceIds('api_platform.graphql.mutation_resolver', true)->willReturn(['foo' => [], 'bar' => [['id' => 'my_id']]])->shouldNotBeCalled();
+
+        $filterPass->process($containerBuilderProphecy->reveal());
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlQueryResolverPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlQueryResolverPassTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolverPass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class GraphQlQueryResolverPassTest extends TestCase
+{
+    public function testProcess()
+    {
+        $filterPass = new GraphQlQueryResolverPass();
+
+        $this->assertInstanceOf(CompilerPassInterface::class, $filterPass);
+
+        $typeLocatorDefinitionProphecy = $this->prophesize(Definition::class);
+        $typeLocatorDefinitionProphecy->addArgument(Argument::that(function (array $arg) {
+            return !isset($arg['foo']) && isset($arg['bar']) && $arg['bar'] instanceof Reference;
+        }))->shouldBeCalled();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('api_platform.graphql.enabled')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->findTaggedServiceIds('api_platform.graphql.query_resolver', true)->willReturn(['foo' => [], 'bar' => [['id' => 'bar']]])->shouldBeCalled();
+        $containerBuilderProphecy->getDefinition('api_platform.graphql.query_resolver_locator')->willReturn($typeLocatorDefinitionProphecy->reveal())->shouldBeCalled();
+
+        $filterPass->process($containerBuilderProphecy->reveal());
+    }
+
+    public function testDisabled()
+    {
+        $filterPass = new GraphQlQueryResolverPass();
+
+        $this->assertInstanceOf(CompilerPassInterface::class, $filterPass);
+
+        $typeLocatorDefinitionProphecy = $this->prophesize(Definition::class);
+        $typeLocatorDefinitionProphecy->addArgument(Argument::any())->shouldNotBeCalled();
+
+        $typesFactoryDefinitionProphecy = $this->prophesize(Definition::class);
+        $typesFactoryDefinitionProphecy->addArgument(['my_id'])->shouldNotBeCalled();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('api_platform.graphql.enabled')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->findTaggedServiceIds('api_platform.graphql.query_resolver', true)->willReturn(['foo' => [], 'bar' => [['id' => 'my_id']]])->shouldNotBeCalled();
+
+        $filterPass->process($containerBuilderProphecy->reveal());
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlTypePassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/GraphQlTypePassTest.php
@@ -41,6 +41,7 @@ class GraphQlTypePassTest extends TestCase
         $typesFactoryDefinitionProphecy->addArgument(['my_id'])->shouldBeCalled();
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('api_platform.graphql.enabled')->willReturn(true)->shouldBeCalled();
         $containerBuilderProphecy->findTaggedServiceIds('api_platform.graphql.type', true)->willReturn(['foo' => [], 'bar' => [['id' => 'my_id']]])->shouldBeCalled();
         $containerBuilderProphecy->getDefinition('api_platform.graphql.type_locator')->willReturn($typeLocatorDefinitionProphecy->reveal())->shouldBeCalled();
         $containerBuilderProphecy->getDefinition('api_platform.graphql.types_factory')->willReturn($typesFactoryDefinitionProphecy->reveal())->shouldBeCalled();
@@ -63,9 +64,31 @@ class GraphQlTypePassTest extends TestCase
         $typesFactoryDefinitionProphecy->addArgument(['bar'])->shouldBeCalled();
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('api_platform.graphql.enabled')->willReturn(true)->shouldBeCalled();
         $containerBuilderProphecy->findTaggedServiceIds('api_platform.graphql.type', true)->willReturn(['foo' => [], 'bar' => [['hi' => 'hello']]])->shouldBeCalled();
         $containerBuilderProphecy->getDefinition('api_platform.graphql.type_locator')->willReturn($typeLocatorDefinitionProphecy->reveal())->shouldBeCalled();
         $containerBuilderProphecy->getDefinition('api_platform.graphql.types_factory')->willReturn($typesFactoryDefinitionProphecy->reveal())->shouldBeCalled();
+
+        $filterPass->process($containerBuilderProphecy->reveal());
+    }
+
+    public function testDisabled()
+    {
+        $filterPass = new GraphQlTypePass();
+
+        $this->assertInstanceOf(CompilerPassInterface::class, $filterPass);
+
+        $typeLocatorDefinitionProphecy = $this->prophesize(Definition::class);
+        $typeLocatorDefinitionProphecy->addArgument(Argument::any())->shouldNotBeCalled();
+
+        $typesFactoryDefinitionProphecy = $this->prophesize(Definition::class);
+        $typesFactoryDefinitionProphecy->addArgument(['my_id'])->shouldNotBeCalled();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('api_platform.graphql.enabled')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->findTaggedServiceIds('api_platform.graphql.type', true)->willReturn(['foo' => [], 'bar' => [['id' => 'my_id']]])->shouldNotBeCalled();
+        $containerBuilderProphecy->getDefinition('api_platform.graphql.type_locator')->willReturn($typeLocatorDefinitionProphecy->reveal())->shouldNotBeCalled();
+        $containerBuilderProphecy->getDefinition('api_platform.graphql.types_factory')->willReturn($typesFactoryDefinitionProphecy->reveal())->shouldNotBeCalled();
 
         $filterPass->process($containerBuilderProphecy->reveal());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na

Compiler passes ran with no graphql which was producing errors.
