### PR TITLE
Make sure to always use the persistResult for follow-up actions

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -61,9 +61,10 @@ final class WriteListener
 
                 if (null === $persistResult) {
                     @trigger_error(sprintf('Returning void from %s::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.', DataPersisterInterface::class), E_USER_DEPRECATED);
+                } else {
+                    $controllerResult = $persistResult;
+                    $event->setControllerResult($controllerResult);
                 }
-
-                $event->setControllerResult($persistResult ?? $controllerResult);
 
                 if (null === $this->iriConverter) {
                     return;


### PR DESCRIPTION
Not using the persistResult could cause issues in generating the IRI for
new resources because the ID was not set on the controllerResult but
only on the persistResult for example.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | not sure?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2692 
| License       | MIT
| Doc PR        | not relevant?

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
