### PR TITLE
[GraphQL] Non-null input for mutations

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -17,6 +17,10 @@ Feature: GraphQL mutation support
             type {
               name
               kind
+              ofType {
+                name
+                kind
+              }
             }
           }
         }
@@ -31,8 +35,9 @@ Feature: GraphQL mutation support
     And the JSON node "data.__type.fields[0].type.name" should match "/^delete[A-z0-9]+Payload$/"
     And the JSON node "data.__type.fields[0].type.kind" should be equal to "OBJECT"
     And the JSON node "data.__type.fields[0].args[0].name" should be equal to "input"
-    And the JSON node "data.__type.fields[0].args[0].type.name" should match "/^delete[A-z0-9]+Input$/"
-    And the JSON node "data.__type.fields[0].args[0].type.kind" should be equal to "INPUT_OBJECT"
+    And the JSON node "data.__type.fields[0].args[0].type.kind" should be equal to "NON_NULL"
+    And the JSON node "data.__type.fields[0].args[0].type.ofType.name" should match "/^delete[A-z0-9]+Input$/"
+    And the JSON node "data.__type.fields[0].args[0].type.ofType.kind" should be equal to "INPUT_OBJECT"
 
   Scenario: Create an item
     When I send the following GraphQL request:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Relay Input Object Mutations Specification was not fully respected: https://facebook.github.io/relay/graphql/mutations.htm#sec-Mutation-inputs.

The input object needs to be wrapped around a non-null wrapper.