### PR TITLE
Added an additional test for strict types validation

### DIFF
--- a/features/security/strong_typing.feature
+++ b/features/security/strong_typing.feature
@@ -56,7 +56,7 @@ Feature: Handle properly invalid data submitted to the API
     And the JSON node "@context" should be equal to "/contexts/Error"
     And the JSON node "@type" should be equal to "hydra:Error"
     And the JSON node "hydra:title" should be equal to "An error occurred"
-    And the JSON node "hydra:description" should be equal to 'The type of the "name" attribute must be "string", "null" given.'
+    And the JSON node "hydra:description" should be equal to 'The type of the "name" attribute must be "string", "NULL" given.'
 
   Scenario: Create a resource with wrong value type for relation
     When I add "Content-Type" header equal to "application/ld+json"

--- a/features/security/strong_typing.feature
+++ b/features/security/strong_typing.feature
@@ -42,6 +42,22 @@ Feature: Handle properly invalid data submitted to the API
     }
     """
 
+  Scenario: Create a resource without a required property with a strongly-typed setter
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": null
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON node "@context" should be equal to "/contexts/Error"
+    And the JSON node "@type" should be equal to "hydra:Error"
+    And the JSON node "hydra:title" should be equal to "An error occurred"
+    And the JSON node "hydra:description" should be equal to 'The type of the "name" attribute must be "string", "null" given.'
+
   Scenario: Create a resource with wrong value type for relation
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummies" with body:

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -188,12 +188,12 @@ class Dummy
         $this->id = $id;
     }
 
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/core/pull/2054
| License       | MIT
| Doc PR        |

Apparently this has been fixed in the meantime. I still added the test and fixed it (`gettype()` returns `null` uppercase).