### PR TITLE
Apply DenyAccessListener before deserialization

### DIFF
--- a/features/authorization/deny.feature
+++ b/features/authorization/deny.feature
@@ -58,15 +58,39 @@ Feature: Authorization checking
     """
     Then the response status code should be 201
 
-  Scenario: An user cannot retrieve an item he doesn't own
+  Scenario: A user cannot retrieve an item he doesn't own
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/1"
     Then the response status code should be 403
     And the response should be in JSON
 
-  Scenario: An user can retrieve an item he owns
+  Scenario: A user can retrieve an item he owns
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/2"
+    Then the response status code should be 200
+
+  Scenario: A user can't assign him an item he doesn't own
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send a "PUT" request to "/secured_dummies/2" with body:
+    """
+    {
+        "owner": "kitten"
+    }
+    """
+    Then the response status code should be 403
+
+  Scenario: A user can update an item he owns and transfer it
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send a "PUT" request to "/secured_dummies/2" with body:
+    """
+    {
+        "owner": "vincent"
+    }
+    """
     Then the response status code should be 200

--- a/src/Bridge/Symfony/Bundle/Resources/config/security.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/security.xml
@@ -21,7 +21,7 @@
             <argument type="service" id="api_platform.security.resource_access_checker" />
 
             <!-- This listener must be executed only when the current object is available -->
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="1" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="3" />
         </service>
 
         <service id="api_platform.security.expression_language_provider" class="ApiPlatform\Core\Security\Core\Authorization\ExpressionLanguageProvider" public="false">

--- a/src/Security/EventListener/DenyAccessListener.php
+++ b/src/Security/EventListener/DenyAccessListener.php
@@ -50,8 +50,6 @@ final class DenyAccessListener
     }
 
     /**
-     * Sets the applicable format to the HttpFoundation Request.
-     *
      * @throws AccessDeniedException
      */
     public function onKernelRequest(GetResponseEvent $event): void

--- a/tests/Fixtures/TestBundle/Document/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SecuredDummy.php
@@ -30,7 +30,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
  *     },
  *     graphql={
  *         "query"={},

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -29,7 +29,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="has_role('ROLE_USER') and object.getOwner() ==  user"},
  *     },
  *     graphql={
  *         "query"={},


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1646
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

I agree with @vincentchalamon that the priority is not the expected one.
The access control must be checked against the data read from the DB in the first place.
We have been discussing this during the EU-FOSSA Hackathon and couldn't really imagine a scenario where this would not be the expected behavior

ping @dunglas 

