### PR TITLE
Resource resolver for inheritance

### DIFF
--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyGroup as DummyGroup
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyOffer as DummyOfferDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProduct as DummyProductDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProperty as DummyPropertyDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyTableInheritanceNotApiResourceChild as DummyTableInheritanceNotApiResourceChildDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\EmbeddableDummy as EmbeddableDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\EmbeddedDummy as EmbeddedDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\FileConfigDummy as FileConfigDummyDocument;
@@ -74,6 +75,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyImmutableDate;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyOffer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProduct;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProperty;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceNotApiResourceChild;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddableDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy;
@@ -162,6 +164,17 @@ final class DoctrineContext implements Context
             $this->manager->persist($dummy);
         }
 
+        $this->manager->flush();
+    }
+
+    /**
+     * @When some dummy table inheritance data but not api resource child are created
+     */
+    public function someDummyTableInheritanceDataButNotApiResourceChildAreCreated()
+    {
+        $dummy = $this->buildDummyTableInheritanceNotApiResourceChild();
+        $dummy->setName('Foobarbaz inheritance');
+        $this->manager->persist($dummy);
         $this->manager->flush();
     }
 
@@ -1270,6 +1283,14 @@ final class DoctrineContext implements Context
     private function buildDummy()
     {
         return $this->isOrm() ? new Dummy() : new DummyDocument();
+    }
+
+    /**
+     * @return DummyTableInheritanceNotApiResourceChild|DummyTableInheritanceNotApiResourceChildDocument
+     */
+    private function buildDummyTableInheritanceNotApiResourceChild()
+    {
+        return $this->isOrm() ? new DummyTableInheritanceNotApiResourceChild() : new DummyTableInheritanceNotApiResourceChildDocument();
     }
 
     /**

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -1561,4 +1561,44 @@ final class DoctrineContext implements Context
         $this->manager->flush();
         $this->manager->clear();
     }
+
+    /**
+     * @Given there are :nb sites with internal owner
+     */
+    public function thereAreSitesWithInternalOwner(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $internalUser = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\InternalUser();
+            $internalUser->setFirstname('Internal');
+            $internalUser->setLastname('User');
+            $internalUser->setEmail('john.doe@example.com');
+            $internalUser->setInternalId('INT');
+            $site = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Site();
+            $site->setTitle('title');
+            $site->setDescription('description');
+            $site->setOwner($internalUser);
+            $this->manager->persist($site);
+        }
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there are :nb sites with external owner
+     */
+    public function thereAreSitesWithExternalOwner(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $externalUser = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ExternalUser();
+            $externalUser->setFirstname('External');
+            $externalUser->setLastname('User');
+            $externalUser->setEmail('john.doe@example.com');
+            $externalUser->setExternalId('EXT');
+            $site = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Site();
+            $site->setTitle('title');
+            $site->setDescription('description');
+            $site->setOwner($externalUser);
+            $this->manager->persist($site);
+        }
+        $this->manager->flush();
+    }
 }

--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -307,6 +307,16 @@ Feature: Table inheritance
            "items": {
              "type": "object",
              "properties": {
+               "@type": {
+                 "type": "string",
+                 "pattern": "^ResourceInterface$",
+                 "required": "true"
+               },
+               "@id": {
+                 "type": "string",
+                 "pattern": "^/resource_interfaces/",
+                 "required": "true"
+               },
                "foo": {
                  "type": "string",
                  "required": "true"
@@ -337,6 +347,16 @@ Feature: Table inheritance
         "context": {
           "type": "string",
           "pattern": "ResourceInterface$"
+        },
+        "@id": {
+          "type": "string",
+          "pattern": "^/resource_interfaces",
+          "required": "true"
+        },
+        "@type": {
+          "type": "string",
+          "pattern": "^ResourceInterface$",
+          "required": "true"
         },
         "foo": {
           "type": "string",

--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -446,3 +446,114 @@ Feature: Table inheritance
       }
     }
     """
+
+  @!mongodb
+  Scenario: Generate iri from parent resource
+    Given there are 3 sites with internal owner
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/sites"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@type": {
+                "type": "string",
+                "pattern": "^Site$",
+                "required": "true"
+              },
+              "@id": {
+                "type": "string",
+                "pattern": "^/sites/\\d+$",
+                "required": "true"
+              },
+              "id": {
+                "type": "integer",
+                "required": "true"
+              },
+              "title": {
+                "type": "string",
+                "required": "true"
+              },
+              "description": {
+                "type": "string",
+                "required": "true"
+              },
+              "owner": {
+                "type": "string",
+                "pattern": "^/custom_users/\\d+$",
+                "required": "true"
+              }
+            }
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "required": "true"
+        }
+      }
+    }
+    """
+
+  @!mongodb
+  @createSchema
+  Scenario: Generate iri from current resource even if parent class is a resource
+    Given there are 3 sites with external owner
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/sites"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@type": {
+                "type": "string",
+                "pattern": "^Site$",
+                "required": "true"
+              },
+              "@id": {
+                "type": "string",
+                "pattern": "^/sites/\\d+$",
+                "required": "true"
+              },
+              "id": {
+                "type": "integer",
+                "required": "true"
+              },
+              "title": {
+                "type": "string",
+                "required": "true"
+              },
+              "description": {
+                "type": "string",
+                "required": "true"
+              },
+              "owner": {
+                "type": "string",
+                "pattern": "^/external_users/\\d+$",
+                "required": "true"
+              }
+            }
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "required": "true"
+        }
+      }
+    }
+    """

--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -20,15 +20,18 @@ Feature: Table inheritance
       "properties": {
         "@type": {
           "type": "string",
-          "pattern": "^DummyTableInheritanceChild$"
+          "pattern": "^DummyTableInheritanceChild$",
+          "required": "true"
         },
         "@context": {
           "type": "string",
-          "pattern": "^/contexts/DummyTableInheritanceChild$"
+          "pattern": "^/contexts/DummyTableInheritanceChild$",
+          "required": "true"
         },
         "@id": {
           "type": "string",
-          "pattern": "^/dummy_table_inheritance_children/1$"
+          "pattern": "^/dummy_table_inheritance_children/1$",
+          "required": "true"
         },
         "name": {
           "type": "string",
@@ -61,7 +64,8 @@ Feature: Table inheritance
             "properties": {
               "@type": {
                 "type": "string",
-                "pattern": "^DummyTableInheritanceChild$"
+                "pattern": "^DummyTableInheritanceChild$",
+                "required": "true"
               },
               "name": {
                 "type": "string",
@@ -80,7 +84,40 @@ Feature: Table inheritance
     }
     """
 
-  @createSchema
+  Scenario: Some children not api resources are created in the app
+    When some dummy table inheritance data but not api resource child are created
+    And I send a "GET" request to "/dummy_table_inheritances"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@type": {
+                "type": "string",
+                "pattern": "^DummyTableInheritance(Child)?$",
+                "required": "true"
+              },
+              "name": {
+                "type": "string",
+                "required": "true"
+              }
+            }
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["hydra:member"]
+    }
+    """
+
   Scenario: Create a table inherited resource
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummy_table_inheritance_children" with body:
@@ -97,15 +134,18 @@ Feature: Table inheritance
       "properties": {
         "@type": {
           "type": "string",
-          "pattern": "^DummyTableInheritanceChild$"
+          "pattern": "^DummyTableInheritanceChild$",
+          "required": "true"
         },
         "@context": {
           "type": "string",
-          "pattern": "^/contexts/DummyTableInheritanceChild$"
+          "pattern": "^/contexts/DummyTableInheritanceChild$",
+          "required": "true"
         },
         "@id": {
           "type": "string",
-          "pattern": "^/dummy_table_inheritance_children/1$"
+          "pattern": "^/dummy_table_inheritance_children/3$",
+          "required": "true"
         },
         "name": {
           "type": "string",
@@ -136,15 +176,18 @@ Feature: Table inheritance
       "properties": {
         "@type": {
           "type": "string",
-          "pattern": "^DummyTableInheritanceDifferentChild$"
+          "pattern": "^DummyTableInheritanceDifferentChild$",
+          "required": "true"
         },
         "@context": {
           "type": "string",
-          "pattern": "^/contexts/DummyTableInheritanceDifferentChild$"
+          "pattern": "^/contexts/DummyTableInheritanceDifferentChild$",
+          "required": "true"
         },
         "@id": {
           "type": "string",
-          "pattern": "^/dummy_table_inheritance_different_children/2$"
+          "pattern": "^/dummy_table_inheritance_different_children/4$",
+          "required": "true"
         },
         "name": {
           "type": "string",
@@ -167,7 +210,7 @@ Feature: Table inheritance
     {
       "children": [
         "/dummy_table_inheritance_children/1",
-        "/dummy_table_inheritance_different_children/2"
+        "/dummy_table_inheritance_different_children/4"
       ]
     }
     """
@@ -181,15 +224,18 @@ Feature: Table inheritance
       "properties": {
         "@type": {
           "type": "string",
-          "pattern": "^DummyTableInheritanceRelated$"
+          "pattern": "^DummyTableInheritanceRelated$",
+          "required": "true"
         },
         "@context": {
           "type": "string",
-          "pattern": "^/contexts/DummyTableInheritanceRelated$"
+          "pattern": "^/contexts/DummyTableInheritanceRelated$",
+          "required": "true"
         },
         "@id": {
           "type": "string",
-          "pattern": "^/dummy_table_inheritance_relateds/1$"
+          "pattern": "^/dummy_table_inheritance_relateds/1$",
+          "required": "true"
         },
         "children": {
           "items": {
@@ -199,7 +245,8 @@ Feature: Table inheritance
                 "properties": {
                   "@type": {
                     "type": "string",
-                    "pattern": "^DummyTableInheritanceChild$"
+                    "pattern": "^DummyTableInheritanceChild$",
+                    "required": "true"
                   },
                   "name": {
                     "type": "string",
@@ -215,7 +262,21 @@ Feature: Table inheritance
                 "properties": {
                   "@type": {
                     "type": "string",
-                    "pattern": "^DummyTableInheritanceDifferentChild$"
+                    "pattern": "^DummyTableInheritance$",
+                    "required": "true"
+                  },
+                  "name": {
+                    "type": "string",
+                    "required": "true"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "@type": {
+                    "type": "string",
+                    "pattern": "^DummyTableInheritanceDifferentChild$",
+                    "required": "true"
                   },
                   "name": {
                     "type": "string",
@@ -255,7 +316,8 @@ Feature: Table inheritance
                 "properties": {
                   "@type": {
                     "type": "string",
-                    "pattern": "^DummyTableInheritanceChild$"
+                    "pattern": "^DummyTableInheritanceChild$",
+                    "required": "true"
                   },
                   "name": {
                     "type": "string",
@@ -271,7 +333,21 @@ Feature: Table inheritance
                 "properties": {
                   "@type": {
                     "type": "string",
-                    "pattern": "^DummyTableInheritanceDifferentChild$"
+                    "pattern": "^DummyTableInheritance$",
+                    "required": "true"
+                  },
+                  "name": {
+                    "type": "string",
+                    "required": "true"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "@type": {
+                    "type": "string",
+                    "pattern": "^DummyTableInheritanceDifferentChild$",
+                    "required": "true"
                   },
                   "name": {
                     "type": "string",

--- a/src/Api/IdentifiersExtractor.php
+++ b/src/Api/IdentifiersExtractor.php
@@ -67,7 +67,9 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
     public function getIdentifiersFromItem($item): array
     {
         $identifiers = [];
-        $resourceClass = $this->getObjectClass($item);
+        $type = $this->getObjectClass($item);
+        $resourceClass = $this->resourceClassResolver->isResourceClass($type) ? $this->resourceClassResolver->getResourceClass($item) : $type;
+
         foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $propertyName) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $propertyName);
             $identifier = $propertyMetadata->isIdentifier();

--- a/src/Api/IdentifiersExtractor.php
+++ b/src/Api/IdentifiersExtractor.php
@@ -67,8 +67,10 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
     public function getIdentifiersFromItem($item): array
     {
         $identifiers = [];
-        $type = $this->getObjectClass($item);
-        $resourceClass = $this->resourceClassResolver->isResourceClass($type) ? $this->resourceClassResolver->getResourceClass($item) : $type;
+        $resourceClass = $this->getObjectClass($item);
+        if (null !== $this->resourceClassResolver) { // BC Layer
+            $resourceClass = $this->resourceClassResolver->isResourceClass($resourceClass) ? $this->resourceClassResolver->getResourceClass($item) : $resourceClass;
+        }
 
         foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $propertyName) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $propertyName);

--- a/src/Api/IriConverterInterface.php
+++ b/src/Api/IriConverterInterface.php
@@ -21,6 +21,8 @@ use ApiPlatform\Core\Exception\RuntimeException;
  * Converts item and resources to IRI and vice versa.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated in favor of ResourceIriConverterInterface to be removed in ApiPlatform 3.0
  */
 interface IriConverterInterface
 {
@@ -41,6 +43,10 @@ interface IriConverterInterface
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException
+     *
+     * @return string Class name of resource
+     *
+     * @deprecated in favor of `ResourceIriConverterInterface::getIriFromItemWithResource`
      */
     public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
 

--- a/src/Api/ResourceClassResolverInterface.php
+++ b/src/Api/ResourceClassResolverInterface.php
@@ -25,7 +25,7 @@ interface ResourceClassResolverInterface
     /**
      * Guesses the associated resource.
      *
-     * @param object $value         Object you're playing with
+     * @param mixed  $value         Object you're playing with
      * @param string $resourceClass Resource class it is supposed to be (could be parent class for instance)
      * @param bool   $strict        value must be type of resource class given or it will return type
      *

--- a/src/Api/ResourceClassResolverInterface.php
+++ b/src/Api/ResourceClassResolverInterface.php
@@ -25,12 +25,20 @@ interface ResourceClassResolverInterface
     /**
      * Guesses the associated resource.
      *
+     * @param object $value         Object you're playing with
+     * @param string $resourceClass Resource class it is supposed to be (could be parent class for instance)
+     * @param bool   $strict        value must be type of resource class given or it will return type
+     *
      * @throws InvalidArgumentException
+     *
+     * @return string Resolved resource class
      */
     public function getResourceClass($value, string $resourceClass = null, bool $strict = false): string;
 
     /**
-     * Is the given class a resource class?
+     * Is the given class name an api platform resource?
+     *
+     * @param string $type FQCN of the resource
      */
     public function isResourceClass(string $type): bool;
 }

--- a/src/Api/ResourceIriConverterInterface.php
+++ b/src/Api/ResourceIriConverterInterface.php
@@ -19,7 +19,7 @@ use ApiPlatform\Core\Exception\RuntimeException;
 /**
  * Converts item and resources to IRI and vice versa.
  *
- * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Maxime Veber <maxime.veber@nekland.fr>
  */
 interface ResourceIriConverterInterface extends IriConverterInterface
 {

--- a/src/Api/ResourceIriConverterInterface.php
+++ b/src/Api/ResourceIriConverterInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Api;
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\RuntimeException;
+
+/**
+ * Converts item and resources to IRI and vice versa.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface ResourceIriConverterInterface extends IriConverterInterface
+{
+    /**
+     * Gets the IRI associated with the given item and resource class.
+     *
+     * @param object $item
+     * @param string $resourceClass resource class to use for generation
+     *
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     *
+     * @return string Class name of resource
+     */
+    public function getIriFromItemWithResource($item, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
+}

--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -121,9 +121,11 @@ final class PublishMercureUpdatesListener
     private function storeEntityToPublish($entity, string $property): void
     {
         $resourceClass = $this->getObjectClass($entity);
+
         if (!$this->resourceClassResolver->isResourceClass($resourceClass)) {
             return;
         }
+        $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
 
         $value = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('mercure', false);
         if (false === $value) {

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -15,8 +15,8 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Api\IdentifiersExtractor;
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
-use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Api\ResourceIriConverterInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\OperationDataProviderTrait;
@@ -40,7 +40,7 @@ use Symfony\Component\Routing\RouterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class IriConverter implements IriConverterInterface
+final class IriConverter implements ResourceIriConverterInterface
 {
     use ClassInfoTrait;
     use OperationDataProviderTrait;
@@ -112,10 +112,21 @@ final class IriConverter implements IriConverterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated use `getIriFromItemWithResource` instead to be removed in ApiPlatform 3.0
      */
     public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
         $resourceClass = $this->getObjectClass($item);
+
+        return $this->getIriFromItemWithResource($item, $resourceClass, $referenceType);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIriFromItemWithResource($item, string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
+    {
         $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
 
         try {

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -72,7 +72,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
         // Use resolved resource class instead of given resource class to support multiple inheritance child types
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
         $context = $this->initContext($resourceClass, $context);
-        $iri = $this->iriConverter->getIriFromItem($object);
+        $iri = $this->iriConverter->getIriFromItemWithResource($object, $resourceClass);
         $context['iri'] = $iri;
         $context['api_normalize'] = true;
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -129,7 +129,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
         // Use resolved resource class instead of given resource class to support multiple inheritance child types
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
         $context = $this->initContext($resourceClass, $context);
-        $iri = $context['iri'] ?? $this->iriConverter->getIriFromItem($object);
+        $iri = $context['iri'] ?? $this->iriConverter->getIriFromItemWithResource($object, $resourceClass);
         $context['iri'] = $iri;
         $context['api_normalize'] = true;
 
@@ -546,7 +546,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
             $type->isCollection() &&
             ($collectionValueType = $type->getCollectionValueType()) &&
             ($className = $collectionValueType->getClassName()) &&
-            $this->resourceClassResolver->isResourceClass($className)
+            $this->resourceClassResolver->isResourceClass($className) &&
+            ($className = $this->resourceClassResolver->getResourceClass($attributeValue, $className, true))
         ) {
             return $this->normalizeCollectionOfRelations($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
         }
@@ -554,7 +555,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
         if (
             $type &&
             ($className = $type->getClassName()) &&
-            $this->resourceClassResolver->isResourceClass($className)
+            $this->resourceClassResolver->isResourceClass($className) &&
+            ($className = $this->resourceClassResolver->getResourceClass($attributeValue, $className, true))
         ) {
             return $this->normalizeRelation($propertyMetadata, $attributeValue, $className, $format, $this->createChildContext($context, $attribute));
         }
@@ -606,7 +608,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
             return $this->serializer->normalize($relatedObject, $format, $context);
         }
 
-        $iri = $this->iriConverter->getIriFromItem($relatedObject);
+        $iri = $this->iriConverter->getIriFromItemWithResource($relatedObject, $resourceClass);
+
         if (isset($context['resources'])) {
             $context['resources'][$iri] = $iri;
         }

--- a/tests/Api/IdentifiersExtractorTest.php
+++ b/tests/Api/IdentifiersExtractorTest.php
@@ -179,6 +179,7 @@ class IdentifiersExtractorTest extends TestCase
         $resourceClassResolver->isResourceClass(Argument::type('string'))->will(function ($args) {
             return !(Uuid::class === $args[0]);
         });
+        $resourceClassResolver->getResourceClass(Argument::any())->will(function ($args) {return \get_class($args[0]); });
 
         return $resourceClassResolver->reveal();
     }

--- a/tests/Api/ResourceClassResolverTest.php
+++ b/tests/Api/ResourceClassResolverTest.php
@@ -170,7 +170,7 @@ class ResourceClassResolverTest extends TestCase
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
 
-        $this->assertEquals(DummyTableInheritanceChild::class, $resourceClassResolver->getResourceClass($t, DummyTableInheritance::class));
+        $this->assertEquals(DummyTableInheritance::class, $resourceClassResolver->getResourceClass($t, DummyTableInheritance::class));
     }
 
     public function testGetResourceClassWithInterfaceResource()
@@ -182,5 +182,34 @@ class ResourceClassResolverTest extends TestCase
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
         $resourceClassResolver->getResourceClass($dummy, DummyResourceInterface::class, true);
+    }
+
+    public function testGetResourceClassWithoutSecondParameterIsAccurate()
+    {
+        $dummy = new DummyResourceImplementation();
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([DummyResourceInterface::class]))->shouldBeCalled();
+
+        $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+        $this->assertEquals(DummyResourceInterface::class, $resourceClassResolver->getResourceClass($dummy));
+    }
+
+    public function testGetResourceInterfaceWithResourceClassParameterReturnTheResouceClass()
+    {
+        $dummy = new DummyResourceImplementation();
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([DummyResourceInterface::class]))->shouldBeCalled();
+
+        $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+        $this->assertEquals(DummyResourceInterface::class, $resourceClassResolver->getResourceClass($dummy, DummyResourceInterface::class));
+    }
+
+    public function testInterfaceCanBeResourceClass()
+    {
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([DummyResourceInterface::class]))->shouldBeCalled();
+
+        $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+        $this->assertTrue($resourceClassResolver->isResourceClass(DummyResourceImplementation::class));
     }
 }

--- a/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Symfony\Component\Mercure\Update;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -56,6 +57,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
         $resourceClassResolverProphecy->isResourceClass(DummyCar::class)->willReturn(true);
         $resourceClassResolverProphecy->isResourceClass(DummyFriend::class)->willReturn(true);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type('object'))->will(function ($args) { return \get_class($args[0]); });
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($toInsert, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
@@ -136,6 +138,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type('object'))->will(function ($args) { return \get_class($args[0]); });
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 

--- a/tests/Fixtures/TestBundle/Document/DummyTableInheritance.php
+++ b/tests/Fixtures/TestBundle/Document/DummyTableInheritance.php
@@ -21,7 +21,12 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField(value="discr")
- * @ODM\DiscriminatorMap({"dummyTableInheritance"=DummyTableInheritance::class, "dummyTableInheritanceChild"=DummyTableInheritanceChild::class, "dummyTableInheritanceDifferentChild"=DummyTableInheritanceDifferentChild::class})
+ * @ODM\DiscriminatorMap({
+ *     "dummyTableInheritance"=DummyTableInheritance::class,
+ *     "dummyTableInheritanceChild"=DummyTableInheritanceChild::class,
+ *     "dummyTableInheritanceDifferentChild"=DummyTableInheritanceDifferentChild::class,
+ *     "dummyTableInheritanceNotApiResourceChild"=DummyTableInheritanceNotApiResourceChild::class
+ * })
  * @ApiResource
  */
 class DummyTableInheritance

--- a/tests/Fixtures/TestBundle/Document/DummyTableInheritanceNotApiResourceChild.php
+++ b/tests/Fixtures/TestBundle/Document/DummyTableInheritanceNotApiResourceChild.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class DummyTableInheritanceNotApiResourceChild extends DummyTableInheritance
+{
+    /**
+     * @var bool The dummy swagg
+     *
+     * @ODM\Field(type="boolean")
+     */
+    private $swaggerThanParent;
+
+    public function __construct()
+    {
+        // Definitely always swagger than parents
+        $this->swaggerThanParent = true;
+    }
+
+    public function isSwaggerThanParent(): bool
+    {
+        return $this->swaggerThanParent;
+    }
+
+    public function setSwaggerThanParent(bool $swaggerThanParent)
+    {
+        $this->swaggerThanParent = $swaggerThanParent;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/AbstractUser.php
+++ b/tests/Fixtures/TestBundle/Entity/AbstractUser.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ApiResource(
+ *     collectionOperations={
+ *         "get"={"path"="/custom_users"}
+ *     },
+ *     itemOperations={
+ *         "get"={"path"="/custom_users/{id}"}
+ *     }
+ * )
+ */
+abstract class AbstractUser
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+    /**
+     * @ORM\Column
+     */
+    private $firstname;
+    /**
+     * @ORM\Column
+     */
+    private $lastname;
+    /**
+     * @ORM\Column
+     */
+    private $email;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getFirstname(): ?string
+    {
+        return $this->firstname;
+    }
+
+    public function setFirstname(string $firstname): self
+    {
+        $this->firstname = $firstname;
+
+        return $this;
+    }
+
+    public function getLastname(): ?string
+    {
+        return $this->lastname;
+    }
+
+    public function setLastname(string $lastname): self
+    {
+        $this->lastname = $lastname;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritance.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritance.php
@@ -21,7 +21,12 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @ORM\Entity
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
- * @ORM\DiscriminatorMap({"dummyTableInheritance"="DummyTableInheritance", "dummyTableInheritanceChild"="DummyTableInheritanceChild", "dummyTableInheritanceDifferentChild"="DummyTableInheritanceDifferentChild"})
+ * @ORM\DiscriminatorMap({
+ *     "dummyTableInheritance"="DummyTableInheritance",
+ *     "dummyTableInheritanceChild"="DummyTableInheritanceChild",
+ *     "dummyTableInheritanceDifferentChild"="DummyTableInheritanceDifferentChild",
+ *     "dummyTableInheritanceNotApiResourceChild"="DummyTableInheritanceNotApiResourceChild"
+ * })
  * @ApiResource
  */
 class DummyTableInheritance

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceNotApiResourceChild.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceNotApiResourceChild.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class DummyTableInheritanceNotApiResourceChild extends DummyTableInheritance
+{
+    /**
+     * @var bool The dummy swagg
+     *
+     * @ORM\Column(type="boolean")
+     */
+    private $swaggerThanParent;
+
+    public function __construct()
+    {
+        // Definitely always swagger than parents
+        $this->swaggerThanParent = true;
+    }
+
+    public function isSwaggerThanParent(): bool
+    {
+        return $this->swaggerThanParent;
+    }
+
+    public function setSwaggerThanParent(bool $swaggerThanParent)
+    {
+        $this->swaggerThanParent = $swaggerThanParent;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ExternalUser.php
+++ b/tests/Fixtures/TestBundle/Entity/ExternalUser.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ApiResource
+ */
+class ExternalUser extends AbstractUser
+{
+    /**
+     * @ORM\Column
+     */
+    private $externalId;
+
+    public function getExternalId(): ?string
+    {
+        return $this->externalId;
+    }
+
+    public function setExternalId(string $externalId): self
+    {
+        $this->externalId = $externalId;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/InternalUser.php
+++ b/tests/Fixtures/TestBundle/Entity/InternalUser.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class InternalUser extends AbstractUser
+{
+    /**
+     * @ORM\Column
+     */
+    private $internalId;
+
+    public function getInternalId(): ?string
+    {
+        return $this->internalId;
+    }
+
+    public function setInternalId(string $internalId): self
+    {
+        $this->internalId = $internalId;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Site.php
+++ b/tests/Fixtures/TestBundle/Entity/Site.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class Site
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+    /**
+     * @ORM\Column
+     */
+    private $title;
+    /**
+     * @ORM\Column
+     */
+    private $description;
+    /**
+     * @ORM\OneToOne(targetEntity="AbstractUser", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $owner;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getOwner(): ?AbstractUser
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(AbstractUser $owner): self
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+}

--- a/tests/GraphQl/Serializer/ItemNormalizerTest.php
+++ b/tests/GraphQl/Serializer/ItemNormalizerTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\GraphQl\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Api\ResourceIriConverterInterface;
 use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -43,7 +44,7 @@ class ItemNormalizerTest extends TestCase
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true)->shouldBeCalled();
@@ -78,8 +79,8 @@ class ItemNormalizerTest extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItemWithResource($dummy, Dummy::class)->willReturn('/dummies/1')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Hal\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Api\ResourceIriConverterInterface;
 use ApiPlatform\Core\Hal\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -79,7 +80,7 @@ class ItemNormalizerTest extends TestCase
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true)->shouldBeCalled();
@@ -121,13 +122,14 @@ class ItemNormalizerTest extends TestCase
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class), '', true, false, false)
         )->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/related-dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItemWithResource($relatedDummy, RelatedDummy::class)->willReturn('/related-dummies/2')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($relatedDummy, RelatedDummy::class, true)->willReturn(RelatedDummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -187,13 +189,14 @@ class ItemNormalizerTest extends TestCase
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class), '', true, false, false)
         )->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/related-dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItemWithResource($relatedDummy, RelatedDummy::class)->willReturn('/related-dummies/2')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($relatedDummy, RelatedDummy::class, true)->willReturn(RelatedDummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -281,6 +284,7 @@ class ItemNormalizerTest extends TestCase
         $resourceClassResolverProphecy->getResourceClass($level1, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->getResourceClass($level2, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->getResourceClass($level3, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass(null, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->isResourceClass(MaxDepthDummy::class)->willReturn(true)->shouldBeCalled();
 
         $normalizer = new ItemNormalizer(

--- a/tests/JsonLd/Serializer/ItemNormalizerTest.php
+++ b/tests/JsonLd/Serializer/ItemNormalizerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\JsonLd\Serializer;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Api\ResourceIriConverterInterface;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -42,7 +42,7 @@ class ItemNormalizerTest extends TestCase
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
         $resourceClassResolverProphecy->getResourceClass(['dummy'], 'Dummy')->willReturn(Dummy::class);
@@ -66,7 +66,7 @@ class ItemNormalizerTest extends TestCase
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
@@ -103,8 +103,8 @@ class ItemNormalizerTest extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1988')->shouldBeCalled();
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItemWithResource($dummy, Argument::type('string'))->willReturn('/dummies/1988')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Api\ResourceIriConverterInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
@@ -161,9 +162,9 @@ class AbstractItemNormalizerTest extends TestCase
             )
         )->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/dummies/2')->shouldBeCalled();
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItemWithResource($dummy, Dummy::class)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItemWithResource($relatedDummy, RelatedDummy::class)->willReturn('/dummies/2')->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->getValue($dummy, 'name')->willReturn('foo')->shouldBeCalled();
@@ -174,6 +175,7 @@ class AbstractItemNormalizerTest extends TestCase
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass(Argument::any(), RelatedDummy::class, true)->willReturn(RelatedDummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(RelatedDummy::class)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -243,8 +245,8 @@ class AbstractItemNormalizerTest extends TestCase
             )
         )->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItemWithResource($dummy, Dummy::class)->willReturn('/dummies/1')->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->getValue($dummy, 'relatedDummy')->willReturn($relatedDummy)->shouldBeCalled();
@@ -252,6 +254,7 @@ class AbstractItemNormalizerTest extends TestCase
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass(Argument::any(), RelatedDummy::class, true)->willReturn(RelatedDummy::class)->shouldBeCalled();
         $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(RelatedDummy::class)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -825,8 +828,8 @@ class AbstractItemNormalizerTest extends TestCase
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING, true), '', true, true, false, false, false, false, null, DummyTableInheritanceChild::class)
         )->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItemWithResource($dummy, DummyTableInheritance::class)->willReturn('/dummies/1')->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->getValue($dummy, 'name')->willReturn('foo')->shouldBeCalled();

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Api\ResourceIriConverterInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -83,8 +84,8 @@ class ItemNormalizerTest extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy = $this->prophesize(ResourceIriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItemWithResource($dummy, Dummy::class)->willReturn('/dummies/1')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2609 / #2683 / #2759
| License       | MIT
| Doc PR        | N/A

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

1. The resource class resolver now works well with inheritance and is able to resolve resources using the ApiPlatform resource list (more clever work, was needed considering `isResource` is doing it!)
2. This change adds a new feature: inherited items from API resources now are working as an API, a new behat test proves it
3. some parts of ApiPlatform were not compatible because it does not uses the resource resolver but "get class" to get the resource, theses parts are also fixed

Notice: the cache from the resource class resolver is removed here. It was introduced in 2015 and was probably a great improvement, but since 2016 resources are not re-generated on each call to the factory but we call instead of a cache factory. This cache was just adding complexity so I removed it.
