### PR TITLE
Change Messenger DataPersister to a high priority

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/messenger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/messenger.xml
@@ -11,7 +11,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.message_bus" />
 
-            <tag name="api_platform.data_persister" priority="-900" />
+            <tag name="api_platform.data_persister" priority="1000" />
         </service>
 
         <service id="api_platform.messenger.data_transformer" class="ApiPlatform\Core\Bridge\Symfony\Messenger\DataTransformer" public="false">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/api-platform/issues/1100
| License       | MIT
| Doc PR        | N/A

If the user needs a custom DataPersister that kicks in when `messenger` property is set to `true`, then they could use a higher priority, but that should be an edge case.