### PR TITLE
[GraphQL] Make id field optional for custom mutations

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -459,6 +459,24 @@ Feature: GraphQL mutation support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.sumDummyCustomMutation.dummyCustomMutation.result" should be equal to "8"
 
+  Scenario: Execute a custom mutation without ID
+    When I send the following GraphQL request:
+    """
+    mutation {
+      sumCreateDummyCustomMutation(input: {operandA: 4, operandB: 5}) {
+        dummyCustomMutation {
+          id
+          result
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.sumCreateDummyCustomMutation.dummyCustomMutation.id" should be equal to "/dummy_custom_mutations/2"
+    And the JSON node "data.sumCreateDummyCustomMutation.dummyCustomMutation.result" should be equal to "9"
+
   Scenario: Execute a not persisted custom mutation
     When I send the following GraphQL request:
     """

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -134,7 +134,8 @@ final class FieldsBuilder implements FieldsBuilderInterface
     public function getResourceObjectTypeFields(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, int $depth = 0, ?array $ioMetadata = null): array
     {
         $fields = [];
-        $idField = ['type' => GraphQLType::nonNull(GraphQLType::id())];
+        $optionalIdField = ['type' => GraphQLType::id()];
+        $requiredIdField = ['type' => GraphQLType::nonNull(GraphQLType::id())];
         $clientMutationId = GraphQLType::string();
 
         if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null === $ioMetadata['class']) {
@@ -147,7 +148,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
         if ('delete' === $mutationName) {
             $fields = [
-                'id' => $idField,
+                'id' => $requiredIdField,
             ];
 
             if ($input) {
@@ -157,8 +158,10 @@ final class FieldsBuilder implements FieldsBuilderInterface
             return $fields;
         }
 
-        if (!$input || 'create' !== $mutationName) {
-            $fields['id'] = $idField;
+        if (!$input || !$mutationName || \in_array($mutationName, ['update', 'delete'], true)) {
+            $fields['id'] = $requiredIdField;
+        } elseif ('create' !== $mutationName) {
+            $fields['id'] = $optionalIdField;
         }
 
         ++$depth; // increment the depth for the call to getResourceFieldConfiguration.

--- a/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
@@ -27,6 +27,11 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         "normalization_context"={"groups"={"result"}},
  *         "denormalization_context"={"groups"={"sum"}}
  *     },
+ *     "sumCreate"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_create",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"create"}}
+ *     },
  *     "sumNotPersisted"={
  *         "mutation"="app.graphql.mutation_resolver.dummy_custom_not_persisted",
  *         "normalization_context"={"groups"={"result"}},
@@ -52,6 +57,7 @@ class DummyCustomMutation
     /**
      * @var int
      *
+     * @Groups({"create"})
      * @ODM\Field(type="integer")
      */
     private $operandA;
@@ -59,7 +65,7 @@ class DummyCustomMutation
     /**
      * @var int
      *
-     * @Groups({"sum"})
+     * @Groups({"sum", "create"})
      * @ODM\Field(type="integer", nullable=true)
      */
     private $operandB;

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
@@ -27,6 +27,11 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         "normalization_context"={"groups"={"result"}},
  *         "denormalization_context"={"groups"={"sum"}}
  *     },
+ *     "sumCreate"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_create",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"create"}}
+ *     },
  *     "sumNotPersisted"={
  *         "mutation"="app.graphql.mutation_resolver.dummy_custom_not_persisted",
  *         "normalization_context"={"groups"={"result"}},
@@ -54,6 +59,7 @@ class DummyCustomMutation
     /**
      * @var int
      *
+     * @Groups({"create"})
      * @ORM\Column(type="integer", nullable=true)
      */
     private $operandA;
@@ -61,7 +67,7 @@ class DummyCustomMutation
     /**
      * @var int
      *
-     * @Groups({"sum"})
+     * @Groups({"sum", "create"})
      * @ORM\Column(type="integer", nullable=true)
      */
     private $operandB;

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/SumCreateMutationResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/SumCreateMutationResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomMutation as DummyCustomMutationDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomMutation;
+
+/**
+ * Resolver for custom mutation without id.
+ *
+ * @author Lukas Lücke <lukas@luecke.me>
+ */
+class SumCreateMutationResolver implements MutationResolverInterface
+{
+    /**
+     * @param DummyCustomMutation|DummyCustomMutationDocument|null $item
+     *
+     * @return DummyCustomMutation|DummyCustomMutationDocument
+     */
+    public function __invoke($item, array $context)
+    {
+        $item->setResult($item->getOperandA() + $item->getOperandB());
+
+        return $item;
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -264,6 +264,12 @@ services:
         tags:
             - { name: 'api_platform.graphql.mutation_resolver' }
 
+    app.graphql.mutation_resolver.dummy_custom_create:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumCreateMutationResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.mutation_resolver' }
+
     app.graphql.mutation_resolver.dummy_custom_not_persisted:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumNotPersistedMutationResolver'
         public: false

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -463,7 +463,7 @@ class FieldsBuilderTest extends TestCase
                 true, null, 'mutation', null,
                 [
                     'id' => [
-                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                        'type' => GraphQLType::id(),
                     ],
                     'propertyBool' => [
                         'type' => GraphQLType::nonNull(GraphQLType::string()),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2736
| License       | MIT
| Doc PR        | -

All other mutations (except `create`) get an optional id field to allow different kinds of custom mutations.