### PR TITLE
 Fix bug in WriteListener.php

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -74,11 +74,11 @@ final class WriteListener
                 if (null !== $this->resourceMetadataFactory) {
                     $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
                     $outputMetadata = $resourceMetadata->getOperationAttribute($attributes, 'output', ['class' => $attributes['resource_class']], true);
-                    $hasOutput = \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'] && $controllerResult instanceof $outputMetadata['class'];
+                    $hasOutput = \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'] && $event->getControllerResult() instanceof $outputMetadata['class'];
                 }
 
                 if ($hasOutput) {
-                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
+                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($event->getControllerResult()));
                 }
             break;
             case 'DELETE':


### PR DESCRIPTION
Alternative to https://github.com/api-platform/core/pull/2283

When calling POST on a non ORM resource, tha call failed with 400: "Unable to generate an IRI for the item of type..."
on api-platform/core/src/Bridge/Symfony/Routing/IriConverter.php line 131

This is supposed to fix it, as it tries to get the IRI from inserted resource, not from original data (where it does not exist in a POST).

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | I don't know, I did not run tests. 
| Fixed tickets | 
| License       | MIT
| Doc PR        | api-platform/doc#1234

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
