### PR TITLE
Rename ContainerBuilder::addRemovedBindingId to ContainerBuilder::removeBindings

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -71,7 +71,7 @@ parameters:
 			message: '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Util\\QueryBuilderHelper::mapJoinAliases() should return array<string, array<string>\|string> but returns array<int|string, mixed>\.#'
 			path: %currentWorkingDirectory%/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
 		-
-			message: "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component.+' and 'addRemovedBindingIds?' will always evaluate to false\\.#"
+			message: "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component.+' and '(removeBindings|addRemovedBindingIds)' will always evaluate to false\\.#"
 			path: %currentWorkingDirectory%/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
 		- "#Call to method PHPUnit\\\\Framework\\\\Assert::assertSame\\(\\) with array\\('(collection_context|item_context|subresource_context)'\\) and array<Symfony\\\\Component\\\\VarDumper\\\\Cloner\\\\Data>\\|bool\\|float\\|int\\|string\\|null will always evaluate to false\\.#"
 		# https://github.com/doctrine/doctrine2/pull/7298/files

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -845,10 +845,10 @@ class ApiPlatformExtensionTest extends TestCase
 
         // irrelevant, but to prevent errors
         // https://github.com/symfony/symfony/pull/29944
-        if (method_exists(ContainerBuilder::class, 'addRemovedBindingId')) {
-            $containerBuilderProphecy->addRemovedBindingId(Argument::type('string'))->will(function () {});
+        if (method_exists(ContainerBuilder::class, 'removeBindings')) {
+            $containerBuilderProphecy->removeBindings(Argument::type('string'))->will(function () {});
         } elseif (method_exists(ContainerBuilder::class, 'addRemovedBindingIds')) {
-            // https://github.com/symfony/symfony/pull/31173
+            // remove this once https://github.com/symfony/symfony/pull/31173 is released
             $containerBuilderProphecy->addRemovedBindingIds(Argument::type('string'))->will(function () {});
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

We should wait for https://github.com/symfony/symfony/pull/31173 to be merged first.