### PR TITLE
Fix handling of empty request content by allowing to disable listeners per operation

### DIFF
--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -91,6 +91,12 @@ Feature: Create-Retrieve-Update-Delete
     }
     """
 
+  Scenario: Create a resource with empty body
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummies"
+    Then the response status code should be 400
+    And the JSON node "hydra:description" should be equal to "Syntax error"
+
   Scenario: Get a not found exception
     When I send a "GET" request to "/dummies/42"
     Then the response status code should be 404
@@ -526,42 +532,8 @@ Feature: Create-Retrieve-Update-Delete
   Scenario: Update a resource with empty body
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/dummies/1"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the header "Content-Location" should be equal to "/dummies/1"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/Dummy",
-      "@id": "/dummies/1",
-      "@type": "Dummy",
-      "description": null,
-      "dummy": null,
-      "dummyBoolean": null,
-      "dummyDate": "2018-12-01T13:12:00+00:00",
-      "dummyFloat": null,
-      "dummyPrice": null,
-      "relatedDummy": null,
-      "relatedDummies": [],
-      "jsonData": [
-        {
-          "key": "value1"
-        },
-        {
-          "key": "value2"
-        }
-      ],
-      "arrayData": [],
-      "name_converted": null,
-      "relatedOwnedDummy": null,
-      "relatedOwningDummy": null,
-      "id": 1,
-      "name": "A nice dummy",
-      "alias": null,
-      "foo": null
-    }
-    """
+    Then the response status code should be 400
+    And the JSON node "hydra:description" should be equal to "Syntax error"
 
   Scenario: Delete a resource
     When I send a "DELETE" request to "/dummies/1"

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface as SerializerExceptionInterface;
 
 /**
  * The configuration of the bundle.
@@ -369,7 +369,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('exception_to_status')
                     ->defaultValue([
-                        ExceptionInterface::class => Response::HTTP_BAD_REQUEST,
+                        SerializerExceptionInterface::class => Response::HTTP_BAD_REQUEST,
                         InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
                         FilterValidationException::class => Response::HTTP_BAD_REQUEST,
                         OptimisticLockException::class => Response::HTTP_CONFLICT,

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -154,6 +154,7 @@
             <argument type="service" id="api_platform.subresource_data_provider" />
             <argument type="service" id="api_platform.serializer.context_builder" />
             <argument type="service" id="api_platform.identifier.converter" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="4" />
         </service>
@@ -161,7 +162,7 @@
         <service id="api_platform.listener.view.write" class="ApiPlatform\Core\EventListener\WriteListener">
             <argument type="service" id="api_platform.data_persister" />
             <argument type="service" id="api_platform.iri_converter" on-invalid="null" />
-            <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="null" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
 
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="32" />
         </service>
@@ -170,6 +171,7 @@
             <argument type="service" id="api_platform.serializer" />
             <argument type="service" id="api_platform.serializer.context_builder" />
             <argument type="service" id="api_platform.formats_provider" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="2" />
         </service>
@@ -177,6 +179,7 @@
         <service id="api_platform.listener.view.serialize" class="ApiPlatform\Core\EventListener\SerializeListener">
             <argument type="service" id="api_platform.serializer" />
             <argument type="service" id="api_platform.serializer.context_builder" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
 
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="16" />
         </service>

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -16,6 +16,8 @@ namespace ApiPlatform\Core\EventListener;
 use ApiPlatform\Core\Api\FormatMatcher;
 use ApiPlatform\Core\Api\FormatsProviderInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ToggleableOperationAttributeTrait;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,6 +33,10 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 final class DeserializeListener
 {
+    use ToggleableOperationAttributeTrait;
+
+    public const OPERATION_ATTRIBUTE_KEY = 'deserialize';
+
     private $serializer;
     private $serializerContextBuilder;
     private $formats = [];
@@ -40,7 +46,7 @@ final class DeserializeListener
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(SerializerInterface $serializer, SerializerContextBuilderInterface $serializerContextBuilder, /* FormatsProviderInterface */$formatsProvider)
+    public function __construct(SerializerInterface $serializer, SerializerContextBuilderInterface $serializerContextBuilder, /* FormatsProviderInterface */$formatsProvider, ResourceMetadataFactoryInterface $resourceMetadataFactory = null)
     {
         $this->serializer = $serializer;
         $this->serializerContextBuilder = $serializerContextBuilder;
@@ -54,6 +60,7 @@ final class DeserializeListener
 
             $this->formatsProvider = $formatsProvider;
         }
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
 
     /**
@@ -69,18 +76,12 @@ final class DeserializeListener
             || $request->isMethodSafe(false)
             || !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
-            || (
-                    '' === ($requestContent = $request->getContent())
-                    && ('POST' === $method || 'PUT' === $method)
-               )
+            || $this->isOperationAttributeDisabled($attributes, self::OPERATION_ATTRIBUTE_KEY)
         ) {
             return;
         }
 
         $context = $this->serializerContextBuilder->createFromRequest($request, false, $attributes);
-        if (isset($context['input']) && \array_key_exists('class', $context['input']) && null === $context['input']['class']) {
-            return;
-        }
 
         // BC check to be removed in 3.0
         if (null !== $this->formatsProvider) {
@@ -96,9 +97,7 @@ final class DeserializeListener
 
         $request->attributes->set(
             'data',
-            $this->serializer->deserialize(
-                $requestContent, $context['resource_class'], $format, $context
-            )
+            $this->serializer->deserialize($request->getContent(), $context['resource_class'], $format, $context)
         );
     }
 

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -20,6 +20,8 @@ use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ToggleableOperationAttributeTrait;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use ApiPlatform\Core\Util\RequestParser;
@@ -34,16 +36,20 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 final class ReadListener
 {
     use OperationDataProviderTrait;
+    use ToggleableOperationAttributeTrait;
+
+    public const OPERATION_ATTRIBUTE_KEY = 'read';
 
     private $serializerContextBuilder;
 
-    public function __construct(CollectionDataProviderInterface $collectionDataProvider, ItemDataProviderInterface $itemDataProvider, SubresourceDataProviderInterface $subresourceDataProvider = null, SerializerContextBuilderInterface $serializerContextBuilder = null, IdentifierConverterInterface $identifierConverter = null)
+    public function __construct(CollectionDataProviderInterface $collectionDataProvider, ItemDataProviderInterface $itemDataProvider, SubresourceDataProviderInterface $subresourceDataProvider = null, SerializerContextBuilderInterface $serializerContextBuilder = null, IdentifierConverterInterface $identifierConverter = null, ResourceMetadataFactoryInterface $resourceMetadataFactory = null)
     {
         $this->collectionDataProvider = $collectionDataProvider;
         $this->itemDataProvider = $itemDataProvider;
         $this->subresourceDataProvider = $subresourceDataProvider;
         $this->serializerContextBuilder = $serializerContextBuilder;
         $this->identifierConverter = $identifierConverter;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
 
     /**
@@ -57,6 +63,8 @@ final class ReadListener
         if (
             !($attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['receive']
+            || $request->isMethod('POST') && isset($attributes['collection_operation_name'])
+            || $this->isOperationAttributeDisabled($attributes, self::OPERATION_ATTRIBUTE_KEY)
         ) {
             return;
         }
@@ -74,7 +82,7 @@ final class ReadListener
         }
 
         if (isset($attributes['collection_operation_name'])) {
-            $request->attributes->set('data', $request->isMethod('POST') ? null : $this->getCollectionData($attributes, $context));
+            $request->attributes->set('data', $this->getCollectionData($attributes, $context));
 
             return;
         }

--- a/src/Metadata/Resource/Factory/InputOutputResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/InputOutputResourceMetadataFactory.php
@@ -66,12 +66,20 @@ final class InputOutputResourceMetadataFactory implements ResourceMetadataFactor
             $operation['output'] = isset($operation['output']) ? $this->transformInputOutput($operation['output']) : $resourceAttributes['output'];
 
             if (
-                !isset($operation['status'])
-                && isset($operation['output'])
+                isset($operation['input'])
+                && \array_key_exists('class', $operation['input'])
+                && null === $operation['input']['class']
+            ) {
+                $operation['deserialize'] ?? $operation['deserialize'] = false;
+                $operation['validate'] ?? $operation['validate'] = false;
+            }
+
+            if (
+                isset($operation['output'])
                 && \array_key_exists('class', $operation['output'])
                 && null === $operation['output']['class']
             ) {
-                $operation['status'] = 204;
+                $operation['status'] ?? $operation['status'] = 204;
             }
         }
 

--- a/src/Metadata/Resource/ToggleableOperationAttributeTrait.php
+++ b/src/Metadata/Resource/ToggleableOperationAttributeTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\Resource;
+
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+
+/**
+ * @internal
+ */
+trait ToggleableOperationAttributeTrait
+{
+    /**
+     * @var ResourceMetadataFactoryInterface|null
+     */
+    private $resourceMetadataFactory;
+
+    private function isOperationAttributeDisabled(array $attributes, string $attribute, bool $default = false, bool $resourceFallback = true): bool
+    {
+        if (null === $this->resourceMetadataFactory) {
+            return $default;
+        }
+
+        $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
+
+        return !((bool) $resourceMetadata->getOperationAttribute($attributes, $attribute, !$default, $resourceFallback));
+    }
+}

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidateListenerTest.php
@@ -37,18 +37,17 @@ class ValidateListenerTest extends TestCase
     public function testNotAnApiPlatformRequest()
     {
         $validatorProphecy = $this->prophesize(ValidatorInterface::class);
-        $validatorProphecy->validate()->shouldNotBeCalled();
+        $validatorProphecy->validate(Argument::cetera())->shouldNotBeCalled();
         $validator = $validatorProphecy->reveal();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create()->shouldNotBeCalled();
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
         $request = new Request();
         $request->setMethod('POST');
 
         $event = $this->prophesize(GetResponseForControllerResultEvent::class);
-        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getRequest()->willReturn($request);
 
         $listener = new ValidateListener($validator, $resourceMetadataFactory);
         $listener->onKernelView($event->reveal());

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -15,7 +15,10 @@ namespace ApiPlatform\Core\Tests\EventListener;
 
 use ApiPlatform\Core\Api\FormatsProviderInterface;
 use ApiPlatform\Core\EventListener\DeserializeListener;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,7 +43,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
+        $serializerProphecy->deserialize(Argument::cetera())->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
         $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->shouldNotBeCalled();
@@ -50,36 +53,6 @@ class DeserializeListenerTest extends TestCase
 
         $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), $formatsProviderProphecy->reveal());
         $listener->onKernelRequest($eventProphecy->reveal());
-    }
-
-    /**
-     * @dataProvider allowedEmptyRequestMethodsProvider
-     */
-    public function testDoNotCallWhenSendingAndEmptyRequestContent($method)
-    {
-        $eventProphecy = $this->prophesize(GetResponseEvent::class);
-
-        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_item_operation_name' => 'put'], [], [], [], '');
-        $request->setMethod($method);
-        $request->headers->set('Content-Type', 'application/json');
-        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
-
-        $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
-
-        $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
-        $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->shouldNotBeCalled();
-
-        $formatsProviderProphecy = $this->prophesize(FormatsProviderInterface::class);
-        $formatsProviderProphecy->getFormatsFromAttributes(Argument::type('array'))->shouldNotBeCalled();
-
-        $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), $formatsProviderProphecy->reveal());
-        $listener->onKernelRequest($eventProphecy->reveal());
-    }
-
-    public function allowedEmptyRequestMethodsProvider()
-    {
-        return [['PUT'], ['POST']];
     }
 
     public function testDoNotCallWhenRequestNotManaged()
@@ -91,7 +64,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
+        $serializerProphecy->deserialize(Argument::cetera())->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
         $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->shouldNotBeCalled();
@@ -103,45 +76,51 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testDoNotCallWhenReceiveFlagIsFalse()
+    public function testDoNotDeserializeWhenReceiveFlagIsFalse()
     {
-        $eventProphecy = $this->prophesize(GetResponseEvent::class);
-
-        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_receive' => false]);
-        $request->setMethod('POST');
-        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
-
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
+        $serializerProphecy->deserialize(Argument::cetera())->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
-        $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->shouldNotBeCalled();
 
         $formatsProviderProphecy = $this->prophesize(FormatsProviderInterface::class);
-        $formatsProviderProphecy->getFormatsFromAttributes(Argument::type('array'))->shouldNotBeCalled();
+
+        $request = new Request([], [], ['data' => new Dummy(), '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'post', '_api_receive' => false]);
+        $request->setMethod('POST');
+
+        $eventProphecy = $this->prophesize(GetResponseEvent::class);
+        $eventProphecy->getRequest()->willReturn($request);
 
         $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), $formatsProviderProphecy->reveal());
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function testDoNotCallWhenInputClassDisabled()
+    public function testDoNotDeserializeWhenDisabledInOperationAttribute()
     {
-        $eventProphecy = $this->prophesize(GetResponseEvent::class);
-
-        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post'], [], [], [], 'content');
-        $request->setMethod('POST');
-        $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
-
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
+        $serializerProphecy->deserialize(Argument::cetera())->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
-        $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->willReturn(['input' => ['class' => null], 'output' => ['class' => null]]);
 
         $formatsProviderProphecy = $this->prophesize(FormatsProviderInterface::class);
-        $formatsProviderProphecy->getFormatsFromAttributes(Argument::type('array'))->shouldNotBeCalled();
+        $formatsProviderProphecy->getFormatsFromAttributes(Argument::type('array'));
 
-        $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), $formatsProviderProphecy->reveal());
+        $resourceMetadata = new ResourceMetadata('Dummy', null, null, [], [
+            'post' => [
+                'deserialize' => false,
+            ],
+        ]);
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($resourceMetadata);
+
+        $request = new Request([], [], ['data' => new Dummy(), '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'post']);
+        $request->setMethod('POST');
+
+        $eventProphecy = $this->prophesize(GetResponseEvent::class);
+        $eventProphecy->getRequest()->willReturn($request);
+
+        $listener = new DeserializeListener($serializerProphecy->reveal(), $serializerContextBuilderProphecy->reveal(), $formatsProviderProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal());
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
@@ -260,7 +239,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
+        $serializerProphecy->deserialize(Argument::cetera())->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
         $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->willReturn(['input' => ['class' => 'Foo'], 'output' => ['class' => 'Foo']]);
@@ -289,7 +268,7 @@ class DeserializeListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
+        $serializerProphecy->deserialize(Argument::cetera())->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
         $serializerContextBuilderProphecy->createFromRequest(Argument::type(Request::class), false, Argument::type('array'))->willReturn(['input' => ['class' => 'Foo'], 'output' => ['class' => 'Foo']]);
@@ -311,10 +290,8 @@ class DeserializeListenerTest extends TestCase
         $this->expectExceptionMessage('The "$formatsProvider" argument is expected to be an implementation of the "ApiPlatform\\Core\\Api\\FormatsProviderInterface" interface.');
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
-        $serializerContextBuilderProphecy->createFromRequest()->shouldNotBeCalled();
 
         new DeserializeListener(
             $serializerProphecy->reveal(),
@@ -330,10 +307,8 @@ class DeserializeListenerTest extends TestCase
     public function testLegacyFormatsParameter()
     {
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->deserialize()->shouldNotBeCalled();
 
         $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
-        $serializerContextBuilderProphecy->createFromRequest()->shouldNotBeCalled();
 
         new DeserializeListener(
             $serializerProphecy->reveal(),

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -20,6 +20,9 @@ use ApiPlatform\Core\EventListener\ReadListener;
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
@@ -72,26 +75,58 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
     }
 
-    public function testDoNotCallWhenReceiveFlagIsFalse()
+    public function testDoNotReadWhenReceiveFlagIsFalse()
     {
-        $identifierConverter = $this->prophesize(IdentifierConverterInterface::class);
-
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
-        $collectionDataProvider->getCollection()->shouldNotBeCalled();
+        $collectionDataProvider->getCollection(Argument::cetera())->shouldNotBeCalled();
 
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
-        $itemDataProvider->getItem()->shouldNotBeCalled();
+        $itemDataProvider->getItem(Argument::cetera())->shouldNotBeCalled();
 
         $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
-        $subresourceDataProvider->getSubresource()->shouldNotBeCalled();
+        $subresourceDataProvider->getSubresource(Argument::cetera())->shouldNotBeCalled();
 
-        $request = new Request([], [], ['data' => new \stdClass(), '_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_receive' => false]);
+        $identifierConverter = $this->prophesize(IdentifierConverterInterface::class);
+
+        $request = new Request([], [], ['id' => 1, 'data' => new Dummy(), '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'put', '_api_receive' => false]);
         $request->setMethod('PUT');
 
         $event = $this->prophesize(GetResponseEvent::class);
-        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getRequest()->willReturn($request);
 
         $listener = new ReadListener($collectionDataProvider->reveal(), $itemDataProvider->reveal(), $subresourceDataProvider->reveal(), null, $identifierConverter->reveal());
+        $listener->onKernelRequest($event->reveal());
+    }
+
+    public function testDoNotReadWhenDisabledInOperationAttribute()
+    {
+        $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
+        $collectionDataProvider->getCollection(Argument::cetera())->shouldNotBeCalled();
+
+        $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
+        $itemDataProvider->getItem(Argument::cetera())->shouldNotBeCalled();
+
+        $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+        $subresourceDataProvider->getSubresource(Argument::cetera())->shouldNotBeCalled();
+
+        $identifierConverter = $this->prophesize(IdentifierConverterInterface::class);
+
+        $resourceMetadata = new ResourceMetadata('Dummy', null, null, [
+            'put' => [
+                'read' => false,
+            ],
+        ]);
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($resourceMetadata);
+
+        $request = new Request([], [], ['id' => 1, 'data' => new Dummy(), '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'put']);
+        $request->setMethod('PUT');
+
+        $event = $this->prophesize(GetResponseEvent::class);
+        $event->getRequest()->willReturn($request);
+
+        $listener = new ReadListener($collectionDataProvider->reveal(), $itemDataProvider->reveal(), $subresourceDataProvider->reveal(), null, $identifierConverter->reveal(), $resourceMetadataFactoryProphecy->reveal());
         $listener->onKernelRequest($event->reveal());
     }
 
@@ -112,13 +147,12 @@ class ReadListenerTest extends TestCase
         $request->setMethod('POST');
 
         $event = $this->prophesize(GetResponseEvent::class);
-        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getRequest()->willReturn($request);
 
         $listener = new ReadListener($collectionDataProvider->reveal(), $itemDataProvider->reveal(), $subresourceDataProvider->reveal(), null, $identifierConverter->reveal());
         $listener->onKernelRequest($event->reveal());
 
-        $this->assertTrue($request->attributes->has('data'));
-        $this->assertNull($request->attributes->get('data'));
+        $this->assertFalse($request->attributes->has('data'));
     }
 
     public function testRetrieveCollectionGet()

--- a/tests/EventListener/WriteListenerTest.php
+++ b/tests/EventListener/WriteListenerTest.php
@@ -23,6 +23,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -215,21 +216,44 @@ class WriteListenerTest extends TestCase
         (new WriteListener($dataPersisterProphecy->reveal()))->onKernelView($event);
     }
 
-    public function testOnKernelViewWithPersistFlagOff()
+    public function testDoNotWriteWhenControllerResultIsResponse()
+    {
+        $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
+        $dataPersisterProphecy->supports(Argument::cetera())->shouldNotBeCalled();
+        $dataPersisterProphecy->persist(Argument::cetera())->shouldNotBeCalled();
+        $dataPersisterProphecy->remove(Argument::cetera())->shouldNotBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $request = new Request();
+
+        $response = new Response();
+
+        $event = new GetResponseForControllerResultEvent(
+            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        );
+
+        $listener = new WriteListener($dataPersisterProphecy->reveal(), $iriConverterProphecy->reveal());
+        $listener->onKernelView($event);
+    }
+
+    public function testDoNotWriteWhenPersistFlagIsFalse()
     {
         $dummy = new Dummy();
         $dummy->setName('Dummyrino');
 
         $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
-        $dataPersisterProphecy->supports($dummy, Argument::type('array'))->shouldNotBeCalled();
-        $dataPersisterProphecy->persist($dummy, Argument::type('array'))->shouldNotBeCalled();
-        $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
+        $dataPersisterProphecy->supports(Argument::cetera())->shouldNotBeCalled();
+        $dataPersisterProphecy->persist(Argument::cetera())->shouldNotBeCalled();
+        $dataPersisterProphecy->remove(Argument::cetera())->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
 
-        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'head', '_api_persist' => false]);
-        $request->setMethod('HEAD');
+        $request = new Request([], [], ['data' => new Dummy(), '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'post', '_api_persist' => false]);
+        $request->setMethod('POST');
 
         $event = new GetResponseForControllerResultEvent(
             $this->prophesize(HttpKernelInterface::class)->reveal(),
@@ -238,7 +262,43 @@ class WriteListenerTest extends TestCase
             $dummy
         );
 
-        (new WriteListener($dataPersisterProphecy->reveal(), $iriConverterProphecy->reveal()))->onKernelView($event);
+        $listener = new WriteListener($dataPersisterProphecy->reveal(), $iriConverterProphecy->reveal());
+        $listener->onKernelView($event);
+    }
+
+    public function testDoNotWriteWhenDisabledInOperationAttribute()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('Dummyrino');
+
+        $dataPersisterProphecy = $this->prophesize(DataPersisterInterface::class);
+        $dataPersisterProphecy->supports(Argument::cetera())->shouldNotBeCalled();
+        $dataPersisterProphecy->persist(Argument::cetera())->shouldNotBeCalled();
+        $dataPersisterProphecy->remove(Argument::cetera())->shouldNotBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $resourceMetadata = new ResourceMetadata('Dummy', null, null, [], [
+            'post' => [
+                'write' => false,
+            ],
+        ]);
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($resourceMetadata);
+
+        $request = new Request([], [], ['data' => new Dummy(), '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'post']);
+        $request->setMethod('POST');
+
+        $event = new GetResponseForControllerResultEvent(
+            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $dummy
+        );
+
+        $listener = new WriteListener($dataPersisterProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal());
+        $listener->onKernelView($event);
     }
 
     public function testOnKernelViewWithNoResourceClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes?
| New feature?  | kinda?
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1282, #2731
| License       | MIT
| Doc PR        | TODO

The toggleable listeners are:
- ReadListener ("read")
- DeserializeListener ("deserialize")
- ValidateListener ("validate")
- WriteListener ("write")
- SerializeListener ("serialize")

Basically, we fix the handling of empty request content by **removing** explicit handling of empty request content (which was wrong, resulting in weird bugs such as #2731), but allowing the user to be in control instead.

TODO:

- [x] Fix tests
- [x] Add tests
- [ ] GraphQL support