### PR TITLE
Ability to modify the Vary header

### DIFF
--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -70,9 +70,10 @@ final class AddHeadersListener
             $response->setMaxAge($maxAge);
         }
 
-        $defaultVary = $resourceCacheHeaders['vary'] ?? $this->vary;
-        if (null !== $defaultVary) {
-            $response->setVary(array_diff($defaultVary, $response->getVary()), false);
+        if (isset($resourceCacheHeaders['vary'])) {
+            $response->setVary($resourceCacheHeaders['vary']);
+        } elseif (null !== $this->vary) {
+            $response->setVary(array_diff($this->vary, $response->getVary()), false);
         }
 
         if (null !== ($sharedMaxAge = $resourceCacheHeaders['shared_max_age'] ?? $this->sharedMaxAge) && !$response->headers->hasCacheControlDirective('s-maxage')) {

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -70,8 +70,9 @@ final class AddHeadersListener
             $response->setMaxAge($maxAge);
         }
 
-        if (null !== $this->vary) {
-            $response->setVary(array_diff($this->vary, $response->getVary()), false);
+        $defaultVary = $resourceCacheHeaders['vary'] ?? $this->vary;
+        if (null !== $defaultVary) {
+            $response->setVary(array_diff($defaultVary, $response->getVary()), false);
         }
 
         if (null !== ($sharedMaxAge = $resourceCacheHeaders['shared_max_age'] ?? $this->sharedMaxAge) && !$response->headers->hasCacheControlDirective('s-maxage')) {

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -29,7 +29,7 @@ class ApiResourceTest extends TestCase
         $resource = new ApiResource([
             'accessControl' => 'has_role("ROLE_FOO")',
             'accessControlMessage' => 'You are not foo.',
-            'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux'], 'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => 'Custom-Vary']],
+            'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux'], 'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => ['Custom-Vary-1', 'Custom-Vary-2']]],
             'collectionOperations' => ['bar' => ['foo']],
             'denormalizationContext' => ['groups' => ['foo']],
             'description' => 'description',
@@ -97,7 +97,7 @@ class ApiResourceTest extends TestCase
             'route_prefix' => '/foo',
             'swagger_context' => ['description' => 'bar'],
             'validation_groups' => ['baz', 'qux'],
-            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => 'Custom-Vary'],
+            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => ['Custom-Vary-1', 'Custom-Vary-2']],
             'sunset' => 'Thu, 11 Oct 2018 00:00:00 +0200',
         ], $resource->attributes);
     }
@@ -120,7 +120,7 @@ class ApiResourceTest extends TestCase
             'route_prefix' => '/whatever',
             'access_control' => "has_role('ROLE_FOO')",
             'access_control_message' => 'You are not foo.',
-            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => 'Custom-Vary'],
+            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => ['Custom-Vary-1', 'Custom-Vary-2']],
         ], $resource->attributes);
     }
 

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -29,7 +29,7 @@ class ApiResourceTest extends TestCase
         $resource = new ApiResource([
             'accessControl' => 'has_role("ROLE_FOO")',
             'accessControlMessage' => 'You are not foo.',
-            'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux'], 'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0]],
+            'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux'], 'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => 'Custom-Vary']],
             'collectionOperations' => ['bar' => ['foo']],
             'denormalizationContext' => ['groups' => ['foo']],
             'description' => 'description',
@@ -97,7 +97,7 @@ class ApiResourceTest extends TestCase
             'route_prefix' => '/foo',
             'swagger_context' => ['description' => 'bar'],
             'validation_groups' => ['baz', 'qux'],
-            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0],
+            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => 'Custom-Vary'],
             'sunset' => 'Thu, 11 Oct 2018 00:00:00 +0200',
         ], $resource->attributes);
     }
@@ -120,7 +120,7 @@ class ApiResourceTest extends TestCase
             'route_prefix' => '/whatever',
             'access_control' => "has_role('ROLE_FOO')",
             'access_control_message' => 'You are not foo.',
-            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0],
+            'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => 'Custom-Vary'],
         ], $resource->attributes);
     }
 

--- a/tests/Fixtures/AnnotatedClass.php
+++ b/tests/Fixtures/AnnotatedClass.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *     itemOperations={"foo"={"bar"}},
  *     collectionOperations={"bar"={"foo"}},
  *     graphql={"query"={"normalization_context"={"groups"={"foo", "bar"}}}},
- *     attributes={"foo"="bar", "route_prefix"="/whatever", "cache_headers"={"max_age"=0, "shared_max_age"=0}},
+ *     attributes={"foo"="bar", "route_prefix"="/whatever", "cache_headers"={"max_age"=0, "shared_max_age"=0, "vary"="Custom-Vary"}},
  *     routePrefix="/foo",
  *     accessControl="has_role('ROLE_FOO')",
  *     accessControlMessage="You are not foo."

--- a/tests/Fixtures/AnnotatedClass.php
+++ b/tests/Fixtures/AnnotatedClass.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *     itemOperations={"foo"={"bar"}},
  *     collectionOperations={"bar"={"foo"}},
  *     graphql={"query"={"normalization_context"={"groups"={"foo", "bar"}}}},
- *     attributes={"foo"="bar", "route_prefix"="/whatever", "cache_headers"={"max_age"=0, "shared_max_age"=0, "vary"="Custom-Vary"}},
+ *     attributes={"foo"="bar", "route_prefix"="/whatever", "cache_headers"={"max_age"=0, "shared_max_age"=0, "vary"={"Custom-Vary-1", "Custom-Vary-2"}}},
  *     routePrefix="/foo",
  *     accessControl="has_role('ROLE_FOO')",
  *     accessControlMessage="You are not foo."

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -126,11 +126,12 @@ class AddHeadersListenerTest extends TestCase
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn(new ResourceMetadata())->shouldBeCalled();
 
-        $listener = new AddHeadersListener(true, 100, 200, [], true, $factory->reveal());
+        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], true, $factory->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('"etag"', $response->getEtag());
         $this->assertSame('max-age=300, public, s-maxage=400', $response->headers->get('Cache-Control'));
+        $this->assertSame(['Accept', 'Cookie', 'Accept-Encoding'], $response->getVary());
     }
 
     public function testSetHeadersFromResourceMetadata()
@@ -142,7 +143,7 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $metadata = new ResourceMetadata(null, null, null, null, null, ['cache_headers' => ['max_age' => 123, 'shared_max_age' => 456]]);
+        $metadata = new ResourceMetadata(null, null, null, null, null, ['cache_headers' => ['max_age' => 123, 'shared_max_age' => 456, 'vary' => ['Meta-1', 'Meta-2']]]);
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
 
@@ -150,5 +151,6 @@ class AddHeadersListenerTest extends TestCase
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));
+        $this->assertSame(['Accept', 'Cookie', 'Meta-1', 'Meta-2'], $response->getVary());
     }
 }

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -143,7 +143,7 @@ class AddHeadersListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $metadata = new ResourceMetadata(null, null, null, null, null, ['cache_headers' => ['max_age' => 123, 'shared_max_age' => 456, 'vary' => ['Meta-1', 'Meta-2']]]);
+        $metadata = new ResourceMetadata(null, null, null, null, null, ['cache_headers' => ['max_age' => 123, 'shared_max_age' => 456, 'vary' => ['Vary-1', 'Vary-2']]]);
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
 
@@ -151,6 +151,6 @@ class AddHeadersListenerTest extends TestCase
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));
-        $this->assertSame(['Accept', 'Cookie', 'Meta-1', 'Meta-2'], $response->getVary());
+        $this->assertSame(['Vary-1', 'Vary-2'], $response->getVary());
     }
 }


### PR DESCRIPTION
Besides of setting the default value of the `vary` header, it would be useful if one could also set/modify it by resource.

Real life use case:
I have to implement an authenticated and cached API. Most of the endpoints' results should be cached per user, so the default setting like this works fine:

```yaml
vary: ['Content-Type', 'Authorization', 'Accept-Language']
```

But there are some endpoints that serve common, shared resources, so they shouldn't vary by Authorization.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2742 
| License       | MIT
| Doc PR        | api-platform/docs#820

