### PR TITLE
[GraphQL] Services Refactoring

### DIFF
--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -113,7 +113,7 @@ Feature: GraphQL collection support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.dummies.edges[1].node.name" should be equal to "Dummy #2"
-    And the JSON node "data.dummies.edges[1].node.dummyDate" should be equal to "2015-04-02T00:00:00+00:00"
+    And the JSON node "data.dummies.edges[1].node.dummyDate" should be equal to "2015-04-02"
     And the JSON node "data.dummyGroup.foo" should be equal to "Foo #2"
 
   @createSchema

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -63,7 +63,7 @@ Feature: Collections filtering
     }
     """
     Then the JSON node "data.dummies.edges" should have 1 element
-    And the JSON node "data.dummies.edges[0].node.dummyDate" should be equal to "2015-04-02T00:00:00+00:00"
+    And the JSON node "data.dummies.edges[0].node.dummyDate" should be equal to "2015-04-02"
 
   @createSchema
   Scenario: Retrieve a collection filtered using the search filter

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -228,7 +228,7 @@ Feature: GraphQL mutation support
     And the JSON node "data.updateDummy.dummy.id" should be equal to "/dummies/1"
     And the JSON node "data.updateDummy.dummy.name" should be equal to "Dummy #1"
     And the JSON node "data.updateDummy.dummy.description" should be equal to "Modified description."
-    And the JSON node "data.updateDummy.dummy.dummyDate" should be equal to "2018-06-05T00:00:00+00:00"
+    And the JSON node "data.updateDummy.dummy.dummyDate" should be equal to "2018-06-05"
     And the JSON node "data.updateDummy.dummy.relatedDummies.edges[0].node.name" should be equal to "RelatedDummy11"
     And the JSON node "data.updateDummy.clientMutationId" should be equal to "myId"
 

--- a/features/graphql/type.feature
+++ b/features/graphql/type.feature
@@ -1,0 +1,78 @@
+Feature: GraphQL type support
+  @createSchema
+  Scenario: Use a custom type for a field
+    Given there are 2 dummy objects with dummyDate
+    When I send the following GraphQL request:
+    """
+    {
+      dummy(id: "/dummies/1") {
+        dummyDate
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummy.dummyDate" should be equal to "2015-04-01"
+
+  Scenario: Use a custom type for an input field
+    When I send the following GraphQL request:
+    """
+    mutation {
+      updateDummy(input: {id: "/dummies/1", dummyDate: "2019-05-24T00:00:00+00:00"}) {
+        dummy {
+          dummyDate
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.updateDummy.dummy.dummyDate" should be equal to "2019-05-24"
+
+  Scenario: Use a custom type for a query variable
+    When I have the following GraphQL request:
+    """
+    mutation UpdateDummyDate($itemId: ID!, $itemDate: DateTime!) {
+      updateDummy(input: {id: $itemId, dummyDate: $itemDate}) {
+        dummy {
+          dummyDate
+        }
+      }
+    }
+    """
+    And I send the GraphQL request with variables:
+    """
+    {
+      "itemId": "/dummies/1",
+      "itemDate": "2017-11-14T00:00:00+00:00"
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.updateDummy.dummy.dummyDate" should be equal to "2017-11-14"
+
+  Scenario: Use a custom type for a query variable and use a bad value
+    When I have the following GraphQL request:
+    """
+    mutation UpdateDummyDate($itemId: ID!, $itemDate: DateTime!) {
+      updateDummy(input: {id: $itemId, dummyDate: $itemDate}) {
+        dummy {
+          dummyDate
+        }
+      }
+    }
+    """
+    And I send the GraphQL request with variables:
+    """
+    {
+      "itemId": "/dummies/1",
+      "itemDate": "bad date"
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "errors[0].message" should be equal to 'Variable "$itemDate" got invalid value "bad date"; Expected type DateTime; DateTime cannot represent non date value: "bad date"'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -84,6 +84,7 @@ parameters:
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Filter\\AbstractFilter::apply\(\) invoked with 5 parameters, 3-4 required\.#'
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Filter\\AbstractFilter::filterProperty\(\) invoked with 7 parameters, 5-6 required\.#'
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Filter\\FilterInterface::apply\(\) invoked with 5 parameters, 3-4 required\.#'
+		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Filter\\ExistsFilter::filterProperty\(\) invoked with 7 parameters, 5-6 required\.#'
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Filter\\OrderFilter::filterProperty\(\) invoked with 7 parameters, 5-6 required\.#'
 		- '#Method ApiPlatform\\Core\\DataProvider\\CollectionDataProviderInterface::getCollection\(\) invoked with 3 parameters, 1-2 required\.#'
 		- '#Method Symfony\\Component\\Serializer\\NameConverter\\NameConverterInterface::normalize\(\) invoked with 3 parameters, 1 required\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -76,6 +76,7 @@ parameters:
 		-
 			message: '#Binary operation "\+" between (float\|int\|)?string and 0 results in an error\.#'
 			path: %currentWorkingDirectory%/src/Bridge/Doctrine/Common/Filter/RangeFilterTrait.php
+		- '#Parameter \#1 \$objectValue of method GraphQL\\Type\\Definition\\InterfaceType::resolveType\(\) expects object, array(<string, string>)? given.#'
 
 		# Expected, due to deprecations
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryResult(Item|Collection)ExtensionInterface::getResult\(\) invoked with 4 parameters, 1 required\.#'

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -60,22 +60,50 @@
             <tag name="container.service_locator" />
         </service>
 
+        <service id="api_platform.graphql.types_container" class="ApiPlatform\Core\GraphQl\Type\TypesContainer" />
+
         <service id="api_platform.graphql.types_factory" class="ApiPlatform\Core\GraphQl\Type\TypesFactory">
             <argument type="service" id="api_platform.graphql.type_locator" />
         </service>
 
-        <service id="api_platform.graphql.schema_builder" class="ApiPlatform\Core\GraphQl\Type\SchemaBuilder" public="false">
+        <service id="api_platform.graphql.type_converter" class="ApiPlatform\Core\GraphQl\Type\TypeConverter">
+            <argument type="service" id="api_platform.graphql.type_builder" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+        </service>
+
+        <service id="api_platform.graphql.type_builder" class="ApiPlatform\Core\GraphQl\Type\TypeBuilder" public="false">
+            <argument type="service" id="api_platform.graphql.types_container" />
+            <argument type="service" id="api_platform.graphql.resolver.resource_field" />
+            <argument type="service" id="api_platform.graphql.fields_builder_locator" />
+        </service>
+
+        <service id="api_platform.graphql.fields_builder" class="ApiPlatform\Core\GraphQl\Type\FieldsBuilder" public="false">
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
-            <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.graphql.types_container" />
+            <argument type="service" id="api_platform.graphql.type_builder" />
+            <argument type="service" id="api_platform.graphql.type_converter" />
             <argument type="service" id="api_platform.graphql.resolver.factory.item" />
             <argument type="service" id="api_platform.graphql.resolver.factory.collection" />
             <argument type="service" id="api_platform.graphql.resolver.factory.item_mutation" />
-            <argument type="service" id="api_platform.graphql.resolver.resource_field" />
-            <argument type="service" id="api_platform.graphql.types_factory" />
             <argument type="service" id="api_platform.filter_locator" />
             <argument>%api_platform.collection.pagination.enabled%</argument>
+        </service>
+
+        <service id="api_platform.graphql.fields_builder_locator" class="Symfony\Component\DependencyInjection\ServiceLocator" public="false">
+            <argument type="collection">
+                <argument type="service" id="api_platform.graphql.fields_builder" />
+            </argument>
+            <tag name="container.service_locator"/>
+        </service>
+
+        <service id="api_platform.graphql.schema_builder" class="ApiPlatform\Core\GraphQl\Type\SchemaBuilder" public="false">
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.graphql.types_factory" />
+            <argument type="service" id="api_platform.graphql.types_container" />
+            <argument type="service" id="api_platform.graphql.fields_builder" />
         </service>
 
         <!-- Action -->

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -1,0 +1,371 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use ApiPlatform\Core\GraphQl\Resolver\Factory\ResolverFactoryInterface;
+use ApiPlatform\Core\GraphQl\Type\Definition\TypeInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use Doctrine\Common\Inflector\Inflector;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use GraphQL\Type\Definition\WrappingType;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Builds the GraphQL fields.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class FieldsBuilder implements FieldsBuilderInterface
+{
+    private $propertyNameCollectionFactory;
+    private $propertyMetadataFactory;
+    private $resourceMetadataFactory;
+    private $typesContainer;
+    private $typeBuilder;
+    private $typeConverter;
+    private $itemResolverFactory;
+    private $collectionResolverFactory;
+    private $itemMutationResolverFactory;
+    private $filterLocator;
+    private $paginationEnabled;
+
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, TypesContainerInterface $typesContainer, TypeBuilderInterface $typeBuilder, TypeConverterInterface $typeConverter, ResolverFactoryInterface $itemResolverFactory, ResolverFactoryInterface $collectionResolverFactory, ResolverFactoryInterface $itemMutationResolverFactory, ContainerInterface $filterLocator, bool $paginationEnabled)
+    {
+        $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
+        $this->propertyMetadataFactory = $propertyMetadataFactory;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->typesContainer = $typesContainer;
+        $this->typeBuilder = $typeBuilder;
+        $this->typeConverter = $typeConverter;
+        $this->itemResolverFactory = $itemResolverFactory;
+        $this->collectionResolverFactory = $collectionResolverFactory;
+        $this->itemMutationResolverFactory = $itemMutationResolverFactory;
+        $this->filterLocator = $filterLocator;
+        $this->paginationEnabled = $paginationEnabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeQueryFields(): array
+    {
+        return [
+            'type' => $this->typeBuilder->getNodeInterface(),
+            'args' => [
+                'id' => ['type' => GraphQLType::nonNull(GraphQLType::id())],
+            ],
+            'resolve' => ($this->itemResolverFactory)(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQueryFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $queryName, $itemConfiguration, $collectionConfiguration): array
+    {
+        $queryFields = [];
+        $shortName = $resourceMetadata->getShortName();
+        $fieldName = lcfirst('query' === $queryName ? $shortName : $queryName.$shortName);
+
+        $deprecationReason = $resourceMetadata->getGraphqlAttribute($queryName, 'deprecation_reason', '', true);
+
+        if (false !== $itemConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration($resourceClass, $resourceMetadata, null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass), $resourceClass, false, $queryName, null)) {
+            $itemConfiguration['args'] = $itemConfiguration['args'] ?? ['id' => ['type' => GraphQLType::nonNull(GraphQLType::id())]];
+
+            $queryFields[$fieldName] = array_merge($fieldConfiguration, $itemConfiguration);
+        }
+
+        if (false !== $collectionConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration($resourceClass, $resourceMetadata, null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, $resourceClass)), $resourceClass, false, $queryName, null)) {
+            $queryFields[Inflector::pluralize($fieldName)] = array_merge($fieldConfiguration, $collectionConfiguration);
+        }
+
+        return $queryFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMutationFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $mutationName): array
+    {
+        $mutationFields = [];
+        $shortName = $resourceMetadata->getShortName();
+        $resourceType = new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass);
+        $deprecationReason = $resourceMetadata->getGraphqlAttribute($mutationName, 'deprecation_reason', '', true);
+
+        if ($fieldConfiguration = $this->getResourceFieldConfiguration($resourceClass, $resourceMetadata, null, ucfirst("{$mutationName}s a $shortName."), $deprecationReason, $resourceType, $resourceClass, false, null, $mutationName)) {
+            $fieldConfiguration['args'] += ['input' => $this->getResourceFieldConfiguration($resourceClass, $resourceMetadata, null, null, $deprecationReason, $resourceType, $resourceClass, true, null, $mutationName)];
+
+            if (!$this->typeBuilder->isCollection($resourceType)) {
+                $fieldConfiguration['resolve'] = ($this->itemMutationResolverFactory)($resourceClass, null, $mutationName);
+            }
+        }
+
+        $mutationFields[$mutationName.$resourceMetadata->getShortName()] = $fieldConfiguration ?? [];
+
+        return $mutationFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourceObjectTypeFields(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, int $depth = 0, ?array $ioMetadata = null): array
+    {
+        $fields = [];
+        $idField = ['type' => GraphQLType::nonNull(GraphQLType::id())];
+        $clientMutationId = GraphQLType::string();
+
+        if (null !== $ioMetadata && null === $ioMetadata['class']) {
+            if ($input) {
+                return ['clientMutationId' => $clientMutationId];
+            }
+
+            return [];
+        }
+
+        if ('delete' === $mutationName) {
+            $fields = [
+                'id' => $idField,
+            ];
+
+            if ($input) {
+                $fields['clientMutationId'] = $clientMutationId;
+            }
+
+            return $fields;
+        }
+
+        if (!$input || 'create' !== $mutationName) {
+            $fields['id'] = $idField;
+        }
+
+        ++$depth; // increment the depth for the call to getResourceFieldConfiguration.
+
+        if (null !== $resourceClass) {
+            foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
+                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['graphql_operation_name' => $mutationName ?? $queryName ?? 'query']);
+                if (
+                    null === ($propertyType = $propertyMetadata->getType())
+                    || (!$input && false === $propertyMetadata->isReadable())
+                    || ($input && null !== $mutationName && false === $propertyMetadata->isWritable())
+                ) {
+                    continue;
+                }
+
+                $rootResource = $resourceClass;
+                if (null !== $propertyMetadata->getSubresource()) {
+                    $resourceClass = $propertyMetadata->getSubresource()->getResourceClass();
+                    $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+                }
+                if ($fieldConfiguration = $this->getResourceFieldConfiguration($resourceClass, $resourceMetadata, $property, $propertyMetadata->getDescription(), $propertyMetadata->getAttribute('deprecation_reason', ''), $propertyType, $rootResource, $input, $queryName, $mutationName, $depth)) {
+                    $fields['id' === $property ? '_id' : $property] = $fieldConfiguration;
+                }
+                $resourceClass = $rootResource;
+            }
+        }
+
+        if (null !== $mutationName && $input) {
+            $fields['clientMutationId'] = $clientMutationId;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Get the field configuration of a resource.
+     *
+     * @see http://webonyx.github.io/graphql-php/type-system/object-types/
+     */
+    private function getResourceFieldConfiguration(string $resourceClass, ResourceMetadata $resourceMetadata, ?string $property, ?string $fieldDescription, string $deprecationReason, Type $type, string $rootResource, bool $input, ?string $queryName, ?string $mutationName, int $depth = 0): ?array
+    {
+        try {
+            if (null === $graphqlType = $this->convertType($type, $input, $queryName, $mutationName, $resourceClass, $property, $depth)) {
+                return null;
+            }
+
+            $graphqlWrappedType = $graphqlType instanceof WrappingType ? $graphqlType->getWrappedType() : $graphqlType;
+            $isStandardGraphqlType = \in_array($graphqlWrappedType, GraphQLType::getStandardTypes(), true);
+            if ($isStandardGraphqlType) {
+                $className = '';
+            } else {
+                $className = $this->typeBuilder->isCollection($type) && ($collectionValueType = $type->getCollectionValueType()) ? $collectionValueType->getClassName() : $type->getClassName();
+            }
+
+            $args = [];
+            if (!$input && null === $mutationName && !$isStandardGraphqlType && $this->typeBuilder->isCollection($type)) {
+                if ($this->paginationEnabled) {
+                    $args = [
+                        'first' => [
+                            'type' => GraphQLType::int(),
+                            'description' => 'Returns the first n elements from the list.',
+                        ],
+                        'last' => [
+                            'type' => GraphQLType::int(),
+                            'description' => 'Returns the last n elements from the list.',
+                        ],
+                        'before' => [
+                            'type' => GraphQLType::string(),
+                            'description' => 'Returns the elements in the list that come before the specified cursor.',
+                        ],
+                        'after' => [
+                            'type' => GraphQLType::string(),
+                            'description' => 'Returns the elements in the list that come after the specified cursor.',
+                        ],
+                    ];
+                }
+
+                foreach ($resourceMetadata->getGraphqlAttribute($queryName ?? 'query', 'filters', [], true) as $filterId) {
+                    if (null === $this->filterLocator || !$this->filterLocator->has($filterId)) {
+                        continue;
+                    }
+
+                    foreach ($this->filterLocator->get($filterId)->getDescription($resourceClass) as $key => $value) {
+                        $nullable = isset($value['required']) ? !$value['required'] : true;
+                        $filterType = \in_array($value['type'], Type::$builtinTypes, true) ? new Type($value['type'], $nullable) : new Type('object', $nullable, $value['type']);
+                        $graphqlFilterType = $this->convertType($filterType, false, $queryName, $mutationName, $resourceClass, $property, $depth);
+
+                        if ('[]' === substr($key, -2)) {
+                            $graphqlFilterType = GraphQLType::listOf($graphqlFilterType);
+                            $key = substr($key, 0, -2).'_list';
+                        }
+
+                        parse_str($key, $parsed);
+                        if (\array_key_exists($key, $parsed) && \is_array($parsed[$key])) {
+                            $parsed = [$key => ''];
+                        }
+                        array_walk_recursive($parsed, function (&$value) use ($graphqlFilterType) {
+                            $value = $graphqlFilterType;
+                        });
+                        $args = $this->mergeFilterArgs($args, $parsed, $resourceMetadata, $key);
+                    }
+                }
+                $args = $this->convertFilterArgsToTypes($args);
+            }
+
+            if ($isStandardGraphqlType || $input) {
+                $resolve = null;
+            } elseif ($this->typeBuilder->isCollection($type)) {
+                $resolve = ($this->collectionResolverFactory)($className, $rootResource, $queryName);
+            } else {
+                $resolve = ($this->itemResolverFactory)($className, $rootResource, $queryName);
+            }
+
+            return [
+                'type' => $graphqlType,
+                'description' => $fieldDescription,
+                'args' => $args,
+                'resolve' => $resolve,
+                'deprecationReason' => $deprecationReason,
+            ];
+        } catch (InvalidTypeException $e) {
+            // just ignore invalid types
+        }
+
+        return null;
+    }
+
+    private function mergeFilterArgs(array $args, array $parsed, ResourceMetadata $resourceMetadata = null, $original = ''): array
+    {
+        foreach ($parsed as $key => $value) {
+            // Never override keys that cannot be merged
+            if (isset($args[$key]) && !\is_array($args[$key])) {
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $value = $this->mergeFilterArgs($args[$key] ?? [], $value);
+                if (!isset($value['#name'])) {
+                    $name = (false === $pos = strrpos($original, '[')) ? $original : substr($original, 0, (int) $pos);
+                    $value['#name'] = ($resourceMetadata ? $resourceMetadata->getShortName() : '').'Filter_'.strtr($name, ['[' => '_', ']' => '', '.' => '__']);
+                }
+            }
+
+            $args[$key] = $value;
+        }
+
+        return $args;
+    }
+
+    private function convertFilterArgsToTypes(array $args): array
+    {
+        foreach ($args as $key => $value) {
+            if (strpos($key, '.')) {
+                // Declare relations/nested fields in a GraphQL compatible syntax.
+                $args[str_replace('.', '_', $key)] = $value;
+                unset($args[$key]);
+            }
+        }
+
+        foreach ($args as $key => $value) {
+            if (!\is_array($value) || !isset($value['#name'])) {
+                continue;
+            }
+
+            $name = $value['#name'];
+
+            if ($this->typesContainer->has($name)) {
+                $args[$key] = $this->typesContainer->get($name);
+                continue;
+            }
+
+            unset($value['#name']);
+
+            $filterArgType = new InputObjectType([
+                'name' => $name,
+                'fields' => $this->convertFilterArgsToTypes($value),
+            ]);
+
+            $this->typesContainer->set($name, $filterArgType);
+
+            $args[$key] = $filterArgType;
+        }
+
+        return $args;
+    }
+
+    /**
+     * Converts a built-in type to its GraphQL equivalent.
+     *
+     * @throws InvalidTypeException
+     */
+    private function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, ?string $property, int $depth)
+    {
+        $graphqlType = $this->typeConverter->convertType($type, $input, $queryName, $mutationName, $resourceClass, $property, $depth);
+
+        if (null === $graphqlType) {
+            throw new InvalidTypeException(sprintf('The type "%s" is not supported.', $type->getBuiltinType()));
+        }
+
+        if (\is_string($graphqlType)) {
+            if (!$this->typesContainer->has($graphqlType)) {
+                throw new InvalidTypeException(sprintf('The GraphQL type %s is not valid. Valid types are: %s. Have you registered this type by implementing %s?', $graphqlType, implode(', ', array_keys($this->typesContainer->all())), TypeInterface::class));
+            }
+
+            $graphqlType = $this->typesContainer->get($graphqlType);
+        }
+
+        if ($this->typeBuilder->isCollection($type)) {
+            return $this->paginationEnabled && !$input ? $this->typeBuilder->getResourcePaginatedCollectionType($graphqlType) : GraphQLType::listOf($graphqlType);
+        }
+
+        return $type->isNullable() || (null !== $mutationName && 'update' === $mutationName) ? $graphqlType : GraphQLType::nonNull($graphqlType);
+    }
+}

--- a/src/GraphQl/Type/FieldsBuilderInterface.php
+++ b/src/GraphQl/Type/FieldsBuilderInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+
+/**
+ * Interface implemented to build GraphQL fields.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface FieldsBuilderInterface
+{
+    /**
+     * Gets the fields of a node for a query.
+     */
+    public function getNodeQueryFields(): array;
+
+    /**
+     * Gets the query fields of the schema.
+     *
+     * @param array|false $itemConfiguration       false if not configured
+     * @param array|false $collectionConfiguration false if not configured
+     */
+    public function getQueryFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $queryName, $itemConfiguration, $collectionConfiguration): array;
+
+    /**
+     * Gets the mutation fields of the schema.
+     */
+    public function getMutationFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $mutationName): array;
+
+    /**
+     * Gets the fields of the type of the given resource.
+     */
+    public function getResourceObjectTypeFields(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, int $depth, ?array $ioMetadata): array;
+}

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Builds the GraphQL types.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class TypeBuilder implements TypeBuilderInterface
+{
+    private $typesContainer;
+    private $defaultFieldResolver;
+    private $fieldsBuilderLocator;
+
+    public function __construct(TypesContainerInterface $typesContainer, callable $defaultFieldResolver, ContainerInterface $fieldsBuilderLocator)
+    {
+        $this->typesContainer = $typesContainer;
+        $this->defaultFieldResolver = $defaultFieldResolver;
+        $this->fieldsBuilderLocator = $fieldsBuilderLocator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourceObjectType(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped = false, int $depth = 0): GraphQLType
+    {
+        $shortName = $resourceMetadata->getShortName();
+
+        if (null !== $mutationName) {
+            $shortName = $mutationName.ucfirst($shortName);
+        }
+        if ($input) {
+            $shortName .= 'Input';
+        } elseif (null !== $mutationName) {
+            if ($depth > 0) {
+                $shortName .= 'Nested';
+            }
+            $shortName .= 'Payload';
+        }
+        if ($wrapped && null !== $mutationName) {
+            $shortName .= 'Data';
+        }
+
+        if ($this->typesContainer->has($shortName)) {
+            return $this->typesContainer->get($shortName);
+        }
+
+        $ioMetadata = $resourceMetadata->getGraphqlAttribute($mutationName ?? 'query', $input ? 'input' : 'output', null, true);
+        if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
+            $resourceClass = $ioMetadata['class'];
+        }
+
+        $wrapData = !$wrapped && null !== $mutationName && !$input && $depth < 1;
+
+        $configuration = [
+            'name' => $shortName,
+            'description' => $resourceMetadata->getDescription(),
+            'resolveField' => $this->defaultFieldResolver,
+            'fields' => function () use ($resourceClass, $resourceMetadata, $input, $mutationName, $queryName, $wrapData, $depth, $ioMetadata) {
+                if ($wrapData) {
+                    $queryNormalizationContext = $resourceMetadata->getGraphqlAttribute($queryName ?? 'query', 'normalization_context', [], true);
+                    $mutationNormalizationContext = $resourceMetadata->getGraphqlAttribute($mutationName ?? '', 'normalization_context', [], true);
+                    // Use a new type for the wrapped object only if there is a specific normalization context for the mutation.
+                    // If not, use the query type in order to ensure the client cache could be used.
+                    $useWrappedType = $queryNormalizationContext !== $mutationNormalizationContext;
+
+                    return [
+                        lcfirst($resourceMetadata->getShortName()) => $useWrappedType ?
+                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, true, $depth) :
+                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, null, true, $depth),
+                        'clientMutationId' => GraphQLType::string(),
+                    ];
+                }
+
+                return $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder')->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $depth, $ioMetadata);
+            },
+            'interfaces' => $wrapData ? [] : [$this->getNodeInterface()],
+        ];
+
+        $resourceObjectType = $input ? GraphQLType::nonNull(new InputObjectType($configuration)) : new ObjectType($configuration);
+        $this->typesContainer->set($shortName, $resourceObjectType);
+
+        return $resourceObjectType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeInterface(): InterfaceType
+    {
+        if ($this->typesContainer->has('Node')) {
+            return $this->typesContainer->get('Node');
+        }
+
+        $nodeInterface = new InterfaceType([
+            'name' => 'Node',
+            'description' => 'A node, according to the Relay specification.',
+            'fields' => [
+                'id' => [
+                    'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    'description' => 'The id of this node.',
+                ],
+            ],
+            'resolveType' => function ($value) {
+                if (!isset($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY])) {
+                    return null;
+                }
+
+                $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName();
+
+                return $this->typesContainer->has($shortName) ? $this->typesContainer->get($shortName) : null;
+            },
+        ]);
+
+        $this->typesContainer->set('Node', $nodeInterface);
+
+        return $nodeInterface;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourcePaginatedCollectionType(GraphQLType $resourceType): GraphQLType
+    {
+        $shortName = $resourceType->name;
+
+        if ($this->typesContainer->has("{$shortName}Connection")) {
+            return $this->typesContainer->get("{$shortName}Connection");
+        }
+
+        $edgeObjectTypeConfiguration = [
+            'name' => "{$shortName}Edge",
+            'description' => "Edge of $shortName.",
+            'fields' => [
+                'node' => $resourceType,
+                'cursor' => GraphQLType::nonNull(GraphQLType::string()),
+            ],
+        ];
+        $edgeObjectType = new ObjectType($edgeObjectTypeConfiguration);
+        $this->typesContainer->set("{$shortName}Edge", $edgeObjectType);
+
+        $pageInfoObjectTypeConfiguration = [
+            'name' => "{$shortName}PageInfo",
+            'description' => 'Information about the current page.',
+            'fields' => [
+                'endCursor' => GraphQLType::string(),
+                'startCursor' => GraphQLType::string(),
+                'hasNextPage' => GraphQLType::nonNull(GraphQLType::boolean()),
+                'hasPreviousPage' => GraphQLType::nonNull(GraphQLType::boolean()),
+            ],
+        ];
+        $pageInfoObjectType = new ObjectType($pageInfoObjectTypeConfiguration);
+        $this->typesContainer->set("{$shortName}PageInfo", $pageInfoObjectType);
+
+        $configuration = [
+            'name' => "{$shortName}Connection",
+            'description' => "Connection for $shortName.",
+            'fields' => [
+                'edges' => GraphQLType::listOf($edgeObjectType),
+                'pageInfo' => GraphQLType::nonNull($pageInfoObjectType),
+                'totalCount' => GraphQLType::nonNull(GraphQLType::int()),
+            ],
+        ];
+
+        $resourcePaginatedCollectionType = new ObjectType($configuration);
+        $this->typesContainer->set("{$shortName}Connection", $resourcePaginatedCollectionType);
+
+        return $resourcePaginatedCollectionType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCollection(Type $type): bool
+    {
+        return $type->isCollection() && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType();
+    }
+}

--- a/src/GraphQl/Type/TypeBuilderInterface.php
+++ b/src/GraphQl/Type/TypeBuilderInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Interface implemented to build a GraphQL type.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface TypeBuilderInterface
+{
+    /**
+     * Gets the object type of the given resource.
+     *
+     * @return ObjectType|NonNull
+     */
+    public function getResourceObjectType(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped, int $depth): GraphQLType;
+
+    /**
+     * Get the interface type of a node.
+     */
+    public function getNodeInterface(): InterfaceType;
+
+    /**
+     * Gets the type of a paginated collection of the given resource type.
+     */
+    public function getResourcePaginatedCollectionType(GraphQLType $resourceType): GraphQLType;
+
+    /**
+     * Returns true if a type is a collection.
+     */
+    public function isCollection(Type $type): bool;
+}

--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Convert a built-in type to its GraphQL equivalent.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class TypeConverter implements TypeConverterInterface
+{
+    private $resourceMetadataFactory;
+    private $typeBuilder;
+
+    public function __construct(TypeBuilderInterface $typeBuilder, ResourceMetadataFactoryInterface $resourceMetadataFactory)
+    {
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->typeBuilder = $typeBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, ?string $property, int $depth)
+    {
+        switch ($type->getBuiltinType()) {
+            case Type::BUILTIN_TYPE_BOOL:
+                return GraphQLType::boolean();
+            case Type::BUILTIN_TYPE_INT:
+                return GraphQLType::int();
+            case Type::BUILTIN_TYPE_FLOAT:
+                return GraphQLType::float();
+            case Type::BUILTIN_TYPE_STRING:
+                return GraphQLType::string();
+            case Type::BUILTIN_TYPE_ARRAY:
+            case Type::BUILTIN_TYPE_ITERABLE:
+                return 'Iterable';
+            case Type::BUILTIN_TYPE_OBJECT:
+                if ($input && $depth > 0) {
+                    return GraphQLType::string();
+                }
+
+                if (is_a($type->getClassName(), \DateTimeInterface::class, true)) {
+                    return GraphQLType::string();
+                }
+
+                return $this->getResourceType($type, $input, $queryName, $mutationName, $depth);
+            default:
+                return null;
+        }
+    }
+
+    private function getResourceType(Type $type, bool $input, ?string $queryName, ?string $mutationName, int $depth): ?GraphQLType
+    {
+        $resourceClass = $this->typeBuilder->isCollection($type) && ($collectionValueType = $type->getCollectionValueType()) ? $collectionValueType->getClassName() : $type->getClassName();
+        if (null === $resourceClass) {
+            return null;
+        }
+
+        try {
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+            if ([] === ($resourceMetadata->getGraphql() ?? [])) {
+                return null;
+            }
+        } catch (ResourceClassNotFoundException $e) {
+            // Skip objects that are not resources for now
+            return null;
+        }
+
+        return $this->typeBuilder->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, false, $depth);
+    }
+}

--- a/src/GraphQl/Type/TypeConverterInterface.php
+++ b/src/GraphQl/Type/TypeConverterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Convert a built-in type to its GraphQL equivalent.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface TypeConverterInterface
+{
+    /**
+     * @return string|GraphQLType|null
+     */
+    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, ?string $property, int $depth);
+}

--- a/src/GraphQl/Type/TypeNotFoundException.php
+++ b/src/GraphQl/Type/TypeNotFoundException.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * Exception thrown when a type has not been found in the types container.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class TypeNotFoundException extends \InvalidArgumentException implements NotFoundExceptionInterface
+{
+    private $typeId;
+
+    public function __construct(string $message, string $typeId)
+    {
+        $this->typeId = $typeId;
+
+        parent::__construct($message);
+    }
+
+    /**
+     * Returns the type identifier causing this exception.
+     */
+    public function getTypeId(): string
+    {
+        return $this->typeId;
+    }
+}

--- a/src/GraphQl/Type/TypesContainer.php
+++ b/src/GraphQl/Type/TypesContainer.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use GraphQL\Type\Definition\Type as GraphQLType;
+
+/**
+ * Container having the built GraphQL types.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class TypesContainer implements TypesContainerInterface
+{
+    private $graphqlTypes = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set(string $id, GraphQLType $type): void
+    {
+        $this->graphqlTypes[$id] = $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id): GraphQLType
+    {
+        if ($this->has($id)) {
+            return $this->graphqlTypes[$id];
+        }
+
+        throw new TypeNotFoundException(
+            sprintf('Type with id "%s" is not present in the types container', $id),
+            $id
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all(): array
+    {
+        return $this->graphqlTypes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id): bool
+    {
+        return \array_key_exists($id, $this->graphqlTypes);
+    }
+}

--- a/src/GraphQl/Type/TypesContainerInterface.php
+++ b/src/GraphQl/Type/TypesContainerInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Type;
+
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Interface implemented to contain the GraphQL types.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface TypesContainerInterface extends ContainerInterface
+{
+    /**
+     * Sets a type.
+     *
+     * @param string      $id   The type identifier
+     * @param GraphQLType $type The type instance
+     */
+    public function set(string $id, GraphQLType $type): void;
+
+    /**
+     * Gets a type.
+     *
+     * @param string $id The type identifier
+     *
+     * @throws TypeNotFoundException When a type has not been found
+     *
+     * @return GraphQLType The type found in the container
+     */
+    public function get($id): GraphQLType;
+
+    /**
+     * Gets all the types.
+     *
+     * @return array An array of types
+     */
+    public function all(): array;
+
+    /**
+     * Returns true if the given type is present in the container.
+     *
+     * @param string $id The type identifier
+     *
+     * @return bool true if the type is present, false otherwise
+     */
+    public function has($id): bool;
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -302,12 +302,17 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.item', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.resource_field', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.executor', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.type_builder', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.fields_builder', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.fields_builder_locator', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.schema_builder', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.normalizer.item', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.normalizer.object', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.iterable_type', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.type_locator', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.types_container', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.types_factory', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.type_converter', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.query_resolver_locator', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.mutation_resolver_locator', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.command.export_command', Argument::type(Definition::class))->shouldNotBeCalled();
@@ -1030,6 +1035,9 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.doctrine_mongodb.odm.subresource_data_provider',
             'api_platform.graphql.action.entrypoint',
             'api_platform.graphql.executor',
+            'api_platform.graphql.type_builder',
+            'api_platform.graphql.fields_builder',
+            'api_platform.graphql.fields_builder_locator',
             'api_platform.graphql.schema_builder',
             'api_platform.graphql.resolver.factory.item',
             'api_platform.graphql.resolver.factory.collection',
@@ -1037,7 +1045,9 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.resolver.resource_field',
             'api_platform.graphql.iterable_type',
             'api_platform.graphql.type_locator',
+            'api_platform.graphql.types_container',
             'api_platform.graphql.types_factory',
+            'api_platform.graphql.type_converter',
             'api_platform.graphql.query_resolver_locator',
             'api_platform.graphql.mutation_resolver_locator',
             'api_platform.graphql.normalizer.item',

--- a/tests/Fixtures/TestBundle/GraphQl/Type/Definition/DateTimeType.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Type/Definition/DateTimeType.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Type\Definition;
+
+use ApiPlatform\Core\GraphQl\Type\Definition\TypeInterface;
+use GraphQL\Error\Error;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\Utils;
+
+/**
+ * Represents a DateTime type.
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class DateTimeType extends ScalarType implements TypeInterface
+{
+    public function __construct()
+    {
+        $this->name = 'DateTime';
+        $this->description = 'The `DateTime` scalar type represents time data.';
+
+        parent::__construct();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value)
+    {
+        // Already serialized.
+        if (\is_string($value)) {
+            // Should be better in a custom normalizer.
+            return (new \DateTime($value))->format('Y-m-d');
+        }
+
+        if (!($value instanceof \DateTime)) {
+            throw new Error(sprintf('Value must be an instance of DateTime to be represented by DateTime: %s', Utils::printSafe($value)));
+        }
+
+        return $value->format(\DateTime::ATOM);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseValue($value)
+    {
+        if (!\is_string($value)) {
+            throw new Error(sprintf('DateTime cannot represent non string value: %s', Utils::printSafeJson($value)));
+        }
+
+        if (false === \DateTime::createFromFormat(\DateTime::ATOM, $value)) {
+            throw new Error(sprintf('DateTime cannot represent non date value: %s', Utils::printSafeJson($value)));
+        }
+
+        // Will be denormalized into a \DateTime.
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseLiteral($valueNode, ?array $variables = null)
+    {
+        if ($valueNode instanceof StringValueNode) {
+            return $valueNode->value;
+        }
+
+        // Intentionally without message, as all information already in wrapped Exception
+        throw new \Exception();
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Type;
+
+use ApiPlatform\Core\GraphQl\Type\TypeConverterInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy as DummyDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Convert a built-in type to its GraphQL equivalent.
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class TypeConverter implements TypeConverterInterface
+{
+    private $defaultTypeConverter;
+
+    public function __construct(TypeConverterInterface $defaultTypeConverter)
+    {
+        $this->defaultTypeConverter = $defaultTypeConverter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, ?string $property, int $depth)
+    {
+        if ('dummyDate' === $property
+            && \in_array($resourceClass, [Dummy::class, DummyDocument::class], true)
+            && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()
+            && is_a($type->getClassName(), \DateTimeInterface::class, true)
+        ) {
+            return 'DateTime';
+        }
+
+        return $this->defaultTypeConverter->convertType($type, $input, $queryName, $mutationName, $resourceClass, $property, $depth);
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -280,3 +280,15 @@ services:
         public: false
         tags:
             - { name: 'api_platform.graphql.mutation_resolver' }
+
+    app.graphql.date_time_type:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Type\Definition\DateTimeType'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.type' }
+
+    app.graphql.type_converter:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Type\TypeConverter'
+        decorates: 'api_platform.graphql.type_converter'
+        arguments: ['@app.graphql.type_converter.inner']
+        public: false

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -1,0 +1,520 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Type;
+
+use ApiPlatform\Core\Api\FilterInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Factory\ResolverFactoryInterface;
+use ApiPlatform\Core\GraphQl\Type\FieldsBuilder;
+use ApiPlatform\Core\GraphQl\Type\TypeBuilderInterface;
+use ApiPlatform\Core\GraphQl\Type\TypeConverterInterface;
+use ApiPlatform\Core\GraphQl\Type\TypesContainerInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Core\Metadata\Property\SubresourceMetadata;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class FieldsBuilderTest extends TestCase
+{
+    /** @var ObjectProphecy */
+    private $propertyNameCollectionFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $propertyMetadataFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $resourceMetadataFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $typesContainerProphecy;
+
+    /** @var ObjectProphecy */
+    private $typeBuilderProphecy;
+
+    /** @var ObjectProphecy */
+    private $typeConverterProphecy;
+
+    /** @var ObjectProphecy */
+    private $itemResolverFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $collectionResolverFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $itemMutationResolverFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $filterLocatorProphecy;
+
+    /** @var FieldsBuilder */
+    private $fieldsBuilder;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $this->propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $this->typesContainerProphecy = $this->prophesize(TypesContainerInterface::class);
+        $this->typeBuilderProphecy = $this->prophesize(TypeBuilderInterface::class);
+        $this->typeConverterProphecy = $this->prophesize(TypeConverterInterface::class);
+        $this->itemResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
+        $this->collectionResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
+        $this->itemMutationResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
+        $this->filterLocatorProphecy = $this->prophesize(ContainerInterface::class);
+        $this->fieldsBuilder = new FieldsBuilder($this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), $this->typesContainerProphecy->reveal(), $this->typeBuilderProphecy->reveal(), $this->typeConverterProphecy->reveal(), $this->itemResolverFactoryProphecy->reveal(), $this->collectionResolverFactoryProphecy->reveal(), $this->itemMutationResolverFactoryProphecy->reveal(), $this->filterLocatorProphecy->reveal(), true);
+    }
+
+    public function testGetNodeQueryFields(): void
+    {
+        $nodeInterfaceType = $this->prophesize(InterfaceType::class)->reveal();
+        $this->typeBuilderProphecy->getNodeInterface()->shouldBeCalled()->willReturn($nodeInterfaceType);
+
+        $itemResolver = function () {
+        };
+        $this->itemResolverFactoryProphecy->__invoke()->shouldBeCalled()->willReturn($itemResolver);
+
+        $nodeQueryFields = $this->fieldsBuilder->getNodeQueryFields();
+        $this->assertArrayHasKey('type', $nodeQueryFields);
+        $this->assertArrayHasKey('args', $nodeQueryFields);
+        $this->assertArrayHasKey('resolve', $nodeQueryFields);
+
+        $this->assertSame($nodeInterfaceType, $nodeQueryFields['type']);
+        $this->assertArrayHasKey('id', $nodeQueryFields['args']);
+        $this->assertArrayHasKey('type', $nodeQueryFields['args']['id']);
+        $this->assertInstanceOf(NonNull::class, $nodeQueryFields['args']['id']['type']);
+        /** @var NonNull $idType */
+        $idType = $nodeQueryFields['args']['id']['type'];
+        $this->assertSame(GraphQLType::id(), $idType->getWrappedType());
+        $this->assertSame($itemResolver, $nodeQueryFields['resolve']);
+    }
+
+    /**
+     * @dataProvider queryFieldsProvider
+     */
+    public function testGetQueryFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $queryName, $itemConfiguration, $collectionConfiguration, GraphQLType $graphqlType, bool $isTypeCollection, ?callable $itemResolve, ?callable $collectionResolve, array $expectedQueryFields): void
+    {
+        $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, $queryName, null, $resourceClass, null, 0)->willReturn($graphqlType);
+        $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn($isTypeCollection);
+        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType)->willReturn($graphqlType);
+        $this->itemResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, $queryName)->willReturn($itemResolve);
+        $this->collectionResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, $queryName)->willReturn($collectionResolve);
+        $this->filterLocatorProphecy->has('my_filter')->willReturn(true);
+        $filterProphecy = $this->prophesize(FilterInterface::class);
+        $filterProphecy->getDescription($resourceClass)->willReturn([
+            'boolField' => ['type' => 'bool', 'required' => true],
+            'boolField[]' => ['type' => 'bool', 'required' => true],
+            'parent.child[related.nested]' => ['type' => 'bool', 'required' => true],
+            'dateField[before]' => ['type' => \DateTimeInterface::class, 'required' => false],
+        ]);
+        $this->filterLocatorProphecy->get('my_filter')->willReturn($filterProphecy->reveal());
+        $this->typesContainerProphecy->has('ShortNameFilter_dateField')->willReturn(false);
+        $this->typesContainerProphecy->has('ShortNameFilter_parent__child')->willReturn(false);
+        $this->typesContainerProphecy->set('ShortNameFilter_dateField', Argument::type(InputObjectType::class));
+        $this->typesContainerProphecy->set('ShortNameFilter_parent__child', Argument::type(InputObjectType::class));
+
+        $queryFields = $this->fieldsBuilder->getQueryFields($resourceClass, $resourceMetadata, $queryName, $itemConfiguration, $collectionConfiguration);
+
+        $this->assertEquals($expectedQueryFields, $queryFields);
+    }
+
+    public function queryFieldsProvider(): array
+    {
+        return [
+            'no configuration' => ['resourceClass', new ResourceMetadata(), 'action', false, false, GraphQLType::string(), false, null, null, []],
+            'nominal standard type case with deprecation reason' => ['resourceClass', (new ResourceMetadata('ShortName'))->withGraphql(['action' => ['deprecation_reason' => 'not useful']]), 'action', [], false, GraphQLType::string(), false, null, null,
+                [
+                    'actionShortName' => [
+                        'type' => GraphQLType::string(),
+                        'description' => null,
+                        'args' => [
+                            'id' => ['type' => GraphQLType::nonNull(GraphQLType::id())],
+                        ],
+                        'resolve' => null,
+                        'deprecationReason' => 'not useful',
+                    ],
+                ],
+            ],
+            'nominal item case' => ['resourceClass', new ResourceMetadata('ShortName'), 'action', [], false, $graphqlType = new ObjectType(['name' => 'item']), false, $itemResolve = function () {
+            }, null,
+                [
+                    'actionShortName' => [
+                        'type' => $graphqlType,
+                        'description' => null,
+                        'args' => [
+                            'id' => ['type' => GraphQLType::nonNull(GraphQLType::id())],
+                        ],
+                        'resolve' => $itemResolve,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
+            'override args and add fields' => [
+                'resourceClass', new ResourceMetadata('ShortName'), 'query', ['args' => [], 'name' => 'customActionName'], false, GraphQLType::string(), false, null, null,
+                [
+                    'shortName' => [
+                        'type' => GraphQLType::string(),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                        'name' => 'customActionName',
+                    ],
+                ],
+            ],
+            'wrapped collection type' => ['resourceClass', new ResourceMetadata('ShortName'), 'action', false, [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), true, null, $collectionResolve = function () {
+            },
+                [
+                    'actionShortNames' => [
+                        'type' => $graphqlType,
+                        'description' => null,
+                        'args' => [
+                            'first' => [
+                                'type' => GraphQLType::int(),
+                                'description' => 'Returns the first n elements from the list.',
+                            ],
+                            'last' => [
+                                'type' => GraphQLType::int(),
+                                'description' => 'Returns the last n elements from the list.',
+                            ],
+                            'before' => [
+                                'type' => GraphQLType::string(),
+                                'description' => 'Returns the elements in the list that come before the specified cursor.',
+                            ],
+                            'after' => [
+                                'type' => GraphQLType::string(),
+                                'description' => 'Returns the elements in the list that come after the specified cursor.',
+                            ],
+                        ],
+                        'resolve' => $collectionResolve,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
+            'collection with filters' => ['resourceClass', (new ResourceMetadata('ShortName'))->withGraphql(['action' => ['filters' => ['my_filter']]]), 'action', false, [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), true, null, $collectionResolve = function () {
+            },
+                [
+                    'actionShortNames' => [
+                        'type' => $graphqlType,
+                        'description' => null,
+                        'args' => [
+                            'first' => [
+                                'type' => GraphQLType::int(),
+                                'description' => 'Returns the first n elements from the list.',
+                            ],
+                            'last' => [
+                                'type' => GraphQLType::int(),
+                                'description' => 'Returns the last n elements from the list.',
+                            ],
+                            'before' => [
+                                'type' => GraphQLType::string(),
+                                'description' => 'Returns the elements in the list that come before the specified cursor.',
+                            ],
+                            'after' => [
+                                'type' => GraphQLType::string(),
+                                'description' => 'Returns the elements in the list that come after the specified cursor.',
+                            ],
+                            'boolField' => $graphqlType,
+                            'boolField_list' => GraphQLType::listOf($graphqlType),
+                            'parent_child' => new InputObjectType(['name' => 'ShortNameFilter_parent__child', 'fields' => ['related_nested' => $graphqlType]]),
+                            'dateField' => new InputObjectType(['name' => 'ShortNameFilter_dateField', 'fields' => ['before' => $graphqlType]]),
+                        ],
+                        'resolve' => $collectionResolve,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider mutationFieldsProvider
+     */
+    public function testGetMutationFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $mutationName, GraphQLType $graphqlType, bool $isTypeCollection, ?callable $mutationResolve, ?callable $collectionResolve, array $expectedMutationFields): void
+    {
+        $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, null, $mutationName, $resourceClass, null, 0)->willReturn($graphqlType);
+        $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, null, $mutationName, $resourceClass, null, 0)->willReturn($graphqlType);
+        $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn($isTypeCollection);
+        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType)->willReturn($graphqlType);
+        $this->collectionResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, null)->willReturn($collectionResolve);
+        $this->itemMutationResolverFactoryProphecy->__invoke($resourceClass, null, $mutationName)->willReturn($mutationResolve);
+
+        $mutationFields = $this->fieldsBuilder->getMutationFields($resourceClass, $resourceMetadata, $mutationName);
+
+        $this->assertEquals($expectedMutationFields, $mutationFields);
+    }
+
+    public function mutationFieldsProvider(): array
+    {
+        return [
+            'nominal case with deprecation reason' => ['resourceClass', (new ResourceMetadata('ShortName'))->withGraphql(['action' => ['deprecation_reason' => 'not useful']]), 'action', GraphQLType::string(), false, $mutationResolve = function () {
+            }, null,
+                [
+                    'actionShortName' => [
+                        'type' => GraphQLType::string(),
+                        'description' => 'Actions a ShortName.',
+                        'args' => [
+                            'input' => [
+                                'type' => GraphQLType::string(),
+                                'description' => null,
+                                'args' => [],
+                                'resolve' => null,
+                                'deprecationReason' => 'not useful',
+                            ],
+                        ],
+                        'resolve' => $mutationResolve,
+                        'deprecationReason' => 'not useful',
+                    ],
+                ],
+            ],
+            'wrapped collection type' => ['resourceClass', new ResourceMetadata('ShortName'), 'action', $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), true, null, $collectionResolve = function () {
+            },
+                [
+                    'actionShortName' => [
+                        'type' => $graphqlType,
+                        'description' => 'Actions a ShortName.',
+                        'args' => [
+                            'input' => [
+                                'type' => GraphQLType::listOf($graphqlType),
+                                'description' => null,
+                                'args' => [],
+                                'resolve' => null,
+                                'deprecationReason' => '',
+                            ],
+                        ],
+                        'resolve' => $collectionResolve,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider resourceObjectTypeFieldsProvider
+     */
+    public function testGetResourceObjectTypeFields(string $resourceClass, ResourceMetadata $resourceMetadata, array $properties, bool $input, ?string $queryName, ?string $mutationName, ?array $ioMetadata, array $expectedResourceObjectTypeFields): void
+    {
+        $this->propertyNameCollectionFactoryProphecy->create($resourceClass)->willReturn(new PropertyNameCollection(array_keys($properties)));
+        foreach ($properties as $propertyName => $propertyMetadata) {
+            $this->propertyMetadataFactoryProphecy->create($resourceClass, $propertyName, ['graphql_operation_name' => $queryName ?? $mutationName])->willReturn($propertyMetadata);
+            $this->propertyMetadataFactoryProphecy->create($resourceClass, $propertyName, ['graphql_operation_name' => $queryName ?? $mutationName])->willReturn($propertyMetadata);
+            $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_NULL), Argument::type('bool'), $queryName, null, $resourceClass, $propertyName, 1)->willReturn(null);
+            $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_CALLABLE), Argument::type('bool'), $queryName, null, $resourceClass, $propertyName, 1)->willReturn('NotRegisteredType');
+            $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), $queryName, null, $resourceClass, $propertyName, 1)->willReturn(GraphQLType::string());
+            $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), null, $mutationName, $resourceClass, $propertyName, 1)->willReturn(GraphQLType::string());
+            $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, null, $mutationName, 'subresourceClass', $propertyName, 1)->willReturn(GraphQLType::string());
+        }
+        $this->typesContainerProphecy->has('NotRegisteredType')->willReturn(false);
+        $this->typesContainerProphecy->all()->willReturn([]);
+        $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn(false);
+        $this->resourceMetadataFactoryProphecy->create('subresourceClass')->willReturn(new ResourceMetadata());
+
+        $resourceObjectTypeFields = $this->fieldsBuilder->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, 0, $ioMetadata);
+
+        $this->assertEquals($expectedResourceObjectTypeFields, $resourceObjectTypeFields);
+    }
+
+    public function resourceObjectTypeFieldsProvider(): array
+    {
+        return [
+            'query' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'property' => new PropertyMetadata(),
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, true, false),
+                    'propertyNotReadable' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, false),
+                ],
+                false, 'query', null, null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'propertyBool' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
+            'query input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'property' => new PropertyMetadata(),
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, false),
+                ],
+                true, 'query', null, null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'propertyBool' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
+            'mutation non input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'property' => new PropertyMetadata(),
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true),
+                    'propertyReadable' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, true, true),
+                ],
+                false, null, 'mutation', null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'propertyReadable' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
+            'mutation input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'property' => new PropertyMetadata(),
+                    'propertyBool' => (new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), 'propertyBool description', false, true))->withAttributes(['deprecation_reason' => 'not useful']),
+                    'propertySubresource' => (new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true))->withSubresource(new SubresourceMetadata('subresourceClass')),
+                    'id' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT), null, false, true),
+                ],
+                true, null, 'mutation', null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'propertyBool' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => 'propertyBool description',
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => 'not useful',
+                    ],
+                    'propertySubresource' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                    ],
+                    '_id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                    ],
+                    'clientMutationId' => GraphQLType::string(),
+                ],
+            ],
+            'delete mutation input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true),
+                ],
+                true, null, 'delete', null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'clientMutationId' => GraphQLType::string(),
+                ],
+            ],
+            'create mutation input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true),
+                ],
+                true, null, 'create', null,
+                [
+                    'propertyBool' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                    ],
+                    'clientMutationId' => GraphQLType::string(),
+                ],
+            ],
+            'update mutation input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true),
+                ],
+                true, null, 'update', null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'propertyBool' => [
+                        'type' => GraphQLType::string(),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => '',
+                    ],
+                    'clientMutationId' => GraphQLType::string(),
+                ],
+            ],
+            'null io metadata non input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true),
+                ],
+                false, null, 'update', ['class' => null], [],
+            ],
+            'null io metadata input' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true),
+                ],
+                true, null, 'update', ['class' => null],
+                [
+                    'clientMutationId' => GraphQLType::string(),
+                ],
+            ],
+            'invalid types' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'propertyInvalidType' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_NULL), null, true, false),
+                    'propertyNotRegisteredType' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_CALLABLE), null, true, false),
+                ],
+                false, 'query', null, null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -13,308 +13,136 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\GraphQl\Type;
 
-use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
-use ApiPlatform\Core\GraphQl\Resolver\Factory\ResolverFactoryInterface;
-use ApiPlatform\Core\GraphQl\Type\Definition\IterableType;
+use ApiPlatform\Core\GraphQl\Type\FieldsBuilderInterface;
 use ApiPlatform\Core\GraphQl\Type\SchemaBuilder;
+use ApiPlatform\Core\GraphQl\Type\TypesContainerInterface;
 use ApiPlatform\Core\GraphQl\Type\TypesFactoryInterface;
-use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
-use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
-use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
-use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
-use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Symfony\Component\PropertyInfo\Type;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
 class SchemaBuilderTest extends TestCase
 {
-    public function testGetSchemaAllFields()
+    /** @var ObjectProphecy */
+    private $resourceNameCollectionFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $resourceMetadataFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $typesFactoryProphecy;
+
+    /** @var ObjectProphecy */
+    private $typesContainerProphecy;
+
+    /** @var ObjectProphecy */
+    private $fieldsBuilderProphecy;
+
+    /** @var SchemaBuilder */
+    private $schemaBuilder;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
     {
-        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
-            return new PropertyMetadata(
-                new Type(
-                    $builtinType,
-                    false,
-                    'GraphqlResource3' === $resourceClassName ? 'unknownResource' : $resourceClassName
-                ),
-                "{$builtinType}Description",
-                null,
-                null,
-                null,
-                null,
-                null,
-                Type::BUILTIN_TYPE_INT === $builtinType
-            );
-        };
-
-        $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, false);
-        $this->assertEquals([
-            'node',
-            'shortName1',
-            'shortName1s',
-            'shortName2',
-            'shortName2s',
-            'shortName3',
-            'shortName3s',
-        ], array_keys($mockedSchemaBuilder->getSchema()->getConfig()->getQuery()->getFields()));
-    }
-
-    public function testGetSchemaResourceClassNotFound()
-    {
-        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
-            return new PropertyMetadata(
-                new Type(
-                    $builtinType,
-                    false,
-                    'GraphqlResource3' === $resourceClassName ? 'unknownResource' : $resourceClassName
-                ),
-                "{$builtinType}Description",
-                null,
-                null,
-                null,
-                null,
-                null,
-                Type::BUILTIN_TYPE_INT === $builtinType
-            );
-        };
-        $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, false);
-        $schema = $mockedSchemaBuilder->getSchema();
-        $queryFields = $schema->getConfig()->getQuery()->getFields();
-
-        // objectProperty has been skipped.
-        /** @var ObjectType $type */
-        $type = $queryFields['shortName3']->getType();
-        $this->assertArrayNotHasKey('objectProperty', $type->getFields());
-    }
-
-    public function testConvertFilterArgsToTypes()
-    {
-        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
-            return new PropertyMetadata();
-        };
-        $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, false);
-
-        $reflectionClass = new \ReflectionClass(SchemaBuilder::class);
-        $method = $reflectionClass->getMethod('convertFilterArgsToTypes');
-        $method->setAccessible(true);
-        $filterArgs = [
-            'aField' => 'string',
-            'GraphqlRelatedResource.nestedFieldA' => 'string',
-            'GraphqlRelatedResource.nestedFieldB' => 'string',
-        ];
-
-        $this->assertSame(
-            [
-                'aField' => 'string',
-                'GraphqlRelatedResource_nestedFieldA' => 'string',
-                'GraphqlRelatedResource_nestedFieldB' => 'string',
-            ],
-            $method->invoke($mockedSchemaBuilder, $filterArgs)
-        );
+        $this->resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $this->typesFactoryProphecy = $this->prophesize(TypesFactoryInterface::class);
+        $this->typesContainerProphecy = $this->prophesize(TypesContainerInterface::class);
+        $this->fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $this->schemaBuilder = new SchemaBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), $this->typesFactoryProphecy->reveal(), $this->typesContainerProphecy->reveal(), $this->fieldsBuilderProphecy->reveal());
     }
 
     /**
-     * @dataProvider paginationProvider
+     * @dataProvider schemaProvider
      */
-    public function testGetSchema(bool $paginationEnabled)
+    public function testGetSchema(string $resourceClass, ResourceMetadata $resourceMetadata, ObjectType $expectedQueryType, ?ObjectType $expectedMutationType): void
     {
-        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
-            return new PropertyMetadata(
-                new Type(
-                    $builtinType,
-                    false,
-                    'GraphqlResource3' === $resourceClassName ? \DateTime::class : $resourceClassName,
-                    Type::BUILTIN_TYPE_OBJECT === $builtinType && 'GraphqlResource3' !== $resourceClassName,
-                    null,
-                    Type::BUILTIN_TYPE_OBJECT === $builtinType ? new Type(Type::BUILTIN_TYPE_STRING, false, $resourceClassName) : null
-                ),
-                "{$builtinType}Description",
-                true,
-                true,
-                null,
-                null,
-                null
-            );
-        };
-        $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, $paginationEnabled);
-        $schema = $mockedSchemaBuilder->getSchema();
+        $type = $this->prophesize(GraphQLType::class)->reveal();
+        $type->name = 'MyType';
+        $this->typesFactoryProphecy->getTypes()->shouldBeCalled()->willReturn(['typeId' => $type]);
+        $this->typesContainerProphecy->set('typeId', $type)->shouldBeCalled();
+        $this->typesContainerProphecy->get('MyType')->willReturn($type);
+        $typeFoo = $this->prophesize(GraphQLType::class)->reveal();
+        $typeFoo->name = 'Foo';
+        $this->typesContainerProphecy->get('Foo')->willReturn(GraphQLType::listOf($typeFoo));
+        $this->fieldsBuilderProphecy->getNodeQueryFields()->shouldBeCalled()->willReturn(['node_fields']);
+        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'query', [], [])->willReturn(['query' => ['query_fields']]);
+        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'custom_item_query', ['item_query' => 'item_query_resolver'], false)->willReturn(['custom_item_query' => ['custom_item_query_fields']]);
+        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'custom_collection_query', false, ['collection_query' => 'collection_query_resolver'])->willReturn(['custom_collection_query' => ['custom_collection_query_fields']]);
+        $this->fieldsBuilderProphecy->getMutationFields($resourceClass, $resourceMetadata, 'mutation')->willReturn(['mutation' => ['mutation_fields']]);
 
-        $queryFields = $schema->getConfig()->getQuery()->getFields();
-        $mutationFields = $schema->getConfig()->getMutation()->getFields();
+        $this->resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([$resourceClass]));
+        $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn($resourceMetadata);
 
-        $this->assertSame([
-            'node',
-            'shortName1',
-            'shortName1s',
-            'shortName2',
-            'shortName2s',
-            'shortName3',
-            'shortName3s',
-        ], array_keys($queryFields));
-
-        $this->assertEquals([
-            'createShortName1',
-            'createShortName2',
-            'createShortName3',
-        ], array_keys($mutationFields));
-
-        /** @var ObjectType $type */
-        $type = $queryFields['shortName2']->getType();
-        $resourceTypeFields = $type->getFields();
-        $this->assertSame(
-            ['id', '_id', 'floatProperty', 'stringProperty', 'boolProperty', 'objectProperty', 'arrayProperty', 'iterableProperty'],
-            array_keys($resourceTypeFields)
-        );
-
-        // Types are equal because of the cache.
-        /** @var ObjectType $type */
-        $type = $queryFields['shortName1']->getType();
-        if ($paginationEnabled) {
-            /** @var ObjectType $objectPropertyFieldType */
-            $objectPropertyFieldType = $type->getFields()['objectProperty']->getType();
-            $this->assertSame('ShortName1Connection', $objectPropertyFieldType->name);
-            $this->assertEquals(GraphQLType::nonNull(GraphQLType::int()), $objectPropertyFieldType->getField('totalCount')->getType());
-            /** @var ListOfType $edgesType */
-            $edgesType = $objectPropertyFieldType->getFields()['edges']->getType();
-            /** @var ObjectType $edgeType */
-            $edgeType = $edgesType->getWrappedType();
-            $this->assertSame('ShortName1Edge', $edgeType->name);
-            $this->assertEquals(GraphQLType::nonNull(GraphQLType::string()), $edgeType->getField('cursor')->getType());
-            $this->assertEquals($type, $edgeType->getField('node')->getType());
-        } else {
-            /** @var ListOfType $objectPropertyFieldType */
-            $objectPropertyFieldType = $type->getFields()['objectProperty']->getType();
-            $this->assertEquals($type, $objectPropertyFieldType->getWrappedType());
-        }
-
-        // DateTime is considered as a string instead of an object.
-        /** @var ObjectType $type */
-        $type = $queryFields['shortName3']->getType();
-        /** @var ListOfType $objectPropertyFieldType */
-        $objectPropertyFieldType = $type->getField('objectProperty')->getType();
-        $this->assertEquals(GraphQLType::nonNull(GraphQLType::string()), $objectPropertyFieldType);
-
-        /** @var ObjectType $type */
-        $type = $mutationFields['createShortName2']->getType();
-        $resourceTypeFields = $type->getFields();
-        $this->assertEquals(
-            ['shortName2', 'clientMutationId'],
-            array_keys($resourceTypeFields)
-        );
+        $schema = $this->schemaBuilder->getSchema();
+        $this->assertEquals($expectedQueryType, $schema->getQueryType());
+        $this->assertEquals($expectedMutationType, $schema->getMutationType());
+        $this->assertEquals($type, $schema->getType('MyType'));
+        $this->assertEquals($typeFoo, $schema->getType('Foo'));
     }
 
-    /**
-     * Tests that the GraphQL SchemaBuilder supports an edge case where a property is typed as an Type::BUILTIN_TYPE_OBJECT but has no class related.
-     */
-    public function testObjectTypeWithoutClass()
-    {
-        $propertyMetadataMockBuilder = function ($builtinType, $resourceClassName) {
-            return new PropertyMetadata(
-                new Type(
-                    $builtinType
-                ),
-                "{$builtinType}Description",
-                true,
-                true,
-                null,
-                null,
-                null
-            );
-        };
-
-        $mockedSchemaBuilder = $this->createSchemaBuilder($propertyMetadataMockBuilder, false);
-        $this->assertEquals([
-            'node',
-            'shortName1',
-            'shortName1s',
-            'shortName2',
-            'shortName2s',
-            'shortName3',
-            'shortName3s',
-        ], array_keys($mockedSchemaBuilder->getSchema()->getConfig()->getQuery()->getFields()));
-    }
-
-    public function paginationProvider(): array
+    public function schemaProvider(): array
     {
         return [
-            [true],
-            [false],
+            'no graphql configuration' => ['resourceClass', new ResourceMetadata(),
+                new ObjectType([
+                    'name' => 'Query',
+                    'fields' => [
+                        'node' => ['node_fields'],
+                    ],
+                ]), null,
+            ],
+            'query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['query' => []]),
+                new ObjectType([
+                    'name' => 'Query',
+                    'fields' => [
+                        'node' => ['node_fields'],
+                        'query' => ['query_fields'],
+                    ],
+                ]), null,
+            ],
+            'custom item query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['custom_item_query' => ['item_query' => 'item_query_resolver']]),
+                new ObjectType([
+                    'name' => 'Query',
+                    'fields' => [
+                        'node' => ['node_fields'],
+                        'custom_item_query' => ['custom_item_query_fields'],
+                    ],
+                ]), null,
+            ],
+            'custom collection query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['custom_collection_query' => ['collection_query' => 'collection_query_resolver']]),
+                new ObjectType([
+                    'name' => 'Query',
+                    'fields' => [
+                        'node' => ['node_fields'],
+                        'custom_collection_query' => ['custom_collection_query_fields'],
+                    ],
+                ]), null,
+            ],
+            'mutation' => ['resourceClass', (new ResourceMetadata())->withGraphql(['mutation' => []]),
+                new ObjectType([
+                    'name' => 'Query',
+                    'fields' => [
+                        'node' => ['node_fields'],
+                    ],
+                ]),
+                new ObjectType([
+                    'name' => 'Mutation',
+                    'fields' => [
+                        'mutation' => ['mutation_fields'],
+                    ],
+                ]),
+            ],
         ];
-    }
-
-    private function createSchemaBuilder($propertyMetadataMockBuilder, bool $paginationEnabled): SchemaBuilder
-    {
-        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $itemResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
-        $collectionResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
-        $itemMutationResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
-        $typesFactoryProphecy = $this->prophesize(TypesFactoryInterface::class);
-
-        $resourceClassNames = [];
-        for ($i = 1; $i <= 3; ++$i) {
-            $resourceClassName = "GraphqlResource$i";
-            $resourceClassNames[] = $resourceClassName;
-            $resourceMetadata = new ResourceMetadata(
-                "ShortName$i",
-                "Description$i",
-                null,
-                null,
-                null,
-                null,
-                null,
-                ['query' => [], 'create' => []]
-            );
-            $resourceMetadataFactoryProphecy->create($resourceClassName)->willReturn($resourceMetadata);
-            $resourceMetadataFactoryProphecy->create('unknownResource')->willThrow(new ResourceClassNotFoundException());
-
-            $propertyNames = [];
-            foreach (Type::$builtinTypes as $builtinType) {
-                $propertyName = Type::BUILTIN_TYPE_INT === $builtinType ? 'id' : "{$builtinType}Property";
-                $propertyNames[] = $propertyName;
-                $propertyMetadataFactoryProphecy->create($resourceClassName, $propertyName, ['graphql_operation_name' => 'query'])->willReturn($propertyMetadataMockBuilder($builtinType, $resourceClassName));
-                $propertyMetadataFactoryProphecy->create($resourceClassName, $propertyName, ['graphql_operation_name' => 'create'])->willReturn($propertyMetadataMockBuilder($builtinType, $resourceClassName));
-            }
-            $propertyNameCollection = new PropertyNameCollection($propertyNames);
-            $propertyNameCollectionFactoryProphecy->create($resourceClassName)->willReturn($propertyNameCollection);
-        }
-        $resourceNameCollection = new ResourceNameCollection($resourceClassNames);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn($resourceNameCollection);
-
-        $itemResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {
-        });
-        $collectionResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {
-        });
-        $itemMutationResolverFactoryProphecy->__invoke(Argument::cetera())->willReturn(function () {
-        });
-
-        $typesFactoryProphecy->getTypes()->willReturn(['Iterable' => new IterableType()]);
-
-        return new SchemaBuilder(
-            $propertyNameCollectionFactoryProphecy->reveal(),
-            $propertyMetadataFactoryProphecy->reveal(),
-            $resourceNameCollectionFactoryProphecy->reveal(),
-            $resourceMetadataFactoryProphecy->reveal(),
-            $itemResolverFactoryProphecy->reveal(),
-            $collectionResolverFactoryProphecy->reveal(),
-            $itemMutationResolverFactoryProphecy->reveal(),
-            function () {
-            },
-            $typesFactoryProphecy->reveal(),
-            null,
-            $paginationEnabled
-        );
     }
 }

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -1,0 +1,319 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Type;
+
+use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
+use ApiPlatform\Core\GraphQl\Type\FieldsBuilderInterface;
+use ApiPlatform\Core\GraphQl\Type\TypeBuilder;
+use ApiPlatform\Core\GraphQl\Type\TypesContainerInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class TypeBuilderTest extends TestCase
+{
+    /** @var ObjectProphecy */
+    private $typesContainerProphecy;
+
+    /** @var callable */
+    private $defaultFieldResolver;
+
+    /** @var ObjectProphecy */
+    private $fieldsBuilderLocatorProphecy;
+
+    /** @var TypeBuilder */
+    private $typeBuilder;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->typesContainerProphecy = $this->prophesize(TypesContainerInterface::class);
+        $this->defaultFieldResolver = function () {
+        };
+        $this->fieldsBuilderLocatorProphecy = $this->prophesize(ContainerInterface::class);
+        $this->typeBuilder = new TypeBuilder($this->typesContainerProphecy->reveal(), $this->defaultFieldResolver, $this->fieldsBuilderLocatorProphecy->reveal());
+    }
+
+    public function testGetResourceObjectType(): void
+    {
+        $resourceMetadata = new ResourceMetadata('shortName', 'description');
+        $this->typesContainerProphecy->has('shortName')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('shortName', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, null);
+        $this->assertSame('shortName', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, null, 0, null)->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $resourceObjectType->config['fields']();
+    }
+
+    public function testGetResourceObjectTypeOutputClass(): void
+    {
+        $resourceMetadata = (new ResourceMetadata('shortName', 'description'))
+            ->withGraphql(['query' => ['output' => ['class' => 'outputClass']]]);
+        $this->typesContainerProphecy->has('shortName')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('shortName', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, null);
+        $this->assertSame('shortName', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('outputClass', $resourceMetadata, false, null, null, 0, ['class' => 'outputClass'])->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $resourceObjectType->config['fields']();
+    }
+
+    public function testGetResourceObjectTypeInput(): void
+    {
+        $resourceMetadata = new ResourceMetadata('shortName', 'description');
+        $this->typesContainerProphecy->has('shortNameInput')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('shortNameInput', Argument::type(NonNull::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var NonNull $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, true, null, null);
+        /** @var InputObjectType $wrappedType */
+        $wrappedType = $resourceObjectType->getWrappedType();
+        $this->assertInstanceOf(InputObjectType::class, $wrappedType);
+        $this->assertSame('shortNameInput', $wrappedType->name);
+        $this->assertSame('description', $wrappedType->description);
+        $this->assertArrayHasKey('interfaces', $wrappedType->config);
+        $this->assertArrayHasKey('fields', $wrappedType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, true, null, null, 0, null)->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $wrappedType->config['fields']();
+    }
+
+    public function testGetResourceObjectTypeMutation(): void
+    {
+        $resourceMetadata = new ResourceMetadata('shortName', 'description');
+        $this->typesContainerProphecy->has('createShortNamePayload')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('createShortNamePayload', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create');
+        $this->assertSame('createShortNamePayload', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertSame([], $resourceObjectType->config['interfaces']);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        // Recursive call (not using wrapped type)
+        $this->typesContainerProphecy->has('shortName')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('shortName', Argument::type(ObjectType::class))->shouldBeCalled();
+
+        $fieldsType = $resourceObjectType->config['fields']();
+        $this->assertArrayHasKey('shortName', $fieldsType);
+        $this->assertArrayHasKey('clientMutationId', $fieldsType);
+        $this->assertSame(GraphQLType::string(), $fieldsType['clientMutationId']);
+    }
+
+    public function testGetResourceObjectTypeMutationWrappedType(): void
+    {
+        $resourceMetadata = (new ResourceMetadata('shortName', 'description'))
+            ->withGraphql([
+                'query' => ['normalization_context' => ['groups' => ['query']]],
+                'create' => ['normalization_context' => ['groups' => ['create']]],
+            ]);
+        $this->typesContainerProphecy->has('createShortNamePayload')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('createShortNamePayload', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create');
+        $this->assertSame('createShortNamePayload', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertSame([], $resourceObjectType->config['interfaces']);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        // Recursive call (using wrapped type)
+        $this->typesContainerProphecy->has('createShortNamePayloadData')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('createShortNamePayloadData', Argument::type(ObjectType::class))->shouldBeCalled();
+
+        $fieldsType = $resourceObjectType->config['fields']();
+        $this->assertArrayHasKey('shortName', $fieldsType);
+        $this->assertArrayHasKey('clientMutationId', $fieldsType);
+        $this->assertSame(GraphQLType::string(), $fieldsType['clientMutationId']);
+
+        /** @var ObjectType $wrappedType */
+        $wrappedType = $fieldsType['shortName'];
+        $this->assertSame('createShortNamePayloadData', $wrappedType->name);
+        $this->assertSame('description', $wrappedType->description);
+        $this->assertSame($this->defaultFieldResolver, $wrappedType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $wrappedType->config);
+        $this->assertArrayHasKey('fields', $wrappedType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, 'create', 0, null)->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $wrappedType->config['fields']();
+    }
+
+    public function testGetResourceObjectTypeMutationNested(): void
+    {
+        $resourceMetadata = new ResourceMetadata('shortName', 'description');
+        $this->typesContainerProphecy->has('createShortNameNestedPayload')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('createShortNameNestedPayload', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create', false, 1);
+        $this->assertSame('createShortNameNestedPayload', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, 'create', 1, null)->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $resourceObjectType->config['fields']();
+    }
+
+    public function testGetNodeInterface(): void
+    {
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        $nodeInterface = $this->typeBuilder->getNodeInterface();
+        $this->assertSame('Node', $nodeInterface->name);
+        $this->assertSame('A node, according to the Relay specification.', $nodeInterface->description);
+        $this->assertArrayHasKey('id', $nodeInterface->getFields());
+
+        $this->assertNull($nodeInterface->resolveType([], [], $this->prophesize(ResolveInfo::class)->reveal()));
+
+        $this->typesContainerProphecy->has('Dummy')->shouldBeCalled()->willReturn(false);
+        $this->assertNull($nodeInterface->resolveType([ItemNormalizer::ITEM_RESOURCE_CLASS_KEY => Dummy::class], [], $this->prophesize(ResolveInfo::class)->reveal()));
+
+        $this->typesContainerProphecy->has('Dummy')->shouldBeCalled()->willReturn(true);
+        $this->typesContainerProphecy->get('Dummy')->shouldBeCalled()->willReturn(GraphQLType::string());
+        /** @var GraphQLType $resolvedType */
+        $resolvedType = $nodeInterface->resolveType([ItemNormalizer::ITEM_RESOURCE_CLASS_KEY => Dummy::class], [], $this->prophesize(ResolveInfo::class)->reveal());
+        $this->assertSame(GraphQLType::string(), $resolvedType);
+    }
+
+    public function testGetResourcePaginatedCollectionType(): void
+    {
+        $this->typesContainerProphecy->has('StringConnection')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('StringConnection', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->set('StringEdge', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->set('StringPageInfo', Argument::type(ObjectType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourcePaginatedCollectionType */
+        $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string());
+        $this->assertSame('StringConnection', $resourcePaginatedCollectionType->name);
+        $this->assertSame('Connection for String.', $resourcePaginatedCollectionType->description);
+
+        $resourcePaginatedCollectionTypeFields = $resourcePaginatedCollectionType->getFields();
+        $this->assertArrayHasKey('edges', $resourcePaginatedCollectionTypeFields);
+        $this->assertArrayHasKey('pageInfo', $resourcePaginatedCollectionTypeFields);
+        $this->assertArrayHasKey('totalCount', $resourcePaginatedCollectionTypeFields);
+
+        /** @var ListOfType $edgesType */
+        $edgesType = $resourcePaginatedCollectionTypeFields['edges']->getType();
+        /** @var ObjectType $wrappedType */
+        $wrappedType = $edgesType->getWrappedType();
+        $this->assertSame('StringEdge', $wrappedType->name);
+        $this->assertSame('Edge of String.', $wrappedType->description);
+        $edgeObjectTypeFields = $wrappedType->getFields();
+        $this->assertArrayHasKey('node', $edgeObjectTypeFields);
+        $this->assertArrayHasKey('cursor', $edgeObjectTypeFields);
+        $this->assertSame(GraphQLType::string(), $edgeObjectTypeFields['node']->getType());
+        $this->assertInstanceOf(NonNull::class, $edgeObjectTypeFields['cursor']->getType());
+        $this->assertSame(GraphQLType::string(), $edgeObjectTypeFields['cursor']->getType()->getWrappedType());
+
+        /** @var NonNull $pageInfoType */
+        $pageInfoType = $resourcePaginatedCollectionTypeFields['pageInfo']->getType();
+        /** @var ObjectType $wrappedType */
+        $wrappedType = $pageInfoType->getWrappedType();
+        $this->assertSame('StringPageInfo', $wrappedType->name);
+        $this->assertSame('Information about the current page.', $wrappedType->description);
+        $pageInfoObjectTypeFields = $wrappedType->getFields();
+        $this->assertArrayHasKey('endCursor', $pageInfoObjectTypeFields);
+        $this->assertArrayHasKey('startCursor', $pageInfoObjectTypeFields);
+        $this->assertArrayHasKey('hasNextPage', $pageInfoObjectTypeFields);
+        $this->assertArrayHasKey('hasPreviousPage', $pageInfoObjectTypeFields);
+        $this->assertSame(GraphQLType::string(), $pageInfoObjectTypeFields['endCursor']->getType());
+        $this->assertSame(GraphQLType::string(), $pageInfoObjectTypeFields['startCursor']->getType());
+        $this->assertInstanceOf(NonNull::class, $pageInfoObjectTypeFields['hasNextPage']->getType());
+        $this->assertSame(GraphQLType::boolean(), $pageInfoObjectTypeFields['hasNextPage']->getType()->getWrappedType());
+        $this->assertInstanceOf(NonNull::class, $pageInfoObjectTypeFields['hasPreviousPage']->getType());
+        $this->assertSame(GraphQLType::boolean(), $pageInfoObjectTypeFields['hasPreviousPage']->getType()->getWrappedType());
+
+        /** @var NonNull $totalCountType */
+        $totalCountType = $resourcePaginatedCollectionTypeFields['totalCount']->getType();
+        $this->assertInstanceOf(NonNull::class, $totalCountType);
+        $this->assertSame(GraphQLType::int(), $totalCountType->getWrappedType());
+    }
+
+    /**
+     * @dataProvider typesProvider
+     */
+    public function testIsCollection(Type $type, bool $expectedIsCollection): void
+    {
+        $this->assertSame($expectedIsCollection, $this->typeBuilder->isCollection($type));
+    }
+
+    public function typesProvider(): array
+    {
+        return [
+            [new Type(Type::BUILTIN_TYPE_BOOL), false],
+            [new Type(Type::BUILTIN_TYPE_OBJECT), false],
+            [new Type(Type::BUILTIN_TYPE_RESOURCE, false, null, false), false],
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true), true],
+        ];
+    }
+}

--- a/tests/GraphQl/Type/TypeConverterTest.php
+++ b/tests/GraphQl/Type/TypeConverterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Type;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\GraphQl\Type\TypeBuilderInterface;
+use ApiPlatform\Core\GraphQl\Type\TypeConverter;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class TypeConverterTest extends TestCase
+{
+    /** @var ObjectProphecy */
+    private $typeBuilderProphecy;
+
+    /** @var ObjectProphecy */
+    private $resourceMetadataFactoryProphecy;
+
+    /** @var TypeConverter */
+    private $typeConverter;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->typeBuilderProphecy = $this->prophesize(TypeBuilderInterface::class);
+        $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $this->typeConverter = new TypeConverter($this->typeBuilderProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal());
+    }
+
+    /**
+     * @dataProvider convertTypeProvider
+     *
+     * @param string|GraphQLType|null $expectedGraphqlType
+     */
+    public function testConvertType(Type $type, bool $input, int $depth, $expectedGraphqlType): void
+    {
+        $this->typeBuilderProphecy->isCollection($type)->willReturn(false);
+
+        $graphqlType = $this->typeConverter->convertType($type, $input, null, null, 'resourceClass', null, $depth);
+        $this->assertEquals($expectedGraphqlType, $graphqlType);
+    }
+
+    public function convertTypeProvider(): array
+    {
+        return [
+            [new Type(Type::BUILTIN_TYPE_BOOL), false, 0, GraphQLType::boolean()],
+            [new Type(Type::BUILTIN_TYPE_INT), false, 0, GraphQLType::int()],
+            [new Type(Type::BUILTIN_TYPE_FLOAT), false, 0, GraphQLType::float()],
+            [new Type(Type::BUILTIN_TYPE_STRING), false, 0, GraphQLType::string()],
+            [new Type(Type::BUILTIN_TYPE_ARRAY), false, 0, 'Iterable'],
+            [new Type(Type::BUILTIN_TYPE_ITERABLE), false, 0, 'Iterable'],
+            [new Type(Type::BUILTIN_TYPE_OBJECT), true, 1, GraphQLType::string()],
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateTimeInterface::class), false, 0, GraphQLType::string()],
+            [new Type(Type::BUILTIN_TYPE_OBJECT), false, 0, null],
+            [new Type(Type::BUILTIN_TYPE_CALLABLE), false, 0, null],
+            [new Type(Type::BUILTIN_TYPE_NULL), false, 0, null],
+            [new Type(Type::BUILTIN_TYPE_RESOURCE), false, 0, null],
+        ];
+    }
+
+    public function testConvertTypeNoGraphQlResourceMetadata(): void
+    {
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummy');
+
+        $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(false);
+        $this->resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn(new ResourceMetadata());
+
+        $graphqlType = $this->typeConverter->convertType($type, false, null, null, 'resourceClass', null, 0);
+        $this->assertNull($graphqlType);
+    }
+
+    public function testConvertTypeResourceClassNotFound(): void
+    {
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummy');
+
+        $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(false);
+        $this->resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willThrow(new ResourceClassNotFoundException());
+
+        $graphqlType = $this->typeConverter->convertType($type, false, null, null, 'resourceClass', null, 0);
+        $this->assertNull($graphqlType);
+    }
+
+    public function testConvertTypeResource(): void
+    {
+        $graphqlResourceMetadata = (new ResourceMetadata())->withGraphql(['test']);
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummyValue'));
+        $expectedGraphqlType = new ObjectType(['name' => 'resourceObjectType']);
+
+        $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(true);
+        $this->resourceMetadataFactoryProphecy->create('dummyValue')->shouldBeCalled()->willReturn($graphqlResourceMetadata);
+        $this->typeBuilderProphecy->getResourceObjectType('dummyValue', $graphqlResourceMetadata, false, null, null, false, 0)->shouldBeCalled()->willReturn($expectedGraphqlType);
+
+        $graphqlType = $this->typeConverter->convertType($type, false, null, null, 'resourceClass', null, 0);
+        $this->assertEquals($expectedGraphqlType, $graphqlType);
+    }
+}

--- a/tests/GraphQl/Type/TypesContainerTest.php
+++ b/tests/GraphQl/Type/TypesContainerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Type;
+
+use ApiPlatform\Core\GraphQl\Type\TypeNotFoundException;
+use ApiPlatform\Core\GraphQl\Type\TypesContainer;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class TypesContainerTest extends TestCase
+{
+    /**
+     * @var TypesContainer
+     */
+    private $typesContainer;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->typesContainer = new TypesContainer();
+    }
+
+    public function testSet(): void
+    {
+        $type = $this->prophesize(GraphQLType::class)->reveal();
+
+        $this->typesContainer->set('test', $type);
+        $this->assertSame($type, $this->typesContainer->get('test'));
+    }
+
+    public function testGet(): void
+    {
+        $type = $this->prophesize(GraphQLType::class)->reveal();
+
+        $this->typesContainer->set('test', $type);
+        $this->assertSame($type, $this->typesContainer->get('test'));
+    }
+
+    public function testGetTypeNotFound(): void
+    {
+        $this->expectException(TypeNotFoundException::class);
+        $this->expectExceptionMessage('Type with id "test" is not present in the types container');
+
+        $this->typesContainer->get('test');
+    }
+
+    public function testAll(): void
+    {
+        $type = $this->prophesize(GraphQLType::class)->reveal();
+
+        $this->typesContainer->set('test', $type);
+        $this->assertSame(['test' => $type], $this->typesContainer->all());
+    }
+
+    public function testHas(): void
+    {
+        $type = $this->prophesize(GraphQLType::class)->reveal();
+
+        $this->typesContainer->set('test', $type);
+        $this->assertTrue($this->typesContainer->has('test'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes (experimental)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

A big improvement of the GraphQL system with more services having consistent responsibilities.
With this refactoring, the system will be more maintainable, well tested and customizable :rocket:

Featuring:
- a new `TypeConverter` service to manage types. It can be decorated to manage custom types. An example is done in the tests.
- a `TypesContainer` service containing all the loaded types and respecting the PSR-11.
- all unit tests rewritten to cover the majority of cases for each service.

In order to do so, it was mandatory to break the circular dependencies of the services induced by the recursive way the system is working.
That's why a `fields_builder_locator` is used in the `TypeBuilder` service (used to construct an object type because it needs the corresponding fields).

@dunglas @lukasluecke I would like your opinion on this PR if you are willing to.