### PR TITLE
Add the original data to attributes and allow to access it in ExpressionLanguage

### DIFF
--- a/features/authorization/deny.feature
+++ b/features/authorization/deny.feature
@@ -58,15 +58,39 @@ Feature: Authorization checking
     """
     Then the response status code should be 201
 
-  Scenario: An user cannot retrieve an item he doesn't own
+  Scenario: A user cannot retrieve an item he doesn't own
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/1"
     Then the response status code should be 403
     And the response should be in JSON
 
-  Scenario: An user can retrieve an item he owns
+  Scenario: A user can retrieve an item he owns
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/2"
+    Then the response status code should be 200
+
+  Scenario: A user can't assign him an item he doesn't own
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send a "PUT" request to "/secured_dummies/2" with body:
+    """
+    {
+        "owner": "kitten"
+    }
+    """
+    Then the response status code should be 403
+
+  Scenario: A user can update an item he owns and transfer it
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send a "PUT" request to "/secured_dummies/2" with body:
+    """
+    {
+        "owner": "vincent"
+    }
+    """
     Then the response status code should be 200

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -107,5 +107,6 @@ final class ReadListener
         }
 
         $request->attributes->set('data', $data);
+        $request->attributes->set('previous_data', \is_object($data) ? clone $data : $data);
     }
 }

--- a/src/Security/EventListener/DenyAccessListener.php
+++ b/src/Security/EventListener/DenyAccessListener.php
@@ -50,8 +50,6 @@ final class DenyAccessListener
     }
 
     /**
-     * Sets the applicable format to the HttpFoundation Request.
-     *
      * @throws AccessDeniedException
      */
     public function onKernelRequest(GetResponseEvent $event): void
@@ -71,6 +69,7 @@ final class DenyAccessListener
 
         $extraVariables = $request->attributes->all();
         $extraVariables['object'] = $request->attributes->get('data');
+        $extraVariables['previous_object'] = $request->attributes->get('previous_data');
         $extraVariables['request'] = $request;
 
         if (!$this->resourceAccessChecker->isGranted($attributes['resource_class'], $isGranted, $extraVariables)) {

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -119,6 +119,7 @@ class ReadListenerTest extends TestCase
 
         $this->assertTrue($request->attributes->has('data'));
         $this->assertNull($request->attributes->get('data'));
+        $this->assertFalse($request->attributes->has('previous_data'));
     }
 
     public function testRetrieveCollectionGet()
@@ -144,6 +145,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
 
         $this->assertSame([], $request->attributes->get('data'));
+        $this->assertFalse($request->attributes->has('previous_data'));
     }
 
     public function testRetrieveItem()
@@ -171,6 +173,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
 
         $this->assertSame($data, $request->attributes->get('data'));
+        $this->assertEquals($data, $request->attributes->get('previous_data'));
     }
 
     public function testRetrieveItemNoIdentifier()
@@ -223,6 +226,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
 
         $this->assertSame($data, $request->attributes->get('data'));
+        $this->assertSame($data, $request->attributes->get('previous_data'));
     }
 
     public function testRetrieveSubresourceNoDataProvider()

--- a/tests/Fixtures/TestBundle/Document/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SecuredDummy.php
@@ -30,7 +30,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
  *         "query"={},

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -29,7 +29,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
  *     },
  *     graphql={
  *         "query"={},


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1646
| License       | MIT
| Doc PR        | TODO

Alternative approach to #2710 as discussed there.

The good thing about this one is that it is totally BC.
The disadvantage is that it might be harder to discover even if covered by documentation and users will not be "protected" out of the box.
