### PR TITLE
swagger/openapi bug with PropertyFilter use ?properties[]= not ?properties=

### DIFF
--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -79,7 +79,7 @@ final class PropertyFilter implements FilterInterface
                 'required' => false,
                 'swagger' => [
                     'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$example,
-                    'name' => $this->parameterName,
+                    'name' => "$this->parameterName[]",
                     'type' => 'array',
                     'items' => [
                         'type' => 'string',
@@ -87,7 +87,7 @@ final class PropertyFilter implements FilterInterface
                 ],
                 'openapi' => [
                     'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$example,
-                    'name' => $this->parameterName,
+                    'name' => "$this->parameterName[]",
                     'schema' => [
                         'type' => 'array',
                         'items' => [

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -132,7 +132,7 @@ class PropertyFilterTest extends TestCase
                 'required' => false,
                 'swagger' => [
                     'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
-                    'name' => 'custom_properties',
+                    'name' => 'custom_properties[]',
                     'type' => 'array',
                     'items' => [
                         'type' => 'string',
@@ -140,7 +140,7 @@ class PropertyFilterTest extends TestCase
                 ],
                 'openapi' => [
                     'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
-                    'name' => 'custom_properties',
+                    'name' => 'custom_properties[]',
                     'schema' => [
                         'type' => 'array',
                         'items' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | See https://github.com/api-platform/core/issues/2370#issuecomment-459306935
| License       | MIT
| Doc PR        | not needed

Found when making the SymfonyCasts tutorial :). The Swagger/OpenAPI description of the filter was awesome - it's just missing the `[]` when you actually *try* it. 

Cheers!