### PR TITLE
Allow to set HTTP STATUS CODE in GetResponseForControllerResultEvent dynamically

### DIFF
--- a/src/EventListener/RespondListener.php
+++ b/src/EventListener/RespondListener.php
@@ -79,6 +79,10 @@ final class RespondListener
             }
 
             $status = $resourceMetadata->getOperationAttribute($attributes, 'status');
+
+            if ('request_attributes_status' === $status) {
+                $status = $request->attributes->get($status);
+            }
         }
 
         $event->setResponse(new Response(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | todo

This feature allow to set status from controller event. Some resource can return 200 or 201 code.