### PR TITLE
[DX] Dockerfile and docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+    php:
+        build:
+            context: ./docker
+        ports:
+            - "27017:27017"
+        environment:
+            XDEBUG_CONFIG: remote_host=REPLACE_WITH_YOUR_BRIDGE_IP
+            PHP_IDE_CONFIG: "serverName=docker"
+        volumes:
+            - .:/srv/php:rw,cached
+            - /opt:/opt
+        working_dir: /srv/php

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM php:7.3-fpm-alpine
+
+RUN apk update && apk add autoconf openssl-dev g++ make openssl mongodb && \
+    pecl install mongodb && \
+    docker-php-ext-enable mongodb && \
+    apk del --purge autoconf openssl-dev g++ make
+
+RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS && \
+    pecl install \
+            xdebug \
+       && rm -rf /tmp/pear \
+       && docker-php-ext-enable xdebug && \
+    apk del .build-deps && \
+    sed -i '1 a xdebug.remote_enable=1' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    sed -i '1 a xdebug.remote_log=/srv/php/tests/Fixtures/app/var/log/xdebug_remote.log' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["php-fpm"]
+
+VOLUME /data/db
+
+EXPOSE 27017

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+mongod &
+
+exec docker-php-entrypoint "$@"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

I'm using Docker for testing API Platform and I think it could be interesting to add it to API Platform to improve DX.

The image comes with MongoDB and XDebug.

It's complementary to https://github.com/api-platform/core/pull/2703 because even if the tests are not run with MongoDB by default, if some tests related to MongoDB fail in Travis, you might need to run them locally.

WDYT?