### PR TITLE
Skip not readable and not writable properties in Swagger

### DIFF
--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -595,6 +595,10 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $options = isset($serializerContext[AbstractNormalizer::GROUPS]) ? ['serializer_groups' => $serializerContext[AbstractNormalizer::GROUPS]] : [];
         foreach ($this->propertyNameCollectionFactory->create($resourceClass, $options) as $propertyName) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $propertyName);
+            if (!$propertyMetadata->isReadable() && !$propertyMetadata->isWritable()) {
+                continue;
+            }
+
             $normalizedPropertyName = $this->nameConverter ? $this->nameConverter->normalize($propertyName, $resourceClass, self::FORMAT, $serializerContext ?? []) : $propertyName;
             if ($propertyMetadata->isRequired()) {
                 $definitionSchema['required'][] = $normalizedPropertyName;


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

I noticed that in Swagger docs properties that are not readable and not writable are presented anyway.
In our case it was `id` field that we don't want do expose in API in favor of `pif` field.
Below I include our configuration, simplified to focus on bug

Resource configuration
```yaml
App\Entity\BankAccount:
    attributes:
      normalization_context:
        groups: ['bankAccount:read']
      denormalization_context:
        groups: ['bankAccount:write']
    collectionOperations:
      get: ~
    itemOperations:
      get: ~
    properties:
      id:
        identifier: false
      pid:
        identifier: true
```

serializer configuration
```yaml
App\Entity\BankAccount:
  attributes:
    pid:
      groups: ['bankAccount:read']
    created:
      groups: ['bankAccount:read']
    updated:
      groups: ['bankAccount:read']
```

Generated docs:
<img width="1376" alt="Zrzut ekranu 2019-05-12 o 18 21 27" src="https://user-images.githubusercontent.com/2283090/57585054-fac29d80-74e2-11e9-820a-d740032e337c.png">

Example response:
```json
[
  {
    "pid": "8585395d229d2653",
    "created": "2014-06-09T17:26:33+00:00",
    "updated": "2014-06-09T17:26:33+00:00"
  },
  {
    "pid": "B1C8270F-7BC8-44D4-9B2D-BE221C0BF2BC",
    "created": "2015-02-23T12:01:26+00:00",
    "updated": "2015-02-23T12:01:26+00:00"
  },
  {
    "pid": "C977EDD7-AEE5-485C-87C5-8302A11CFED0",
    "created": "2015-03-12T11:39:58+00:00",
    "updated": "2015-03-12T11:39:58+00:00"
  }
]
```

As you can see in docs `id` field is wrongly presented.

This PR fix Swagger Documentation Normalizer to skip fields that are not readable and not writable