### PR TITLE
Fix joinRelations with multiple associations.

### DIFF
--- a/features/doctrine/eager_loading.feature
+++ b/features/doctrine/eager_loading.feature
@@ -8,7 +8,7 @@ Feature: Eager Loading
   Scenario: Eager loading for a relation
     Given there is a RelatedDummy with 2 friends
     When I send a "GET" request to "/related_dummies/1"
-    And the response status code should be 200
+    Then the response status code should be 200
     And the DQL should be equal to:
     """
     SELECT o, thirdLevel_a1, relatedToDummyFriend_a2, dummyFriend_a3
@@ -42,7 +42,7 @@ Feature: Eager Loading
   Scenario: Eager loading for a relation and a search filter
     Given there is a RelatedDummy with 2 friends
     When I send a "GET" request to "/related_dummies?relatedToDummyFriend.dummyFriend=2"
-    And the response status code should be 200
+    Then the response status code should be 200
     And the DQL should be equal to:
     """
     SELECT o, thirdLevel_a4, relatedToDummyFriend_a1, dummyFriend_a5
@@ -57,6 +57,22 @@ Feature: Eager Loading
             WHERE relatedToDummyFriend_a3.dummyFriend = :dummyFriend_p1
         )
     ORDER BY o.id ASC
+    """
+
+  Scenario: Eager loading for a relation and a property filter with multiple relations
+    Given there is a dummy travel
+    When I send a "GET" request to "/dummy_travels/1?properties[]=confirmed&properties[car][]=brand&properties[passenger][]=nickname"
+    Then the response status code should be 200
+    And the JSON node "confirmed" should be equal to "true"
+    And the JSON node "car.carBrand" should be equal to "DummyBrand"
+    And the JSON node "passenger.nickname" should be equal to "Tom"
+    And the DQL should be equal to:
+    """
+    SELECT o, car_a1, passenger_a2
+    FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTravel o
+        LEFT JOIN o.car car_a1
+        LEFT JOIN o.passenger passenger_a2
+    WHERE o.id = :id_id
     """
 
   Scenario: Eager loading for a relation with complex sub-query filter

--- a/features/filter/property_filter.feature
+++ b/features/filter/property_filter.feature
@@ -7,14 +7,14 @@ Feature: Set properties to include
   Scenario: Test properties filter
     Given there are 1 dummy objects with relatedDummy and its thirdLevel
     When I send a "GET" request to "/dummies/1?properties[]=name&properties[]=alias&properties[]=relatedDummy&properties[]=name_converted"
-    And the JSON node "name" should be equal to "Dummy #1"
+    Then the JSON node "name" should be equal to "Dummy #1"
     And the JSON node "alias" should be equal to "Alias #0"
     And the JSON node "relatedDummies" should not exist
     And the JSON node "name_converted" should exist
 
   Scenario: Test relation embedding
     When I send a "GET" request to "/dummies/1?properties[]=name&properties[]=alias&properties[relatedDummy][]=name"
-    And the JSON node "name" should be equal to "Dummy #1"
+    Then the JSON node "name" should be equal to "Dummy #1"
     And the JSON node "alias" should be equal to "Alias #0"
     And the JSON node "relatedDummy.name" should be equal to "RelatedDummy #1"
     And the JSON node "relatedDummies" should not exist

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -167,10 +167,11 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
                 continue;
             }
 
+            // prepare the child context
+            $childNormalizationContext = $normalizationContext;
             if (isset($normalizationContext[AbstractNormalizer::ATTRIBUTES])) {
                 if ($inAttributes = isset($normalizationContext[AbstractNormalizer::ATTRIBUTES][$association])) {
-                    // prepare the child context
-                    $normalizationContext[AbstractNormalizer::ATTRIBUTES] = $normalizationContext[AbstractNormalizer::ATTRIBUTES][$association];
+                    $childNormalizationContext[AbstractNormalizer::ATTRIBUTES] = $normalizationContext[AbstractNormalizer::ATTRIBUTES][$association];
                 }
             } else {
                 $inAttributes = null;
@@ -236,7 +237,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
                 }
             }
 
-            $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $fetchPartial, $associationAlias, $options, $normalizationContext, $isLeftJoin, $joinCount, $currentDepth);
+            $this->joinRelations($queryBuilder, $queryNameGenerator, $mapping['targetEntity'], $forceEager, $fetchPartial, $associationAlias, $options, $childNormalizationContext, $isLeftJoin, $joinCount, $currentDepth);
         }
     }
 

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -48,9 +48,11 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyFriend as DummyFrie
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyGroup as DummyGroupDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyMercure as DummyMercureDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyOffer as DummyOfferDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyPassenger as DummyPassengerDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProduct as DummyProductDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProperty as DummyPropertyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyTableInheritanceNotApiResourceChild as DummyTableInheritanceNotApiResourceChildDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyTravel as DummyTravelDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\EmbeddableDummy as EmbeddableDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\EmbeddedDummy as EmbeddedDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\FileConfigDummy as FileConfigDummyDocument;
@@ -117,9 +119,11 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyGroup;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyImmutableDate;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyMercure;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyOffer;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyPassenger;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProduct;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProperty;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceNotApiResourceChild;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTravel;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddableDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ExternalUser;
@@ -1094,6 +1098,30 @@ final class DoctrineContext implements Context
     }
 
     /**
+     * @Given there is a dummy travel
+     */
+    public function thereIsADummyTravel()
+    {
+        $car = $this->buildDummyCar();
+        $car->setName('model x');
+        $car->setCanSell(true);
+        $car->setAvailableAt(new \DateTime());
+        $this->manager->persist($car);
+
+        $passenger = $this->buildDummyPassenger();
+        $passenger->nickname = 'Tom';
+        $this->manager->persist($passenger);
+
+        $travel = $this->buildDummyTravel();
+        $travel->car = $car;
+        $travel->passenger = $passenger;
+        $travel->confirmed = true;
+        $this->manager->persist($travel);
+
+        $this->manager->flush();
+    }
+
+    /**
      * @Given there is a RelatedDummy with :nb friends
      */
     public function thereIsARelatedDummyWithFriends(int $nb)
@@ -1828,6 +1856,22 @@ final class DoctrineContext implements Context
     private function buildDummyCarColor()
     {
         return $this->isOrm() ? new DummyCarColor() : new DummyCarColorDocument();
+    }
+
+    /**
+     * @return DummyPassenger|DummyPassengerDocument
+     */
+    private function buildDummyPassenger()
+    {
+        return $this->isOrm() ? new DummyPassenger() : new DummyPassengerDocument();
+    }
+
+    /**
+     * @return DummyTravel|DummyTravelDocument
+     */
+    private function buildDummyTravel()
+    {
+        return $this->isOrm() ? new DummyTravel() : new DummyTravelDocument();
     }
 
     /**

--- a/tests/Fixtures/TestBundle/Document/DummyPassenger.php
+++ b/tests/Fixtures/TestBundle/Document/DummyPassenger.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ApiResource
+ * @ODM\Document
+ */
+class DummyPassenger
+{
+    /**
+     * @ODM\Id(strategy="INCREMENT", type="int")
+     */
+    private $id;
+
+    /**
+     * @ODM\Field(type="string")
+     */
+    public $nickname;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/DummyTravel.php
+++ b/tests/Fixtures/TestBundle/Document/DummyTravel.php
@@ -11,37 +11,34 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
 
 use ApiPlatform\Core\Annotation\ApiResource;
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * @ApiResource(filters={"dummy_travel.property"})
- * @ORM\Entity
+ * @ODM\Document
  */
 class DummyTravel
 {
     /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ODM\Id(strategy="INCREMENT", type="int")
      */
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="DummyCar")
-     * @ORM\JoinColumn(name="car_id", referencedColumnName="id_id")
+     * @ODM\ReferenceOne(targetDocument=DummyCar::class)
      */
     public $car;
 
     /**
-     * @ORM\Column(type="boolean")
+     * @ODM\Field(type="bool")
      */
     public $confirmed;
+
     /**
-     * @ORM\ManyToOne(targetEntity="DummyPassenger")
-     * @ORM\JoinColumn(name="passenger_id", referencedColumnName="id")
+     * @ODM\ReferenceOne(targetDocument=DummyPassenger::class)
      */
     public $passenger;
 

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -126,6 +126,10 @@ services:
         parent:    'api_platform.serializer.property_filter'
         tags:      [ { name: 'api_platform.filter', id: 'my_dummy.property' } ]
 
+    app.dummy_travel_resource.property_filter:
+        parent: 'api_platform.serializer.property_filter'
+        tags: [ { name: 'api_platform.filter', id: 'dummy_travel.property' } ]
+
     ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter\RequiredFilter:
         arguments: ['@doctrine']
         tags: ['api_platform.filter']


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
Hello,
I propose my first contribution to the project.

I found that the final SQL query was not correct in the case where an entity had several doctrinal relationships and was asked to retrieve some properties with the [PropertyFilter](https://api-platform.com/docs/core/filters/#property-filter).

Example:
```php
class Example {
     public $property;
     public $relation1;
     public $relation2;
}
class Relation {
     public $property1;
     public $property2;
}
```
uri: `/api/examples?properties[relation1][]=property1&properties[relation2][]=property2`

In this case the relation1 has been added but relation2 is ignored.

After searching, you can see that the bug is coming from: `src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php` line 169 or the context is overwritten.

I propose my modification to fix the bug.

Sorry I'm not good at unit testing so if someone can help me write it I'm interested.