### PR TITLE
Allow nullable relationships to be POST or PUT with null value

### DIFF
--- a/src/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
+++ b/src/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
@@ -82,10 +82,10 @@ final class DoctrineOrmPropertyMetadataFactory implements PropertyMetadataFactor
                 if (!isset($associationMapping['joinColumns'])) {
                     continue;
                 }
-                
+
                 $isNullable = true;
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
-                    if (!$joinColumn['nullable']) {
+                    if (!isset($joinColumn['nullable']) || !$joinColumn['nullable']) {
                         $isNullable = false;
                         break;
                     }

--- a/src/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
+++ b/src/Bridge/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
@@ -79,6 +79,10 @@ final class DoctrineOrmPropertyMetadataFactory implements PropertyMetadataFactor
 
         foreach ($doctrineClassMetadata->getAssociationMappings() as $associationMapping) {
             if ($associationMapping['fieldName'] === $property) {
+                if (!isset($associationMapping['joinColumns'])) {
+                    continue;
+                }
+                
                 $isNullable = true;
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
                     if (!$joinColumn['nullable']) {

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -451,11 +451,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
         if (!\is_array($value)) {
             // repeat the code so that IRIs keep working with the json format
             if (true === $this->allowPlainIdentifiers && $this->itemDataProvider) {
-                $type = $propertyMetadata->getType();
-                if ($type && $type->isNullable() && null === $value) {
-                    return null;
-                }
-                
                 $item = $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true]);
                 if (null === $item) {
                     throw new ItemNotFoundException(sprintf('Item not found for "%s".', $value));

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -451,6 +451,11 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer implement
         if (!\is_array($value)) {
             // repeat the code so that IRIs keep working with the json format
             if (true === $this->allowPlainIdentifiers && $this->itemDataProvider) {
+                $type = $propertyMetadata->getType();
+                if ($type && $type->isNullable() && null === $value) {
+                    return null;
+                }
+                
                 $item = $this->itemDataProvider->getItem($className, $value, null, $context + ['fetch_data' => true]);
                 if (null === $item) {
                     throw new ItemNotFoundException(sprintf('Item not found for "%s".', $value));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not sure
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hello,

Preface: I'm using `allow_identifiers` for my relationships instead of IRIs (legacy requirement, can't change it).

I have an entity that has an optional ("nullable") relation but when I tried to POST a new entity with said relation set to `null`, I was getting an error:

`"Invalid identifier \"\", \"id\" was not found."`

Turns out that when the `AbstractItemNormalizer` tries to get the relationship value, because the value is "null", it's unable to find the matching item in the database.

Upon further investigation, the `nullable` option of the `@JoinColumn` annotation is ignored when the `PropertyMetadata` is built.

My PR adds the required code in `DoctrineOrmPropertyMetadataFactory` to mark a relationship as nullable if it is.

Note: A relationship will be considered nullable only if all the JoinColumns are nullable=true.

After this code is implemented it's now possible to POST something like:

`{"mandatory_relation":1,"nullable_relation":null}` and have API Platform correctly save a new Entity without the nullable_relation set.