### PR TITLE
Fix ResourceClassResolver handling of inheritance 

### DIFF
--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyGroup as DummyGroup
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyOffer as DummyOfferDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProduct as DummyProductDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProperty as DummyPropertyDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyTableInheritanceNotApiResourceChild as DummyTableInheritanceNotApiResourceChildDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\EmbeddableDummy as EmbeddableDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\EmbeddedDummy as EmbeddedDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\FileConfigDummy as FileConfigDummyDocument;
@@ -74,6 +75,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyImmutableDate;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyOffer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProduct;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProperty;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceNotApiResourceChild;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddableDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy;
@@ -162,6 +164,17 @@ final class DoctrineContext implements Context
             $this->manager->persist($dummy);
         }
 
+        $this->manager->flush();
+    }
+
+    /**
+     * @When some dummy table inheritance data but not api resource child are created
+     */
+    public function someDummyTableInheritanceDataButNotApiResourceChildAreCreated()
+    {
+        $dummy = $this->buildDummyTableInheritanceNotApiResourceChild();
+        $dummy->setName('Foobarbaz inheritance');
+        $this->manager->persist($dummy);
         $this->manager->flush();
     }
 
@@ -1273,6 +1286,14 @@ final class DoctrineContext implements Context
     }
 
     /**
+     * @return DummyTableInheritanceNotApiResourceChild|DummyTableInheritanceNotApiResourceChildDocument
+     */
+    private function buildDummyTableInheritanceNotApiResourceChild()
+    {
+        return $this->isOrm() ? new DummyTableInheritanceNotApiResourceChild() : new DummyTableInheritanceNotApiResourceChildDocument();
+    }
+
+    /**
      * @return DummyAggregateOffer|DummyAggregateOfferDocument
      */
     private function buildDummyAggregateOffer()
@@ -1539,5 +1560,45 @@ final class DoctrineContext implements Context
 
         $this->manager->flush();
         $this->manager->clear();
+    }
+
+    /**
+     * @Given there are :nb sites with internal owner
+     */
+    public function thereAreSitesWithInternalOwner(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $internalUser = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\InternalUser();
+            $internalUser->setFirstname('Internal');
+            $internalUser->setLastname('User');
+            $internalUser->setEmail('john.doe@example.com');
+            $internalUser->setInternalId('INT');
+            $site = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Site();
+            $site->setTitle('title');
+            $site->setDescription('description');
+            $site->setOwner($internalUser);
+            $this->manager->persist($site);
+        }
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there are :nb sites with external owner
+     */
+    public function thereAreSitesWithExternalOwner(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $externalUser = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ExternalUser();
+            $externalUser->setFirstname('External');
+            $externalUser->setLastname('User');
+            $externalUser->setEmail('john.doe@example.com');
+            $externalUser->setExternalId('EXT');
+            $site = new \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Site();
+            $site->setTitle('title');
+            $site->setDescription('description');
+            $site->setOwner($externalUser);
+            $this->manager->persist($site);
+        }
+        $this->manager->flush();
     }
 }

--- a/features/main/operation.feature
+++ b/features/main/operation.feature
@@ -4,7 +4,6 @@ Feature: Operation support
   I need to be able to add custom operations and remove built-in ones
 
   @createSchema
-  @dropSchema
   Scenario: Can not write readonly property
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/readable_only_properties" with body:

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -491,7 +491,7 @@ Feature: Relations support
     Given there are people having pets
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/people"
-    And the response status code should be 200
+    Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be equal to:
     """
@@ -621,8 +621,6 @@ Feature: Relations support
     }
     """
 
-
-  @dropSchema
   Scenario: Passing an invalid IRI to a relation
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/relation_embedders" with body:
@@ -634,7 +632,7 @@ Feature: Relations support
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON node "hydra:description" should contain "Invalid value provided (invalid IRI?)."
+    And the JSON node "hydra:description" should contain 'Invalid IRI "certainly not an iri and not a plain identifier".'
 
   Scenario: Passing an invalid type to a relation
     When I add "Content-Type" header equal to "application/ld+json"
@@ -647,4 +645,32 @@ Feature: Relations support
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON node "hydra:description" should contain "Invalid value provided (invalid IRI?)."
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "string",
+          "pattern": "^/contexts/Error$"
+        },
+        "@type": {
+          "type": "string",
+          "pattern": "^hydra:Error$"
+        },
+        "hydra:title": {
+          "type": "string",
+          "pattern": "^An error occurred$"
+        },
+        "hydra:description": {
+          "pattern": "^Expected IRI or document for resource \"ApiPlatform\\\\Core\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\RelatedDummy\", \"integer\" given.$"
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "hydra:title",
+        "hydra:description"
+      ]
+    }
+    """

--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -32,15 +32,20 @@ Feature: Table inheritance
         },
         "name": {
           "type": "string",
-          "pattern": "^foo$",
-          "required": "true"
+          "pattern": "^foo$"
         },
         "nickname": {
           "type": "string",
-          "pattern": "^bar$",
-          "required": "true"
+          "pattern": "^bar$"
         }
-      }
+      },
+      "required": [
+        "@type",
+        "@context",
+        "@id",
+        "name",
+        "nickname"
+      ]
     }
     """
 
@@ -56,31 +61,114 @@ Feature: Table inheritance
       "properties": {
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@type": {
-                "type": "string",
-                "pattern": "^DummyTableInheritanceChild$"
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritanceChild$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummy_table_inheritance_children/1$"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "nickname": {
+                  "type": "string"
+                }
               },
-              "name": {
-                "type": "string",
-                "required": "true"
-              },
-              "nickname": {
-                "type": "string",
-                "required": "true"
-              }
+              "required": [
+                "@type",
+                "@id",
+                "name",
+                "nickname"
+              ]
             }
-          },
-          "minItems": 1
+          ],
+          "additionalItems": false
         }
       },
-      "required": ["hydra:member"]
+      "required": [
+        "hydra:member"
+      ]
     }
     """
 
-  @createSchema
+  Scenario: Some children not api resources are created in the app
+    When some dummy table inheritance data but not api resource child are created
+    And I send a "GET" request to "/dummy_table_inheritances"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "hydra:member": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritanceChild$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummy_table_inheritance_children/1$"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "name"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritance$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummy_table_inheritances/2$"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "name"
+              ]
+            }
+          ],
+          "additionalItems": false
+        },
+        "hydra:totalItems": {
+          "type": "integer",
+          "minimum": 2,
+          "maximum": 2
+        }
+      },
+      "required": [
+        "hydra:member",
+        "hydra:totalItems"
+      ]
+    }
+    """
+
   Scenario: Create a table inherited resource
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/dummy_table_inheritance_children" with body:
@@ -105,19 +193,24 @@ Feature: Table inheritance
         },
         "@id": {
           "type": "string",
-          "pattern": "^/dummy_table_inheritance_children/1$"
+          "pattern": "^/dummy_table_inheritance_children/3$"
         },
         "name": {
           "type": "string",
-          "pattern": "^foo$",
-          "required": "true"
+          "pattern": "^foo$"
         },
         "nickname": {
           "type": "string",
-          "pattern": "^bar$",
-          "required": "true"
+          "pattern": "^bar$"
         }
-      }
+      },
+      "required": [
+        "@type",
+        "@context",
+        "@id",
+        "name",
+        "nickname"
+      ]
     }
     """
 
@@ -144,19 +237,24 @@ Feature: Table inheritance
         },
         "@id": {
           "type": "string",
-          "pattern": "^/dummy_table_inheritance_different_children/2$"
+          "pattern": "^/dummy_table_inheritance_different_children/4$"
         },
         "name": {
           "type": "string",
-          "pattern": "^foo$",
-          "required": "true"
+          "pattern": "^foo$"
         },
         "email": {
           "type": "string",
-          "pattern": "^bar\\@localhost$",
-          "required": "true"
+          "pattern": "^bar\\@localhost$"
         }
-      }
+      },
+      "required": [
+        "@type",
+        "@context",
+        "@id",
+        "name",
+        "email"
+      ]
     }
     """
 
@@ -167,7 +265,7 @@ Feature: Table inheritance
     {
       "children": [
         "/dummy_table_inheritance_children/1",
-        "/dummy_table_inheritance_different_children/2"
+        "/dummy_table_inheritance_different_children/4"
       ]
     }
     """
@@ -192,47 +290,58 @@ Feature: Table inheritance
           "pattern": "^/dummy_table_inheritance_relateds/1$"
         },
         "children": {
-          "items": {
-            "type": "object",
-            "anyOf": [
-              {
-                "properties": {
-                  "@type": {
-                    "type": "string",
-                    "pattern": "^DummyTableInheritanceChild$"
-                  },
-                  "name": {
-                    "type": "string",
-                    "required": "true"
-                  },
-                  "nickname": {
-                    "type": "string",
-                    "required": "true"
-                  }
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritanceChild$"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "nickname": {
+                  "type": "string"
                 }
               },
-              {
-                "properties": {
-                  "@type": {
-                    "type": "string",
-                    "pattern": "^DummyTableInheritanceDifferentChild$"
-                  },
-                  "name": {
-                    "type": "string",
-                    "required": "true"
-                  },
-                  "email": {
-                    "type": "string",
-                    "required": "true"
-                  }
+              "required": [
+                "@type",
+                "name",
+                "nickname"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritanceDifferentChild$"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
                 }
-              }
-            ]
-          },
-          "minItems": 2,
-          "maxItems": 2
+              },
+              "required": [
+                "@type",
+                "name",
+                "email"
+              ]
+            }
+          ],
+          "additionalItems": false
         }
-      }
+      },
+      "required": [
+        "@type",
+        "@context",
+        "@id",
+        "children"
+      ]
     }
     """
 
@@ -248,81 +357,170 @@ Feature: Table inheritance
       "properties": {
         "hydra:member": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "anyOf": [
-              {
-                "properties": {
-                  "@type": {
-                    "type": "string",
-                    "pattern": "^DummyTableInheritanceChild$"
-                  },
-                  "name": {
-                    "type": "string",
-                    "required": "true"
-                  },
-                  "nickname": {
-                    "type": "string",
-                    "required": "true"
-                  }
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritanceChild$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummy_table_inheritance_children/1$"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "nickname": {
+                  "type": "string"
                 }
               },
-              {
-                "properties": {
-                  "@type": {
-                    "type": "string",
-                    "pattern": "^DummyTableInheritanceDifferentChild$"
-                  },
-                  "name": {
-                    "type": "string",
-                    "required": "true"
-                  },
-                  "email": {
-                    "type": "string",
-                    "required": "true"
-                  }
+              "required": [
+                "@type",
+                "@id",
+                "name",
+                "nickname"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritance$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummy_table_inheritances/2$"
+                },
+                "name": {
+                  "type": "string"
                 }
-              }
-            ]
-          },
-          "minItems": 2
+              },
+              "required": [
+                "@type",
+                "@id",
+                "name"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^DummyTableInheritanceChild$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/dummy_table_inheritance_children/3$"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "nickname": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "name",
+                "nickname"
+              ]
+            }
+          ],
+          "additionalItems": false
+        },
+        "hydra:totalItems": {
+          "type": "integer",
+          "minimum": 4,
+          "maximum": 4
         }
       },
-      "required": ["hydra:member"]
+      "required": [
+        "hydra:member",
+        "hydra:totalItems"
+      ]
     }
     """
 
    Scenario: Get the parent interface collection
-     When I send a "GET" request to "/resource_interfaces"
-     Then the response status code should be 200
-     And the response should be in JSON
-     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-     And the JSON should be valid according to this schema:
-     """
-     {
-       "type": "object",
-       "properties": {
-         "hydra:member": {
-           "type": "array",
-           "items": {
-             "type": "object",
-             "properties": {
-               "foo": {
-                 "type": "string",
-                 "required": "true"
-               },
-               "fooz": {
-                 "type": "string",
-                 "required": "true"
-               }
-             }
-           },
-           "minItems": 1
-         }
-       },
-       "required": ["hydra:member"]
-     }
-     """
+    When I send a "GET" request to "/resource_interfaces"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "hydra:member": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^ResourceInterface$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/resource_interfaces/item1"
+                },
+                "foo": {
+                  "type": "string",
+                  "pattern": "^item1$"
+                },
+                "fooz": {
+                  "type": "string",
+                  "pattern": "^fooz$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "foo",
+                "fooz"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^ResourceInterface$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/resource_interfaces/item2"
+                },
+                "foo": {
+                  "type": "string",
+                  "pattern": "^item2$"
+                },
+                "fooz": {
+                  "type": "string",
+                  "pattern": "^fooz$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "foo",
+                "fooz"
+              ]
+            }
+          ],
+          "additionalItems": false
+        }
+      },
+      "required": [
+        "hydra:member"
+      ]
+    }
+    """
 
   Scenario: Get an interface resource item
     When I send a "GET" request to "/resource_interfaces/some-id"
@@ -334,19 +532,267 @@ Feature: Table inheritance
     {
       "type": "object",
       "properties": {
-        "context": {
+        "@context": {
           "type": "string",
-          "pattern": "ResourceInterface$"
+          "pattern": "^/contexts/ResourceInterface$"
+        },
+        "@id": {
+          "type": "string",
+          "pattern": "^/resource_interfaces/single%2520item$"
+        },
+        "@type": {
+          "type": "string",
+          "pattern": "^ResourceInterface$"
         },
         "foo": {
           "type": "string",
-          "required": "true"
+          "pattern": "^single item$"
         },
         "fooz": {
           "type": "string",
-          "required": "true",
           "pattern": "fooz"
         }
-      }
+      },
+      "required": [
+        "@context",
+        "@id",
+        "@type",
+        "foo",
+        "fooz"
+      ],
+      "additionalProperties": false
+    }
+    """
+
+  @!mongodb
+  Scenario: Generate iri from parent resource
+    Given there are 3 sites with internal owner
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/sites"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "hydra:member": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^Site$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/sites/1$"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string",
+                  "pattern": "^/custom_users/1$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "title",
+                "description",
+                "owner"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^Site$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/sites/2$"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string",
+                  "pattern": "^/custom_users/2$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "title",
+                "description",
+                "owner"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^Site$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/sites/3$"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string",
+                  "pattern": "^/custom_users/3$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "title",
+                "description",
+                "owner"
+              ]
+            }
+          ],
+          "additionalItems": false
+        }
+      },
+      "required": [
+        "hydra:member"
+      ]
+    }
+    """
+
+  @!mongodb
+  @createSchema
+  Scenario: Generate iri from current resource even if parent class is a resource
+    Given there are 3 sites with external owner
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/sites"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "hydra:member": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^Site$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/sites/1$"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string",
+                  "pattern": "^/external_users/1$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "title",
+                "description",
+                "owner"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^Site$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/sites/2$"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string",
+                  "pattern": "^/external_users/2$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "title",
+                "description",
+                "owner"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@type": {
+                  "type": "string",
+                  "pattern": "^Site$"
+                },
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/sites/3$"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string",
+                  "pattern": "^/external_users/3$"
+                }
+              },
+              "required": [
+                "@type",
+                "@id",
+                "title",
+                "description",
+                "owner"
+              ]
+            }
+          ],
+          "additionalItems": false
+        }
+      },
+      "required": [
+        "hydra:member"
+      ]
     }
     """

--- a/features/security/strong_typing.feature
+++ b/features/security/strong_typing.feature
@@ -73,7 +73,7 @@ Feature: Handle properly invalid data submitted to the API
     And the JSON node "@context" should be equal to "/contexts/Error"
     And the JSON node "@type" should be equal to "hydra:Error"
     And the JSON node "hydra:title" should be equal to "An error occurred"
-    And the JSON node "hydra:description" should be equal to 'Expected IRI or nested document for attribute "relatedDummy", "string" given.'
+    And the JSON node "hydra:description" should be equal to 'Invalid IRI "1".'
     And the JSON node "trace" should exist
 
   Scenario: Ignore invalid dates

--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -26,28 +26,28 @@ Feature: Value object as ApiResource
     Then the response status code should be 201
     And the JSON should be equal to:
     """
-     {
-         "@context": "/contexts/VoDummyCar",
-         "@id": "/vo_dummy_cars/1",
-         "@type": "VoDummyCar",
-         "mileage": 1500,
-         "bodyType": "suv",
-         "inspections": [],
-         "make": "CustomCar",
-         "insuranceCompany": {
-             "@id": "/vo_dummy_insurance_companies/1",
-             "@type": "VoDummyInsuranceCompany",
-             "name": "Safe Drive Company"
-         },
-         "drivers": [
-             {
-                 "@id": "/vo_dummy_drivers/1",
-                 "@type": "VoDummyDriver",
-                 "firstName": "John",
-                 "lastName": "Doe"
-             }
-         ]
-     }
+    {
+        "@context": "/contexts/VoDummyCar",
+        "@id": "/vo_dummy_cars/1",
+        "@type": "VoDummyCar",
+        "mileage": 1500,
+        "bodyType": "suv",
+        "inspections": [],
+        "make": "CustomCar",
+        "insuranceCompany": {
+            "@id": "/vo_dummy_insurance_companies/1",
+            "@type": "VoDummyInsuranceCompany",
+            "name": "Safe Drive Company"
+        },
+        "drivers": [
+            {
+                "@id": "/vo_dummy_drivers/1",
+                "@type": "VoDummyDriver",
+                "firstName": "John",
+                "lastName": "Doe"
+            }
+        ]
+    }
     """
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
@@ -98,8 +98,7 @@ Feature: Value object as ApiResource
         "@type": "VoDummyInspection",
         "accepted": true,
         "car": "/vo_dummy_cars/1",
-        "performed": "2018-08-24T00:00:00+00:00",
-        "id": 1
+        "performed": "2018-08-24T00:00:00+00:00"
     }
     """
 
@@ -117,27 +116,36 @@ Feature: Value object as ApiResource
     }
     """
     Then the response status code should be 400
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be valid according to this schema:
     """
     {
       "type": "object",
       "properties": {
         "@context": {
-          "enum": ["/contexts/Error"]
+          "type": "string",
+          "pattern": "^/contexts/Error$"
         },
-        "type": {
-          "enum": ["hydra:Error"]
+        "@type": {
+          "type": "string",
+          "pattern": "^hydra:Error$"
         },
         "hydra:title": {
-          "enum": ["An error occurred"]
+          "type": "string",
+          "pattern": "^An error occurred$"
         },
         "hydra:description": {
           "pattern": "^Cannot create an instance of ApiPlatform\\\\Core\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar from serialized data because its constructor requires parameter \"drivers\" to be present.$"
         }
-      }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "hydra:title",
+        "hydra:description"
+      ]
     }
     """
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
   @createSchema
   Scenario: Create Value object without default param

--- a/src/Api/CachedIdentifiersExtractor.php
+++ b/src/Api/CachedIdentifiersExtractor.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Api;
 
-use ApiPlatform\Core\Util\ClassInfoTrait;
+use ApiPlatform\Core\Util\ResourceClassInfoTrait;
 use Psr\Cache\CacheException;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -26,14 +26,13 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 final class CachedIdentifiersExtractor implements IdentifiersExtractorInterface
 {
-    use ClassInfoTrait;
+    use ResourceClassInfoTrait;
 
     public const CACHE_KEY_PREFIX = 'iri_identifiers';
 
     private $cacheItemPool;
     private $propertyAccessor;
     private $decorated;
-    private $resourceClassResolver;
     private $localCache = [];
     private $localResourceCache = [];
 
@@ -82,9 +81,7 @@ final class CachedIdentifiersExtractor implements IdentifiersExtractorInterface
                 continue;
             }
 
-            $relatedResourceClass = $this->getObjectClass($identifiers[$propertyName]);
-
-            if (null !== $this->resourceClassResolver && !$this->resourceClassResolver->isResourceClass($relatedResourceClass)) {
+            if (null === $relatedResourceClass = $this->getResourceClass($identifiers[$propertyName])) {
                 continue;
             }
 

--- a/src/Api/IdentifiersExtractor.php
+++ b/src/Api/IdentifiersExtractor.php
@@ -16,7 +16,7 @@ namespace ApiPlatform\Core\Api;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
-use ApiPlatform\Core\Util\ClassInfoTrait;
+use ApiPlatform\Core\Util\ResourceClassInfoTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -27,12 +27,11 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 final class IdentifiersExtractor implements IdentifiersExtractorInterface
 {
-    use ClassInfoTrait;
+    use ResourceClassInfoTrait;
 
     private $propertyNameCollectionFactory;
     private $propertyMetadataFactory;
     private $propertyAccessor;
-    private $resourceClassResolver;
 
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, PropertyAccessorInterface $propertyAccessor = null, ResourceClassResolverInterface $resourceClassResolver = null)
     {
@@ -67,7 +66,8 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
     public function getIdentifiersFromItem($item): array
     {
         $identifiers = [];
-        $resourceClass = $this->getObjectClass($item);
+        $resourceClass = $this->getResourceClass($item, true);
+
         foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $propertyName) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $propertyName);
             $identifier = $propertyMetadata->isIdentifier();
@@ -81,9 +81,7 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
                 continue;
             }
 
-            $relatedResourceClass = $this->getObjectClass($identifier);
-
-            if (null !== $this->resourceClassResolver && !$this->resourceClassResolver->isResourceClass($relatedResourceClass)) {
+            if (null === $relatedResourceClass = $this->getResourceClass($identifier)) {
                 continue;
             }
 

--- a/src/Api/ResourceClassResolverInterface.php
+++ b/src/Api/ResourceClassResolverInterface.php
@@ -25,6 +25,9 @@ interface ResourceClassResolverInterface
     /**
      * Guesses the associated resource.
      *
+     * @param string $resourceClass The expected resource class
+     * @param bool   $strict        If true, value must match the expected resource class
+     *
      * @throws InvalidArgumentException
      */
     public function getResourceClass($value, string $resourceClass = null, bool $strict = false): string;

--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -19,7 +19,7 @@ use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use ApiPlatform\Core\Util\ClassInfoTrait;
+use ApiPlatform\Core\Util\ResourceClassInfoTrait;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Mercure\Update;
@@ -35,9 +35,8 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 final class PublishMercureUpdatesListener
 {
-    use ClassInfoTrait;
+    use ResourceClassInfoTrait;
 
-    private $resourceClassResolver;
     private $iriConverter;
     private $resourceMetadataFactory;
     private $serializer;
@@ -120,8 +119,7 @@ final class PublishMercureUpdatesListener
      */
     private function storeEntityToPublish($entity, string $property): void
     {
-        $resourceClass = $this->getObjectClass($entity);
-        if (!$this->resourceClassResolver->isResourceClass($resourceClass)) {
+        if (null === $resourceClass = $this->getResourceClass($entity)) {
             return;
         }
 

--- a/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -81,6 +81,8 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
     }
 
     /**
+     * {@inheritdoc}
+     *
      * The context may contain serialization groups which helps defining joined entities that are readable.
      */
     public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null, array $context = [])
@@ -111,6 +113,10 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
             return;
         }
 
+        if (!empty($context[AbstractNormalizer::GROUPS])) {
+            $options['serializer_groups'] = $context[AbstractNormalizer::GROUPS];
+        }
+
         $this->joinRelations($queryBuilder, $queryNameGenerator, $resourceClass, $forceEager, $fetchPartial, $queryBuilder->getRootAliases()[0], $options, $context);
     }
 
@@ -133,10 +139,6 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
         $entityManager = $queryBuilder->getEntityManager();
         $classMetadata = $entityManager->getClassMetadata($resourceClass);
         $attributesMetadata = $this->classMetadataFactory ? $this->classMetadataFactory->getMetadataFor($resourceClass)->getAttributesMetadata() : null;
-
-        if (!empty($normalizationContext[AbstractNormalizer::GROUPS])) {
-            $options['serializer_groups'] = $normalizationContext[AbstractNormalizer::GROUPS];
-        }
 
         foreach ($classMetadata->associationMappings as $association => $mapping) {
             //Don't join if max depth is enabled and the current depth limit is reached

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -61,6 +61,7 @@
             <argument type="service" id="api_platform.identifiers_extractor.cached" />
             <argument type="service" id="api_platform.subresource_data_provider" on-invalid="ignore" />
             <argument type="service" id="api_platform.identifier.converter" on-invalid="ignore" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
         </service>
         <service id="ApiPlatform\Core\Api\IriConverterInterface" alias="api_platform.iri_converter" />
 

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IdentifiersExtractor;
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\OperationDataProviderTrait;
@@ -29,7 +30,7 @@ use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Util\AttributesExtractor;
-use ApiPlatform\Core\Util\ClassInfoTrait;
+use ApiPlatform\Core\Util\ResourceClassInfoTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;
@@ -42,14 +43,14 @@ use Symfony\Component\Routing\RouterInterface;
  */
 final class IriConverter implements IriConverterInterface
 {
-    use ClassInfoTrait;
+    use ResourceClassInfoTrait;
     use OperationDataProviderTrait;
 
     private $routeNameResolver;
     private $router;
     private $identifiersExtractor;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ItemDataProviderInterface $itemDataProvider, RouteNameResolverInterface $routeNameResolver, RouterInterface $router, PropertyAccessorInterface $propertyAccessor = null, IdentifiersExtractorInterface $identifiersExtractor = null, SubresourceDataProviderInterface $subresourceDataProvider = null, IdentifierConverterInterface $identifierConverter = null)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ItemDataProviderInterface $itemDataProvider, RouteNameResolverInterface $routeNameResolver, RouterInterface $router, PropertyAccessorInterface $propertyAccessor = null, IdentifiersExtractorInterface $identifiersExtractor = null, SubresourceDataProviderInterface $subresourceDataProvider = null, IdentifierConverterInterface $identifierConverter = null, ResourceClassResolverInterface $resourceClassResolver = null)
     {
         $this->itemDataProvider = $itemDataProvider;
         $this->routeNameResolver = $routeNameResolver;
@@ -57,6 +58,7 @@ final class IriConverter implements IriConverterInterface
         $this->identifiersExtractor = $identifiersExtractor;
         $this->subresourceDataProvider = $subresourceDataProvider;
         $this->identifierConverter = $identifierConverter;
+        $this->resourceClassResolver = $resourceClassResolver;
 
         if (null === $identifiersExtractor) {
             @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3', IdentifiersExtractorInterface::class), E_USER_DEPRECATED);
@@ -115,7 +117,7 @@ final class IriConverter implements IriConverterInterface
      */
     public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string
     {
-        $resourceClass = $this->getObjectClass($item);
+        $resourceClass = $this->getResourceClass($item, true);
         $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
 
         try {

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -77,12 +77,14 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
 
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             $wrapFieldName = lcfirst($resourceMetadata->getShortName());
-            $normalizationContext = $resourceMetadata->getGraphqlAttribute($operationName ?? '', 'normalization_context', [], true);
-            $normalizationContext['attributes'] = $this->fieldsToAttributes($info)[$wrapFieldName] ?? [];
+            $baseNormalizationContext = $resourceMetadata->getGraphqlAttribute($operationName ?? '', 'normalization_context', [], true);
+            $baseNormalizationContext['attributes'] = $this->fieldsToAttributes($info)[$wrapFieldName] ?? [];
+            $normalizationContext = $baseNormalizationContext;
+            $normalizationContext['resource_class'] = $resourceClass;
 
             if (isset($args['input']['id'])) {
                 try {
-                    $item = $this->iriConverter->getItemFromIri($args['input']['id'], $normalizationContext);
+                    $item = $this->iriConverter->getItemFromIri($args['input']['id'], $baseNormalizationContext);
                 } catch (ItemNotFoundException $e) {
                     throw Error::createLocatedError(sprintf('Item "%s" not found.', $args['input']['id']), $info->fieldNodes, $info->path);
                 }

--- a/src/GraphQl/Resolver/ItemResolver.php
+++ b/src/GraphQl/Resolver/ItemResolver.php
@@ -72,6 +72,7 @@ final class ItemResolver
         $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $item, 'query');
 
         $normalizationContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
+        $normalizationContext['resource_class'] = $resourceClass;
 
         return $this->normalizer->normalize($item, ItemNormalizer::FORMAT, $normalizationContext + $baseNormalizationContext);
     }

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -56,8 +56,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $context['cache_key'] = $this->getHalCacheKey($format, $context);
         }
 
-        // Use resolved resource class instead of given resource class to support multiple inheritance child types
-        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
+        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, isset($context['resource_class']));
         $context = $this->initContext($resourceClass, $context);
         $iri = $this->iriConverter->getIriFromItem($object);
         $context['iri'] = $iri;

--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -17,7 +17,6 @@ use ApiPlatform\Core\Api\FilterCollection;
 use ApiPlatform\Core\Api\FilterInterface;
 use ApiPlatform\Core\Api\FilterLocatorTrait;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
-use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
@@ -71,19 +70,12 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
     public function normalize($object, $format = null, array $context = [])
     {
         $data = $this->collectionNormalizer->normalize($object, $format, $context);
-        if (isset($context['api_sub_level'])) {
+
+        if (!isset($context['resource_class']) || isset($context['api_sub_level'])) {
             return $data;
         }
 
-        try {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
-        } catch (InvalidArgumentException $e) {
-            if (!isset($context['resource_class'])) {
-                return $data;
-            }
-
-            throw $e;
-        }
+        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class']);
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
 
         $operationName = $context['collection_operation_name'] ?? null;

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -18,7 +18,6 @@ use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
-use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait;
 use ApiPlatform\Core\Serializer\ContextTrait;
@@ -67,21 +66,13 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        if (isset($context['api_sub_level'])) {
+        if (!isset($context['resource_class']) || isset($context['api_sub_level'])) {
             return $this->normalizeRawCollection($object, $format, $context);
         }
 
-        try {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
-        } catch (InvalidArgumentException $e) {
-            if (!isset($context['resource_class'])) {
-                return $this->normalizeRawCollection($object, $format, $context);
-            }
-
-            throw $e;
-        }
-        $data = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
+        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class']);
         $context = $this->initContext($resourceClass, $context);
+        $data = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
 
         if (isset($context['operation_type']) && OperationType::SUBRESOURCE === $context['operation_type']) {
             $data['@id'] = $this->iriConverter->getSubresourceIriFromResourceClass($resourceClass, $context);

--- a/src/JsonApi/Serializer/ObjectNormalizer.php
+++ b/src/JsonApi/Serializer/ObjectNormalizer.php
@@ -75,7 +75,7 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
         }
 
         if (isset($originalResource)) {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($originalResource, $context['resource_class'] ?? null, true);
+            $resourceClass = $this->resourceClassResolver->getResourceClass($originalResource);
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
 
             $resourceData = [

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -69,8 +69,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             return parent::normalize($object, $format, $context);
         }
 
-        // Use resolved resource class instead of given resource class to support multiple inheritance child types
-        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
+        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, isset($context['resource_class']));
         $context = $this->initContext($resourceClass, $context);
         $iri = $this->iriConverter->getIriFromItem($object);
         $context['iri'] = $iri;

--- a/src/Serializer/AbstractCollectionNormalizer.php
+++ b/src/Serializer/AbstractCollectionNormalizer.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Core\Serializer;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
-use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -71,21 +70,13 @@ abstract class AbstractCollectionNormalizer implements NormalizerInterface, Norm
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        if (isset($context['api_sub_level'])) {
+        if (!isset($context['resource_class']) || isset($context['api_sub_level'])) {
             return $this->normalizeRawCollection($object, $format, $context);
         }
 
-        try {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null, true);
-        } catch (InvalidArgumentException $e) {
-            if (!isset($context['resource_class'])) {
-                return $this->normalizeRawCollection($object, $format, $context);
-            }
-
-            throw $e;
-        }
-        $data = [];
+        $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class']);
         $context = $this->initContext($resourceClass, $context);
+        $data = [];
 
         return array_merge_recursive(
             $data,

--- a/src/Util/ResourceClassInfoTrait.php
+++ b/src/Util/ResourceClassInfoTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Util;
+
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+
+/**
+ * Retrieves information about a resource class.
+ *
+ * @internal
+ */
+trait ResourceClassInfoTrait
+{
+    use ClassInfoTrait;
+
+    /**
+     * @var ResourceClassResolverInterface|null
+     */
+    private $resourceClassResolver;
+
+    /**
+     * Gets the resource class of the given object.
+     *
+     * @param object $object
+     * @param bool   $strict If true, object class is expected to be a resource class
+     *
+     * @return string|null The resource class, or null if object class is not a resource class
+     */
+    private function getResourceClass($object, bool $strict = false): ?string
+    {
+        $objectClass = $this->getObjectClass($object);
+
+        if (null === $this->resourceClassResolver) {
+            return $objectClass;
+        }
+
+        if (!$strict && !$this->resourceClassResolver->isResourceClass($objectClass)) {
+            return null;
+        }
+
+        return $this->resourceClassResolver->getResourceClass($object);
+    }
+}

--- a/tests/Api/IdentifiersExtractorTest.php
+++ b/tests/Api/IdentifiersExtractorTest.php
@@ -23,6 +23,8 @@ use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Doctrine\Generator\Uuid;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\OtherResources\ResourceInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\OtherResources\ResourceInterfaceImplementation;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -31,32 +33,13 @@ use Prophecy\Argument;
  */
 class IdentifiersExtractorTest extends TestCase
 {
-    private function getMetadataFactoryProphecies($class, $identifiers, array $prophecies = null)
-    {
-        //adds a random property that is not an identifier
-        $properties = array_merge(['foo'], $identifiers);
-
-        if (!$prophecies) {
-            $prophecies = [$this->prophesize(PropertyNameCollectionFactoryInterface::class), $this->prophesize(PropertyMetadataFactoryInterface::class)];
-        }
-
-        [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $prophecies;
-
-        $propertyNameCollectionFactoryProphecy->create($class)->shouldBeCalled()->willReturn(new PropertyNameCollection($properties));
-
-        foreach ($properties as $prop) {
-            $metadata = new PropertyMetadata();
-            $propertyMetadataFactoryProphecy->create($class, $prop)->shouldBeCalled()->willReturn($metadata->withIdentifier(\in_array($prop, $identifiers, true)));
-        }
-
-        return [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy];
-    }
-
     public function testGetIdentifiersFromResourceClass()
     {
         [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $this->getMetadataFactoryProphecies(Dummy::class, ['id']);
 
-        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $this->getResourceClassResolver());
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
 
         $this->assertSame(['id'], $identifiersExtractor->getIdentifiersFromResourceClass(Dummy::class));
     }
@@ -65,7 +48,9 @@ class IdentifiersExtractorTest extends TestCase
     {
         [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'name']);
 
-        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $this->getResourceClassResolver());
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
 
         $this->assertSame(['id', 'name'], $identifiersExtractor->getIdentifiersFromResourceClass(Dummy::class));
     }
@@ -89,7 +74,11 @@ class IdentifiersExtractorTest extends TestCase
     {
         [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $this->getMetadataFactoryProphecies(Dummy::class, ['id']);
 
-        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $this->getResourceClassResolver());
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($item)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->isResourceClass(Uuid::class)->willReturn(false);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
 
         $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
     }
@@ -114,7 +103,11 @@ class IdentifiersExtractorTest extends TestCase
     {
         [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'name']);
 
-        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $this->getResourceClassResolver());
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($item)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->isResourceClass(Uuid::class)->willReturn(false);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
 
         $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
     }
@@ -148,7 +141,13 @@ class IdentifiersExtractorTest extends TestCase
         $prophecies = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'relatedDummy']);
         [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $this->getMetadataFactoryProphecies(RelatedDummy::class, ['id'], $prophecies);
 
-        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $this->getResourceClassResolver());
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($item)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(RelatedDummy::class))->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
+        $resourceClassResolverProphecy->isResourceClass(Uuid::class)->willReturn(false);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
 
         $this->assertSame($expected, $identifiersExtractor->getIdentifiersFromItem($item));
     }
@@ -158,11 +157,6 @@ class IdentifiersExtractorTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No identifier found in "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\RelatedDummy" through relation "relatedDummy" of "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy" used as identifier');
 
-        $prophecies = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'relatedDummy']);
-        [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $this->getMetadataFactoryProphecies(RelatedDummy::class, [], $prophecies);
-
-        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $this->getResourceClassResolver());
-
         $related = new RelatedDummy();
         $related->setId(2);
 
@@ -170,17 +164,39 @@ class IdentifiersExtractorTest extends TestCase
         $dummy->setId(1);
         $dummy->setRelatedDummy($related);
 
+        $prophecies = $this->getMetadataFactoryProphecies(Dummy::class, ['id', 'relatedDummy']);
+        [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $this->getMetadataFactoryProphecies(RelatedDummy::class, [], $prophecies);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(RelatedDummy::class))->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
+
         $identifiersExtractor->getIdentifiersFromItem($dummy);
     }
 
-    private function getResourceClassResolver()
+    public function testGetsIdentifiersFromCorrectResourceClass(): void
     {
-        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolver->isResourceClass(Argument::type('string'))->will(function ($args) {
-            return !(Uuid::class === $args[0]);
-        });
+        $item = new ResourceInterfaceImplementation();
+        $item->setFoo('woot');
 
-        return $resourceClassResolver->reveal();
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(ResourceInterface::class)->willReturn(new PropertyNameCollection(['foo', 'fooz']));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(ResourceInterface::class, 'foo')->willReturn((new PropertyMetadata())->withIdentifier(true));
+        $propertyMetadataFactoryProphecy->create(ResourceInterface::class, 'fooz')->willReturn(new PropertyMetadata());
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($item)->willReturn(ResourceInterface::class);
+
+        $identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
+
+        $identifiersExtractor->getIdentifiersFromItem($item);
+
+        $this->assertSame(['foo' => 'woot'], $identifiersExtractor->getIdentifiersFromItem($item));
     }
 
     /**
@@ -197,5 +213,26 @@ class IdentifiersExtractorTest extends TestCase
         $dummy->setId(1);
 
         $this->assertSame(['id' => 1], $identifiersExtractor->getIdentifiersFromItem($dummy));
+    }
+
+    private function getMetadataFactoryProphecies($class, $identifiers, array $prophecies = null)
+    {
+        //adds a random property that is not an identifier
+        $properties = array_merge(['foo'], $identifiers);
+
+        if (!$prophecies) {
+            $prophecies = [$this->prophesize(PropertyNameCollectionFactoryInterface::class), $this->prophesize(PropertyMetadataFactoryInterface::class)];
+        }
+
+        [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy] = $prophecies;
+
+        $propertyNameCollectionFactoryProphecy->create($class)->willReturn(new PropertyNameCollection($properties));
+
+        foreach ($properties as $prop) {
+            $metadata = new PropertyMetadata();
+            $propertyMetadataFactoryProphecy->create($class, $prop)->willReturn($metadata->withIdentifier(\in_array($prop, $identifiers, true)));
+        }
+
+        return [$propertyNameCollectionFactoryProphecy, $propertyMetadataFactoryProphecy];
     }
 }

--- a/tests/Api/ResourceClassResolverTest.php
+++ b/tests/Api/ResourceClassResolverTest.php
@@ -33,67 +33,71 @@ class ResourceClassResolverTest extends TestCase
 {
     public function testGetResourceClassWithIntendedClassName()
     {
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]));
+
         $dummy = new Dummy();
         $dummy->setName('Smail');
-        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClass = $resourceClassResolver->getResourceClass($dummy, Dummy::class);
-        $this->assertEquals($resourceClass, Dummy::class);
+
+        $this->assertEquals(Dummy::class, $resourceClassResolver->getResourceClass($dummy, Dummy::class));
     }
 
-    public function testGetResourceClassWithOtherClassName()
+    public function testGetResourceClassWithNonResourceClassName()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Specified class "ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar" is not a resource class.');
+
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]));
+
         $dummy = new Dummy();
         $dummy->setName('Smail');
-        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClass = $resourceClassResolver->getResourceClass($dummy, DummyCar::class, true);
-        $this->assertEquals($resourceClass, Dummy::class);
+
+        $resourceClassResolver->getResourceClass($dummy, DummyCar::class, true);
     }
 
     public function testGetResourceClassWithNoClassName()
     {
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]));
+
         $dummy = new Dummy();
         $dummy->setName('Smail');
-        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClass = $resourceClassResolver->getResourceClass($dummy);
-        $this->assertEquals($resourceClass, Dummy::class);
+
+        $this->assertEquals(Dummy::class, $resourceClassResolver->getResourceClass($dummy));
     }
 
     public function testGetResourceClassWithTraversableAsValue()
     {
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]));
+
         $dummy = new Dummy();
         $dummy->setName('JLM');
 
         $dummies = new \ArrayIterator([$dummy]);
 
-        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
-
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClass = $resourceClassResolver->getResourceClass($dummies, Dummy::class);
 
-        $this->assertEquals($resourceClass, Dummy::class);
+        $this->assertEquals(Dummy::class, $resourceClassResolver->getResourceClass($dummies, Dummy::class));
     }
 
     public function testGetResourceClassWithPaginatorInterfaceAsValue()
     {
-        $paginatorProphecy = $this->prophesize(PaginatorInterface::class);
-
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
 
-        $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClass = $resourceClassResolver->getResourceClass($paginatorProphecy->reveal(), Dummy::class);
+        $paginatorProphecy = $this->prophesize(PaginatorInterface::class);
 
-        $this->assertEquals($resourceClass, Dummy::class);
+        $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+
+        $this->assertEquals(Dummy::class, $resourceClassResolver->getResourceClass($paginatorProphecy->reveal(), Dummy::class));
     }
 
     public function testGetResourceClassWithWrongClassName()
@@ -105,82 +109,85 @@ class ResourceClassResolverTest extends TestCase
         $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+
         $resourceClassResolver->getResourceClass(new \stdClass());
     }
 
     public function testGetResourceClassWithNoResourceClassName()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No resource class found.');
+        $this->expectExceptionMessage('Resource type could not be determined. Resource class must be specified.');
 
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+
         $resourceClassResolver->getResourceClass(new \ArrayIterator([]));
     }
 
     public function testIsResourceClassWithIntendedClassName()
     {
-        $dummy = new Dummy();
-        $dummy->setName('Smail');
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]));
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClass = $resourceClassResolver->isResourceClass(Dummy::class);
-        $this->assertTrue($resourceClass);
+
+        $this->assertTrue($resourceClassResolver->isResourceClass(Dummy::class));
     }
 
     public function testIsResourceClassWithWrongClassName()
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([\ArrayIterator::class]))->shouldBeCalled();
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([\ArrayIterator::class]));
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClass = $resourceClassResolver->isResourceClass('');
-        $this->assertFalse($resourceClass);
+
+        $this->assertFalse($resourceClassResolver->isResourceClass(''));
     }
 
     public function testGetResourceClassWithNoResourceClassNameAndNoObject()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No resource class found.');
+        $this->expectExceptionMessage('Resource type could not be determined. Resource class must be specified.');
 
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+
         $resourceClassResolver->getResourceClass(false);
     }
 
     public function testGetResourceClassWithResourceClassNameAndNoObject()
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]))->shouldBeCalled();
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([Dummy::class]));
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $this->assertEquals($resourceClassResolver->getResourceClass(false, Dummy::class), Dummy::class);
+
+        $this->assertEquals(Dummy::class, $resourceClassResolver->getResourceClass(false, Dummy::class));
     }
 
     public function testGetResourceClassWithChildResource()
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([DummyTableInheritance::class]))->shouldBeCalled();
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([DummyTableInheritance::class, DummyTableInheritanceChild::class]));
 
-        $t = new DummyTableInheritanceChild();
+        $dummy = new DummyTableInheritanceChild();
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
 
-        $this->assertEquals(DummyTableInheritanceChild::class, $resourceClassResolver->getResourceClass($t, DummyTableInheritance::class));
+        $this->assertEquals(DummyTableInheritanceChild::class, $resourceClassResolver->getResourceClass($dummy, DummyTableInheritance::class));
     }
 
     public function testGetResourceClassWithInterfaceResource()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The given object's resource is the interface \"ApiPlatform\Core\Tests\Fixtures\DummyResourceInterface\", finding a class is not possible.");
-        $dummy = new DummyResourceImplementation();
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([DummyResourceInterface::class]));
+
+        $dummy = new DummyResourceImplementation();
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
-        $resourceClassResolver->getResourceClass($dummy, DummyResourceInterface::class, true);
+
+        $this->assertEquals(DummyResourceInterface::class, $resourceClassResolver->getResourceClass($dummy, DummyResourceInterface::class, true));
     }
 }

--- a/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Symfony\Component\Mercure\Update;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -52,6 +53,9 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $toDeleteExpressionLanguage->setId(4);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(DummyCar::class))->willReturn(DummyCar::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(DummyFriend::class))->willReturn(DummyFriend::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
         $resourceClassResolverProphecy->isResourceClass(DummyCar::class)->willReturn(true);
@@ -135,6 +139,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $toInsert = new Dummy();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);

--- a/tests/Fixtures/TestBundle/Document/DummyTableInheritance.php
+++ b/tests/Fixtures/TestBundle/Document/DummyTableInheritance.php
@@ -21,7 +21,12 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField(value="discr")
- * @ODM\DiscriminatorMap({"dummyTableInheritance"=DummyTableInheritance::class, "dummyTableInheritanceChild"=DummyTableInheritanceChild::class, "dummyTableInheritanceDifferentChild"=DummyTableInheritanceDifferentChild::class})
+ * @ODM\DiscriminatorMap({
+ *     "dummyTableInheritance"=DummyTableInheritance::class,
+ *     "dummyTableInheritanceChild"=DummyTableInheritanceChild::class,
+ *     "dummyTableInheritanceDifferentChild"=DummyTableInheritanceDifferentChild::class,
+ *     "dummyTableInheritanceNotApiResourceChild"=DummyTableInheritanceNotApiResourceChild::class
+ * })
  * @ApiResource
  */
 class DummyTableInheritance

--- a/tests/Fixtures/TestBundle/Document/DummyTableInheritanceNotApiResourceChild.php
+++ b/tests/Fixtures/TestBundle/Document/DummyTableInheritanceNotApiResourceChild.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class DummyTableInheritanceNotApiResourceChild extends DummyTableInheritance
+{
+    /**
+     * @var bool The dummy swagg
+     *
+     * @ODM\Field(type="boolean")
+     */
+    private $swaggerThanParent;
+
+    public function __construct()
+    {
+        // Definitely always swagger than parents
+        $this->swaggerThanParent = true;
+    }
+
+    public function isSwaggerThanParent(): bool
+    {
+        return $this->swaggerThanParent;
+    }
+
+    public function setSwaggerThanParent(bool $swaggerThanParent)
+    {
+        $this->swaggerThanParent = $swaggerThanParent;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/VoDummyCar.php
+++ b/tests/Fixtures/TestBundle/Document/VoDummyCar.php
@@ -21,8 +21,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ApiResource(attributes={
- *     "normalization_context"={"groups"={"read", "write"}},
- *     "denormalization_context"={"groups"={"write"}}
+ *     "normalization_context"={"groups"={"car_read"}},
+ *     "denormalization_context"={"groups"={"car_write"}}
  * })
  * @ODM\Document
  */
@@ -32,7 +32,7 @@ class VoDummyCar extends VoDummyVehicle
      * @var int
      *
      * @ODM\Field(type="integer")
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $mileage;
 
@@ -40,7 +40,7 @@ class VoDummyCar extends VoDummyVehicle
      * @var string
      *
      * @ODM\Field
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $bodyType;
 
@@ -48,7 +48,7 @@ class VoDummyCar extends VoDummyVehicle
      * @var VoDummyInspection[]|Collection
      *
      * @ODM\ReferenceMany(targetDocument=VoDummyInspection::class, mappedBy="car", cascade={"persist"})
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $inspections;
 

--- a/tests/Fixtures/TestBundle/Document/VoDummyDriver.php
+++ b/tests/Fixtures/TestBundle/Document/VoDummyDriver.php
@@ -29,7 +29,7 @@ class VoDummyDriver
      * @var string
      *
      * @ODM\Field
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $firstName;
 
@@ -37,7 +37,7 @@ class VoDummyDriver
      * @var string
      *
      * @ODM\Field
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $lastName;
 

--- a/tests/Fixtures/TestBundle/Document/VoDummyInspection.php
+++ b/tests/Fixtures/TestBundle/Document/VoDummyInspection.php
@@ -19,7 +19,10 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
- * @ApiResource
+ * @ApiResource(attributes={
+ *     "normalization_context"={"groups"={"inspection_read"}},
+ *     "denormalization_context"={"groups"={"inspection_write"}}
+ * })
  * @ODM\Document
  */
 class VoDummyInspection
@@ -30,7 +33,7 @@ class VoDummyInspection
      * @var bool
      *
      * @ODM\Field(type="boolean")
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write", "inspection_read", "inspection_write"})
      */
     private $accepted;
 
@@ -38,7 +41,7 @@ class VoDummyInspection
      * @var VoDummyCar
      *
      * @ODM\ReferenceOne(targetDocument=VoDummyCar::class, inversedBy="inspections")
-     * @Groups({"write"})
+     * @Groups({"inspection_read", "inspection_write"})
      */
     private $car;
 
@@ -46,7 +49,7 @@ class VoDummyInspection
      * @var DateTime
      *
      * @ODM\Field(type="date")
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write", "inspection_read", "inspection_write"})
      */
     private $performed;
 

--- a/tests/Fixtures/TestBundle/Document/VoDummyInsuranceCompany.php
+++ b/tests/Fixtures/TestBundle/Document/VoDummyInsuranceCompany.php
@@ -29,7 +29,7 @@ class VoDummyInsuranceCompany
      * @var string
      *
      * @ODM\Field
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $name;
 

--- a/tests/Fixtures/TestBundle/Document/VoDummyVehicle.php
+++ b/tests/Fixtures/TestBundle/Document/VoDummyVehicle.php
@@ -29,7 +29,7 @@ abstract class VoDummyVehicle
      * @var string
      *
      * @ODM\Field
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $make;
 
@@ -37,7 +37,7 @@ abstract class VoDummyVehicle
      * @var VoDummyInsuranceCompany
      *
      * @ODM\ReferenceOne(targetDocument=VoDummyInsuranceCompany::class, cascade={"persist"})
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $insuranceCompany;
 
@@ -45,7 +45,7 @@ abstract class VoDummyVehicle
      * @var VoDummyDriver[]|Collection
      *
      * @ODM\ReferenceMany(targetDocument=VoDummyDriver::class, cascade={"persist"})
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $drivers;
 

--- a/tests/Fixtures/TestBundle/Entity/AbstractUser.php
+++ b/tests/Fixtures/TestBundle/Entity/AbstractUser.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ApiResource(
+ *     collectionOperations={
+ *         "get"={"path"="/custom_users"}
+ *     },
+ *     itemOperations={
+ *         "get"={"path"="/custom_users/{id}"}
+ *     }
+ * )
+ */
+abstract class AbstractUser
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+    /**
+     * @ORM\Column
+     */
+    private $firstname;
+    /**
+     * @ORM\Column
+     */
+    private $lastname;
+    /**
+     * @ORM\Column
+     */
+    private $email;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getFirstname(): ?string
+    {
+        return $this->firstname;
+    }
+
+    public function setFirstname(string $firstname): self
+    {
+        $this->firstname = $firstname;
+
+        return $this;
+    }
+
+    public function getLastname(): ?string
+    {
+        return $this->lastname;
+    }
+
+    public function setLastname(string $lastname): self
+    {
+        $this->lastname = $lastname;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritance.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritance.php
@@ -21,7 +21,12 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @ORM\Entity
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
- * @ORM\DiscriminatorMap({"dummyTableInheritance"="DummyTableInheritance", "dummyTableInheritanceChild"="DummyTableInheritanceChild", "dummyTableInheritanceDifferentChild"="DummyTableInheritanceDifferentChild"})
+ * @ORM\DiscriminatorMap({
+ *     "dummyTableInheritance"="DummyTableInheritance",
+ *     "dummyTableInheritanceChild"="DummyTableInheritanceChild",
+ *     "dummyTableInheritanceDifferentChild"="DummyTableInheritanceDifferentChild",
+ *     "dummyTableInheritanceNotApiResourceChild"="DummyTableInheritanceNotApiResourceChild"
+ * })
  * @ApiResource
  */
 class DummyTableInheritance

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceNotApiResourceChild.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceNotApiResourceChild.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class DummyTableInheritanceNotApiResourceChild extends DummyTableInheritance
+{
+    /**
+     * @var bool The dummy swagg
+     *
+     * @ORM\Column(type="boolean")
+     */
+    private $swaggerThanParent;
+
+    public function __construct()
+    {
+        // Definitely always swagger than parents
+        $this->swaggerThanParent = true;
+    }
+
+    public function isSwaggerThanParent(): bool
+    {
+        return $this->swaggerThanParent;
+    }
+
+    public function setSwaggerThanParent(bool $swaggerThanParent)
+    {
+        $this->swaggerThanParent = $swaggerThanParent;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceRelated.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableInheritanceRelated.php
@@ -44,6 +44,7 @@ class DummyTableInheritanceRelated
      * @var ArrayCollection Related children
      *
      * @ORM\OneToMany(targetEntity="DummyTableInheritance", mappedBy="parent")
+     * @ORM\OrderBy({"id"="ASC"})
      *
      * @Groups({"default"})
      */

--- a/tests/Fixtures/TestBundle/Entity/ExternalUser.php
+++ b/tests/Fixtures/TestBundle/Entity/ExternalUser.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ApiResource
+ */
+class ExternalUser extends AbstractUser
+{
+    /**
+     * @ORM\Column
+     */
+    private $externalId;
+
+    public function getExternalId(): ?string
+    {
+        return $this->externalId;
+    }
+
+    public function setExternalId(string $externalId): self
+    {
+        $this->externalId = $externalId;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/InternalUser.php
+++ b/tests/Fixtures/TestBundle/Entity/InternalUser.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class InternalUser extends AbstractUser
+{
+    /**
+     * @ORM\Column
+     */
+    private $internalId;
+
+    public function getInternalId(): ?string
+    {
+        return $this->internalId;
+    }
+
+    public function setInternalId(string $internalId): self
+    {
+        $this->internalId = $internalId;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Site.php
+++ b/tests/Fixtures/TestBundle/Entity/Site.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class Site
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+    /**
+     * @ORM\Column
+     */
+    private $title;
+    /**
+     * @ORM\Column
+     */
+    private $description;
+    /**
+     * @ORM\OneToOne(targetEntity="AbstractUser", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $owner;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getOwner(): ?AbstractUser
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(AbstractUser $owner): self
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/VoDummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyCar.php
@@ -21,8 +21,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ApiResource(attributes={
- *     "normalization_context"={"groups"={"read", "write"}},
- *     "denormalization_context"={"groups"={"write"}}
+ *     "normalization_context"={"groups"={"car_read"}},
+ *     "denormalization_context"={"groups"={"car_write"}}
  * })
  * @ORM\Entity
  */
@@ -32,7 +32,7 @@ class VoDummyCar extends VoDummyVehicle
      * @var int
      *
      * @ORM\Column(type="integer")
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $mileage;
 
@@ -40,7 +40,7 @@ class VoDummyCar extends VoDummyVehicle
      * @var string
      *
      * @ORM\Column
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $bodyType;
 
@@ -48,7 +48,7 @@ class VoDummyCar extends VoDummyVehicle
      * @var VoDummyInspection[]|Collection
      *
      * @ORM\OneToMany(targetEntity="VoDummyInspection", mappedBy="car", cascade={"persist"})
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $inspections;
 

--- a/tests/Fixtures/TestBundle/Entity/VoDummyDriver.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyDriver.php
@@ -29,7 +29,7 @@ class VoDummyDriver
      * @var string
      *
      * @ORM\Column
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $firstName;
 
@@ -37,7 +37,7 @@ class VoDummyDriver
      * @var string
      *
      * @ORM\Column
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $lastName;
 

--- a/tests/Fixtures/TestBundle/Entity/VoDummyInspection.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyInspection.php
@@ -19,7 +19,10 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
- * @ApiResource
+ * @ApiResource(attributes={
+ *     "normalization_context"={"groups"={"inspection_read"}},
+ *     "denormalization_context"={"groups"={"inspection_write"}}
+ * })
  * @ORM\Entity
  */
 class VoDummyInspection
@@ -30,7 +33,7 @@ class VoDummyInspection
      * @var bool
      *
      * @ORM\Column(type="boolean")
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write", "inspection_read", "inspection_write"})
      */
     private $accepted;
 
@@ -38,7 +41,7 @@ class VoDummyInspection
      * @var VoDummyCar
      *
      * @ORM\ManyToOne(targetEntity="VoDummyCar", inversedBy="inspections")
-     * @Groups({"write"})
+     * @Groups({"inspection_read", "inspection_write"})
      */
     private $car;
 
@@ -46,7 +49,7 @@ class VoDummyInspection
      * @var DateTime
      *
      * @ORM\Column(type="datetime")
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write", "inspection_read", "inspection_write"})
      */
     private $performed;
 

--- a/tests/Fixtures/TestBundle/Entity/VoDummyInsuranceCompany.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyInsuranceCompany.php
@@ -29,7 +29,7 @@ class VoDummyInsuranceCompany
      * @var string
      *
      * @ORM\Column
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $name;
 

--- a/tests/Fixtures/TestBundle/Entity/VoDummyVehicle.php
+++ b/tests/Fixtures/TestBundle/Entity/VoDummyVehicle.php
@@ -29,7 +29,7 @@ abstract class VoDummyVehicle
      * @var string
      *
      * @ORM\Column
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $make;
 
@@ -37,7 +37,7 @@ abstract class VoDummyVehicle
      * @var VoDummyInsuranceCompany
      *
      * @ORM\ManyToOne(targetEntity="VoDummyInsuranceCompany", cascade={"persist"})
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $insuranceCompany;
 
@@ -45,7 +45,7 @@ abstract class VoDummyVehicle
      * @var VoDummyDriver[]|Collection
      *
      * @ORM\ManyToMany(targetEntity="VoDummyDriver", cascade={"persist"})
-     * @Groups({"write"})
+     * @Groups({"car_read", "car_write"})
      */
     private $drivers;
 

--- a/tests/GraphQl/Serializer/ItemNormalizerTest.php
+++ b/tests/GraphQl/Serializer/ItemNormalizerTest.php
@@ -72,21 +72,21 @@ class ItemNormalizerTest extends TestCase
 
         $propertyNameCollection = new PropertyNameCollection(['name']);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection);
 
         $propertyMetadata = new PropertyMetadata(null, null, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, null, false)->willReturn(Dummy::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);
-        $serializerProphecy->normalize('hello', ItemNormalizer::FORMAT, Argument::type('array'))->willReturn('hello')->shouldBeCalled();
+        $serializerProphecy->normalize('hello', ItemNormalizer::FORMAT, Argument::type('array'))->willReturn('hello');
 
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -104,7 +104,13 @@ class ItemNormalizerTest extends TestCase
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
-        $this->assertEquals(['name' => 'hello', ItemNormalizer::ITEM_KEY => serialize($dummy)], $normalizer->normalize($dummy, ItemNormalizer::FORMAT, ['resources' => []]));
+        $expected = [
+            'name' => 'hello',
+            ItemNormalizer::ITEM_KEY => serialize($dummy),
+        ];
+        $this->assertEquals($expected, $normalizer->normalize($dummy, ItemNormalizer::FORMAT, [
+            'resources' => [],
+        ]));
     }
 
     public function testDenormalize()
@@ -122,6 +128,7 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(DenormalizerInterface::class);

--- a/tests/Hal/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hal/Serializer/CollectionNormalizerTest.php
@@ -113,31 +113,34 @@ class CollectionNormalizerTest extends TestCase
     private function normalizePaginator($partial = false)
     {
         $paginatorProphecy = $this->prophesize($partial ? PartialPaginatorInterface::class : PaginatorInterface::class);
-        $paginatorProphecy->getCurrentPage()->willReturn(3)->shouldBeCalled();
-        $paginatorProphecy->getItemsPerPage()->willReturn(12)->shouldBeCalled();
-        $paginatorProphecy->rewind()->shouldBeCalled();
-        $paginatorProphecy->valid()->willReturn(true, false)->shouldBeCalled();
-        $paginatorProphecy->current()->willReturn('foo')->shouldBeCalled();
-        $paginatorProphecy->next()->willReturn()->shouldBeCalled();
+        $paginatorProphecy->getCurrentPage()->willReturn(3);
+        $paginatorProphecy->getItemsPerPage()->willReturn(12);
+        $paginatorProphecy->rewind()->will(function () {});
+        $paginatorProphecy->valid()->willReturn(true, false);
+        $paginatorProphecy->current()->willReturn('foo');
+        $paginatorProphecy->next()->will(function () {});
 
         if (!$partial) {
-            $paginatorProphecy->getLastPage()->willReturn(7)->shouldBeCalled();
-            $paginatorProphecy->getTotalItems()->willReturn(1312)->shouldBeCalled();
+            $paginatorProphecy->getLastPage()->willReturn(7);
+            $paginatorProphecy->getTotalItems()->willReturn(1312);
         } else {
-            $paginatorProphecy->count()->willReturn(12)->shouldBeCalled();
+            $paginatorProphecy->count()->willReturn(12);
         }
 
-        $paginator = $paginatorProphecy->reveal();
-
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($paginator, null, true)->willReturn('Foo')->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($paginatorProphecy, 'Foo')->willReturn('Foo');
 
         $itemNormalizer = $this->prophesize(NormalizerInterface::class);
-        $itemNormalizer->normalize('foo', null, ['api_sub_level' => true, 'resource_class' => 'Foo'])->willReturn(['_links' => ['self' => '/me'], 'name' => 'Kévin']);
+        $itemNormalizer->normalize('foo', CollectionNormalizer::FORMAT, [
+            'api_sub_level' => true,
+            'resource_class' => 'Foo',
+        ])->willReturn(['_links' => ['self' => '/me'], 'name' => 'Kévin']);
 
         $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page');
         $normalizer->setNormalizer($itemNormalizer->reveal());
 
-        return $normalizer->normalize($paginator);
+        return $normalizer->normalize($paginatorProphecy->reveal(), CollectionNormalizer::FORMAT, [
+            'resource_class' => 'Foo',
+        ]);
     }
 }

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -82,8 +82,8 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true)->shouldBeCalled();
-        $resourceClassResolverProphecy->isResourceClass(\stdClass::class)->willReturn(false)->shouldBeCalled();
+        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
+        $resourceClassResolverProphecy->isResourceClass(\stdClass::class)->willReturn(false);
 
         $nameConverter = $this->prophesize(NameConverterInterface::class);
 
@@ -111,32 +111,33 @@ class ItemNormalizerTest extends TestCase
 
         $propertyNameCollection = new PropertyNameCollection(['name', 'relatedDummy']);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection);
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', true)
-        )->shouldBeCalled();
+        );
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class), '', true, false, false)
-        )->shouldBeCalled();
+        );
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/related-dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1');
+        $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/related-dummies/2');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, null, false)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass($relatedDummy, RelatedDummy::class, true)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);
-        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello')->shouldBeCalled();
+        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello');
 
         $nameConverter = $this->prophesize(NameConverterInterface::class);
-        $nameConverter->normalize('name', Argument::any(), Argument::any(), Argument::any())->shouldBeCalled()->willReturn('name');
-        $nameConverter->normalize('relatedDummy', Argument::any(), Argument::any(), Argument::any())->shouldBeCalled()->willReturn('related_dummy');
+        $nameConverter->normalize('name', Argument::any(), Argument::any(), Argument::any())->willReturn('name');
+        $nameConverter->normalize('relatedDummy', Argument::any(), Argument::any(), Argument::any())->willReturn('related_dummy');
 
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -177,32 +178,33 @@ class ItemNormalizerTest extends TestCase
 
         $propertyNameCollection = new PropertyNameCollection(['name', 'relatedDummy']);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection);
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', true)
-        )->shouldBeCalled();
+        );
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class), '', true, false, false)
-        )->shouldBeCalled();
+        );
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/related-dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1');
+        $iriConverterProphecy->getIriFromItem($relatedDummy)->willReturn('/related-dummies/2');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, null, false)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass($relatedDummy, RelatedDummy::class, true)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);
-        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello')->shouldBeCalled();
+        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello');
 
         $nameConverter = $this->prophesize(NameConverterInterface::class);
-        $nameConverter->normalize('name', Argument::any(), Argument::any(), Argument::any())->shouldBeCalled()->willReturn('name');
-        $nameConverter->normalize('relatedDummy', Argument::any(), Argument::any(), Argument::any())->shouldBeCalled()->willReturn('related_dummy');
+        $nameConverter->normalize('name', Argument::any(), Argument::any(), Argument::any())->willReturn('name');
+        $nameConverter->normalize('relatedDummy', Argument::any(), Argument::any(), Argument::any())->willReturn('related_dummy');
 
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -258,30 +260,31 @@ class ItemNormalizerTest extends TestCase
 
         $propertyNameCollection = new PropertyNameCollection(['id', 'name', 'child']);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(MaxDepthDummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(MaxDepthDummy::class, [])->willReturn($propertyNameCollection);
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(MaxDepthDummy::class, 'id', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT), '', true)
-        )->shouldBeCalled();
+        );
         $propertyMetadataFactoryProphecy->create(MaxDepthDummy::class, 'name', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', true)
-        )->shouldBeCalled();
+        );
         $propertyMetadataFactoryProphecy->create(MaxDepthDummy::class, 'child', [])->willReturn(
             new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, false, MaxDepthDummy::class), '', true, false, true)
-        )->shouldBeCalled();
+        );
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($level1)->willReturn('/max_depth_dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($level2)->willReturn('/max_depth_dummies/2')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($level3)->willReturn('/max_depth_dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($level1)->willReturn('/max_depth_dummies/1');
+        $iriConverterProphecy->getIriFromItem($level2)->willReturn('/max_depth_dummies/2');
+        $iriConverterProphecy->getIriFromItem($level3)->willReturn('/max_depth_dummies/3');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($level1, null, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->getResourceClass($level1, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->getResourceClass($level2, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->getResourceClass($level3, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->isResourceClass(MaxDepthDummy::class)->willReturn(true)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($level1, null, false)->willReturn(MaxDepthDummy::class);
+        $resourceClassResolverProphecy->getResourceClass($level1, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class);
+        $resourceClassResolverProphecy->getResourceClass($level2, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class);
+        $resourceClassResolverProphecy->getResourceClass($level3, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class);
+        $resourceClassResolverProphecy->getResourceClass(null, MaxDepthDummy::class, true)->willReturn(MaxDepthDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(MaxDepthDummy::class)->willReturn(true);
 
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),

--- a/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
@@ -196,13 +196,16 @@ class CollectionFiltersNormalizerTest extends TestCase
         $dummy = new Dummy();
 
         $decoratedProphecy = $this->prophesize(NormalizerInterface::class);
-        $decoratedProphecy->normalize($dummy, null, ['collection_operation_name' => 'get'])->willReturn(['name' => 'foo'])->shouldBeCalled();
+        $decoratedProphecy->normalize($dummy, CollectionNormalizer::FORMAT, [
+            'collection_operation_name' => 'get',
+            'resource_class' => Dummy::class,
+        ])->willReturn(['name' => 'foo']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('foo', '', null, [], ['get' => []]));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class)->willReturn(Dummy::class);
 
         $normalizer = new CollectionFiltersNormalizer(
             $decoratedProphecy->reveal(),
@@ -211,7 +214,10 @@ class CollectionFiltersNormalizerTest extends TestCase
             $this->prophesize(ContainerInterface::class)->reveal()
         );
 
-        $this->assertEquals(['name' => 'foo'], $normalizer->normalize($dummy, null, ['collection_operation_name' => 'get']));
+        $this->assertEquals(['name' => 'foo'], $normalizer->normalize($dummy, CollectionNormalizer::FORMAT, [
+            'collection_operation_name' => 'get',
+            'resource_class' => Dummy::class,
+        ]));
     }
 
     public function testDoNothingIfNoRequestUri()
@@ -219,13 +225,15 @@ class CollectionFiltersNormalizerTest extends TestCase
         $dummy = new Dummy();
 
         $decoratedProphecy = $this->prophesize(NormalizerInterface::class);
-        $decoratedProphecy->normalize($dummy, null, [])->willReturn(['name' => 'foo'])->shouldBeCalled();
+        $decoratedProphecy->normalize($dummy, CollectionNormalizer::FORMAT, [
+            'resource_class' => Dummy::class,
+        ])->willReturn(['name' => 'foo']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('foo', '', null, [], [], ['filters' => ['foo']]));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class)->willReturn(Dummy::class);
 
         $normalizer = new CollectionFiltersNormalizer(
             $decoratedProphecy->reveal(),
@@ -234,7 +242,9 @@ class CollectionFiltersNormalizerTest extends TestCase
             $this->prophesize(ContainerInterface::class)->reveal()
         );
 
-        $this->assertEquals(['name' => 'foo'], $normalizer->normalize($dummy));
+        $this->assertEquals(['name' => 'foo'], $normalizer->normalize($dummy, CollectionNormalizer::FORMAT, [
+            'resource_class' => Dummy::class,
+        ]));
     }
 
     public function testNormalize()
@@ -282,13 +292,16 @@ class CollectionFiltersNormalizerTest extends TestCase
         $dummy = new Dummy();
 
         $decoratedProphecy = $this->prophesize(NormalizerInterface::class);
-        $decoratedProphecy->normalize($dummy, null, ['request_uri' => '/foo?bar=baz'])->willReturn(['name' => 'foo'])->shouldBeCalled();
+        $decoratedProphecy->normalize($dummy, CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foo?bar=baz',
+            'resource_class' => Dummy::class,
+        ])->willReturn(['name' => 'foo']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('foo', '', null, [], [], ['filters' => ['foo']]));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class)->willReturn(Dummy::class);
 
         $normalizer = new CollectionFiltersNormalizer(
             $decoratedProphecy->reveal(),
@@ -312,6 +325,9 @@ class CollectionFiltersNormalizerTest extends TestCase
                     ],
                 ],
             ],
-        ], $normalizer->normalize($dummy, null, ['request_uri' => '/foo?bar=baz']));
+        ], $normalizer->normalize($dummy, CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foo?bar=baz',
+            'resource_class' => Dummy::class,
+        ]));
     }
 }

--- a/tests/JsonApi/Serializer/CollectionNormalizerTest.php
+++ b/tests/JsonApi/Serializer/CollectionNormalizerTest.php
@@ -42,41 +42,35 @@ class CollectionNormalizerTest extends TestCase
     public function testNormalizePaginator()
     {
         $paginatorProphecy = $this->prophesize(PaginatorInterface::class);
-        $paginatorProphecy->getCurrentPage()->willReturn(3.)->shouldBeCalled();
-        $paginatorProphecy->getLastPage()->willReturn(7.)->shouldBeCalled();
-        $paginatorProphecy->getItemsPerPage()->willReturn(12.)->shouldBeCalled();
-        $paginatorProphecy->getTotalItems()->willReturn(1312.)->shouldBeCalled();
-        $paginatorProphecy->rewind()->shouldBeCalled();
-        $paginatorProphecy->next()->willReturn()->shouldBeCalled();
-        $paginatorProphecy->current()->willReturn('foo')->shouldBeCalled();
-        $paginatorProphecy->valid()->willReturn(true, false)->shouldBeCalled();
+        $paginatorProphecy->getCurrentPage()->willReturn(3.);
+        $paginatorProphecy->getLastPage()->willReturn(7.);
+        $paginatorProphecy->getItemsPerPage()->willReturn(12.);
+        $paginatorProphecy->getTotalItems()->willReturn(1312.);
+        $paginatorProphecy->rewind()->will(function () {});
+        $paginatorProphecy->next()->will(function () {});
+        $paginatorProphecy->current()->willReturn('foo');
+        $paginatorProphecy->valid()->willReturn(true, false);
 
         $paginator = $paginatorProphecy->reveal();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($paginator, null, true)->willReturn('Foo')->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($paginator, 'Foo')->willReturn('Foo');
 
         $itemNormalizer = $this->prophesize(NormalizerInterface::class);
-        $itemNormalizer
-            ->normalize(
-                'foo',
-                CollectionNormalizer::FORMAT,
-                [
-                    'request_uri' => '/foos?page=3',
-                    'api_sub_level' => true,
-                    'resource_class' => 'Foo',
-                ]
-            )
-            ->willReturn([
-                'data' => [
-                    'type' => 'Foo',
+        $itemNormalizer->normalize('foo', CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos?page=3',
+            'api_sub_level' => true,
+            'resource_class' => 'Foo',
+        ])->willReturn([
+            'data' => [
+                'type' => 'Foo',
+                'id' => 1,
+                'attributes' => [
                     'id' => 1,
-                    'attributes' => [
-                        'id' => 1,
-                        'name' => 'Kévin',
-                    ],
+                    'name' => 'Kévin',
                 ],
-            ]);
+            ],
+        ]);
 
         $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page');
         $normalizer->setNormalizer($itemNormalizer->reveal());
@@ -106,46 +100,43 @@ class CollectionNormalizerTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $normalizer->normalize($paginator, CollectionNormalizer::FORMAT, ['request_uri' => '/foos?page=3']));
+        $this->assertEquals($expected, $normalizer->normalize($paginator, CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos?page=3',
+            'resource_class' => 'Foo',
+        ]));
     }
 
     public function testNormalizePartialPaginator()
     {
         $paginatorProphecy = $this->prophesize(PartialPaginatorInterface::class);
-        $paginatorProphecy->getCurrentPage()->willReturn(3.)->shouldBeCalled();
-        $paginatorProphecy->getItemsPerPage()->willReturn(12.)->shouldBeCalled();
-        $paginatorProphecy->rewind()->shouldBeCalled();
-        $paginatorProphecy->next()->willReturn()->shouldBeCalled();
-        $paginatorProphecy->current()->willReturn('foo')->shouldBeCalled();
-        $paginatorProphecy->valid()->willReturn(true, false)->shouldBeCalled();
-        $paginatorProphecy->count()->willReturn(1312)->shouldBeCalled();
+        $paginatorProphecy->getCurrentPage()->willReturn(3.);
+        $paginatorProphecy->getItemsPerPage()->willReturn(12.);
+        $paginatorProphecy->rewind()->will(function () {});
+        $paginatorProphecy->next()->will(function () {});
+        $paginatorProphecy->current()->willReturn('foo');
+        $paginatorProphecy->valid()->willReturn(true, false);
+        $paginatorProphecy->count()->willReturn(1312);
 
         $paginator = $paginatorProphecy->reveal();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($paginator, null, true)->willReturn('Foo')->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($paginator, 'Foo')->willReturn('Foo');
 
         $itemNormalizer = $this->prophesize(NormalizerInterface::class);
-        $itemNormalizer
-            ->normalize(
-                'foo',
-                CollectionNormalizer::FORMAT,
-                [
-                    'request_uri' => '/foos?page=3',
-                    'api_sub_level' => true,
-                    'resource_class' => 'Foo',
-                ]
-            )
-            ->willReturn([
-                'data' => [
-                    'type' => 'Foo',
+        $itemNormalizer->normalize('foo', CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos?page=3',
+            'api_sub_level' => true,
+            'resource_class' => 'Foo',
+        ])->willReturn([
+            'data' => [
+                'type' => 'Foo',
+                'id' => 1,
+                'attributes' => [
                     'id' => 1,
-                    'attributes' => [
-                        'id' => 1,
-                        'name' => 'Kévin',
-                    ],
+                    'name' => 'Kévin',
                 ],
-            ]);
+            ],
+        ]);
 
         $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page');
         $normalizer->setNormalizer($itemNormalizer->reveal());
@@ -172,7 +163,10 @@ class CollectionNormalizerTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $normalizer->normalize($paginator, CollectionNormalizer::FORMAT, ['request_uri' => '/foos?page=3']));
+        $this->assertEquals($expected, $normalizer->normalize($paginator, CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos?page=3',
+            'resource_class' => 'Foo',
+        ]));
     }
 
     public function testNormalizeArray()
@@ -180,29 +174,23 @@ class CollectionNormalizerTest extends TestCase
         $data = ['foo'];
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($data, null, true)->willReturn('Foo')->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($data, 'Foo')->willReturn('Foo');
 
         $itemNormalizer = $this->prophesize(NormalizerInterface::class);
-        $itemNormalizer
-            ->normalize(
-                'foo',
-                CollectionNormalizer::FORMAT,
-                [
-                    'request_uri' => '/foos',
-                    'api_sub_level' => true,
-                    'resource_class' => 'Foo',
-                ]
-            )
-            ->willReturn([
-                'data' => [
-                    'type' => 'Foo',
+        $itemNormalizer->normalize('foo', CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos',
+            'api_sub_level' => true,
+            'resource_class' => 'Foo',
+        ])->willReturn([
+            'data' => [
+                'type' => 'Foo',
+                'id' => 1,
+                'attributes' => [
                     'id' => 1,
-                    'attributes' => [
-                        'id' => 1,
-                        'name' => 'Baptiste',
-                    ],
+                    'name' => 'Baptiste',
                 ],
-            ]);
+            ],
+        ]);
 
         $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page');
         $normalizer->setNormalizer($itemNormalizer->reveal());
@@ -222,7 +210,10 @@ class CollectionNormalizerTest extends TestCase
             'meta' => ['totalItems' => 1],
         ];
 
-        $this->assertEquals($expected, $normalizer->normalize($data, CollectionNormalizer::FORMAT, ['request_uri' => '/foos']));
+        $this->assertEquals($expected, $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos',
+            'resource_class' => 'Foo',
+        ]));
     }
 
     public function testNormalizeIncludedData()
@@ -230,39 +221,33 @@ class CollectionNormalizerTest extends TestCase
         $data = ['foo'];
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($data, null, true)->willReturn('Foo')->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($data, 'Foo')->willReturn('Foo');
 
         $itemNormalizer = $this->prophesize(NormalizerInterface::class);
-        $itemNormalizer
-            ->normalize(
-                'foo',
-                CollectionNormalizer::FORMAT,
+        $itemNormalizer->normalize('foo', CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos',
+            'api_sub_level' => true,
+            'resource_class' => 'Foo',
+        ])->willReturn([
+            'data' => [
+                'type' => 'Foo',
+                'id' => 1,
+                'attributes' => [
+                    'id' => 1,
+                    'name' => 'Baptiste',
+                ],
+            ],
+            'included' => [
                 [
-                    'request_uri' => '/foos',
-                    'api_sub_level' => true,
-                    'resource_class' => 'Foo',
-                ]
-            )
-            ->willReturn([
-                'data' => [
-                    'type' => 'Foo',
+                    'type' => 'Bar',
                     'id' => 1,
                     'attributes' => [
                         'id' => 1,
-                        'name' => 'Baptiste',
+                        'name' => 'Anto',
                     ],
                 ],
-                'included' => [
-                    [
-                        'type' => 'Bar',
-                        'id' => 1,
-                        'attributes' => [
-                            'id' => 1,
-                            'name' => 'Anto',
-                        ],
-                    ],
-                ],
-            ]);
+            ],
+        ]);
 
         $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page');
         $normalizer->setNormalizer($itemNormalizer->reveal());
@@ -292,7 +277,10 @@ class CollectionNormalizerTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $normalizer->normalize($data, CollectionNormalizer::FORMAT, ['request_uri' => '/foos']));
+        $this->assertEquals($expected, $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos',
+            'resource_class' => 'Foo',
+        ]));
     }
 
     public function testNormalizeWithoutDataKey()
@@ -303,24 +291,21 @@ class CollectionNormalizerTest extends TestCase
         $data = ['foo'];
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($data, null, true)->willReturn('Foo')->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($data, 'Foo')->willReturn('Foo');
 
         $itemNormalizer = $this->prophesize(NormalizerInterface::class);
-        $itemNormalizer
-            ->normalize(
-                'foo',
-                CollectionNormalizer::FORMAT,
-                [
-                    'request_uri' => '/foos',
-                    'api_sub_level' => true,
-                    'resource_class' => 'Foo',
-                ]
-            )
-            ->willReturn([]);
+        $itemNormalizer->normalize('foo', CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos',
+            'api_sub_level' => true,
+            'resource_class' => 'Foo',
+        ])->willReturn([]);
 
         $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page');
         $normalizer->setNormalizer($itemNormalizer->reveal());
 
-        $normalizer->normalize($data, CollectionNormalizer::FORMAT, ['request_uri' => '/foos']);
+        $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
+            'request_uri' => '/foos',
+            'resource_class' => 'Foo',
+        ]);
     }
 }

--- a/tests/JsonApi/Serializer/ItemNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ItemNormalizerTest.php
@@ -114,7 +114,7 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/10');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy, null, false)->willReturn(Dummy::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class);
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
@@ -170,7 +170,7 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy->getIriFromItem($circularReferenceEntity)->willReturn('/circular_references/1');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($circularReferenceEntity, null, true)->willReturn(CircularReference::class);
+        $resourceClassResolverProphecy->getResourceClass($circularReferenceEntity, null, false)->willReturn(CircularReference::class);
         $resourceClassResolverProphecy->getResourceClass($circularReferenceEntity, CircularReference::class, true)->willReturn(CircularReference::class);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
@@ -226,7 +226,7 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy, null, false)->willReturn(Dummy::class);
         $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class);
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
@@ -252,66 +252,67 @@ class ItemNormalizerTest extends TestCase
 
     public function testDenormalize()
     {
+        $data = [
+            'data' => [
+                'type' => 'dummy',
+                'attributes' => [
+                    'name' => 'foo',
+                    'ghost' => 'invisible',
+                ],
+                'relationships' => [
+                    'relatedDummy' => [
+                        'data' => [
+                            'type' => 'related-dummy',
+                            'id' => '/related_dummies/1',
+                        ],
+                    ],
+                    'relatedDummies' => [
+                        'data' => [
+                            [
+                                'type' => 'related-dummy',
+                                'id' => '/related_dummies/2',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
         $relatedDummy1 = new RelatedDummy();
         $relatedDummy1->setId(1);
         $relatedDummy2 = new RelatedDummy();
         $relatedDummy2->setId(2);
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(
-            new PropertyNameCollection(['name', 'ghost', 'relatedDummy', 'relatedDummies'])
-        )->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['name', 'ghost', 'relatedDummy', 'relatedDummies']));
+
+        $relatedDummyType = new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class);
+        $relatedDummiesType = new Type(Type::BUILTIN_TYPE_OBJECT, false, ArrayCollection::class, true, new Type(Type::BUILTIN_TYPE_INT), $relatedDummyType);
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn(
-            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', false, true)
-        )->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'ghost', [])->willReturn(
-            new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', false, true)
-        )->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn(
-            new PropertyMetadata(
-                new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class),
-                '',
-                false,
-                true,
-                false,
-                false
-            )
-        )->shouldBeCalled();
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummies', [])->willReturn(
-            new PropertyMetadata(
-                new Type(Type::BUILTIN_TYPE_OBJECT,
-                    false,
-                    ArrayCollection::class,
-                    true,
-                    new Type(Type::BUILTIN_TYPE_INT),
-                    new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummy::class)
-                ),
-                '',
-                false,
-                true,
-                false,
-                false
-            )
-        )->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', false, true));
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'ghost', [])->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), '', false, true));
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn(new PropertyMetadata($relatedDummyType, '', false, true, false, false));
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummies', [])->willReturn(new PropertyMetadata($relatedDummiesType, '', false, true, false, false));
 
         $getItemFromIriSecondArgCallback = function ($arg) {
             return \is_array($arg) && isset($arg['fetch_data']) && true === $arg['fetch_data'];
         };
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getItemFromIri('/related_dummies/1', Argument::that($getItemFromIriSecondArgCallback))->willReturn($relatedDummy1)->shouldBeCalled();
-        $iriConverterProphecy->getItemFromIri('/related_dummies/2', Argument::that($getItemFromIriSecondArgCallback))->willReturn($relatedDummy2)->shouldBeCalled();
+        $iriConverterProphecy->getItemFromIri('/related_dummies/1', Argument::that($getItemFromIriSecondArgCallback))->willReturn($relatedDummy1);
+        $iriConverterProphecy->getItemFromIri('/related_dummies/2', Argument::that($getItemFromIriSecondArgCallback))->willReturn($relatedDummy2);
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
-        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'name', 'foo')->shouldBeCalled();
-        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'ghost', 'invisible')->willThrow(new NoSuchPropertyException())->shouldBeCalled();
-        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'relatedDummy', $relatedDummy1)->shouldBeCalled();
-        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'relatedDummies', [$relatedDummy2])->shouldBeCalled();
+        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'name', 'foo')->will(function () {});
+        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'ghost', 'invisible')->willThrow(new NoSuchPropertyException());
+        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'relatedDummy', $relatedDummy1)->will(function () {});
+        $propertyAccessorProphecy->setValue(Argument::type(Dummy::class), 'relatedDummies', [$relatedDummy2])->will(function () {});
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass(null, RelatedDummy::class)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);
@@ -332,38 +333,7 @@ class ItemNormalizerTest extends TestCase
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
-        $this->assertInstanceOf(
-            Dummy::class,
-            $normalizer->denormalize(
-                [
-                    'data' => [
-                        'type' => 'dummy',
-                        'attributes' => [
-                            'name' => 'foo',
-                            'ghost' => 'invisible',
-                        ],
-                        'relationships' => [
-                            'relatedDummy' => [
-                                'data' => [
-                                    'type' => 'related-dummy',
-                                    'id' => '/related_dummies/1',
-                                ],
-                            ],
-                            'relatedDummies' => [
-                                'data' => [
-                                    [
-                                        'type' => 'related-dummy',
-                                        'id' => '/related_dummies/2',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                Dummy::class,
-                ItemNormalizer::FORMAT
-            )
-        );
+        $this->assertInstanceOf(Dummy::class, $normalizer->denormalize($data, Dummy::class, ItemNormalizer::FORMAT));
     }
 
     public function testDenormalizeUpdateOperationNotAllowed()
@@ -403,8 +373,19 @@ class ItemNormalizerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The type of the "relatedDummies" attribute must be "array", "string" given.');
 
+        $data = [
+            'data' => [
+                'type' => 'dummy',
+                'relationships' => [
+                    'relatedDummies' => [
+                        'data' => 'foo',
+                    ],
+                ],
+            ],
+        ];
+
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['relatedDummies']))->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['relatedDummies']));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummies', [])->willReturn(
@@ -422,7 +403,16 @@ class ItemNormalizerTest extends TestCase
                 false,
                 false
             )
-        )->shouldBeCalled();
+        );
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass(null, RelatedDummy::class)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
         $resourceMetadataFactory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactory->create(Dummy::class)->willThrow(ResourceClassNotFoundException::class);
@@ -430,29 +420,16 @@ class ItemNormalizerTest extends TestCase
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $this->prophesize(IriConverterInterface::class)->reveal(),
-            $this->prophesize(ResourceClassResolverInterface::class)->reveal(),
-            $this->prophesize(PropertyAccessorInterface::class)->reveal(),
+            $iriConverterProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $propertyAccessorProphecy->reveal(),
             new ReservedAttributeNameConverter(),
             $resourceMetadataFactory->reveal(),
             [],
             []
         );
 
-        $normalizer->denormalize(
-            [
-                'data' => [
-                    'type' => 'dummy',
-                    'relationships' => [
-                        'relatedDummies' => [
-                            'data' => 'foo',
-                        ],
-                    ],
-                ],
-            ],
-            Dummy::class,
-            ItemNormalizer::FORMAT
-        );
+        $normalizer->denormalize($data, Dummy::class, ItemNormalizer::FORMAT);
     }
 
     public function testDenormalizeCollectionWithInvalidKey()
@@ -460,8 +437,24 @@ class ItemNormalizerTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The type of the key "0" must be "string", "integer" given.');
 
+        $data = [
+            'data' => [
+                'type' => 'dummy',
+                'relationships' => [
+                    'relatedDummies' => [
+                        'data' => [
+                            [
+                                'type' => 'related-dummy',
+                                'id' => '2',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['relatedDummies']))->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['relatedDummies']));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummies', [])->willReturn(
@@ -479,7 +472,16 @@ class ItemNormalizerTest extends TestCase
                 false,
                 false
             )
-        )->shouldBeCalled();
+        );
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass(null, RelatedDummy::class)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
         $resourceMetadataFactory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactory->create(Dummy::class)->willThrow(ResourceClassNotFoundException::class);
@@ -487,34 +489,16 @@ class ItemNormalizerTest extends TestCase
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $this->prophesize(IriConverterInterface::class)->reveal(),
-            $this->prophesize(ResourceClassResolverInterface::class)->reveal(),
-            $this->prophesize(PropertyAccessorInterface::class)->reveal(),
+            $iriConverterProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $propertyAccessorProphecy->reveal(),
             new ReservedAttributeNameConverter(),
             $resourceMetadataFactory->reveal(),
             [],
             []
         );
 
-        $normalizer->denormalize(
-            [
-                'data' => [
-                    'type' => 'dummy',
-                    'relationships' => [
-                        'relatedDummies' => [
-                            'data' => [
-                                [
-                                    'type' => 'related-dummy',
-                                    'id' => '2',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            Dummy::class,
-            ItemNormalizer::FORMAT
-        );
+        $normalizer->denormalize($data, Dummy::class, ItemNormalizer::FORMAT);
     }
 
     public function testDenormalizeRelationIsNotResourceLinkage()
@@ -522,8 +506,19 @@ class ItemNormalizerTest extends TestCase
         $this->expectException(NotNormalizableValueException::class);
         $this->expectExceptionMessage('Only resource linkage supported currently, see: http://jsonapi.org/format/#document-resource-object-linkage.');
 
+        $data = [
+            'data' => [
+                'type' => 'dummy',
+                'relationships' => [
+                    'relatedDummy' => [
+                        'data' => 'foo',
+                    ],
+                ],
+            ],
+        ];
+
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['relatedDummy']))->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn(new PropertyNameCollection(['relatedDummy']));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', [])->willReturn(
@@ -535,10 +530,16 @@ class ItemNormalizerTest extends TestCase
                 false,
                 false
             )
-        )->shouldBeCalled();
+        );
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass(null, RelatedDummy::class)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
         $resourceMetadataFactory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactory->create(Dummy::class)->willThrow(ResourceClassNotFoundException::class);
@@ -546,28 +547,15 @@ class ItemNormalizerTest extends TestCase
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $this->prophesize(IriConverterInterface::class)->reveal(),
+            $iriConverterProphecy->reveal(),
             $resourceClassResolverProphecy->reveal(),
-            $this->prophesize(PropertyAccessorInterface::class)->reveal(),
+            $propertyAccessorProphecy->reveal(),
             new ReservedAttributeNameConverter(),
             $resourceMetadataFactory->reveal(),
             [],
             []
         );
 
-        $normalizer->denormalize(
-            [
-                'data' => [
-                    'type' => 'dummy',
-                    'relationships' => [
-                        'relatedDummy' => [
-                            'data' => 'foo',
-                        ],
-                    ],
-                ],
-            ],
-            Dummy::class,
-            ItemNormalizer::FORMAT
-        );
+        $normalizer->denormalize($data, Dummy::class, ItemNormalizer::FORMAT);
     }
 }

--- a/tests/JsonLd/Serializer/ItemNormalizerTest.php
+++ b/tests/JsonLd/Serializer/ItemNormalizerTest.php
@@ -97,22 +97,22 @@ class ItemNormalizerTest extends TestCase
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy'));
         $propertyNameCollection = new PropertyNameCollection(['name']);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection);
 
         $propertyMetadata = new PropertyMetadata(null, null, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1988')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1988');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
-        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, null, false)->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy, Dummy::class, true)->willReturn(Dummy::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);
-        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello')->shouldBeCalled();
+        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello');
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
         $contextBuilderProphecy->getResourceContextUri(Dummy::class)->willReturn('/contexts/Dummy');
 
@@ -131,7 +131,8 @@ class ItemNormalizerTest extends TestCase
         );
         $normalizer->setSerializer($serializerProphecy->reveal());
 
-        $expected = ['@context' => '/contexts/Dummy',
+        $expected = [
+            '@context' => '/contexts/Dummy',
             '@id' => '/dummies/1988',
             '@type' => 'Dummy',
             'name' => 'hello',

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -50,8 +50,8 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true)->shouldBeCalled();
-        $resourceClassResolverProphecy->isResourceClass(\stdClass::class)->willReturn(false)->shouldBeCalled();
+        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
+        $resourceClassResolverProphecy->isResourceClass(\stdClass::class)->willReturn(false);
 
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -77,21 +77,21 @@ class ItemNormalizerTest extends TestCase
 
         $propertyNameCollection = new PropertyNameCollection(['name']);
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection)->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, [])->willReturn($propertyNameCollection);
 
         $propertyMetadata = new PropertyMetadata(null, null, true);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1');
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->getResourceClass($dummy, null, true)->willReturn(Dummy::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->getResourceClass($dummy, null, false)->willReturn(Dummy::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);
-        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello')->shouldBeCalled();
+        $serializerProphecy->normalize('hello', null, Argument::type('array'))->willReturn('hello');
 
         $normalizer = new ItemNormalizer(
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -127,6 +127,7 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(DenormalizerInterface::class);
@@ -166,6 +167,7 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy->getItemFromIri('/dummies/12', ['resource_class' => Dummy::class, 'api_allow_update' => true, 'fetch_data' => true])->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(DenormalizerInterface::class);
@@ -241,6 +243,7 @@ class ItemNormalizerTest extends TestCase
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, Dummy::class)->willReturn(Dummy::class);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(DenormalizerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2609, #2683, #2759
| License       | MIT
| Doc PR        | N/A

Alternative to https://github.com/api-platform/core/pull/2714

TODO:
- [x] Add tests from https://github.com/api-platform/core/pull/2714

Notable changes:
- `ResourceClassResolver` returns the most specific resource class for an object.
- Use `ResourceClassResolver` where we didn't before.
- Denormalization of non-resources no longer handled by our `ItemNormalizer`.