### PR TITLE
Fixing bug where servers would be added and set to an empty string in OpenAPI

### DIFF
--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -698,7 +698,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
 
         if ($v3) {
             $docs = ['openapi' => self::OPENAPI_VERSION];
-            if ('/' !== $baseUrl) {
+            if ('/' !== $baseUrl && '' !== $baseUrl) {
                 $docs['servers'] = [['url' => $context[self::BASE_URL] ?? $this->defaultContext[self::BASE_URL]]];
             }
         } else {

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -350,6 +350,8 @@ class DocumentationNormalizerV3Test extends TestCase
         ];
 
         $this->assertEquals($expected, $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/app_dev.php/']));
+        $this->assertArrayNotHasKey('servers', (array) $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '/']));
+        $this->assertArrayNotHasKey('servers', (array) $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['base_url' => '']));
     }
 
     public function testNormalizeWithNameConverter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

Hi!

I noticed that the `servers` key on OpenAPI always look like this:

<img width="196" alt="Screen Shot 2019-05-16 at 10 06 49 AM" src="https://user-images.githubusercontent.com/121003/57860209-73b34500-77c2-11e9-9cde-3537308eac9d.png">

The `url` originally comes from `$request->getBasePath()` in `DocumentationAction`. The problem is that if I try to pass the URL to the documentation straight to Postman (which supports OpenAPI 3), I see this error:

> Error while importing Open API 3.0: The OpenAPI spec should have a valid URL in each servers object

In fact, `servers` defaults to `/` in OpenAPI if not specified. There was just a bit of missing logic to skip setting it if the base path is an empty string. This fixes the import into Postman.

Cheers!