### PR TITLE
set _api_write_item_iri only if result object is a subclass of a resource class

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -91,7 +91,7 @@ final class WriteListener
                 }
 
                 if ($hasOutput) {
-                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
+                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromResourceClass($attributes['resource_class']));
                 }
             break;
             case 'DELETE':

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -84,13 +84,22 @@ final class WriteListener
                 }
 
                 $hasOutput = true;
+                $getIriFromItem = false;
+                $getIriFromResourceClass = false;
                 if (null !== $this->resourceMetadataFactory) {
                     $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
                     $outputMetadata = $resourceMetadata->getOperationAttribute($attributes, 'output', ['class' => $attributes['resource_class']], true);
                     $hasOutput = \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'] && $controllerResult instanceof $outputMetadata['class'];
+                    if ($outputMetadata['class'] === $attributes['resource_class']) {
+                        $getIriFromItem = true;
+                    } else {
+                        $getIriFromResourceClass = true;
+                    }
                 }
 
-                if ($hasOutput) {
+                if ($hasOutput && $getIriFromItem) {
+                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
+                } elseif ($hasOutput && $getIriFromResourceClass) {
                     $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromResourceClass($attributes['resource_class']));
                 }
             break;

--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -84,23 +84,14 @@ final class WriteListener
                 }
 
                 $hasOutput = true;
-                $getIriFromItem = false;
-                $getIriFromResourceClass = false;
                 if (null !== $this->resourceMetadataFactory) {
                     $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
                     $outputMetadata = $resourceMetadata->getOperationAttribute($attributes, 'output', ['class' => $attributes['resource_class']], true);
                     $hasOutput = \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'] && $controllerResult instanceof $outputMetadata['class'];
-                    if ($outputMetadata['class'] === $attributes['resource_class']) {
-                        $getIriFromItem = true;
-                    } else {
-                        $getIriFromResourceClass = true;
-                    }
                 }
 
-                if ($hasOutput && $getIriFromItem) {
+                if ($hasOutput && is_subclass_of($controllerResult, $attributes['resource_class'], true)) {
                     $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
-                } elseif ($hasOutput && $getIriFromResourceClass) {
-                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromResourceClass($attributes['resource_class']));
                 }
             break;
             case 'DELETE':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #2803 
| License       | MIT
| Doc PR        | -

Issue happens when `output` class for a specific operation is not related to a class that represents api resource.
`WriteListener` tries to set `_api_write_item_iri` from a result object (defined in `output` attribute of an operation) but fails as it's not possible.
