### PR TITLE
Backport original_data access control variable to 2.4 as a bug fix

### DIFF
--- a/features/authorization/deny.feature
+++ b/features/authorization/deny.feature
@@ -58,15 +58,39 @@ Feature: Authorization checking
     """
     Then the response status code should be 201
 
-  Scenario: An user cannot retrieve an item he doesn't own
+  Scenario: A user cannot retrieve an item he doesn't own
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/1"
     Then the response status code should be 403
     And the response should be in JSON
 
-  Scenario: An user can retrieve an item he owns
+  Scenario: A user can retrieve an item he owns
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/2"
+    Then the response status code should be 200
+
+  Scenario: A user can't assign him an item he doesn't own
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send a "PUT" request to "/secured_dummies/2" with body:
+    """
+    {
+        "owner": "kitten"
+    }
+    """
+    Then the response status code should be 403
+
+  Scenario: A user can update an item he owns and transfer it
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send a "PUT" request to "/secured_dummies/2" with body:
+    """
+    {
+        "owner": "vincent"
+    }
+    """
     Then the response status code should be 200

--- a/src/EventListener/ReadListener.php
+++ b/src/EventListener/ReadListener.php
@@ -115,5 +115,6 @@ final class ReadListener
         }
 
         $request->attributes->set('data', $data);
+        $request->attributes->set('previous_data', \is_object($data) ? clone $data : $data);
     }
 }

--- a/src/Security/EventListener/DenyAccessListener.php
+++ b/src/Security/EventListener/DenyAccessListener.php
@@ -50,8 +50,6 @@ final class DenyAccessListener
     }
 
     /**
-     * Sets the applicable format to the HttpFoundation Request.
-     *
      * @throws AccessDeniedException
      */
     public function onKernelRequest(GetResponseEvent $event): void
@@ -71,6 +69,7 @@ final class DenyAccessListener
 
         $extraVariables = $request->attributes->all();
         $extraVariables['object'] = $request->attributes->get('data');
+        $extraVariables['previous_object'] = $request->attributes->get('previous_data');
         $extraVariables['request'] = $request;
 
         if (!$this->resourceAccessChecker->isGranted($attributes['resource_class'], $isGranted, $extraVariables)) {

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -153,6 +153,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
 
         $this->assertFalse($request->attributes->has('data'));
+        $this->assertFalse($request->attributes->has('previous_data'));
     }
 
     public function testRetrieveCollectionGet()
@@ -178,6 +179,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
 
         $this->assertSame([], $request->attributes->get('data'));
+        $this->assertFalse($request->attributes->has('previous_data'));
     }
 
     public function testRetrieveItem()
@@ -205,6 +207,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
 
         $this->assertSame($data, $request->attributes->get('data'));
+        $this->assertEquals($data, $request->attributes->get('previous_data'));
     }
 
     public function testRetrieveItemNoIdentifier()
@@ -257,6 +260,7 @@ class ReadListenerTest extends TestCase
         $listener->onKernelRequest($event->reveal());
 
         $this->assertSame($data, $request->attributes->get('data'));
+        $this->assertSame($data, $request->attributes->get('previous_data'));
     }
 
     public function testRetrieveSubresourceNoDataProvider()

--- a/tests/Fixtures/TestBundle/Document/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SecuredDummy.php
@@ -30,7 +30,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
  *         "query"={},

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -29,7 +29,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"}
+ *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
  *     },
  *     graphql={
  *         "query"={},


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | api-platform/doc#814

Hi friends!

#2779 was coded as a feature and therefore was merged into master. I think that's a mistake, as it's related to security. It's currently not possible to do something like this:

```
"access_control"="is_granted('ROLE_USER') and object.getOwner() == user",
```

Without potentially exposing your API to unwanted access: a user could change the `owner` to be themselves. For the reason, even though this *is* technically a feature, I think it's critical enough for security (and simple) that it should be backported.

Thanks!