### PR TITLE
GraphQL: add support for previous_object in access_control

### DIFF
--- a/features/authorization/deny.feature
+++ b/features/authorization/deny.feature
@@ -58,20 +58,20 @@ Feature: Authorization checking
     """
     Then the response status code should be 201
 
-  Scenario: A user cannot retrieve an item he doesn't own
+  Scenario: A user cannot retrieve an item they doesn't own
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/1"
     Then the response status code should be 403
     And the response should be in JSON
 
-  Scenario: A user can retrieve an item he owns
+  Scenario: A user can retrieve an item they owns
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send a "GET" request to "/secured_dummies/2"
     Then the response status code should be 200
 
-  Scenario: A user can't assign him an item he doesn't own
+  Scenario: A user can't assign to themself an item they doesn't own
     When I add "Accept" header equal to "application/ld+json"
     And I add "Content-Type" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
@@ -83,7 +83,7 @@ Feature: Authorization checking
     """
     Then the response status code should be 403
 
-  Scenario: A user can update an item he owns and transfer it
+  Scenario: A user can update an item they owns and transfer it
     When I add "Accept" header equal to "application/ld+json"
     And I add "Content-Type" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="

--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -40,7 +40,7 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
 
-  Scenario: An anonymous user tries to create a resource they is not allowed to
+  Scenario: An anonymous user tries to create a resource they are not allowed to
     When I send the following GraphQL request:
     """
     mutation {

--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -40,7 +40,7 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
 
-  Scenario: An anonymous user tries to create a resource he is not allowed to
+  Scenario: An anonymous user tries to create a resource they is not allowed to
     When I send the following GraphQL request:
     """
     mutation {
@@ -96,7 +96,7 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.createSecuredDummy.securedDummy.owner" should be equal to "dunglas"
 
-  Scenario: A user cannot retrieve an item he doesn't own
+  Scenario: A user cannot retrieve an item they doesn't own
     When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send the following GraphQL request:
     """
@@ -112,7 +112,7 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
 
-  Scenario: A user can retrieve an item he owns
+  Scenario: A user can retrieve an item they owns
     When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send the following GraphQL request:
     """
@@ -128,7 +128,7 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.securedDummy.owner" should be equal to the string "dunglas"
 
-  Scenario: A user can't assign him an item he doesn't own
+  Scenario: A user can't assign to themself an item they doesn't own
     When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
     And I send the following GraphQL request:
     """
@@ -147,7 +147,7 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
 
-  Scenario: A user can update an item he owns and transfer it
+  Scenario: A user can update an item they owns and transfer it
     When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
     And I send the following GraphQL request:
     """

--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -56,3 +56,112 @@ Feature: Authorization checking
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Only admins can create a secured dummy."
+
+  @createSchema
+  Scenario: An admin can create a secured resource
+    When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send the following GraphQL request:
+    """
+    mutation {
+      createSecuredDummy(input: {owner: "someone", title: "Hi", description: "Desc"}) {
+        securedDummy {
+          id
+          title
+          owner
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createSecuredDummy.securedDummy.owner" should be equal to "someone"
+
+  Scenario: An admin can create another secured resource
+    When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send the following GraphQL request:
+    """
+    mutation {
+      createSecuredDummy(input: {owner: "dunglas", title: "Hi", description: "Desc"}) {
+        securedDummy {
+          id
+          title
+          owner
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createSecuredDummy.securedDummy.owner" should be equal to "dunglas"
+
+  Scenario: A user cannot retrieve an item he doesn't own
+    When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send the following GraphQL request:
+    """
+    {
+      securedDummy(id: "/secured_dummies/1") {
+        owner
+        title
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "errors[0].message" should be equal to "Access Denied."
+
+  Scenario: A user can retrieve an item he owns
+    When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send the following GraphQL request:
+    """
+    {
+      securedDummy(id: "/secured_dummies/2") {
+        owner
+        title
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.securedDummy.owner" should be equal to the string "dunglas"
+
+  Scenario: A user can't assign him an item he doesn't own
+    When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send the following GraphQL request:
+    """
+    mutation {
+      updateSecuredDummy(input: {id: "/secured_dummies/1", owner: "kitten"}) {
+        securedDummy {
+          id
+          title
+          owner
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "errors[0].message" should be equal to "Access Denied."
+
+  Scenario: A user can update an item he owns and transfer it
+    When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send the following GraphQL request:
+    """
+    mutation {
+      updateSecuredDummy(input: {id: "/secured_dummies/2", owner: "vincent"}) {
+        securedDummy {
+          id
+          title
+          owner
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.updateSecuredDummy.securedDummy.owner" should be equal to the string "vincent"

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -92,7 +92,10 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
                 $collection = $this->collectionDataProvider->getCollection($resourceClass, null, $dataProviderContext);
             }
 
-            $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $collection, $operationName ?? 'query');
+            $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, [
+                'object' => $collection,
+                'previous_object' => \is_object($collection) ? clone $collection : $collection,
+            ], $operationName ?? 'query');
 
             if (!$this->paginationEnabled) {
                 $data = [];

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -93,43 +93,56 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                     throw Error::createLocatedError(sprintf('Item "%s" did not match expected type "%s".', $args['input']['id'], $resourceMetadata->getShortName()), $info->fieldNodes, $info->path);
                 }
             }
-
-            $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $item, $operationName);
+            $previousItem = \is_object($item) ? clone $item : $item;
 
             $inputMetadata = $resourceMetadata->getGraphqlAttribute($operationName, 'input', null, true);
             $inputClass = null;
             if (\is_array($inputMetadata) && \array_key_exists('class', $inputMetadata)) {
                 if (null === $inputMetadata['class']) {
+                    $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, [
+                        'object' => $item,
+                        'previous_object' => $previousItem,
+                    ], $operationName);
+
                     return $data;
                 }
 
                 $inputClass = $inputMetadata['class'];
             }
 
-            switch ($operationName) {
-                case 'create':
-                case 'update':
-                    $context = ['resource_class' => $resourceClass, 'graphql_operation_name' => $operationName];
-                    if (null !== $item) {
-                        $context['object_to_populate'] = $item;
-                    }
-                    $context += $resourceMetadata->getGraphqlAttribute($operationName, 'denormalization_context', [], true);
-                    $item = $this->normalizer->denormalize($args['input'], $inputClass ?: $resourceClass, ItemNormalizer::FORMAT, $context);
-                    $this->validate($item, $info, $resourceMetadata, $operationName);
-                    $persistResult = $this->dataPersister->persist($item, $context);
+            if ('create' === $operationName || 'update' === $operationName) {
+                $context = ['resource_class' => $resourceClass, 'graphql_operation_name' => $operationName];
+                if (null !== $item) {
+                    $context['object_to_populate'] = $item;
+                }
 
-                    if (null === $persistResult) {
-                        @trigger_error(sprintf('Returning void from %s::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.', DataPersisterInterface::class), E_USER_DEPRECATED);
-                    }
+                $context += $resourceMetadata->getGraphqlAttribute($operationName, 'denormalization_context', [], true);
+                $item = $this->normalizer->denormalize($args['input'], $inputClass ?: $resourceClass, ItemNormalizer::FORMAT, $context);
+                $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, [
+                    'object' => $item,
+                    'previous_object' => $previousItem,
+                ], $operationName);
+                $this->validate($item, $info, $resourceMetadata, $operationName);
+                $persistResult = $this->dataPersister->persist($item, $context);
 
-                    return [$wrapFieldName => $this->normalizer->normalize($persistResult ?? $item, ItemNormalizer::FORMAT, $normalizationContext)] + $data;
-                case 'delete':
-                    if ($item) {
-                        $this->dataPersister->remove($item);
-                        $data[$wrapFieldName]['id'] = $args['input']['id'];
-                    } else {
-                        $data[$wrapFieldName]['id'] = null;
-                    }
+                if (null === $persistResult) {
+                    @trigger_error(sprintf('Returning void from %s::persist() is deprecated since API Platform 2.3 and will not be supported in API Platform 3, an object should always be returned.', DataPersisterInterface::class), E_USER_DEPRECATED);
+                }
+
+                return [$wrapFieldName => $this->normalizer->normalize($persistResult ?? $item, ItemNormalizer::FORMAT, $normalizationContext)] + $data;
+            }
+
+            $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, [
+                'object' => $item,
+                'previous_object' => $previousItem,
+            ], $operationName);
+
+            if ('delete' === $operationName) {
+                $data[$wrapFieldName]['id'] = null;
+                if ($item) {
+                    $this->dataPersister->remove($item);
+                    $data[$wrapFieldName]['id'] = $args['input']['id'];
+                }
             }
 
             return $data;

--- a/src/GraphQl/Resolver/ItemResolver.php
+++ b/src/GraphQl/Resolver/ItemResolver.php
@@ -69,7 +69,10 @@ final class ItemResolver
 
         $resourceClass = $this->getObjectClass($item);
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-        $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, $item, 'query');
+        $this->canAccess($this->resourceAccessChecker, $resourceMetadata, $resourceClass, $info, [
+            'object' => $item,
+            'previous_object' => \is_object($item) ? clone $item : $item,
+        ], 'query');
 
         $normalizationContext = $resourceMetadata->getGraphqlAttribute('query', 'normalization_context', [], true);
         $normalizationContext['resource_class'] = $resourceClass;

--- a/src/GraphQl/Resolver/ResourceAccessCheckerTrait.php
+++ b/src/GraphQl/Resolver/ResourceAccessCheckerTrait.php
@@ -28,18 +28,16 @@ use GraphQL\Type\Definition\ResolveInfo;
 trait ResourceAccessCheckerTrait
 {
     /**
-     * @param mixed|null $object
-     *
      * @throws Error
      */
-    public function canAccess(?ResourceAccessCheckerInterface $resourceAccessChecker, ResourceMetadata $resourceMetadata, string $resourceClass, ResolveInfo $info, $object = null, string $operationName = null): void
+    public function canAccess(?ResourceAccessCheckerInterface $resourceAccessChecker, ResourceMetadata $resourceMetadata, string $resourceClass, ResolveInfo $info, $extraVariables = [], string $operationName = null): void
     {
         if (null === $resourceAccessChecker) {
             return;
         }
 
         $isGranted = $resourceMetadata->getGraphqlAttribute($operationName ?? '', 'access_control', null, true);
-        if (null === $isGranted || $resourceAccessChecker->isGranted($resourceClass, $isGranted, ['object' => $object])) {
+        if (null === $isGranted || $resourceAccessChecker->isGranted($resourceClass, $isGranted, $extraVariables)) {
             return;
         }
 

--- a/tests/Fixtures/TestBundle/Document/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SecuredDummy.php
@@ -34,9 +34,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
- *         "query"={},
+ *         "query"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
  *         "delete"={},
- *         "update"={},
+ *         "update"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
  *         "create"={"access_control"="has_role('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}
  *     }
  * )

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -33,9 +33,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
  *     },
  *     graphql={
- *         "query"={},
+ *         "query"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
  *         "delete"={},
- *         "update"={},
+ *         "update"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
  *         "create"={"access_control"="has_role('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}
  *     }
  * )


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes (kind of)
| New feature?  | yes
| BC breaks?    | yes (in an experimental trait)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Add support for `previous_object` in GraphQL too, and fix an inconsistency between REST and GraphQL (previously, the object was passed to the security expression before the deserialization, while with REST it was after).

See #2779 and #2811 (/cc @weaverryan)