### PR TITLE
[GraphQL] Resolve types in custom operations

### DIFF
--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -482,6 +482,78 @@ Feature: GraphQL collection support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.dummies.edges" should have 0 element
 
+  Scenario: Custom collection query
+    Given there are 2 dummyCustomQuery objects
+    When I send the following GraphQL request:
+    """
+    {
+      testCollectionDummyCustomQueries {
+        edges {
+          node {
+            message
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON should be equal to:
+    """
+    {
+      "data": {
+        "testCollectionDummyCustomQueries": {
+          "edges": [
+            {
+              "node": {"message": "Success!"}
+            },
+            {
+              "node": {"message": "Success!"}
+            }
+          ]
+        }
+      }
+    }
+    """
+
+  @createSchema
+  Scenario: Custom collection query with custom arguments
+    Given there are 2 dummyCustomQuery objects
+    When I send the following GraphQL request:
+    """
+    {
+      testCollectionCustomArgumentsDummyCustomQueries(customArgumentString: "A string") {
+        edges {
+          node {
+            message
+            customArgs
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON should be equal to:
+    """
+    {
+      "data": {
+        "testCollectionCustomArgumentsDummyCustomQueries": {
+          "edges": [
+            {
+              "node": {"message": "Success!", "customArgs": {"customArgumentString": "A string"}}
+            },
+            {
+              "node": {"message": "Success!", "customArgs": {"customArgumentString": "A string"}}
+            }
+          ]
+        }
+      }
+    }
+    """
+
   @!mongodb
   @createSchema
   Scenario: Retrieve an item with composite primitive identifiers through a GraphQL query

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -204,7 +204,7 @@ Feature: GraphQL mutation support
     When I send the following GraphQL request:
     """
     mutation {
-      updateDummy(input: {id: "/dummies/1", description: "Modified description.", dummyDate: "2018-06-05", clientMutationId: "myId"}) {
+      updateDummy(input: {id: "/dummies/1", description: "Modified description.", dummyDate: "2018-06-05T00:00:00+00:00", clientMutationId: "myId"}) {
         dummy {
           id
           name
@@ -475,3 +475,21 @@ Feature: GraphQL mutation support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.sumNotPersistedDummyCustomMutation.dummyCustomMutation" should be null
+
+  Scenario: Execute a custom mutation with custom arguments
+    When I send the following GraphQL request:
+    """
+    mutation {
+      testCustomArgumentsDummyCustomMutation(input: {operandC: 18, clientMutationId: "myId"}) {
+        dummyCustomMutation {
+          result
+        }
+        clientMutationId
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.testCustomArgumentsDummyCustomMutation.dummyCustomMutation.result" should be equal to "18"
+    And the JSON node "data.testCustomArgumentsDummyCustomMutation.clientMutationId" should be equal to "myId"

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -331,16 +331,22 @@ Feature: GraphQL query support
     }
     """
 
-  Scenario: Custom collection query
+  Scenario: Custom item query with custom arguments
+    Given there are 2 dummyCustomQuery objects
     When I send the following GraphQL request:
     """
     {
-      testCollectionDummyCustomQueries {
-        edges {
-          node {
-            message
-          }
-        }
+      testItemCustomArgumentsDummyCustomQuery(
+        id: "/dummy_custom_queries/1",
+        customArgumentBool: true,
+        customArgumentInt: 3,
+        customArgumentString: "A string",
+        customArgumentFloat: 2.6,
+        customArgumentIntArray: [4],
+        customArgumentCustomType: "2019-05-24T00:00:00+00:00"
+      ) {
+        message
+        customArgs
       }
     }
     """
@@ -351,15 +357,17 @@ Feature: GraphQL query support
     """
     {
       "data": {
-        "testCollectionDummyCustomQueries": {
-          "edges": [
-            {
-              "node": {"message": "Success!"}
-            },
-            {
-              "node": {"message": "Success!"}
-            }
-          ]
+        "testItemCustomArgumentsDummyCustomQuery": {
+          "message": "Success!",
+          "customArgs": {
+            "id": "/dummy_custom_queries/1",
+            "customArgumentBool": true,
+            "customArgumentInt": 3,
+            "customArgumentString": "A string",
+            "customArgumentFloat": 2.6,
+            "customArgumentIntArray": [4],
+            "customArgumentCustomType": "2019-05-24T00:00:00+00:00"
+          }
         }
       }
     }

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -68,6 +68,7 @@
 
         <service id="api_platform.graphql.type_converter" class="ApiPlatform\Core\GraphQl\Type\TypeConverter">
             <argument type="service" id="api_platform.graphql.type_builder" />
+            <argument type="service" id="api_platform.graphql.types_container" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
         </service>
 

--- a/src/GraphQl/Type/FieldsBuilderInterface.php
+++ b/src/GraphQl/Type/FieldsBuilderInterface.php
@@ -46,4 +46,9 @@ interface FieldsBuilderInterface
      * Gets the fields of the type of the given resource.
      */
     public function getResourceObjectTypeFields(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, int $depth, ?array $ioMetadata): array;
+
+    /**
+     * Resolve the args of a resource by resolving its types.
+     */
+    public function resolveResourceArgs(array $args, string $operationName, string $shortName): array;
 }

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -95,7 +95,15 @@ final class TypeBuilder implements TypeBuilderInterface
                     ];
                 }
 
-                return $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder')->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $depth, $ioMetadata);
+                $fieldsBuilder = $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder');
+
+                $fields = $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $depth, $ioMetadata);
+
+                if ($input && null !== $mutationName && null !== $mutationArgs = $resourceMetadata->getGraphql()[$mutationName]['args'] ?? null) {
+                    return $fieldsBuilder->resolveResourceArgs($mutationArgs, $mutationName, $resourceMetadata->getShortName()) + ['clientMutationId' => $fields['clientMutationId']];
+                }
+
+                return $fields;
             },
             'interfaces' => $wrapData ? [] : [$this->getNodeInterface()],
         ];

--- a/src/GraphQl/Type/TypeConverterInterface.php
+++ b/src/GraphQl/Type/TypeConverterInterface.php
@@ -17,7 +17,7 @@ use GraphQL\Type\Definition\Type as GraphQLType;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
- * Convert a built-in type to its GraphQL equivalent.
+ * Converts a type to its GraphQL equivalent.
  *
  * @experimental
  *
@@ -26,7 +26,15 @@ use Symfony\Component\PropertyInfo\Type;
 interface TypeConverterInterface
 {
     /**
+     * Converts a built-in type to its GraphQL equivalent.
+     * A string can be returned for a custom registered type.
+     *
      * @return string|GraphQLType|null
      */
     public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, ?string $property, int $depth);
+
+    /**
+     * Resolves a type written with the GraphQL type system to its object representation.
+     */
+    public function resolveType(string $type): ?GraphQLType;
 }

--- a/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
@@ -31,6 +31,10 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         "mutation"="app.graphql.mutation_resolver.dummy_custom_not_persisted",
  *         "normalization_context"={"groups"={"result"}},
  *         "denormalization_context"={"groups"={"sum"}}
+ *     },
+ *     "testCustomArguments"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom",
+ *         "args"={"operandC"={"type"="Int!"}}
  *     }
  * })
  *

--- a/tests/Fixtures/TestBundle/Document/DummyCustomQuery.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCustomQuery.php
@@ -29,8 +29,27 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  *         "item_query"="app.graphql.query_resolver.dummy_custom_not_retrieved_item_document",
  *         "args"={}
  *     },
+ *     "testItemCustomArguments"={
+ *         "item_query"="app.graphql.query_resolver.dummy_custom_item",
+ *         "args"={
+ *             "id"={"type"="ID"},
+ *             "customArgumentNullableBool"={"type"="Boolean"},
+ *             "customArgumentBool"={"type"="Boolean!"},
+ *             "customArgumentInt"={"type"="Int!"},
+ *             "customArgumentString"={"type"="String!"},
+ *             "customArgumentFloat"={"type"="Float!"},
+ *             "customArgumentIntArray"={"type"="[Int!]!"},
+ *             "customArgumentCustomType"={"type"="DateTime!"}
+ *         }
+ *     },
  *     "testCollection"={
  *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection"
+ *     },
+ *     "testCollectionCustomArguments"={
+ *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection",
+ *         "args"={
+ *             "customArgumentString"={"type"="String!"}
+ *         }
  *     }
  * })
  * @ODM\Document
@@ -48,4 +67,9 @@ class DummyCustomQuery
      * @var string
      */
     public $message;
+
+    /**
+     * @var array
+     */
+    public $customArgs = [];
 }

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
@@ -31,6 +31,10 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         "mutation"="app.graphql.mutation_resolver.dummy_custom_not_persisted",
  *         "normalization_context"={"groups"={"result"}},
  *         "denormalization_context"={"groups"={"sum"}}
+ *     },
+ *     "testCustomArguments"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom",
+ *         "args"={"operandC"={"type"="Int!"}}
  *     }
  * })
  *
@@ -50,7 +54,7 @@ class DummyCustomMutation
     /**
      * @var int
      *
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type="integer", nullable=true)
      */
     private $operandA;
 

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomQuery.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomQuery.php
@@ -29,8 +29,27 @@ use Doctrine\ORM\Mapping as ORM;
  *         "item_query"="app.graphql.query_resolver.dummy_custom_not_retrieved_item",
  *         "args"={}
  *     },
+ *     "testItemCustomArguments"={
+ *         "item_query"="app.graphql.query_resolver.dummy_custom_item",
+ *         "args"={
+ *             "id"={"type"="ID"},
+ *             "customArgumentNullableBool"={"type"="Boolean"},
+ *             "customArgumentBool"={"type"="Boolean!"},
+ *             "customArgumentInt"={"type"="Int!"},
+ *             "customArgumentString"={"type"="String!"},
+ *             "customArgumentFloat"={"type"="Float!"},
+ *             "customArgumentIntArray"={"type"="[Int!]!"},
+ *             "customArgumentCustomType"={"type"="DateTime!"}
+ *         }
+ *     },
  *     "testCollection"={
  *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection"
+ *     },
+ *     "testCollectionCustomArguments"={
+ *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection",
+ *         "args"={
+ *             "customArgumentString"={"type"="String!"}
+ *         }
  *     }
  * })
  * @ORM\Entity
@@ -50,4 +69,9 @@ class DummyCustomQuery
      * @var string
      */
     public $message;
+
+    /**
+     * @var array
+     */
+    public $customArgs = [];
 }

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryCollectionResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryCollectionResolver.php
@@ -33,6 +33,7 @@ class DummyCustomQueryCollectionResolver implements QueryCollectionResolverInter
     {
         foreach ($collection as $dummy) {
             $dummy->message = 'Success!';
+            $dummy->customArgs = $context['args'];
         }
 
         return $collection;

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryItemResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryItemResolver.php
@@ -32,6 +32,7 @@ class DummyCustomQueryItemResolver implements QueryItemResolverInterface
     public function __invoke($item, array $context)
     {
         $item->message = 'Success!';
+        $item->customArgs = $context['args'];
 
         return $item;
     }

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/SumMutationResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/SumMutationResolver.php
@@ -31,6 +31,12 @@ class SumMutationResolver implements MutationResolverInterface
      */
     public function __invoke($item, array $context)
     {
+        if (null !== $operandC = $context['args']['input']['operandC'] ?? null) {
+            $item->setResult((int) $operandC);
+
+            return $item;
+        }
+
         $item->setResult($item->getOperandA() + $item->getOperandB());
 
         return $item;

--- a/tests/Fixtures/TestBundle/GraphQl/Type/Definition/DateTimeType.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Type/Definition/DateTimeType.php
@@ -79,7 +79,7 @@ final class DateTimeType extends ScalarType implements TypeInterface
      */
     public function parseLiteral($valueNode, ?array $variables = null)
     {
-        if ($valueNode instanceof StringValueNode) {
+        if ($valueNode instanceof StringValueNode && false !== \DateTime::createFromFormat(\DateTime::ATOM, $valueNode->value)) {
             return $valueNode->value;
         }
 

--- a/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
@@ -16,10 +16,11 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Type;
 use ApiPlatform\Core\GraphQl\Type\TypeConverterInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy as DummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use GraphQL\Type\Definition\Type as GraphQLType;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
- * Convert a built-in type to its GraphQL equivalent.
+ * Converts a built-in type to its GraphQL equivalent.
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
@@ -46,5 +47,13 @@ final class TypeConverter implements TypeConverterInterface
         }
 
         return $this->defaultTypeConverter->convertType($type, $input, $queryName, $mutationName, $resourceClass, $property, $depth);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveType(string $type): ?GraphQLType
+    {
+        return $this->defaultTypeConverter->resolveType($type);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/830

The last feature needed before documenting the custom queries and mutations!

It allows to modify args of custom queries or mutations by using the GraphQL type system.

For instance, if you want to change the default args of a custom mutation (the `id` of the mutated item by default), you can do it like this:
```php
/**
 * @ApiResource(graphql={
 *     "myMutation"={
 *         "mutation"="app.graphql.mutation_resolver.my_mutation",
 *         "args"={"customArg"={"type"="[Int!]!"}}
 *     }
 * })
 */
class Example
```
Now, the `myMutation` mutation will require a `customArg` argument, an array of integers.