### PR TITLE
Don't try to mock UnitOfWork as it's final

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,20 +83,12 @@ commands:
       - run:
           name: Disable Xdebug PHP extension
           command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-  install-doctrine-mongodb-odm:
-    steps:
-      - run:
-          name: Install Doctrine MongoDB ODM
-          command: |
-            composer require --prefer-dist --no-progress --no-suggest --no-update --ansi \
-              doctrine/mongodb-odm:^2.0@beta \
-              doctrine/mongodb-odm-bundle:^4.0@beta \
   install-mongodb-php-extension:
     steps:
       - run:
           name: Install mongodb PHP extension
           command: |
-            sudo pecl install mongodb
+            sudo pecl install mongodb-1.5.4
             sudo docker-php-ext-enable mongodb
   merge-code-coverage-reports:
     parameters:
@@ -274,17 +266,18 @@ jobs:
     working_directory: ~/api-platform/core
     steps:
       - checkout
-      - restore-composer-cache
-      - restore-php-cs-fixer-cache
+      - install-mongodb-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
+      - restore-composer-cache
       - run:
           name: Install PHP-CS-Fixer
           command: |
             composer global require --prefer-dist --no-progress --no-suggest --ansi \
               friendsofphp/php-cs-fixer:^2.14
       - save-composer-cache
+      - restore-php-cs-fixer-cache
       - run:
           name: Run PHP-CS-Fixer
           command: |
@@ -300,16 +293,15 @@ jobs:
     working_directory: ~/api-platform/core
     steps:
       - checkout
-      - restore-composer-cache
-      - restore-phpstan-cache
+      - install-mongodb-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
-      - install-mongodb-php-extension
       - update-composer
-      - install-doctrine-mongodb-odm
+      - restore-composer-cache
       - update-project-dependencies
       - save-composer-cache
       - clear-test-app-cache
+      - restore-phpstan-cache
       - run:
           name: Run PHPStan
           command: vendor/bin/phpstan analyse --ansi
@@ -321,11 +313,11 @@ jobs:
     working_directory: ~/api-platform/core
     steps:
       - checkout
-      - restore-composer-cache
-      - restore-npm-cache
+      - install-mongodb-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
+      - restore-composer-cache
       - update-project-dependencies
       - save-composer-cache
       - clear-test-app-cache
@@ -337,6 +329,7 @@ jobs:
             export PARALLEL='-j10% --joblog build/logs/parallel.log --rpl {_}\ s/\\//_/g;'
             phpunit_cmd='phpdbg -qrr vendor/bin/phpunit --coverage-php build/coverage/coverage-{_}.cov --log-junit build/logs/phpunit/{_}.xml --exclude-group mongodb,resource-hog --colors=always {}'
             echo "$split_tests" | parallel "$phpunit_cmd" || echo "$split_tests" | parallel --retry-failed "$phpunit_cmd"
+      - restore-npm-cache
       - merge-test-reports:
           dir: build/logs/phpunit
           out: build/logs/phpunit/junit.xml
@@ -367,11 +360,11 @@ jobs:
     working_directory: ~/api-platform/core
     steps:
       - checkout
-      - restore-composer-cache
-      - restore-npm-cache
+      - install-mongodb-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
+      - restore-composer-cache
       - update-project-dependencies
       - save-composer-cache
       - clear-test-app-cache
@@ -383,6 +376,7 @@ jobs:
               _f=$(echo "$f" | tr / _)
               FEATURE="${_f}" phpdbg -qrr vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat/"${_f}" --profile=default-coverage --no-interaction "$f"
             done
+      - restore-npm-cache
       - merge-test-reports:
           dir: build/logs/behat
           out: build/logs/behat/junit.xml
@@ -411,13 +405,11 @@ jobs:
     working_directory: ~/api-platform/core
     steps:
       - checkout
-      - restore-composer-cache
-      - restore-npm-cache
+      - install-mongodb-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
-      - install-mongodb-php-extension
       - update-composer
-      - install-doctrine-mongodb-odm
+      - restore-composer-cache
       - update-project-dependencies
       - save-composer-cache
       - clear-test-app-cache
@@ -435,6 +427,7 @@ jobs:
       - store_artifacts:
           path: build/logs/clover.xml
           destination: build/logs/clover.xml
+      - restore-npm-cache
       - codecov/upload:
           file: build/logs/clover.xml
           flags: phpunit_mongodb
@@ -449,13 +442,11 @@ jobs:
     working_directory: ~/api-platform/core
     steps:
       - checkout
-      - restore-composer-cache
-      - restore-npm-cache
+      - install-mongodb-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
-      - install-mongodb-php-extension
       - update-composer
-      - install-doctrine-mongodb-odm
+      - restore-composer-cache
       - update-project-dependencies
       - save-composer-cache
       - clear-test-app-cache
@@ -465,6 +456,7 @@ jobs:
           command: |
             mkdir -p build/logs/behat
             phpdbg -qrr vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat --profile=mongodb-coverage --no-interaction
+      - restore-npm-cache
       - merge-test-reports:
           dir: build/logs/behat
           out: build/logs/behat/junit.xml
@@ -493,11 +485,11 @@ jobs:
     working_directory: ~/api-platform/core
     steps:
       - checkout
-      - restore-composer-cache
-      - restore-npm-cache
+      - install-mongodb-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
+      - restore-composer-cache
       - update-project-dependencies
       - save-composer-cache
       - clear-test-app-cache
@@ -507,6 +499,7 @@ jobs:
           command: |
             mkdir -p build/logs/behat
             phpdbg -qrr vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat --profile=elasticsearch-coverage --no-interaction
+      - restore-npm-cache
       - merge-test-reports:
           dir: build/logs/behat
           out: build/logs/behat/junit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ cache:
       echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - &disable-xdebug-php-extension |
       phpenv config-rm xdebug.ini || echo "xdebug not available"
-  - &install-doctrine-mongodb-odm |
-      composer require --prefer-dist --no-progress --no-suggest --no-update --ansi \
-        doctrine/mongodb-odm:^2.0@beta \
-        doctrine/mongodb-odm-bundle:^4.0@beta \
   - &install-mongodb-php-extension |
       echo "extension=mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/mongodb.ini
   - &run-behat-tests |
@@ -39,10 +35,16 @@ jobs:
   include:
     - php: '7.1'
       before_install:
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
+        - |
+          composer remove --dev --no-progress --no-update --ansi \
+            doctrine/mongodb-odm \
+            doctrine/mongodb-odm-bundle \
+        - sed -i '33,39d' tests/Fixtures/app/config/config_common.yml
         - *update-project-dependencies
       before_script:
         - *clear-test-app-cache
@@ -57,8 +59,9 @@ jobs:
 
     - php: '7.2'
       before_install:
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
         - *update-project-dependencies
@@ -75,8 +78,9 @@ jobs:
 
     - php: '7.3'
       before_install:
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
         - *update-project-dependencies
@@ -94,8 +98,9 @@ jobs:
     - php: '7.3'
       env: deps=low
       before_install:
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
         - composer update --prefer-dist --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi
@@ -115,8 +120,9 @@ jobs:
       services:
         - postgresql
       before_install:
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
         - *update-project-dependencies
@@ -137,8 +143,9 @@ jobs:
       services:
         - mysql
       before_install:
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
         - *update-project-dependencies
@@ -159,12 +166,11 @@ jobs:
       services:
         - mongodb
       before_install:
-        - *disable-php-memory-limit
         - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
-        - *install-doctrine-mongodb-odm
         - *update-project-dependencies
       before_script:
         - *clear-test-app-cache
@@ -186,8 +192,9 @@ jobs:
         - sudo apt-get update
         - sudo apt-get install elasticsearch
         - sudo service elasticsearch start
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
         - *update-project-dependencies
@@ -205,8 +212,9 @@ jobs:
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
       before_install:
-        - *disable-php-memory-limit
+        - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
+        - *disable-php-memory-limit
         - *add-composer-bin-dir-to-path
       install:
         - *update-project-dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - echo extension=php_mongodb.dll >> php.ini
   - echo memory_limit=3G >> php.ini
   - cd %APPVEYOR_BUILD_FOLDER%
-  - composer install --no-interaction --no-progress --no-suggest --ignore-platform-reqs
+  - composer install --no-progress --no-suggest --no-interaction
 
 services:
   - mongodb

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,11 @@
         "behat/symfony2-extension": "^2.1.1",
         "behatch/contexts": "3.1.0",
         "doctrine/annotations": "^1.2",
+        "doctrine/data-fixtures": "^1.2.2",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/doctrine-cache-bundle": "^1.3.5",
+        "doctrine/mongodb-odm": "^2.0@beta",
+        "doctrine/mongodb-odm-bundle": "^4.0@beta",
         "doctrine/orm": "^2.6.3",
         "elasticsearch/elasticsearch": "^6.0",
         "friendsofsymfony/user-bundle": "^2.2@dev",
@@ -102,10 +105,14 @@
         "webonyx/graphql-php": "To support GraphQL."
     },
     "autoload": {
-        "psr-4": { "ApiPlatform\\Core\\": "src/" }
+        "psr-4": {
+            "ApiPlatform\\Core\\": "src/"
+        }
     },
     "autoload-dev": {
-        "psr-4": { "ApiPlatform\\Core\\Tests\\": "tests/" }
+        "psr-4": {
+            "ApiPlatform\\Core\\Tests\\": "tests/"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/tests/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtensionTest.php
@@ -21,6 +21,8 @@ use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Test\DoctrineMongoDbOdmSetup;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Count;
@@ -30,7 +32,6 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Skip;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Doctrine\ODM\MongoDB\UnitOfWork;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -44,6 +45,8 @@ class PaginationExtensionTest extends TestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
     }
 
@@ -337,25 +340,16 @@ class PaginationExtensionTest extends TestCase
 
     public function testGetResult()
     {
-        $result = $this->getPaginationExtensionResult();
-
-        $this->assertInstanceOf(PartialPaginatorInterface::class, $result);
-        $this->assertInstanceOf(PaginatorInterface::class, $result);
-    }
-
-    private function getPaginationExtensionResult()
-    {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory);
 
-        $unitOfWorkProphecy = $this->prophesize(UnitOfWork::class);
+        $fixturesPath = \dirname((string) (new \ReflectionClass(Dummy::class))->getFileName());
+        $config = DoctrineMongoDbOdmSetup::createAnnotationMetadataConfiguration([$fixturesPath], true);
+        $documentManager = DocumentManager::create(null, $config);
 
-        $documentManagerProphecy = $this->prophesize(DocumentManager::class);
-        $documentManagerProphecy->getUnitOfWork()->willReturn($unitOfWorkProphecy->reveal());
-
-        $this->managerRegistryProphecy->getManagerForClass('Foo')->willReturn($documentManagerProphecy->reveal());
+        $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($documentManager);
 
         $iteratorProphecy = $this->prophesize(Iterator::class);
         $iteratorProphecy->toArray()->willReturn([
@@ -389,7 +383,10 @@ class PaginationExtensionTest extends TestCase
             $pagination
         );
 
-        return $paginationExtension->getResult($aggregationBuilderProphecy->reveal(), 'Foo');
+        $result = $paginationExtension->getResult($aggregationBuilderProphecy->reveal(), Dummy::class);
+
+        $this->assertInstanceOf(PartialPaginatorInterface::class, $result);
+        $this->assertInstanceOf(PaginatorInterface::class, $result);
     }
 
     private function mockAggregationBuilder($expectedOffset, $expectedLimit)

--- a/tests/Bridge/Doctrine/MongoDbOdm/PaginatorTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/PaginatorTest.php
@@ -15,9 +15,10 @@ namespace ApiPlatform\Core\Tests\Bridge\Doctrine\MongoDbOdm;
 
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Paginator;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Test\DoctrineMongoDbOdmSetup;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
-use Doctrine\ODM\MongoDB\UnitOfWork;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -129,9 +130,11 @@ class PaginatorTest extends TestCase
             ],
         ]);
 
-        $unitOfWork = $this->prophesize(UnitOfWork::class);
+        $fixturesPath = \dirname((string) (new \ReflectionClass(Dummy::class))->getFileName());
+        $config = DoctrineMongoDbOdmSetup::createAnnotationMetadataConfiguration([$fixturesPath], true);
+        $documentManager = DocumentManager::create(null, $config);
 
-        return new Paginator($iterator->reveal(), $unitOfWork->reveal(), Dummy::class, $pipeline);
+        return new Paginator($iterator->reveal(), $documentManager->getUnitOfWork(), Dummy::class, $pipeline);
     }
 
     private function getPaginatorWithMissingStage($facet = false, $results = false, $count = false, $maxResults = false)
@@ -157,9 +160,12 @@ class PaginatorTest extends TestCase
         }
 
         $iterator = $this->prophesize(Iterator::class);
-        $unitOfWork = $this->prophesize(UnitOfWork::class);
 
-        return new Paginator($iterator->reveal(), $unitOfWork->reveal(), Dummy::class, $pipeline);
+        $fixturesPath = \dirname((string) (new \ReflectionClass(Dummy::class))->getFileName());
+        $config = DoctrineMongoDbOdmSetup::createAnnotationMetadataConfiguration([$fixturesPath], true);
+        $documentManager = DocumentManager::create(null, $config);
+
+        return new Paginator($iterator->reveal(), $documentManager->getUnitOfWork(), Dummy::class, $pipeline);
     }
 
     private function getPaginatorWithNoCount($firstResult = 1, $maxResults = 15)
@@ -184,9 +190,12 @@ class PaginatorTest extends TestCase
                 'results' => [],
             ],
         ]);
-        $unitOfWork = $this->prophesize(UnitOfWork::class);
 
-        return new Paginator($iterator->reveal(), $unitOfWork->reveal(), Dummy::class, $pipeline);
+        $fixturesPath = \dirname((string) (new \ReflectionClass(Dummy::class))->getFileName());
+        $config = DoctrineMongoDbOdmSetup::createAnnotationMetadataConfiguration([$fixturesPath], true);
+        $documentManager = DocumentManager::create(null, $config);
+
+        return new Paginator($iterator->reveal(), $documentManager->getUnitOfWork(), Dummy::class, $pipeline);
     }
 
     public function initializeProvider()

--- a/tests/Fixtures/app/bootstrap.php
+++ b/tests/Fixtures/app/bootstrap.php
@@ -12,8 +12,6 @@
 declare(strict_types=1);
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\DBAL\Types\DateType;
-use Doctrine\DBAL\Types\Type;
 
 date_default_timezone_set('UTC');
 
@@ -21,10 +19,5 @@ $loader = require __DIR__.'/../../../vendor/autoload.php';
 require __DIR__.'/AppKernel.php';
 
 AnnotationRegistry::registerLoader('class_exists');
-
-if (!array_key_exists('date_immutable', Type::getTypesMap())) {
-    // Hack to avoid Unknown column type "date_immutable" requested with doctrine < 2.6 when loading DummyImmutableDate
-    Type::addType('date_immutable', DateType::class);
-}
 
 return $loader;

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -30,6 +30,13 @@ doctrine:
         auto_generate_proxy_classes:   '%kernel.debug%'
         auto_mapping:                  true
 
+doctrine_mongodb:
+    connections:
+        default: ~
+    document_managers:
+        default:
+            auto_mapping: true
+
 twig:
     strict_variables: '%kernel.debug%'
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Also re-add mongodb packages to `require-dev` as we want developers to be able to run `phpstan` successfully. This means they must have `ext-mongodb`, but it's easy to satisfy this requirement...