### PR TITLE
Fixed denormalization of a constructor argument which is a collection of non-resources

### DIFF
--- a/features/serializer/deserialize_objects_using_constructor.feature
+++ b/features/serializer/deserialize_objects_using_constructor.feature
@@ -10,7 +10,12 @@ Feature: Resource with constructor deserializable
     """
     {
       "foo": "hello",
-      "bar": "world"
+      "bar": "world",
+      "items": [
+        {
+          "foo": "bar"
+        }
+      ]
     }
     """
     Then the response status code should be 201
@@ -25,7 +30,11 @@ Feature: Resource with constructor deserializable
       "id": 1,
       "foo": "hello",
       "bar": "world",
+      "items": [
+        {
+          "foo": "bar"
+        }
+      ],
       "baz": null
     }
     """
-

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -677,7 +677,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
             unset($context['resource_class']);
 
-            return $this->serializer->denormalize($value, $className, $format, $context);
+            return $this->serializer->denormalize($value, $className.'[]', $format, $context);
         }
 
         if (null !== $className = $type->getClassName()) {

--- a/tests/Fixtures/TestBundle/Document/DummyEntityWithConstructor.php
+++ b/tests/Fixtures/TestBundle/Document/DummyEntityWithConstructor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\DummyObjectWithoutConstructor;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -62,10 +63,19 @@ class DummyEntityWithConstructor
      */
     private $baz;
 
-    public function __construct(string $foo, string $bar)
+    /**
+     * @var DummyObjectWithoutConstructor[]
+     */
+    private $items;
+
+    /**
+     * @param DummyObjectWithoutConstructor[] $items
+     */
+    public function __construct(string $foo, string $bar, array $items)
     {
         $this->foo = $foo;
         $this->bar = $bar;
+        $this->items = $items;
     }
 
     public function getId(): int
@@ -81,6 +91,14 @@ class DummyEntityWithConstructor
     public function getBar(): string
     {
         return $this->bar;
+    }
+
+    /**
+     * @return DummyObjectWithoutConstructor[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
     }
 
     /**

--- a/tests/Fixtures/TestBundle/Entity/DummyEntityWithConstructor.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyEntityWithConstructor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\DummyObjectWithoutConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -64,10 +65,19 @@ class DummyEntityWithConstructor
      */
     private $baz;
 
-    public function __construct(string $foo, string $bar)
+    /**
+     * @var DummyObjectWithoutConstructor[]
+     */
+    private $items;
+
+    /**
+     * @param DummyObjectWithoutConstructor[] $items
+     */
+    public function __construct(string $foo, string $bar, array $items)
     {
         $this->foo = $foo;
         $this->bar = $bar;
+        $this->items = $items;
     }
 
     public function getId(): int
@@ -83,6 +93,14 @@ class DummyEntityWithConstructor
     public function getBar(): string
     {
         return $this->bar;
+    }
+
+    /**
+     * @return DummyObjectWithoutConstructor[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
     }
 
     /**


### PR DESCRIPTION
Hi Folks!

After upgrading to 2.4.4 (from 2.4.2) I started getting an error.
The error wording is: `The property path constructor needs a string or an instance of \"Symfony\\Component\\PropertyAccess\\PropertyPath\". Got: \"integer\" in symfony/serializer/Normalizer/AbstractObjectNormalizer.php, line 302`.

I fixed this bug by adding '[]' to the class of the collection argument at [this line](https://github.com/api-platform/core/blob/v2.4.4/src/Serializer/AbstractItemNormalizer.php#L666).

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | PR adds the test case
| License       | MIT
| Doc PR        | api-platform/doc#1234

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
