### PR TITLE
Allow messenger handler to return non-resource output

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -164,6 +164,7 @@
             <argument type="service" id="api_platform.data_persister" />
             <argument type="service" id="api_platform.iri_converter" on-invalid="null" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
 
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="32" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2860 #2810
| License       | MIT

Hi folks!

Let's imagine ResetPasswordRequest / ResetPasswordRequestHandler case from the api-platform docs (https://api-platform.com/docs/core/messenger/).

Before api-platform v2.4.3 it was possible to return the output dto object (ResetPasswordResponse) directly from the messenger handler. It was very convenient, and that's what dto's are for - return a custom response without exposing an entity.
As of v2.4.3 it started to complain that ResetPasswordResponse must be a resource, so this PR allows returning the non-resource output.