### PR TITLE
Allow data provider to throw ItemNotFoundException

### DIFF
--- a/src/DataProvider/CollectionDataProviderInterface.php
+++ b/src/DataProvider/CollectionDataProviderInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\DataProvider;
 
+use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
@@ -26,6 +27,7 @@ interface CollectionDataProviderInterface
      * Retrieves a collection.
      *
      * @throws ResourceClassNotSupportedException
+     * @throws ItemNotFoundException              if the collection does not exist
      *
      * @return array|\Traversable
      */

--- a/src/DataProvider/ItemDataProviderInterface.php
+++ b/src/DataProvider/ItemDataProviderInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\DataProvider;
 
+use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
@@ -28,6 +29,7 @@ interface ItemDataProviderInterface
      * @param array|int|string $id
      *
      * @throws ResourceClassNotSupportedException
+     * @throws ItemNotFoundException              if the item does not exist
      *
      * @return object|null
      */

--- a/src/DataProvider/SubresourceDataProviderInterface.php
+++ b/src/DataProvider/SubresourceDataProviderInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\DataProvider;
 
+use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 
 /**
@@ -31,6 +32,7 @@ interface SubresourceDataProviderInterface
      * @param string $operationName
      *
      * @throws ResourceClassNotSupportedException
+     * @throws ItemNotFoundException              if the subresource does not exist
      *
      * @return array|object|null
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Converted to `NotFoundHttpException` in `ReadListener`

TODO:

- [ ] Add tests