### PR TITLE
Remove ignored errors in phpstan which have been resolved upstream

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,13 +32,6 @@ parameters:
 			path: %currentWorkingDirectory%/src/GraphQl/Resolver/FieldsToAttributesTrait.php
 		- '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy<(\\?[a-zA-Z0-9_]+)+>::\$[a-zA-Z0-9_]+#'
 		- '#Call to an undefined method Doctrine\\Common\\Persistence\\ObjectManager::getConnection\(\)#'
-		# https://github.com/symfony/symfony/pull/31903
-		-
-			message: '#Access to property \$headers on an unknown class Symfony\\Component\\HttpKernel\\Response\.#'
-			path: %currentWorkingDirectory%/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
-		-
-			message: '#Call to method getStatusCode\(\) on an unknown class Symfony\\Component\\HttpKernel\\Response\.#'
-			path: %currentWorkingDirectory%/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
 		- '#Parameter \#1 \$function of function call_user_func expects callable\(\): mixed, .+ given\.#'
 		- '#Parameter \#1 \$exception of static method Symfony\\Component\\Debug\\Exception\\FlattenException::create\(\) expects Exception, Symfony\\Component\\Serializer\\Exception\\ExceptionInterface given\.#'
 		- '#Parameter \#1 \$classes of class ApiPlatform\\Core\\Metadata\\Resource\\ResourceNameCollection constructor expects array<string>, array<int, int\|string> given\.#'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

symfony/symfony#31903 was released.

https://github.com/api-platform/core/pull/2885 is blocked on `2.4`, but this should be good for `master`.