### PR TITLE
A faulty Content-Type should return the 415 status code, not 406

### DIFF
--- a/features/security/validate_incoming_content-types.feature
+++ b/features/security/validate_incoming_content-types.feature
@@ -11,6 +11,6 @@ Feature: Validate incoming content type
     """
     something
     """
-    Then the response status code should be 406
+    Then the response status code should be 415
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON node "hydra:description" should be equal to 'The content-type "text/plain" is not supported. Supported MIME types are "application/ld+json", "application/hal+json", "application/vnd.api+json", "application/xml", "text/xml", "application/json", "text/html".'

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -22,7 +22,6 @@ use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -66,6 +65,8 @@ final class DeserializeListener
 
     /**
      * Deserializes the data sent in the requested format.
+     *
+     * @throws UnsupportedMediaTypeHttpException
      */
     public function onKernelRequest(GetResponseEvent $event): void
     {
@@ -105,7 +106,7 @@ final class DeserializeListener
     /**
      * Extracts the format from the Content-Type header and check that it is supported.
      *
-     * @throws NotAcceptableHttpException
+     * @throws UnsupportedMediaTypeHttpException
      */
     private function getFormat(Request $request): string
     {

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -23,6 +23,7 @@ use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -113,7 +114,7 @@ final class DeserializeListener
          */
         $contentType = $request->headers->get('CONTENT_TYPE');
         if (null === $contentType) {
-            throw new NotAcceptableHttpException('The "Content-Type" header must exist.');
+            throw new UnsupportedMediaTypeHttpException('The "Content-Type" header must exist.');
         }
 
         $format = $this->formatMatcher->getFormat($contentType);
@@ -125,7 +126,7 @@ final class DeserializeListener
                 }
             }
 
-            throw new NotAcceptableHttpException(sprintf(
+            throw new UnsupportedMediaTypeHttpException(sprintf(
                 'The content-type "%s" is not supported. Supported MIME types are "%s".',
                 $contentType,
                 implode('", "', $supportedMimeTypes)

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -227,7 +227,7 @@ class DeserializeListenerTest extends TestCase
 
     public function testNotSupportedContentType()
     {
-        $this->expectException(NotAcceptableHttpException::class);
+        $this->expectException(UnsupportedMediaTypeHttpException::class);
         $this->expectExceptionMessage('The content-type "application/rdf+xml" is not supported. Supported MIME types are "application/ld+json", "text/xml".');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);
@@ -257,7 +257,7 @@ class DeserializeListenerTest extends TestCase
 
     public function testNoContentType()
     {
-        $this->expectException(NotAcceptableHttpException::class);
+        $this->expectException(UnsupportedMediaTypeHttpException::class);
         $this->expectExceptionMessage('The "Content-Type" header must exist.');
 
         $eventProphecy = $this->prophesize(GetResponseEvent::class);


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a
