### PR TITLE
Allow to extract blank values from composite identifier

### DIFF
--- a/src/Identifier/CompositeIdentifierParser.php
+++ b/src/Identifier/CompositeIdentifierParser.php
@@ -33,7 +33,7 @@ final class CompositeIdentifierParser
     {
         $matches = [];
         $identifiers = [];
-        $num = preg_match_all('/(\w+)=(?<=\w=)(.+?)(?=;\w+=)|(\w+)=([^;]+);?$/', $identifier, $matches, PREG_SET_ORDER);
+        $num = preg_match_all('/(\w+)=(?<=\w=)(.*?)(?=;\w+=)|(\w+)=([^;]*);?$/', $identifier, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $i => $match) {
             if ($i === $num - 1) {

--- a/tests/Identifier/CompositeIdentifierParserTest.php
+++ b/tests/Identifier/CompositeIdentifierParserTest.php
@@ -37,6 +37,8 @@ class CompositeIdentifierParserTest extends TestCase
             'a=test;b=bar;foo;c=123' => ['a' => 'test', 'b' => 'bar;foo', 'c' => '123'],
             'a=test;b=bar ;foo;c=123;459;barz=123asgfjasdg4;' => ['a' => 'test', 'b' => 'bar ;foo', 'c' => '123;459', 'barz' => '123asgfjasdg4'],
             'foo=test=bar;;bar=bazzz;' => ['foo' => 'test=bar;', 'bar' => 'bazzz'],
+            'foo=test=bar;bar=;test=foo' => ['foo' => 'test=bar', 'bar' => '', 'test' => 'foo'],
+            'foo=test=bar;bar=' => ['foo' => 'test=bar', 'bar' => ''],
         ]]];
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

This modification allow to correctly fetch item with composite identifiers where some fields might be blank (not null) but are still needed to determine the correct record.

Currently it would fail as the `ApiPlatform\Core\Identifier\IdentifierConverter` would throw an `ApiPlatform\Core\Exception\InvalidIdentifierException` [here](https://github.com/api-platform/core/blob/d46ac32d404e0858c2d2dd13966fb1a5a52f6719/src/Identifier/IdentifierConverter.php#L54-L65) resulting in a `Symfony\Component\HttpKernel\Exception\NotFoundHttpException` in the `ApiPlatform\Core\EventListener\ReadLister`, because of an invalid identifier configuration` [here](https://github.com/api-platform/core/blob/d46ac32d404e0858c2d2dd13966fb1a5a52f6719/src/EventListener/ReadListener.php#L109-L111)