### PR TITLE
Change arrow function to an IE11 compatible function

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Bridge/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -1,6 +1,6 @@
 'use strict';
 
-window.onload = () => {
+window.onload = function() {
     manageWebbyDisplay();
 
     new MutationObserver(function (mutations, self) {


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/nelmio/NelmioApiDocBundle/issues/1517
| License       | MIT

Quick fix just to change the arrow function to something that IE11 supports. Everything else in the Nelmio API Doc Bundle works, just this single file arrow function breaks it in IE11