### PR TITLE
Replace has_role() by is_granted()

### DIFF
--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -27,7 +27,7 @@ class ApiResourceTest extends TestCase
     public function testConstruct()
     {
         $resource = new ApiResource([
-            'accessControl' => 'has_role("ROLE_FOO")',
+            'accessControl' => 'is_granted("ROLE_FOO")',
             'accessControlMessage' => 'You are not foo.',
             'attributes' => ['foo' => 'bar', 'validation_groups' => ['baz', 'qux'], 'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0]],
             'collectionOperations' => ['bar' => ['foo']],
@@ -71,7 +71,7 @@ class ApiResourceTest extends TestCase
         $this->assertSame([], $resource->subresourceOperations);
         $this->assertSame(['query' => ['normalization_context' => ['groups' => ['foo', 'bar']]]], $resource->graphql);
         $this->assertEquals([
-            'access_control' => 'has_role("ROLE_FOO")',
+            'access_control' => 'is_granted("ROLE_FOO")',
             'access_control_message' => 'You are not foo.',
             'denormalization_context' => ['groups' => ['foo']],
             'fetch_partial' => true,
@@ -118,7 +118,7 @@ class ApiResourceTest extends TestCase
         $this->assertEquals([
             'foo' => 'bar',
             'route_prefix' => '/whatever',
-            'access_control' => "has_role('ROLE_FOO')",
+            'access_control' => "is_granted('ROLE_FOO')",
             'access_control_message' => 'You are not foo.',
             'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0],
         ], $resource->attributes);

--- a/tests/Fixtures/AnnotatedClass.php
+++ b/tests/Fixtures/AnnotatedClass.php
@@ -25,7 +25,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
  *     graphql={"query"={"normalization_context"={"groups"={"foo", "bar"}}}},
  *     attributes={"foo"="bar", "route_prefix"="/whatever", "cache_headers"={"max_age"=0, "shared_max_age"=0}},
  *     routePrefix="/foo",
- *     accessControl="has_role('ROLE_FOO')",
+ *     accessControl="is_granted('ROLE_FOO')",
  *     accessControlMessage="You are not foo."
  * )
  *

--- a/tests/Fixtures/TestBundle/Document/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SecuredDummy.php
@@ -24,20 +24,20 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Alan Poulain <contact@alanpoulain.eu>
  *
  * @ApiResource(
- *     attributes={"access_control"="has_role('ROLE_USER')"},
+ *     attributes={"access_control"="is_granted('ROLE_USER')"},
  *     collectionOperations={
  *         "get",
- *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
+ *         "post"={"access_control"="is_granted('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
- *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() == user"},
+ *         "get"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
- *         "query"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "query"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
  *         "delete"={},
- *         "update"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
- *         "create"={"access_control"="has_role('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}
+ *         "update"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() ==  user"},
+ *         "create"={"access_control"="is_granted('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}
  *     }
  * )
  * @ODM\Document

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -23,20 +23,20 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
  * @ApiResource(
- *     attributes={"access_control"="has_role('ROLE_USER')"},
+ *     attributes={"access_control"="is_granted('ROLE_USER')"},
  *     collectionOperations={
  *         "get",
- *         "post"={"access_control"="has_role('ROLE_ADMIN')"}
+ *         "post"={"access_control"="is_granted('ROLE_ADMIN')"}
  *     },
  *     itemOperations={
- *         "get"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
- *         "put"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
+ *         "get"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "put"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() ==  user"},
  *     },
  *     graphql={
- *         "query"={"access_control"="has_role('ROLE_USER') and object.getOwner() == user"},
+ *         "query"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
  *         "delete"={},
- *         "update"={"access_control"="has_role('ROLE_USER') and previous_object.getOwner() ==  user"},
- *         "create"={"access_control"="has_role('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}
+ *         "update"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() ==  user"},
+ *         "create"={"access_control"="is_granted('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}
  *     }
  * )
  * @ORM\Entity

--- a/tests/Security/EventListener/DenyAccessListenerTest.php
+++ b/tests/Security/EventListener/DenyAccessListenerTest.php
@@ -78,13 +78,13 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
 
         $resourceAccessCheckerProphecy = $this->prophesize(ResourceAccessCheckerInterface::class);
-        $resourceAccessCheckerProphecy->isGranted('Foo', 'has_role("ROLE_ADMIN")', Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $resourceAccessCheckerProphecy->isGranted('Foo', 'is_granted("ROLE_ADMIN")', Argument::type('array'))->willReturn(true)->shouldBeCalled();
 
         $listener = $this->getListener($resourceMetadataFactoryProphecy->reveal(), $resourceAccessCheckerProphecy->reveal());
         $listener->onKernelRequest($event);
@@ -100,13 +100,13 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
 
         $resourceAccessCheckerProphecy = $this->prophesize(ResourceAccessCheckerInterface::class);
-        $resourceAccessCheckerProphecy->isGranted('Foo', 'has_role("ROLE_ADMIN")', Argument::type('array'))->willReturn(false)->shouldBeCalled();
+        $resourceAccessCheckerProphecy->isGranted('Foo', 'is_granted("ROLE_ADMIN")', Argument::type('array'))->willReturn(false)->shouldBeCalled();
 
         $listener = $this->getListener($resourceMetadataFactoryProphecy->reveal(), $resourceAccessCheckerProphecy->reveal());
         $listener->onKernelRequest($event);
@@ -123,13 +123,13 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")', 'access_control_message' => 'You are not admin.']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")', 'access_control_message' => 'You are not admin.']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
 
         $resourceAccessCheckerProphecy = $this->prophesize(ResourceAccessCheckerInterface::class);
-        $resourceAccessCheckerProphecy->isGranted('Foo', 'has_role("ROLE_ADMIN")', Argument::type('array'))->willReturn(false)->shouldBeCalled();
+        $resourceAccessCheckerProphecy->isGranted('Foo', 'is_granted("ROLE_ADMIN")', Argument::type('array'))->willReturn(false)->shouldBeCalled();
 
         $listener = $this->getListener($resourceMetadataFactoryProphecy->reveal(), $resourceAccessCheckerProphecy->reveal());
         $listener->onKernelRequest($event);
@@ -147,13 +147,13 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
 
         $expressionLanguageProphecy = $this->prophesize(ExpressionLanguage::class);
-        $expressionLanguageProphecy->evaluate('has_role("ROLE_ADMIN")', Argument::type('array'))->willReturn(true)->shouldBeCalled();
+        $expressionLanguageProphecy->evaluate('is_granted("ROLE_ADMIN")', Argument::type('array'))->willReturn(true)->shouldBeCalled();
 
         $listener = $this->getLegacyListener($resourceMetadataFactoryProphecy->reveal(), $expressionLanguageProphecy->reveal());
         $listener->onKernelRequest($event);
@@ -172,13 +172,13 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
 
         $expressionLanguageProphecy = $this->prophesize(ExpressionLanguage::class);
-        $expressionLanguageProphecy->evaluate('has_role("ROLE_ADMIN")', Argument::type('array'))->willReturn(false)->shouldBeCalled();
+        $expressionLanguageProphecy->evaluate('is_granted("ROLE_ADMIN")', Argument::type('array'))->willReturn(false)->shouldBeCalled();
 
         $listener = $this->getLegacyListener($resourceMetadataFactoryProphecy->reveal(), $expressionLanguageProphecy->reveal());
         $listener->onKernelRequest($event);
@@ -197,7 +197,7 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
@@ -219,7 +219,7 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
@@ -245,7 +245,7 @@ class DenyAccessListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request)->shouldBeCalled();
         $event = $eventProphecy->reveal();
 
-        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'has_role("ROLE_ADMIN")']);
+        $resourceMetadata = new ResourceMetadata(null, null, null, null, null, ['access_control' => 'is_granted("ROLE_ADMIN")']);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();

--- a/tests/Security/ResourceAccessCheckerTest.php
+++ b/tests/Security/ResourceAccessCheckerTest.php
@@ -33,7 +33,7 @@ class ResourceAccessCheckerTest extends TestCase
     public function testIsGranted(bool $granted)
     {
         $expressionLanguageProphecy = $this->prophesize(ExpressionLanguage::class);
-        $expressionLanguageProphecy->evaluate('has_role("ROLE_ADMIN")', Argument::type('array'))->willReturn($granted)->shouldBeCalled();
+        $expressionLanguageProphecy->evaluate('is_granted("ROLE_ADMIN")', Argument::type('array'))->willReturn($granted)->shouldBeCalled();
 
         $authenticationTrustResolverProphecy = $this->prophesize(AuthenticationTrustResolverInterface::class);
         $tokenStorageProphecy = $this->prophesize(TokenStorageInterface::class);
@@ -46,7 +46,7 @@ class ResourceAccessCheckerTest extends TestCase
         $tokenStorageProphecy->getToken()->willReturn($tokenProphecy);
 
         $checker = new ResourceAccessChecker($expressionLanguageProphecy->reveal(), $authenticationTrustResolverProphecy->reveal(), null, $tokenStorageProphecy->reveal());
-        $this->assertSame($granted, $checker->isGranted(Dummy::class, 'has_role("ROLE_ADMIN")'));
+        $this->assertSame($granted, $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")'));
     }
 
     public function getGranted(): array
@@ -60,7 +60,7 @@ class ResourceAccessCheckerTest extends TestCase
         $this->expectExceptionMessage('The "symfony/security" library must be installed to use the "access_control" attribute.');
 
         $checker = new ResourceAccessChecker($this->prophesize(ExpressionLanguage::class)->reveal());
-        $checker->isGranted(Dummy::class, 'has_role("ROLE_ADMIN")');
+        $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")');
     }
 
     public function testExpressionLanguageNotInstalled()
@@ -73,7 +73,7 @@ class ResourceAccessCheckerTest extends TestCase
         $tokenStorageProphecy->getToken()->willReturn($this->prophesize(TokenInterface::class)->reveal());
 
         $checker = new ResourceAccessChecker(null, $authenticationTrustResolverProphecy->reveal(), null, $tokenStorageProphecy->reveal());
-        $checker->isGranted(Dummy::class, 'has_role("ROLE_ADMIN")');
+        $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")');
     }
 
     public function testNotBehindAFirewall()
@@ -85,6 +85,6 @@ class ResourceAccessCheckerTest extends TestCase
         $tokenStorageProphecy = $this->prophesize(TokenStorageInterface::class);
 
         $checker = new ResourceAccessChecker(null, $authenticationTrustResolverProphecy->reveal(), null, $tokenStorageProphecy->reveal());
-        $checker->isGranted(Dummy::class, 'has_role("ROLE_ADMIN")');
+        $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")');
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #2896 
| License       | MIT
| Doc PR        | api-platform/doc

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

This PR remove this deprecation notice : Using the "has_role()" function in security expressions is deprecated since Symfony 4.2, use "is_granted()" instead.
