### PR TITLE
Use workaround for a phpstan error

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -84,9 +84,6 @@ parameters:
 			message: '#Binary operation "\+" between (float\|int\|)?string and 0 results in an error\.#'
 			path: %currentWorkingDirectory%/src/Bridge/Doctrine/Common/Filter/RangeFilterTrait.php
 		- '#Parameter \#1 \$objectValue of method GraphQL\\Type\\Definition\\InterfaceType::resolveType\(\) expects object, array(<string, string>)? given.#'
-		-
-			message: '#Parameter \#1 $callback of function array_map expects (callable)|null, array<int, mixed> given\.#'
-			path: %currentWorkingDirectory%/src/Bridge/Doctrine/*/Filter/AbstractFilter.php
 
 		# Expected, due to deprecations
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryResult(Item|Collection)ExtensionInterface::getResult\(\) invoked with 4 parameters, 1 required\.#'

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/AbstractFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/AbstractFilter.php
@@ -93,7 +93,7 @@ abstract class AbstractFilter implements FilterInterface
 
     protected function denormalizePropertyName($property)
     {
-        if (null === $this->nameConverter) {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
             return $property;
         }
 
@@ -102,7 +102,7 @@ abstract class AbstractFilter implements FilterInterface
 
     protected function normalizePropertyName($property)
     {
-        if (null === $this->nameConverter) {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
             return $property;
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php
@@ -144,7 +144,7 @@ abstract class AbstractFilter implements FilterInterface
 
     protected function denormalizePropertyName($property)
     {
-        if (null === $this->nameConverter) {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
             return $property;
         }
 
@@ -153,7 +153,7 @@ abstract class AbstractFilter implements FilterInterface
 
     protected function normalizePropertyName($property)
     {
-        if (null === $this->nameConverter) {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
             return $property;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Use a workaround for a phpstan error ignored in https://github.com/api-platform/core/pull/2897

See https://github.com/phpstan/phpstan/issues/1905#issuecomment-464388880 for some context. But in short:

phpstan does not infer property type from constructor argument type, and it's not planned to be supported

I believe this would be a problem for any project that follows the current Symfony CS of not adding `@var` on a property when the matching argument is already type-hinted in the constructor. We've been told that IDEs support that just fine, but we will not have relief in phpstan until we can upgrade to PHP 7.4