### PR TITLE
Fix deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <ini name="memory_limit" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0" />
         <server name="KERNEL_DIR" value="tests/Fixtures/app/" />
         <server name="KERNEL_CLASS" value="AppKernel" />
         <server name="APP_ENV" value="test" />

--- a/phpunit_mongodb.xml
+++ b/phpunit_mongodb.xml
@@ -10,7 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <ini name="memory_limit" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0" />
         <server name="KERNEL_DIR" value="tests/Fixtures/app/" />
         <server name="KERNEL_CLASS" value="AppKernel" />
         <server name="APP_ENV" value="mongodb" />

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -29,7 +29,6 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
-use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -97,11 +96,10 @@ class AppKernel extends Kernel
 
         $loader->load(__DIR__."/config/config_{$this->getEnvironment()}.yml");
 
-        $alg = class_exists(SodiumPasswordEncoder::class) && SodiumPasswordEncoder::isSupported() ? 'auto' : 'bcrypt';
         $securityConfig = [
             'encoders' => [
-                User::class => $alg,
-                UserDocument::class => $alg,
+                User::class => 'auto',
+                UserDocument::class => 'auto',
                 // Don't use plaintext in production!
                 UserInterface::class => 'plaintext',
             ],


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2896
| License       | MIT
| Doc PR        | 

We can't use `max[total]=0`

The remaining ones are:
```
Remaining indirect deprecation notices (5)

  1x: The "FOS\UserBundle\Controller\SecurityController" class extends "Symfony\Bundle\FrameworkBundle\Controller\Controller" that is deprecated since Symfony 4.2, use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead.
    1x in BooleanFilterTest::setUp from ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter

  1x: The "FOS\UserBundle\Controller\ProfileController" class extends "Symfony\Bundle\FrameworkBundle\Controller\Controller" that is deprecated since Symfony 4.2, use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead.
    1x in BooleanFilterTest::setUp from ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter

  1x: The "FOS\UserBundle\Controller\RegistrationController" class extends "Symfony\Bundle\FrameworkBundle\Controller\Controller" that is deprecated since Symfony 4.2, use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead.
    1x in BooleanFilterTest::setUp from ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter

  1x: The "FOS\UserBundle\Controller\ChangePasswordController" class extends "Symfony\Bundle\FrameworkBundle\Controller\Controller" that is deprecated since Symfony 4.2, use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead.
    1x in BooleanFilterTest::setUp from ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter

  1x: The "FOS\UserBundle\Controller\ResettingController" class extends "Symfony\Bundle\FrameworkBundle\Controller\Controller" that is deprecated since Symfony 4.2, use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead.
    1x in BooleanFilterTest::setUp from ApiPlatform\Core\Tests\Bridge\Doctrine\Orm\Filter
```

What about all the `legacy` deprecations like this? Remove in 3.0? I think another PR is needed to standardise the deprecation messages.
https://github.com/api-platform/core/blob/master/src/Bridge/Doctrine/Orm/Filter/AbstractFilter.php#L49-L51
