### PR TITLE
[Mercure integration] Publish collection IRIs in topics

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -148,6 +148,7 @@ final class PublishMercureUpdatesListener
             $this->deletedEntities[(object) [
                 'id' => $this->iriConverter->getIriFromItem($entity),
                 'iri' => $this->iriConverter->getIriFromItem($entity, UrlGeneratorInterface::ABS_URL),
+                'classIri' => $this->iriConverter->getIriFromResourceClass(get_class($entity), UrlGeneratorInterface::ABS_URL),
             ]] = $value;
 
             return;
@@ -165,13 +166,16 @@ final class PublishMercureUpdatesListener
             // By convention, if the entity has been deleted, we send only its IRI
             // This may change in the feature, because it's not JSON Merge Patch compliant,
             // and I'm not a fond of this approach
-            $iri = $entity->iri;
+            $iri = [$entity->iri, $entity->classIri];
             $data = json_encode(['@id' => $entity->id]);
         } else {
             $resourceClass = $this->getObjectClass($entity);
             $context = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('normalization_context', []);
 
-            $iri = $this->iriConverter->getIriFromItem($entity, UrlGeneratorInterface::ABS_URL);
+            $iri = [
+                $this->iriConverter->getIriFromItem($entity, UrlGeneratorInterface::ABS_URL),
+                $this->iriConverter->getIriFromResourceClass(get_class($entity), UrlGeneratorInterface::ABS_URL),
+            ];
             $data = $this->serializer->serialize($entity, key($this->formats), $context);
         }
 

--- a/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -68,6 +68,8 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $iriConverterProphecy->getIriFromItem($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResourceClass(DummyFriend::class, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends')->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => true, 'normalization_context' => ['groups' => ['foo', 'bar']]]));
@@ -111,7 +113,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $listener->onFlush($eventArgs);
         $listener->postFlush();
 
-        $this->assertSame(['http://example.com/dummies/1', 'http://example.com/dummies/2', 'http://example.com/dummies/3', 'http://example.com/dummy_friends/4'], $topics);
+        $this->assertSame(['http://example.com/dummies/1', 'http://example.com/dummies', 'http://example.com/dummies/2', 'http://example.com/dummies', 'http://example.com/dummies/3', 'http://example.com/dummies', 'http://example.com/dummy_friends/4', 'http://example.com/dummy_friends'], $topics);
         $this->assertSame([[], [], [], ['foo', 'bar']], $targets);
     }
 


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2913
| License       | MIT

This PR adds collection IRI so it's possible to subscribe to all resource updates. See more explanation in #2913

```
$update = new Update([
  'https://example.com/notifications/1',
  'https://example.com/notifications', //collection IRI (without ID)
], $data, $targets);
```