### PR TITLE
Add error code for JsonApi errors.

### DIFF
--- a/src/Exception/ErrorCodeSerializableInterface.php
+++ b/src/Exception/ErrorCodeSerializableInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Exception;
+
+/**
+ * An exception which has a serializable application-specific error code.
+ */
+interface ErrorCodeSerializableInterface
+{
+    /**
+     * Gets the application-specific error code.
+     */
+    public static function getErrorCode(): string;
+}

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\JsonApi\Serializer;
 
-use ApiPlatform\Core\Exception\ErrorCodeSerializableInterface;
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
 use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\JsonApi\Serializer;
 
+use ApiPlatform\Core\Exception\ErrorCodeSerializableInterface;
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
 use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
@@ -42,12 +43,16 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, string $format = null, array $context = [])
     {
         $data = [
             'title' => $context[self::TITLE] ?? $this->defaultContext[self::TITLE],
             'description' => $this->getErrorMessage($object, $context, $this->debug),
         ];
+
+        if (null !== $errorCode = $this->getErrorCode($object)) {
+            $data['code'] = $errorCode;
+        }
 
         if ($this->debug && null !== $trace = $object->getTrace()) {
             $data['trace'] = $trace;

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -43,7 +43,7 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = [])
     {
         $data = [
             'title' => $context[self::TITLE] ?? $this->defaultContext[self::TITLE],

--- a/src/Problem/Serializer/ErrorNormalizerTrait.php
+++ b/src/Problem/Serializer/ErrorNormalizerTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Problem\Serializer;
 
+use ApiPlatform\Core\Exception\ErrorCodeSerializableInterface;
 use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,5 +36,19 @@ trait ErrorNormalizerTrait
         }
 
         return $message;
+    }
+
+    private function getErrorCode($object): ?string
+    {
+        $exceptionClass = get_class($object);
+        if ($object instanceof FlattenException || $object instanceof LegacyFlattenException) {
+            $exceptionClass = $object->getClass();
+        }
+
+        if (is_a($exceptionClass, ErrorCodeSerializableInterface::class, true)) {
+            return $exceptionClass::getErrorCode();
+        }
+
+        return null;
     }
 }

--- a/src/Problem/Serializer/ErrorNormalizerTrait.php
+++ b/src/Problem/Serializer/ErrorNormalizerTrait.php
@@ -40,9 +40,10 @@ trait ErrorNormalizerTrait
 
     private function getErrorCode($object): ?string
     {
-        $exceptionClass = get_class($object);
         if ($object instanceof FlattenException || $object instanceof LegacyFlattenException) {
             $exceptionClass = $object->getClass();
+        } else {
+            $exceptionClass = get_class($object);
         }
 
         if (is_a($exceptionClass, ErrorCodeSerializableInterface::class, true)) {

--- a/src/Problem/Serializer/ErrorNormalizerTrait.php
+++ b/src/Problem/Serializer/ErrorNormalizerTrait.php
@@ -43,7 +43,7 @@ trait ErrorNormalizerTrait
         if ($object instanceof FlattenException || $object instanceof LegacyFlattenException) {
             $exceptionClass = $object->getClass();
         } else {
-            $exceptionClass = get_class($object);
+            $exceptionClass = \get_class($object);
         }
 
         if (is_a($exceptionClass, ErrorCodeSerializableInterface::class, true)) {

--- a/tests/JsonApi/Serializer/ErrorNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ErrorNormalizerTest.php
@@ -16,7 +16,7 @@ namespace ApiPlatform\Core\Tests\JsonApi\Serializer;
 use ApiPlatform\Core\JsonApi\Serializer\ErrorNormalizer;
 use ApiPlatform\Core\Tests\Mock\Exception\ErrorCodeSerializable;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/tests/JsonApi/Serializer/ErrorNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ErrorNormalizerTest.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\JsonApi\Serializer;
 
 use ApiPlatform\Core\JsonApi\Serializer\ErrorNormalizer;
+use ApiPlatform\Core\Tests\Mock\Exception\ErrorCodeSerializable;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -57,6 +58,42 @@ class ErrorNormalizerTest extends TestCase
         if ($debug) {
             $expected['trace'] = $exception->getTrace();
         }
+
+        $this->assertEquals($expected, $normalizer->normalize($exception, ErrorNormalizer::FORMAT, ['statusCode' => $status]));
+    }
+
+    public function testNormalizeAnExceptionWithCustomErrorCode(): void
+    {
+        $status = Response::HTTP_BAD_REQUEST;
+        $originalMessage = 'my-message';
+        $debug = false;
+
+        $normalizer = new ErrorNormalizer($debug);
+        $exception = new ErrorCodeSerializable($originalMessage);
+
+        $expected = [
+            'title' => 'An error occurred',
+            'description' => 'my-message',
+            'code' => ErrorCodeSerializable::getErrorCode(),
+        ];
+
+        $this->assertEquals($expected, $normalizer->normalize($exception, ErrorNormalizer::FORMAT, ['statusCode' => $status]));
+    }
+
+    public function testNormalizeAFlattenExceptionWithCustomErrorCode(): void
+    {
+        $status = Response::HTTP_BAD_REQUEST;
+        $originalMessage = 'my-message';
+        $debug = false;
+
+        $normalizer = new ErrorNormalizer($debug);
+        $exception = FlattenException::create(new ErrorCodeSerializable($originalMessage), $status);
+
+        $expected = [
+            'title' => 'An error occurred',
+            'description' => 'my-message',
+            'code' => ErrorCodeSerializable::getErrorCode(),
+        ];
 
         $this->assertEquals($expected, $normalizer->normalize($exception, ErrorNormalizer::FORMAT, ['statusCode' => $status]));
     }

--- a/tests/Mock/Exception/ErrorCodeSerializable.php
+++ b/tests/Mock/Exception/ErrorCodeSerializable.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Mock\Exception;
+
+use ApiPlatform\Core\Exception\ErrorCodeSerializableInterface;
+
+class ErrorCodeSerializable extends \Exception implements ErrorCodeSerializableInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getErrorCode(): string
+    {
+        return '1234';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hi,
I added the possibility to specify an error code for JsonApi Errors as specified in the JsonApi Spec.
https://jsonapi.org/format/#errors

In short when throwing an Exception like:
```
throw new MyError('my bad error', 1234);
```
the Normalizer now uses the Exception Code like so:
```
{
  "title": "..",
  "description": "...",
  "code": 1234
}
```
It's a minor change so I'm not sure if master is the correct base branch.