### PR TITLE
Fix compatibility with Symfony 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -209,7 +209,7 @@ jobs:
         - *validate-openapi-v3-yaml
 
     - php: '7.3'
-      env: SYMFONY_DEPRECATIONS_HELPER=0
+      env: SYMFONY_DEPRECATIONS_HELPER=max[total]=5 # 5 deprecation notices from FOSUserBundle
       before_install:
         - *install-mongodb-php-extension
         - *disable-xdebug-php-extension
@@ -229,5 +229,5 @@ jobs:
         - *validate-openapi-v3-yaml
 
   allow_failures:
-    - env: SYMFONY_DEPRECATIONS_HELPER=0
+    - env: SYMFONY_DEPRECATIONS_HELPER=max[total]=5 # 5 deprecation notices from FOSUserBundle
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^6.0",
         "jangregor/phpstan-prophecy": "^0.3",
         "justinrainbow/json-schema": "^5.0",
-        "nelmio/api-doc-bundle": "^2.13.3",
+        "nelmio/api-doc-bundle": "^2.13.4",
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
         "phpdocumentor/type-resolver": "^0.3 || ^0.4",
         "phpspec/prophecy": "^1.8",
@@ -74,7 +74,7 @@
         "symfony/framework-bundle": "^4.2",
         "symfony/mercure-bundle": "*",
         "symfony/messenger": "^4.2",
-        "symfony/phpunit-bridge": "^4.3",
+        "symfony/phpunit-bridge": "^4.3.1",
         "symfony/routing": "^3.4 || ^4.0",
         "symfony/security-bundle": "^3.4 || ^4.0",
         "symfony/security-core": "^3.4 || ^4.0",
@@ -86,8 +86,7 @@
     },
     "conflict": {
         "doctrine/common": "<2.7",
-        "doctrine/mongodb-odm": "<2.0",
-        "symfony/messenger": ">=4.3"
+        "doctrine/mongodb-odm": "<2.0"
     },
     "suggest": {
         "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",

--- a/features/bootstrap/HydraContext.php
+++ b/features/bootstrap/HydraContext.php
@@ -230,7 +230,7 @@ final class HydraContext implements Context
             }
         }
 
-        throw new \InvalidArgumentException(sprintf('Property "%s" of class "%s" does\'nt exist', $propertyName, $className));
+        throw new \InvalidArgumentException(sprintf('Property "%s" of class "%s" doesn\'t exist', $propertyName, $className));
     }
 
     /**

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -324,7 +324,7 @@ Feature: GraphQL mutation support
     When I send the following GraphQL request:
     """
     mutation {
-      createDummy(input: {_id: 12, name: "", foo: [], clientMutationId: "myId"}) {
+      createDummy(input: {name: "", foo: [], clientMutationId: "myId"}) {
         clientMutationId
       }
     }

--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -56,8 +56,6 @@ Feature: Documentation support
     And the value of the node "hydra:title" of the Hydra class "Dummy" is "Dummy"
     And the value of the node "hydra:description" of the Hydra class "Dummy" is "Dummy."
     # Properties
-    And "id" property is readable for Hydra class "Dummy"
-    And "id" property is writable for Hydra class "Dummy"
     And "name" property is readable for Hydra class "Dummy"
     And "name" property is writable for Hydra class "Dummy"
     And "name" property is required for Hydra class "Dummy"

--- a/features/jsonld/context.feature
+++ b/features/jsonld/context.feature
@@ -41,7 +41,6 @@ Feature: JSON-LD contexts generation
             "jsonData": "Dummy/jsonData",
             "arrayData": "Dummy/arrayData",
             "nameConverted": "Dummy/nameConverted",
-            "id": "Dummy/id",
             "name": "http://schema.org/name",
             "alias": "https://schema.org/alternateName",
             "foo": "Dummy/foo"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,13 +32,6 @@ parameters:
 			path: %currentWorkingDirectory%/src/GraphQl/Resolver/FieldsToAttributesTrait.php
 		- '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy<(\\?[a-zA-Z0-9_]+)+>::\$[a-zA-Z0-9_]+#'
 		- '#Call to an undefined method Doctrine\\Common\\Persistence\\ObjectManager::getConnection\(\)#'
-		# https://github.com/symfony/symfony/pull/31903
-		-
-			message: '#Access to an undefined property object::\$headers\.#'
-			path: %currentWorkingDirectory%/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
-		-
-			message: '#Call to an undefined method object::getStatusCode\(\)\.#'
-			path: %currentWorkingDirectory%/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
 		- '#Parameter \#1 \$function of function call_user_func expects callable\(\): mixed, .+ given\.#'
 		- '#Parameter \#1 \$exception of static method Symfony\\Component\\Debug\\Exception\\FlattenException::create\(\) expects Exception, Symfony\\Component\\Serializer\\Exception\\ExceptionInterface given\.#'
 		- '#Parameter \#1 \$classes of class ApiPlatform\\Core\\Metadata\\Resource\\ResourceNameCollection constructor expects array<string>, array<int, int\|string> given\.#'
@@ -75,8 +68,9 @@ parameters:
 		-
 			message: '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Util\\QueryBuilderHelper::mapJoinAliases() should return array<string, array<string>\|string> but returns array<int|string, mixed>\.#'
 			path: %currentWorkingDirectory%/src/Bridge/Doctrine/Orm/Util/QueryBuilderHelper.php
+		# https://github.com/phpstan/phpstan/issues/1482
 		-
-			message: "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component.+' and '(removeBindings|addRemovedBindingIds)' will always evaluate to false\\.#"
+			message: "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component.+' and 'removeBindings' will always evaluate to false\\.#"
 			path: %currentWorkingDirectory%/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
 		-
 			message: "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component.+' and 'getReachableRoleNam.+' will always evaluate to false\\.#"
@@ -85,7 +79,7 @@ parameters:
 			message: "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component.+' and 'getRoleNames' will always evaluate to false\\.#"
 			path: %currentWorkingDirectory%/tests/Security/EventListener/DenyAccessListenerTest.php
 		- "#Call to method PHPUnit\\\\Framework\\\\Assert::assertSame\\(\\) with array\\('(collection_context|item_context|subresource_context)'\\) and array<Symfony\\\\Component\\\\VarDumper\\\\Cloner\\\\Data>\\|bool\\|float\\|int\\|string\\|null will always evaluate to false\\.#"
-		# https://github.com/doctrine/doctrine2/pull/7298/files
+		# https://github.com/doctrine/doctrine2/pull/7298
 		- '#Strict comparison using === between null and int will always evaluate to false\.#'
 		-
 			message: '#Binary operation "\+" between (float\|int\|)?string and 0 results in an error\.#'

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -36,6 +36,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -43,6 +44,8 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -521,6 +524,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         if ($this->isConfigEnabled($container, $config['doctrine'])) {
             $loader->load('doctrine_orm_mercure_publisher.xml');
+
+            // BC for Symfony Messenger 4.2
+            if (interface_exists(MessageBusInterface::class) && !class_exists(UnrecoverableMessageHandlingException::class)) {
+                $container->getDefinition('api_platform.doctrine.listener.mercure.publish')->replaceArgument(5, new Reference('message_bus', ContainerInterface::IGNORE_ON_INVALID_REFERENCE));
+            }
         }
     }
 
@@ -531,6 +539,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $loader->load('messenger.xml');
+
+        // BC for Symfony Messenger 4.2
+        if (interface_exists(MessageBusInterface::class) && !class_exists(UnrecoverableMessageHandlingException::class)) {
+            $container->setAlias('api_platform.message_bus', 'message_bus');
+        }
     }
 
     private function registerElasticsearchConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
@@ -14,7 +14,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.serializer" />
             <argument>%api_platform.formats%</argument>
-            <argument type="service" id="message_bus" on-invalid="ignore" />
+            <argument type="service" id="messenger.default_bus" on-invalid="ignore" />
             <argument type="service" id="mercure.hub.default.publisher" />
 
             <tag name="doctrine.event_listener" event="onFlush" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/messenger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/messenger.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="api_platform.message_bus" alias="message_bus" />
+        <service id="api_platform.message_bus" alias="messenger.default_bus" />
 
         <service id="api_platform.messenger.data_persister" class="ApiPlatform\Core\Bridge\Symfony\Messenger\DataPersister" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />

--- a/src/Bridge/Symfony/Messenger/DataPersister.php
+++ b/src/Bridge/Symfony/Messenger/DataPersister.php
@@ -88,6 +88,9 @@ final class DataPersister implements ContextAwareDataPersisterInterface
      */
     public function remove($data, array $context = [])
     {
-        $this->messageBus->dispatch(new Envelope($data, new RemoveStamp()));
+        $this->messageBus->dispatch(
+            (new Envelope($data))
+                ->with(new RemoveStamp())
+        );
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -92,6 +92,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 
 /**
@@ -492,7 +493,10 @@ class ApiPlatformExtensionTest extends TestCase
     public function testDisabledMessenger()
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
-        $containerBuilderProphecy->setAlias('api_platform.message_bus', 'message_bus')->shouldNotBeCalled();
+        $containerBuilderProphecy->setAlias('api_platform.message_bus', 'messenger.default_bus')->shouldNotBeCalled();
+        if (!class_exists(UnrecoverableMessageHandlingException::class)) {
+            $containerBuilderProphecy->setAlias('api_platform.message_bus', 'message_bus')->shouldNotBeCalled();
+        }
         $containerBuilderProphecy->setDefinition('api_platform.messenger.data_persister', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.messenger.data_transformer', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
@@ -914,15 +918,11 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->getParameter('kernel.project_dir')->willReturn(__DIR__);
         $containerBuilderProphecy->getParameter('kernel.debug')->willReturn(false);
 
-        $containerBuilderProphecy->getDefinition('api_platform.http_cache.purger.varnish')->willReturn(new Definition());
-
         // irrelevant, but to prevent errors
-        // https://github.com/symfony/symfony/pull/29944
+        $definitionDummy = $this->prophesize(Definition::class);
+        $containerBuilderProphecy->getDefinition('api_platform.http_cache.purger.varnish')->willReturn($definitionDummy);
         if (method_exists(ContainerBuilder::class, 'removeBindings')) {
             $containerBuilderProphecy->removeBindings(Argument::type('string'))->will(function () {});
-        } elseif (method_exists(ContainerBuilder::class, 'addRemovedBindingIds')) {
-            // remove this once https://github.com/symfony/symfony/pull/31173 is released
-            $containerBuilderProphecy->addRemovedBindingIds(Argument::type('string'))->will(function () {});
         }
 
         return $containerBuilderProphecy;
@@ -1140,7 +1140,7 @@ class ApiPlatformExtensionTest extends TestCase
 
         $aliases = [
             'api_platform.http_cache.purger' => 'api_platform.http_cache.purger.varnish',
-            'api_platform.message_bus' => 'message_bus',
+            'api_platform.message_bus' => 'messenger.default_bus',
             EagerLoadingExtension::class => 'api_platform.doctrine.orm.query_extension.eager_loading',
             FilterExtension::class => 'api_platform.doctrine.orm.query_extension.filter',
             FilterEagerLoadingExtension::class => 'api_platform.doctrine.orm.query_extension.filter_eager_loading',
@@ -1175,12 +1175,17 @@ class ApiPlatformExtensionTest extends TestCase
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
 
+        if (!class_exists(UnrecoverableMessageHandlingException::class)) {
+            $containerBuilderProphecy->setAlias('api_platform.message_bus', 'message_bus')->shouldBeCalled();
+        }
+
         $containerBuilderProphecy->hasParameter('api_platform.metadata_cache')->willReturn(false);
 
         // irrelevant, but to prevent errors
+        $definitionDummy = $this->prophesize(Definition::class);
         $containerBuilderProphecy->removeDefinition('api_platform.cache_warmer.cache_pool_clearer')->will(function () {});
-
-        $containerBuilderProphecy->getDefinition('api_platform.mercure.listener.response.add_link_header')->willReturn(new Definition());
+        $containerBuilderProphecy->getDefinition('api_platform.mercure.listener.response.add_link_header')->willReturn($definitionDummy);
+        $containerBuilderProphecy->getDefinition('api_platform.doctrine.listener.mercure.publish')->willReturn($definitionDummy);
 
         return $containerBuilderProphecy;
     }

--- a/tests/Bridge/Symfony/Messenger/DataPersisterTest.php
+++ b/tests/Bridge/Symfony/Messenger/DataPersisterTest.php
@@ -80,7 +80,7 @@ class DataPersisterTest extends TestCase
         $dummy = new Dummy();
 
         $messageBus = $this->prophesize(MessageBusInterface::class);
-        $messageBus->dispatch($dummy)->willReturn(new Envelope($dummy, new HandledStamp($dummy, 'DummyHandler::__invoke')))->shouldBeCalled();
+        $messageBus->dispatch($dummy)->willReturn((new Envelope($dummy))->with(new HandledStamp($dummy, 'DummyHandler::__invoke')))->shouldBeCalled();
 
         $dataPersister = new DataPersister($this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(), $messageBus->reveal());
         $this->assertSame($dummy, $dataPersister->persist($dummy));

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -130,7 +130,6 @@ class AppKernel extends Kernel
                     'provider' => 'chain_provider',
                     'http_basic' => null,
                     'anonymous' => null,
-                    'logout_on_user_change' => true,
                 ],
             ],
             'access_control' => [

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -8,8 +8,6 @@ framework:
     session:
         storage_id:                    'session.storage.mock_file'
     form:                              ~ # For FOSUser
-    templating:
-        engines:                       ['twig'] # For Swagger UI
     profiler:
         enabled:                        true
         collect:                        false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2912, api-platform/api-platform#1169
| License       | MIT
| Doc PR        | N/A

#2784 fixed compatibility for Symfony 4.3 in `master` / `2.5`. This is basically the same but without bumping the dependencies.

Together with #2920 (and maybe more to do in #2911) this should allow full Symfony 4.3 compatibility in `2.4`.