### PR TITLE
Unwrap exception thrown in handler for Symfony Messenger 4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,13 @@ commands:
           command: |
             sudo pecl install mongodb-1.5.4
             sudo docker-php-ext-enable mongodb
+  install-pcov-php-extension:
+    steps:
+      - run:
+          name: Install pcov PHP extension
+          command: |
+            sudo pecl install pcov-1.0.6
+            sudo docker-php-ext-enable pcov
   merge-code-coverage-reports:
     parameters:
       dir:
@@ -51,14 +58,16 @@ commands:
       - run:
           name: Download phpcov
           command: |
-            if [ ! -e phpcov.phar ]; then
+            if ! command -v phpcov; then
               wget https://phar.phpunit.de/phpcov.phar
+              chmod +x phpcov.phar
+              sudo mv phpcov.phar /usr/local/bin/phpcov
             fi
       - run:
           name: Merge code coverage reports
           command: |
             mkdir -p "$(dirname -- "<< parameters.out >>")"
-            phpdbg -qrr phpcov.phar merge --clover "<< parameters.out >>" "<< parameters.dir >>"
+            phpcov merge --clover "<< parameters.out >>" "<< parameters.dir >>"
   merge-test-reports:
     parameters:
       dir:
@@ -263,6 +272,7 @@ jobs:
     steps:
       - checkout
       - install-mongodb-php-extension
+      - install-pcov-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
@@ -276,7 +286,7 @@ jobs:
             mkdir -p build/logs/phpunit build/coverage
             split_tests=$(find tests -name '*Test.php' | circleci tests split --split-by=timings)
             export PARALLEL='-j10% --joblog build/logs/parallel.log --rpl {_}\ s/\\//_/g;'
-            phpunit_cmd='phpdbg -qrr vendor/bin/phpunit --coverage-php build/coverage/coverage-{_}.cov --log-junit build/logs/phpunit/{_}.xml --exclude-group mongodb,resource-hog --colors=always {}'
+            phpunit_cmd='vendor/bin/phpunit --coverage-php build/coverage/coverage-{_}.cov --log-junit build/logs/phpunit/{_}.xml --exclude-group mongodb,resource-hog --colors=always {}'
             echo "$split_tests" | parallel "$phpunit_cmd" || echo "$split_tests" | parallel --retry-failed "$phpunit_cmd"
       - restore-npm-cache
       - merge-test-reports:
@@ -310,6 +320,7 @@ jobs:
     steps:
       - checkout
       - install-mongodb-php-extension
+      - install-pcov-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
@@ -323,7 +334,7 @@ jobs:
             mkdir -p build/logs/behat build/coverage
             for f in $(find features -name '*.feature' -not -path 'features/main/exposed_state.feature' -not -path 'features/elasticsearch/*' -not -path 'features/mongodb/*' | circleci tests split --split-by=timings); do
               _f=$(echo "$f" | tr / _)
-              FEATURE="${_f}" phpdbg -qrr vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat/"${_f}" --profile=default-coverage --no-interaction "$f"
+              FEATURE="${_f}" vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat/"${_f}" --profile=default-coverage --no-interaction "$f"
             done
       - restore-npm-cache
       - merge-test-reports:
@@ -355,6 +366,7 @@ jobs:
     steps:
       - checkout
       - install-mongodb-php-extension
+      - install-pcov-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
@@ -367,7 +379,7 @@ jobs:
           name: Run PHPUnit tests
           command: |
             mkdir -p build/logs/phpunit
-            phpdbg -qrr vendor/bin/phpunit --coverage-clover build/logs/clover.xml --log-junit build/logs/phpunit/junit.xml --exclude-group resource-hog --colors=always --configuration phpunit_mongodb.xml
+            vendor/bin/phpunit --coverage-clover build/logs/clover.xml --log-junit build/logs/phpunit/junit.xml --exclude-group resource-hog --colors=always --configuration phpunit_mongodb.xml
       - store_test_results:
           path: build/logs
       - store_artifacts:
@@ -392,6 +404,7 @@ jobs:
     steps:
       - checkout
       - install-mongodb-php-extension
+      - install-pcov-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
@@ -404,7 +417,7 @@ jobs:
           name: Run Behat tests
           command: |
             mkdir -p build/logs/behat
-            phpdbg -qrr vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat --profile=mongodb-coverage --no-interaction
+            vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat --profile=mongodb-coverage --no-interaction
       - restore-npm-cache
       - merge-test-reports:
           dir: build/logs/behat
@@ -435,6 +448,7 @@ jobs:
     steps:
       - checkout
       - install-mongodb-php-extension
+      - install-pcov-php-extension
       - disable-xdebug-php-extension
       - disable-php-memory-limit
       - update-composer
@@ -447,7 +461,7 @@ jobs:
           name: Run Behat tests
           command: |
             mkdir -p build/logs/behat
-            phpdbg -qrr vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat --profile=elasticsearch-coverage --no-interaction
+            vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat --profile=elasticsearch-coverage --no-interaction
       - restore-npm-cache
       - merge-test-reports:
           dir: build/logs/behat

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.php_cs
 /.php_cs.cache
+/.phpunit.result.cache
 /build/
 /composer.lock
 /composer.phar

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "phpstan/phpstan-doctrine": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
         "phpstan/phpstan-symfony": "^0.11",
-        "phpunit/phpunit": "^7.5.2",
+        "phpunit/phpunit": "^7.5.2 || ^8.0",
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.7",
         "ramsey/uuid-doctrine": "^1.4",

--- a/features/json/input_output.feature
+++ b/features/json/input_output.feature
@@ -7,7 +7,7 @@ Feature: JSON DTO input and output
     Given I add "Accept" header equal to "application/json"
     And I add "Content-Type" header equal to "application/json"
 
-  Scenario: Messenger handler returning output object
+  Scenario: Request a password reset
     And I send a "POST" request to "/users/password_reset_request" with body:
     """
     {
@@ -23,3 +23,15 @@ Feature: JSON DTO input and output
       "emailSentAt": "2019-07-05T15:44:00+00:00"
     }
     """
+
+  Scenario: Request a password reset for a non-existent user
+    And I send a "POST" request to "/users/password_reset_request" with body:
+    """
+    {
+      "email": "does-not-exist@example.com"
+    }
+    """
+    Then the response status code should be 404
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
+    And the JSON node "detail" should be equal to "User does not exist."

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -44,7 +44,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -526,7 +526,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $loader->load('doctrine_orm_mercure_publisher.xml');
 
             // BC for Symfony Messenger 4.2
-            if (interface_exists(MessageBusInterface::class) && !class_exists(UnrecoverableMessageHandlingException::class)) {
+            if (interface_exists(MessageBusInterface::class) && !class_exists(HandlerFailedException::class)) {
                 $container->getDefinition('api_platform.doctrine.listener.mercure.publish')->replaceArgument(5, new Reference('message_bus', ContainerInterface::IGNORE_ON_INVALID_REFERENCE));
             }
         }
@@ -541,7 +541,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $loader->load('messenger.xml');
 
         // BC for Symfony Messenger 4.2
-        if (interface_exists(MessageBusInterface::class) && !class_exists(UnrecoverableMessageHandlingException::class)) {
+        if (interface_exists(MessageBusInterface::class) && !class_exists(HandlerFailedException::class)) {
             $container->setAlias('api_platform.message_bus', 'message_bus');
         }
     }

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -21,6 +21,8 @@ use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
+ * @internal
+ *
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
 abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
@@ -45,7 +47,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
      */
     protected $filterClass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
 

--- a/src/Test/DoctrineMongoDbOdmSetup.php
+++ b/src/Test/DoctrineMongoDbOdmSetup.php
@@ -22,6 +22,8 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 /**
  * Convenience class for setting up Doctrine from different installations and configurations.
  *
+ * @internal
+ *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Alan Poulain <contact@alanpoulain.eu>
  */

--- a/src/Test/DoctrineOrmFilterTestCase.php
+++ b/src/Test/DoctrineOrmFilterTestCase.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
+ * @internal
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 abstract class DoctrineOrmFilterTestCase extends KernelTestCase
@@ -53,7 +55,7 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
      */
     protected $filterClass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
 

--- a/tests/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtensionTest.php
@@ -43,7 +43,7 @@ class PaginationExtensionTest extends TestCase
 {
     private $managerRegistryProphecy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Bridge/Elasticsearch/DataProvider/PaginatorTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/PaginatorTest.php
@@ -147,7 +147,7 @@ class PaginatorTest extends TestCase
         );
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->paginator = $this->getPaginator(4, 4);
     }

--- a/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
+++ b/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandTest.php
@@ -30,7 +30,7 @@ class SwaggerCommandTest extends KernelTestCase
      */
     private $tester;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
 
@@ -70,7 +70,7 @@ class SwaggerCommandTest extends KernelTestCase
       operationId: getDummyCarCollection
 YAML;
 
-        $this->assertContains($expected, $result, 'nested object should be present.');
+        $this->assertStringContainsString($expected, $result, 'nested object should be present.');
 
         $expected = <<<YAML
   '/dummy_cars/{id}':
@@ -79,8 +79,8 @@ YAML;
       operationId: getDummyCarItem
 YAML;
 
-        $this->assertContains($expected, $result, 'arrays should be correctly formatted.');
-        $this->assertContains('openapi: 3.0.2', $result);
+        $this->assertStringContainsString($expected, $result, 'arrays should be correctly formatted.');
+        $this->assertStringContainsString('openapi: 3.0.2', $result);
 
         $expected = <<<YAML
 info:
@@ -90,7 +90,7 @@ info:
     This is a test API.
     Made with love
 YAML;
-        $this->assertContains($expected, $result, 'multiline formatting must be preserved (using literal style).');
+        $this->assertStringContainsString($expected, $result, 'multiline formatting must be preserved (using literal style).');
     }
 
     public function testExecuteOpenApiVersion2WithYaml()
@@ -99,7 +99,7 @@ YAML;
 
         $result = $this->tester->getDisplay();
         $this->assertYaml($result);
-        $this->assertContains("swagger: '2.0'", $result);
+        $this->assertStringContainsString("swagger: '2.0'", $result);
     }
 
     public function testExecuteWithBadArguments()

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -47,7 +47,7 @@ class RequestDataCollectorTest extends TestCase
     private $metadataFactory;
     private $filterLocator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->response = $this->createMock(Response::class);
         $this->attributes = $this->prophesize(ParameterBag::class);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -138,13 +138,13 @@ class ApiPlatformExtensionTest extends TestCase
     private $extension;
     private $childDefinitionProphecy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extension = new ApiPlatformExtension();
         $this->childDefinitionProphecy = $this->prophesize(ChildDefinition::class);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->extension = null;
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -92,7 +92,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 
 /**
@@ -494,7 +494,7 @@ class ApiPlatformExtensionTest extends TestCase
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setAlias('api_platform.message_bus', 'messenger.default_bus')->shouldNotBeCalled();
-        if (!class_exists(UnrecoverableMessageHandlingException::class)) {
+        if (!class_exists(HandlerFailedException::class)) {
             $containerBuilderProphecy->setAlias('api_platform.message_bus', 'message_bus')->shouldNotBeCalled();
         }
         $containerBuilderProphecy->setDefinition('api_platform.messenger.data_persister', Argument::type(Definition::class))->shouldNotBeCalled();
@@ -1175,7 +1175,7 @@ class ApiPlatformExtensionTest extends TestCase
             $containerBuilderProphecy->setAlias($alias, $service)->shouldBeCalled();
         }
 
-        if (!class_exists(UnrecoverableMessageHandlingException::class)) {
+        if (!class_exists(HandlerFailedException::class)) {
             $containerBuilderProphecy->setAlias('api_platform.message_bus', 'message_bus')->shouldBeCalled();
         }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -42,7 +42,7 @@ class ConfigurationTest extends TestCase
      */
     private $processor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configuration = new Configuration();
         $this->processor = new Processor();

--- a/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
+++ b/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
@@ -38,7 +38,7 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
     private $schemaTool;
     private $env;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $kernel = self::bootKernel();
@@ -56,7 +56,7 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
         $this->schemaTool->createSchema($classes);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->schemaTool->dropSchema($this->manager->getMetadataFactory()->getAllMetadata());
         $this->manager->clear();
@@ -78,7 +78,7 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
         $block = $crawler->filter('div[class*=sf-toolbar-block-api_platform]');
 
         // Check extra info content
-        $this->assertContains('sf-toolbar-status-default', $block->attr('class'), 'The toolbar block should have the default color.');
+        $this->assertStringContainsString('sf-toolbar-status-default', $block->attr('class'), 'The toolbar block should have the default color.');
         $this->assertSame('Not an API Platform resource', $block->filter('.sf-toolbar-info-piece span')->html());
     }
 
@@ -96,7 +96,7 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
         $block = $crawler->filter('div[class*=sf-toolbar-block-api_platform]');
 
         // Check extra info content
-        $this->assertContains('sf-toolbar-status-default', $block->attr('class'), 'The toolbar block should have the default color.');
+        $this->assertStringContainsString('sf-toolbar-status-default', $block->attr('class'), 'The toolbar block should have the default color.');
         $this->assertSame('mongodb' === $this->env ? DocumentDummy::class : Dummy::class, $block->filter('.sf-toolbar-info-piece span')->html());
     }
 
@@ -177,13 +177,13 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
         // Data provider tab
         $tabContent = $crawler->filter('.tab:nth-of-type(2) .tab-content');
         $this->assertSame('TRUE', $tabContent->filter('table tbody .status-success')->html());
-        $this->assertContains('mongodb' === $this->env ? OdmCollectionDataProvider::class : CollectionDataProvider::class, $tabContent->filter('table tbody')->html());
+        $this->assertStringContainsString('mongodb' === $this->env ? OdmCollectionDataProvider::class : CollectionDataProvider::class, $tabContent->filter('table tbody')->html());
 
-        $this->assertContains('No calls to item data provider have been recorded.', $tabContent->html());
-        $this->assertContains('No calls to subresource data provider have been recorded.', $tabContent->html());
+        $this->assertStringContainsString('No calls to item data provider have been recorded.', $tabContent->html());
+        $this->assertStringContainsString('No calls to subresource data provider have been recorded.', $tabContent->html());
 
         // Data persiters tab
-        $this->assertContains('No calls to data persister have been recorded.', $crawler->filter('.tab:nth-of-type(3) .tab-content .empty')->html());
+        $this->assertStringContainsString('No calls to data persister have been recorded.', $crawler->filter('.tab:nth-of-type(3) .tab-content .empty')->html());
     }
 
     public function testPostCollectionProfiler()
@@ -202,14 +202,14 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
 
         // Data provider tab
         $tabContent = $crawler->filter('.tab:nth-of-type(2) .tab-content');
-        $this->assertContains('No calls to collection data provider have been recorded.', $tabContent->html());
-        $this->assertContains('No calls to item data provider have been recorded.', $tabContent->html());
-        $this->assertContains('No calls to subresource data provider have been recorded.', $tabContent->html());
+        $this->assertStringContainsString('No calls to collection data provider have been recorded.', $tabContent->html());
+        $this->assertStringContainsString('No calls to item data provider have been recorded.', $tabContent->html());
+        $this->assertStringContainsString('No calls to subresource data provider have been recorded.', $tabContent->html());
 
         // Data persiters tab
         $tabContent = $crawler->filter('.tab:nth-of-type(3) .tab-content');
         $this->assertSame('TRUE', $tabContent->filter('table tbody .status-success')->html());
-        $this->assertContains(DataPersister::class, $tabContent->filter('table tbody')->html());
+        $this->assertStringContainsString(DataPersister::class, $tabContent->filter('table tbody')->html());
     }
 
     /**
@@ -241,12 +241,12 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
         $this->assertSame(ContainNonResourceItemDataProvider::class, $tabContent->filter('table tbody tr:first-of-type td:nth-of-type(3)')->html());
 
         $this->assertSame('TRUE', $tabContent->filter('table tbody .status-success')->html());
-        $this->assertContains('mongodb' === $this->env ? OdmItemDataProvider::class : ItemDataProvider::class, $tabContent->filter('table tbody')->html());
+        $this->assertStringContainsString('mongodb' === $this->env ? OdmItemDataProvider::class : ItemDataProvider::class, $tabContent->filter('table tbody')->html());
 
-        $this->assertContains('No calls to collection data provider have been recorded.', $tabContent->html());
-        $this->assertContains('No calls to subresource data provider have been recorded.', $tabContent->html());
+        $this->assertStringContainsString('No calls to collection data provider have been recorded.', $tabContent->html());
+        $this->assertStringContainsString('No calls to subresource data provider have been recorded.', $tabContent->html());
 
         // Data persiters tab
-        $this->assertContains('No calls to data persister have been recorded.', $crawler->filter('.tab:nth-of-type(3) .tab-content .empty')->html());
+        $this->assertStringContainsString('No calls to data persister have been recorded.', $crawler->filter('.tab:nth-of-type(3) .tab-content .empty')->html());
     }
 }

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -31,7 +31,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
 {
     private $validatorClassMetadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->validatorClassMetadata = new ClassMetadata(DummyValidatedEntity::class);
         (new AnnotationLoader(new AnnotationReader()))->loadClassMetadata($this->validatorClassMetadata);

--- a/tests/Fixtures/TestBundle/MessageHandler/PasswordResetRequestHandler.php
+++ b/tests/Fixtures/TestBundle/MessageHandler/PasswordResetRequestHandler.php
@@ -15,12 +15,17 @@ namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\MessageHandler;
 
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\PasswordResetRequest;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\PasswordResetRequestResult;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 class PasswordResetRequestHandler implements MessageHandlerInterface
 {
     public function __invoke(PasswordResetRequest $passwordResetRequest): PasswordResetRequestResult
     {
+        if ('does-not-exist@example.com' === $passwordResetRequest->getEmail()) {
+            throw new NotFoundHttpException('User does not exist.');
+        }
+
         return new PasswordResetRequestResult(new \DateTimeImmutable('2019-07-05T15:44:00Z'));
     }
 }

--- a/tests/JsonApi/EventListener/TransformFieldsetsParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformFieldsetsParametersListenerTest.php
@@ -25,7 +25,7 @@ class TransformFieldsetsParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('dummy'));

--- a/tests/JsonApi/EventListener/TransformFilteringParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformFilteringParametersListenerTest.php
@@ -25,7 +25,7 @@ class TransformFilteringParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new TransformFilteringParametersListener();
     }

--- a/tests/JsonApi/EventListener/TransformPaginationParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformPaginationParametersListenerTest.php
@@ -25,7 +25,7 @@ class TransformPaginationParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new TransformPaginationParametersListener();
     }

--- a/tests/JsonApi/EventListener/TransformSortingParametersListenerTest.php
+++ b/tests/JsonApi/EventListener/TransformSortingParametersListenerTest.php
@@ -25,7 +25,7 @@ class TransformSortingParametersListenerTest extends TestCase
 {
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new TransformSortingParametersListener();
     }

--- a/tests/JsonApi/Serializer/ReservedAttributeNameConverterTest.php
+++ b/tests/JsonApi/Serializer/ReservedAttributeNameConverterTest.php
@@ -24,7 +24,7 @@ class ReservedAttributeNameConverterTest extends TestCase
 {
     private $reservedAttributeNameConverter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->reservedAttributeNameConverter = new ReservedAttributeNameConverter(new CustomConverter());
     }

--- a/tests/JsonLd/ContextBuilderTest.php
+++ b/tests/JsonLd/ContextBuilderTest.php
@@ -40,7 +40,7 @@ class ContextBuilderTest extends TestCase
     private $propertyMetadataFactoryProphecy;
     private $urlGeneratorProphecy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->entityClass = '\Dummy\DummyEntity';
         $this->resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);

--- a/tests/Metadata/schema/XmlSchemaTest.php
+++ b/tests/Metadata/schema/XmlSchemaTest.php
@@ -30,7 +30,7 @@ class XmlSchemaTest extends TestCase
             XmlUtils::loadFile($fixtures.'invalid.xml', $schema);
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertContains('ERROR 1845', $e->getMessage());
+            $this->assertStringContainsString('ERROR 1845', $e->getMessage());
         }
 
         $this->assertInstanceOf(\DOMDocument::class, XmlUtils::loadFile($fixtures.'valid.xml', $schema));

--- a/tests/Serializer/JsonEncoderTest.php
+++ b/tests/Serializer/JsonEncoderTest.php
@@ -26,7 +26,7 @@ class JsonEncoderTest extends TestCase
      */
     private $encoder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->encoder = new JsonEncoder('json');
     }

--- a/tests/Serializer/ResourceListTest.php
+++ b/tests/Serializer/ResourceListTest.php
@@ -23,7 +23,7 @@ class ResourceListTest extends TestCase
      */
     private $resourceList;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resourceList = new ResourceList();
     }

--- a/tests/Serializer/SerializerContextBuilderTest.php
+++ b/tests/Serializer/SerializerContextBuilderTest.php
@@ -31,7 +31,7 @@ class SerializerContextBuilderTest extends TestCase
      */
     private $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $resourceMetadata = new ResourceMetadata(
             null,

--- a/tests/Swagger/Serializer/ApiGatewayNormalizerTest.php
+++ b/tests/Swagger/Serializer/ApiGatewayNormalizerTest.php
@@ -39,7 +39,7 @@ final class ApiGatewayNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->documentationNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
         $this->documentationNormalizerProphecy->willImplement(CacheableSupportsMethodInterface::class);

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -28,7 +28,7 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
 {
     private $extractor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
         $this->extractor = new AnnotationFilterExtractor(self::$kernel->getContainer()->get('test.annotation_reader'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2856
| License       | MIT
| Doc PR        | N/A

As suggested by @karser

Also, since coverage jobs were failing, due to a `phpdbg` bug (see https://github.com/symfony/symfony/issues/32521):

Allow phpunit 8 and use `pcov` for coverage jobs.