### PR TITLE
[GraphQL] Disable some steps by setting operation attributes

### DIFF
--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -518,6 +518,35 @@ Feature: GraphQL collection support
     """
 
   @createSchema
+  Scenario: Custom collection query with read and serialize set to false
+    Given there are 2 dummyCustomQuery objects
+    When I send the following GraphQL request:
+    """
+    {
+      testCollectionNoReadAndSerializeDummyCustomQueries {
+        edges {
+          node {
+            message
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON should be equal to:
+    """
+    {
+      "data": {
+        "testCollectionNoReadAndSerializeDummyCustomQueries": {
+          "edges": []
+        }
+      }
+    }
+    """
+
+  @createSchema
   Scenario: Custom collection query with custom arguments
     Given there are 2 dummyCustomQuery objects
     When I send the following GraphQL request:

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -459,7 +459,7 @@ Feature: GraphQL mutation support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.sumDummyCustomMutation.dummyCustomMutation.result" should be equal to "8"
 
-  Scenario: Execute a not persisted custom mutation
+  Scenario: Execute a not persisted custom mutation (resolver returns null)
     When I send the following GraphQL request:
     """
     mutation {
@@ -475,6 +475,40 @@ Feature: GraphQL mutation support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.sumNotPersistedDummyCustomMutation.dummyCustomMutation" should be null
+
+  Scenario: Execute a not persisted custom mutation (write set to false) with custom result
+    When I send the following GraphQL request:
+    """
+    mutation {
+      sumNoWriteCustomResultDummyCustomMutation(input: {id: "/dummy_custom_mutations/1", operandB: 5}) {
+        dummyCustomMutation {
+          id
+          result
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.sumNoWriteCustomResultDummyCustomMutation.dummyCustomMutation.result" should be equal to "1234"
+
+  Scenario: Execute a custom mutation with read, deserialize, validate and serialize set to false
+    When I send the following GraphQL request:
+    """
+    mutation {
+      sumOnlyPersistDummyCustomMutation(input: {id: "/dummy_custom_mutations/1", operandB: 5}) {
+        dummyCustomMutation {
+          id
+          result
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.sumOnlyPersistDummyCustomMutation.dummyCustomMutation" should be null
 
   Scenario: Execute a custom mutation with custom arguments
     When I send the following GraphQL request:

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -307,6 +307,27 @@ Feature: GraphQL query support
     }
     """
 
+  Scenario: Custom item query with read and serialize set to false
+    When I send the following GraphQL request:
+    """
+    {
+      testNoReadAndSerializeItemDummyCustomQuery(id: "/not_used") {
+        message
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON should be equal to:
+    """
+    {
+      "data": {
+        "testNoReadAndSerializeItemDummyCustomQuery": null
+      }
+    }
+    """
+
   Scenario: Custom item query
     Given there are 2 dummyCustomQuery objects
     When I send the following GraphQL request:

--- a/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
@@ -32,6 +32,21 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         "normalization_context"={"groups"={"result"}},
  *         "denormalization_context"={"groups"={"sum"}}
  *     },
+ *     "sumNoWriteCustomResult"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_no_write_custom_result",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}},
+ *         "write"=false
+ *     },
+ *     "sumOnlyPersist"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_only_persist_document",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}},
+ *         "read"=false,
+ *         "deserialize"=false,
+ *         "validate"=false,
+ *         "serialize"=false
+ *     },
  *     "testCustomArguments"={
  *         "mutation"="app.graphql.mutation_resolver.dummy_custom",
  *         "args"={"operandC"={"type"="Int!"}}

--- a/tests/Fixtures/TestBundle/Document/DummyCustomQuery.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCustomQuery.php
@@ -29,6 +29,11 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  *         "item_query"="app.graphql.query_resolver.dummy_custom_not_retrieved_item_document",
  *         "args"={}
  *     },
+ *     "testNoReadAndSerializeItem"={
+ *         "item_query"="app.graphql.query_resolver.dummy_custom_item_no_read_and_serialize_document",
+ *         "read"=false,
+ *         "serialize"=false
+ *     },
  *     "testItemCustomArguments"={
  *         "item_query"="app.graphql.query_resolver.dummy_custom_item",
  *         "args"={
@@ -44,6 +49,11 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  *     },
  *     "testCollection"={
  *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection"
+ *     },
+ *     "testCollectionNoReadAndSerialize"={
+ *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection_no_read_and_serialize",
+ *         "read"=false,
+ *         "serialize"=false
  *     },
  *     "testCollectionCustomArguments"={
  *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection",

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
@@ -32,6 +32,21 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         "normalization_context"={"groups"={"result"}},
  *         "denormalization_context"={"groups"={"sum"}}
  *     },
+ *     "sumNoWriteCustomResult"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_no_write_custom_result",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}},
+ *         "write"=false
+ *     },
+ *     "sumOnlyPersist"={
+ *         "mutation"="app.graphql.mutation_resolver.dummy_custom_only_persist",
+ *         "normalization_context"={"groups"={"result"}},
+ *         "denormalization_context"={"groups"={"sum"}},
+ *         "read"=false,
+ *         "deserialize"=false,
+ *         "validate"=false,
+ *         "serialize"=false
+ *     },
  *     "testCustomArguments"={
  *         "mutation"="app.graphql.mutation_resolver.dummy_custom",
  *         "args"={"operandC"={"type"="Int!"}}

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomQuery.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomQuery.php
@@ -29,6 +29,11 @@ use Doctrine\ORM\Mapping as ORM;
  *         "item_query"="app.graphql.query_resolver.dummy_custom_not_retrieved_item",
  *         "args"={}
  *     },
+ *     "testNoReadAndSerializeItem"={
+ *         "item_query"="app.graphql.query_resolver.dummy_custom_item_no_read_and_serialize",
+ *         "read"=false,
+ *         "serialize"=false
+ *     },
  *     "testItemCustomArguments"={
  *         "item_query"="app.graphql.query_resolver.dummy_custom_item",
  *         "args"={
@@ -44,6 +49,11 @@ use Doctrine\ORM\Mapping as ORM;
  *     },
  *     "testCollection"={
  *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection"
+ *     },
+ *     "testCollectionNoReadAndSerialize"={
+ *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection_no_read_and_serialize",
+ *         "read"=false,
+ *         "serialize"=false
  *     },
  *     "testCollectionCustomArguments"={
  *         "collection_query"="app.graphql.query_resolver.dummy_custom_collection",

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNoReadAndSerializeCollectionResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNoReadAndSerializeCollectionResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\DataProvider\ArrayPaginator;
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
+
+/**
+ * Resolver for dummy collection custom query (collection not read and no result serialized).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class DummyCustomQueryNoReadAndSerializeCollectionResolver implements QueryCollectionResolverInterface
+{
+    /**
+     * @param iterable<DummyCustomQuery|DummyCustomQueryDocument> $collection
+     *
+     * @return ArrayPaginator
+     */
+    public function __invoke(iterable $collection, array $context): iterable
+    {
+        if (!empty($collection)) {
+            throw new RuntimeException('Collection should be empty');
+        }
+
+        return new ArrayPaginator(['Foo', 'Bar'], 0, 2); // Should not ne normalized.
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNoReadAndSerializeItemDocumentResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNoReadAndSerializeItemDocumentResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
+
+/**
+ * Resolver for dummy item custom query (item not read and no result serialized).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class DummyCustomQueryNoReadAndSerializeItemDocumentResolver implements QueryItemResolverInterface
+{
+    /**
+     * @param DummyCustomQueryDocument|null $item
+     *
+     * @return DummyCustomQueryDocument
+     */
+    public function __invoke($item, array $context)
+    {
+        if (null !== $item) {
+            throw new RuntimeException('Item should be null');
+        }
+
+        return new DummyCustomQueryDocument(); // Should not be normalized.
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNoReadAndSerializeItemResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNoReadAndSerializeItemResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
+
+/**
+ * Resolver for dummy item custom query (item not read and no result serialized).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class DummyCustomQueryNoReadAndSerializeItemResolver implements QueryItemResolverInterface
+{
+    /**
+     * @param DummyCustomQuery|null $item
+     *
+     * @return DummyCustomQuery
+     */
+    public function __invoke($item, array $context)
+    {
+        if (null !== $item) {
+            throw new RuntimeException('Item should be null');
+        }
+
+        return new DummyCustomQuery(); // Should not be normalized.
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/SumNoWriteCustomResultMutationResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/SumNoWriteCustomResultMutationResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomMutation as DummyCustomMutationDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomMutation;
+
+/**
+ * Resolver for custom mutation (item not persisted but with a custom result).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class SumNoWriteCustomResultMutationResolver implements MutationResolverInterface
+{
+    /**
+     * @param DummyCustomMutation|DummyCustomMutationDocument|null $item
+     */
+    public function __invoke($item, array $context)
+    {
+        // Side-effect.
+
+        $item->setResult(1234);
+
+        return $item;
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/SumOnlyPersistDocumentMutationResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/SumOnlyPersistDocumentMutationResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomMutation as DummyCustomMutationDocument;
+
+/**
+ * Resolver for custom mutation (item not received and no result sent).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class SumOnlyPersistDocumentMutationResolver implements MutationResolverInterface
+{
+    /**
+     * @param DummyCustomMutationDocument|null $item
+     */
+    public function __invoke($item, array $context)
+    {
+        if (null !== $item) {
+            throw new RuntimeException('Item should be null');
+        }
+
+        return new DummyCustomMutationDocument(); // Should not be normalized.
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/SumOnlyPersistMutationResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/SumOnlyPersistMutationResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver;
+
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomMutation;
+
+/**
+ * Resolver for custom mutation (item not received and no result sent).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class SumOnlyPersistMutationResolver implements MutationResolverInterface
+{
+    /**
+     * @param DummyCustomMutation|null $item
+     */
+    public function __invoke($item, array $context)
+    {
+        if (null !== $item) {
+            throw new RuntimeException('Item should be null');
+        }
+
+        return new DummyCustomMutation(); // Should not be normalized.
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -263,6 +263,12 @@ services:
         tags:
             - { name: 'api_platform.graphql.query_resolver' }
 
+    app.graphql.query_resolver.dummy_custom_collection_no_read_and_serialize:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryNoReadAndSerializeCollectionResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.query_resolver' }
+
     app.graphql.mutation_resolver.dummy_custom:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumMutationResolver'
         public: false
@@ -271,6 +277,12 @@ services:
 
     app.graphql.mutation_resolver.dummy_custom_not_persisted:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumNotPersistedMutationResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.mutation_resolver' }
+
+    app.graphql.mutation_resolver.dummy_custom_no_write_custom_result:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumNoWriteCustomResultMutationResolver'
         public: false
         tags:
             - { name: 'api_platform.graphql.mutation_resolver' }

--- a/tests/Fixtures/app/config/config_mongodb.yml
+++ b/tests/Fixtures/app/config/config_mongodb.yml
@@ -105,6 +105,18 @@ services:
         tags:
             - { name: 'api_platform.graphql.query_resolver' }
 
+    app.graphql.query_resolver.dummy_custom_item_no_read_and_serialize_document:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryNoReadAndSerializeItemDocumentResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.query_resolver' }
+
+    app.graphql.mutation_resolver.dummy_custom_only_persist_document:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumOnlyPersistDocumentMutationResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.mutation_resolver' }
+
     app.messenger_handler.messenger_with_inputs:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\MessengerHandler\Document\MessengerWithInputHandler'
         public: false

--- a/tests/Fixtures/app/config/config_test.yml
+++ b/tests/Fixtures/app/config/config_test.yml
@@ -107,6 +107,18 @@ services:
         tags:
             - { name: 'api_platform.graphql.query_resolver' }
 
+    app.graphql.query_resolver.dummy_custom_item_no_read_and_serialize:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryNoReadAndSerializeItemResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.query_resolver' }
+
+    app.graphql.mutation_resolver.dummy_custom_only_persist:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumOnlyPersistMutationResolver'
+        public: false
+        tags:
+            - { name: 'api_platform.graphql.mutation_resolver' }
+
     app.messenger_handler.messenger_with_inputs:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\MessengerHandler\Entity\MessengerWithInputHandler'
         public: false

--- a/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -189,6 +189,81 @@ class CollectionResolverFactoryTest extends TestCase
         );
     }
 
+    public function testCreateCollectionNoRead(): void
+    {
+        $factory = $this->createCollectionResolverFactory([
+            'Object1',
+            'Object2',
+        ], [], [], false, null, ['query' => ['read' => false]]);
+
+        $resolver = $factory(RelatedDummy::class, Dummy::class);
+
+        $resolveInfo = new ResolveInfo('relatedDummies', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
+
+        $this->assertEquals(
+            [],
+            $resolver(null, [], null, $resolveInfo)
+        );
+    }
+
+    public function testCreateSubresourceCollectionNoRead(): void
+    {
+        $identifiers = ['id' => 1];
+        $factory = $this->createCollectionResolverFactory([
+            'Object1',
+            'Object2',
+        ], ['Subobject1', 'Subobject2'], $identifiers, false, null, ['query' => ['read' => false]]);
+
+        $resolver = $factory(RelatedDummy::class, Dummy::class, 'query');
+
+        $resolveInfo = new ResolveInfo('relatedDummies', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
+
+        $source = [
+            'relatedDummies' => [],
+            ItemNormalizer::ITEM_IDENTIFIERS_KEY => $identifiers,
+        ];
+
+        $this->assertEquals([], $resolver($source, [], null, $resolveInfo));
+    }
+
+    public function testCreateCollectionNoSerialize(): void
+    {
+        $factory = $this->createCollectionResolverFactory([
+            'Object1',
+            'Object2',
+        ], [], [], false, null, ['custom_query' => ['collection_query' => 'query_resolver_id', 'serialize' => false]]);
+
+        $resolver = $factory(RelatedDummy::class, Dummy::class, 'custom_query');
+
+        $resolveInfo = new ResolveInfo('relatedDummies', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
+
+        $this->assertEquals(
+            [],
+            $resolver(null, [], null, $resolveInfo)
+        );
+    }
+
+    public function testCreateCollectionNoSerializeNoPagination(): void
+    {
+        $factory = $this->createCollectionResolverFactory([
+            'Object1',
+            'Object2',
+        ], [], [], true, null, ['custom_query' => ['collection_query' => 'query_resolver_id', 'serialize' => false]]);
+
+        $resolver = $factory(RelatedDummy::class, Dummy::class, 'custom_query');
+
+        $resolveInfo = new ResolveInfo('relatedDummies', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
+
+        $this->assertEquals(
+            [
+                'totalCount' => 0.0,
+                'edges' => [],
+                'pageInfo' => ['startCursor' => null, 'endCursor' => null, 'hasNextPage' => false, 'hasPreviousPage' => false],
+            ],
+            $resolver(null, [], null, $resolveInfo)
+        );
+    }
+
     /**
      * @param array|\Iterator $collection
      */

--- a/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
@@ -131,6 +131,33 @@ class ItemResolverFactoryTest extends TestCase
         $this->assertEquals('normalizedItem', ($this->itemResolverFactory)(null, null, 'custom_query')(null, ['id' => '/related_dummies/3'], null, $resolveInfo));
     }
 
+    public function testCreateItemResolverNoRead(): void
+    {
+        $this->iriConverterProphecy->getItemFromIri(Argument::cetera())->shouldNotBeCalled();
+        $this->normalizerProphecy->normalize(null, Argument::cetera())->willReturn('nullItem');
+
+        $resolveInfo = new ResolveInfo('name', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
+
+        $this->resourceMetadataFactoryProphecy->create(RelatedDummy::class)->willReturn(new ResourceMetadata('RelatedDummy', null, null, null, null, null, null, ['query' => ['read' => false]]));
+
+        $this->assertEquals('nullItem', ($this->itemResolverFactory)(RelatedDummy::class)(null, ['id' => '/related_dummies/3'], null, $resolveInfo));
+    }
+
+    public function testCreateItemResolverNoSerialize(): void
+    {
+        $item = new RelatedDummy();
+        $returnedItem = new RelatedDummy();
+        $returnedItem->setName('returned');
+        $this->iriConverterProphecy->getItemFromIri('/related_dummies/3', ['attributes' => []])->willReturn($item);
+        $this->normalizerProphecy->normalize(Argument::cetera())->shouldNotBeCalled();
+
+        $resolveInfo = new ResolveInfo('name', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
+
+        $this->resourceMetadataFactoryProphecy->create(RelatedDummy::class)->willReturn(new ResourceMetadata('RelatedDummy', null, null, null, null, null, null, ['query' => ['serialize' => false]]));
+
+        $this->assertNull(($this->itemResolverFactory)()(null, ['id' => '/related_dummies/3'], null, $resolveInfo));
+    }
+
     /**
      * @dataProvider subresourceProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | Will be added in https://github.com/api-platform/docs/pull/830

Since the introduction of custom queries and mutations, a needed feature was missing: the possibility to disable some "steps" the main resolver is doing.

For instance, if we want to create a custom mutation and letting it persist the mutated item as it wants, it was not possible before (`null` could be returned but the returned data was also `null`).

Now it can be done by disabling the `write` step in the operation attributes:
```php
<?php

namespace App\Model;

use ApiPlatform\Core\Annotation\ApiResource;
use App\Resolver\MyMutationResolver;

/**
 * @ApiResource(graphql={
 *     "noWrite"={
 *         "mutation"=MyMutationResolver::class,
 *         "write"=false
 *     }
 * })
 */
```
The REST part has already the possibility to do so (see https://api-platform.com/docs/core/events/#built-in-event-listeners).

However this PR also shows that the resolvers are getting bigger and bigger and a refactor is required.
I think adopting an architecture based on events could be a solution (the resolver only sends the events and the current code will be divided into the listeners) or we can introduce new services and interfaces to do so. WDYT @api-platform/core-team?

Fortunately, I think the added `if` clauses can help to break the different steps the resolver is doing.