### PR TITLE
Fix Elasticsearch order filter on related entity property

### DIFF
--- a/src/Bridge/Elasticsearch/DataProvider/Filter/AbstractFilter.php
+++ b/src/Bridge/Elasticsearch/DataProvider/Filter/AbstractFilter.php
@@ -81,13 +81,13 @@ abstract class AbstractFilter implements FilterInterface
     protected function getMetadata(string $resourceClass, string $property): array
     {
         $noop = [null, null, null, null];
+        $properties = explode('.', $property);
+        $totalProperties = \count($properties);
 
-        if (!$this->hasProperty($resourceClass, $property)) {
+        if (1 === $totalProperties && !$this->hasProperty($resourceClass, $property)) {
             return $noop;
         }
 
-        $properties = explode('.', $property);
-        $totalProperties = \count($properties);
         $currentResourceClass = $resourceClass;
         $hasAssociation = false;
         $currentProperty = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I use Elasticsearch integration and I want to sort on properties like `user.id` where `user` is a related entity and `id` is an integer. The serialization and the ES mapping allow the order to operate.

Current implementation try to check dotted properties after searching if the property exists, period. So the whole code seems to be for nothing. 

I'm not sure if the real fix should be that `hasProperty` return true even for dotted property. But currently this patch seems to be ok for me, so Hi!
