### PR TITLE
WIP: Ability to remove the item operation

### DIFF
--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -78,6 +78,8 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConvertedOwner;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConvertedRelated;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConvertedString;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Customer;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DisableItemOperation;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DisableItemOperation as DisableItemOperationDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyAggregateOffer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
@@ -1484,6 +1486,17 @@ final class DoctrineContext implements Context
         $this->manager->flush();
     }
 
+    /**
+     * @Given there is 1 DisableItemOperation
+     */
+    public function thereIsOneDisableItemOperation()
+    {
+        $item = $this->buildDisableItemOperation();
+        $item->name = 'Test';
+        $this->manager->persist($item);
+        $this->manager->flush();
+    }
+
     private function isOrm(): bool
     {
         return null !== $this->schemaTool;
@@ -1852,5 +1865,13 @@ final class DoctrineContext implements Context
     private function buildConvertedRelated()
     {
         return $this->isOrm() ? new ConvertedRelated() : new ConvertedRelatedDocument();
+    }
+
+    /**
+     * @return DisableItemOperation|DisableItemOperationDocument
+     */
+    private function buildDisableItemOperation()
+    {
+        return $this->isOrm() ? new DisableItemOperation() : new DisableItemOperationDocument();
     }
 }

--- a/features/main/operation.feature
+++ b/features/main/operation.feature
@@ -55,3 +55,9 @@ Feature: Operation support
         }
     }
     """
+
+  @createSchema
+  Scenario: Get a resource that doesn't have a defined item operation
+    Given there is 1 DisableItemOperation
+    When I send a "GET" request to "/disable_item_operations"
+    Then the response status code should be 200

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\JsonLd\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -71,7 +72,13 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null);
         $context = $this->initContext($resourceClass, $context);
-        $iri = $this->iriConverter->getIriFromItem($object);
+
+        try {
+            $iri = $this->iriConverter->getIriFromItem($object);
+        } catch (InvalidArgumentException $e) {
+            $iri = '_:'.(\function_exists('spl_object_id') ? spl_object_id($object) : spl_object_hash($object));
+        }
+
         $context['iri'] = $iri;
         $context['api_normalize'] = true;
 

--- a/tests/Fixtures/TestBundle/Document/DisableItemOperation.php
+++ b/tests/Fixtures/TestBundle/Document/DisableItemOperation.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * DisableItemOperation.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @ApiResource(itemOperations={}, collectionOperations={"get"})
+ * @ODM\Document
+ */
+class DisableItemOperation
+{
+    /**
+     * @ODM\Id(strategy="INCREMENT", type="integer")
+     */
+    private $id;
+
+    /**
+     * @var string The dummy name
+     *
+     * @ODM\Field
+     */
+    public $name;
+
+    public function getId() {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DisableItemOperation.php
+++ b/tests/Fixtures/TestBundle/Entity/DisableItemOperation.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * DisableItemOperation.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @ApiResource(itemOperations={}, collectionOperations={"get", "post"})
+ * @ORM\Entity
+ */
+class DisableItemOperation
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer", nullable=true)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string The dummy name
+     *
+     * @ORM\Column
+     */
+    public $name;
+
+    public function getId() {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | lots? https://github.com/api-platform/core/issues/2796
| License       | MIT
| Doc PR        | na

This is a proposal to make resources work without a defined GET item operation. When it fails we should fallback to a blank IRI instead of resulting in a 400 error.

Note that I think that we should make this behavior configurable. If we decide that it should be the default behavior maybe a configuration to keep the old behavior?
About the implementation:
- I'd like to put this further down the stack so that we can use the CachedRouteResolver with these (performance issue)
- I thought about adding a new `getSafeIriFromItem` that never throws (means to add a new interface that extends the current one)

This definitely breaks some current behavior but I think that it also makes ApiPlatform less strict regarding this item operation. The only solution for now is to decorate the IriConverter with our own where it patches these kind of Resources. Also, by using a blank iri we enforce a good practice regarding JSON-LD.