### PR TITLE
Fix compatibility with symfony/error-renderer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,11 @@ commands:
       - run:
           name: Update project dependencies
           command: composer update --prefer-dist --no-progress --no-suggest --ansi
+  update-project-dependencies-high:
+    steps:
+      - run:
+          name: Update project dependencies (high deps)
+          command: composer config minimum-stability dev && composer require symfony/error-renderer:^4.4 --no-update && composer update --prefer-dist --no-progress --no-suggest --ansi
   wait-for-elasticsearch:
     steps:
       - wait-for-service:
@@ -255,7 +260,7 @@ jobs:
       - disable-php-memory-limit
       - update-composer
       - restore-composer-cache
-      - update-project-dependencies
+      - update-project-dependencies-high
       - save-composer-cache
       - clear-test-app-cache
       - restore-phpstan-cache

--- a/src/Action/ExceptionAction.php
+++ b/src/Action/ExceptionAction.php
@@ -14,7 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Action;
 
 use ApiPlatform\Core\Util\ErrorFormatGuesser;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -59,8 +60,12 @@ final class ExceptionAction
     /**
      * Converts a an exception to a JSON response.
      */
-    public function __invoke(FlattenException $exception, Request $request): Response
+    public function __invoke(/* FlattenException */$exception, Request $request): Response
     {
+        if (!$exception instanceof FlattenException && !$exception instanceof LegacyFlattenException) {
+            throw new \TypeError(sprintf('Argument 1 passed to %s() must be an instance of %s or %s.', __METHOD__, FlattenException::class, LegacyFlattenException::class));
+        }
+
         $exceptionClass = $exception->getClass();
         $statusCode = $exception->getStatusCode();
 

--- a/src/Hydra/Serializer/ErrorNormalizer.php
+++ b/src/Hydra/Serializer/ErrorNormalizer.php
@@ -15,12 +15,13 @@ namespace ApiPlatform\Core\Hydra\Serializer;
 
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Converts {@see \Exception} or {@see \Symfony\Component\Debug\Exception\FlattenException} to a Hydra error representation.
+ * Converts {@see \Exception} or {@see \Symfony\Component\ErrorRenderer\Exception\FlattenException} to a Hydra error representation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
@@ -67,7 +68,7 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
      */
     public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException || $data instanceof LegacyFlattenException);
     }
 
     /**

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\JsonApi\Serializer;
 
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Converts {@see \Exception} or {@see \Symfony\Component\Debug\Exception\FlattenException} to a JSON API error representation.
+ * Converts {@see \Exception} or {@see \Symfony\Component\ErrorRenderer\Exception\FlattenException} to a JSON API error representation.
  *
  * @author Héctor Hurtarte <hectorh30@gmail.com>
  */
@@ -60,7 +61,7 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
      */
     public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException || $data instanceof LegacyFlattenException);
     }
 
     /**

--- a/src/Problem/Serializer/ErrorNormalizerTrait.php
+++ b/src/Problem/Serializer/ErrorNormalizerTrait.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Problem\Serializer;
 
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
 
 trait ErrorNormalizerTrait
@@ -26,7 +27,7 @@ trait ErrorNormalizerTrait
             return $message;
         }
 
-        if ($object instanceof FlattenException) {
+        if ($object instanceof FlattenException || $object instanceof LegacyFlattenException) {
             $statusCode = $context['statusCode'] ?? $object->getStatusCode();
             if ($statusCode >= 500 && $statusCode < 600) {
                 $message = Response::$statusTexts[$statusCode];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Opens the door to error-renderer while keeping compat with debug, on 2.4. 
Cannot be tested since error-renderer conflicts with http-kernel <4.4 and http-kernel ^3.4|^4.0 is supported here, so `--prefer-lowest` ends up being non-installable.
Support for symfony/debug should probably be deprecated in a next minor, as soon as symfony/* is bumped to `^4.4`.