### PR TITLE
Making assertArraySubset() compatible with phpunit v6

### DIFF
--- a/src/Bridge/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Bridge/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -88,7 +88,7 @@ trait ApiTestAssertionsTrait
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws \Exception
      */
-    public static function assertArraySubset($subset, $array, bool $checkForObjectIdentity = false, string $message = ''): void
+    public static function assertArraySubset($subset, $array, $checkForObjectIdentity = false, $message = '')
     {
         $constraint = new ArraySubset($subset, $checkForObjectIdentity);
         static::assertThat($array, $constraint, $message);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

Hi!

I'm playing around with the unreleased new test files. I'm using them with `simple-phpunit`, which on my system installed phpunit 6.5 (which happens via the phpunit.xml.dist file via the recipe https://github.com/symfony/recipes/blob/master/symfony/phpunit-bridge/4.1/phpunit.xml.dist#L15).

Anyways, using version 6.5 causes an error because the `assertArraySubset()` method DOES exist in that version of phpunit, but the signatures don't match. Removing the type-hints, which not ideal, fixes the problem with (I think) minimal pain.

Thanks!