### PR TITLE
[OpenAPI] Extract the JSON Schema builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "symfony/http-client": "^4.3",
         "symfony/mercure-bundle": "*",
         "symfony/messenger": "^4.3",
-        "symfony/phpunit-bridge": "^4.3.1",
+        "symfony/phpunit-bridge": "^4.3@dev",
         "symfony/routing": "^3.4 || ^4.0",
         "symfony/security-bundle": "^3.4 || ^4.0",
         "symfony/security-core": "^4.3",

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -95,7 +95,7 @@ Feature: Documentation support
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 6 elements
 
     # Subcollection - check schema
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend-fakemanytomany"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend:jsonld-fakemanytomany"
 
     # Deprecations
     And the JSON node "paths./dummies.get.deprecated" should not exist

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -52,9 +52,6 @@ parameters:
 		- '#Parameter \#(2|3) \$(resourceMetadataFactory|pagination) of class ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\PaginationExtension constructor expects (ApiPlatform\\Core\\Metadata\\Resource\\Factory\\ResourceMetadataFactoryInterface\|Symfony\\Component\\HttpFoundation\\RequestStack|ApiPlatform\\Core\\DataProvider\\Pagination\|ApiPlatform\\Core\\Metadata\\Resource\\Factory\\ResourceMetadataFactoryInterface), stdClass given\.#'
 		- '#Parameter \#[0-9] \$filterLocator of class ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\FilterExtension constructor expects ApiPlatform\\Core\\Api\\FilterCollection|Psr\\Container\\ContainerInterface(\|null)?, ArrayObject given\.#'
 		-
-			message: '#Parameter \#9 \$nameConverter of class ApiPlatform\\Core\\Swagger\\Serializer\\DocumentationNormalizer constructor expects Symfony\\Component\\Serializer\\NameConverter\\NameConverterInterface\|null, object given\.#'
-			path: %currentWorkingDirectory%/tests/Swagger/Serializer/DocumentationNormalizer*Test.php
-		-
 			message: '#Parameter \#1 \$resource of method ApiPlatform\\Core\\Metadata\\Extractor\\XmlExtractor::getAttributes\(\) expects SimpleXMLElement, object given\.#'
 			path: %currentWorkingDirectory%/src/Metadata/Extractor/XmlExtractor.php
 		-

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -311,6 +311,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             return;
         }
 
+        $loader->load('json_schema.xml');
         $loader->load('swagger.xml');
 
         if ($config['enable_swagger_ui'] || $config['enable_re_doc']) {

--- a/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
@@ -76,6 +76,12 @@
             <argument type="service" id="api_platform.filter_locator" />
         </service>
 
+        <!-- JSON Schema -->
+
+        <service id="api_platform.hydra.json_schema.schema_factory" class="ApiPlatform\Core\Hydra\JsonSchema\SchemaFactory" decorates="api_platform.json_schema.schema_factory">
+            <argument type="service" id="api_platform.hydra.json_schema.schema_factory.inner" />
+        </service>
+
     </services>
 
 </container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="false" />
+
+        <service id="api_platform.json_schema.type_factory" class="ApiPlatform\Core\JsonSchema\TypeFactory">
+            <call method="setSchemaFactory">
+                <argument type="service" id="api_platform.json_schema.schema_factory"/>
+            </call>
+        </service>
+        <service id="ApiPlatform\Core\JsonSchema\TypeFactoryInterface" alias="api_platform.json_schema.type_factory" />
+
+        <service id="api_platform.json_schema.schema_factory" class="ApiPlatform\Core\JsonSchema\SchemaFactory">
+            <argument type="service" id="api_platform.json_schema.type_factory"></argument>
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+        </service>
+        <service id="ApiPlatform\Core\JsonSchema\SchemaFactoryInterface" alias="api_platform.json_schema.schema_factory" />
+    </services>
+
+</container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -10,12 +10,12 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
-            <argument type="service" id="api_platform.resource_class_resolver" />
-            <argument>null</argument>
+            <argument type="service" id="api_platform.json_schema.schema_factory" />
+            <argument type="service" id="api_platform.json_schema.type_factory" />
             <argument type="service" id="api_platform.operation_path_resolver" />
             <argument>null</argument>
             <argument type="service" id="api_platform.filter_locator" />
-            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument>null</argument>
             <argument>%api_platform.oauth.enabled%</argument>
             <argument>%api_platform.oauth.type%</argument>
             <argument>%api_platform.oauth.flow%</argument>

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Hydra\JsonSchema;
+
+use ApiPlatform\Core\JsonSchema\Schema;
+use ApiPlatform\Core\JsonSchema\SchemaFactory as BaseSchemaFactory;
+use ApiPlatform\Core\JsonSchema\SchemaFactoryInterface;
+
+/**
+ * Generates the JSON Schema corresponding to a Hydra document.
+ *
+ * @experimental
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class SchemaFactory implements SchemaFactoryInterface
+{
+    private const BASE_PROP = [
+        'readOnly' => true,
+        'type' => 'string',
+    ];
+    private const BASE_PROPS = [
+        '@context' => self::BASE_PROP,
+        '@id' => self::BASE_PROP,
+        '@type' => self::BASE_PROP,
+    ];
+
+    private $schemaFactory;
+
+    public function __construct(BaseSchemaFactory $schemaFactory)
+    {
+        $this->schemaFactory = $schemaFactory;
+        $schemaFactory->addDistinctFormat('jsonld');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildSchema(string $resourceClass, string $format = 'jsonld', bool $output = true, ?string $operationType = null, ?string $operationName = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
+    {
+        $schema = $this->schemaFactory->buildSchema($resourceClass, $format, $output, $operationType, $operationName, $schema, $serializerContext, $forceCollection);
+        if ('jsonld' !== $format) {
+            return $schema;
+        }
+
+        $definitions = $schema->getDefinitions();
+        if ($key = $schema->getRootDefinitionKey()) {
+            $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
+
+            return $schema;
+        }
+
+        if (($schema['type'] ?? '') === 'array') {
+            // hydra:collection
+            $items = $schema['items'];
+            unset($schema['items']);
+
+            $schema['type'] = 'object';
+            $schema['properties'] = [
+                'hydra:member' => [
+                    'type' => 'array',
+                    'items' => $items,
+                ],
+                'hydra:totalItems' => [
+                    'type' => 'integer',
+                    'minimum' => 1,
+                ],
+                'hydra:view' => [
+                    'type' => 'object',
+                    'properties' => [
+                        '@id' => ['type' => 'string'],
+                        '@type' => ['type' => 'string'],
+                        'hydra:first' => [
+                            'type' => 'integer',
+                            'minimum' => 1,
+                        ],
+                        'hydra:last' => [
+                            'type' => 'integer',
+                            'minimum' => 1,
+                        ],
+                        'hydra:next' => [
+                            'type' => 'integer',
+                            'minimum' => 1,
+                        ],
+                    ],
+                ],
+                'hydra:search' => [
+                    'type' => 'object',
+                    'properties' => [
+                        '@type' => ['type' => 'string'],
+                        'hydra:template' => ['type' => 'string'],
+                        'hydra:variableRepresentation' => ['type' => 'string'],
+                        'hydra:mapping' => [
+                            'type' => 'array',
+                            'items' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    '@type' => ['type' => 'string'],
+                                    'variable' => ['type' => 'string'],
+                                    'property' => ['type' => 'string'],
+                                    'required' => ['type' => 'boolean'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+            return $schema;
+        }
+
+        return $schema;
+    }
+}

--- a/src/JsonSchema/Schema.php
+++ b/src/JsonSchema/Schema.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonSchema;
+
+/**
+ * Represents a JSON Schema document.
+ *
+ * Both the standard version and the OpenAPI flavors (v2 and v3) are supported.
+ *
+ * @see https://json-schema.org/latest/json-schema-core.html
+ * @see https://github.com/OAI/OpenAPI-Specification
+ *
+ * @experimental
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class Schema extends \ArrayObject
+{
+    public const VERSION_JSON_SCHEMA = 'json-schema';
+    public const VERSION_SWAGGER = 'swagger';
+    public const VERSION_OPENAPI = 'openapi';
+
+    private $version;
+
+    public function __construct(string $version = self::VERSION_JSON_SCHEMA)
+    {
+        $this->version = $version;
+
+        parent::__construct(self::VERSION_JSON_SCHEMA === $this->version ? ['$schema' => 'http://json-schema.org/draft-07/schema#'] : []);
+    }
+
+    /**
+     * The flavor used for this document: JSON Schema, OpenAPI v2 or OpenAPI v3.
+     */
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param bool $includeDefinitions if set to false, definitions will not be included in the resulting array
+     */
+    public function getArrayCopy(bool $includeDefinitions = true): array
+    {
+        $schema = parent::getArrayCopy();
+
+        if (!$includeDefinitions) {
+            unset($schema['definitions'], $schema['components']);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Retrieves the definitions used by this schema.
+     */
+    public function getDefinitions(): \ArrayObject
+    {
+        $definitions = $this['definitions'] ?? $this['components']['schemas'] ?? new \ArrayObject();
+        $this->setDefinitions($definitions);
+
+        return $definitions;
+    }
+
+    /**
+     * Associates existing definitions to this schema.
+     */
+    public function setDefinitions(\ArrayObject $definitions): void
+    {
+        if (self::VERSION_OPENAPI === $this->version) {
+            $this['components']['schemas'] = $definitions;
+
+            return;
+        }
+
+        $this['definitions'] = $definitions;
+    }
+
+    /**
+     * Returns the name of the root definition, if defined.
+     */
+    public function getRootDefinitionKey(): ?string
+    {
+        if (!isset($this['$ref'])) {
+            return null;
+        }
+
+        // strlen('#/definitions/') = 14
+        // strlen('#/components/schemas/') = 21
+        $prefix = self::VERSION_OPENAPI === $this->version ? 21 : 14;
+
+        return substr($this['$ref'], $prefix);
+    }
+
+    /**
+     * Checks if this schema is initialized.
+     */
+    public function isDefined(): bool
+    {
+        return isset($this['$ref']) || isset($this['type']);
+    }
+}

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -1,0 +1,248 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonSchema;
+
+use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+/**
+ * {@inheritdoc}
+ *
+ * @experimental
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class SchemaFactory implements SchemaFactoryInterface
+{
+    private $resourceMetadataFactory;
+    private $propertyNameCollectionFactory;
+    private $propertyMetadataFactory;
+    private $typeFactory;
+    private $nameConverter;
+    private $distinctFormats = [];
+
+    public function __construct(TypeFactoryInterface $typeFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, NameConverterInterface $nameConverter = null)
+    {
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
+        $this->propertyMetadataFactory = $propertyMetadataFactory;
+        $this->nameConverter = $nameConverter;
+        $this->typeFactory = $typeFactory;
+    }
+
+    /**
+     * When added to the list, the given format will lead to the creation of a new definition.
+     *
+     * @internal
+     */
+    public function addDistinctFormat(string $format): void
+    {
+        $this->distinctFormats[$format] = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildSchema(string $resourceClass, string $format = 'json', bool $output = true, ?string $operationType = null, ?string $operationName = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
+    {
+        $schema = $schema ?? new Schema();
+        if (null === $metadata = $this->getMetadata($resourceClass, $output, $operationType, $operationName, $serializerContext)) {
+            return $schema;
+        }
+        [$resourceMetadata, $serializerContext, $inputOrOutputClass] = $metadata;
+
+        $version = $schema->getVersion();
+        $definitionName = $this->buildDefinitionName($resourceClass, $format, $output, $operationType, $operationName, $serializerContext);
+        if (!isset($schema['$ref']) && !isset($schema['type'])) {
+            $ref = Schema::VERSION_OPENAPI === $version ? '#/components/schemas/'.$definitionName : '#/definitions/'.$definitionName;
+
+            $method = null !== $operationType && null !== $operationName ? $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'method', 'GET') : 'GET';
+            if ($forceCollection || (OperationType::COLLECTION === $operationType && 'POST' !== $method)) {
+                $schema['type'] = 'array';
+                $schema['items'] = ['$ref' => $ref];
+            } else {
+                $schema['$ref'] = $ref;
+            }
+        }
+
+        $definitions = $schema->getDefinitions();
+        if (isset($definitions[$definitionName])) {
+            // Already computed
+            return $schema;
+        }
+
+        $definition = new \ArrayObject(['type' => 'object']);
+        $definitions[$definitionName] = $definition;
+        if (null !== $description = $resourceMetadata->getDescription()) {
+            $definition['description'] = $description;
+        }
+        // see https://github.com/json-schema-org/json-schema-spec/pull/737
+        if (
+            Schema::VERSION_SWAGGER !== $version &&
+            (
+                (null !== $operationType && null !== $operationName && null !== $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'deprecation_reason', null, true)) ||
+                null !== $resourceMetadata->getAttribute('deprecation_reason', null)
+            )
+        ) {
+            $definition['deprecated'] = true;
+        }
+        // externalDocs is an OpenAPI specific extension, but JSON Schema allows additional keys, so we always add it
+        // See https://json-schema.org/latest/json-schema-core.html#rfc.section.6.4
+        if (null !== $iri = $resourceMetadata->getIri()) {
+            $definition['externalDocs'] = ['url' => $iri];
+        }
+
+        $options = isset($serializerContext[AbstractNormalizer::GROUPS]) ? ['serializer_groups' => $serializerContext[AbstractNormalizer::GROUPS]] : [];
+        foreach ($this->propertyNameCollectionFactory->create($inputOrOutputClass, $options) as $propertyName) {
+            $propertyMetadata = $this->propertyMetadataFactory->create($inputOrOutputClass, $propertyName);
+            if (!$propertyMetadata->isReadable() && !$propertyMetadata->isWritable()) {
+                continue;
+            }
+
+            $normalizedPropertyName = $this->nameConverter ? $this->nameConverter->normalize($propertyName, $inputOrOutputClass, $format, $serializerContext) : $propertyName;
+            if ($propertyMetadata->isRequired()) {
+                $definition['required'][] = $normalizedPropertyName;
+            }
+
+            $this->buildPropertySchema($schema, $definitionName, $normalizedPropertyName, $propertyMetadata, $serializerContext, $format);
+        }
+
+        return $schema;
+    }
+
+    private function buildPropertySchema(Schema $schema, string $definitionName, string $normalizedPropertyName, PropertyMetadata $propertyMetadata, array $serializerContext, string $format): void
+    {
+        $version = $schema->getVersion();
+        $swagger = false;
+        switch ($version) {
+            case Schema::VERSION_SWAGGER:
+                $swagger = true;
+                $basePropertySchemaAttribute = 'swagger_context';
+                break;
+            case Schema::VERSION_OPENAPI:
+                $basePropertySchemaAttribute = 'openapi_context';
+                break;
+            default:
+                $basePropertySchemaAttribute = 'json_schema_context';
+        }
+
+        $propertySchema = $propertyMetadata->getAttributes()[$basePropertySchemaAttribute] ?? [];
+        if (false === $propertyMetadata->isWritable() && !$propertyMetadata->isInitializable()) {
+            $propertySchema['readOnly'] = true;
+        }
+        if (!$swagger && false === $propertyMetadata->isReadable()) {
+            $propertySchema['writeOnly'] = true;
+        }
+        if (null !== $description = $propertyMetadata->getDescription()) {
+            $propertySchema['description'] = $description;
+        }
+        // see https://github.com/json-schema-org/json-schema-spec/pull/737
+        if (!$swagger && null !== $propertyMetadata->getAttribute('deprecation_reason')) {
+            $propertySchema['deprecated'] = true;
+        }
+        // externalDocs is an OpenAPI specific extension, but JSON Schema allows additional keys, so we always add it
+        // See https://json-schema.org/latest/json-schema-core.html#rfc.section.6.4
+        if (null !== $iri = $propertyMetadata->getIri()) {
+            $propertySchema['externalDocs'] = ['url' => $iri];
+        }
+
+        $valueSchema = [];
+        if (null !== $type = $propertyMetadata->getType()) {
+            $isCollection = $type->isCollection();
+            if (null === $valueType = $isCollection ? $type->getCollectionValueType() : $type) {
+                $builtinType = 'string';
+                $className = null;
+            } else {
+                $builtinType = $valueType->getBuiltinType();
+                $className = $valueType->getClassName();
+            }
+
+            $valueSchema = $this->typeFactory->getType(new Type($builtinType, $type->isNullable(), $className, $isCollection), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
+        }
+
+        $propertySchema = new \ArrayObject($propertySchema + $valueSchema);
+        if (DocumentationNormalizer::OPENAPI_VERSION === $version) {
+            $schema->getDefinitions()[$definitionName]['properties'][$normalizedPropertyName] = $propertySchema;
+
+            return;
+        }
+
+        $schema->getDefinitions()[$definitionName]['properties'][$normalizedPropertyName] = $propertySchema;
+    }
+
+    private function buildDefinitionName(string $resourceClass, string $format = 'json', bool $output = true, ?string $operationType = null, ?string $operationName = null, ?array $serializerContext = null): string
+    {
+        [$resourceMetadata, $serializerContext, $inputOrOutputClass] = $this->getMetadata($resourceClass, $output, $operationType, $operationName, $serializerContext);
+
+        $prefix = $resourceMetadata->getShortName();
+        if (null !== $inputOrOutputClass && $resourceClass !== $inputOrOutputClass) {
+            $prefix .= ':'.md5($inputOrOutputClass);
+        }
+
+        if (isset($this->distinctFormats[$format])) {
+            // JSON is the default, and so isn't included in the definition name
+            $prefix .= ':'.$format;
+        }
+
+        if (isset($serializerContext[DocumentationNormalizer::SWAGGER_DEFINITION_NAME])) {
+            $name = sprintf('%s-%s', $prefix, $serializerContext[DocumentationNormalizer::SWAGGER_DEFINITION_NAME]);
+        } else {
+            $groups = (array) ($serializerContext[AbstractNormalizer::GROUPS] ?? []);
+            $name = $groups ? sprintf('%s-%s', $prefix, implode('_', $groups)) : $prefix;
+        }
+
+        return $name;
+    }
+
+    private function getMetadata(string $resourceClass, bool $output, ?string $operationType, ?string $operationName, ?array $serializerContext): ?array
+    {
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+        $attribute = $output ? 'output' : 'input';
+        if (null === $operationType || null === $operationName) {
+            $inputOrOutput = $resourceMetadata->getAttribute($attribute, ['class' => $resourceClass]);
+        } else {
+            $inputOrOutput = $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, $attribute, ['class' => $resourceClass], true);
+        }
+
+        if (null === ($inputOrOutput['class'] ?? null)) {
+            // input or output disabled
+            return null;
+        }
+
+        return [
+            $resourceMetadata,
+            $serializerContext ?? $this->getSerializerContext($resourceMetadata, $output, $operationType, $operationName),
+            $inputOrOutput['class'],
+        ];
+    }
+
+    private function getSerializerContext(ResourceMetadata $resourceMetadata, bool $output, ?string $operationType, ?string $operationName): array
+    {
+        $attribute = $output ? 'normalization_context' : 'denormalization_context';
+
+        if (null === $operationType || null === $operationName) {
+            return $resourceMetadata->getAttribute($attribute, []);
+        }
+
+        return $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, $attribute, [], true);
+    }
+}

--- a/src/JsonSchema/SchemaFactoryInterface.php
+++ b/src/JsonSchema/SchemaFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonSchema;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+
+/**
+ * Builds a JSON Schema from an API Platform resource definition.
+ *
+ * @experimental
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface SchemaFactoryInterface
+{
+    /**
+     * @throws ResourceClassNotFoundException
+     */
+    public function buildSchema(string $resourceClass, string $format = 'json', bool $output = true, ?string $operationType = null, ?string $operationName = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema;
+}

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonSchema;
+
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * {@inheritdoc}
+ *
+ * @experimental
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class TypeFactory implements TypeFactoryInterface
+{
+    /**
+     * @var SchemaFactoryInterface|null
+     */
+    private $schemaFactory;
+
+    /**
+     * Injects the JSON Schema factory to use.
+     */
+    public function setSchemaFactory(SchemaFactoryInterface $schemaFactory): void
+    {
+        $this->schemaFactory = $schemaFactory;
+    }
+
+    /**
+     * Gets the OpenAPI type corresponding to the given PHP type, and recursively adds needed new schema to the current schema if provided.
+     */
+    public function getType(Type $type, string $format = 'json', ?bool $readableLink = null, ?array $serializerContext = null, Schema $schema = null): array
+    {
+        if ($type->isCollection()) {
+            $subType = new Type($type->getBuiltinType(), $type->isNullable(), $type->getClassName(), false);
+
+            return [
+                'type' => 'array',
+                'items' => $this->getType($subType, $format, $readableLink, $serializerContext, $schema),
+            ];
+        }
+
+        switch ($type->getBuiltinType()) {
+            case Type::BUILTIN_TYPE_INT:
+                return ['type' => 'integer'];
+            case Type::BUILTIN_TYPE_FLOAT:
+                return ['type' => 'number'];
+            case Type::BUILTIN_TYPE_BOOL:
+                return ['type' => 'boolean'];
+            case Type::BUILTIN_TYPE_OBJECT:
+                return $this->getClassType($type->getClassName(), $format, $readableLink, $serializerContext, $schema);
+            default:
+                return ['type' => 'string'];
+        }
+    }
+
+    /**
+     * Gets the OpenAPI type corresponding to the given PHP class, and recursively adds needed new schema to the current schema if provided.
+     */
+    private function getClassType(?string $className, string $format = 'json', ?bool $readableLink = null, ?array $serializerContext = null, ?Schema $schema = null): array
+    {
+        if (null === $className) {
+            return ['type' => 'string'];
+        }
+
+        if (is_subclass_of($className, \DateTimeInterface::class)) {
+            return ['type' => 'string', 'format' => 'date-time'];
+        }
+
+        if (null !== $this->schemaFactory && true === $readableLink && null !== $schema) { // Skip if $baseSchema is null (filters only support basic types)
+            $version = $schema->getVersion();
+
+            $subSchema = new Schema($version);
+            /*
+             * @var Schema $schema Prevents a false positive in PHPStan
+             */
+            $subSchema->setDefinitions($schema->getDefinitions()); // Populate definitions of the main schema
+
+            $this->schemaFactory->buildSchema($className, $format, true, null, null, $subSchema, $serializerContext);
+
+            return ['$ref' => $subSchema['$ref']];
+        }
+
+        return ['type' => 'string'];
+    }
+}

--- a/src/JsonSchema/TypeFactoryInterface.php
+++ b/src/JsonSchema/TypeFactoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonSchema;
+
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Gets the OpenAPI type corresponding to the given PHP type, and recursively adds needed new schema to the current schema if provided.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface TypeFactoryInterface
+{
+    public function getType(Type $type, string $format = 'json', ?bool $readableLink = null, ?array $serializerContext = null, Schema $schema = null): array;
+}

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -23,9 +23,13 @@ use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Documentation\Documentation;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\JsonSchema\Schema;
+use ApiPlatform\Core\JsonSchema\SchemaFactory;
+use ApiPlatform\Core\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Core\JsonSchema\TypeFactory;
+use ApiPlatform\Core\JsonSchema\TypeFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
-use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Operation\Factory\SubresourceOperationFactoryInterface;
@@ -33,7 +37,6 @@ use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
-use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -64,10 +67,8 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     private $resourceMetadataFactory;
     private $propertyNameCollectionFactory;
     private $propertyMetadataFactory;
-    private $resourceClassResolver;
     private $operationMethodResolver;
     private $operationPathResolver;
-    private $nameConverter;
     private $oauthEnabled;
     private $oauthType;
     private $oauthFlow;
@@ -84,6 +85,14 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     private $paginationClientEnabledParameterName;
     private $formats;
     private $formatsProvider;
+    /**
+     * @var SchemaFactoryInterface
+     */
+    private $jsonSchemaFactory;
+    /**
+     * @var TypeFactoryInterface
+     */
+    private $jsonSchemaTypeFactory;
     private $defaultContext = [
         self::BASE_URL => '/',
         self::SPEC_VERSION => 2,
@@ -91,16 +100,38 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     ];
 
     /**
-     * @param ContainerInterface|FilterCollection|null     $filterLocator The new filter locator or the deprecated filter collection
-     * @param array|OperationAwareFormatsProviderInterface $formats
+     * @param SchemaFactoryInterface|ResourceClassResolverInterface|null $jsonSchemaFactory
+     * @param ContainerInterface|FilterCollection|null                   $filterLocator
+     * @param array|OperationAwareFormatsProviderInterface               $formats
+     * @param mixed|null                                                 $jsonSchemaTypeFactory
      */
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, OperationMethodResolverInterface $operationMethodResolver = null, OperationPathResolverInterface $operationPathResolver, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, bool $oauthEnabled = false, string $oauthType = '', string $oauthFlow = '', string $oauthTokenUrl = '', string $oauthAuthorizationUrl = '', array $oauthScopes = [], array $apiKeys = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $paginationEnabled = true, string $paginationPageParameterName = 'page', bool $clientItemsPerPage = false, string $itemsPerPageParameterName = 'itemsPerPage', $formats = [], bool $paginationClientEnabled = false, string $paginationClientEnabledParameterName = 'pagination', array $defaultContext = [])
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, $jsonSchemaFactory = null, $jsonSchemaTypeFactory = null, OperationPathResolverInterface $operationPathResolver, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, bool $oauthEnabled = false, string $oauthType = '', string $oauthFlow = '', string $oauthTokenUrl = '', string $oauthAuthorizationUrl = '', array $oauthScopes = [], array $apiKeys = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $paginationEnabled = true, string $paginationPageParameterName = 'page', bool $clientItemsPerPage = false, string $itemsPerPageParameterName = 'itemsPerPage', $formats = [], bool $paginationClientEnabled = false, string $paginationClientEnabledParameterName = 'pagination', array $defaultContext = [])
     {
+        if ($jsonSchemaTypeFactory instanceof OperationMethodResolverInterface) {
+            @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.5 and will be removed in 3.0.', OperationMethodResolverInterface::class, __METHOD__), E_USER_DEPRECATED);
+
+            $this->operationMethodResolver = $jsonSchemaTypeFactory;
+            $this->jsonSchemaTypeFactory = new TypeFactory();
+        } else {
+            $this->jsonSchemaTypeFactory = $jsonSchemaTypeFactory ?? new TypeFactory();
+        }
+
+        if ($jsonSchemaFactory instanceof ResourceClassResolverInterface) {
+            @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.5 and will be removed in 3.0.', ResourceClassResolverInterface::class, __METHOD__), E_USER_DEPRECATED);
+        }
+
+        if (null === $jsonSchemaFactory || $jsonSchemaFactory instanceof ResourceClassResolverInterface) {
+            $jsonSchemaFactory = new SchemaFactory($this->jsonSchemaTypeFactory, $resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, $nameConverter);
+            $this->jsonSchemaTypeFactory->setSchemaFactory($jsonSchemaFactory);
+        }
+        $this->jsonSchemaFactory = $jsonSchemaFactory;
+
+        if ($nameConverter) {
+            @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.5 and will be removed in 3.0.', NameConverterInterface::class, __METHOD__), E_USER_DEPRECATED);
+        }
+
         if ($urlGenerator) {
             @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.1 and will be removed in 3.0.', UrlGeneratorInterface::class, __METHOD__), E_USER_DEPRECATED);
-        }
-        if ($operationMethodResolver) {
-            @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.5 and will be removed in 3.0.', OperationMethodResolverInterface::class, __METHOD__), E_USER_DEPRECATED);
         }
 
         if ($formats instanceof FormatsProviderInterface) {
@@ -116,10 +147,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
-        $this->resourceClassResolver = $resourceClassResolver;
-        $this->operationMethodResolver = $operationMethodResolver;
         $this->operationPathResolver = $operationPathResolver;
-        $this->nameConverter = $nameConverter;
         $this->oauthEnabled = $oauthEnabled;
         $this->oauthType = $oauthType;
         $this->oauthFlow = $oauthFlow;
@@ -236,8 +264,8 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             $requestFormats = $responseFormats = $this->formatsProvider->getFormatsFromOperation($resourceClass, $operationName, $operationType);
         }
 
-        $requestMimeTypes = $this->extractMimeTypes($requestFormats);
-        $responseMimeTypes = $this->extractMimeTypes($responseFormats);
+        $requestMimeTypes = $this->flattenMimeTypes($requestFormats);
+        $responseMimeTypes = $this->flattenMimeTypes($responseFormats);
         switch ($method) {
             case 'GET':
                 return $this->updateGetOperation($v3, $pathOperation, $responseMimeTypes, $operationType, $resourceMetadata, $resourceClass, $resourceShortName, $operationName, $definitions);
@@ -255,45 +283,46 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         return $pathOperation;
     }
 
-    private function updateGetOperation(bool $v3, \ArrayObject $pathOperation, array $mimeTypes, string $operationType, ResourceMetadata $resourceMetadata, string $resourceClass, string $resourceShortName, string $operationName, \ArrayObject $definitions): \ArrayObject
+    private function addSchemas(bool $v3, array $message, Schema $jsonSchema, \ArrayObject $definitions, string $resourceClass, string $operationType, string $operationName, array $mimeTypes, bool $output = true, bool $forceCollection = false)
     {
-        $serializerContext = $this->getSerializerContext($operationType, false, $resourceMetadata, $operationName);
-
-        $responseDefinitionKey = false;
-        $outputMetadata = $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'output', ['class' => $resourceClass], true);
-        if (null !== $outputClass = $outputMetadata['class'] ?? null) {
-            $responseDefinitionKey = $this->getDefinition($v3, $definitions, $resourceMetadata, $resourceClass, $outputClass, $serializerContext);
+        if (!$jsonSchema->isDefined()) {
+            return $message;
         }
 
+        if (!$v3) {
+            $message['schema'] = $jsonSchema->getArrayCopy(false);
+
+            return $message;
+        }
+
+        foreach ($mimeTypes as $mimeType => $format) {
+            if ('json' !== $format) {
+                $jsonSchema = $this->getJsonSchema($v3, $definitions, $resourceClass, $output, $operationType, $operationName, $format, null, $forceCollection);
+            }
+
+            $message['content'][$mimeType] = ['schema' => $jsonSchema->getArrayCopy(false)];
+        }
+
+        return $message;
+    }
+
+    private function updateGetOperation(bool $v3, \ArrayObject $pathOperation, array $mimeTypes, string $operationType, ResourceMetadata $resourceMetadata, string $resourceClass, string $resourceShortName, string $operationName, \ArrayObject $definitions): \ArrayObject
+    {
+        $jsonSchema = $this->getJsonSchema($v3, $definitions, $resourceClass, true, $operationType, $operationName);
         $successStatus = (string) $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'status', '200');
 
         if (!$v3) {
-            $pathOperation['produces'] ?? $pathOperation['produces'] = $mimeTypes;
+            $pathOperation['produces'] ?? $pathOperation['produces'] = array_keys($mimeTypes);
         }
 
         if (OperationType::COLLECTION === $operationType) {
             $pathOperation['summary'] ?? $pathOperation['summary'] = sprintf('Retrieves the collection of %s resources.', $resourceShortName);
 
             $successResponse = ['description' => sprintf('%s collection response', $resourceShortName)];
-
-            if ($responseDefinitionKey) {
-                if ($v3) {
-                    $successResponse['content'] = array_fill_keys($mimeTypes, [
-                        'schema' => [
-                            'type' => 'array',
-                            'items' => ['$ref' => sprintf('#/components/schemas/%s', $responseDefinitionKey)],
-                        ],
-                    ]);
-                } else {
-                    $successResponse['schema'] = [
-                        'type' => 'array',
-                        'items' => ['$ref' => sprintf('#/definitions/%s', $responseDefinitionKey)],
-                    ];
-                }
-            }
+            $successResponse = $this->addSchemas($v3, $successResponse, $jsonSchema, $definitions, $resourceClass, $operationType, $operationName, $mimeTypes);
 
             $pathOperation['responses'] ?? $pathOperation['responses'] = [$successStatus => $successResponse];
-            $pathOperation['parameters'] ?? $pathOperation['parameters'] = $this->getFiltersParameters($v3, $resourceClass, $operationName, $resourceMetadata, $definitions, $serializerContext);
+            $pathOperation['parameters'] ?? $pathOperation['parameters'] = $this->getFiltersParameters($v3, $resourceClass, $operationName, $resourceMetadata);
 
             $this->addPaginationParameters($v3, $resourceMetadata, $operationName, $pathOperation);
 
@@ -305,13 +334,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $pathOperation = $this->addItemOperationParameters($v3, $pathOperation);
 
         $successResponse = ['description' => sprintf('%s resource response', $resourceShortName)];
-        if ($responseDefinitionKey) {
-            if ($v3) {
-                $successResponse['content'] = array_fill_keys($mimeTypes, ['schema' => ['$ref' => sprintf('#/components/schemas/%s', $responseDefinitionKey)]]);
-            } else {
-                $successResponse['schema'] = ['$ref' => sprintf('#/definitions/%s', $responseDefinitionKey)];
-            }
-        }
+        $successResponse = $this->addSchemas($v3, $successResponse, $jsonSchema, $definitions, $resourceClass, $operationType, $operationName, $mimeTypes);
 
         $pathOperation['responses'] ?? $pathOperation['responses'] = [
             $successStatus => $successResponse,
@@ -364,10 +387,11 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     private function addSubresourceOperation(bool $v3, array $subresourceOperation, \ArrayObject $definitions, string $operationId, ResourceMetadata $resourceMetadata): \ArrayObject
     {
         $operationName = 'get'; // TODO: we might want to extract that at some point to also support other subresource operations
+        $collection = $subresourceOperation['collection'] ?? false;
 
         $subResourceMetadata = $this->resourceMetadataFactory->create($subresourceOperation['resource_class']);
-        $serializerContext = $this->getSerializerContext(OperationType::SUBRESOURCE, false, $subResourceMetadata, $operationName);
-        $responseDefinitionKey = $this->getDefinition($v3, $definitions, $subResourceMetadata, $subresourceOperation['resource_class'], null, $serializerContext);
+        $jsonSchema = $this->getJsonSchema($v3, $definitions, $subresourceOperation['resource_class'], true, OperationType::SUBRESOURCE, $operationName, 'json', null, $collection);
+
         $pathOperation = new \ArrayObject([]);
         $pathOperation['tags'] = $subresourceOperation['shortNames'];
         $pathOperation['operationId'] = $operationId;
@@ -384,13 +408,19 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             $responseFormats = $this->formatsProvider->getFormatsFromOperation($subresourceOperation['resource_class'], $operationName, OperationType::SUBRESOURCE);
         }
 
-        $mimeTypes = $this->extractMimeTypes($responseFormats);
+        $mimeTypes = $this->flattenMimeTypes($responseFormats);
 
         if (!$v3) {
-            $pathOperation['produces'] = $mimeTypes;
+            $pathOperation['produces'] = array_keys($mimeTypes);
         }
 
-        $pathOperation['responses'] = $this->getSubresourceResponse($v3, $mimeTypes, $subresourceOperation['collection'], $subresourceOperation['shortNames'][0], $responseDefinitionKey);
+        $successResponse = [
+            'description' => sprintf('%s %s response', $subresourceOperation['shortNames'][0], $collection ? 'collection' : 'resource'),
+        ];
+        $successResponse = $this->addSchemas($v3, $successResponse, $jsonSchema, $definitions, $subresourceOperation['resource_class'], OperationType::SUBRESOURCE, $operationName, $mimeTypes, true, $collection);
+
+        $pathOperation['responses'] = ['200' => $successResponse, '404' => ['description' => 'Resource not found']];
+
         // Avoid duplicates parameters when there is a filter on a subresource identifier
         $parametersMemory = [];
         $pathOperation['parameters'] = [];
@@ -402,7 +432,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
                 $parametersMemory[] = $identifier;
             }
         }
-        if ($parameters = $this->getFiltersParameters($v3, $subresourceOperation['resource_class'], $operationName, $subResourceMetadata, $definitions, $serializerContext)) {
+        if ($parameters = $this->getFiltersParameters($v3, $subresourceOperation['resource_class'], $operationName, $subResourceMetadata)) {
             foreach ($parameters as $parameter) {
                 if (!\in_array($parameter['name'], $parametersMemory, true)) {
                     $pathOperation['parameters'][] = $parameter;
@@ -417,38 +447,11 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         return new \ArrayObject(['get' => $pathOperation]);
     }
 
-    private function getSubresourceResponse(bool $v3, $mimeTypes, bool $collection, string $shortName, string $definitionKey): array
-    {
-        if ($collection) {
-            $okResponse = [
-                'description' => sprintf('%s collection response', $shortName),
-            ];
-
-            if ($v3) {
-                $okResponse['content'] = array_fill_keys($mimeTypes, ['schema' => ['type' => 'array', 'items' => ['$ref' => sprintf('#/components/schemas/%s', $definitionKey)]]]);
-            } else {
-                $okResponse['schema'] = ['type' => 'array', 'items' => ['$ref' => sprintf('#/definitions/%s', $definitionKey)]];
-            }
-        } else {
-            $okResponse = [
-                'description' => sprintf('%s resource response', $shortName),
-            ];
-
-            if ($v3) {
-                $okResponse['content'] = array_fill_keys($mimeTypes, ['schema' => ['$ref' => sprintf('#/components/schemas/%s', $definitionKey)]]);
-            } else {
-                $okResponse['schema'] = ['$ref' => sprintf('#/definitions/%s', $definitionKey)];
-            }
-        }
-
-        return ['200' => $okResponse, '404' => ['description' => 'Resource not found']];
-    }
-
     private function updatePostOperation(bool $v3, \ArrayObject $pathOperation, array $requestMimeTypes, array $responseMimeTypes, string $operationType, ResourceMetadata $resourceMetadata, string $resourceClass, string $resourceShortName, string $operationName, \ArrayObject $definitions, \ArrayObject $links): \ArrayObject
     {
         if (!$v3) {
-            $pathOperation['consumes'] ?? $pathOperation['consumes'] = $requestMimeTypes;
-            $pathOperation['produces'] ?? $pathOperation['produces'] = $responseMimeTypes;
+            $pathOperation['consumes'] ?? $pathOperation['consumes'] = array_keys($requestMimeTypes);
+            $pathOperation['produces'] ?? $pathOperation['produces'] = array_keys($responseMimeTypes);
         }
 
         $pathOperation['summary'] ?? $pathOperation['summary'] = sprintf('Creates a %s resource.', $resourceShortName);
@@ -458,21 +461,14 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             $pathOperation = $this->addItemOperationParameters($v3, $pathOperation);
         }
 
-        $responseDefinitionKey = false;
-        $outputMetadata = $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'output', ['class' => $resourceClass], true);
-        if (null !== $outputClass = $outputMetadata['class'] ?? null) {
-            $responseDefinitionKey = $this->getDefinition($v3, $definitions, $resourceMetadata, $resourceClass, $outputClass, $this->getSerializerContext($operationType, false, $resourceMetadata, $operationName));
-        }
+        $jsonSchema = $this->getJsonSchema($v3, $definitions, $resourceClass, true, $operationType, $operationName);
 
         $successResponse = ['description' => sprintf('%s resource created', $resourceShortName)];
-        if ($responseDefinitionKey) {
-            if ($v3) {
-                $successResponse['content'] = array_fill_keys($responseMimeTypes, ['schema' => ['$ref' => sprintf('#/components/schemas/%s', $responseDefinitionKey)]]);
-                if ($links[$key = 'get'.ucfirst($resourceShortName).ucfirst(OperationType::ITEM)] ?? null) {
-                    $successResponse['links'] = [ucfirst($key) => $links[$key]];
-                }
-            } else {
-                $successResponse['schema'] = ['$ref' => sprintf('#/definitions/%s', $responseDefinitionKey)];
+        if ($jsonSchema->isDefined()) {
+            $successResponse = $this->addSchemas($v3, $successResponse, $jsonSchema, $definitions, $resourceClass, $operationType, $operationName, $responseMimeTypes);
+
+            if ($v3 && ($links[$key = 'get'.ucfirst($resourceShortName).ucfirst(OperationType::ITEM)] ?? null)) {
+                $successResponse['links'] = [ucfirst($key) => $links[$key]];
             }
         }
 
@@ -482,25 +478,26 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             '404' => ['description' => 'Resource not found'],
         ];
 
-        $inputMetadata = $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'input', ['class' => $resourceClass], true);
-        if (null === $inputClass = $inputMetadata['class'] ?? null) {
+        $jsonSchema = $this->getJsonSchema($v3, $definitions, $resourceClass, false, $operationType, $operationName);
+        if (!$jsonSchema->isDefined()) {
             return $pathOperation;
         }
 
-        $requestDefinitionKey = $this->getDefinition($v3, $definitions, $resourceMetadata, $resourceClass, $inputClass, $this->getSerializerContext($operationType, true, $resourceMetadata, $operationName));
         if ($v3) {
-            $pathOperation['requestBody'] ?? $pathOperation['requestBody'] = [
-                'content' => array_fill_keys($requestMimeTypes, ['schema' => ['$ref' => sprintf('#/components/schemas/%s', $requestDefinitionKey)]]),
-                'description' => sprintf('The new %s resource', $resourceShortName),
-            ];
-        } else {
-            $userDefinedParameters ?? $pathOperation['parameters'][] = [
-                'name' => lcfirst($resourceShortName),
-                'in' => 'body',
-                'description' => sprintf('The new %s resource', $resourceShortName),
-                'schema' => ['$ref' => sprintf('#/definitions/%s', $requestDefinitionKey)],
-            ];
+            if (!isset($pathOperation['requestBody'])) {
+                $pathOperation['requestBody'] = $this->addSchemas($v3, [], $jsonSchema, $definitions, $resourceClass, $operationType, $operationName, $requestMimeTypes, false);
+                $pathOperation['requestBody']['description'] = sprintf('The new %s resource', $resourceShortName);
+            }
+
+            return $pathOperation;
         }
+
+        $userDefinedParameters ?? $pathOperation['parameters'][] = [
+            'name' => lcfirst($resourceShortName),
+            'in' => 'body',
+            'description' => sprintf('The new %s resource', $resourceShortName),
+            'schema' => $jsonSchema->getArrayCopy(false),
+        ];
 
         return $pathOperation;
     }
@@ -508,27 +505,19 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     private function updatePutOperation(bool $v3, \ArrayObject $pathOperation, array $requestMimeTypes, array $responseMimeTypes, string $operationType, ResourceMetadata $resourceMetadata, string $resourceClass, string $resourceShortName, string $operationName, \ArrayObject $definitions): \ArrayObject
     {
         if (!$v3) {
-            $pathOperation['consumes'] ?? $pathOperation['consumes'] = $requestMimeTypes;
-            $pathOperation['produces'] ?? $pathOperation['produces'] = $responseMimeTypes;
+            $pathOperation['consumes'] ?? $pathOperation['consumes'] = array_keys($requestMimeTypes);
+            $pathOperation['produces'] ?? $pathOperation['produces'] = array_keys($responseMimeTypes);
         }
 
         $pathOperation['summary'] ?? $pathOperation['summary'] = sprintf('Replaces the %s resource.', $resourceShortName);
 
         $pathOperation = $this->addItemOperationParameters($v3, $pathOperation);
 
-        $responseDefinitionKey = false;
-        $outputMetadata = $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'output', ['class' => $resourceClass], true);
-        if (null !== $outputClass = $outputMetadata['class'] ?? null) {
-            $responseDefinitionKey = $this->getDefinition($v3, $definitions, $resourceMetadata, $resourceClass, $outputClass, $this->getSerializerContext($operationType, false, $resourceMetadata, $operationName));
-        }
+        $jsonSchema = $this->getJsonSchema($v3, $definitions, $resourceClass, true, $operationType, $operationName);
 
         $successResponse = ['description' => sprintf('%s resource updated', $resourceShortName)];
-        if ($responseDefinitionKey) {
-            if ($v3) {
-                $successResponse['content'] = array_fill_keys($responseMimeTypes, ['schema' => ['$ref' => sprintf('#/components/schemas/%s', $responseDefinitionKey)]]);
-            } else {
-                $successResponse['schema'] = ['$ref' => sprintf('#/definitions/%s', $responseDefinitionKey)];
-            }
+        if ($jsonSchema->isDefined()) {
+            $successResponse = $this->addSchemas($v3, $successResponse, $jsonSchema, $definitions, $resourceClass, $operationType, $operationName, $responseMimeTypes);
         }
 
         $pathOperation['responses'] ?? $pathOperation['responses'] = [
@@ -537,25 +526,26 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             '404' => ['description' => 'Resource not found'],
         ];
 
-        $inputMetadata = $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'input', ['class' => $resourceClass], true);
-        if (null === $inputClass = $inputMetadata['class'] ?? null) {
+        $jsonSchema = $this->getJsonSchema($v3, $definitions, $resourceClass, false, $operationType, $operationName);
+        if (!$jsonSchema->isDefined()) {
             return $pathOperation;
         }
 
-        $requestDefinitionKey = $this->getDefinition($v3, $definitions, $resourceMetadata, $resourceClass, $inputClass, $this->getSerializerContext($operationType, true, $resourceMetadata, $operationName));
         if ($v3) {
-            $pathOperation['requestBody'] ?? $pathOperation['requestBody'] = [
-                'content' => array_fill_keys($requestMimeTypes, ['schema' => ['$ref' => sprintf('#/components/schemas/%s', $requestDefinitionKey)]]),
-                'description' => sprintf('The updated %s resource', $resourceShortName),
-            ];
-        } else {
-            $pathOperation['parameters'][] = [
-                'name' => lcfirst($resourceShortName),
-                'in' => 'body',
-                'description' => sprintf('The updated %s resource', $resourceShortName),
-                'schema' => ['$ref' => sprintf('#/definitions/%s', $requestDefinitionKey)],
-            ];
+            if (!isset($pathOperation['requestBody'])) {
+                $pathOperation['requestBody'] = $this->addSchemas($v3, [], $jsonSchema, $definitions, $resourceClass, $operationType, $operationName, $requestMimeTypes, false);
+                $pathOperation['requestBody']['description'] = sprintf('The updated %s resource', $resourceShortName);
+            }
+
+            return $pathOperation;
         }
+
+        $pathOperation['parameters'][] = [
+            'name' => lcfirst($resourceShortName),
+            'in' => 'body',
+            'description' => sprintf('The updated %s resource', $resourceShortName),
+            'schema' => $jsonSchema->getArrayCopy(false),
+        ];
 
         return $pathOperation;
     }
@@ -584,151 +574,14 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         return $pathOperation;
     }
 
-    private function getDefinition(bool $v3, \ArrayObject $definitions, ResourceMetadata $resourceMetadata, string $resourceClass, ?string $publicClass, array $serializerContext = null): string
+    private function getJsonSchema(bool $v3, \ArrayObject $definitions, string $resourceClass, bool $output, ?string $operationType, ?string $operationName, string $format = 'json', ?array $serializerContext = null, bool $forceCollection = false): Schema
     {
-        $keyPrefix = $resourceMetadata->getShortName();
-        if (null !== $publicClass && $resourceClass !== $publicClass) {
-            $keyPrefix .= ':'.md5($publicClass);
-        }
+        $schema = new Schema($v3 ? Schema::VERSION_OPENAPI : Schema::VERSION_SWAGGER);
+        $schema->setDefinitions($definitions);
 
-        if (isset($serializerContext[self::SWAGGER_DEFINITION_NAME])) {
-            $definitionKey = sprintf('%s-%s', $keyPrefix, $serializerContext[self::SWAGGER_DEFINITION_NAME]);
-        } else {
-            $definitionKey = $this->getDefinitionKey($keyPrefix, (array) ($serializerContext[AbstractNormalizer::GROUPS] ?? []));
-        }
+        $this->jsonSchemaFactory->buildSchema($resourceClass, $format, $output, $operationType, $operationName, $schema, $serializerContext, $forceCollection);
 
-        if (!isset($definitions[$definitionKey])) {
-            $definitions[$definitionKey] = [];  // Initialize first to prevent infinite loop
-            $definitions[$definitionKey] = $this->getDefinitionSchema($v3, $publicClass ?? $resourceClass, $resourceMetadata, $definitions, $serializerContext);
-        }
-
-        return $definitionKey;
-    }
-
-    private function getDefinitionKey(string $resourceShortName, array $groups): string
-    {
-        return $groups ? sprintf('%s-%s', $resourceShortName, implode('_', $groups)) : $resourceShortName;
-    }
-
-    /**
-     * Gets a definition Schema Object.
-     *
-     * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject
-     */
-    private function getDefinitionSchema(bool $v3, string $resourceClass, ResourceMetadata $resourceMetadata, \ArrayObject $definitions, array $serializerContext = null): \ArrayObject
-    {
-        $definitionSchema = new \ArrayObject(['type' => 'object']);
-
-        if (null !== $description = $resourceMetadata->getDescription()) {
-            $definitionSchema['description'] = $description;
-        }
-
-        if (null !== $iri = $resourceMetadata->getIri()) {
-            $definitionSchema['externalDocs'] = ['url' => $iri];
-        }
-
-        $options = isset($serializerContext[AbstractNormalizer::GROUPS]) ? ['serializer_groups' => $serializerContext[AbstractNormalizer::GROUPS]] : [];
-        foreach ($this->propertyNameCollectionFactory->create($resourceClass, $options) as $propertyName) {
-            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $propertyName);
-            if (!$propertyMetadata->isReadable() && !$propertyMetadata->isWritable()) {
-                continue;
-            }
-
-            $normalizedPropertyName = $this->nameConverter ? $this->nameConverter->normalize($propertyName, $resourceClass, self::FORMAT, $serializerContext ?? []) : $propertyName;
-            if ($propertyMetadata->isRequired()) {
-                $definitionSchema['required'][] = $normalizedPropertyName;
-            }
-
-            $definitionSchema['properties'][$normalizedPropertyName] = $this->getPropertySchema($v3, $propertyMetadata, $definitions, $serializerContext);
-        }
-
-        return $definitionSchema;
-    }
-
-    /**
-     * Gets a property Schema Object.
-     *
-     * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject
-     */
-    private function getPropertySchema(bool $v3, PropertyMetadata $propertyMetadata, \ArrayObject $definitions, array $serializerContext = null): \ArrayObject
-    {
-        $propertySchema = new \ArrayObject($propertyMetadata->getAttributes()[$v3 ? 'openapi_context' : 'swagger_context'] ?? []);
-
-        if (false === $propertyMetadata->isWritable() && !$propertyMetadata->isInitializable()) {
-            $propertySchema['readOnly'] = true;
-        }
-
-        if (null !== $description = $propertyMetadata->getDescription()) {
-            $propertySchema['description'] = $description;
-        }
-
-        if (null === $type = $propertyMetadata->getType()) {
-            return $propertySchema;
-        }
-
-        $isCollection = $type->isCollection();
-        if (null === $valueType = $isCollection ? $type->getCollectionValueType() : $type) {
-            $builtinType = 'string';
-            $className = null;
-        } else {
-            $builtinType = $valueType->getBuiltinType();
-            $className = $valueType->getClassName();
-        }
-
-        $valueSchema = $this->getType($v3, $builtinType, $isCollection, $className, $propertyMetadata->isReadableLink(), $definitions, $serializerContext);
-
-        return new \ArrayObject((array) $propertySchema + $valueSchema);
-    }
-
-    /**
-     * Gets the Swagger's type corresponding to the given PHP's type.
-     */
-    private function getType(bool $v3, string $type, bool $isCollection, ?string $className, ?bool $readableLink, \ArrayObject $definitions, array $serializerContext = null): array
-    {
-        if ($isCollection) {
-            return ['type' => 'array', 'items' => $this->getType($v3, $type, false, $className, $readableLink, $definitions, $serializerContext)];
-        }
-
-        if (Type::BUILTIN_TYPE_STRING === $type) {
-            return ['type' => 'string'];
-        }
-
-        if (Type::BUILTIN_TYPE_INT === $type) {
-            return ['type' => 'integer'];
-        }
-
-        if (Type::BUILTIN_TYPE_FLOAT === $type) {
-            return ['type' => 'number'];
-        }
-
-        if (Type::BUILTIN_TYPE_BOOL === $type) {
-            return ['type' => 'boolean'];
-        }
-
-        if (Type::BUILTIN_TYPE_OBJECT === $type) {
-            if (null === $className) {
-                return ['type' => 'string'];
-            }
-
-            if (is_subclass_of($className, \DateTimeInterface::class)) {
-                return ['type' => 'string', 'format' => 'date-time'];
-            }
-
-            if (!$this->resourceClassResolver->isResourceClass($className)) {
-                return ['type' => 'string'];
-            }
-
-            if (true === $readableLink) {
-                return [
-                    '$ref' => sprintf(
-                        $v3 ? '#/components/schemas/%s' : '#/definitions/%s',
-                        $this->getDefinition($v3, $definitions, $resourceMetadata = $this->resourceMetadataFactory->create($className), $className, $resourceMetadata->getAttribute('output')['class'] ?? $className, $serializerContext)
-                    ),
-                ];
-            }
-        }
-
-        return ['type' => 'string'];
+        return $schema;
     }
 
     private function computeDoc(bool $v3, Documentation $documentation, \ArrayObject $definitions, \ArrayObject $paths, array $context): array
@@ -818,7 +671,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     /**
      * Gets parameters corresponding to enabled filters.
      */
-    private function getFiltersParameters(bool $v3, string $resourceClass, string $operationName, ResourceMetadata $resourceMetadata, \ArrayObject $definitions, array $serializerContext = null): array
+    private function getFiltersParameters(bool $v3, string $resourceClass, string $operationName, ResourceMetadata $resourceMetadata): array
     {
         if (null === $this->filterLocator) {
             return [];
@@ -838,10 +691,10 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
                     'required' => $data['required'],
                 ];
 
-                $type = $this->getType($v3, $data['type'], $data['is_collection'] ?? false, null, null, $definitions, $serializerContext);
+                $type = \in_array($data['type'], Type::$builtinTypes, true) ? $this->jsonSchemaTypeFactory->getType(new Type($data['type'], false, null, $data['is_collection'] ?? false)) : ['type' => 'string'];
                 $v3 ? $parameter['schema'] = $type : $parameter += $type;
 
-                if ('array' === $type['type'] ?? '') {
+                if ('array' === ($type['type'] ?? '')) {
                     $deepObject = \in_array($data['type'], [Type::BUILTIN_TYPE_ARRAY, Type::BUILTIN_TYPE_OBJECT], true);
 
                     if ($v3) {
@@ -867,7 +720,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return self::FORMAT === $format && $data instanceof Documentation;
     }
@@ -880,23 +733,12 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         return true;
     }
 
-    private function getSerializerContext(string $operationType, bool $denormalization, ResourceMetadata $resourceMetadata, string $operationName): ?array
-    {
-        $contextKey = $denormalization ? 'denormalization_context' : 'normalization_context';
-
-        if (OperationType::COLLECTION === $operationType) {
-            return $resourceMetadata->getCollectionOperationAttribute($operationName, $contextKey, null, true);
-        }
-
-        return $resourceMetadata->getItemOperationAttribute($operationName, $contextKey, null, true);
-    }
-
-    private function extractMimeTypes(array $responseFormats): array
+    private function flattenMimeTypes(array $responseFormats): array
     {
         $responseMimeTypes = [];
-        foreach ($responseFormats as $mimeTypes) {
+        foreach ($responseFormats as $responseFormat => $mimeTypes) {
             foreach ($mimeTypes as $mimeType) {
-                $responseMimeTypes[] = $mimeType;
+                $responseMimeTypes[$mimeType] = $responseFormat;
             }
         }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -66,6 +66,8 @@ use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilderInterface as GraphQlSerializerContextBuilderInterface;
 use ApiPlatform\Core\GraphQl\Type\Definition\TypeInterface as GraphQlTypeInterface;
+use ApiPlatform\Core\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Core\JsonSchema\TypeFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
@@ -1150,6 +1152,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.hydra.normalizer.entrypoint',
             'api_platform.hydra.normalizer.error',
             'api_platform.hydra.normalizer.partial_collection_view',
+            'api_platform.hydra.json_schema.schema_factory',
             'api_platform.jsonld.action.context',
             'api_platform.jsonld.context_builder',
             'api_platform.jsonld.encoder',
@@ -1182,6 +1185,8 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.swagger.listener.ui',
             'api_platform.swagger.normalizer.api_gateway',
             'api_platform.swagger.normalizer.documentation',
+            'api_platform.json_schema.type_factory',
+            'api_platform.json_schema.schema_factory',
             'api_platform.validator',
             'test.api_platform.client',
         ];
@@ -1235,6 +1240,8 @@ class ApiPlatformExtensionTest extends TestCase
             NumericFilter::class => 'api_platform.doctrine.orm.numeric_filter',
             ExistsFilter::class => 'api_platform.doctrine.orm.exists_filter',
             GraphQlSerializerContextBuilderInterface::class => 'api_platform.graphql.serializer.context_builder',
+            TypeFactoryInterface::class => 'api_platform.json_schema.type_factory',
+            SchemaFactoryInterface::class => 'api_platform.json_schema.schema_factory',
         ];
 
         if (\in_array('odm', $doctrineIntegrationsToLoad, true)) {

--- a/tests/JsonSchema/SchemaTest.php
+++ b/tests/JsonSchema/SchemaTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\JsonSchema;
+
+use ApiPlatform\Core\JsonSchema\Schema;
+use PHPUnit\Framework\TestCase;
+
+class SchemaTest extends TestCase
+{
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testJsonSchemaVersion(string $version, string $ref): void
+    {
+        $schema = new Schema($version);
+        $schema['$ref'] = $ref;
+
+        $this->assertInstanceOf(\ArrayObject::class, $schema);
+        $this->assertSame($version, $schema->getVersion());
+        $this->assertSame('Foo', $schema->getRootDefinitionKey());
+    }
+
+    public function versionProvider(): iterable
+    {
+        yield [Schema::VERSION_JSON_SCHEMA, '#/definitions/Foo'];
+        yield [Schema::VERSION_SWAGGER, '#/definitions/Foo'];
+        yield [Schema::VERSION_OPENAPI, '#/components/schemas/Foo'];
+    }
+
+    public function testNoRootDefinitionKey(): void
+    {
+        $this->assertNull((new Schema())->getRootDefinitionKey());
+    }
+
+    public function testContainsJsonSchemaVersion(): void
+    {
+        $schema = new Schema();
+        $this->assertSame('http://json-schema.org/draft-07/schema#', $schema['$schema']);
+    }
+
+    /**
+     * @dataProvider definitionsDataProvider
+     */
+    public function testDefinitions(string $version, array $baseDefinitions): void
+    {
+        $schema = new Schema($version);
+        $schema->setDefinitions(new \ArrayObject($baseDefinitions));
+
+        if (Schema::VERSION_OPENAPI === $version) {
+            $this->assertArrayHasKey('schemas', $schema['components']);
+        } else {
+            $this->assertArrayHasKey('definitions', $schema);
+        }
+
+        $definitions = $schema->getDefinitions();
+        $this->assertArrayHasKey('foo', $definitions);
+
+        $this->assertArrayNotHasKey('definitions', $schema->getArrayCopy(false));
+        $this->assertArrayNotHasKey('components', $schema->getArrayCopy(false));
+    }
+
+    public function definitionsDataProvider(): iterable
+    {
+        yield [Schema::VERSION_OPENAPI,  ['foo' => []]];
+        yield [Schema::VERSION_JSON_SCHEMA,  ['foo' => []]];
+    }
+
+    public function testIsDefined(): void
+    {
+        $this->assertFalse((new Schema())->isDefined());
+
+        $schema = new Schema();
+        $schema['$ref'] = 'foo';
+        $this->assertTrue($schema->isDefined());
+
+        $schema = new Schema();
+        $schema['type'] = 'object';
+        $this->assertTrue($schema->isDefined());
+    }
+}

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -418,8 +418,8 @@ class DocumentationNormalizerV3Test extends TestCase
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'nameConverted')->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'This is a converted name.', true, true, null, null, false));
 
         $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
-        $nameConverterProphecy->normalize('name', Dummy::class, DocumentationNormalizer::FORMAT, [])->willReturn('name')->shouldBeCalled();
-        $nameConverterProphecy->normalize('nameConverted', Dummy::class, DocumentationNormalizer::FORMAT, [])->willReturn('name_converted')->shouldBeCalled();
+        $nameConverterProphecy->normalize('name', Dummy::class, 'jsonld', [])->willReturn('name')->shouldBeCalled();
+        $nameConverterProphecy->normalize('nameConverted', Dummy::class, 'jsonld', [])->willReturn('name_converted')->shouldBeCalled();
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2715, #2415, #2502, api-platform/api-platform#1222
| License       | MIT
| Doc PR        | todo

Introduce a new service allowing to generate a JSON Schema from any class, including those marked with `@ApiResource`.

It's an alternative approach to https://github.com/api-platform/core/pull/2715 to support specific JSON Schemas per MIME type in OpenAPI (this part is not ready yet).
It will also allow to generate JSON Schema directly, without having to rely on OpenAPI. It can be practical for validation, or to use libraries such as https://github.com/mozilla-services/react-jsonschema-form

This new capability will also replace https://github.com/dunglas/php-to-json-schema

TODO:

* [ ] Add support for formats