### PR TITLE
add command to generate json schema

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
@@ -22,6 +22,12 @@
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
         </service>
         <service id="ApiPlatform\Core\JsonSchema\SchemaFactoryInterface" alias="api_platform.json_schema.schema_factory" />
+
+        <service id="api_platform.json_schema.json_schema_generate_command" class="ApiPlatform\Core\JsonSchema\Command\JsonSchemaGenerateCommand">
+            <argument type="service" id="api_platform.json_schema.schema_factory"/>
+            <argument>%api_platform.formats%</argument>
+            <tag name="console.command" />
+        </service>
     </services>
 
 </container>

--- a/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
+++ b/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonSchema\Command;
+
+use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\JsonSchema\SchemaFactoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Generates a resource JSON Schema.
+ *
+ * @author Jacques Lefebvre <jacques@les-tilleuls.coop>
+ */
+final class JsonSchemaGenerateCommand extends Command
+{
+    private $schemaFactory;
+
+    private $formats;
+
+    public function __construct(SchemaFactoryInterface $schemaFactory, array $formats)
+    {
+        $this->schemaFactory = $schemaFactory;
+        $this->formats = $formats;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('api:json-schema:generate')
+            ->setDescription('Generates the JSON Schema for a resource operation.')
+            ->addArgument('resource', InputArgument::REQUIRED, 'The Fully Qualified Class Name (FQCN) of the resource')
+            ->addOption('itemOperation', null, InputOption::VALUE_OPTIONAL, 'The item operation')
+            ->addOption('collectionOperation', null, InputOption::VALUE_OPTIONAL, 'The collection operation')
+            ->addOption('format', null, InputOption::VALUE_OPTIONAL, 'The response format', array_key_first($this->formats))
+            ->addOption('output', null, InputOption::VALUE_NONE, 'Use this option to get the output version')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $resource = $input->getArgument('resource');
+        $itemOperation = $input->getOption('itemOperation');
+        $collectionOperation = $input->getOption('collectionOperation');
+        $format = $input->getOption('format');
+        $outputType = $input->getOption('output');
+
+        if (!isset($this->formats[$format])) {
+            throw new InvalidOptionException(\sprintf('The response format "%s" is not supported. Supported formats are : %s.', $format, implode(', ', array_keys($this->formats))));
+        }
+
+        $operationType = null;
+        $operationName = null;
+
+        if ($itemOperation && $collectionOperation) {
+            throw new InvalidOptionException('You can only use one of "--itemOperation" and "--collectionOperation" options at the same time.');
+        }
+
+        if (null !== $itemOperation || null !== $collectionOperation) {
+            $operationType = $itemOperation ? OperationType::ITEM : OperationType::COLLECTION;
+            $operationName = $itemOperation ?? $collectionOperation;
+        }
+
+        $schema = $this->schemaFactory->buildSchema($resource, $format,  $outputType , $operationType, $operationName);
+
+        if (!$schema->isDefined()) {
+            $io->error(\sprintf('There is no %s defined for the operation "%s" of the resource "%s".',  $outputType ? 'outputs': 'inputs', $operationName, $resource));
+            return;
+        }
+
+        $io->text(\json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
+++ b/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace ApiPlatform\Core\JsonSchema\Command;
@@ -22,13 +31,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class JsonSchemaGenerateCommand extends Command
 {
     private $schemaFactory;
-
     private $formats;
 
     public function __construct(SchemaFactoryInterface $schemaFactory, array $formats)
     {
         $this->schemaFactory = $schemaFactory;
-        $this->formats = $formats;
+        $this->formats = array_keys($formats);
 
         parent::__construct();
     }
@@ -42,11 +50,10 @@ final class JsonSchemaGenerateCommand extends Command
             ->setName('api:json-schema:generate')
             ->setDescription('Generates the JSON Schema for a resource operation.')
             ->addArgument('resource', InputArgument::REQUIRED, 'The Fully Qualified Class Name (FQCN) of the resource')
-            ->addOption('itemOperation', null, InputOption::VALUE_OPTIONAL, 'The item operation')
-            ->addOption('collectionOperation', null, InputOption::VALUE_OPTIONAL, 'The collection operation')
-            ->addOption('format', null, InputOption::VALUE_OPTIONAL, 'The response format', array_key_first($this->formats))
-            ->addOption('output', null, InputOption::VALUE_NONE, 'Use this option to get the output version')
-        ;
+            ->addOption('itemOperation', null, InputOption::VALUE_REQUIRED, 'The item operation')
+            ->addOption('collectionOperation', null, InputOption::VALUE_REQUIRED, 'The collection operation')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The response format', (string) $this->formats[0])
+            ->addOption('type', null, InputOption::VALUE_REQUIRED, 'The type of schema to generate (input or output)', 'input');
     }
 
     /**
@@ -56,21 +63,36 @@ final class JsonSchemaGenerateCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
+        /** @var string $resource */
         $resource = $input->getArgument('resource');
+        /** @var ?string $itemOperation */
         $itemOperation = $input->getOption('itemOperation');
+        /** @var ?string $collectionOperation */
         $collectionOperation = $input->getOption('collectionOperation');
+        /** @var string $format */
         $format = $input->getOption('format');
-        $outputType = $input->getOption('output');
+        /** @var string $outputType */
+        $outputType = $input->getOption('type');
 
-        if (!isset($this->formats[$format])) {
-            throw new InvalidOptionException(\sprintf('The response format "%s" is not supported. Supported formats are : %s.', $format, implode(', ', array_keys($this->formats))));
+        if (!\in_array($outputType, ['input', 'output'], true)) {
+            $io->error('You can only use "input" or "output" for the "type" option');
+
+            return 1;
         }
 
+        if (!\in_array($format, $this->formats, true)) {
+            throw new InvalidOptionException(sprintf('The response format "%s" is not supported. Supported formats are : %s.', $format, implode(', ', $this->formats)));
+        }
+
+        /** @var ?string $operationType */
         $operationType = null;
+        /** @var ?string $operationName */
         $operationName = null;
 
         if ($itemOperation && $collectionOperation) {
-            throw new InvalidOptionException('You can only use one of "--itemOperation" and "--collectionOperation" options at the same time.');
+            $io->error('You can only use one of "--itemOperation" and "--collectionOperation" options at the same time.');
+
+            return 1;
         }
 
         if (null !== $itemOperation || null !== $collectionOperation) {
@@ -78,13 +100,16 @@ final class JsonSchemaGenerateCommand extends Command
             $operationName = $itemOperation ?? $collectionOperation;
         }
 
-        $schema = $this->schemaFactory->buildSchema($resource, $format,  $outputType , $operationType, $operationName);
+        $schema = $this->schemaFactory->buildSchema($resource, $format, 'output' === $outputType, $operationType, $operationName);
 
-        if (!$schema->isDefined()) {
-            $io->error(\sprintf('There is no %s defined for the operation "%s" of the resource "%s".',  $outputType ? 'outputs': 'inputs', $operationName, $resource));
-            return;
+        if (null !== $operationType && null !== $operationName && !$schema->isDefined()) {
+            $io->error(sprintf('There is no %ss defined for the operation "%s" of the resource "%s".', $outputType, $operationName, $resource));
+
+            return 1;
         }
 
-        $io->text(\json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $io->text((string) json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return 0;
     }
 }

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -72,6 +73,13 @@ final class SchemaFactory implements SchemaFactoryInterface
 
         $version = $schema->getVersion();
         $definitionName = $this->buildDefinitionName($resourceClass, $format, $output, $operationType, $operationName, $serializerContext);
+
+        $method = (null !== $operationType && null !== $operationName) ? $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'method') : 'GET';
+
+        if (!$output && !in_array($method, [Request::METHOD_POST, Request::METHOD_PATCH, Request::METHOD_PUT], true)) {
+            return $schema;
+        }
+
         if (!isset($schema['$ref']) && !isset($schema['type'])) {
             $ref = Schema::VERSION_OPENAPI === $version ? '#/components/schemas/'.$definitionName : '#/definitions/'.$definitionName;
 

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -20,7 +20,6 @@ use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -76,7 +75,7 @@ final class SchemaFactory implements SchemaFactoryInterface
 
         $method = (null !== $operationType && null !== $operationName) ? $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'method') : 'GET';
 
-        if (!$output && !in_array($method, [Request::METHOD_POST, Request::METHOD_PATCH, Request::METHOD_PUT], true)) {
+        if (!$output && !\in_array($method, ['POST', 'PATCH', 'PUT'], true)) {
             return $schema;
         }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1184,6 +1184,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.swagger.normalizer.documentation',
             'api_platform.json_schema.type_factory',
             'api_platform.json_schema.schema_factory',
+            'api_platform.json_schema.json_schema_generate_command',
             'api_platform.validator',
             'test.api_platform.client',
         ];

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\JsonSchema\Command;
+
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+/**
+ * @author Jacques Lefebvre <jacques@les-tilleuls.coop>
+ */
+class JsonSchemaGenerateCommandTest extends KernelTestCase
+{
+    /**
+     * @var ApplicationTester
+     */
+    private $tester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $application = new Application(static::$kernel);
+        $application->setCatchExceptions(true);
+        $application->setAutoExit(false);
+
+        $this->tester = new ApplicationTester($application);
+    }
+
+    public function testExecuteWithoutOption()
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class]);
+
+        $this->assertJson($this->tester->getDisplay());
+    }
+
+    public function testExecuteWithItemOperationGet()
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--itemOperation' => 'get']);
+
+        $this->assertJson($this->tester->getDisplay());
+    }
+
+    public function testExecuteWithCollectionOperationGet()
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--collectionOperation' => 'get']);
+
+        $this->assertJson($this->tester->getDisplay());
+    }
+
+    public function testExecuteWithTooManyOptions()
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--collectionOperation' => 'get', '--itemOperation' => 'get']);
+
+        $this->assertStringContainsString('You can only use one of "--itemOperation" and "--collectionOperation" options at the same time.', $this->tester->getDisplay());
+    }
+
+    public function testExecuteWithJsonldFormatOption()
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--format' => 'jsonld']);
+        $result = $this->tester->getDisplay();
+
+        $this->assertStringContainsString('@id', $result);
+        $this->assertStringContainsString('@context', $result);
+        $this->assertStringContainsString('@type', $result);
+    }
+}

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\JsonSchema\Command;
 
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy as DocumentDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -19,48 +29,51 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
      */
     private $tester;
 
+    private $entityClass;
+
     protected function setUp(): void
     {
-        self::bootKernel();
+        $kernel = self::bootKernel();
 
         $application = new Application(static::$kernel);
         $application->setCatchExceptions(true);
         $application->setAutoExit(false);
 
+        $this->entityClass = 'mongodb' === $kernel->getEnvironment() ? DocumentDummy::class : Dummy::class;
         $this->tester = new ApplicationTester($application);
     }
 
     public function testExecuteWithoutOption()
     {
-        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class]);
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass]);
 
         $this->assertJson($this->tester->getDisplay());
     }
 
     public function testExecuteWithItemOperationGet()
     {
-        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--itemOperation' => 'get']);
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--itemOperation' => 'get', '--type' => 'output']);
 
         $this->assertJson($this->tester->getDisplay());
     }
 
     public function testExecuteWithCollectionOperationGet()
     {
-        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--collectionOperation' => 'get']);
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--collectionOperation' => 'get', '--type' => 'output']);
 
         $this->assertJson($this->tester->getDisplay());
     }
 
     public function testExecuteWithTooManyOptions()
     {
-        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--collectionOperation' => 'get', '--itemOperation' => 'get']);
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--collectionOperation' => 'get', '--itemOperation' => 'get', '--type' => 'output']);
 
-        $this->assertStringContainsString('You can only use one of "--itemOperation" and "--collectionOperation" options at the same time.', $this->tester->getDisplay());
+        $this->assertStringStartsWith('[ERROR] You can only use one of "--itemOperation" and "--collectionOperation"', trim(str_replace(["\r", "\n"], '', $this->tester->getDisplay())));
     }
 
     public function testExecuteWithJsonldFormatOption()
     {
-        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => Dummy::class, '--format' => 'jsonld']);
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--collectionOperation' => 'post', '--format' => 'jsonld']);
         $result = $this->tester->getDisplay();
 
         $this->assertStringContainsString('@id', $result);


### PR DESCRIPTION
Add a command to generate a JSON Schema for a resource.
Can be used for the whole resource or by operation


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

