### PR TITLE
Fix docblock DataTransformerInterface::supportsTransformation

### DIFF
--- a/src/DataTransformer/DataTransformerInterface.php
+++ b/src/DataTransformer/DataTransformerInterface.php
@@ -31,9 +31,9 @@ interface DataTransformerInterface
     public function transform($object, string $to, array $context = []);
 
     /**
-     * Checks whether the transformation is supported for a given object and context.
+     * Checks whether the transformation is supported for a given data and context.
      *
-     * @param object $object
+     * @param object|array $data object on normalize / array on denormalize
      */
-    public function supportsTransformation($object, string $to, array $context = []): bool;
+    public function supportsTransformation($data, string $to, array $context = []): bool;
 }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -605,11 +605,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
     /**
      * Finds the first supported data transformer if any.
+     *
+     * @param object|array $data object on normalize / array on denormalize
      */
-    protected function getDataTransformer($object, string $to, array $context = []): ?DataTransformerInterface
+    protected function getDataTransformer($data, string $to, array $context = []): ?DataTransformerInterface
     {
         foreach ($this->dataTransformers as $dataTransformer) {
-            if ($dataTransformer->supportsTransformation($object, $to, $context)) {
+            if ($dataTransformer->supportsTransformation($data, $to, $context)) {
                 return $dataTransformer;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Update docblock for data transformer interface. Support method signature was wrong, object name is wrong too. It can be object or array depending if we normalize / denormalize.