### PR TITLE
Improve serialization groups filter doc

### DIFF
--- a/src/Api/FilterInterface.php
+++ b/src/Api/FilterInterface.php
@@ -29,20 +29,17 @@ interface FilterInterface
      *   - required: if this filter is required
      *   - strategy (optional): the used strategy
      *   - is_collection (optional): is this filter is collection
-     *   - swagger (optional): additional parameters for the path operation,
-     *     e.g. 'swagger' => [
-     *       'description' => 'My Description',
-     *       'name' => 'My Name',
-     *       'type' => 'integer',
+     *   - schema (optional): additional parameters related to schema description
+     *     e.g. 'schema' => [
+     *         'type' => 'string',
+     *         'enum' => [
+     *             'value1',
+     *             'value2',
+     *         ],
      *     ]
-     *   - openapi (optional): additional parameters for the path operation in the version 3 spec,
-     *     e.g. 'openapi' => [
-     *       'description' => 'My Description',
-     *       'name' => 'My Name',
-     *       'schema' => [
-     *          'type' => 'integer',
-     *       ]
-     *     ]
+     *   - description (optional): a string describing filter usage
+     *   - swagger (optional/deprecated): additional parameters for the path operation
+     *   - openapi (optional/deprecated): additional parameters for the path operation in the version 3
      * The description can contain additional data specific to a filter.
      *
      * @see \ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer::getFiltersParameters

--- a/src/Serializer/Filter/GroupFilter.php
+++ b/src/Serializer/Filter/GroupFilter.php
@@ -65,13 +65,17 @@ final class GroupFilter implements FilterInterface
      */
     public function getDescription(string $resourceClass): array
     {
-        return [
-            "$this->parameterName[]" => [
-                'property' => null,
-                'type' => 'string',
-                'is_collection' => true,
-                'required' => false,
-            ],
+        $description = [
+            'property' => null,
+            'type' => 'string',
+            'is_collection' => true,
+            'required' => false,
         ];
+
+        if ($this->whitelist) {
+            $description['schema'] = ['type' => 'array', 'items' => ['type' => 'string', 'enum' => $this->whitelist]];
+        }
+
+        return ["$this->parameterName[]" => $description];
     }
 }

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -82,24 +82,7 @@ final class PropertyFilter implements FilterInterface
                 'type' => 'string',
                 'is_collection' => true,
                 'required' => false,
-                'swagger' => [
-                    'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$example,
-                    'name' => "$this->parameterName[]",
-                    'type' => 'array',
-                    'items' => [
-                        'type' => 'string',
-                    ],
-                ],
-                'openapi' => [
-                    'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$example,
-                    'name' => "$this->parameterName[]",
-                    'schema' => [
-                        'type' => 'array',
-                        'items' => [
-                            'type' => 'string',
-                        ],
-                    ],
-                ],
+                'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$example,
             ],
         ];
     }

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -706,11 +706,18 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
                     'required' => $data['required'],
                 ];
 
+                if (isset($data['description'])) {
+                    $parameter['description'] = $data['description'];
+                }
+
                 $type = \in_array($data['type'], Type::$builtinTypes, true) ? $this->jsonSchemaTypeFactory->getType(new Type($data['type'], false, null, $data['is_collection'] ?? false)) : ['type' => 'string'];
                 $v3 ? $parameter['schema'] = $type : $parameter += $type;
 
                 if ($v3 && isset($data['schema'])) {
                     $parameter['schema'] = $data['schema'];
+                }
+                if (!$v3 && isset($data['schema']['items'])) {
+                    $parameter['items'] = $data['schema']['items'];
                 }
 
                 if ('array' === ($type['type'] ?? '')) {
@@ -724,6 +731,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
                     }
                 }
 
+                /** @deprecated schema key should be used instead */
                 $key = $v3 ? 'openapi' : 'swagger';
                 if (isset($data[$key])) {
                     $parameter = $data[$key] + $parameter;

--- a/tests/Serializer/Filter/GroupFilterTest.php
+++ b/tests/Serializer/Filter/GroupFilterTest.php
@@ -125,4 +125,26 @@ class GroupFilterTest extends TestCase
 
         $this->assertEquals($expectedDescription, $groupFilter->getDescription(DummyGroup::class));
     }
+
+    public function testGetDescriptionForWhitelistedGroups()
+    {
+        $groupFilter = new GroupFilter('whitlisted_groups', false, ['foo', 'bar']);
+        $expectedDescription = [
+            'whitlisted_groups[]' => [
+                'property' => null,
+                'type' => 'string',
+                'is_collection' => true,
+                'required' => false,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => ['foo', 'bar'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedDescription, $groupFilter->getDescription(DummyGroup::class));
+    }
 }

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -218,24 +218,7 @@ class PropertyFilterTest extends TestCase
                 'type' => 'string',
                 'is_collection' => true,
                 'required' => false,
-                'swagger' => [
-                    'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
-                    'name' => 'custom_properties[]',
-                    'type' => 'array',
-                    'items' => [
-                        'type' => 'string',
-                    ],
-                ],
-                'openapi' => [
-                    'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
-                    'name' => 'custom_properties[]',
-                    'schema' => [
-                        'type' => 'array',
-                        'items' => [
-                            'type' => 'string',
-                        ],
-                    ],
-                ],
+                'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
             ],
         ];
 

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -1655,6 +1655,23 @@ class DocumentationNormalizerV2Test extends TestCase
                 'required' => true,
                 'strategy' => 'exact',
             ]]),
+            'f4' => new DummyFilter(['serializer' => [
+                'property' => 'group',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => true,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => [
+                            'group1',
+                            'group2',
+                        ],
+                    ],
+                ],
+            ]]),
         ];
 
         foreach ($filters as $filterId => $filter) {
@@ -1662,7 +1679,7 @@ class DocumentationNormalizerV2Test extends TestCase
             $filterLocatorProphecy->get($filterId)->willReturn($filter)->shouldBeCalled();
         }
 
-        $filterLocatorProphecy->has('f4')->willReturn(false)->shouldBeCalled();
+        $filterLocatorProphecy->has('f5')->willReturn(false)->shouldBeCalled();
 
         $this->normalizeWithFilters($filterLocatorProphecy->reveal());
     }
@@ -1693,6 +1710,23 @@ class DocumentationNormalizerV2Test extends TestCase
                 'is_collection' => true,
                 'required' => true,
                 'strategy' => 'exact',
+            ]]),
+            'f4' => new DummyFilter(['serializer' => [
+                'property' => 'group',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => true,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => [
+                            'group1',
+                            'group2',
+                        ],
+                    ],
+                ],
             ]]),
         ]));
     }
@@ -2051,7 +2085,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'This is a dummy.',
             null,
             [],
-            ['get' => ['method' => 'GET', 'filters' => ['f1', 'f2', 'f3', 'f4']] + self::OPERATION_FORMATS]
+            ['get' => ['method' => 'GET', 'filters' => ['f1', 'f2', 'f3', 'f4', 'f5']] + self::OPERATION_FORMATS]
         );
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn($dummyMetadata);
@@ -2118,6 +2152,20 @@ class DocumentationNormalizerV2Test extends TestCase
                                     'type' => 'string',
                                 ],
                                 'collectionFormat' => 'csv',
+                            ],
+                            [
+                                'name' => 'serializer',
+                                'in' => 'query',
+                                'required' => false,
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'string',
+                                    'enum' => [
+                                        'group1',
+                                        'group2',
+                                    ],
+                                ],
+                                'collectionFormat' => 'multi',
                             ],
                             [
                                 'name' => 'page',

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -1512,6 +1512,23 @@ class DocumentationNormalizerV3Test extends TestCase
                     'enum' => ['asc', 'desc'],
                 ],
             ]]),
+            'f5' => new DummyFilter(['serializer' => [
+                'property' => 'group',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => true,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => [
+                            'group1',
+                            'group2',
+                        ],
+                    ],
+                ],
+            ]]),
         ];
 
         foreach ($filters as $filterId => $filter) {
@@ -1519,7 +1536,7 @@ class DocumentationNormalizerV3Test extends TestCase
             $filterLocatorProphecy->get($filterId)->willReturn($filter)->shouldBeCalled();
         }
 
-        $filterLocatorProphecy->has('f5')->willReturn(false)->shouldBeCalled();
+        $filterLocatorProphecy->has('f6')->willReturn(false)->shouldBeCalled();
 
         $this->normalizeWithFilters($filterLocatorProphecy->reveal());
     }
@@ -1558,6 +1575,23 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schema' => [
                     'type' => 'string',
                     'enum' => ['asc', 'desc'],
+                ],
+            ]]),
+            'f5' => new DummyFilter(['serializer' => [
+                'property' => 'group',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => true,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => [
+                            'group1',
+                            'group2',
+                        ],
+                    ],
                 ],
             ]]),
         ]));
@@ -2031,7 +2065,7 @@ class DocumentationNormalizerV3Test extends TestCase
             'This is a dummy.',
             null,
             [],
-            ['get' => ['method' => 'GET', 'filters' => ['f1', 'f2', 'f3', 'f4', 'f5']] + self::OPERATION_FORMATS]
+            ['get' => ['method' => 'GET', 'filters' => ['f1', 'f2', 'f3', 'f4', 'f5', 'f6']] + self::OPERATION_FORMATS]
         );
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn($dummyMetadata);
@@ -2129,6 +2163,23 @@ class DocumentationNormalizerV3Test extends TestCase
                                     'type' => 'string',
                                     'enum' => ['asc', 'desc'],
                                 ],
+                            ],
+                            [
+                                'name' => 'serializer',
+                                'in' => 'query',
+                                'required' => false,
+                                'schema' => [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'string',
+                                        'enum' => [
+                                            'group1',
+                                            'group2',
+                                        ],
+                                    ],
+                                ],
+                                'style' => 'form',
+                                'explode' => true,
                             ],
                             [
                                 'name' => 'page',


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2891 
| License       | MIT
| Doc PR        | -

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

@dunglas @teohhanhui, I got inspired by existing `getDescription` function of FilterProperty to add `'enum'` information to generated documentation.
https://github.com/api-platform/core/blob/master/src/Serializer/Filter/PropertyFilter.php#L73-L105

However, I was wondering if I should not use your newly created `TypeFactory` to enrich generated array. I would do that by :
- creating a new `Schema` in `FilterProperty::getDescription` method with one unique `enum` property set to the withlisted serialization groups.
- return description array with a new `schema` key
- update https://github.com/api-platform/core/blob/master/src/Swagger/Serializer/DocumentationNormalizer.php#L690 to pass optional `schema` value found in parameter data as last `getType` argument
- update `TypeFactory::getType` method to use provided schema to improve returned type (not only for `BUILTIN_TYPE_OBJECT` as it is the case right now)

What do you think ? This could be ported as well on #2971, which is currently relying on a new `Schema` property defined without the `Schema::class` type.

#hackdayparis