### PR TITLE
[GraphQL] making item_query and collection_query as top level operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * GraphQL: Allow to use a search and an exist filter on the same resource
 * GraphQL: Refactor the architecture of the whole system to allow the decoration of useful services (`TypeConverter` to manage custom types, `SerializerContextBuilder` to modify the (de)serialization context dynamically, etc.)
 
+**BC Break** 
+* GraphQL: Separate item_query and collection_query operations so user can use different security and serialization groups for them
+
 ## 2.4.6
 
 * GraphQL: Use correct resource configuration for filter arguments of nested collection

--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -168,7 +168,7 @@ Feature: Authorization checking
 
   Scenario: An admin can retrieve collection resource
     When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
-    When I send the following GraphQL request:
+    And I send the following GraphQL request:
     """
     {
       securedDummies {
@@ -188,7 +188,7 @@ Feature: Authorization checking
 
   Scenario: A regular user can't retrieve collection resource
     When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
-    When I send the following GraphQL request:
+    And I send the following GraphQL request:
     """
     {
       securedDummies {

--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -165,3 +165,44 @@ Feature: Authorization checking
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.updateSecuredDummy.securedDummy.owner" should be equal to the string "vincent"
+
+  Scenario: An admin can retrieve collection resource
+    When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    When I send the following GraphQL request:
+    """
+    {
+      securedDummies {
+        edges {
+          node {
+            title
+            description
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.securedDummies" should not be null
+
+  Scenario: A regular user can't retrieve collection resource
+    When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    When I send the following GraphQL request:
+    """
+    {
+      securedDummies {
+        edges {
+          node {
+            title
+            description
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.securedDummies" should be null
+    And the JSON node "errors[0].message" should be equal to "Access Denied."

--- a/features/graphql/authorization.feature
+++ b/features/graphql/authorization.feature
@@ -40,6 +40,47 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "errors[0].message" should be equal to "Access Denied."
 
+  Scenario: An admin can retrieve collection resource
+    When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send the following GraphQL request:
+    """
+    {
+      securedDummies {
+        edges {
+          node {
+            title
+            description
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.securedDummies" should not be null
+
+  Scenario: A regular user can't retrieve collection resource
+    When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send the following GraphQL request:
+    """
+    {
+      securedDummies {
+        edges {
+          node {
+            title
+            description
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.securedDummies" should be null
+    And the JSON node "errors[0].message" should be equal to "Access Denied."
+
   Scenario: An anonymous user tries to create a resource they are not allowed to
     When I send the following GraphQL request:
     """
@@ -166,43 +207,3 @@ Feature: Authorization checking
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.updateSecuredDummy.securedDummy.owner" should be equal to the string "vincent"
 
-  Scenario: An admin can retrieve collection resource
-    When I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
-    And I send the following GraphQL request:
-    """
-    {
-      securedDummies {
-        edges {
-          node {
-            title
-            description
-          }
-        }
-      }
-    }
-    """
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.securedDummies" should not be null
-
-  Scenario: A regular user can't retrieve collection resource
-    When I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
-    And I send the following GraphQL request:
-    """
-    {
-      securedDummies {
-        edges {
-          node {
-            title
-            description
-          }
-        }
-      }
-    }
-    """
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.securedDummies" should be null
-    And the JSON node "errors[0].message" should be equal to "Access Denied."

--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -9,7 +9,7 @@ Feature: GraphQL collection support
         ...dummyFields
       }
     }
-    fragment dummyFields on DummyConnection {
+    fragment dummyFields on DummyCollectionConnection {
       edges {
         node {
           id

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -21,7 +21,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      type1: __type(name: "DummyProduct") {
+      type1: __type(name: "DummyProductItem") {
         description,
         fields {
           name
@@ -35,7 +35,7 @@ Feature: GraphQL introspection support
           }
         }
       }
-      type2: __type(name: "DummyAggregateOfferConnection") {
+      type2: __type(name: "DummyAggregateOfferItemConnection") {
         description,
         fields {
           name
@@ -49,7 +49,7 @@ Feature: GraphQL introspection support
           }
         }
       }
-      type3: __type(name: "DummyAggregateOfferEdge") {
+      type3: __type(name: "DummyAggregateOfferItemEdge") {
         description,
         fields {
           name
@@ -69,12 +69,12 @@ Feature: GraphQL introspection support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.type1.description" should be equal to "Dummy Product."
-    And the JSON node "data.type1.fields[1].type.name" should be equal to "DummyAggregateOfferConnection"
+    And the JSON node "data.type1.fields[1].type.name" should be equal to "DummyAggregateOfferItemConnection"
     And the JSON node "data.type2.fields[0].name" should be equal to "edges"
-    And the JSON node "data.type2.fields[0].type.ofType.name" should be equal to "DummyAggregateOfferEdge"
+    And the JSON node "data.type2.fields[0].type.ofType.name" should be equal to "DummyAggregateOfferItemEdge"
     And the JSON node "data.type3.fields[0].name" should be equal to "node"
     And the JSON node "data.type3.fields[1].name" should be equal to "cursor"
-    And the JSON node "data.type3.fields[0].type.name" should be equal to "DummyAggregateOffer"
+    And the JSON node "data.type3.fields[0].type.name" should be equal to "DummyAggregateOfferItem"
 
   Scenario: Introspect deprecated queries
     When I send the following GraphQL request:
@@ -121,7 +121,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      __type(name: "DeprecatedResource") {
+      __type(name: "DeprecatedResourceItem") {
         fields(includeDeprecated: true) {
           name
           isDeprecated
@@ -224,7 +224,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      __type(name: "Dummy") {
+      __type(name: "DummyItem") {
         description,
         fields {
           name
@@ -250,7 +250,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      typeQuery: __type(name: "DummyGroup") {
+      typeQuery: __type(name: "DummyGroupItem") {
         description,
         fields {
           name
@@ -405,4 +405,4 @@ Feature: GraphQL introspection support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.dummyItem.name" should be equal to "Dummy #3"
     And the JSON node "data.dummyItem.relatedDummy.name" should be equal to "RelatedDummy #3"
-    And the JSON node "data.dummyItem.relatedDummy.__typename" should be equal to "RelatedDummy"
+    And the JSON node "data.dummyItem.relatedDummy.__typename" should be equal to "RelatedDummyItem"

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -23,7 +23,7 @@ Feature: GraphQL query support
     {
       node(id: "/dummies/1") {
         id
-        ... on Dummy {
+        ... on DummyItem {
           name
         }
       }

--- a/features/graphql/schema.feature
+++ b/features/graphql/schema.feature
@@ -5,7 +5,7 @@ Feature: GraphQL schema-related features
     When I run the command "api:graphql:export"
     Then the command output should contain:
     """
-    ###Dummy Friend.###
+   ###Dummy Friend.###
     type DummyFriend implements Node {
       id: ID!
 
@@ -16,25 +16,47 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    ###Connection for DummyFriend.###
-    type DummyFriendConnection {
-      edges: [DummyFriendEdge]
-      pageInfo: DummyFriendPageInfo!
+    ###Dummy Friend.###
+    type DummyFriendCollection implements Node {
+      id: ID!
+
+      ###The id###
+      _id: Int!
+
+      ###The dummy name###
+      name: String!
+    }
+
+    ###Connection for DummyFriendCollection.###
+    type DummyFriendCollectionConnection {
+      edges: [DummyFriendCollectionEdge]
+      pageInfo: DummyFriendCollectionPageInfo!
       totalCount: Int!
     }
 
-    ###Edge of DummyFriend.###
-    type DummyFriendEdge {
-      node: DummyFriend
+    ###Edge of DummyFriendCollection.###
+    type DummyFriendCollectionEdge {
+      node: DummyFriendCollection
       cursor: String!
     }
 
     ###Information about the current page.###
-    type DummyFriendPageInfo {
+    type DummyFriendCollectionPageInfo {
       endCursor: String
       startCursor: String
       hasNextPage: Boolean!
       hasPreviousPage: Boolean!
+    }
+
+    ###Dummy Friend.###
+    type DummyFriendItem implements Node {
+      id: ID!
+
+      ###The id###
+      _id: Int!
+
+      ###The dummy name###
+      name: String!
     }
     """
 
@@ -54,24 +76,46 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    # Connection for DummyFriend.
-    type DummyFriendConnection {
-      edges: [DummyFriendEdge]
-      pageInfo: DummyFriendPageInfo!
+    # Dummy Friend.
+    type DummyFriendCollection implements Node {
+      id: ID!
+
+      # The id
+      _id: Int!
+
+      # The dummy name
+      name: String!
+    }
+
+    # Connection for DummyFriendCollection.
+    type DummyFriendCollectionConnection {
+      edges: [DummyFriendCollectionEdge]
+      pageInfo: DummyFriendCollectionPageInfo!
       totalCount: Int!
     }
 
-    # Edge of DummyFriend.
-    type DummyFriendEdge {
-      node: DummyFriend
+    # Edge of DummyFriendCollection.
+    type DummyFriendCollectionEdge {
+      node: DummyFriendCollection
       cursor: String!
     }
 
     # Information about the current page.
-    type DummyFriendPageInfo {
+    type DummyFriendCollectionPageInfo {
       endCursor: String
       startCursor: String
       hasNextPage: Boolean!
       hasPreviousPage: Boolean!
+    }
+
+    # Dummy Friend.
+    type DummyFriendItem implements Node {
+      id: ID!
+
+      # The id
+      _id: Int!
+
+      # The dummy name
+      name: String!
     }
     """

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -70,7 +70,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
                 );
             }
 
-            $operationName = $operationName ?? 'query';
+            $operationName = $operationName ?? 'collection_query';
             $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false];
 
             $collection = ($this->readStage)($resourceClass, $rootClass, $operationName, $resolverContext);

--- a/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
@@ -64,7 +64,7 @@ final class ItemResolverFactory implements ResolverFactoryInterface
                 return $source[$info->fieldName];
             }
 
-            $operationName = $operationName ?? 'query';
+            $operationName = $operationName ?? 'item_query';
             $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
 
             $item = ($this->readStage)($resourceClass, $rootClass, $operationName, $resolverContext);

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -90,14 +90,14 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
         $deprecationReason = $resourceMetadata->getGraphqlAttribute($queryName, 'deprecation_reason', '', true);
 
-        if ('collection_query' !== $queryName && false !== $itemConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass), $resourceClass, false, $queryName, null)) {
+        if (false !== $itemConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass), $resourceClass, false, $queryName, null)) {
             $args = $this->resolveResourceArgs($itemConfiguration['args'] ?? [], $queryName, $shortName);
             $itemConfiguration['args'] = $args ?: $itemConfiguration['args'] ?? ['id' => ['type' => GraphQLType::nonNull(GraphQLType::id())]];
 
             $queryFields[$fieldName] = array_merge($fieldConfiguration, $itemConfiguration);
         }
 
-        if ('item_query' !== $queryName && false !== $collectionConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, $resourceClass)), $resourceClass, false, $queryName, null)) {
+        if (false !== $collectionConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, $resourceClass)), $resourceClass, false, $queryName, null)) {
             $args = $this->resolveResourceArgs($collectionConfiguration['args'] ?? [], $queryName, $shortName);
             $collectionConfiguration['args'] = $args ?: $collectionConfiguration['args'] ?? $fieldConfiguration['args'];
 

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -167,7 +167,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
         if (null !== $resourceClass) {
             foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
-                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['graphql_operation_name' => $mutationName ?? $queryName ?? 'query_item']);
+                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['graphql_operation_name' => $mutationName ?? $queryName ?? 'item_query']);
                 if (
                     null === ($propertyType = $propertyMetadata->getType())
                     || (!$input && false === $propertyMetadata->isReadable())

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -86,18 +86,18 @@ final class FieldsBuilder implements FieldsBuilderInterface
     {
         $queryFields = [];
         $shortName = $resourceMetadata->getShortName();
-        $fieldName = lcfirst('query' === $queryName ? $shortName : $queryName.$shortName);
+        $fieldName = lcfirst('item_query' === $queryName || 'collection_query' === $queryName ? $shortName : $queryName.$shortName);
 
         $deprecationReason = $resourceMetadata->getGraphqlAttribute($queryName, 'deprecation_reason', '', true);
 
-        if (false !== $itemConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass), $resourceClass, false, $queryName, null)) {
+        if ('collection_query' !== $queryName && false !== $itemConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, true, $resourceClass), $resourceClass, false, $queryName, null)) {
             $args = $this->resolveResourceArgs($itemConfiguration['args'] ?? [], $queryName, $shortName);
             $itemConfiguration['args'] = $args ?: $itemConfiguration['args'] ?? ['id' => ['type' => GraphQLType::nonNull(GraphQLType::id())]];
 
             $queryFields[$fieldName] = array_merge($fieldConfiguration, $itemConfiguration);
         }
 
-        if (false !== $collectionConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, $resourceClass)), $resourceClass, false, $queryName, null)) {
+        if ('item_query' !== $queryName && false !== $collectionConfiguration && $fieldConfiguration = $this->getResourceFieldConfiguration(null, null, $deprecationReason, new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, $resourceClass)), $resourceClass, false, $queryName, null)) {
             $args = $this->resolveResourceArgs($collectionConfiguration['args'] ?? [], $queryName, $shortName);
             $collectionConfiguration['args'] = $args ?: $collectionConfiguration['args'] ?? $fieldConfiguration['args'];
 
@@ -167,7 +167,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
         if (null !== $resourceClass) {
             foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
-                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['graphql_operation_name' => $mutationName ?? $queryName ?? 'query']);
+                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['graphql_operation_name' => $mutationName ?? $queryName ?? 'query_item']);
                 if (
                     null === ($propertyType = $propertyMetadata->getType())
                     || (!$input && false === $propertyMetadata->isReadable())

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -60,8 +60,14 @@ final class SchemaBuilder implements SchemaBuilderInterface
             /** @var array<string, mixed> $graphqlConfiguration */
             $graphqlConfiguration = $resourceMetadata->getGraphql() ?? [];
             foreach ($graphqlConfiguration as $operationName => $value) {
-                if ('item_query' === $operationName || 'collection_query' === $operationName) {
-                    $queryFields += $this->fieldsBuilder->getQueryFields($resourceClass, $resourceMetadata, $operationName, [], []);
+                if ('item_query' === $operationName) {
+                    $queryFields += $this->fieldsBuilder->getQueryFields($resourceClass, $resourceMetadata, $operationName, [], false);
+
+                    continue;
+                }
+
+                if ('collection_query' === $operationName) {
+                    $queryFields += $this->fieldsBuilder->getQueryFields($resourceClass, $resourceMetadata, $operationName, false, []);
 
                     continue;
                 }

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -60,7 +60,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
             /** @var array<string, mixed> $graphqlConfiguration */
             $graphqlConfiguration = $resourceMetadata->getGraphql() ?? [];
             foreach ($graphqlConfiguration as $operationName => $value) {
-                if ('query' === $operationName) {
+                if ('item_query' === $operationName || 'collection_query' === $operationName) {
                     $queryFields += $this->fieldsBuilder->getQueryFields($resourceClass, $resourceMetadata, $operationName, [], []);
 
                     continue;

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -61,6 +61,11 @@ final class TypeBuilder implements TypeBuilderInterface
             }
             $shortName .= 'Payload';
         }
+        if ('item_query' === $queryName) {
+            $shortName .= 'Item';
+        } elseif ('collection_query' === $queryName) {
+            $shortName .= 'Collection';
+        }
         if ($wrapped && null !== $mutationName) {
             $shortName .= 'Data';
         }
@@ -153,6 +158,7 @@ final class TypeBuilder implements TypeBuilderInterface
                 }
 
                 $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName();
+                $shortName .= 'Item';
 
                 return $this->typesContainer->has($shortName) ? $this->typesContainer->get($shortName) : null;
             },

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -63,7 +63,8 @@ final class TypeBuilder implements TypeBuilderInterface
         }
         if ('item_query' === $queryName) {
             $shortName .= 'Item';
-        } elseif ('collection_query' === $queryName) {
+        }
+        if ('collection_query' === $queryName) {
             $shortName .= 'Collection';
         }
         if ($wrapped && null !== $mutationName) {
@@ -157,8 +158,7 @@ final class TypeBuilder implements TypeBuilderInterface
                     return null;
                 }
 
-                $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName();
-                $shortName .= 'Item';
+                $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName().'Item';
 
                 return $this->typesContainer->has($shortName) ? $this->typesContainer->get($shortName) : null;
             },

--- a/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
@@ -83,7 +83,7 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
 
         $graphql = $resourceMetadata->getGraphql();
         if (null === $graphql) {
-            $resourceMetadata = $resourceMetadata->withGraphql(['query' => [], 'delete' => [], 'update' => [], 'create' => []]);
+            $resourceMetadata = $resourceMetadata->withGraphql(['item_query' => [], 'collection_query' => [], 'delete' => [], 'update' => [], 'create' => []]);
         } else {
             $resourceMetadata = $this->normalizeGraphQl($resourceMetadata, $graphql);
         }

--- a/tests/Fixtures/FileConfigurations/single_resource.yml
+++ b/tests/Fixtures/FileConfigurations/single_resource.yml
@@ -14,7 +14,10 @@
         my_collection_subresource:
             path: 'the/subresource/path'
     graphql:
-        query:
+        item_query:
+            normalization_context:
+                groups: ['graphql']
+        collection_query:
             normalization_context:
                 groups: ['graphql']
     attributes:

--- a/tests/Fixtures/FileConfigurations/single_resource.yml
+++ b/tests/Fixtures/FileConfigurations/single_resource.yml
@@ -14,10 +14,7 @@
         my_collection_subresource:
             path: 'the/subresource/path'
     graphql:
-        item_query:
-            normalization_context:
-                groups: ['graphql']
-        collection_query:
+        query:
             normalization_context:
                 groups: ['graphql']
     attributes:

--- a/tests/Fixtures/TestBundle/Document/DummyGroup.php
+++ b/tests/Fixtures/TestBundle/Document/DummyGroup.php
@@ -37,7 +37,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         }
  *     },
  *     graphql={
- *         "query"={"normalization_context"={"groups"={"dummy_foo"}}},
+ *         "item_query"={"normalization_context"={"groups"={"dummy_foo"}}},
+ *         "collection_query"={"normalization_context"={"groups"={"dummy_foo"}}},
  *         "delete",
  *         "create"={
  *             "normalization_context"={"groups"={"dummy_bar"}},

--- a/tests/Fixtures/TestBundle/Document/DummyProperty.php
+++ b/tests/Fixtures/TestBundle/Document/DummyProperty.php
@@ -35,7 +35,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         }
  *     },
  *     graphql={
- *         "query",
+ *         "item_query",
+ *         "collection_query",
  *         "update",
  *         "delete",
  *         "create"={

--- a/tests/Fixtures/TestBundle/Document/LegacySecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/LegacySecuredDummy.php
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "put"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
- *         "query"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "item_query"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
  *         "delete"={},
  *         "update"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() ==  user"},
  *         "create"={"access_control"="is_granted('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}

--- a/tests/Fixtures/TestBundle/Document/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SecuredDummy.php
@@ -39,7 +39,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "put"={"security_post_denormalize"="is_granted('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
- *         "query"={"security"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "item_query"={"security"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "collection_query"={"security"="is_granted('ROLE_ADMIN')"},
  *         "delete"={},
  *         "update"={"security_post_denormalize"="is_granted('ROLE_USER') and previous_object.getOwner() ==  user"},
  *         "create"={"security"="is_granted('ROLE_ADMIN')", "security_message"="Only admins can create a secured dummy."}

--- a/tests/Fixtures/TestBundle/Entity/DummyGroup.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyGroup.php
@@ -36,7 +36,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         }
  *     },
  *     graphql={
- *         "query"={"normalization_context"={"groups"={"dummy_foo"}}},
+ *         "item_query"={"normalization_context"={"groups"={"dummy_foo"}}},
+ *         "collection_query"={"normalization_context"={"groups"={"dummy_foo"}}},
  *         "delete",
  *         "create"={
  *             "normalization_context"={"groups"={"dummy_bar"}},

--- a/tests/Fixtures/TestBundle/Entity/DummyProperty.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyProperty.php
@@ -35,7 +35,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *         }
  *     },
  *     graphql={
- *         "query",
+ *         "item_query",
+ *         "collection_query",
  *         "update",
  *         "delete",
  *         "create"={

--- a/tests/Fixtures/TestBundle/Entity/LegacySecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/LegacySecuredDummy.php
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "put"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
- *         "query"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "item_query"={"access_control"="is_granted('ROLE_USER') and object.getOwner() == user"},
  *         "delete"={},
  *         "update"={"access_control"="is_granted('ROLE_USER') and previous_object.getOwner() == user"},
  *         "create"={"access_control"="is_granted('ROLE_ADMIN')", "access_control_message"="Only admins can create a secured dummy."}

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -38,7 +38,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         "put"={"security_post_denormalize"="is_granted('ROLE_USER') and previous_object.getOwner() == user"},
  *     },
  *     graphql={
- *         "query"={"security"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "item_query"={"security"="is_granted('ROLE_USER') and object.getOwner() == user"},
+ *         "collection_query"={"security"="is_granted('ROLE_ADMIN')"},
  *         "delete"={},
  *         "update"={"security_post_denormalize"="is_granted('ROLE_USER') and previous_object.getOwner() == user"},
  *         "create"={"security"="is_granted('ROLE_ADMIN')", "security_message"="Only admins can create a secured dummy."}

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -180,7 +180,7 @@ class FieldsBuilderTest extends TestCase
                 ],
             ],
             'empty overridden args and add fields' => [
-                'resourceClass', new ResourceMetadata('ShortName'), 'query', ['args' => [], 'name' => 'customActionName'], false, GraphQLType::string(), false, null, null,
+                'resourceClass', new ResourceMetadata('ShortName'), 'item_query', ['args' => [], 'name' => 'customActionName'], false, GraphQLType::string(), false, null, null,
                 [
                     'shortName' => [
                         'type' => GraphQLType::string(),
@@ -193,7 +193,7 @@ class FieldsBuilderTest extends TestCase
                 ],
             ],
             'override args with custom ones' => [
-                'resourceClass', new ResourceMetadata('ShortName'), 'query', ['args' => ['customArg' => ['type' => 'a type']]], false, GraphQLType::string(), false, null, null,
+                'resourceClass', new ResourceMetadata('ShortName'), 'item_query', ['args' => ['customArg' => ['type' => 'a type']]], false, GraphQLType::string(), false, null, null,
                 [
                     'shortName' => [
                         'type' => GraphQLType::string(),

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -76,7 +76,8 @@ class SchemaBuilderTest extends TestCase
         $typeFoo->name = 'Foo';
         $this->typesContainerProphecy->get('Foo')->willReturn(GraphQLType::listOf($typeFoo));
         $this->fieldsBuilderProphecy->getNodeQueryFields()->shouldBeCalled()->willReturn(['node_fields']);
-        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'query', [], [])->willReturn(['query' => ['query_fields']]);
+        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'item_query', [], [])->willReturn(['query' => ['query_fields']]);
+        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'collection_query', [], [])->willReturn(['query' => ['query_fields']]);
         $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'custom_item_query', ['item_query' => 'item_query_resolver'], false)->willReturn(['custom_item_query' => ['custom_item_query_fields']]);
         $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'custom_collection_query', false, ['collection_query' => 'collection_query_resolver'])->willReturn(['custom_collection_query' => ['custom_collection_query_fields']]);
         $this->fieldsBuilderProphecy->getMutationFields($resourceClass, $resourceMetadata, 'mutation')->willReturn(['mutation' => ['mutation_fields']]);
@@ -102,7 +103,16 @@ class SchemaBuilderTest extends TestCase
                     ],
                 ]), null,
             ],
-            'query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['query' => []]),
+            'item query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['item_query' => []]),
+                new ObjectType([
+                    'name' => 'Query',
+                    'fields' => [
+                        'node' => ['node_fields'],
+                        'query' => ['query_fields'],
+                    ],
+                ]), null,
+            ],
+            'collection query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['collection_query' => []]),
                 new ObjectType([
                     'name' => 'Query',
                     'fields' => [

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -76,8 +76,8 @@ class SchemaBuilderTest extends TestCase
         $typeFoo->name = 'Foo';
         $this->typesContainerProphecy->get('Foo')->willReturn(GraphQLType::listOf($typeFoo));
         $this->fieldsBuilderProphecy->getNodeQueryFields()->shouldBeCalled()->willReturn(['node_fields']);
-        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'item_query', [], [])->willReturn(['query' => ['query_fields']]);
-        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'collection_query', [], [])->willReturn(['query' => ['query_fields']]);
+        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'item_query', [], false)->willReturn(['query' => ['query_fields']]);
+        $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'collection_query', false, [])->willReturn(['query' => ['query_fields']]);
         $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'custom_item_query', ['item_query' => 'item_query_resolver'], false)->willReturn(['custom_item_query' => ['custom_item_query_fields']]);
         $this->fieldsBuilderProphecy->getQueryFields($resourceClass, $resourceMetadata, 'custom_collection_query', false, ['collection_query' => 'collection_query_resolver'])->willReturn(['custom_collection_query' => ['custom_collection_query_fields']]);
         $this->fieldsBuilderProphecy->getMutationFields($resourceClass, $resourceMetadata, 'mutation')->willReturn(['mutation' => ['mutation_fields']]);

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -262,11 +262,11 @@ class TypeBuilderTest extends TestCase
 
         $this->assertNull($nodeInterface->resolveType([], [], $this->prophesize(ResolveInfo::class)->reveal()));
 
-        $this->typesContainerProphecy->has('Dummy')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->has('DummyItem')->shouldBeCalled()->willReturn(false);
         $this->assertNull($nodeInterface->resolveType([ItemNormalizer::ITEM_RESOURCE_CLASS_KEY => Dummy::class], [], $this->prophesize(ResolveInfo::class)->reveal()));
 
-        $this->typesContainerProphecy->has('Dummy')->shouldBeCalled()->willReturn(true);
-        $this->typesContainerProphecy->get('Dummy')->shouldBeCalled()->willReturn(GraphQLType::string());
+        $this->typesContainerProphecy->has('DummyItem')->shouldBeCalled()->willReturn(true);
+        $this->typesContainerProphecy->get('DummyItem')->shouldBeCalled()->willReturn(GraphQLType::string());
         /** @var GraphQLType $resolvedType */
         $resolvedType = $nodeInterface->resolveType([ItemNormalizer::ITEM_RESOURCE_CLASS_KEY => Dummy::class], [], $this->prophesize(ResolveInfo::class)->reveal());
         $this->assertSame(GraphQLType::string(), $resolvedType);


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2988 
| License       | MIT
| Doc PR        | api-platform/doc
<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
This allows user to be able to use different security  and serialization groups for items and collections.
I didn't create pull request for docs because I wasn't sure you will accept this.
