### PR TITLE
Improve error message when Filter class is not imported

### DIFF
--- a/src/Annotation/ApiFilter.php
+++ b/src/Annotation/ApiFilter.php
@@ -58,7 +58,7 @@ final class ApiFilter
         }
 
         if (!is_a($options['value'], FilterInterface::class, true)) {
-            throw new InvalidArgumentException(sprintf('The filter class "%s" does not implement "%s".', $options['value'], FilterInterface::class));
+            throw new InvalidArgumentException(sprintf('The filter class "%s" does not implement "%s". Did you forget a use statement ?', $options['value'], FilterInterface::class));
         }
 
         $this->filterClass = $options['value'];

--- a/tests/Annotation/ApiFilterTest.php
+++ b/tests/Annotation/ApiFilterTest.php
@@ -34,7 +34,7 @@ class ApiFilterTest extends TestCase
     public function testInvalidFilter()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The filter class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy" does not implement "ApiPlatform\\Core\\Api\\FilterInterface".');
+        $this->expectExceptionMessage('The filter class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy" does not implement "ApiPlatform\\Core\\Api\\FilterInterface". Did you forget a use statement ?');
 
         new ApiFilter(['value' => Dummy::class]);
     }


### PR DESCRIPTION
Using a Filter class without indicate the FQCN throw the message `The filter class "%s" does not implement FilterInterface` but most if the time it's just because the Filter class was not imported.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
