### PR TITLE
Fix ApiTestCase::createClient when the BrowserKit component is not installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "ramsey/uuid-doctrine": "^1.4",
         "sebastian/object-enumerator": "^3.0.3",
         "symfony/asset": "^3.4 || ^4.0",
+        "symfony/browser-kit": "^4.3",
         "symfony/cache": "^3.4 || ^4.0",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/console": "^3.4 || ^4.0",

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -46,6 +46,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpClient\HttpClientTrait;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -128,8 +129,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->registerForAutoconfiguration(FilterInterface::class)
             ->addTag('api_platform.filter');
 
-        if ($container->hasParameter('test.client.parameters') && class_exists(AbstractBrowser::class) && trait_exists('Symfony\Component\HttpClient\HttpClientTrait')) {
+        if ($container->hasParameter('test.client.parameters')) {
             $loader->load('test.xml');
+
+            if (!class_exists(AbstractBrowser::class) || !trait_exists(HttpClientTrait::class)) {
+                $container->removeDefinition('test.api_platform.client');
+            }
         }
     }
 

--- a/src/Bridge/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Bridge/Symfony/Bundle/Test/ApiTestCase.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Test;
 
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpClient\HttpClientTrait;
 
 /**
  * Base class for functional API tests.
@@ -54,10 +55,11 @@ abstract class ApiTestCase extends KernelTestCase
              */
             $client = $kernel->getContainer()->get('test.api_platform.client');
         } catch (ServiceNotFoundException $e) {
-            if (class_exists(KernelBrowser::class) && trait_exists('Symfony\Component\HttpClient\HttpClientTrait')) {
-                throw new \LogicException('You cannot create the client used in functional tests if the "framework.test" config is not set to true.');
+            if (!class_exists(AbstractBrowser::class) || !trait_exists(HttpClientTrait::class)) {
+                throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit and HttpClient components are not available. Try running "composer require --dev symfony/browser-kit symfony/http-client".');
             }
-            throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit and HttpClient components are not available. Try running "composer require --dev symfony/browser-kit symfony/http-client".');
+
+            throw new \LogicException('You cannot create the client used in functional tests if the "framework.test" config is not set to true.');
         }
 
         $client->setDefaultOptions($defaultOptions);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | related: #2982, #2994, #2999
| License       | MIT
| Doc PR        | N/A

Currently it results in:

```
Error: Class 'Symfony\Component\BrowserKit\AbstractBrowser' not found
```