### PR TITLE
[GraphQL] Allow user to disable pagination per resource and operation

### DIFF
--- a/src/DataProvider/Pagination.php
+++ b/src/DataProvider/Pagination.php
@@ -53,9 +53,9 @@ final class Pagination
     public function getPage(array $context = []): int
     {
         $page = (int) $this->getParameterFromContext(
-            $context,
-            $this->options['page_parameter_name'],
-            $this->options['page_default']
+          $context,
+          $this->options['page_parameter_name'],
+          $this->options['page_default']
         );
 
         if (1 > $page) {
@@ -116,7 +116,7 @@ final class Pagination
         }
 
         if ($graphql && null !== ($before = $this->getParameterFromContext($context, 'before'))
-            && (false === ($before = base64_decode($before, true)) ? 0 : (int) $before - $limit) < 0) {
+          && (false === ($before = base64_decode($before, true)) ? 0 : (int) $before - $limit) < 0) {
             $limit = (int) $before;
         }
 
@@ -189,9 +189,14 @@ final class Pagination
 
         if (null !== $resourceClass) {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-            $enabled = $resourceMetadata->getCollectionOperationAttribute($operationName, $partial ? 'pagination_partial' : 'pagination_enabled', $enabled, true);
+            if (isset($context['graphql_operation_name']) && null !== $operationName) {
+                $enabled = $resourceMetadata->getGraphqlAttribute($operationName, 'pagination_enabled', $enabled, true);
+                $clientEnabled = false;
+            } else {
+                $enabled = $resourceMetadata->getCollectionOperationAttribute($operationName, $partial ? 'pagination_partial' : 'pagination_enabled', $enabled, true);
 
-            $clientEnabled = $resourceMetadata->getCollectionOperationAttribute($operationName, $partial ? 'pagination_client_partial' : 'pagination_client_enabled', $clientEnabled, true);
+                $clientEnabled = $resourceMetadata->getCollectionOperationAttribute($operationName, $partial ? 'pagination_client_partial' : 'pagination_client_enabled', $clientEnabled, true);
+            }
         }
 
         if ($clientEnabled) {

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -100,7 +100,7 @@ final class ReadStage implements ReadStageInterface
             return $subresourceCollection;
         }
 
-        return $this->collectionDataProvider->getCollection($resourceClass, null, $normalizationContext);
+        return $this->collectionDataProvider->getCollection($resourceClass, $operationName, $normalizationContext);
     }
 
     private function getIdentifier(array $context): ?string

--- a/src/GraphQl/Resolver/Stage/SerializeStage.php
+++ b/src/GraphQl/Resolver/Stage/SerializeStage.php
@@ -84,7 +84,7 @@ final class SerializeStage implements SerializeStageInterface
         }
 
         if ($isCollection && is_iterable($itemOrCollection)) {
-            if (!$this->paginationEnabled) {
+            if (!$resourceMetadata->getGraphqlAttribute($operationName, 'pagination_enabled', $this->paginationEnabled, true)) {
                 $data = [];
                 foreach ($itemOrCollection as $index => $object) {
                     $data[$index] = $this->normalizer->normalize($object, ItemNormalizer::FORMAT, $normalizationContext);

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -203,7 +203,7 @@ class ReadStageTest extends TestCase
 
         $this->subresourceDataProviderProphecy->getSubresource($resourceClass, ['id' => 3], $normalizationContext + ['filters' => $expectedFilters, 'property' => $fieldName, 'identifiers' => [['id', $resourceClass]], 'collection' => true])->willReturn(['subresource']);
 
-        $this->collectionDataProviderProphecy->getCollection($resourceClass, null, $normalizationContext + ['filters' => $expectedFilters])->willReturn($expectedResult);
+        $this->collectionDataProviderProphecy->getCollection($resourceClass, $operationName, $normalizationContext + ['filters' => $expectedFilters])->willReturn($expectedResult);
 
         $result = ($this->readStage)($resourceClass, $rootClass, $operationName, $context);
 


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #2965
| License       | MIT
| Doc PR        | n/a
<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

This allows user to disable pagination per resource, just like the rest.
Branch master build was failing already but I tested it in real project and if we change this line:
https://github.com/api-platform/core/blob/6e9ccf7418bf973d273b125d55ccc521b89afb06/src/EventListener/AddFormatListener.php#L113
to 
```php
 if (!empty($accept)) {
```
most of failed tests will be resolved but I didn't add it because it wasn't related to this pull request.
