### PR TITLE
WIP: Call Doctrine QueryExtension on Subresource request

### DIFF
--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -114,6 +114,10 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
             }
         }
 
+        foreach ($this->itemExtensions as $extension) {
+            $extension->applyToItem($queryBuilder, $queryNameGenerator, $resourceClass, $identifiers, $context['subresource_operation_name'], $context);
+        }
+
         $query = $queryBuilder->getQuery();
 
         return $context['collection'] ? $query->getResult() : $query->getOneOrNullResult();


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes (I think)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hi,
What do you think about calling the ItemExtensions for the parent resource query on Subrequest operation?

It can be useful if the parent resource has an ItemExtension like:

```php
class EnabledExtension implements QueryItemExtensionInterface, QueryCollectionExtensionInterface
{
    public function applyToItem(...)
    {
        if (is_subclass_of($resourceClass, EnabledInterface::class)) {
            $queryBuilder->andWhere(
                sprintf('%s.isEnabled = 1', $queryBuilder->getRootAliases()[0])
            );
        }
    }
}
```

otherwise, I find no way to change the parent subquery...

