### PR TITLE
Expose iri subformat

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
@@ -8,6 +8,7 @@
         <defaults public="false" />
 
         <service id="api_platform.json_schema.type_factory" class="ApiPlatform\Core\JsonSchema\TypeFactory">
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory"></argument>
             <call method="setSchemaFactory">
                 <argument type="service" id="api_platform.json_schema.schema_factory"/>
             </call>

--- a/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
@@ -8,7 +8,7 @@
         <defaults public="false" />
 
         <service id="api_platform.json_schema.type_factory" class="ApiPlatform\Core\JsonSchema\TypeFactory">
-            <argument type="service" id="api_platform.metadata.resource.name_collection_factory"></argument>
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory"/>
             <call method="setSchemaFactory">
                 <argument type="service" id="api_platform.json_schema.schema_factory"/>
             </call>

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -31,16 +31,18 @@ final class TypeFactory implements TypeFactoryInterface
     private $schemaFactory;
 
     /**
+     * @var ResourceNameCollectionFactoryInterface|null
+     */
+    private $resourceNameCollectionFactory;
+
+    /**
      * @var array
      */
     private $resourceClasses;
 
-    /**
-     * TypeFactory constructor.
-     */
     public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory = null)
     {
-        $this->resourceClasses = $resourceNameCollectionFactory ? iterator_to_array($resourceNameCollectionFactory->create()) : [];
+        $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
     }
 
     /**
@@ -108,10 +110,22 @@ final class TypeFactory implements TypeFactoryInterface
 
         $classType = ['type' => 'string'];
 
-        if (\in_array($className, $this->resourceClasses, true)) {
+        if (\in_array($className, $this->getDeclaredResources(), true)) {
             $classType['format'] = 'iri-reference';
         }
 
         return $classType;
+    }
+
+    /**
+     * Returns classes declared as resources.
+     */
+    private function getDeclaredResources(): array
+    {
+        if (null === $this->resourceClasses) {
+            $this->resourceClasses = $this->resourceNameCollectionFactory ? iterator_to_array($this->resourceNameCollectionFactory->create()) : [];
+        }
+
+        return $this->resourceClasses;
     }
 }

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\JsonSchema;
 
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -28,6 +29,19 @@ final class TypeFactory implements TypeFactoryInterface
      * @var SchemaFactoryInterface|null
      */
     private $schemaFactory;
+
+    /**
+     * @var array
+     */
+    private $resourceClasses;
+
+    /**
+     * TypeFactory constructor.
+     */
+    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory = null)
+    {
+        $this->resourceClasses = $resourceNameCollectionFactory ? iterator_to_array($resourceNameCollectionFactory->create()) : [];
+    }
 
     /**
      * Injects the JSON Schema factory to use.
@@ -92,6 +106,12 @@ final class TypeFactory implements TypeFactoryInterface
             return ['$ref' => $subSchema['$ref']];
         }
 
-        return ['type' => 'string'];
+        $classType = ['type' => 'string'];
+
+        if (\in_array($className, $this->resourceClasses, true)) {
+            $classType['format'] = 'iri-reference';
+        }
+
+        return $classType;
     }
 }

--- a/tests/JsonSchema/TypeFactoryTest.php
+++ b/tests/JsonSchema/TypeFactoryTest.php
@@ -16,6 +16,8 @@ namespace ApiPlatform\Core\Tests\JsonSchema;
 use ApiPlatform\Core\JsonSchema\Schema;
 use ApiPlatform\Core\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\Core\JsonSchema\TypeFactory;
+use ApiPlatform\Core\Metadata\Extractor\ExtractorInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -28,7 +30,16 @@ class TypeFactoryTest extends TestCase
      */
     public function testGetType(array $schema, Type $type): void
     {
-        $typeFactory = new TypeFactory();
+        $typeFactory = new TypeFactory(new ExtractorResourceNameCollectionFactory(
+            new class() implements ExtractorInterface {
+                public function getResources(): array
+                {
+                    return [
+                        Dummy::class => [],
+                    ];
+                }
+            }
+        ));
         $this->assertSame($schema, $typeFactory->getType($type));
     }
 
@@ -39,7 +50,7 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'boolean'], new Type(Type::BUILTIN_TYPE_BOOL)];
         yield [['type' => 'string'], new Type(Type::BUILTIN_TYPE_OBJECT)];
         yield [['type' => 'string', 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateTimeImmutable::class)];
-        yield [['type' => 'string'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
     }
 

--- a/tests/JsonSchema/TypeFactoryTest.php
+++ b/tests/JsonSchema/TypeFactoryTest.php
@@ -16,8 +16,8 @@ namespace ApiPlatform\Core\Tests\JsonSchema;
 use ApiPlatform\Core\JsonSchema\Schema;
 use ApiPlatform\Core\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\Core\JsonSchema\TypeFactory;
-use ApiPlatform\Core\Metadata\Extractor\ExtractorInterface;
-use ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -30,16 +30,10 @@ class TypeFactoryTest extends TestCase
      */
     public function testGetType(array $schema, Type $type): void
     {
-        $typeFactory = new TypeFactory(new ExtractorResourceNameCollectionFactory(
-            new class() implements ExtractorInterface {
-                public function getResources(): array
-                {
-                    return [
-                        Dummy::class => [],
-                    ];
-                }
-            }
-        ));
+        $resourceNameCollectionFactory = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactory->create()->willReturn(new ResourceNameCollection([Dummy::class]));
+        $typeFactory = new TypeFactory($resourceNameCollectionFactory->reveal());
+
         $this->assertSame($schema, $typeFactory->getType($type));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR adds the `iri-reference` subformat to OpenAPI for declared resources. Other PHP objects aren't affected by this extra information.

![iri-reference](https://user-images.githubusercontent.com/5569077/64521955-42263280-d2f9-11e9-967b-6a8d7f431e3e.png)
