### PR TITLE
Disable put and delete operations support for elastic item data provider

### DIFF
--- a/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -63,7 +63,7 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
             }
 
             $method = $resourceMetadata->getItemOperationAttribute($operationName, 'method');
-            if (\in_array($method, ['PUT', 'PATCH', 'DELETE'])) {
+            if (\in_array($method, ['PUT', 'PATCH', 'DELETE'], true)) {
                 return false;
             }
         } catch (ResourceClassNotFoundException $e) {

--- a/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -56,7 +56,7 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
      */
     public function supports(string $resourceClass, ?string $operationName = null, array $context = []): bool
     {
-        if (in_array($operationName, ['put', 'delete'])) {
+        if (\in_array($operationName, ['put', 'delete'], true)) {
             return false;
         }
 

--- a/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -56,13 +56,14 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
      */
     public function supports(string $resourceClass, ?string $operationName = null, array $context = []): bool
     {
-        if (\in_array($operationName, ['put', 'delete'], true)) {
-            return false;
-        }
-
         try {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             if (false === $resourceMetadata->getItemOperationAttribute($operationName, 'elasticsearch', true, true)) {
+                return false;
+            }
+
+            $method = $resourceMetadata->getItemOperationAttribute($operationName, 'method');
+            if (\in_array($method, ['PUT', 'PATCH', 'DELETE'])) {
                 return false;
             }
         } catch (ResourceClassNotFoundException $e) {

--- a/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -56,6 +56,10 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
      */
     public function supports(string $resourceClass, ?string $operationName = null, array $context = []): bool
     {
+        if (in_array($operationName, ['put', 'delete'])) {
+            return false;
+        }
+
         try {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
             if (false === $resourceMetadata->getItemOperationAttribute($operationName, 'elasticsearch', true, true)) {

--- a/tests/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
@@ -78,6 +78,8 @@ class ItemDataProviderTest extends TestCase
         );
 
         self::assertTrue($itemDataProvider->supports(Foo::class));
+        self::assertFalse($itemDataProvider->supports(Foo::class, 'put'));
+        self::assertFalse($itemDataProvider->supports(Foo::class, 'delete'));
         self::assertFalse($itemDataProvider->supports(Dummy::class));
         self::assertFalse($itemDataProvider->supports(CompositeRelation::class));
         self::assertFalse($itemDataProvider->supports(DummyCar::class));

--- a/tests/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
@@ -37,6 +37,13 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class ItemDataProviderTest extends TestCase
 {
+    private const DEFAULT_ITEM_OPERATIONS = [
+        'get' => ['method' => 'GET'],
+        'put' => ['method' => 'PUT'],
+        'patch' => ['method' => 'PATCH'],
+        'delete' => ['method' => 'DELETE'],
+    ];
+
     public function testConstruct()
     {
         self::assertInstanceOf(
@@ -63,7 +70,7 @@ class ItemDataProviderTest extends TestCase
         $identifierExtractorProphecy->getIdentifierFromResourceClass(CompositeRelation::class)->willThrow(new NonUniqueIdentifierException())->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Foo::class)->shouldBeCalled()->willReturn(new ResourceMetadata());
+        $resourceMetadataFactoryProphecy->create(Foo::class)->shouldBeCalled()->willReturn((new ResourceMetadata())->withItemOperations(self::DEFAULT_ITEM_OPERATIONS));
         $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn(new ResourceMetadata());
         $resourceMetadataFactoryProphecy->create(CompositeRelation::class)->shouldBeCalled()->willReturn(new ResourceMetadata());
         $resourceMetadataFactoryProphecy->create(DummyCar::class)->shouldBeCalled()->willReturn((new ResourceMetadata())->withAttributes(['elasticsearch' => false]));
@@ -78,7 +85,9 @@ class ItemDataProviderTest extends TestCase
         );
 
         self::assertTrue($itemDataProvider->supports(Foo::class));
+        self::assertTrue($itemDataProvider->supports(Foo::class, 'get'));
         self::assertFalse($itemDataProvider->supports(Foo::class, 'put'));
+        self::assertFalse($itemDataProvider->supports(Foo::class, 'patch'));
         self::assertFalse($itemDataProvider->supports(Foo::class, 'delete'));
         self::assertFalse($itemDataProvider->supports(Dummy::class));
         self::assertFalse($itemDataProvider->supports(CompositeRelation::class));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I enabled elasticsearch support for one entity and everything worked fine until I made a put request. New entity was about to be created instead of updating existing one. 

It appears that when elasticsearch support is turned on even on put and delete requests entities are loaded from elastic and denormalized from the payload - as a result doctrine see them as detached entities. This leads to a new entity create on `put` operation and 500 error on `delete`.

I think elasticsearch item data provider shouldn't support either `put` or `delete` operations. Or is there a better way to fix this issue?
