### PR TITLE
[GraphQL] Adding serialization group difference condition for item_query and collection_query types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0 beta 3
+
+* GraphQL: Use different types (`MyTypeItem` and `MyTypeCollection`) only if serialization groups are different for `item_query` and `collection_query` (#3083)
+
 ## 2.5.0 beta 2
 
 * Allow to not declare GET item operation

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCarColor as DummyCa
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomMutation as DummyCustomMutationDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDate as DummyDateDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDifferentGraphQlSerializationGroup as DummyDifferentGraphQlSerializationGroupDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDtoCustom as DummyDtoCustomDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDtoNoInput as DummyDtoNoInputDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDtoNoOutput as DummyDtoNoOutputDocument;
@@ -85,6 +86,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCarColor;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomMutation;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDate;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDifferentGraphQlSerializationGroup;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDtoCustom;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDtoNoInput;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDtoNoOutput;
@@ -1225,6 +1227,21 @@ final class DoctrineContext implements Context
     }
 
     /**
+     * @Given there are :nb dummy with different GraphQL serialization groups objects
+     */
+    public function thereAreDummyWithDifferentGraphQLSerializationGroupsObjects(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $dummyDifferentSerializationGroup = $this->buildDummyDifferentSerializationGroup();
+            $dummyDifferentSerializationGroup->setName('Name #'.$i);
+            $dummyDifferentSerializationGroup->setTitle('Title #'.$i);
+            $this->manager->persist($dummyDifferentSerializationGroup);
+        }
+
+        $this->manager->flush();
+    }
+
+    /**
      * @Given there is a ramsey identified resource with uuid :uuid
      */
     public function thereIsARamseyIdentifiedResource(string $uuid)
@@ -1581,6 +1598,14 @@ final class DoctrineContext implements Context
     private function buildDummyDate()
     {
         return $this->isOrm() ? new DummyDate() : new DummyDateDocument();
+    }
+
+    /**
+     * @return DummyDifferentGraphQlSerializationGroup|DummyDifferentGraphQlSerializationGroupDocument
+     */
+    private function buildDummyDifferentSerializationGroup()
+    {
+        return $this->isOrm() ? new DummyDifferentGraphQlSerializationGroup() : new DummyDifferentGraphQlSerializationGroupDocument();
     }
 
     /**

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -1229,13 +1229,13 @@ final class DoctrineContext implements Context
     /**
      * @Given there are :nb dummy with different GraphQL serialization groups objects
      */
-    public function thereAreDummyWithDifferentGraphQLSerializationGroupsObjects(int $nb)
+    public function thereAreDummyWithDifferentGraphQlSerializationGroupsObjects(int $nb)
     {
         for ($i = 1; $i <= $nb; ++$i) {
-            $dummyDifferentSerializationGroup = $this->buildDummyDifferentSerializationGroup();
-            $dummyDifferentSerializationGroup->setName('Name #'.$i);
-            $dummyDifferentSerializationGroup->setTitle('Title #'.$i);
-            $this->manager->persist($dummyDifferentSerializationGroup);
+            $dummyDifferentGraphQlSerializationGroup = $this->buildDummyDifferentGraphQlSerializationGroup();
+            $dummyDifferentGraphQlSerializationGroup->setName('Name #'.$i);
+            $dummyDifferentGraphQlSerializationGroup->setTitle('Title #'.$i);
+            $this->manager->persist($dummyDifferentGraphQlSerializationGroup);
         }
 
         $this->manager->flush();
@@ -1603,7 +1603,7 @@ final class DoctrineContext implements Context
     /**
      * @return DummyDifferentGraphQlSerializationGroup|DummyDifferentGraphQlSerializationGroupDocument
      */
-    private function buildDummyDifferentSerializationGroup()
+    private function buildDummyDifferentGraphQlSerializationGroup()
     {
         return $this->isOrm() ? new DummyDifferentGraphQlSerializationGroup() : new DummyDifferentGraphQlSerializationGroupDocument();
     }

--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -9,7 +9,7 @@ Feature: GraphQL collection support
         ...dummyFields
       }
     }
-    fragment dummyFields on DummyCollectionConnection {
+    fragment dummyFields on DummyConnection {
       edges {
         node {
           id
@@ -656,3 +656,27 @@ Feature: GraphQL collection support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.dummies.edges[1].node.name_converted" should be equal to "Converted 2"
+
+  @createSchema
+  Scenario: Retrieve a collection with different serialization groups for item_query and collection_query
+    Given there are 3 dummy with different GraphQL serialization groups objects
+    When I send the following GraphQL request:
+    """
+    {
+      dummyDifferentGraphQlSerializationGroups {
+        edges {
+          node {
+            name
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[0].node.name" should exist
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[1].node.name" should exist
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[2].node.name" should exist
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[0].node.title" should not exist
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[1].node.title" should not exist
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[2].node.title" should not exist

--- a/features/graphql/input_output.feature
+++ b/features/graphql/input_output.feature
@@ -107,7 +107,7 @@ Feature: GraphQL DTO input and output
     {
       "errors": [
         {
-          "message": "Cannot query field \"id\" on type \"DummyDtoNoOutputItem\".",
+          "message": "Cannot query field \"id\" on type \"DummyDtoNoOutput\".",
           "extensions": {
             "category": "graphql"
           },

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -21,7 +21,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      type1: __type(name: "DummyProductItem") {
+      type1: __type(name: "DummyProduct") {
         description,
         fields {
           name
@@ -35,7 +35,7 @@ Feature: GraphQL introspection support
           }
         }
       }
-      type2: __type(name: "DummyAggregateOfferItemConnection") {
+      type2: __type(name: "DummyAggregateOfferConnection") {
         description,
         fields {
           name
@@ -49,7 +49,7 @@ Feature: GraphQL introspection support
           }
         }
       }
-      type3: __type(name: "DummyAggregateOfferItemEdge") {
+      type3: __type(name: "DummyAggregateOfferEdge") {
         description,
         fields {
           name
@@ -69,12 +69,53 @@ Feature: GraphQL introspection support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.type1.description" should be equal to "Dummy Product."
-    And the JSON node "data.type1.fields[1].type.name" should be equal to "DummyAggregateOfferItemConnection"
+    And the JSON node "data.type1.fields[1].type.name" should be equal to "DummyAggregateOfferConnection"
     And the JSON node "data.type2.fields[0].name" should be equal to "edges"
-    And the JSON node "data.type2.fields[0].type.ofType.name" should be equal to "DummyAggregateOfferItemEdge"
+    And the JSON node "data.type2.fields[0].type.ofType.name" should be equal to "DummyAggregateOfferEdge"
     And the JSON node "data.type3.fields[0].name" should be equal to "node"
     And the JSON node "data.type3.fields[1].name" should be equal to "cursor"
-    And the JSON node "data.type3.fields[0].type.name" should be equal to "DummyAggregateOfferItem"
+    And the JSON node "data.type3.fields[0].type.name" should be equal to "DummyAggregateOffer"
+
+  Scenario: Introspect types with different serialization groups for item_query and collection_query
+    When I send the following GraphQL request:
+    """
+    {
+      type1: __type(name: "DummyDifferentGraphQlSerializationGroupCollection") {
+        description,
+        fields {
+          name
+          type {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+      type2: __type(name: "DummyDifferentGraphQlSerializationGroupItem") {
+        description,
+        fields {
+          name
+          type {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.type1.description" should be equal to "Dummy with different serialization groups for item_query and collection_query."
+    And the JSON node "data.type1.fields[3].name" should not exist
+    And the JSON node "data.type2.fields[3].name" should be equal to "title"
 
   Scenario: Introspect deprecated queries
     When I send the following GraphQL request:
@@ -121,7 +162,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      __type(name: "DeprecatedResourceItem") {
+      __type(name: "DeprecatedResource") {
         fields(includeDeprecated: true) {
           name
           isDeprecated
@@ -224,7 +265,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      __type(name: "DummyItem") {
+      __type(name: "Dummy") {
         description,
         fields {
           name
@@ -250,7 +291,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      typeQuery: __type(name: "DummyGroupItem") {
+      typeQuery: __type(name: "DummyGroup") {
         description,
         fields {
           name
@@ -390,7 +431,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      dummyItem: dummy(id: "/dummies/3") {
+      dummy: dummy(id: "/dummies/3") {
         name
         relatedDummy {
           id
@@ -403,6 +444,6 @@ Feature: GraphQL introspection support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.dummyItem.name" should be equal to "Dummy #3"
-    And the JSON node "data.dummyItem.relatedDummy.name" should be equal to "RelatedDummy #3"
-    And the JSON node "data.dummyItem.relatedDummy.__typename" should be equal to "RelatedDummyItem"
+    And the JSON node "data.dummy.name" should be equal to "Dummy #3"
+    And the JSON node "data.dummy.relatedDummy.name" should be equal to "RelatedDummy #3"
+    And the JSON node "data.dummy.relatedDummy.__typename" should be equal to "RelatedDummy"

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -61,7 +61,7 @@ Feature: GraphQL mutation support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.createFoo.foo.id" should be equal to "/foos/1"
     And the JSON node "data.createFoo.foo._id" should be equal to 1
-    And the JSON node "data.createFoo.foo.__typename" should be equal to "FooItem"
+    And the JSON node "data.createFoo.foo.__typename" should be equal to "Foo"
     And the JSON node "data.createFoo.foo.name" should be equal to "A new one"
     And the JSON node "data.createFoo.foo.bar" should be equal to "new"
     And the JSON node "data.createFoo.clientMutationId" should be equal to "myId"
@@ -113,7 +113,7 @@ Feature: GraphQL mutation support
     And the JSON node "data.createDummy.dummy.name" should be equal to "A dummy"
     And the JSON node "data.createDummy.dummy.foo" should have 0 elements
     And the JSON node "data.createDummy.dummy.relatedDummy.name" should be equal to "RelatedDummy #1"
-    And the JSON node "data.createDummy.dummy.relatedDummy.__typename" should be equal to "RelatedDummyItem"
+    And the JSON node "data.createDummy.dummy.relatedDummy.__typename" should be equal to "RelatedDummy"
     And the JSON node "data.createDummy.dummy.name_converted" should be equal to "Converted"
     And the JSON node "data.createDummy.clientMutationId" should be equal to "myId"
 

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -25,7 +25,7 @@ Feature: GraphQL query support
     {
       node(id: "/dummies/1") {
         id
-        ... on DummyItem {
+        ... on Dummy {
           name
         }
       }
@@ -395,3 +395,20 @@ Feature: GraphQL query support
       }
     }
     """
+
+  @createSchema
+  Scenario: Retrieve an item with different serialization groups for item_query and collection_query
+    Given there are 1 dummy with different GraphQL serialization groups objects
+    When I send the following GraphQL request:
+    """
+    {
+      dummyDifferentGraphQlSerializationGroup(id:"/dummy_different_graph_ql_serialization_groups/1") {
+        name
+        title
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroup.name" should be equal to "Name #1"
+    And the JSON node "data.dummyDifferentGraphQlSerializationGroup.title" should be equal to "Title #1"

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -402,7 +402,7 @@ Feature: GraphQL query support
     When I send the following GraphQL request:
     """
     {
-      dummyDifferentGraphQlSerializationGroup(id:"/dummy_different_graph_ql_serialization_groups/1") {
+      dummyDifferentGraphQlSerializationGroup(id: "/dummy_different_graph_ql_serialization_groups/1") {
         name
         title
       }

--- a/features/graphql/schema.feature
+++ b/features/graphql/schema.feature
@@ -6,7 +6,7 @@ Feature: GraphQL schema-related features
     Then the command output should contain:
     """
     ###Dummy Friend.###
-    type DummyFriendCollection implements Node {
+    type DummyFriend implements Node {
       id: ID!
 
       ###The id###
@@ -16,36 +16,25 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    ###Connection for DummyFriendCollection.###
-    type DummyFriendCollectionConnection {
-      edges: [DummyFriendCollectionEdge]
-      pageInfo: DummyFriendCollectionPageInfo!
+    ###Connection for DummyFriend.###
+    type DummyFriendConnection {
+      edges: [DummyFriendEdge]
+      pageInfo: DummyFriendPageInfo!
       totalCount: Int!
     }
 
-    ###Edge of DummyFriendCollection.###
-    type DummyFriendCollectionEdge {
-      node: DummyFriendCollection
+    ###Edge of DummyFriend.###
+    type DummyFriendEdge {
+      node: DummyFriend
       cursor: String!
     }
 
     ###Information about the current page.###
-    type DummyFriendCollectionPageInfo {
+    type DummyFriendPageInfo {
       endCursor: String
       startCursor: String
       hasNextPage: Boolean!
       hasPreviousPage: Boolean!
-    }
-
-    ###Dummy Friend.###
-    type DummyFriendItem implements Node {
-      id: ID!
-
-      ###The id###
-      _id: Int!
-
-      ###The dummy name###
-      name: String!
     }
     """
 
@@ -55,7 +44,7 @@ Feature: GraphQL schema-related features
     Then the command output should contain:
     """
     # Dummy Friend.
-    type DummyFriendCollection implements Node {
+    type DummyFriend implements Node {
       id: ID!
 
       # The id
@@ -65,35 +54,24 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    # Connection for DummyFriendCollection.
-    type DummyFriendCollectionConnection {
-      edges: [DummyFriendCollectionEdge]
-      pageInfo: DummyFriendCollectionPageInfo!
+    # Connection for DummyFriend.
+    type DummyFriendConnection {
+      edges: [DummyFriendEdge]
+      pageInfo: DummyFriendPageInfo!
       totalCount: Int!
     }
 
-    # Edge of DummyFriendCollection.
-    type DummyFriendCollectionEdge {
-      node: DummyFriendCollection
+    # Edge of DummyFriend.
+    type DummyFriendEdge {
+      node: DummyFriend
       cursor: String!
     }
 
     # Information about the current page.
-    type DummyFriendCollectionPageInfo {
+    type DummyFriendPageInfo {
       endCursor: String
       startCursor: String
       hasNextPage: Boolean!
       hasPreviousPage: Boolean!
-    }
-
-    # Dummy Friend.
-    type DummyFriendItem implements Node {
-      id: ID!
-
-      # The id
-      _id: Int!
-
-      # The dummy name
-      name: String!
     }
     """

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -61,12 +61,15 @@ final class TypeBuilder implements TypeBuilderInterface
             }
             $shortName .= 'Payload';
         }
-        if ('item_query' === $queryName) {
-            $shortName .= 'Item';
+        if (('item_query' === $queryName || 'collection_query' === $queryName) && $resourceMetadata->getGraphqlAttribute('item_query', 'normalization_context', [], true) !== $resourceMetadata->getGraphqlAttribute('collection_query', 'normalization_context', [], true)) {
+            if ('item_query' === $queryName) {
+                $shortName .= 'Item';
+            }
+            if ('collection_query' === $queryName) {
+                $shortName .= 'Collection';
+            }
         }
-        if ('collection_query' === $queryName) {
-            $shortName .= 'Collection';
-        }
+
         if ($wrapped && null !== $mutationName) {
             $shortName .= 'Data';
         }
@@ -158,7 +161,7 @@ final class TypeBuilder implements TypeBuilderInterface
                     return null;
                 }
 
-                $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName().'Item';
+                $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName();
 
                 return $this->typesContainer->has($shortName) ? $this->typesContainer->get($shortName) : null;
             },

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -61,7 +61,8 @@ final class TypeBuilder implements TypeBuilderInterface
             }
             $shortName .= 'Payload';
         }
-        if (('item_query' === $queryName || 'collection_query' === $queryName) && $resourceMetadata->getGraphqlAttribute('item_query', 'normalization_context', [], true) !== $resourceMetadata->getGraphqlAttribute('collection_query', 'normalization_context', [], true)) {
+        if (('item_query' === $queryName || 'collection_query' === $queryName)
+            && $resourceMetadata->getGraphqlAttribute('item_query', 'normalization_context', [], true) !== $resourceMetadata->getGraphqlAttribute('collection_query', 'normalization_context', [], true)) {
             if ('item_query' === $queryName) {
                 $shortName .= 'Item';
             }
@@ -69,7 +70,6 @@ final class TypeBuilder implements TypeBuilderInterface
                 $shortName .= 'Collection';
             }
         }
-
         if ($wrapped && null !== $mutationName) {
             $shortName .= 'Data';
         }

--- a/tests/Fixtures/TestBundle/Document/DummyDifferentGraphQlSerializationGroup.php
+++ b/tests/Fixtures/TestBundle/Document/DummyDifferentGraphQlSerializationGroup.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * Dummy with different serialization groups for item_query and collection_query.
+ *
+ * @author Mahmood Bazdar <mahmood@bazdar.me>
+ *
+ * @ApiResource(
+ *     graphql={
+ *         "item_query"={"normalization_context"={"groups"={"item_query"}}},
+ *         "collection_query"={"normalization_context"={"groups"={"collection_query"}}}
+ *     }
+ * )
+ * @ODM\Document
+ */
+class DummyDifferentGraphQlSerializationGroup
+{
+    /**
+     * @var int The id
+     *
+     * @ODM\Id(strategy="INCREMENT", type="integer", nullable=true)
+     * @Groups({"item_query", "collection_query"})
+     */
+    private $id;
+
+    /**
+     * @var string The dummy name
+     *
+     * @ODM\Field(type="string")
+     * @Groups({"item_query", "collection_query"})
+     */
+    private $name;
+
+    /**
+     * @var string The dummy title
+     *
+     * @ODM\Field(nullable=true)
+     * @Groups({"item_query"})
+     */
+    private $title;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyDifferentGraphQlSerializationGroup.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyDifferentGraphQlSerializationGroup.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * Dummy with different serialization groups for item_query and collection_query.
+ *
+ * @author Mahmood Bazdar <mahmood@bazdar.me>
+ *
+ * @ApiResource(
+ *     graphql={
+ *         "item_query"={"normalization_context"={"groups"={"item_query"}}},
+ *         "collection_query"={"normalization_context"={"groups"={"collection_query"}}}
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class DummyDifferentGraphQlSerializationGroup
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer", nullable=true)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @Groups({"item_query", "collection_query"})
+     */
+    private $id;
+
+    /**
+     * @var string The dummy name
+     *
+     * @ORM\Column
+     * @Groups({"item_query", "collection_query"})
+     */
+    private $name;
+
+    /**
+     * @var string The dummy title
+     *
+     * @ORM\Column(nullable=true)
+     * @Groups({"item_query"})
+     */
+    private $title;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+}

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -107,14 +107,14 @@ class TypeBuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider resourceObjectTypeSerializationGroupsProvider
+     * @dataProvider resourceObjectTypeQuerySerializationGroupsProvider
      */
-    public function testGetResourceObjectTypeQuerySerializationGroups(string $itemSerializationGroup, string $collectionSerilizationGroup, string $shortName, string $queryName)
+    public function testGetResourceObjectTypeQuerySerializationGroups(string $itemSerializationGroup, string $collectionSerializationGroup, string $shortName, string $queryName)
     {
         $resourceMetadata = (new ResourceMetadata('shortName', 'description'))
             ->withGraphql([
                 'item_query' => ['normalization_context' => ['groups' => [$itemSerializationGroup]]],
-                'collection_query' => ['normalization_context' => ['groups' => [$collectionSerilizationGroup]]],
+                'collection_query' => ['normalization_context' => ['groups' => [$collectionSerializationGroup]]],
             ]);
         $this->typesContainerProphecy->has($shortName)->shouldBeCalled()->willReturn(false);
         $this->typesContainerProphecy->set($shortName, Argument::type(ObjectType::class))->shouldBeCalled();
@@ -124,14 +124,9 @@ class TypeBuilderTest extends TestCase
         /** @var ObjectType $resourceObjectType */
         $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, $queryName, null);
         $this->assertSame($shortName, $resourceObjectType->name);
-
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
-        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, $queryName, null, 0, null)->shouldBeCalled();
-        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
-        $resourceObjectType->config['fields']();
     }
 
-    public function resourceObjectTypeSerializationGroupsProvider(): array
+    public function resourceObjectTypeQuerySerializationGroupsProvider(): array
     {
         return [
             'same serialization groups for item_query and collection_query' => [
@@ -140,13 +135,13 @@ class TypeBuilderTest extends TestCase
                 'shortName',
                 'item_query',
             ],
-            'different serialization groups for item_query and collection_query when calling to item_query' => [
+            'different serialization groups for item_query and collection_query when using item_query' => [
                 'item_group',
                 'collection_group',
                 'shortNameItem',
                 'item_query',
             ],
-            'different serialization groups for item_query and collection_query when calling to collection_query' => [
+            'different serialization groups for item_query and collection_query when using collection_query' => [
                 'item_group',
                 'collection_group',
                 'shortNameCollection',


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3059
| License       | MIT
| Doc PR        | N/A

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
Adding condition based on serialization groups for GraphQL item_query and collection_query types.
check the issue ticket for more info.

@lukasluecke Sorry it took that long. I hope you didn't spend time on this.
