### PR TITLE
Add entrypoints sorting

### DIFF
--- a/features/bootstrap/JsonApiContext.php
+++ b/features/bootstrap/JsonApiContext.php
@@ -108,6 +108,26 @@ final class JsonApiContext implements Context
     }
 
     /**
+     * @Then the JSON node :node should be sorted
+     * @Then the JSON should be sorted
+     */
+    public function theJsonNodeShouldBeSorted($node = '')
+    {
+        $actual = (array) $this->getValueOfNode($node);
+
+        if (!is_array($actual)) {
+            throw new \Exception(sprintf('The "%s" node value is not an array', $node));
+        }
+
+        $expected = $actual;
+        ksort($expected);
+
+        if ($actual !== $expected) {
+            throw new ExpectationFailedException(sprintf('The json node "%s" is not sorted by keys', $node));
+        }
+    }
+
+    /**
      * @Given there is a RelatedDummy
      */
     public function thereIsARelatedDummy()

--- a/features/hydra/entrypoint.feature
+++ b/features/hydra/entrypoint.feature
@@ -8,6 +8,7 @@ Feature: Entrypoint support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be sorted
     And the JSON node "@context" should be equal to "/contexts/Entrypoint"
     And the JSON node "@id" should be equal to "/"
     And the JSON node "@type" should be equal to "Entrypoint"

--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -65,6 +65,8 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
             }
         }
 
+        ksort($entrypoint);
+
         return $entrypoint;
     }
 

--- a/tests/Hydra/Serializer/EntrypointNormalizerTest.php
+++ b/tests/Hydra/Serializer/EntrypointNormalizerTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FooDummy;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -47,14 +48,16 @@ class EntrypointNormalizerTest extends TestCase
 
     public function testNormalize()
     {
-        $collection = new ResourceNameCollection([Dummy::class]);
+        $collection = new ResourceNameCollection([FooDummy::class, Dummy::class]);
         $entrypoint = new Entrypoint($collection);
 
         $factoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy', null, null, null, ['get']))->shouldBeCalled();
+        $factoryProphecy->create(FooDummy::class)->willReturn(new ResourceMetadata('FooDummy', null, null, null, ['get']))->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/api/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResourceClass(FooDummy::class)->willReturn('/api/foo_dummies')->shouldBeCalled();
 
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
         $urlGeneratorProphecy->generate('api_entrypoint')->willReturn('/api')->shouldBeCalled();
@@ -67,6 +70,7 @@ class EntrypointNormalizerTest extends TestCase
             '@id' => '/api',
             '@type' => 'Entrypoint',
             'dummy' => '/api/dummies',
+            'fooDummy' => '/api/foo_dummies',
         ];
         $this->assertEquals($expected, $normalizer->normalize($entrypoint, EntrypointNormalizer::FORMAT));
     }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3091
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->

As described in https://github.com/api-platform/core/issues/3091, the main entrypoint returns resources names without any coherent sorting, as it can change depending of your `get_declared_classes()` returned values order.

Caution : this can be a BC break as tests can fail for existing projects.
