### PR TITLE
Fix missing "as" attribute for pushed resources 

### DIFF
--- a/features/push_relations/push.feature
+++ b/features/push_relations/push.feature
@@ -9,9 +9,9 @@ Feature: Push relations using HTTP/2
     Given there are 2 dummy objects with relatedDummy
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/dummies"
-    Then the header "Link" should be equal to '</related_dummies/1>; rel="preload",</related_dummies/2>; rel="preload",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
+    Then the header "Link" should be equal to '</related_dummies/1>; rel="preload"; as="fetch",</related_dummies/2>; rel="preload"; as="fetch",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
 
   Scenario: Push the relations of an item
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/dummies/1"
-    Then the header "Link" should be equal to '</related_dummies/1>; rel="preload",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
+    Then the header "Link" should be equal to '</related_dummies/1>; rel="preload"; as="fetch",<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'

--- a/src/EventListener/SerializeListener.php
+++ b/src/EventListener/SerializeListener.php
@@ -101,7 +101,7 @@ final class SerializeListener
 
         $linkProvider = $request->attributes->get('_links', new GenericLinkProvider());
         foreach ($resourcesToPush as $resourceToPush) {
-            $linkProvider = $linkProvider->withLink(new Link('preload', $resourceToPush));
+            $linkProvider = $linkProvider->withLink((new Link('preload', $resourceToPush))->withAttribute('as', 'fetch'));
         }
         $request->attributes->set('_links', $linkProvider);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3107 
| License       | MIT