### PR TITLE
Bugfix: Notice: Undefined index: method thrown in SerializerContextBu…

### DIFF
--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -94,7 +94,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         }
 
         foreach ($resourceMetadata->getItemOperations() as $operation) {
-            if ('PATCH' === $operation['method'] && \in_array('application/merge-patch+json', $operation['input_formats']['json'] ?? [], true)) {
+            if (\in_array('application/merge-patch+json', $operation['input_formats']['json'] ?? [], true) && 'PATCH' === $operation['method']) {
                 $context['skip_null_values'] = true;
 
                 break;

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -94,7 +94,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         }
 
         foreach ($resourceMetadata->getItemOperations() as $operation) {
-            if (\in_array('application/merge-patch+json', $operation['input_formats']['json'] ?? [], true) && 'PATCH' === $operation['method']) {
+            if ('PATCH' === ($operation['method'] ?? '') && \in_array('application/merge-patch+json', $operation['input_formats']['json'] ?? [], true)) {
                 $context['skip_null_values'] = true;
 
                 break;


### PR DESCRIPTION
Bugfix: Notice: Undefined index: method thrown in SerializerContextBuilder (since version 2.5.0)
- switch the order of the checks in the if statement to prevent checking for non-existent 'method' key in $operation check.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no tests written
| Fixed tickets | no ticket yet
| License       | MIT
| Doc PR        | api-platform/doc#1234

Upgrading from 2.4.* to 2.5 caused the above error. If you simply switch the order of the checks everything works as expected.
