### PR TITLE
[GraphQL] If resource has no operations, skip only root query fields

### DIFF
--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -105,7 +105,7 @@ final class TypeConverter implements TypeConverterInterface
 
         try {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-            if ([] === ($resourceMetadata->getGraphql() ?? [])) {
+            if (0 === $depth && [] === ($resourceMetadata->getGraphql() ?? [])) {
                 return null;
             }
         } catch (ResourceClassNotFoundException $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3136 
| License       | MIT
| Doc PR        | N/A

This way we still generate the types necessary to use these resources elsewhere, e.g. in relations.