### PR TITLE
[MongoDB] Possibility to add execute options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.0
+
+* MongoDB: Possibility to add execute options (aggregate command fields) for a resource, like `allowDiskUse` (#3144)
+
 ## 2.5.0
 
 * Fix BC-break when using short-syntax notation for `access_control`

--- a/src/Bridge/Doctrine/MongoDbOdm/CollectionDataProvider.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/CollectionDataProvider.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Extension\AggregationResultColle
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -32,14 +33,16 @@ use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 final class CollectionDataProvider implements CollectionDataProviderInterface, RestrictedDataProviderInterface
 {
     private $managerRegistry;
+    private $resourceMetadataFactory;
     private $collectionExtensions;
 
     /**
      * @param AggregationCollectionExtensionInterface[] $collectionExtensions
      */
-    public function __construct(ManagerRegistry $managerRegistry, iterable $collectionExtensions = [])
+    public function __construct(ManagerRegistry $managerRegistry, ResourceMetadataFactoryInterface $resourceMetadataFactory, iterable $collectionExtensions = [])
     {
         $this->managerRegistry = $managerRegistry;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->collectionExtensions = $collectionExtensions;
     }
 
@@ -72,6 +75,10 @@ final class CollectionDataProvider implements CollectionDataProviderInterface, R
             }
         }
 
-        return $aggregationBuilder->hydrate($resourceClass)->execute();
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+        $attribute = $resourceMetadata->getCollectionOperationAttribute($operationName, 'doctrine_mongodb', [], true);
+        $executeOptions = $attribute['execute_options'] ?? [];
+
+        return $aggregationBuilder->hydrate($resourceClass)->execute($executeOptions);
     }
 }

--- a/src/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtension.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Extension;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Paginator;
 use ApiPlatform\Core\DataProvider\Pagination;
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -33,11 +34,13 @@ use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 final class PaginationExtension implements AggregationResultCollectionExtensionInterface
 {
     private $managerRegistry;
+    private $resourceMetadataFactory;
     private $pagination;
 
-    public function __construct(ManagerRegistry $managerRegistry, Pagination $pagination)
+    public function __construct(ManagerRegistry $managerRegistry, ResourceMetadataFactoryInterface $resourceMetadataFactory, Pagination $pagination)
     {
         $this->managerRegistry = $managerRegistry;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->pagination = $pagination;
     }
 
@@ -113,7 +116,11 @@ final class PaginationExtension implements AggregationResultCollectionExtensionI
             throw new RuntimeException(sprintf('The manager for "%s" must be an instance of "%s".', $resourceClass, DocumentManager::class));
         }
 
-        return new Paginator($aggregationBuilder->execute(), $manager->getUnitOfWork(), $resourceClass, $aggregationBuilder->getPipeline());
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+        $attribute = $resourceMetadata->getCollectionOperationAttribute($operationName, 'doctrine_mongodb', [], true);
+        $executeOptions = $attribute['execute_options'] ?? [];
+
+        return new Paginator($aggregationBuilder->execute($executeOptions), $manager->getUnitOfWork(), $resourceClass, $aggregationBuilder->getPipeline());
     }
 
     private function addCountToContext(Builder $aggregationBuilder, array $context): array

--- a/src/Bridge/Doctrine/MongoDbOdm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/ItemDataProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -38,14 +39,16 @@ final class ItemDataProvider implements DenormalizedIdentifiersAwareItemDataProv
     use IdentifierManagerTrait;
 
     private $managerRegistry;
+    private $resourceMetadataFactory;
     private $itemExtensions;
 
     /**
      * @param AggregationItemExtensionInterface[] $itemExtensions
      */
-    public function __construct(ManagerRegistry $managerRegistry, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, iterable $itemExtensions = [])
+    public function __construct(ManagerRegistry $managerRegistry, ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, iterable $itemExtensions = [])
     {
         $this->managerRegistry = $managerRegistry;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->itemExtensions = $itemExtensions;
@@ -95,6 +98,10 @@ final class ItemDataProvider implements DenormalizedIdentifiersAwareItemDataProv
             }
         }
 
-        return $aggregationBuilder->hydrate($resourceClass)->execute()->current() ?: null;
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+        $attribute = $resourceMetadata->getItemOperationAttribute($operationName, 'doctrine_mongodb', [], true);
+        $executeOptions = $attribute['execute_options'] ?? [];
+
+        return $aggregationBuilder->hydrate($resourceClass)->execute($executeOptions)->current() ?: null;
     }
 }

--- a/src/Bridge/Doctrine/MongoDbOdm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/SubresourceDataProvider.php
@@ -24,6 +24,7 @@ use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -43,6 +44,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
     use IdentifierManagerTrait;
 
     private $managerRegistry;
+    private $resourceMetadataFactory;
     private $collectionExtensions;
     private $itemExtensions;
 
@@ -50,9 +52,10 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
      * @param AggregationCollectionExtensionInterface[] $collectionExtensions
      * @param AggregationItemExtensionInterface[]       $itemExtensions
      */
-    public function __construct(ManagerRegistry $managerRegistry, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, iterable $collectionExtensions = [], iterable $itemExtensions = [])
+    public function __construct(ManagerRegistry $managerRegistry, ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, iterable $collectionExtensions = [], iterable $itemExtensions = [])
     {
         $this->managerRegistry = $managerRegistry;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->collectionExtensions = $collectionExtensions;
@@ -80,7 +83,11 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
             throw new ResourceClassNotSupportedException('The given resource class is not a subresource.');
         }
 
-        $aggregationBuilder = $this->buildAggregation($identifiers, $context, $repository->createAggregationBuilder(), \count($context['identifiers']));
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+        $attribute = $resourceMetadata->getSubresourceOperationAttribute($operationName, 'doctrine_mongodb', [], true);
+        $executeOptions = $attribute['execute_options'] ?? [];
+
+        $aggregationBuilder = $this->buildAggregation($identifiers, $context, $executeOptions, $repository->createAggregationBuilder(), \count($context['identifiers']));
 
         if (true === $context['collection']) {
             foreach ($this->collectionExtensions as $extension) {
@@ -98,7 +105,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
             }
         }
 
-        $iterator = $aggregationBuilder->hydrate($resourceClass)->execute();
+        $iterator = $aggregationBuilder->hydrate($resourceClass)->execute($executeOptions);
 
         return $context['collection'] ? $iterator->toArray() : ($iterator->current() ?: null);
     }
@@ -106,7 +113,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
     /**
      * @throws RuntimeException
      */
-    private function buildAggregation(array $identifiers, array $context, Builder $previousAggregationBuilder, int $remainingIdentifiers, Builder $topAggregationBuilder = null): Builder
+    private function buildAggregation(array $identifiers, array $context, array $executeOptions, Builder $previousAggregationBuilder, int $remainingIdentifiers, Builder $topAggregationBuilder = null): Builder
     {
         if ($remainingIdentifiers <= 0) {
             return $previousAggregationBuilder;
@@ -154,9 +161,9 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
         }
 
         // Recurse aggregations
-        $aggregation = $this->buildAggregation($identifiers, $context, $aggregation, --$remainingIdentifiers, $topAggregationBuilder);
+        $aggregation = $this->buildAggregation($identifiers, $context, $executeOptions, $aggregation, --$remainingIdentifiers, $topAggregationBuilder);
 
-        $results = $aggregation->execute()->toArray();
+        $results = $aggregation->execute($executeOptions)->toArray();
         $in = array_reduce($results, function ($in, $result) use ($previousAssociationProperty) {
             return $in + array_map(function ($result) {
                 return $result['_id'];

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
@@ -24,11 +24,13 @@
 
         <service id="api_platform.doctrine_mongodb.odm.collection_data_provider" public="false" abstract="true">
             <argument type="service" id="doctrine_mongodb"/>
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="tagged" tag="api_platform.doctrine_mongodb.odm.aggregation_extension.collection" />
         </service>
 
         <service id="api_platform.doctrine_mongodb.odm.item_data_provider" public="false" abstract="true">
             <argument type="service" id="doctrine_mongodb"/>
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory"/>
             <argument type="service" id="api_platform.metadata.property.metadata_factory"/>
             <argument type="tagged" tag="api_platform.doctrine_mongodb.odm.aggregation_extension.item" />
@@ -36,6 +38,7 @@
 
         <service id="api_platform.doctrine_mongodb.odm.subresource_data_provider" public="false" abstract="true">
             <argument type="service" id="doctrine_mongodb" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="tagged" tag="api_platform.doctrine_mongodb.odm.aggregation_extension.collection" />
@@ -46,7 +49,6 @@
                  parent="api_platform.doctrine_mongodb.odm.collection_data_provider"
                  class="ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\CollectionDataProvider">
             <tag name="api_platform.collection_data_provider"/>
-
         </service>
         <service id="api_platform.doctrine_mongodb.odm.default.item_data_provider"
                  parent="api_platform.doctrine_mongodb.odm.item_data_provider"
@@ -138,6 +140,7 @@
         <service id="api_platform.doctrine_mongodb.odm.aggregation_extension.pagination"
                  class="ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Extension\PaginationExtension" public="false">
             <argument type="service" id="doctrine_mongodb"/>
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.pagination" />
 
             <tag name="api_platform.doctrine_mongodb.odm.aggregation_extension.collection"/>

--- a/tests/Bridge/Doctrine/MongoDbOdm/CollectionDataProviderTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/CollectionDataProviderTest.php
@@ -17,6 +17,8 @@ use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\CollectionDataProvider;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Extension\AggregationCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Extension\AggregationResultCollectionExtensionInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectRepository;
@@ -33,13 +35,27 @@ use PHPUnit\Framework\TestCase;
  */
 class CollectionDataProviderTest extends TestCase
 {
+    private $managerRegistryProphecy;
+    private $resourceMetadataFactoryProphecy;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
+        $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+    }
+
     public function testGetCollection()
     {
         $iterator = $this->prophesize(Iterator::class)->reveal();
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
         $aggregationBuilderProphecy->hydrate(Dummy::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
-        $aggregationBuilderProphecy->execute()->willReturn($iterator)->shouldBeCalled();
+        $aggregationBuilderProphecy->execute([])->willReturn($iterator)->shouldBeCalled();
         $aggregationBuilder = $aggregationBuilderProphecy->reveal();
 
         $repositoryProphecy = $this->prophesize(DocumentRepository::class);
@@ -48,13 +64,46 @@ class CollectionDataProviderTest extends TestCase
         $managerProphecy = $this->prophesize(DocumentManager::class);
         $managerProphecy->getRepository(Dummy::class)->willReturn($repositoryProphecy->reveal())->shouldBeCalled();
 
-        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
-        $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
+        $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
+
+        $this->resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
 
         $extensionProphecy = $this->prophesize(AggregationCollectionExtensionInterface::class);
         $extensionProphecy->applyToCollection($aggregationBuilder, Dummy::class, 'foo', [])->shouldBeCalled();
 
-        $dataProvider = new CollectionDataProvider($managerRegistryProphecy->reveal(), [$extensionProphecy->reveal()]);
+        $dataProvider = new CollectionDataProvider($this->managerRegistryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), [$extensionProphecy->reveal()]);
+        $this->assertEquals($iterator, $dataProvider->getCollection(Dummy::class, 'foo'));
+    }
+
+    public function testGetCollectionWithExecuteOptions()
+    {
+        $iterator = $this->prophesize(Iterator::class)->reveal();
+
+        $aggregationBuilderProphecy = $this->prophesize(Builder::class);
+        $aggregationBuilderProphecy->hydrate(Dummy::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
+        $aggregationBuilderProphecy->execute(['allowDiskUse' => true])->willReturn($iterator)->shouldBeCalled();
+        $aggregationBuilder = $aggregationBuilderProphecy->reveal();
+
+        $repositoryProphecy = $this->prophesize(DocumentRepository::class);
+        $repositoryProphecy->createAggregationBuilder()->willReturn($aggregationBuilder)->shouldBeCalled();
+
+        $managerProphecy = $this->prophesize(DocumentManager::class);
+        $managerProphecy->getRepository(Dummy::class)->willReturn($repositoryProphecy->reveal())->shouldBeCalled();
+
+        $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
+
+        $this->resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(
+            'Dummy',
+            null,
+            null,
+            null,
+            ['foo' => ['doctrine_mongodb' => ['execute_options' => ['allowDiskUse' => true]]]]
+        ));
+
+        $extensionProphecy = $this->prophesize(AggregationCollectionExtensionInterface::class);
+        $extensionProphecy->applyToCollection($aggregationBuilder, Dummy::class, 'foo', [])->shouldBeCalled();
+
+        $dataProvider = new CollectionDataProvider($this->managerRegistryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), [$extensionProphecy->reveal()]);
         $this->assertEquals($iterator, $dataProvider->getCollection(Dummy::class, 'foo'));
     }
 
@@ -69,15 +118,14 @@ class CollectionDataProviderTest extends TestCase
         $managerProphecy = $this->prophesize(DocumentManager::class);
         $managerProphecy->getRepository(Dummy::class)->willReturn($repositoryProphecy->reveal())->shouldBeCalled();
 
-        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
-        $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
+        $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
 
         $extensionProphecy = $this->prophesize(AggregationResultCollectionExtensionInterface::class);
         $extensionProphecy->applyToCollection($aggregationBuilder, Dummy::class, 'foo', [])->shouldBeCalled();
         $extensionProphecy->supportsResult(Dummy::class, 'foo', [])->willReturn(true)->shouldBeCalled();
         $extensionProphecy->getResult($aggregationBuilder, Dummy::class, 'foo', [])->willReturn([])->shouldBeCalled();
 
-        $dataProvider = new CollectionDataProvider($managerRegistryProphecy->reveal(), [$extensionProphecy->reveal()]);
+        $dataProvider = new CollectionDataProvider($this->managerRegistryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), [$extensionProphecy->reveal()]);
         $this->assertEquals([], $dataProvider->getCollection(Dummy::class, 'foo'));
     }
 
@@ -91,21 +139,19 @@ class CollectionDataProviderTest extends TestCase
         $managerProphecy = $this->prophesize(DocumentManager::class);
         $managerProphecy->getRepository(Dummy::class)->willReturn($repositoryProphecy->reveal())->shouldBeCalled();
 
-        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
-        $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
+        $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($managerProphecy->reveal())->shouldBeCalled();
 
-        $dataProvider = new CollectionDataProvider($managerRegistryProphecy->reveal());
+        $dataProvider = new CollectionDataProvider($this->managerRegistryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal());
         $this->assertEquals([], $dataProvider->getCollection(Dummy::class, 'foo'));
     }
 
     public function testUnsupportedClass()
     {
-        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
-        $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn(null)->shouldBeCalled();
+        $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn(null)->shouldBeCalled();
 
         $extensionProphecy = $this->prophesize(AggregationResultCollectionExtensionInterface::class);
 
-        $dataProvider = new CollectionDataProvider($managerRegistryProphecy->reveal(), [$extensionProphecy->reveal()]);
+        $dataProvider = new CollectionDataProvider($this->managerRegistryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), [$extensionProphecy->reveal()]);
         $this->assertFalse($dataProvider->supports(Dummy::class, 'foo'));
     }
 }

--- a/tests/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtensionTest.php
@@ -42,24 +42,28 @@ use PHPUnit\Framework\TestCase;
 class PaginationExtensionTest extends TestCase
 {
     private $managerRegistryProphecy;
+    private $resourceMetadataFactoryProphecy;
 
+    /**
+     * {@inheritdoc}
+     */
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
+        $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
     }
 
     public function testApplyToCollection()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_items_per_page' => 40,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'page_parameter_name' => '_page',
@@ -71,6 +75,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -78,14 +83,13 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionWithItemPerPageZero()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_items_per_page' => 0,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'items_per_page' => 0,
@@ -98,6 +102,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -108,14 +113,13 @@ class PaginationExtensionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Page should not be greater than 1 if limit is equal to 0');
 
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_items_per_page' => 0,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'items_per_page' => 0,
@@ -129,6 +133,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->prophesize(ManagerRegistry::class)->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -139,14 +144,13 @@ class PaginationExtensionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Limit should not be less than 0');
 
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_items_per_page' => -20,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'items_per_page' => -20,
@@ -160,6 +164,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -167,14 +172,13 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionWithItemPerPageTooHigh()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_client_items_per_page' => true,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'page_parameter_name' => '_page',
@@ -187,6 +191,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -194,14 +199,13 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionWithGraphql()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_client_items_per_page' => 20,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory);
 
@@ -211,6 +215,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -218,14 +223,13 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionWithGraphqlAndCountContext()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_client_items_per_page' => 20,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory);
 
@@ -244,6 +248,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -251,9 +256,8 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionNoFilters()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory);
 
@@ -263,6 +267,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -270,9 +275,8 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionPaginationDisabled()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'enabled' => false,
@@ -285,6 +289,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -292,9 +297,8 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionGraphQlPaginationDisabled()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [], [
             'enabled' => false,
@@ -307,6 +311,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -314,14 +319,13 @@ class PaginationExtensionTest extends TestCase
 
     public function testApplyToCollectionWithMaximumItemsPerPage()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $attributes = [
             'pagination_enabled' => true,
             'pagination_client_enabled' => true,
             'pagination_maximum_items_per_page' => 80,
         ];
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], [], $attributes));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'client_enabled' => true,
@@ -335,6 +339,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', 'op', $context);
@@ -342,14 +347,14 @@ class PaginationExtensionTest extends TestCase
 
     public function testSupportsResult()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory);
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $this->assertTrue($extension->supportsResult('Foo', 'op'));
@@ -357,9 +362,8 @@ class PaginationExtensionTest extends TestCase
 
     public function testSupportsResultClientNotAllowedToPaginate()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'enabled' => false,
@@ -368,6 +372,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $this->assertFalse($extension->supportsResult('Foo', 'op', ['filters' => ['pagination' => true]]));
@@ -375,9 +380,8 @@ class PaginationExtensionTest extends TestCase
 
     public function testSupportsResultPaginationDisabled()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [
             'enabled' => false,
@@ -385,6 +389,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $this->assertFalse($extension->supportsResult('Foo', 'op', ['filters' => ['enabled' => false]]));
@@ -392,9 +397,8 @@ class PaginationExtensionTest extends TestCase
 
     public function testSupportsResultGraphQlPaginationDisabled()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $this->resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadata(null, null, null, [], []));
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory, [], [
             'enabled' => false,
@@ -402,6 +406,7 @@ class PaginationExtensionTest extends TestCase
 
         $extension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
         $this->assertFalse($extension->supportsResult('Foo', 'op', ['filters' => ['enabled' => false], 'graphql_operation_name' => 'op']));
@@ -409,8 +414,7 @@ class PaginationExtensionTest extends TestCase
 
     public function testGetResult()
     {
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
 
         $pagination = new Pagination($resourceMetadataFactory);
 
@@ -419,6 +423,8 @@ class PaginationExtensionTest extends TestCase
         $documentManager = DocumentManager::create(null, $config);
 
         $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($documentManager);
+
+        $this->resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata());
 
         $iteratorProphecy = $this->prophesize(Iterator::class);
         $iteratorProphecy->toArray()->willReturn([
@@ -432,7 +438,7 @@ class PaginationExtensionTest extends TestCase
         ]);
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
-        $aggregationBuilderProphecy->execute()->willReturn($iteratorProphecy->reveal());
+        $aggregationBuilderProphecy->execute([])->willReturn($iteratorProphecy->reveal());
         $aggregationBuilderProphecy->getPipeline()->willReturn([
             [
                 '$facet' => [
@@ -449,10 +455,70 @@ class PaginationExtensionTest extends TestCase
 
         $paginationExtension = new PaginationExtension(
             $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
             $pagination
         );
 
         $result = $paginationExtension->getResult($aggregationBuilderProphecy->reveal(), Dummy::class);
+
+        $this->assertInstanceOf(PartialPaginatorInterface::class, $result);
+        $this->assertInstanceOf(PaginatorInterface::class, $result);
+    }
+
+    public function testGetResultWithExecuteOptions()
+    {
+        $resourceMetadataFactory = $this->resourceMetadataFactoryProphecy->reveal();
+
+        $pagination = new Pagination($resourceMetadataFactory);
+
+        $fixturesPath = \dirname((string) (new \ReflectionClass(Dummy::class))->getFileName());
+        $config = DoctrineMongoDbOdmSetup::createAnnotationMetadataConfiguration([$fixturesPath], true);
+        $documentManager = DocumentManager::create(null, $config);
+
+        $this->managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($documentManager);
+
+        $this->resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(
+            'Dummy',
+            null,
+            null,
+            null,
+            ['foo' => ['doctrine_mongodb' => ['execute_options' => ['allowDiskUse' => true]]]]
+        ));
+
+        $iteratorProphecy = $this->prophesize(Iterator::class);
+        $iteratorProphecy->toArray()->willReturn([
+            [
+                'count' => [
+                    [
+                        'count' => 9,
+                    ],
+                ],
+            ],
+        ]);
+
+        $aggregationBuilderProphecy = $this->prophesize(Builder::class);
+        $aggregationBuilderProphecy->execute(['allowDiskUse' => true])->willReturn($iteratorProphecy->reveal());
+        $aggregationBuilderProphecy->getPipeline()->willReturn([
+            [
+                '$facet' => [
+                    'results' => [
+                        ['$skip' => 3],
+                        ['$limit' => 6],
+                    ],
+                    'count' => [
+                        ['$count' => 'count'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $paginationExtension = new PaginationExtension(
+            $this->managerRegistryProphecy->reveal(),
+            $resourceMetadataFactory,
+            $pagination
+        );
+
+        $result = $paginationExtension->getResult($aggregationBuilderProphecy->reveal(), Dummy::class, 'foo');
 
         $this->assertInstanceOf(PartialPaginatorInterface::class, $result);
         $this->assertInstanceOf(PaginatorInterface::class, $result);

--- a/tests/Fixtures/TestBundle/Document/Dummy.php
+++ b/tests/Fixtures/TestBundle/Document/Dummy.php
@@ -27,6 +27,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Alexandre Delplace <alexandre.delplacemille@gmail.com>
  *
  * @ApiResource(attributes={
+ *     "doctrine_mongodb"={
+ *         "execute_options"={
+ *             "allowDiskUse"=true
+ *         }
+ *     },
  *     "filters"={
  *         "my_dummy.mongodb.boolean",
  *         "my_dummy.mongodb.date",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/918

Allow to use execute options (corresponding to the [aggregate command fields](https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields) in MongoDB) like `allowDiskUse`.

To do so, modify the resource configuration like this:
```php
/**
 * @ApiResource(attributes={
 *     "doctrine_mongodb"={
 *       "execute_options"={
 *         "allowDiskUse"=true
 *       }
 *     }
 * })
 * @ODM\Document
 */
```