### PR TITLE
Add test for updating embedded relation using plain identifier

### DIFF
--- a/features/json/relation.feature
+++ b/features/json/relation.feature
@@ -1,0 +1,228 @@
+Feature: JSON relations support
+  In order to use a hypermedia API
+  As a client software developer
+  I need to be able to update relations between resources
+
+  @createSchema
+  Scenario: Create a third level
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/third_levels" with body:
+    """
+    {
+      "level": 3
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/ThirdLevel",
+      "@id": "/third_levels/1",
+      "@type": "ThirdLevel",
+      "fourthLevel": null,
+      "badFourthLevel": null,
+      "id": 1,
+      "level": 3,
+      "test": true
+    }
+    """
+
+  Scenario: Create a new relation
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/relation_embedders" with body:
+    """
+    {
+      "anotherRelated": {
+        "symfony": "laravel"
+      }
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelationEmbedder",
+      "@id": "/relation_embedders/1",
+      "@type": "RelationEmbedder",
+      "krondstadt": "Krondstadt",
+      "anotherRelated": {
+        "@id": "/related_dummies/1",
+        "@type": "https://schema.org/Product",
+        "symfony": "laravel",
+        "thirdLevel": null
+      },
+      "related": null
+    }
+    """
+
+  Scenario: Update the relation with a new one
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "PUT" request to "/relation_embedders/1" with body:
+    """
+    {
+      "anotherRelated": {
+        "symfony": "laravel2"
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelationEmbedder",
+      "@id": "/relation_embedders/1",
+      "@type": "RelationEmbedder",
+      "krondstadt": "Krondstadt",
+      "anotherRelated": {
+        "@id": "/related_dummies/2",
+        "@type": "https://schema.org/Product",
+        "symfony": "laravel2",
+        "thirdLevel": null
+      },
+      "related": null
+    }
+    """
+
+  Scenario: Update an embedded relation using an IRI
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "PUT" request to "/relation_embedders/1" with body:
+    """
+    {
+      "anotherRelated": {
+        "id": "/related_dummies/1",
+        "symfony": "API Platform"
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelationEmbedder",
+      "@id": "/relation_embedders/1",
+      "@type": "RelationEmbedder",
+      "krondstadt": "Krondstadt",
+      "anotherRelated": {
+        "@id": "/related_dummies/1",
+        "@type": "https://schema.org/Product",
+        "symfony": "API Platform",
+        "thirdLevel": null
+      },
+      "related": null
+    }
+    """
+
+  Scenario: Update an embedded relation using plain identifiers
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "PUT" request to "/relation_embedders/1" with body:
+    """
+    {
+      "anotherRelated": {
+        "id": 1,
+        "symfony": "API Platform 2"
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelationEmbedder",
+      "@id": "/relation_embedders/1",
+      "@type": "RelationEmbedder",
+      "krondstadt": "Krondstadt",
+      "anotherRelated": {
+        "@id": "/related_dummies/1",
+        "@type": "https://schema.org/Product",
+        "symfony": "API Platform 2",
+        "thirdLevel": null
+      },
+      "related": null
+    }
+    """
+
+  Scenario: Create a related dummy with a relation
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/related_dummies" with body:
+    """
+    {
+      "thirdLevel": "1"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedDummy",
+      "@id": "/related_dummies/3",
+      "@type": "https://schema.org/Product",
+      "id": 3,
+      "name": null,
+      "symfony": "symfony",
+      "dummyDate": null,
+      "thirdLevel": {
+        "@id": "/third_levels/1",
+        "@type": "ThirdLevel",
+        "fourthLevel": null
+      },
+      "relatedToDummyFriend": [],
+      "dummyBoolean": null,
+      "embeddedDummy": [],
+      "age": null
+    }
+    """
+
+  Scenario: Passing a (valid) plain identifier on a relation
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "relatedDummy": "1",
+      "relatedDummies": [
+        "1"
+      ],
+      "name": "Dummy with plain relations"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
+      "description": null,
+      "dummy": null,
+      "dummyBoolean": null,
+      "dummyDate": null,
+      "dummyFloat": null,
+      "dummyPrice": null,
+      "relatedDummy": "/related_dummies/1",
+      "relatedDummies": [
+        "/related_dummies/1"
+      ],
+      "jsonData": [],
+      "arrayData": [],
+      "name_converted": null,
+      "relatedOwnedDummy": null,
+      "relatedOwningDummy": null,
+      "id": 1,
+      "name": "Dummy with plain relations",
+      "alias": null,
+      "foo": null
+    }
+    """

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -365,66 +365,6 @@ Feature: Relations support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
-  Scenario: Create a new relation (json)
-    When I add "Content-Type" header equal to "application/json"
-    And I send a "POST" request to "/relation_embedders" with body:
-    """
-    {
-      "anotherRelated": {
-        "symfony": "laravel"
-      }
-    }
-    """
-    Then the response status code should be 201
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/RelationEmbedder",
-      "@id": "/relation_embedders/3",
-      "@type": "RelationEmbedder",
-      "krondstadt": "Krondstadt",
-      "anotherRelated": {
-        "@id": "/related_dummies/4",
-        "@type": "https://schema.org/Product",
-        "symfony": "laravel",
-        "thirdLevel": null
-      },
-      "related": null
-    }
-    """
-
-  Scenario: Update the relation with a new one (json)
-    When I add "Content-Type" header equal to "application/json"
-    And I send a "PUT" request to "/relation_embedders/3" with body:
-    """
-    {
-      "anotherRelated": {
-        "symfony": "laravel2"
-      }
-    }
-    """
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/RelationEmbedder",
-      "@id": "/relation_embedders/3",
-      "@type": "RelationEmbedder",
-      "krondstadt": "Krondstadt",
-      "anotherRelated": {
-        "@id": "/related_dummies/5",
-        "@type": "https://schema.org/Product",
-        "symfony": "laravel2",
-        "thirdLevel": null
-      },
-      "related": null
-    }
-    """
-
   Scenario: Update an embedded relation
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/relation_embedders/2" with body:
@@ -453,37 +393,6 @@ Feature: Relations support
         "thirdLevel": null
       },
       "related": null
-    }
-    """
-
-  Scenario: Create a related dummy with a relation (json)
-    When I add "Content-Type" header equal to "application/json"
-    And I send a "POST" request to "/related_dummies" with body:
-    """
-    {"thirdLevel": "1"}
-    """
-    Then the response status code should be 201
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/RelatedDummy",
-      "@id": "/related_dummies/6",
-      "@type": "https://schema.org/Product",
-      "id": 6,
-      "name": null,
-      "symfony": "symfony",
-      "dummyDate": null,
-      "thirdLevel": {
-        "@id": "/third_levels/1",
-        "@type": "ThirdLevel",
-        "fourthLevel": null
-      },
-      "relatedToDummyFriend": [],
-      "dummyBoolean": null,
-      "embeddedDummy": [],
-      "age": null
     }
     """
 
@@ -516,45 +425,6 @@ Feature: Relations support
         }
       ],
       "hydra:totalItems": 1
-    }
-    """
-
-  Scenario: Passing a (valid) plain identifier on a relation
-    When I add "Content-Type" header equal to "application/json"
-    And I send a "POST" request to "/dummies" with body:
-    """
-    {
-      "relatedDummy": "1",
-      "relatedDummies": ["1"],
-      "name": "Dummy with plain relations"
-    }
-    """
-    Then the response status code should be 201
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context":"/contexts/Dummy",
-      "@id":"/dummies/2",
-      "@type":"Dummy",
-      "description":null,
-      "dummy":null,
-      "dummyBoolean":null,
-      "dummyDate":null,
-      "dummyFloat":null,
-      "dummyPrice":null,
-      "relatedDummy":"/related_dummies/1",
-      "relatedDummies":["/related_dummies/1"],
-      "jsonData":[],
-      "arrayData":[],
-      "name_converted":null,
-      "relatedOwnedDummy": null,
-      "relatedOwningDummy": null,
-      "id":2,
-      "name":"Dummy with plain relations",
-      "alias":null,
-      "foo":null
     }
     """
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/xml.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/xml.xml
@@ -26,7 +26,7 @@
         </service>
 
         <service id="api_platform.metadata.property.metadata_factory" alias="api_platform.metadata.property.metadata_factory.xml" />
-        <service id="api_platform.metadata.property.metadata_factory.xml" class="ApiPlatform\Core\Metadata\Property\Factory\ExtractorPropertyMetadataFactory" decoration-priority="20" public="false">
+        <service id="api_platform.metadata.property.metadata_factory.xml" class="ApiPlatform\Core\Metadata\Property\Factory\ExtractorPropertyMetadataFactory" public="false">
             <argument type="service" id="api_platform.metadata.extractor.xml" />
         </service>
     </services>

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -472,14 +472,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     }
 
     /**
-     * Gets a valid context for property name collection / property metadata factories.
+     * Gets the options for the property name collection / property metadata factories.
      */
     protected function getFactoryOptions(array $context): array
     {
         $options = [];
 
         if (isset($context[self::GROUPS])) {
-            /* @see https://github.com/symfony/symfony/blob/v4.2.6/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php */
             $options['serializer_groups'] = $context[self::GROUPS];
         }
 

--- a/tests/Fixtures/TestBundle/Document/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Document/RelatedDummy.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
 
+use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -32,9 +33,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class RelatedDummy extends ParentDummy
 {
     /**
+     * @ApiProperty(writable=false)
      * @ApiSubresource
      * @ODM\Id(strategy="INCREMENT", type="integer")
-     * @Groups({"friends"})
+     * @Groups({"chicago", "friends"})
      */
     private $id;
 

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
+use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -31,11 +32,12 @@ use Symfony\Component\Validator\Constraints as Assert;
 class RelatedDummy extends ParentDummy
 {
     /**
+     * @ApiProperty(writable=false)
      * @ApiSubresource
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
-     * @Groups({"friends"})
+     * @Groups({"chicago", "friends"})
      */
     private $id;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3133
| License       | MIT
| Doc PR        | N/A

Targeting `2.4` so that we're able to demonstrate that it works correctly on `2.4`.

Background:

Before #3036, the `$options` we pass to the PropertyNameCollectionFactory was wrong, because it was using the (Serializer) `$context` directly. Specifically, the `$context['groups']` were not translated to `$options['serializer_groups']`, so they had no effect. (There could have been many bugs caused by that.)

That bug fix however in turn revealed the problem with incorrect property metadata set on API resources in some projects (see for example #3133).

For example, the `id` property in the related resource is not in the serializer groups used for denormalization, which makes sense at first glance, because you don't want to allow updating the `id`. However, the `ItemNormalizer` uses the property metadata to identify the correct identifier property, so it's actually required that the `id` property must be part of the serializer groups used for denormalization (only applicable in the case of using plain identifiers, where you're sending the `id` property). To disallow updating the `id`, the correct solution is to use `@ApiProperty(writable=false)`.