### PR TITLE
Fix #3090 output no persist

### DIFF
--- a/features/jsonld/input_output.feature
+++ b/features/jsonld/input_output.feature
@@ -271,3 +271,16 @@ Feature: JSON-LD DTO input and output
       "data": 123
     }
     """
+
+  @!mongodb
+  Scenario: Get an item with a custom output
+    When I send a "POST" request to "/dummy_dto_post_with_output_no_persist" with body:
+    """
+    {
+      "lorem": "test",
+      "ipsum": "1"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"

--- a/src/JsonLd/Serializer/ObjectNormalizer.php
+++ b/src/JsonLd/Serializer/ObjectNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\JsonLd\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\JsonLd\AnonymousContextBuilderInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
@@ -84,7 +85,12 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
         }
 
         if (isset($originalResource)) {
-            $context['output']['iri'] = $this->iriConverter->getIriFromItem($originalResource);
+            try {
+                $context['output']['iri'] = $this->iriConverter->getIriFromItem($originalResource);
+            } catch (InvalidArgumentException $e) {
+                $context['output']['iri'] = '_:'.md5(\function_exists('spl_object_id') ? spl_object_id($originalResource) : spl_object_hash($originalResource));
+            }
+
             $context['api_resource'] = $originalResource;
         }
 

--- a/tests/Fixtures/TestBundle/Entity/DummyDtoCustom.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyDtoCustom.php
@@ -24,7 +24,28 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  *
  * @ApiResource(
- *     collectionOperations={"post"={"input"=CustomInputDto::class}, "get", "custom_output"={"output"=CustomOutputDto::class, "path"="dummy_dto_custom_output", "method"="GET"}, "post_without_output"={"output"=false, "method"="POST", "path"="dummy_dto_custom_post_without_output"}},
+ *     collectionOperations={
+ *         "post"={
+ *             "input"=CustomInputDto::class
+ *         },
+ *         "get",
+ *         "custom_output"={
+ *             "output"=CustomOutputDto::class,
+ *             "path"="dummy_dto_custom_output",
+ *             "method"="GET"
+ *         },
+ *         "post_without_output"={
+ *             "output"=false,
+ *             "method"="POST",
+ *             "path"="dummy_dto_custom_post_without_output"
+ *         },
+ *         "post_with_output_no_persist"={
+ *             "method"="POST",
+ *             "output"=CustomOutputDto::class,
+ *             "write"=false,
+ *             "path"="dummy_dto_post_with_output_no_persist"
+ *         }
+ *     },
  *     itemOperations={"get", "custom_output"={"output"=CustomOutputDto::class, "method"="GET", "path"="dummy_dto_custom_output/{id}"}, "put", "delete"}
  * )
  */


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3090 
| License       | MIT
| Doc PR        | na

Use a blank node for @id when none is available in case of an output with no persisted input/resource
