### PR TITLE
non-int value in the execute command will be deprecated

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -100,5 +100,7 @@ final class SwaggerCommand extends Command
         } else {
             $output->writeln($content);
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Related to https://github.com/symfony/symfony/pull/33775/

We can already apply this change without BC
It was the only command in this case