### PR TITLE
Fix support for custom filters without constructor in ApiFilter annotation

### DIFF
--- a/src/Api/FilterInterface.php
+++ b/src/Api/FilterInterface.php
@@ -27,7 +27,7 @@ interface FilterInterface
      *   - property: the property where the filter is applied
      *   - type: the type of the filter
      *   - required: if this filter is required
-     *   - strategy: the used strategy
+     *   - strategy (optional): the used strategy
      *   - is_collection (optional): is this filter is collection
      *   - swagger (optional): additional parameters for the path operation,
      *     e.g. 'swagger' => [

--- a/tests/Fixtures/TestBundle/Filter/DoesNotImplementInterfaceFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/DoesNotImplementInterfaceFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+final class DoesNotImplementInterfaceFilter
+{
+    public function getDescription(string $resourceClass): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/TestBundle/Filter/NoConstructorFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/NoConstructorFilter.php
@@ -11,12 +11,21 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Doctrine\Orm\Filter;
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
 
-class AnotherDummyFilter
+use ApiPlatform\Core\Api\FilterInterface;
+
+final class NoConstructorFilter implements FilterInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getDescription(string $resourceClass): array
     {
-        return [];
+        return [
+            'property' => 'foo',
+            'type' => '',
+            'required' => false,
+        ];
     }
 }

--- a/tests/Fixtures/TestBundle/Filter/NoPropertiesArgumentFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/NoPropertiesArgumentFilter.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Filter;
+
+use ApiPlatform\Core\Api\FilterInterface;
+
+final class NoPropertiesArgumentFilter implements FilterInterface
+{
+    private $foo;
+
+    public function __construct(string $foo = 'bar')
+    {
+        $this->foo = $foo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'property' => $this->foo,
+            'type' => '',
+            'required' => false,
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  #3049 
| License       | MIT
| Doc PR        | 

<!-- Bug fixes should be based against the current stable version branch, master is for new features only -->
