### PR TITLE
Add page-based pagination to GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * MongoDB: Possibility to add execute options (aggregate command fields) for a resource, like `allowDiskUse` (#3144)
 * GraphQL: Allow to format GraphQL errors based on exceptions (#3063)
+* GraphQL: Add page-based pagination (#3175)
 
 ## 2.5.2
 

--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -680,3 +680,102 @@ Feature: GraphQL collection support
     And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[0].node.title" should not exist
     And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[1].node.title" should not exist
     And the JSON node "data.dummyDifferentGraphQlSerializationGroups.edges[2].node.title" should not exist
+
+  @createSchema
+  Scenario: Retrieve a paginated collection using page-based pagination
+    Given there are 5 fooDummy objects with fake names
+    When I send the following GraphQL request:
+    """
+    {
+      fooDummies(page: 1) {
+        collection {
+          id
+        }
+        paginationInfo {
+          itemsPerPage
+          lastPage
+          totalCount
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.fooDummies.collection" should have 3 elements
+    And the JSON node "data.fooDummies.collection[0].id" should exist
+    And the JSON node "data.fooDummies.collection[1].id" should exist
+    And the JSON node "data.fooDummies.collection[2].id" should exist
+    And the JSON node "data.fooDummies.paginationInfo.itemsPerPage" should be equal to the number 3
+    And the JSON node "data.fooDummies.paginationInfo.lastPage" should be equal to the number 2
+    And the JSON node "data.fooDummies.paginationInfo.totalCount" should be equal to the number 5
+    When I send the following GraphQL request:
+    """
+    {
+      fooDummies(page: 2) {
+        collection {
+          id
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.fooDummies.collection" should have 2 elements
+    When I send the following GraphQL request:
+    """
+    {
+      fooDummies(page: 3) {
+        collection {
+          id
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.fooDummies.collection" should have 0 elements
+
+  @createSchema
+  Scenario: Retrieve a paginated collection using page-based pagination and client-defined limit
+    Given there are 5 fooDummy objects with fake names
+    When I send the following GraphQL request:
+    """
+    {
+      fooDummies(page: 1, itemsPerPage: 2) {
+        collection {
+          id
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.fooDummies.collection" should have 2 elements
+    And the JSON node "data.fooDummies.collection[0].id" should exist
+    And the JSON node "data.fooDummies.collection[1].id" should exist
+    When I send the following GraphQL request:
+    """
+    {
+      fooDummies(page: 2, itemsPerPage: 2) {
+        collection {
+          id
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.fooDummies.collection" should have 2 elements
+    When I send the following GraphQL request:
+    """
+    {
+      fooDummies(page: 3, itemsPerPage: 2) {
+        collection {
+          id
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.fooDummies.collection" should have 1 element

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -127,6 +127,7 @@
             <argument type="service" id="api_platform.graphql.types_container" />
             <argument type="service" id="api_platform.graphql.resolver.resource_field" />
             <argument type="service" id="api_platform.graphql.fields_builder_locator" />
+            <argument type="service" id="api_platform.pagination" />
         </service>
 
         <service id="api_platform.graphql.fields_builder" class="ApiPlatform\Core\GraphQl\Type\FieldsBuilder" public="false">

--- a/src/DataProvider/Pagination.php
+++ b/src/DataProvider/Pagination.php
@@ -196,6 +196,21 @@ final class Pagination
         return $this->getEnabled($context, $resourceClass, $operationName, true);
     }
 
+    public function getItemsPerPageOptions(): array
+    {
+        return array_intersect_key($this->options, array_flip([
+            'client_items_per_page',
+            'items_per_page_parameter_name',
+        ]));
+    }
+
+    public function getGraphQlPaginationType(string $resourceClass, string $operationName): string
+    {
+        $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+
+        return (string) $resourceMetadata->getGraphqlAttribute($operationName, 'paginationType', 'cursor', true);
+    }
+
     /**
      * Is the classic or partial pagination enabled?
      */

--- a/src/DataProvider/Pagination.php
+++ b/src/DataProvider/Pagination.php
@@ -196,12 +196,9 @@ final class Pagination
         return $this->getEnabled($context, $resourceClass, $operationName, true);
     }
 
-    public function getItemsPerPageOptions(): array
+    public function getOptions(): array
     {
-        return array_intersect_key($this->options, array_flip([
-            'client_items_per_page',
-            'items_per_page_parameter_name',
-        ]));
+        return $this->options;
     }
 
     public function getGraphQlPaginationType(string $resourceClass, string $operationName): string

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -307,16 +307,17 @@ final class FieldsBuilder implements FieldsBuilderInterface
             ];
         }
 
+        $paginationOptions = $this->pagination->getOptions();
+
         $args = [
-            'page' => [
+            $paginationOptions['page_parameter_name'] => [
                 'type' => GraphQLType::int(),
                 'description' => 'Returns the current page.',
             ],
         ];
 
-        $itemsPerPageOptions = $this->pagination->getItemsPerPageOptions();
-        if ($itemsPerPageOptions['client_items_per_page']) {
-            $args[$itemsPerPageOptions['items_per_page_parameter_name']] = [
+        if ($paginationOptions['client_items_per_page']) {
+            $args[$paginationOptions['items_per_page_parameter_name']] = [
                 'type' => GraphQLType::int(),
                 'description' => 'Returns the number of items per page.',
             ];

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -254,24 +254,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
             $args = [];
             if (!$input && null === $mutationName && !$isStandardGraphqlType && $this->typeBuilder->isCollection($type)) {
                 if ($this->pagination->isGraphQlEnabled($resourceClass, $queryName)) {
-                    $args = [
-                        'first' => [
-                            'type' => GraphQLType::int(),
-                            'description' => 'Returns the first n elements from the list.',
-                        ],
-                        'last' => [
-                            'type' => GraphQLType::int(),
-                            'description' => 'Returns the last n elements from the list.',
-                        ],
-                        'before' => [
-                            'type' => GraphQLType::string(),
-                            'description' => 'Returns the elements in the list that come before the specified cursor.',
-                        ],
-                        'after' => [
-                            'type' => GraphQLType::string(),
-                            'description' => 'Returns the elements in the list that come after the specified cursor.',
-                        ],
-                    ];
+                    $args = $this->getGraphQlPaginationArgs($resourceClass, $queryName);
                 }
 
                 $args = $this->getFilterArgs($args, $resourceClass, $resourceMetadata, $rootResource, $property, $queryName, $mutationName, $depth);
@@ -297,6 +280,49 @@ final class FieldsBuilder implements FieldsBuilderInterface
         }
 
         return null;
+    }
+
+    private function getGraphQlPaginationArgs(string $resourceClass, string $queryName): array
+    {
+        $paginationType = $this->pagination->getGraphQlPaginationType($resourceClass, $queryName);
+
+        if ('cursor' === $paginationType) {
+            return [
+                'first' => [
+                    'type' => GraphQLType::int(),
+                    'description' => 'Returns the first n elements from the list.',
+                ],
+                'last' => [
+                    'type' => GraphQLType::int(),
+                    'description' => 'Returns the last n elements from the list.',
+                ],
+                'before' => [
+                    'type' => GraphQLType::string(),
+                    'description' => 'Returns the elements in the list that come before the specified cursor.',
+                ],
+                'after' => [
+                    'type' => GraphQLType::string(),
+                    'description' => 'Returns the elements in the list that come after the specified cursor.',
+                ],
+            ];
+        }
+
+        $args = [
+            'page' => [
+                'type' => GraphQLType::int(),
+                'description' => 'Returns the current page.',
+            ],
+        ];
+
+        $itemsPerPageOptions = $this->pagination->getItemsPerPageOptions();
+        if ($itemsPerPageOptions['client_items_per_page']) {
+            $args[$itemsPerPageOptions['items_per_page_parameter_name']] = [
+                'type' => GraphQLType::int(),
+                'description' => 'Returns the number of items per page.',
+            ];
+        }
+
+        return $args;
     }
 
     private function getFilterArgs(array $args, ?string $resourceClass, ?ResourceMetadata $resourceMetadata, string $rootResource, ?string $property, ?string $queryName, ?string $mutationName, int $depth): array
@@ -418,7 +444,9 @@ final class FieldsBuilder implements FieldsBuilderInterface
         }
 
         if ($this->typeBuilder->isCollection($type)) {
-            return $this->pagination->isGraphQlEnabled($resourceClass, $queryName ?? $mutationName) && !$input ? $this->typeBuilder->getResourcePaginatedCollectionType($graphqlType) : GraphQLType::listOf($graphqlType);
+            $operationName = $queryName ?? $mutationName;
+
+            return $this->pagination->isGraphQlEnabled($resourceClass, $operationName) && !$input ? $this->typeBuilder->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $operationName) : GraphQLType::listOf($graphqlType);
         }
 
         return !$graphqlType instanceof NullableType || $type->isNullable() || (null !== $mutationName && 'update' === $mutationName)

--- a/src/GraphQl/Type/TypeBuilderInterface.php
+++ b/src/GraphQl/Type/TypeBuilderInterface.php
@@ -44,7 +44,7 @@ interface TypeBuilderInterface
     /**
      * Gets the type of a paginated collection of the given resource type.
      */
-    public function getResourcePaginatedCollectionType(GraphQLType $resourceType): GraphQLType;
+    public function getResourcePaginatedCollectionType(GraphQLType $resourceType, string $resourceClass, string $operationName): GraphQLType;
 
     /**
      * Returns true if a type is a collection.

--- a/tests/Fixtures/TestBundle/Document/FooDummy.php
+++ b/tests/Fixtures/TestBundle/Document/FooDummy.php
@@ -21,9 +21,14 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  *
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  *
- * @ApiResource(attributes={
- *     "order"={"dummy.name"}
- * })
+ * @ApiResource(
+ *     attributes={
+ *         "order"={"dummy.name"}
+ *     },
+ *     graphql={
+ *         "collection_query"={"paginationType"="page"}
+ *     }
+ * )
  * @ODM\Document
  */
 class FooDummy

--- a/tests/Fixtures/TestBundle/Entity/FooDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/FooDummy.php
@@ -21,9 +21,14 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  *
- * @ApiResource(attributes={
- *     "order"={"dummy.name"}
- * })
+ * @ApiResource(
+ *     attributes={
+ *         "order"={"dummy.name"}
+ *     },
+ *     graphql={
+ *         "collection_query"={"paginationType"="page"}
+ *     }
+ * )
  * @ORM\Entity
  */
 class FooDummy

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -206,7 +206,7 @@ class FieldsBuilderTest extends TestCase
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, $queryName, null, $resourceClass, $resourceClass, null, 0)->willReturn($graphqlType);
         $this->typeConverterProphecy->resolveType(Argument::type('string'))->willReturn(GraphQLType::string());
         $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn(true);
-        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType)->willReturn($graphqlType);
+        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $queryName)->willReturn($graphqlType);
         $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn($resourceMetadata);
         $this->collectionResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, $queryName)->willReturn($resolver);
         $this->filterLocatorProphecy->has('my_filter')->willReturn(true);
@@ -325,6 +325,27 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
+            'collection with page-based pagination enabled' => ['resourceClass', (new ResourceMetadata('ShortName', null, null, null, null, ['paginationType' => 'page']))->withGraphql(['action' => ['filters' => ['my_filter']]]), 'action', [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function () {
+            },
+                [
+                    'actionShortNames' => [
+                        'type' => $graphqlType,
+                        'description' => null,
+                        'args' => [
+                            'page' => [
+                                'type' => GraphQLType::int(),
+                                'description' => 'Returns the current page.',
+                            ],
+                            'boolField' => $graphqlType,
+                            'boolField_list' => GraphQLType::listOf($graphqlType),
+                            'parent__child' => new InputObjectType(['name' => 'ShortNameFilter_parent__child', 'fields' => ['related__nested' => $graphqlType]]),
+                            'dateField' => new InputObjectType(['name' => 'ShortNameFilter_dateField', 'fields' => ['before' => $graphqlType]]),
+                        ],
+                        'resolve' => $resolver,
+                        'deprecationReason' => '',
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -336,7 +357,7 @@ class FieldsBuilderTest extends TestCase
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, null, $mutationName, $resourceClass, $resourceClass, null, 0)->willReturn($graphqlType);
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, null, $mutationName, $resourceClass, $resourceClass, null, 0)->willReturn($graphqlType);
         $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn($isTypeCollection);
-        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType)->willReturn($graphqlType);
+        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $mutationName)->willReturn($graphqlType);
         $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadata());
         $this->collectionResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, null)->willReturn($collectionResolver);
         $this->itemMutationResolverFactoryProphecy->__invoke($resourceClass, null, $mutationName)->willReturn($mutationResolver);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #2762, https://github.com/api-platform/api-platform/issues/1152
| License       | MIT
| Doc PR        | N/A

This PR allows to use a page-based pagination using GraphQL instead of the default cursor-based pagination. This choice is made at operation/resource level.