### PR TITLE
[2.5] Fix dashed path segment generation

### DIFF
--- a/src/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Operation/DashPathSegmentNameGenerator.php
@@ -27,9 +27,7 @@ final class DashPathSegmentNameGenerator implements PathSegmentNameGeneratorInte
      */
     public function getSegmentName(string $name, bool $collection = true): string
     {
-        $name = $this->dashize($name);
-
-        return $collection ? Inflector::pluralize($name) : $name;
+        return $collection ? $this->dashize(Inflector::pluralize($name)) : $this->dashize($name);
     }
 
     private function dashize(string $string): string

--- a/tests/Operation/DashedPathSegmentNameGeneratorTest.php
+++ b/tests/Operation/DashedPathSegmentNameGeneratorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Operation;
+
+use ApiPlatform\Core\Operation\DashPathSegmentNameGenerator;
+use PHPUnit\Framework\TestCase;
+
+class DashedPathSegmentNameGeneratorTest extends TestCase
+{
+    public function testCreateSegmentNameGeneration()
+    {
+        $generator = new DashPathSegmentNameGenerator();
+        $this->assertSame('ordering-people', $generator->getSegmentName('orderingPerson'));
+        $this->assertSame('some-person-names', $generator->getSegmentName('somePersonName'));
+    }
+}


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fix #3188
| License       | MIT
| Doc PR        | 

This will correctly convert `orderingPerson` to `ordering-people` 