### PR TITLE
Fix denormalization of basic property-types in XML and CSV

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -9,6 +9,7 @@ default:
         - 'HttpHeaderContext'
         - 'GraphqlContext'
         - 'JsonContext'
+        - 'XmlContext'
         - 'HydraContext'
         - 'SwaggerContext'
         - 'HttpCacheContext'

--- a/features/bootstrap/XmlContext.php
+++ b/features/bootstrap/XmlContext.php
@@ -1,0 +1,8 @@
+<?php
+
+use Behatch\Context\XmlContext as BaseXmlContext;
+
+class XmlContext extends BaseXmlContext
+{
+
+}

--- a/features/xml/input_output.feature
+++ b/features/xml/input_output.feature
@@ -1,0 +1,73 @@
+Feature: XML Input and Output
+  In order to use the API with XML
+  As a client software developer
+  I need to be able to use DTOs on my resources as Input or Output objects.
+
+  Background:
+    Given I add "Accept" header equal to "application/xml"
+    And I add "Content-Type" header equal to "application/xml"
+
+  @createSchema
+  Scenario: Posting an XML resource with a string value
+    When I send a "POST" request to "/resource_with_strings" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithString>
+      <myStringField>string</myStringField>
+    </ResourceWithString>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
+
+  @createSchema
+  Scenario Outline: Posting an XML resource with a boolean value
+    When I send a "POST" request to "/resource_with_booleans" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithBoolean>
+      <myBooleanField><value></myBooleanField>
+    </ResourceWithBoolean>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
+  Examples:
+    | value |
+    | true  |
+    | false |
+    | True  |
+    | False |
+    | t     |
+    | f     |
+    | T     |
+    | F     |
+    | 1     |
+    | 0     |
+
+  @createSchema
+  Scenario: Posting an XML resource with an integer value
+    When I send a "POST" request to "/resource_with_integers" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithInteger>
+      <myIntegerField>42</myIntegerField>
+    </ResourceWithInteger>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
+
+
+  @createSchema
+  Scenario: Posting an XML resource with an float value
+    When I send a "POST" request to "/resource_with_floats" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithFloat>
+      <myFloatField>3.14</myFloatField>
+    </ResourceWithFloat>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"

--- a/features/xml/input_output.feature
+++ b/features/xml/input_output.feature
@@ -58,7 +58,6 @@ Feature: XML Input and Output
     And the response should be in XML
     And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
 
-
   @createSchema
   Scenario: Posting an XML resource with an float value
     When I send a "POST" request to "/resource_with_floats" with body:

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -701,6 +701,29 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $this->serializer->denormalize($value, $className, $format, $context);
         }
 
+        if (is_string($value) && 'string' !== $type->getBuiltinType()) {
+
+            if ('bool' === $type->getBuiltinType()) {
+                if (in_array($value, ['true', 'True', 'T', 't', "1"], true)) {
+                    $value = true;
+                }
+                if (in_array($value, ['false', 'False', 'F', 'f', "0"], true)) {
+                    $value = false;
+                }
+            }
+
+            if (is_numeric($value)) {
+
+                if ('int' === $type->getBuiltinType()) {
+                    $value = intval($value);
+                }
+
+                if ('float' === $type->getBuiltinType()) {
+                    $value = floatval($value);
+                }
+            }
+        }
+
         if ($context[static::DISABLE_TYPE_ENFORCEMENT] ?? false) {
             return $value;
         }

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithBoolean.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithBoolean.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithBoolean
+{
+
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
+    private $myBooleanField = false;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getMyBooleanField(): bool
+    {
+        return $this->myBooleanField;
+    }
+
+    /**
+     * @param bool $myBooleanField
+     */
+    public function setMyBooleanField(bool $myBooleanField): void
+    {
+        $this->myBooleanField = $myBooleanField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithFloat.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithFloat.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithFloat
+{
+
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var float
+     *
+     * @ORM\Column(type="float")
+     */
+    private $myFloatField = 0.0;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return float
+     */
+    public function getMyFloatField(): float
+    {
+        return $this->myFloatField;
+    }
+
+    /**
+     * @param float $myFloatField
+     */
+    public function setMyFloatField(float $myFloatField): void
+    {
+        $this->myFloatField = $myFloatField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithInteger.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithInteger.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithInteger
+{
+
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     */
+    private $myIntegerField = 0;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMyIntegerField(): int
+    {
+        return $this->myIntegerField;
+    }
+
+    /**
+     * @param int $myIntegerField
+     */
+    public function setMyIntegerField(int $myIntegerField): void
+    {
+        $this->myIntegerField = $myIntegerField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithString.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithString.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithString
+{
+
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    private $myStringField = '';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMyStringField(): string
+    {
+        return $this->myStringField;
+    }
+
+    /**
+     * @param string $myStringField
+     */
+    public function setMyStringField(string $myStringField): void
+    {
+        $this->myStringField = $myStringField;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes https://github.com/api-platform/api-platform/issues/1299
| License       | MIT

This PR fixes an issue where by posting XML content throws errors when a field has a non string primitive type because the XML encoder can only normalize primitive values as strings. This means that post create and update requests fail. This PR adds some additional behaviour where by the AbstractItemNormalizer will cast valid strings as the correct type.
