### PR TITLE
Move behat tests to CI workflow on GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
   disable-xdebug-php-extension:
     steps:
       - run:
-          name: Disable Xdebug PHP extension
+          name: Disable xdebug PHP extension
           command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
   install-mongodb-php-extension:
     steps:
@@ -95,6 +95,7 @@ commands:
   restore-composer-cache:
     steps:
       - restore_cache:
+          name: Restore Composer cache
           keys:
             - composer-cache-{{ .Revision }}
             - composer-cache-{{ .Branch }}
@@ -102,6 +103,7 @@ commands:
   restore-npm-cache:
     steps:
       - restore_cache:
+          name: Restore npm cache
           keys:
             - npm-cache-{{ .Revision }}
             - npm-cache-{{ .Branch }}
@@ -109,6 +111,7 @@ commands:
   restore-php-cs-fixer-cache:
     steps:
       - restore_cache:
+          name: Restore PHP-CS-Fixer cache
           keys:
             - php-cs-fixer-cache-{{ .Revision }}
             - php-cs-fixer-cache-{{ .Branch }}
@@ -116,6 +119,7 @@ commands:
   restore-phpstan-cache:
     steps:
       - restore_cache:
+          name: Restore PHPStan cache
           keys:
             - phpstan-cache-{{ .Revision }}
             - phpstan-cache-{{ .Branch }}
@@ -123,40 +127,48 @@ commands:
   save-composer-cache:
     steps:
       - save_cache:
+          name: Save Composer cache
           paths:
             - ~/.composer/cache/files
           key: composer-cache-{{ .Branch }}-{{ .BuildNum }}
       - save_cache:
+          name: Save Composer cache
           paths:
             - ~/.composer/cache/files
           key: composer-cache-{{ .Revision }}-{{ .BuildNum }}
   save-npm-cache:
     steps:
       - save_cache:
+          name: Save npm cache
           paths:
             - ~/.npm
           key: npm-cache-{{ .Branch }}-{{ .BuildNum }}
       - save_cache:
+          name: Save npm cache
           paths:
             - ~/.npm
           key: npm-cache-{{ .Revision }}-{{ .BuildNum }}
   save-php-cs-fixer-cache:
     steps:
       - save_cache:
+          name: Save PHP-CS-Fixer cache
           paths:
             - .php_cs.cache
           key: php-cs-fixer-cache-{{ .Branch }}-{{ .BuildNum }}
       - save_cache:
+          name: Save PHP-CS-Fixer cache
           paths:
             - .php_cs.cache
           key: php-cs-fixer-cache-{{ .Revision }}-{{ .BuildNum }}
   save-phpstan-cache:
     steps:
       - save_cache:
+          name: Save PHPStan cache
           paths:
             - /tmp/phpstan/cache
           key: phpstan-cache-{{ .Branch }}-{{ .BuildNum }}
       - save_cache:
+          name: Save PHPStan cache
           paths:
             - /tmp/phpstan/cache
           key: phpstan-cache-{{ .Revision }}-{{ .BuildNum }}
@@ -225,6 +237,7 @@ executors:
 
 jobs:
   php-cs-fixer:
+    description: PHP-CS-Fixer
     executor: php
     environment:
       PHP_CS_FIXER_FUTURE_MODE: '1'
@@ -250,6 +263,7 @@ jobs:
       - save-php-cs-fixer-cache
 
   phpstan:
+    description: PHPStan
     executor: php
     environment:
       APP_DEBUG: '1' # https://github.com/phpstan/phpstan-symfony/issues/37
@@ -271,6 +285,7 @@ jobs:
       - save-phpstan-cache
 
   phpunit-coverage:
+    description: PHPUnit (code coverage)
     executor: php
     parallelism: 2
     working_directory: ~/api-platform/core
@@ -319,6 +334,7 @@ jobs:
       - save-npm-cache
 
   behat-coverage:
+    description: Behat (code coverage)
     executor: php
     parallelism: 2
     working_directory: ~/api-platform/core
@@ -364,6 +380,7 @@ jobs:
       - save-npm-cache
 
   phpunit-mongodb-coverage:
+    description: PHPUnit (MongoDB) (code coverage)
     executor: php-and-mongodb
     environment:
       APP_ENV: mongodb
@@ -402,6 +419,7 @@ jobs:
       - save-npm-cache
 
   behat-mongodb-coverage:
+    description: Behat (MongoDB) (code coverage)
     executor: php-and-mongodb
     environment:
       APP_ENV: mongodb
@@ -446,6 +464,7 @@ jobs:
       - save-npm-cache
 
   behat-elasticsearch-coverage:
+    description: Behat (Elasticsearch) (code coverage)
     executor: php-and-elasticsearch
     environment:
       APP_ENV: elasticsearch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 env:
   COMPOSER_ALLOW_SUPERUSER: '1' # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
+  COMPOSER_INSTALLER_COMMIT: fb22b78362d31c0d2bf516d1f8cdfd2745caa431
+  EXT_MONGODB_VERSION: '1.5.5'
+  LEGACY: '0'
   SYMFONY_REQUIRE: ^3.4 || ^4.0
 
 jobs:
@@ -14,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
     strategy:
       matrix:
         php:
@@ -30,37 +35,108 @@ jobs:
           apk add \
             unzip \
       - name: Install mongodb PHP extension
-        if: matrix.php != '7.1'
+        if: (!startsWith(matrix.php, '7.1'))
         run: |
           apk add $PHPIZE_DEPS
-          pecl install mongodb-1.5.5
+          pecl install mongodb-$EXT_MONGODB_VERSION
           docker-php-ext-enable mongodb
       - name: Disable PHP memory limit
         run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
       - name: Install Composer
-        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/fb22b78362d31c0d2bf516d1f8cdfd2745caa431/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
       - name: Install Symfony Flex
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
       - name: Remove Doctrine MongoDB ODM
-        if: matrix.php == '7.1'
+        if: startsWith(matrix.php, '7.1')
         run: |
           composer remove --dev --no-progress --no-update --ansi \
             doctrine/mongodb-odm \
             doctrine/mongodb-odm-bundle \
       - name: Update project dependencies
-        run: composer update --no-progress --no-suggest --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
       - name: Clear test app cache
-        run: tests/Fixtures/app/console cache:clear --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --colors=always
+
+  behat:
+    name: Behat (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
+    strategy:
+      matrix:
+        php:
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4-rc'
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install system packages
+        run: |
+          apk add \
+            unzip \
+      - name: Install mongodb PHP extension
+        if: (!startsWith(matrix.php, '7.1'))
+        run: |
+          apk add $PHPIZE_DEPS
+          pecl install mongodb-$EXT_MONGODB_VERSION
+          docker-php-ext-enable mongodb
+      - name: Disable PHP memory limit
+        run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
+      - name: Install Composer
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+      - name: Install Symfony Flex
+        run: |
+          composer global require --prefer-dist --no-progress --no-suggest --ansi \
+            symfony/flex
+      - name: Remove Doctrine MongoDB ODM
+        if: startsWith(matrix.php, '7.1')
+        run: |
+          composer remove --dev --no-progress --no-update --ansi \
+            doctrine/mongodb-odm \
+            doctrine/mongodb-odm-bundle \
+      - name: Update project dependencies
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
+      - name: Enable legacy integrations
+        if: startsWith(matrix.php, '7.1') || startsWith(matrix.php, '7.2') || startsWith(matrix.php, '7.3')
+        run: echo '::set-env name=LEGACY::1'
+      - name: Clear test app cache
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
+      - name: Run Behat tests
+        run: |
+          if [ "$LEGACY" = '1' ]; then
+            vendor/bin/behat --format=progress --no-interaction --colors
+          else
+            vendor/bin/behat --format=progress --profile=default-no-legacy --no-interaction --colors
+          fi
 
   phpunit-lowest-deps:
     name: PHPUnit (PHP ${{ matrix.php }}) (lowest dependencies)
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
     strategy:
       matrix:
         php:
@@ -77,28 +153,90 @@ jobs:
       - name: Install mongodb PHP extension
         run: |
           apk add $PHPIZE_DEPS
-          pecl install mongodb-1.5.5
+          pecl install mongodb-$EXT_MONGODB_VERSION
           docker-php-ext-enable mongodb
       - name: Disable PHP memory limit
         run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
       - name: Install Composer
-        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/fb22b78362d31c0d2bf516d1f8cdfd2745caa431/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
       - name: Install Symfony Flex
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
       - name: Update project dependencies
-        run: composer update --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi
       - name: Clear test app cache
-        run: tests/Fixtures/app/console cache:clear --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --colors=always
+
+  behat-lowest-deps:
+    name: Behat (PHP ${{ matrix.php }}) (lowest dependencies)
+    runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
+    strategy:
+      matrix:
+        php:
+          - '7.3'
+          - '7.4-rc'
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install system packages
+        run: |
+          apk add \
+            unzip \
+      - name: Install mongodb PHP extension
+        run: |
+          apk add $PHPIZE_DEPS
+          pecl install mongodb-$EXT_MONGODB_VERSION
+          docker-php-ext-enable mongodb
+      - name: Disable PHP memory limit
+        run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
+      - name: Install Composer
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+      - name: Install Symfony Flex
+        run: |
+          composer global require --prefer-dist --no-progress --no-suggest --ansi \
+            symfony/flex
+      - name: Update project dependencies
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi
+      - name: Enable legacy integrations
+        if: startsWith(matrix.php, '7.3')
+        run: echo '::set-env name=LEGACY::1'
+      - name: Clear test app cache
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
+      - name: Run Behat tests
+        run: |
+          if [ "$LEGACY" = '1' ]; then
+            vendor/bin/behat --format=progress --no-interaction --colors
+          else
+            vendor/bin/behat --format=progress --profile=default-no-legacy --no-interaction --colors
+          fi
 
   phpunit-postgresql:
     name: PHPUnit (PHP ${{ matrix.php }}) (PostgreSQL)
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
     services:
       postgres:
         image: postgres:10-alpine
@@ -106,7 +244,12 @@ jobs:
           POSTGRES_DB: api_platform_test
           POSTGRES_PASSWORD: hk7dFAByeQVVxpLtmZ6GVUzP
           POSTGRES_USER: api-platform
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       matrix:
         php:
@@ -134,28 +277,114 @@ jobs:
       - name: Install mongodb PHP extension
         run: |
           apk add $PHPIZE_DEPS
-          pecl install mongodb-1.5.5
+          pecl install mongodb-$EXT_MONGODB_VERSION
           docker-php-ext-enable mongodb
       - name: Disable PHP memory limit
         run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
       - name: Install Composer
-        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/fb22b78362d31c0d2bf516d1f8cdfd2745caa431/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
       - name: Install Symfony Flex
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
       - name: Update project dependencies
-        run: composer update --no-progress --no-suggest --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
       - name: Clear test app cache
-        run: tests/Fixtures/app/console cache:clear --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --colors=always
+
+  behat-postgresql:
+    name: Behat (PHP ${{ matrix.php }}) (PostgreSQL)
+    runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
+    services:
+      postgres:
+        image: postgres:10-alpine
+        env:
+          POSTGRES_DB: api_platform_test
+          POSTGRES_PASSWORD: hk7dFAByeQVVxpLtmZ6GVUzP
+          POSTGRES_USER: api-platform
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      matrix:
+        php:
+          - '7.3'
+      fail-fast: false
+    env:
+      APP_ENV: postgres
+      DATABASE_URL: postgres://api-platform:hk7dFAByeQVVxpLtmZ6GVUzP@postgres/api_platform_test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install system packages
+        run: |
+          apk add \
+            unzip \
+      - name: Install PHP extensions
+        run: |
+          apk add \
+            $PHPIZE_DEPS \
+            postgresql-dev \
+          ;
+          docker-php-ext-install -j$(nproc) \
+            pdo_pgsql \
+          ;
+      - name: Install mongodb PHP extension
+        run: |
+          apk add $PHPIZE_DEPS
+          pecl install mongodb-$EXT_MONGODB_VERSION
+          docker-php-ext-enable mongodb
+      - name: Disable PHP memory limit
+        run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
+      - name: Install Composer
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+      - name: Install Symfony Flex
+        run: |
+          composer global require --prefer-dist --no-progress --no-suggest --ansi \
+            symfony/flex
+      - name: Update project dependencies
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
+      - name: Enable legacy integrations
+        if: startsWith(matrix.php, '7.3')
+        run: echo '::set-env name=LEGACY::1'
+      - name: Clear test app cache
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
+      - name: Run Behat tests
+        run: |
+          if [ "$LEGACY" = '1' ]; then
+            vendor/bin/behat --format=progress --profile=postgres --no-interaction --colors
+          else
+            vendor/bin/behat --format=progress --profile=postgres-no-legacy --no-interaction --colors
+          fi
 
   phpunit-mysql:
     name: PHPUnit (PHP ${{ matrix.php }}) (MySQL)
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
     services:
       mysql:
         image: mysql:5.7
@@ -164,7 +393,12 @@ jobs:
           MYSQL_PASSWORD: LUhGR5tJ7WA2gbGumknCYBcB
           MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
           MYSQL_USER: api-platform
-        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/mysql
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       matrix:
         php:
@@ -191,28 +425,114 @@ jobs:
       - name: Install mongodb PHP extension
         run: |
           apk add $PHPIZE_DEPS
-          pecl install mongodb-1.5.5
+          pecl install mongodb-$EXT_MONGODB_VERSION
           docker-php-ext-enable mongodb
       - name: Disable PHP memory limit
         run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
       - name: Install Composer
-        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/fb22b78362d31c0d2bf516d1f8cdfd2745caa431/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
       - name: Install Symfony Flex
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
       - name: Update project dependencies
-        run: composer update --no-progress --no-suggest --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
       - name: Clear test app cache
-        run: tests/Fixtures/app/console cache:clear --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --colors=always
+
+  behat-mysql:
+    name: Behat (PHP ${{ matrix.php }}) (MySQL)
+    runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_DATABASE: api_platform_test
+          MYSQL_PASSWORD: LUhGR5tJ7WA2gbGumknCYBcB
+          MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+          MYSQL_USER: api-platform
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/mysql
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      matrix:
+        php:
+          - '7.3'
+      fail-fast: false
+    env:
+      APP_ENV: mysql
+      DATABASE_URL: mysql://api-platform:LUhGR5tJ7WA2gbGumknCYBcB@mysql/api_platform_test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install system packages
+        run: |
+          apk add \
+            unzip \
+      - name: Install PHP extensions
+        run: |
+          apk add \
+            $PHPIZE_DEPS \
+          ;
+          docker-php-ext-install -j$(nproc) \
+            pdo_mysql \
+          ;
+      - name: Install mongodb PHP extension
+        run: |
+          apk add $PHPIZE_DEPS
+          pecl install mongodb-$EXT_MONGODB_VERSION
+          docker-php-ext-enable mongodb
+      - name: Disable PHP memory limit
+        run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
+      - name: Install Composer
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+      - name: Install Symfony Flex
+        run: |
+          composer global require --prefer-dist --no-progress --no-suggest --ansi \
+            symfony/flex
+      - name: Update project dependencies
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
+      - name: Enable legacy integrations
+        if: startsWith(matrix.php, '7.3')
+        run: echo '::set-env name=LEGACY::1'
+      - name: Clear test app cache
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
+      - name: Run Behat tests
+        run: |
+          if [ "$LEGACY" = '1' ]; then
+            vendor/bin/behat --format=progress --no-interaction --colors
+          else
+            vendor/bin/behat --format=progress --profile=default-no-legacy --no-interaction --colors
+          fi
 
   phpunit-mongodb:
     name: PHPUnit (PHP ${{ matrix.php }}) (MongoDB)
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
     services:
       mongo:
         image: mongo:4
@@ -239,28 +559,100 @@ jobs:
       - name: Install mongodb PHP extension
         run: |
           apk add $PHPIZE_DEPS
-          pecl install mongodb-1.5.5
+          pecl install mongodb-$EXT_MONGODB_VERSION
           docker-php-ext-enable mongodb
       - name: Disable PHP memory limit
         run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
       - name: Install Composer
-        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/fb22b78362d31c0d2bf516d1f8cdfd2745caa431/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
       - name: Install Symfony Flex
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
       - name: Update project dependencies
-        run: composer update --no-progress --no-suggest --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
       - name: Clear test app cache
-        run: tests/Fixtures/app/console cache:clear --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --colors=always --configuration phpunit_mongodb.xml
+
+  behat-mongodb:
+    name: Behat (PHP ${{ matrix.php }}) (MongoDB)
+    runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
+    services:
+      mongo:
+        image: mongo:4
+        options: >-
+          --health-cmd "mongo --quiet --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      matrix:
+        php:
+          - '7.3'
+      fail-fast: false
+    env:
+      APP_ENV: mongodb
+      MONGODB_URL: mongodb://mongo:27017
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install system packages
+        run: |
+          apk add \
+            unzip \
+      - name: Install mongodb PHP extension
+        run: |
+          apk add $PHPIZE_DEPS
+          pecl install mongodb-$EXT_MONGODB_VERSION
+          docker-php-ext-enable mongodb
+      - name: Disable PHP memory limit
+        run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
+      - name: Install Composer
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+      - name: Install Symfony Flex
+        run: |
+          composer global require --prefer-dist --no-progress --no-suggest --ansi \
+            symfony/flex
+      - name: Update project dependencies
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
+      - name: Enable legacy integrations
+        if: startsWith(matrix.php, '7.3')
+        run: echo '::set-env name=LEGACY::1'
+      - name: Clear test app cache
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
+      - name: Run Behat tests
+        run: |
+          if [ "$LEGACY" = '1' ]; then
+            vendor/bin/behat --format=progress --profile=mongodb --no-interaction --colors
+          else
+            vendor/bin/behat --format=progress --profile=mongodb-no-legacy --no-interaction --colors
+          fi
 
   phpunit-elasticsearch:
     name: PHPUnit (PHP ${{ matrix.php }}) (Elasticsearch)
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
     services:
       elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:6.8.3 # https://github.com/elastic/elasticsearch/issues/43627
@@ -289,28 +681,102 @@ jobs:
       - name: Install mongodb PHP extension
         run: |
           apk add $PHPIZE_DEPS
-          pecl install mongodb-1.5.5
+          pecl install mongodb-$EXT_MONGODB_VERSION
           docker-php-ext-enable mongodb
       - name: Disable PHP memory limit
         run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
       - name: Install Composer
-        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/fb22b78362d31c0d2bf516d1f8cdfd2745caa431/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
       - name: Install Symfony Flex
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
       - name: Update project dependencies
-        run: composer update --no-progress --no-suggest --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
       - name: Clear test app cache
-        run: tests/Fixtures/app/console cache:clear --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --colors=always
+
+  behat-elasticsearch:
+    name: Behat (PHP ${{ matrix.php }}) (Elasticsearch)
+    runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.3 # https://github.com/elastic/elasticsearch/issues/43627
+        env:
+          discovery.type: single-node
+        options: >-
+          --health-cmd "curl -fsSL http://127.0.0.1:9200/_cluster/health | grep -q '\"status\":[[:space:]]*\"green\"'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      matrix:
+        php:
+          - '7.3'
+      fail-fast: false
+    env:
+      APP_ENV: elasticsearch
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install system packages
+        run: |
+          apk add \
+            unzip \
+      - name: Install mongodb PHP extension
+        run: |
+          apk add $PHPIZE_DEPS
+          pecl install mongodb-$EXT_MONGODB_VERSION
+          docker-php-ext-enable mongodb
+      - name: Disable PHP memory limit
+        run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
+      - name: Install Composer
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+      - name: Install Symfony Flex
+        run: |
+          composer global require --prefer-dist --no-progress --no-suggest --ansi \
+            symfony/flex
+      - name: Update project dependencies
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
+      - name: Enable legacy integrations
+        if: startsWith(matrix.php, '7.3')
+        run: echo '::set-env name=LEGACY::1'
+      - name: Clear test app cache
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
+      - name: Run Behat tests
+        run: |
+          if [ "$LEGACY" = '1' ]; then
+            vendor/bin/behat --format=progress --profile=elasticsearch --no-interaction --colors
+          else
+            vendor/bin/behat --format=progress --profile=elasticsearch-no-legacy --no-interaction --colors
+          fi
 
   phpunit-no-deprecations:
     name: PHPUnit (PHP ${{ matrix.php }}) (no deprecations)
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php }}-alpine
+      options: >-
+        --tmpfs /tmp:exec
     strategy:
       matrix:
         php:
@@ -328,20 +794,26 @@ jobs:
       - name: Install mongodb PHP extension
         run: |
           apk add $PHPIZE_DEPS
-          pecl install mongodb-1.5.5
+          pecl install mongodb-$EXT_MONGODB_VERSION
           docker-php-ext-enable mongodb
       - name: Disable PHP memory limit
         run: echo 'memory_limit=-1' >> /usr/local/etc/php/php.ini
       - name: Install Composer
-        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/fb22b78362d31c0d2bf516d1f8cdfd2745caa431/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
+        run: wget -qO - https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_INSTALLER_COMMIT/web/installer | php -- --install-dir=/usr/local/bin --filename=composer --quiet
       - name: Install Symfony Flex
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
       - name: Update project dependencies
-        run: composer update --no-progress --no-suggest --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/vendor
+          ln -s /tmp/api-platform/core/vendor vendor
+          composer update --no-progress --no-suggest --ansi
       - name: Clear test app cache
-        run: tests/Fixtures/app/console cache:clear --ansi
+        run: |
+          mkdir -p /tmp/api-platform/core/var
+          ln -s /tmp/api-platform/core/var tests/Fixtures/app/var
+          tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --colors=always
         continue-on-error: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,20 @@ cache:
   - &install-symfony-flex |
       composer global require --prefer-dist --no-progress --no-suggest --ansi \
         symfony/flex
-  - &run-behat-tests |
-      vendor/bin/behat --format=progress --no-interaction --colors
   - &update-project-dependencies |
       composer update --no-progress --no-suggest --ansi
   - &validate-openapi-v2-json |
-      tests/Fixtures/app/console api:swagger:export > swagger.json && npx swagger-cli validate swagger.json && rm swagger.json
+      npx swagger-cli validate <(tests/Fixtures/app/console api:swagger:export)
   - &validate-openapi-v2-yaml |
-      tests/Fixtures/app/console api:swagger:export --yaml > swagger.yaml && npx swagger-cli validate swagger.yaml && rm swagger.yaml
+      npx swagger-cli validate <(tests/Fixtures/app/console api:swagger:export --yaml)
   - &validate-openapi-v3-json |
-      tests/Fixtures/app/console api:openapi:export --spec-version 3 > swagger.json && npx swagger-cli validate swagger.json && rm swagger.json
+      npx swagger-cli validate <(tests/Fixtures/app/console api:openapi:export --spec-version 3)
   - &validate-openapi-v3-yaml |
-      tests/Fixtures/app/console api:openapi:export --spec-version 3 --yaml > swagger.yaml && npx swagger-cli validate swagger.yaml && rm swagger.yaml
+      npx swagger-cli validate <(tests/Fixtures/app/console api:openapi:export --spec-version 3 --yaml)
 
 jobs:
   include:
-    - name: 'Behat (PHP 7.1)'
+    - name: '(PHP 7.1)'
       php: '7.1'
       before_install:
         - *disable-xdebug-php-extension
@@ -53,13 +51,12 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - *run-behat-tests
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.2)'
+    - name: '(PHP 7.2)'
       php: '7.2'
       before_install:
         - *enable-mongodb-php-extension
@@ -71,13 +68,12 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - *run-behat-tests
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.3)'
+    - name: '(PHP 7.3)'
       php: '7.3'
       before_install:
         - *enable-mongodb-php-extension
@@ -89,13 +85,12 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - *run-behat-tests
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.4-rc)'
+    - name: '(PHP 7.4-rc)'
       php: '7.4snapshot'
       env: LEGACY=0
       before_install:
@@ -108,13 +103,12 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - vendor/bin/behat --format=progress --profile=default-no-legacy --no-interaction --colors
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.3) (lowest dependencies)'
+    - name: '(PHP 7.3) (lowest dependencies)'
       php: '7.3'
       before_install:
         - *enable-mongodb-php-extension
@@ -126,13 +120,12 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - *run-behat-tests
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.4-rc) (lowest dependencies)'
+    - name: '(PHP 7.4-rc) (lowest dependencies)'
       php: '7.4snapshot'
       env: LEGACY=0
       before_install:
@@ -145,13 +138,12 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - vendor/bin/behat --format=progress --profile=default-no-legacy --no-interaction --colors
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.3) (PostgreSQL)'
+    - name: '(PHP 7.3) (PostgreSQL)'
       php: '7.3'
       env: >-
         APP_ENV=postgres
@@ -171,13 +163,12 @@ jobs:
         - *clear-test-app-cache
         - *create-test-database
       script:
-        - vendor/bin/behat --format=progress --profile=postgres --no-interaction
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.3) (MySQL)'
+    - name: '(PHP 7.3) (MySQL)'
       php: '7.3'
       env: >-
         APP_ENV=mysql
@@ -204,13 +195,12 @@ jobs:
         - *clear-test-app-cache
         - *create-test-database
       script:
-        - *run-behat-tests
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.3) (MongoDB)'
+    - name: '(PHP 7.3) (MongoDB)'
       php: '7.3'
       env: APP_ENV=mongodb
       services:
@@ -225,13 +215,12 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - vendor/bin/behat --format=progress --profile=mongodb --no-interaction
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json
         - *validate-openapi-v3-yaml
 
-    - name: 'Behat (PHP 7.3) (Elasticsearch)'
+    - name: '(PHP 7.3) (Elasticsearch)'
       php: '7.3'
       env: APP_ENV=elasticsearch
       before_install:
@@ -250,7 +239,6 @@ jobs:
       before_script:
         - *clear-test-app-cache
       script:
-        - vendor/bin/behat --format=progress --profile=elasticsearch --no-interaction
         - *validate-openapi-v2-json
         - *validate-openapi-v2-yaml
         - *validate-openapi-v3-json

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -45,7 +45,7 @@ default-no-legacy:
 postgres:
   suites:
     default: false
-    postgres:
+    postgres: &postgres-suite
       contexts:
         - 'CommandContext'
         - 'DoctrineContext':
@@ -67,10 +67,18 @@ postgres:
       filters:
         tags: '~@sqlite&&~@mongodb&&~@elasticsearch'
 
+postgres-no-legacy:
+  suites:
+    default: false
+    postgres:
+      <<: *postgres-suite
+      filters:
+        tags: '~@sqlite&&~@mongodb&&~@elasticsearch&&~@legacy'
+
 mongodb:
   suites:
     default: false
-    mongodb:
+    mongodb: &mongodb-suite
       contexts:
         - 'CommandContext'
         - 'DoctrineContext':
@@ -92,10 +100,18 @@ mongodb:
       filters:
         tags: '~@sqlite&&~@elasticsearch&&~@!mongodb'
 
+mongodb-no-legacy:
+  suites:
+    default: false
+    mongodb:
+      <<: *mongodb-suite
+      filters:
+        tags: '~@sqlite&&~@elasticsearch&&~@!mongodb&&~@legacy'
+
 elasticsearch:
   suites:
     default: false
-    elasticsearch:
+    elasticsearch: &elasticsearch-suite
       paths:
         - '%paths.base%/features/elasticsearch'
       contexts:
@@ -110,6 +126,14 @@ elasticsearch:
         - 'Behat\MinkExtension\Context\MinkContext'
       filters:
         tags: '@elasticsearch'
+
+elasticsearch-no-legacy:
+  suites:
+    default: false
+    elasticsearch:
+      <<: *elasticsearch-suite
+      filters:
+        tags: '@elasticsearch&&~@legacy'
 
 default-coverage:
   suites:
@@ -133,13 +157,12 @@ default-coverage:
         - 'CoverageContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
-      filters:
-        tags: '~@postgres&&~@mongodb&&~@elasticsearch'
 
 mongodb-coverage:
   suites:
     default: false
     mongodb:
+      <<: *mongodb-suite
       contexts:
         - 'CommandContext'
         - 'DoctrineContext':
@@ -159,15 +182,12 @@ mongodb-coverage:
         - 'CoverageContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
-      filters:
-        tags: '~@sqlite&&~@elasticsearch&&~@!mongodb'
 
 elasticsearch-coverage:
   suites:
     default: false
     elasticsearch:
-      paths:
-        - '%paths.base%/features/elasticsearch'
+      <<: *elasticsearch-suite
       contexts:
         - 'CommandContext'
         - 'ElasticsearchContext':
@@ -179,5 +199,3 @@ elasticsearch-coverage:
         - 'CoverageContext'
         - 'Behatch\Context\RestContext'
         - 'Behat\MinkExtension\Context\MinkContext'
-      filters:
-        tags: '@elasticsearch'

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -31,14 +31,353 @@ Feature: GraphQL mutation support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.__type.fields[2].name" should contain "delete"
-    And the JSON node "data.__type.fields[2].description" should match '/^Deletes a [A-z0-9]+.$/'
-    And the JSON node "data.__type.fields[2].type.name" should match "/^delete[A-z0-9]+Payload$/"
-    And the JSON node "data.__type.fields[2].type.kind" should be equal to "OBJECT"
-    And the JSON node "data.__type.fields[2].args[0].name" should be equal to "input"
-    And the JSON node "data.__type.fields[2].args[0].type.kind" should be equal to "NON_NULL"
-    And the JSON node "data.__type.fields[2].args[0].type.ofType.name" should match "/^delete[A-z0-9]+Input$/"
-    And the JSON node "data.__type.fields[2].args[0].type.ofType.kind" should be equal to "INPUT_OBJECT"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": [
+            "__type"
+          ],
+          "properties": {
+            "__type": {
+              "type": "object",
+              "required": [
+                "fields"
+              ],
+              "properties": {
+                "fields": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "description",
+                          "type",
+                          "args"
+                        ],
+                        "properties": {
+                          "name": {
+                            "pattern": "^create[A-z0-9]+$"
+                          },
+                          "description": {
+                            "pattern": "^Creates a [A-z0-9]+.$"
+                          },
+                          "type": {
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "kind"
+                            ],
+                            "properties": {
+                              "name": {
+                                "pattern": "^create[A-z0-9]+Payload$"
+                              },
+                              "kind": {
+                                "enum": ["OBJECT"]
+                              }
+                            }
+                          },
+                          "args": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 1,
+                            "items": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "type"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "enum": ["input"]
+                                  },
+                                  "type": {
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "ofType"
+                                    ],
+                                    "properties": {
+                                      "kind": {
+                                        "enum": ["NON_NULL"]
+                                      },
+                                      "ofType": {
+                                        "type": "object",
+                                        "required": [
+                                          "name",
+                                          "kind"
+                                        ],
+                                        "properties": {
+                                          "name": {
+                                            "pattern": "^create[A-z0-9]+Input$"
+                                          },
+                                          "kind": {
+                                            "enum": ["INPUT_OBJECT"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "description",
+                          "type",
+                          "args"
+                        ],
+                        "properties": {
+                          "name": {
+                            "pattern": "^update[A-z0-9]+$"
+                          },
+                          "description": {
+                            "pattern": "^Updates a [A-z0-9]+.$"
+                          },
+                          "type": {
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "kind"
+                            ],
+                            "properties": {
+                              "name": {
+                                "pattern": "^update[A-z0-9]+Payload$"
+                              },
+                              "kind": {
+                                "enum": ["OBJECT"]
+                              }
+                            }
+                          },
+                          "args": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 1,
+                            "items": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "type"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "enum": ["input"]
+                                  },
+                                  "type": {
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "ofType"
+                                    ],
+                                    "properties": {
+                                      "kind": {
+                                        "enum": ["NON_NULL"]
+                                      },
+                                      "ofType": {
+                                        "type": "object",
+                                        "required": [
+                                          "name",
+                                          "kind"
+                                        ],
+                                        "properties": {
+                                          "name": {
+                                            "pattern": "^update[A-z0-9]+Input$"
+                                          },
+                                          "kind": {
+                                            "enum": ["INPUT_OBJECT"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "description",
+                          "type",
+                          "args"
+                        ],
+                        "properties": {
+                          "name": {
+                            "pattern": "^delete[A-z0-9]+$"
+                          },
+                          "description": {
+                            "pattern": "^Deletes a [A-z0-9]+.$"
+                          },
+                          "type": {
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "kind"
+                            ],
+                            "properties": {
+                              "name": {
+                                "pattern": "^delete[A-z0-9]+Payload$"
+                              },
+                              "kind": {
+                                "enum": ["OBJECT"]
+                              }
+                            }
+                          },
+                          "args": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 1,
+                            "items": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "type"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "enum": ["input"]
+                                  },
+                                  "type": {
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "ofType"
+                                    ],
+                                    "properties": {
+                                      "kind": {
+                                        "enum": ["NON_NULL"]
+                                      },
+                                      "ofType": {
+                                        "type": "object",
+                                        "required": [
+                                          "name",
+                                          "kind"
+                                        ],
+                                        "properties": {
+                                          "name": {
+                                            "pattern": "^delete[A-z0-9]+Input$"
+                                          },
+                                          "kind": {
+                                            "enum": ["INPUT_OBJECT"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "description",
+                          "type",
+                          "args"
+                        ],
+                        "properties": {
+                          "name": {
+                            "pattern": "^(?!create|update|delete)[A-z0-9]+$"
+                          },
+                          "description": {
+                            "pattern": "^(?!Create|Update|Delete)[A-z0-9]+s a [A-z0-9]+.$"
+                          },
+                          "type": {
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "kind"
+                            ],
+                            "properties": {
+                              "name": {
+                                "pattern": "^(?!create|update|delete)[A-z0-9]+Payload$"
+                              },
+                              "kind": {
+                                "enum": ["OBJECT"]
+                              }
+                            }
+                          },
+                          "args": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 1,
+                            "items": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "type"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "enum": ["input"]
+                                  },
+                                  "type": {
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "ofType"
+                                    ],
+                                    "properties": {
+                                      "kind": {
+                                        "enum": ["NON_NULL"]
+                                      },
+                                      "ofType": {
+                                        "type": "object",
+                                        "required": [
+                                          "name",
+                                          "kind"
+                                        ],
+                                        "properties": {
+                                          "name": {
+                                            "pattern": "^(?!create|update|delete)[A-z0-9]+Input$"
+                                          },
+                                          "kind": {
+                                            "enum": ["INPUT_OBJECT"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
 
   Scenario: Create an item
     When I send the following GraphQL request:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Move the Behat tests to the CI workflow on GitHub Actions, so that we can move away from Travis CI completely.

TODO:

- [x] Fix failing Behat test related to GraphQL (previously flaky on CircleCI, but always failing on GitHub Actions :thinking:) (@alanpoulain?)
- [ ] ~Move Swagger / OpenAPI tests to CircleCI?~ Looks like this will complicate things too much...
- [ ] ~See if we can speed up the jobs on CircleCI~ CircleCI doesn't support `tmpfs` for the `docker` executor :disappointed: