### PR TITLE
fix #3189 - JSONAPI pagination ignored when using filter parameter

### DIFF
--- a/features/jsonapi/filtering.feature
+++ b/features/jsonapi/filtering.feature
@@ -23,6 +23,14 @@ Feature: JSON API filter handling
     And the JSON should be valid according to the JSON API schema
     And the JSON node "data" should have 0 elements
 
+  Scenario: Apply filters and pagination at the same time
+    When I send a "GET" request to "/dummies?filter[name]=foo&page[page]=2"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    Then the JSON node "meta.currentPage" should be a number
+    Then the JSON node "meta.currentPage" should be equal to "2"
+
   Scenario: Apply property filter based on the 'fields'
     Given there are 2 dummy property objects
     When I send a "GET" request to "/dummy_properties?fields[DummyProperty]=id,foo,bar"

--- a/src/JsonApi/EventListener/TransformFilteringParametersListener.php
+++ b/src/JsonApi/EventListener/TransformFilteringParametersListener.php
@@ -29,12 +29,12 @@ final class TransformFilteringParametersListener
         $request = $event->getRequest();
         if (
             'jsonapi' !== $request->getRequestFormat() ||
-            null === ($filters = $request->query->get('filter')) ||
-            !\is_array($filters)
+            null === ($filterParameter = $request->query->get('filter')) ||
+            !\is_array($filterParameter)
         ) {
             return;
         }
-
-        $request->attributes->set('_api_filters', $filters);
+        $filters = $request->attributes->get('_api_filters', []);
+        $request->attributes->set('_api_filters', array_merge($filterParameter, $filters));
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  |no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? |no
| Tickets       | fixes #3189 <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

This PR fixes issue #3189, when using the jsonapi protocol pagination was overwritten when applying additional filters.