### PR TITLE
Add links to documentation to ApiResource properties

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -25,10 +25,6 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  * @Attributes(
  *     @Attribute("accessControl", type="string"),
  *     @Attribute("accessControlMessage", type="string"),
- *     @Attribute("security", type="string"),
- *     @Attribute("securityMessage", type="string"),
- *     @Attribute("securityPostDenormalize", type="string"),
- *     @Attribute("securityPostDenormalizeMessage", type="string"),
  *     @Attribute("attributes", type="array"),
  *     @Attribute("cacheHeaders", type="array"),
  *     @Attribute("collectionOperations", type="array"),
@@ -62,6 +58,10 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("paginationPartial", type="bool"),
  *     @Attribute("paginationViaCursor", type="array"),
  *     @Attribute("routePrefix", type="string"),
+ *     @Attribute("security", type="string"),
+ *     @Attribute("securityMessage", type="string"),
+ *     @Attribute("securityPostDenormalize", type="string"),
+ *     @Attribute("securityPostDenormalizeMessage", type="string"),
  *     @Attribute("shortName", type="string"),
  *     @Attribute("subresourceOperations", type="array"),
  *     @Attribute("sunset", type="string"),
@@ -74,9 +74,11 @@ final class ApiResource
     use AttributesHydratorTrait;
 
     /**
-     * @var string
+     * @see https://api-platform.com/docs/core/operations
+     *
+     * @var array
      */
-    public $shortName;
+    public $collectionOperations;
 
     /**
      * @var string
@@ -84,59 +86,38 @@ final class ApiResource
     public $description;
 
     /**
-     * @var string
-     */
-    public $iri;
-
-    /**
-     * @var array
-     */
-    public $itemOperations;
-
-    /**
-     * @var array
-     */
-    public $collectionOperations;
-
-    /**
-     * @var array
-     */
-    public $subresourceOperations;
-
-    /**
+     * @see https://api-platform.com/docs/core/graphql
+     *
      * @var array
      */
     public $graphql;
 
     /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
      * @var string
      */
-    private $security;
+    public $iri;
 
     /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     * @see https://api-platform.com/docs/core/operations
      *
+     * @var array
+     */
+    public $itemOperations;
+
+    /**
      * @var string
      */
-    private $securityMessage;
+    public $shortName;
 
     /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     * @see https://api-platform.com/docs/core/subresources
      *
-     * @var string
+     * @var array
      */
-    private $securityPostDenormalize;
+    public $subresourceOperations;
 
     /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $securityPostDenormalizeMessage;
-
-    /**
+     * @see https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var array
@@ -144,6 +125,7 @@ final class ApiResource
     private $cacheHeaders;
 
     /**
+     * @see https://api-platform.com/docs/core/serialization/#using-serialization-groups
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var array
@@ -151,6 +133,7 @@ final class ApiResource
     private $denormalizationContext;
 
     /**
+     * @see https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var string
@@ -165,6 +148,7 @@ final class ApiResource
     private $elasticsearch;
 
     /**
+     * @see https://api-platform.com/docs/core/performance/#fetch-partial
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var bool
@@ -172,6 +156,7 @@ final class ApiResource
     private $fetchPartial;
 
     /**
+     * @see https://api-platform.com/docs/core/performance/#force-eager
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var bool
@@ -179,6 +164,7 @@ final class ApiResource
     private $forceEager;
 
     /**
+     * @see https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var array
@@ -186,6 +172,7 @@ final class ApiResource
     private $formats;
 
     /**
+     * @see https://api-platform.com/docs/core/filters/#doctrine-orm-and-mongodb-odm-filters
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var string[]
@@ -193,6 +180,7 @@ final class ApiResource
     private $filters;
 
     /**
+     * @see https://api-platform.com/docs/core/extending-jsonld-context/#hydra
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var string[]
@@ -200,74 +188,12 @@ final class ApiResource
     private $hydraContext;
 
     /**
+     * @see https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
-     * @var mixed
+     * @var string|false
      */
-    private $mercure;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool|string
-     */
-    private $messenger;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $normalizationContext;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $order;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationClientEnabled;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationClientItemsPerPage;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationClientPartial;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationEnabled;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationFetchJoinCollection;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var int
-     */
-    private $paginationItemsPerPage;
+    private $input;
 
     /**
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
@@ -279,62 +205,31 @@ final class ApiResource
     private $maximumItemsPerPage;
 
     /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var int
-     */
-    private $paginationMaximumItemsPerPage;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var int
-     */
-    private $paginationPartial;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $routePrefix;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $swaggerContext;
-
-    /**
+     * @see https://api-platform.com/docs/core/mercure
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var mixed
      */
-    private $validationGroups;
+    private $mercure;
 
     /**
+     * @see https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
-     * @var string
+     * @var bool|string
      */
-    private $sunset;
+    private $messenger;
 
     /**
+     * @see https://api-platform.com/docs/core/serialization/#using-serialization-groups
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
-     * @var string|false
+     * @var array
      */
-    private $input;
+    private $normalizationContext;
 
     /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string|false
-     */
-    private $output;
-
-    /**
+     * @see https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var array
@@ -342,11 +237,155 @@ final class ApiResource
     private $openapiContext;
 
     /**
+     * @see https://api-platform.com/docs/core/default-order/#overriding-default-order
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $order;
+
+    /**
+     * @see https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string|false
+     */
+    private $output;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationClientEnabled;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource-3
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationClientItemsPerPage;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource-6
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationClientPartial;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#cursor-based-pagination
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
      * @var array
      */
     private $paginationViaCursor;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationEnabled;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#controlling-the-behavior-of-the-doctrine-orm-paginator
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $paginationFetchJoinCollection;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#changing-the-number-of-items-per-page
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var int
+     */
+    private $paginationItemsPerPage;
+
+    /**
+     * @see https://api-platform.com/docs/core/pagination/#changing-maximum-items-per-page
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var int
+     */
+    private $paginationMaximumItemsPerPage;
+
+    /**
+     * @see https://api-platform.com/docs/core/performance/#partial-pagination
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var int
+     */
+    private $paginationPartial;
+
+    /**
+     * @see https://api-platform.com/docs/core/operations/#prefixing-all-routes-of-all-operations
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $routePrefix;
+
+    /**
+     * @see https://api-platform.com/docs/core/security
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $security;
+
+    /**
+     * @see https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $securityMessage;
+
+    /**
+     * @see https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $securityPostDenormalize;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $securityPostDenormalizeMessage;
+
+    /**
+     * @see https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var string
+     */
+    private $sunset;
+
+    /**
+     * @see https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var array
+     */
+    private $swaggerContext;
+
+    /**
+     * @see https://api-platform.com/docs/core/validation/#using-validation-groups
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var mixed
+     */
+    private $validationGroups;
 
     /**
      * @throws InvalidArgumentException


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | ~fixes~ https://github.com/api-platform/docs/issues/868 <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->

I started work on https://github.com/api-platform/docs/issues/868 because it was marked as `good first issue` :)
First, I added links to documentation for API Resource properties and sort properties alphabetically.

But there are some points I don't understand from this issue.
What should we do with `@see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112` in the class ApiResource?
I found this [PR](https://github.com/api-platform/core/pull/1788#pullrequestreview-107255243) but still can't understand.