### PR TITLE
Remove soon-EOL PHP 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.1'
           - '7.2'
           - '7.3'
           - '7.4-rc'
@@ -35,7 +34,6 @@ jobs:
           apk add \
             unzip \
       - name: Install mongodb PHP extension
-        if: (!startsWith(matrix.php, '7.1'))
         run: |
           apk add $PHPIZE_DEPS
           pecl install mongodb-$EXT_MONGODB_VERSION
@@ -48,12 +46,6 @@ jobs:
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
-      - name: Remove Doctrine MongoDB ODM
-        if: startsWith(matrix.php, '7.1')
-        run: |
-          composer remove --dev --no-progress --no-update --ansi \
-            doctrine/mongodb-odm \
-            doctrine/mongodb-odm-bundle \
       - name: Update project dependencies
         run: |
           mkdir -p /tmp/api-platform/core/vendor
@@ -77,7 +69,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.1'
           - '7.2'
           - '7.3'
           - '7.4-rc'
@@ -90,7 +81,6 @@ jobs:
           apk add \
             unzip \
       - name: Install mongodb PHP extension
-        if: (!startsWith(matrix.php, '7.1'))
         run: |
           apk add $PHPIZE_DEPS
           pecl install mongodb-$EXT_MONGODB_VERSION
@@ -103,19 +93,13 @@ jobs:
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
-      - name: Remove Doctrine MongoDB ODM
-        if: startsWith(matrix.php, '7.1')
-        run: |
-          composer remove --dev --no-progress --no-update --ansi \
-            doctrine/mongodb-odm \
-            doctrine/mongodb-odm-bundle \
       - name: Update project dependencies
         run: |
           mkdir -p /tmp/api-platform/core/vendor
           ln -s /tmp/api-platform/core/vendor vendor
           composer update --no-progress --no-suggest --ansi
       - name: Enable legacy integrations
-        if: startsWith(matrix.php, '7.1') || startsWith(matrix.php, '7.2') || startsWith(matrix.php, '7.3')
+        if: startsWith(matrix.php, '7.2') || startsWith(matrix.php, '7.3')
         run: echo '::set-env name=LEGACY::1'
       - name: Clear test app cache
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,26 +36,6 @@ cache:
 
 jobs:
   include:
-    - name: '(PHP 7.1)'
-      php: '7.1'
-      before_install:
-        - *disable-xdebug-php-extension
-        - *disable-php-memory-limit
-        - *install-symfony-flex
-      install:
-        - |
-          composer remove --dev --no-progress --no-update --ansi \
-            doctrine/mongodb-odm \
-            doctrine/mongodb-odm-bundle \
-        - *update-project-dependencies
-      before_script:
-        - *clear-test-app-cache
-      script:
-        - *validate-openapi-v2-json
-        - *validate-openapi-v2-yaml
-        - *validate-openapi-v3-json
-        - *validate-openapi-v3-yaml
-
     - name: '(PHP 7.2)'
       php: '7.2'
       before_install:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "doctrine/inflector": "^1.0",
         "psr/cache": "^1.0",
         "psr/container": "^1.0",


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #2663 <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->

Drop support for PHP 7.1.

Active support ended on 1 Dec 2018 (10 months ago) and security support will end on  1 Dec 2019 (in 1 month):

![image](https://user-images.githubusercontent.com/1324225/67620023-1f999b80-f80b-11e9-91f0-f1416f49c5cd.png)

https://www.php.net/supported-versions.php

This allows follow-up PRs to make use of new features of PHP introduced in 7.2.

# TODO

* [ ]  Remove the required 7.1 check:

![image](https://user-images.githubusercontent.com/1324225/67620186-c6cb0280-f80c-11e9-9efc-fb62d0fc4607.png)

