### PR TITLE
Make the base exception extend throwable

### DIFF
--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -18,6 +18,6 @@ namespace ApiPlatform\Core\Exception;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface ExceptionInterface
+interface ExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/a
| License       | MIT
| Doc PR        | N/a

This makes it more clear this interface can be 'caught'
