### PR TITLE
Use IriConverter without output with new attribute

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -87,6 +87,7 @@ final class WriteListener
                 }
 
                 $hasOutput = true;
+                $resourceMetadata = null;
                 if ($this->resourceMetadataFactory instanceof ResourceMetadataFactoryInterface) {
                     $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
                     $outputMetadata = $resourceMetadata->getOperationAttribute($attributes, 'output', [
@@ -96,11 +97,11 @@ final class WriteListener
                     $hasOutput = \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'];
                 }
 
-                if (!$hasOutput) {
-                    break;
+                if (null !== $resourceMetadata) {
+                    $hasOutput = $resourceMetadata->getOperationAttribute($attributes, 'set_content_location', $hasOutput, true);
                 }
 
-                if ($this->iriConverter instanceof IriConverterInterface && $this->isResourceClass($this->getObjectClass($controllerResult))) {
+                if ($hasOutput && $this->iriConverter instanceof IriConverterInterface && $this->isResourceClass($this->getObjectClass($controllerResult))) {
                     $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
| Doc PR        | api-platform/docs#...

Allow to have content-location without output if output is set to false and set_content_location (the new attribute) is set to true
 #hackdayparis
