### PR TITLE
Split iri converter interface

### DIFF
--- a/src/Api/IriConverterInterface.php
+++ b/src/Api/IriConverterInterface.php
@@ -13,55 +13,11 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Api;
 
-use ApiPlatform\Core\Exception\InvalidArgumentException;
-use ApiPlatform\Core\Exception\ItemNotFoundException;
-use ApiPlatform\Core\Exception\RuntimeException;
-
 /**
  * Converts item and resources to IRI and vice versa.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface IriConverterInterface
+interface IriConverterInterface extends ItemFromIriConverterInterface, IriFromItemConverterInterface
 {
-    /**
-     * Retrieves an item from its IRI.
-     *
-     * @throws InvalidArgumentException
-     * @throws ItemNotFoundException
-     *
-     * @return object
-     */
-    public function getItemFromIri(string $iri, array $context = []);
-
-    /**
-     * Gets the IRI associated with the given item.
-     *
-     * @param object $item
-     *
-     * @throws InvalidArgumentException
-     * @throws RuntimeException
-     */
-    public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
-
-    /**
-     * Gets the IRI associated with the given resource collection.
-     *
-     * @throws InvalidArgumentException
-     */
-    public function getIriFromResourceClass(string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
-
-    /**
-     * Gets the item IRI associated with the given resource.
-     *
-     * @throws InvalidArgumentException
-     */
-    public function getItemIriFromResourceClass(string $resourceClass, array $identifiers, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
-
-    /**
-     * Gets the IRI associated with the given resource subresource.
-     *
-     * @throws InvalidArgumentException
-     */
-    public function getSubresourceIriFromResourceClass(string $resourceClass, array $identifiers, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
 }

--- a/src/Api/IriFromItemConverterInterface.php
+++ b/src/Api/IriFromItemConverterInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Api;
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\RuntimeException;
+
+interface IriFromItemConverterInterface
+{
+    /**
+     * Gets the IRI associated with the given item.
+     *
+     * @param object $item
+     *
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     */
+    public function getIriFromItem($item, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
+
+    /**
+     * Gets the IRI associated with the given resource collection.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getIriFromResourceClass(string $resourceClass, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
+
+    /**
+     * Gets the item IRI associated with the given resource.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getItemIriFromResourceClass(string $resourceClass, array $identifiers, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
+
+    /**
+     * Gets the IRI associated with the given resource subresource.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getSubresourceIriFromResourceClass(string $resourceClass, array $identifiers, int $referenceType = UrlGeneratorInterface::ABS_PATH): string;
+}

--- a/src/Api/ItemFromIriConverterInterface.php
+++ b/src/Api/ItemFromIriConverterInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Api;
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\ItemNotFoundException;
+
+interface ItemFromIriConverterInterface
+{
+    /**
+     * Retrieves an item from its IRI.
+     *
+     * @throws InvalidArgumentException
+     * @throws ItemNotFoundException
+     *
+     * @return object
+     */
+    public function getItemFromIri(string $iri, array $context = []);
+}

--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Doctrine\EventListener;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Bridge\Symfony\Messenger\DispatchTrait;
@@ -39,7 +39,7 @@ final class PublishMercureUpdatesListener
     use DispatchTrait;
     use ResourceClassInfoTrait;
 
-    private $iriConverter;
+    private $iriFromItemConverter;
     private $resourceMetadataFactory;
     private $serializer;
     private $publisher;
@@ -52,14 +52,14 @@ final class PublishMercureUpdatesListener
     /**
      * @param array<string, string[]|string> $formats
      */
-    public function __construct(ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter, ResourceMetadataFactoryInterface $resourceMetadataFactory, SerializerInterface $serializer, array $formats, MessageBusInterface $messageBus = null, callable $publisher = null, ExpressionLanguage $expressionLanguage = null)
+    public function __construct(ResourceClassResolverInterface $resourceClassResolver, IriFromItemConverterInterface $iriFromItemConverter, ResourceMetadataFactoryInterface $resourceMetadataFactory, SerializerInterface $serializer, array $formats, MessageBusInterface $messageBus = null, callable $publisher = null, ExpressionLanguage $expressionLanguage = null)
     {
         if (null === $messageBus && null === $publisher) {
             throw new InvalidArgumentException('A message bus or a publisher must be provided.');
         }
 
         $this->resourceClassResolver = $resourceClassResolver;
-        $this->iriConverter = $iriConverter;
+        $this->iriFromItemConverter = $iriFromItemConverter;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->serializer = $serializer;
         $this->formats = $formats;
@@ -150,8 +150,8 @@ final class PublishMercureUpdatesListener
 
         if ('deletedEntities' === $property) {
             $this->deletedEntities[(object) [
-                'id' => $this->iriConverter->getIriFromItem($entity),
-                'iri' => $this->iriConverter->getIriFromItem($entity, UrlGeneratorInterface::ABS_URL),
+                'id' => $this->iriFromItemConverter->getIriFromItem($entity),
+                'iri' => $this->iriFromItemConverter->getIriFromItem($entity, UrlGeneratorInterface::ABS_URL),
             ]] = $value;
 
             return;
@@ -176,7 +176,7 @@ final class PublishMercureUpdatesListener
             $resourceClass = $this->getObjectClass($entity);
             $context = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('normalization_context', []);
 
-            $iri = $this->iriConverter->getIriFromItem($entity, UrlGeneratorInterface::ABS_URL);
+            $iri = $this->iriFromItemConverter->getIriFromItem($entity, UrlGeneratorInterface::ABS_URL);
             $data = $this->serializer->serialize($entity, key($this->formats), $context);
         }
 

--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Doctrine\EventListener;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\RuntimeException;
@@ -36,15 +36,15 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 final class PurgeHttpCacheListener
 {
     private $purger;
-    private $iriConverter;
+    private $iriFromItemConverter;
     private $resourceClassResolver;
     private $propertyAccessor;
     private $tags = [];
 
-    public function __construct(PurgerInterface $purger, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null)
+    public function __construct(PurgerInterface $purger, IriFromItemConverterInterface $iriFromItemConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null)
     {
         $this->purger = $purger;
-        $this->iriConverter = $iriConverter;
+        $this->iriFromItemConverter = $iriFromItemConverter;
         $this->resourceClassResolver = $resourceClassResolver;
         $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
@@ -111,10 +111,10 @@ final class PurgeHttpCacheListener
     {
         try {
             $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
-            $iri = $this->iriConverter->getIriFromResourceClass($resourceClass);
+            $iri = $this->iriFromItemConverter->getIriFromResourceClass($resourceClass);
             $this->tags[$iri] = $iri;
             if ($purgeItem) {
-                $iri = $this->iriConverter->getIriFromItem($entity);
+                $iri = $this->iriFromItemConverter->getIriFromItem($entity);
                 $this->tags[$iri] = $iri;
             }
         } catch (InvalidArgumentException $e) {
@@ -154,7 +154,7 @@ final class PurgeHttpCacheListener
     private function addTagForItem($value): void
     {
         try {
-            $iri = $this->iriConverter->getIriFromItem($value);
+            $iri = $this->iriFromItemConverter->getIriFromItem($value);
             $this->tags[$iri] = $iri;
         } catch (InvalidArgumentException $e) {
         } catch (RuntimeException $e) {

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter;
 
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\ItemFromIriConverterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\SearchFilterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\SearchFilterTrait;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
@@ -43,7 +43,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 
     public const DOCTRINE_INTEGER_TYPE = MongoDbType::INTEGER;
 
-    public function __construct(ManagerRegistry $managerRegistry, IriConverterInterface $iriConverter, IdentifiersExtractorInterface $identifiersExtractor, PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null, array $properties = null, NameConverterInterface $nameConverter = null)
+    public function __construct(ManagerRegistry $managerRegistry, ItemFromIriConverterInterface $iriConverter, IdentifiersExtractorInterface $identifiersExtractor, PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null, array $properties = null, NameConverterInterface $nameConverter = null)
     {
         parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
 
@@ -52,7 +52,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         $this->identifiersExtractor = $identifiersExtractor;
     }
 
-    protected function getIriConverter(): IriConverterInterface
+    protected function getIriConverter(): ItemFromIriConverterInterface
     {
         return $this->iriConverter;
     }

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -67,6 +67,8 @@
             <argument type="service" id="api_platform.resource_class_resolver" />
         </service>
         <service id="ApiPlatform\Core\Api\IriConverterInterface" alias="api_platform.iri_converter" />
+        <service id="ApiPlatform\Core\Api\IriFromItemConverterInterface" alias="api_platform.iri_converter" />
+        <service id="ApiPlatform\Core\Api\ItemFromIriConverterInterface" alias="api_platform.iri_converter" />
 
         <service id="api_platform.formats_provider" class="ApiPlatform\Core\Api\FormatsProvider">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />

--- a/src/GraphQl/Resolver/ResourceFieldResolver.php
+++ b/src/GraphQl/Resolver/ResourceFieldResolver.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Resolver;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
 use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Util\ClassInfoTrait;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -29,18 +29,18 @@ final class ResourceFieldResolver
 {
     use ClassInfoTrait;
 
-    private $iriConverter;
+    private $iriFromItemConverter;
 
-    public function __construct(IriConverterInterface $iriConverter)
+    public function __construct(IriFromItemConverterInterface $iriFromItemConverter)
     {
-        $this->iriConverter = $iriConverter;
+        $this->iriFromItemConverter = $iriFromItemConverter;
     }
 
     public function __invoke(?array $source, array $args, $context, ResolveInfo $info)
     {
         $property = null;
         if ('id' === $info->fieldName && !isset($source['_id']) && isset($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY])) {
-            return $this->iriConverter->getItemIriFromResourceClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]);
+            return $this->iriFromItemConverter->getItemIriFromResourceClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]);
         }
 
         if ('_id' === $info->fieldName && !isset($source['_id']) && isset($source['id'])) {

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Resolver\Stage;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\ItemFromIriConverterInterface;
 use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
@@ -36,16 +36,16 @@ final class ReadStage implements ReadStageInterface
     use ClassInfoTrait;
 
     private $resourceMetadataFactory;
-    private $iriConverter;
+    private $itemFromIriConverter;
     private $collectionDataProvider;
     private $subresourceDataProvider;
     private $serializerContextBuilder;
     private $nestingSeparator;
 
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, IriConverterInterface $iriConverter, ContextAwareCollectionDataProviderInterface $collectionDataProvider, SubresourceDataProviderInterface $subresourceDataProvider, SerializerContextBuilderInterface $serializerContextBuilder, string $nestingSeparator)
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, ItemFromIriConverterInterface $itemFromIriConverter, ContextAwareCollectionDataProviderInterface $collectionDataProvider, SubresourceDataProviderInterface $subresourceDataProvider, SerializerContextBuilderInterface $serializerContextBuilder, string $nestingSeparator)
     {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
-        $this->iriConverter = $iriConverter;
+        $this->itemFromIriConverter = $itemFromIriConverter;
         $this->collectionDataProvider = $collectionDataProvider;
         $this->subresourceDataProvider = $subresourceDataProvider;
         $this->serializerContextBuilder = $serializerContextBuilder;
@@ -126,7 +126,7 @@ final class ReadStage implements ReadStageInterface
         }
 
         try {
-            $item = $this->iriConverter->getItemFromIri($identifier, $normalizationContext);
+            $item = $this->itemFromIriConverter->getItemFromIri($identifier, $normalizationContext);
         } catch (ItemNotFoundException $e) {
             return null;
         }

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\HttpCache\EventListener;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
@@ -30,11 +31,11 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  */
 final class AddTagsListener
 {
-    private $iriConverter;
+    private $iriFromItemConverter;
 
-    public function __construct(IriConverterInterface $iriConverter)
+    public function __construct(IriFromItemConverterInterface $iriFromItemConverter)
     {
-        $this->iriConverter = $iriConverter;
+        $this->iriFromItemConverter = $iriFromItemConverter;
     }
 
     /**
@@ -56,7 +57,7 @@ final class AddTagsListener
         $resources = $request->attributes->get('_resources');
         if (isset($attributes['collection_operation_name']) || ($attributes['subresource_context']['collection'] ?? false)) {
             // Allows to purge collections
-            $iri = $this->iriConverter->getIriFromResourceClass($attributes['resource_class']);
+            $iri = $this->iriFromItemConverter->getIriFromResourceClass($attributes['resource_class']);
             $resources[$iri] = $iri;
         }
 

--- a/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\EventListener;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Bridge\Doctrine\EventListener\PublishMercureUpdatesListener;
@@ -61,13 +61,13 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(DummyCar::class)->willReturn(true);
         $resourceClassResolverProphecy->isResourceClass(DummyFriend::class)->willReturn(true);
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($toInsert, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toUpdate, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
+        $iriFromItemConverterProphecy->getIriFromItem($toInsert, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
+        $iriFromItemConverterProphecy->getIriFromItem($toUpdate, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
+        $iriFromItemConverterProphecy->getIriFromItem($toDelete, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
+        $iriFromItemConverterProphecy->getIriFromItem($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
+        $iriFromItemConverterProphecy->getIriFromItem($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
+        $iriFromItemConverterProphecy->getIriFromItem($toDeleteExpressionLanguage, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => true, 'normalization_context' => ['groups' => ['foo', 'bar']]]));
@@ -91,7 +91,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
 
         $listener = new PublishMercureUpdatesListener(
             $resourceClassResolverProphecy->reveal(),
-            $iriConverterProphecy->reveal(),
+            $iriFromItemConverterProphecy->reveal(),
             $resourceMetadataFactoryProphecy->reveal(),
             $serializerProphecy->reveal(),
             $formats,
@@ -122,7 +122,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
 
         new PublishMercureUpdatesListener(
             $this->prophesize(ResourceClassResolverInterface::class)->reveal(),
-            $this->prophesize(IriConverterInterface::class)->reveal(),
+            $this->prophesize(IriFromItemConverterInterface::class)->reveal(),
             $this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(),
             $this->prophesize(SerializerInterface::class)->reveal(),
             ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']],
@@ -142,7 +142,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class);
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
 
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => 1]));
@@ -151,7 +151,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
 
         $listener = new PublishMercureUpdatesListener(
             $resourceClassResolverProphecy->reveal(),
-            $iriConverterProphecy->reveal(),
+            $iriFromItemConverterProphecy->reveal(),
             $resourceMetadataFactoryProphecy->reveal(),
             $serializerProphecy->reveal(),
             ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']],

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Doctrine\MongoDbOdm\Filter;
 
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\ItemFromIriConverterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\SearchFilter;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Test\DoctrineMongoDbOdmFilterTestCase;
@@ -557,9 +557,9 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
     protected function buildSearchFilter(ManagerRegistry $managerRegistry, ?array $properties = null)
     {
         $relatedDummyProphecy = $this->prophesize(RelatedDummy::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $itemFromIriConverterProphecy = $this->prophesize(ItemFromIriConverterInterface::class);
 
-        $iriConverterProphecy->getItemFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
+        $itemFromIriConverterProphecy->getItemFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
             if (false !== strpos($args[0], '/related_dummies')) {
                 $relatedDummyProphecy->getId()->shouldBeCalled()->willReturn(1);
 
@@ -569,7 +569,7 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
             throw new InvalidArgumentException();
         });
 
-        $iriConverter = $iriConverterProphecy->reveal();
+        $iriConverter = $itemFromIriConverterProphecy->reveal();
         $propertyAccessor = self::$kernel->getContainer()->get('test.property_accessor');
 
         $identifierExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -17,6 +17,8 @@ use ApiPlatform\Core\Action\NotFoundAction;
 use ApiPlatform\Core\Api\FilterInterface;
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
+use ApiPlatform\Core\Api\ItemFromIriConverterInterface;
 use ApiPlatform\Core\Api\OperationAwareFormatsProviderInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
@@ -989,6 +991,8 @@ class ApiPlatformExtensionTest extends TestCase
             GroupFilter::class => 'api_platform.serializer.group_filter',
             IdentifiersExtractorInterface::class => 'api_platform.identifiers_extractor.cached',
             IriConverterInterface::class => 'api_platform.iri_converter',
+            IriFromItemConverterInterface::class => 'api_platform.iri_converter',
+            ItemFromIriConverterInterface::class => 'api_platform.iri_converter',
             ItemDataProviderInterface::class => 'api_platform.item_data_provider',
             NotFoundAction::class => 'api_platform.action.not_found',
             OperationAwareFormatsProviderInterface::class => 'api_platform.formats_provider',

--- a/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
+++ b/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\GraphQl\Resolver;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
 use ApiPlatform\Core\GraphQl\Resolver\ResourceFieldResolver;
 use ApiPlatform\Core\GraphQl\Serializer\ItemNormalizer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
@@ -26,44 +26,44 @@ class ResourceFieldResolverTest extends TestCase
 {
     public function testId()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getItemIriFromResourceClass(Dummy::class, ['id' => 1])->willReturn('/dummies/1')->shouldBeCalled();
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
+        $iriFromItemConverterProphecy->getItemIriFromResourceClass(Dummy::class, ['id' => 1])->willReturn('/dummies/1')->shouldBeCalled();
 
         $resolveInfo = new ResolveInfo('id', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 
-        $resolver = new ResourceFieldResolver($iriConverterProphecy->reveal());
+        $resolver = new ResourceFieldResolver($iriFromItemConverterProphecy->reveal());
         $this->assertEquals('/dummies/1', $resolver([ItemNormalizer::ITEM_RESOURCE_CLASS_KEY => Dummy::class, ItemNormalizer::ITEM_IDENTIFIERS_KEY => ['id' => 1]], [], [], $resolveInfo));
     }
 
     public function testOriginalId()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $resolveInfo = new ResolveInfo('_id', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 
-        $resolver = new ResourceFieldResolver($iriConverterProphecy->reveal());
+        $resolver = new ResourceFieldResolver($iriFromItemConverterProphecy->reveal());
         $this->assertEquals(1, $resolver(['id' => 1], [], [], $resolveInfo));
     }
 
     public function testDirectAccess()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $resolveInfo = new ResolveInfo('foo', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 
-        $resolver = new ResourceFieldResolver($iriConverterProphecy->reveal());
+        $resolver = new ResourceFieldResolver($iriFromItemConverterProphecy->reveal());
         $this->assertEquals('bar', $resolver(['foo' => 'bar'], [], [], $resolveInfo));
     }
 
     public function testNonResource()
     {
         $dummy = new Dummy();
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldNotBeCalled();
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
+        $iriFromItemConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldNotBeCalled();
 
         $resolveInfo = new ResolveInfo('id', [], new ObjectType(['name' => '']), new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 
-        $resolver = new ResourceFieldResolver($iriConverterProphecy->reveal());
+        $resolver = new ResourceFieldResolver($iriFromItemConverterProphecy->reveal());
         $this->assertNull($resolver([], [], [], $resolveInfo));
     }
 }

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\GraphQl\Resolver\Stage;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\ItemFromIriConverterInterface;
 use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
@@ -34,7 +34,7 @@ class ReadStageTest extends TestCase
     /** @var ReadStage */
     private $readStage;
     private $resourceMetadataFactoryProphecy;
-    private $iriConverterProphecy;
+    private $itemFromIriConverterProphecy;
     private $collectionDataProviderProphecy;
     private $subresourceDataProviderProphecy;
     private $serializerContextBuilderProphecy;
@@ -45,14 +45,14 @@ class ReadStageTest extends TestCase
     protected function setUp(): void
     {
         $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $this->iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $this->itemFromIriConverterProphecy = $this->prophesize(ItemFromIriConverterInterface::class);
         $this->collectionDataProviderProphecy = $this->prophesize(ContextAwareCollectionDataProviderInterface::class);
         $this->subresourceDataProviderProphecy = $this->prophesize(SubresourceDataProviderInterface::class);
         $this->serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
 
         $this->readStage = new ReadStage(
             $this->resourceMetadataFactoryProphecy->reveal(),
-            $this->iriConverterProphecy->reveal(),
+            $this->itemFromIriConverterProphecy->reveal(),
             $this->collectionDataProviderProphecy->reveal(),
             $this->subresourceDataProviderProphecy->reveal(),
             $this->serializerContextBuilderProphecy->reveal(),
@@ -110,9 +110,9 @@ class ReadStageTest extends TestCase
         $this->serializerContextBuilderProphecy->create($resourceClass, $operationName, $context, true)->shouldBeCalled()->willReturn($normalizationContext);
 
         if ($throwNotFound) {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
+            $this->itemFromIriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
         } else {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willReturn($item);
+            $this->itemFromIriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willReturn($item);
         }
 
         $result = ($this->readStage)($resourceClass, null, $operationName, $context);
@@ -153,9 +153,9 @@ class ReadStageTest extends TestCase
         $this->serializerContextBuilderProphecy->create($resourceClass, $operationName, $context, true)->shouldBeCalled()->willReturn($normalizationContext);
 
         if ($throwNotFound) {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
+            $this->itemFromIriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
         } else {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willReturn($item);
+            $this->itemFromIriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willReturn($item);
         }
 
         if ($expectedExceptionClass) {

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\HttpCache\EventListener;
 
-use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Api\IriFromItemConverterInterface;
 use ApiPlatform\Core\HttpCache\EventListener\AddTagsListener;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +28,7 @@ class AddTagsListenerTest extends TestCase
 {
     public function testDoNotSetHeaderWhenMethodNotCacheable()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
         $request->setMethod('PUT');
@@ -41,7 +41,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertFalse($response->headers->has('Cache-Tags'));
@@ -49,7 +49,7 @@ class AddTagsListenerTest extends TestCase
 
     public function testDoNotSetHeaderWhenResponseNotCacheable()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
 
@@ -59,7 +59,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertFalse($response->headers->has('Cache-Tags'));
@@ -67,7 +67,7 @@ class AddTagsListenerTest extends TestCase
 
     public function testDoNotSetHeaderWhenNotAnApiOperation()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $request = new Request([], [], ['_resources' => ['/foo', '/bar']]);
 
@@ -79,7 +79,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertFalse($response->headers->has('Cache-Tags'));
@@ -87,7 +87,7 @@ class AddTagsListenerTest extends TestCase
 
     public function testDoNotSetHeaderWhenEmptyTagList()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $request = new Request([], [], ['_resources' => [], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
 
@@ -99,7 +99,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertFalse($response->headers->has('Cache-Tags'));
@@ -107,7 +107,7 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddTags()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
 
         $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
 
@@ -119,7 +119,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('/foo,/bar', $response->headers->get('Cache-Tags'));
@@ -127,8 +127,8 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddCollectionIri()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
+        $iriFromItemConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
 
         $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get']);
 
@@ -140,7 +140,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('/foo,/bar,/dummies', $response->headers->get('Cache-Tags'));
@@ -148,8 +148,8 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddCollectionIriWhenCollectionIsEmpty()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
+        $iriFromItemConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
 
         $request = new Request([], [], ['_resources' => [], '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get']);
 
@@ -161,7 +161,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('/dummies', $response->headers->get('Cache-Tags'));
@@ -169,8 +169,8 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddSubResourceCollectionIri()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+        $iriFromItemConverterProphecy = $this->prophesize(IriFromItemConverterInterface::class);
+        $iriFromItemConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
 
         $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_subresource_operation_name' => 'api_dummies_relatedDummies_get_subresource', '_api_subresource_context' => ['collection' => true]]);
 
@@ -182,7 +182,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal());
+        $listener = new AddTagsListener($iriFromItemConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('/foo,/bar,/dummies', $response->headers->get('Cache-Tags'));


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #1664  <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | NA

I have replace the usage of the IriConverterInterface by a more specific one when possible on classes tagged as experimental but some of them are quite old (PurgeHttpCacheListener for exemple) so I don't know if this classes are still experimental.
