### PR TITLE
Make ConstraintViolationListNormalizer use the Symfony's Normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.6.0
 
+* Add parameter `api_platform.enable_symfony_violation_normalizer` in order to deprecate non-usage of Symfony Serializer's `Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer` Normalizer.
 * MongoDB: Possibility to add execute options (aggregate command fields) for a resource, like `allowDiskUse` (#3144)
 
 ## 2.5.0

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -184,6 +184,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.http_cache.shared_max_age', $config['http_cache']['shared_max_age']);
         $container->setParameter('api_platform.http_cache.vary', $config['http_cache']['vary']);
         $container->setParameter('api_platform.http_cache.public', $config['http_cache']['public']);
+        $container->setParameter('api_platform.enable_symfony_violation_normalizer', $config['enable_symfony_violation_normalizer']);
 
         $container->setAlias('api_platform.operation_path_resolver.default', $config['default_operation_path_resolver']);
         $container->setAlias('api_platform.path_segment_name_generator', $config['path_segment_name_generator']);

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -120,6 +120,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_entrypoint')->defaultTrue()->info('Enable the entrypoint')->end()
                 ->booleanNode('enable_docs')->defaultTrue()->info('Enable the docs')->end()
                 ->booleanNode('enable_profiler')->defaultTrue()->info('Enable the data collector and the WebProfilerBundle integration.')->end()
+                ->booleanNode('enable_symfony_violation_normalizer')->defaultFalse()->info('Enable the Symfony ConstraintViolationListNormalizer.')->end()
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/hydra.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="api_platform.router" />
             <argument>%api_platform.validator.serialize_payload_fields%</argument>
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument>%api_platform.enable_symfony_violation_normalizer%</argument>
 
             <tag name="serializer.normalizer" priority="-780" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/problem.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/problem.xml
@@ -15,6 +15,8 @@
         <service id="api_platform.problem.normalizer.constraint_violation_list" class="ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer" public="false">
             <argument>%api_platform.validator.serialize_payload_fields%</argument>
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="collection"></argument>
+            <argument>%api_platform.enable_symfony_violation_normalizer%</argument>
 
             <tag name="serializer.normalizer" priority="-780" />
         </service>

--- a/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
@@ -14,25 +14,47 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Hydra\Serializer;
 
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
-use ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer;
+use ApiPlatform\Core\Serializer\ConstraintViolationListNormalizerTrait;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer as BaseConstraintViolationListNormalizer;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * Converts {@see \Symfony\Component\Validator\ConstraintViolationListInterface} to a Hydra error representation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ConstraintViolationListNormalizer extends AbstractConstraintViolationListNormalizer
+final class ConstraintViolationListNormalizer extends BaseConstraintViolationListNormalizer
 {
+    use ConstraintViolationListNormalizerTrait;
+
     public const FORMAT = 'jsonld';
 
     private $urlGenerator;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator, array $serializePayloadFields = null, NameConverterInterface $nameConverter = null)
+    private $serializePayloadFields;
+
+    protected $nameConverter;
+
+    private $useSymfonyNormalizer;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, array $serializePayloadFields = null, NameConverterInterface $nameConverter = null, bool $useSymfonyNormalizer = false)
     {
-        parent::__construct($serializePayloadFields, $nameConverter);
+        parent::__construct([], $nameConverter);
+
+        $this->nameConverter = $nameConverter;
+        $this->serializePayloadFields = $serializePayloadFields;
 
         $this->urlGenerator = $urlGenerator;
+        $this->useSymfonyNormalizer = $useSymfonyNormalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return static::FORMAT === $format && $data instanceof ConstraintViolationListInterface && parent::supportsNormalization($data, $format);
     }
 
     /**
@@ -40,14 +62,23 @@ final class ConstraintViolationListNormalizer extends AbstractConstraintViolatio
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        [$messages, $violations] = $this->getMessagesAndViolations($object);
-
-        return [
+        $normalized = [
             '@context' => $this->urlGenerator->generate('api_jsonld_context', ['shortName' => 'ConstraintViolationList']),
             '@type' => 'ConstraintViolationList',
             'hydra:title' => $context['title'] ?? 'An error occurred',
-            'hydra:description' => $messages ? implode("\n", $messages) : (string) $object,
-            'violations' => $violations,
         ];
+
+        if ($this->useSymfonyNormalizer) {
+            $parentNormalized = parent::normalize($object, $format, $context);
+            $normalized['hydra:description'] = $parentNormalized['detail'];
+            $normalized['violations'] = $parentNormalized['violations'];
+            $this->addPayloadToViolations($object, $normalized['violations']);
+        } else {
+            [$messages, $violations] = $this->getMessagesAndViolations($object);
+            $normalized['hydra:description'] = $messages ? implode("\n", $messages) : (string) $object;
+            $normalized['violations'] = $violations;
+        }
+
+        return $normalized;
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -850,6 +850,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.defaults' => ['attributes' => []],
             'api_platform.enable_entrypoint' => true,
             'api_platform.enable_docs' => true,
+            'api_platform.enable_symfony_violation_normalizer' => false,
         ];
 
         $pagination = [
@@ -1122,6 +1123,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.validator.serialize_payload_fields' => [],
             'api_platform.elasticsearch.enabled' => false,
             'api_platform.defaults' => ['attributes' => []],
+            'api_platform.enable_symfony_violation_normalizer' => false,
         ];
 
         if ($hasSwagger) {

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -204,6 +204,7 @@ class ConfigurationTest extends TestCase
             ],
             'allow_plain_identifiers' => false,
             'resource_class_directories' => [],
+            'enable_symfony_violation_normalizer' => false,
         ], $config);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes (kinda) <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | fixes #1956 <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

Since Symfony 4.1, the Serializer have it's own `ContraintViolationListNormalizer` which is [RFC 7807](https://tools.ietf.org/html/rfc7807) compliant.

The idea of this PR is to deprecate our Normalizer, and add a parameter to allow user to switch to the Symfony's one.

I am not sure about the implementation, specially on the Payload part. Symfony normalizes a Violations's list, but we want to decorate a Violation (and there is no Violation Normalizer).
 
