### PR TITLE
Add Api-Platform's version in debug bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.6.0
 
+* Display the API Platform's version in the debug-bar
 * MongoDB: Possibility to add execute options (aggregate command fields) for a resource, like `allowDiskUse` (#3144)
 * MongoDB: Mercure support (#3290)
 * GraphQL: Subscription support with Mercure (#3321)

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
         "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",
         "elasticsearch/elasticsearch": "To support Elasticsearch.",
         "guzzlehttp/guzzle": "To use the HTTP cache invalidation system.",
+        "ocramius/package-versions": "To display the API Platform's version in the debug bar.",
         "phpdocumentor/reflection-docblock": "To support extracting metadata from PHPDoc.",
         "psr/cache-implementation": "To use metadata caching.",
         "ramsey/uuid": "To support Ramsey's UUID identifiers.",

--- a/src/Bridge/Symfony/Bundle/DataCollector/RequestDataCollector.php
+++ b/src/Bridge/Symfony/Bundle/DataCollector/RequestDataCollector.php
@@ -23,6 +23,7 @@ use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use PackageVersions\Versions;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -156,6 +157,18 @@ final class RequestDataCollector extends DataCollector
     public function getDataPersisters(): array
     {
         return $this->data['dataPersisters'] ?? ['responses' => []];
+    }
+
+    public function getVersion(): ?string
+    {
+        if (!class_exists(Versions::class)) {
+            return null;
+        }
+
+        $version = Versions::getVersion('api-platform/core');
+        preg_match('/^v(.*?)@/', $version, $output);
+
+        return $output[1] ?? strtok($version, '@');
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
@@ -80,10 +80,15 @@
     {% set icon %}
         {% set status_color = collector.counters.ignored_filters|default(false) ? 'yellow' : 'default' %}
         {{ include('@ApiPlatform/DataCollector/api-platform-icon.svg') }}
-        <span class="sf-toolbar-value">{{ collector.version }}</span>
     {% endset %}
 
     {% set text %}
+        {% if collector.version %}
+            <div class="sf-toolbar-info-piece">
+                <b>Version</b>
+                <span>{{ collector.version }}</span>
+            </div>
+        {% endif %}
         <div class="sf-toolbar-info-piece">
             <b>Resource Class</b>
             <span>{{ collector.resourceClass|default('Not an API Platform resource') }}</span>

--- a/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/DataCollector/request.html.twig
@@ -80,7 +80,7 @@
     {% set icon %}
         {% set status_color = collector.counters.ignored_filters|default(false) ? 'yellow' : 'default' %}
         {{ include('@ApiPlatform/DataCollector/api-platform-icon.svg') }}
-        <span class="sf-toolbar-value"></span>
+        <span class="sf-toolbar-value">{{ collector.version }}</span>
     {% endset %}
 
     {% set text %}

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -30,8 +30,8 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
 use ApiPlatform\Core\Tests\ProphecyTrait;
+use PackageVersions\Versions;
 use PHPUnit\Framework\TestCase;
-use ProxyManager\Version;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -231,7 +231,7 @@ class RequestDataCollectorTest extends TestCase
             $this->response
         );
 
-        $this->assertSame(null !== $dataCollector->getVersion(), class_exists(Version::class));
+        $this->assertSame(null !== $dataCollector->getVersion(), class_exists(Versions::class));
     }
 
     private function apiResourceClassWillReturn($data, $context = [])

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Version;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -210,6 +211,27 @@ class RequestDataCollectorTest extends TestCase
             $this->assertStringStartsWith('class@anonymous', $class);
             $this->assertTrue($response);
         }
+    }
+
+    public function testVersionCollection()
+    {
+        $this->apiResourceClassWillReturn(DummyEntity::class);
+
+        $dataCollector = new RequestDataCollector(
+            $this->metadataFactory->reveal(),
+            $this->filterLocator->reveal(),
+            $this->getUsedCollectionDataProvider(),
+            $this->getUsedItemDataProvider(),
+            $this->getUsedSubresourceDataProvider(),
+            $this->getUsedPersister()
+        );
+
+        $dataCollector->collect(
+            $this->request->reveal(),
+            $this->response
+        );
+
+        $this->assertSame(null !== $dataCollector->getVersion(), class_exists(Version::class));
     }
 
     private function apiResourceClassWillReturn($data, $context = [])

--- a/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
+++ b/tests/Bridge/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
@@ -81,7 +81,7 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
 
         // Check extra info content
         $this->assertStringContainsString('sf-toolbar-status-default', $block->attr('class'), 'The toolbar block should have the default color.');
-        $this->assertSame('Not an API Platform resource', $block->filter('.sf-toolbar-info-piece span')->html());
+        $this->assertSame('Not an API Platform resource', $block->filterXPath('//div[@class="sf-toolbar-info-piece"][./b[contains(., "Resource Class")]]/span')->html());
     }
 
     public function testDebugBarContent()
@@ -99,7 +99,7 @@ class ApiPlatformProfilerPanelTest extends WebTestCase
 
         // Check extra info content
         $this->assertStringContainsString('sf-toolbar-status-default', $block->attr('class'), 'The toolbar block should have the default color.');
-        $this->assertSame('mongodb' === $this->env ? DocumentDummy::class : Dummy::class, $block->filter('.sf-toolbar-info-piece span')->html());
+        $this->assertSame('mongodb' === $this->env ? DocumentDummy::class : Dummy::class, $block->filterXPath('//div[@class="sf-toolbar-info-piece"][./b[contains(., "Resource Class")]]/span')->html());
     }
 
     public function testProfilerGeneralLayoutNotResourceClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

After a small discussion with @dunglas it appears it could be nice to display the Api-Platform's version in the Symfony's debug-bar.

Two solutions were talked about, adding a constant (:-1: because it needs to be maintained), or using ocramius/package-versions (this package is required-dev by symfony/orm).

This feature was proposed to Symfony but it was [refused](https://github.com/symfony/symfony/pull/34221).

So here we are :-)

Output:
![Capture d’écran de 2019-11-03 18-35-05](https://user-images.githubusercontent.com/7721219/68089397-b8ae5f00-fe68-11e9-80ef-467ac4ca4fec.png)
![Capture d’écran de 2019-11-03 18-34-55](https://user-images.githubusercontent.com/7721219/68089398-b8ae5f00-fe68-11e9-807f-a77752e689eb.png)

Note:
I was not sure about adding tests or not, as the outpu depends of a final class, that might exists or not