### PR TITLE
Fix ApiResource annotation : 'int' should be 'bool'

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -321,7 +321,7 @@ final class ApiResource
      * @see https://api-platform.com/docs/core/performance/#partial-pagination
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *
-     * @var int
+     * @var bool
      */
     private $paginationPartial;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`$paginationPartial` in `src/Annotation/ApiResource.php` is declared as a boolean in the attributes annotation, but is declared as an int in the class.