### PR TITLE
Ensure correct return type from AbstractItemNormalizer::normalizeRelation

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,6 +26,9 @@ parameters:
 
 		# False positives
 		-
+			message: '#Variable \$iri might not be defined\.#'
+			path: %currentWorkingDirectory%/src/JsonApi/Serializer/ItemNormalizer.php
+		-
 			message: '#Variable \$positionPm might not be defined\.#'
 			path: %currentWorkingDirectory%/src/Util/ClassInfoTrait.php
 		-
@@ -60,7 +63,6 @@ parameters:
 		-
 			message: '#Property ApiPlatform\\Core\\Test\\DoctrineMongoDbOdmFilterTestCase::\$repository \(Doctrine\\ODM\\MongoDB\\Repository\\DocumentRepository\) does not accept Doctrine\\ORM\\EntityRepository<ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Document\\Dummy>\.#'
 			path: %currentWorkingDirectory%/src/Test/DoctrineMongoDbOdmFilterTestCase.php
-		- '#Method ApiPlatform\\Core\\(Serializer\\Abstract|JsonApi\\Serializer\\)ItemNormalizer::normalizeRelation\(\) should return array\|string but returns array\|bool\|float\|int\|string\|null\.#'
 		- '#Method ApiPlatform\\Core\\Util\\RequestParser::parseRequestParams\(\) should return array but returns array\|false\.#'
 		-
 			message: '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Util\\QueryBuilderHelper::mapJoinAliases() should return array<string, array<string>\|string> but returns array<int|string, mixed>\.#'
@@ -116,3 +118,8 @@ parameters:
 			path: %currentWorkingDirectory%/src/Action/ExceptionAction.php
 		- '#Call to method get(Class|Headers|StatusCode)\(\) on an unknown class Symfony\\Component\\ErrorHandler\\Exception\\FlattenException\.#'
 		- '#Class Symfony\\Component\\ErrorHandler\\Exception\\FlattenException not found\.#'
+		-
+			message: '#Instanceof between bool\|float\|int|null and ArrayObject will always evaluate to false\.#'
+			paths:
+				- %currentWorkingDirectory%/src/JsonApi/Serializer/ItemNormalizer.php
+				- %currentWorkingDirectory%/src/Serializer/AbstractItemNormalizer.php

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\JsonApi\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
-use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -199,34 +198,29 @@ final class ItemNormalizer extends AbstractItemNormalizer
      * {@inheritdoc}
      *
      * @see http://jsonapi.org/format/#document-resource-object-linkage
-     *
-     * @throws LogicException
      */
     protected function normalizeRelation(PropertyMetadata $propertyMetadata, $relatedObject, string $resourceClass, ?string $format, array $context)
     {
-        if (null === $relatedObject) {
-            if (isset($context['operation_type'], $context['subresource_resources'][$resourceClass]) && OperationType::SUBRESOURCE === $context['operation_type']) {
-                $iri = $this->iriConverter->getItemIriFromResourceClass($resourceClass, $context['subresource_resources'][$resourceClass]);
-            } else {
-                if ($this->serializer instanceof NormalizerInterface) {
-                    return $this->serializer->normalize($relatedObject, $format, $context);
-                }
-                throw new LogicException(sprintf('The injected serializer must be an instance of "%s".', NormalizerInterface::class));
-            }
-        } else {
+        if (null !== $relatedObject) {
             $iri = $this->iriConverter->getIriFromItem($relatedObject);
             $context['iri'] = $iri;
 
             if (isset($context['resources'])) {
                 $context['resources'][$iri] = $iri;
             }
-            if (isset($context['api_included'])) {
-                if (!$this->serializer instanceof NormalizerInterface) {
-                    throw new LogicException(sprintf('The injected serializer must be an instance of "%s".', NormalizerInterface::class));
-                }
+        }
 
-                return $this->serializer->normalize($relatedObject, $format, $context);
+        if (null === $relatedObject || isset($context['api_included'])) {
+            if (!$this->serializer instanceof NormalizerInterface) {
+                throw new LogicException(sprintf('The injected serializer must be an instance of "%s".', NormalizerInterface::class));
             }
+
+            $normalizedRelatedObject = $this->serializer->normalize($relatedObject, $format, $context);
+            if (!\is_string($normalizedRelatedObject) && !\is_array($normalizedRelatedObject) && !$normalizedRelatedObject instanceof \ArrayObject && null !== $normalizedRelatedObject) {
+                throw new UnexpectedValueException('Expected normalized relation to be an IRI, array, \ArrayObject or null');
+            }
+
+            return $normalizedRelatedObject;
         }
 
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Stricter type checking in `normalizeRelation` to improve code quality. Also cleaned up some ~dead~ wrong(?) code (related to #2073 and #2074).