### PR TITLE
Fix symfony/error-handler compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "symfony/config": "^3.4 || ^4.0 || ^5.0",
         "symfony/console": "^3.4 || ^4.0 || ^5.0",
         "symfony/css-selector": "^3.4 || ^4.0 || ^5.0",
-        "symfony/debug": "^3.4 || ^4.0 || ^5.0",
+        "symfony/debug": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
         "symfony/doctrine-bridge": "^3.4 || ^4.0 || ^5.0",
         "symfony/dom-crawler": "^3.4 || ^4.0 || ^5.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -109,11 +109,10 @@ parameters:
 
 		# Expected, due to forward compatibility
 		-
-			message: '#Class Symfony\\Component\\ErrorRenderer\\ErrorRenderer not found\.#'
+			message: '#Class Symfony\\Component\\ErrorHandler\\ErrorRenderer\\ErrorRendererInterface not found\.#'
 			path: %currentWorkingDirectory%/tests/Fixtures/app/AppKernel.php
 		-
-			message: '#Parameter \$exception of method ApiPlatform\\Core\\Action\\ExceptionAction::__invoke\(\) has invalid typehint type Symfony\\Component\\ErrorRenderer\\Exception\\FlattenException\.#'
+			message: '#Parameter \$exception of method ApiPlatform\\Core\\Action\\ExceptionAction::__invoke\(\) has invalid typehint type Symfony\\Component\\ErrorHandler\\Exception\\FlattenException\.#'
 			path: %currentWorkingDirectory%/src/Action/ExceptionAction.php
-		-
-			message: '#Call to method get(Class|Headers|StatusCode)\(\) on an unknown class Symfony\\Component\\ErrorRenderer\\Exception\\FlattenException\.#'
-			path: %currentWorkingDirectory%/src/Action/ExceptionAction.php
+		- '#Call to method get(Class|Headers|StatusCode)\(\) on an unknown class Symfony\\Component\\ErrorHandler\\Exception\\FlattenException\.#'
+		- '#Class Symfony\\Component\\ErrorHandler\\Exception\\FlattenException not found\.#'

--- a/src/Action/ExceptionAction.php
+++ b/src/Action/ExceptionAction.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Action;
 
 use ApiPlatform\Core\Util\ErrorFormatGuesser;
 use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
-use Symfony\Component\ErrorRenderer\Exception\FlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\SerializerInterface;

--- a/src/Hydra/Serializer/ErrorNormalizer.php
+++ b/src/Hydra/Serializer/ErrorNormalizer.php
@@ -15,12 +15,13 @@ namespace ApiPlatform\Core\Hydra\Serializer;
 
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Converts {@see \Exception} or {@see \Symfony\Component\Debug\Exception\FlattenException} to a Hydra error representation.
+ * Converts {@see \Exception} or {@see FlattenException} or {@see LegacyFlattenException} to a Hydra error representation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
@@ -67,7 +68,7 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
      */
     public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException || $data instanceof LegacyFlattenException);
     }
 
     /**

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\JsonApi\Serializer;
 
 use ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Converts {@see \Exception} or {@see \Symfony\Component\Debug\Exception\FlattenException} to a JSON API error representation.
+ * Converts {@see \Exception} or {@see FlattenException} or {@see LegacyFlattenException}  to a JSON API error representation.
  *
  * @author Héctor Hurtarte <hectorh30@gmail.com>
  */
@@ -60,7 +61,7 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
      */
     public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException || $data instanceof LegacyFlattenException);
     }
 
     /**

--- a/src/Problem/Serializer/ErrorNormalizer.php
+++ b/src/Problem/Serializer/ErrorNormalizer.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Problem\Serializer;
 
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -67,7 +68,7 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
      */
     public function supportsNormalization($data, $format = null)
     {
-        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException);
+        return self::FORMAT === $format && ($data instanceof \Exception || $data instanceof FlattenException || $data instanceof LegacyFlattenException);
     }
 
     /**

--- a/src/Problem/Serializer/ErrorNormalizerTrait.php
+++ b/src/Problem/Serializer/ErrorNormalizerTrait.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Problem\Serializer;
 
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
 
 trait ErrorNormalizerTrait
@@ -26,7 +27,7 @@ trait ErrorNormalizerTrait
             return $message;
         }
 
-        if ($object instanceof FlattenException) {
+        if ($object instanceof FlattenException || $object instanceof LegacyFlattenException) {
             $statusCode = $context['statusCode'] ?? $object->getStatusCode();
             if ($statusCode >= 500 && $statusCode < 600) {
                 $message = Response::$statusTexts[$statusCode];

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -27,10 +27,10 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\ErrorRenderer\ErrorRenderer;
+use Symfony\Component\ErrorHandler\ErrorRenderer\ErrorRendererInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
-use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -98,7 +98,7 @@ class AppKernel extends Kernel
 
         $loader->load(__DIR__."/config/config_{$this->getEnvironment()}.yml");
 
-        $alg = class_exists(SodiumPasswordEncoder::class) && SodiumPasswordEncoder::isSupported() ? 'auto' : 'bcrypt';
+        $alg = class_exists(NativePasswordEncoder::class) ? 'auto' : 'bcrypt';
         $securityConfig = [
             'encoders' => [
                 User::class => $alg,
@@ -155,7 +155,7 @@ class AppKernel extends Kernel
         }
 
         $twigConfig = ['strict_variables' => '%kernel.debug%'];
-        if (class_exists(ErrorRenderer::class)) {
+        if (interface_exists(ErrorRendererInterface::class)) {
             $twigConfig['exception_controller'] = null;
         }
         $c->prependExtensionConfig('twig', $twigConfig);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The symfony/error-render component has been reverted, its api has been partially added to the error-handler one.
This fixes the outdated compatibility layers and add some missing ones.