### PR TITLE
feat: add payload controller value resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * DataProvider: Add `TraversablePaginator` (#3783)
 * JSON:API: Support inclusion of resources from path (#3288)
 * Swagger UI: Add `swagger_ui_extra_configuration` to Swagger / OpenAPI configuration (#3731)
+* Allow controller argument with a name different from `$data` thanks to an argument resolver (#3263)
 * GraphQL: Support `ApiProperty` security (#4143)
 * GraphQL: **BC** Fix security on association collection properties. The collection resource `item_query` security is no longer used. `ApiProperty` security can now be used to secure collection (or any other) properties. (#4143)
 * Deprecate `allow_plain_identifiers` option (#4167)

--- a/src/Bridge/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
+++ b/src/Bridge/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\ArgumentResolver;
+
+use ApiPlatform\Core\EventListener\ToggleableDeserializationTrait;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
+use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+final class PayloadArgumentResolver implements ArgumentValueResolverInterface
+{
+    use ToggleableDeserializationTrait;
+
+    private $serializationContextBuilder;
+
+    public function __construct(
+        ResourceMetadataFactoryInterface $resourceMetadataFactory,
+        SerializerContextBuilderInterface $serializationContextBuilder
+    ) {
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->serializationContextBuilder = $serializationContextBuilder;
+    }
+
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        if ($argument->isVariadic()) {
+            return false;
+        }
+
+        $class = $argument->getType();
+
+        if (null === $class) {
+            return false;
+        }
+
+        if (null === $request->attributes->get('data')) {
+            return false;
+        }
+
+        $inputClass = $this->getExpectedInputClass($request);
+
+        if (null === $inputClass) {
+            return false;
+        }
+
+        return $inputClass === $class || is_subclass_of($inputClass, $class);
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): \Generator
+    {
+        yield $request->attributes->get('data');
+    }
+
+    private function getExpectedInputClass(Request $request): ?string
+    {
+        $attributes = RequestAttributesExtractor::extractAttributes($request);
+
+        if (!$this->isRequestToDeserialize($request, $attributes)) {
+            return null;
+        }
+
+        $context = $this->serializationContextBuilder->createFromRequest($request, false, $attributes);
+
+        return $context['input'] ?? $context['resource_class'];
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -128,6 +128,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerDataTransformerConfiguration($container);
         $this->registerSecurityConfiguration($container, $loader);
         $this->registerMakerConfiguration($container, $config, $loader);
+        $this->registerArgumentResolverConfiguration($container, $loader);
 
         $container->registerForAutoconfiguration(DataPersisterInterface::class)
             ->addTag('api_platform.data_persister');
@@ -751,6 +752,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $loader->load('maker.xml');
+    }
+
+    private function registerArgumentResolverConfiguration(ContainerBuilder $container, XmlFileLoader $loader): void
+    {
+        $loader->load('argument_resolver.xml');
     }
 
     private function buildDeprecationArgs(string $version, string $message): array

--- a/src/Bridge/Symfony/Bundle/Resources/config/argument_resolver.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/argument_resolver.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api_platform.argument_resolver.payload" class="ApiPlatform\Core\Bridge\Symfony\Bundle\ArgumentResolver\PayloadArgumentResolver" public="false">
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.serializer.context_builder" />
+
+            <tag name="controller.argument_value_resolver" />
+        </service>
+    </services>
+
+</container>

--- a/src/EventListener/DeserializeListener.php
+++ b/src/EventListener/DeserializeListener.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Core\EventListener;
 use ApiPlatform\Core\Api\FormatMatcher;
 use ApiPlatform\Core\Api\FormatsProviderInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use ApiPlatform\Core\Metadata\Resource\ToggleableOperationAttributeTrait;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,7 +31,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 final class DeserializeListener
 {
-    use ToggleableOperationAttributeTrait;
+    use ToggleableDeserializationTrait;
 
     public const OPERATION_ATTRIBUTE_KEY = 'deserialize';
 
@@ -69,15 +68,9 @@ final class DeserializeListener
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
-        $method = $request->getMethod();
+        $attributes = RequestAttributesExtractor::extractAttributes($request);
 
-        if (
-            'DELETE' === $method
-            || $request->isMethodSafe()
-            || !($attributes = RequestAttributesExtractor::extractAttributes($request))
-            || !$attributes['receive']
-            || $this->isOperationAttributeDisabled($attributes, self::OPERATION_ATTRIBUTE_KEY)
-        ) {
+        if (!$this->isRequestToDeserialize($request, $attributes)) {
             return;
         }
 

--- a/src/EventListener/ToggleableDeserializationTrait.php
+++ b/src/EventListener/ToggleableDeserializationTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\EventListener;
+
+use ApiPlatform\Core\Metadata\Resource\ToggleableOperationAttributeTrait;
+use Symfony\Component\HttpFoundation\Request;
+
+trait ToggleableDeserializationTrait
+{
+    use ToggleableOperationAttributeTrait;
+
+    private function isRequestToDeserialize(Request $request, array $attributes): bool
+    {
+        return
+            'DELETE' !== $request->getMethod()
+            && !$request->isMethodSafe()
+            && [] !== $attributes
+            && $attributes['receive']
+            && !$this->isOperationAttributeDisabled($attributes, DeserializeListener::OPERATION_ATTRIBUTE_KEY);
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/ArgumentResolver/NotResource.php
+++ b/tests/Bridge/Symfony/Bundle/ArgumentResolver/NotResource.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\ArgumentResolver;
+
+class NotResource
+{
+}

--- a/tests/Bridge/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
+++ b/tests/Bridge/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
@@ -1,0 +1,308 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\ArgumentResolver;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\ArgumentResolver\PayloadArgumentResolver;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
+use Prophecy\Argument;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+class PayloadArgumentResolverTest extends KernelTestCase
+{
+    public function testItSupportsRequestWithPayloadOfExpectedType(): void
+    {
+        $resolver = $this->createArgumentResolver();
+        $argument = $this->createArgumentMetadata(ResourceImplementation::class);
+
+        $request = $this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ]);
+
+        $this->assertTrue($resolver->supports($request, $argument));
+    }
+
+    public function testItSupportsRequestWithPayloadOfChildType(): void
+    {
+        $resolver = $this->createArgumentResolver();
+        $argument = $this->createArgumentMetadata(ResourceInterface::class);
+
+        $request = $this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ]);
+
+        $this->assertTrue($resolver->supports($request, $argument));
+    }
+
+    public function testItSupportsRequestWithDtoAsInput(): void
+    {
+        $resolver = $this->createArgumentResolver();
+        $argument = $this->createArgumentMetadata(NotResource::class);
+
+        $request = $this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update_with_dto',
+            'data' => new NotResource(),
+        ]);
+
+        $this->assertTrue($resolver->supports($request, $argument));
+    }
+
+    /**
+     * @dataProvider provideUnsupportedArguments
+     */
+    public function testItDoesNotSupportArgumentThatCannotBeResolved(ArgumentMetadata $argument): void
+    {
+        $resolver = $this->createArgumentResolver();
+
+        $request = $this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ]);
+
+        $this->assertFalse($resolver->supports($request, $argument));
+    }
+
+    /**
+     * @dataProvider provideUnsupportedRequests
+     */
+    public function testItDoesNotSupportRequestWithoutPayloadOfExpectedType(Request $request): void
+    {
+        $resolver = $this->createArgumentResolver();
+        $argument = $this->createArgumentMetadata(ResourceInterface::class);
+
+        $this->assertFalse($resolver->supports($request, $argument));
+    }
+
+    public function testItResolvesArgumentFromRequestWithDataOfExpectedType(): void
+    {
+        $resolver = $this->createArgumentResolver();
+        $argument = $this->createArgumentMetadata(ResourceImplementation::class);
+
+        $request = $this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ]);
+
+        $this->assertSame(
+            [$request->attributes->get('data')],
+            iterator_to_array($resolver->resolve($request, $argument))
+        );
+    }
+
+    public function testItResolvesArgumentFromRequestWithDataOfChildType(): void
+    {
+        $resolver = $this->createArgumentResolver();
+        $argument = $this->createArgumentMetadata(ResourceInterface::class);
+
+        $request = $this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ]);
+
+        $this->assertSame(
+            [$request->attributes->get('data')],
+            iterator_to_array($resolver->resolve($request, $argument))
+        );
+    }
+
+    public function provideUnsupportedRequests(): iterable
+    {
+        yield 'GET request' => [$this->createRequest('GET', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ])];
+
+        yield 'HEAD request' => [$this->createRequest('HEAD', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ])];
+
+        yield 'OPTIONS request' => [$this->createRequest('OPTIONS', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ])];
+
+        yield 'TRACE request' => [$this->createRequest('TRACE', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ])];
+
+        yield 'DELETE request' => [$this->createRequest('DELETE', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ])];
+
+        yield 'request without attributes' => [$this->createRequest('PUT', [])];
+
+        yield 'request with receive=false' => [$this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => false,
+            '_api_item_operation_name' => 'update',
+            'data' => new ResourceImplementation(),
+        ])];
+
+        yield 'request on operation with deserialization disabled' => [$this->createRequest('PUT', [
+            '_api_resource_class' => ResourceImplementation::class,
+            '_api_receive' => true,
+            '_api_item_operation_name' => 'update_no_deserialize',
+            'data' => new ResourceImplementation(),
+        ])];
+    }
+
+    public function provideUnsupportedArguments(): iterable
+    {
+        yield 'argument without type declaration' => [$this->createArgumentMetadata()];
+        yield 'variadic argument' => [$this->createArgumentMetadata(ResourceImplementation::class, true)];
+    }
+
+    /**
+     * @dataProvider provideIntegrationCases
+     */
+    public function testIntegration(Request $request, callable $controller, array $expectedArguments): void
+    {
+        self::bootKernel();
+
+        $argumentsResolver = self::$container->get('argument_resolver');
+
+        $arguments = $argumentsResolver->getArguments($request, $controller);
+
+        self::assertSame($expectedArguments, $arguments);
+    }
+
+    public function provideIntegrationCases(): iterable
+    {
+        $resource = new ResourceImplementation();
+
+        yield 'simple' => [
+            $this->createRequest('PUT', [
+                '_api_resource_class' => ResourceImplementation::class,
+                '_api_receive' => true,
+                '_api_item_operation_name' => 'update',
+                'data' => $resource,
+            ]),
+            static function (ResourceImplementation $payload) {},
+            [$resource],
+        ];
+
+        yield 'with another argument named $data' => [
+            $this->createRequest('PUT', [
+                '_api_resource_class' => ResourceImplementation::class,
+                '_api_receive' => true,
+                '_api_item_operation_name' => 'update',
+                'data' => $resource,
+            ]),
+            static function (ResourceImplementation $payload, $data) {},
+            [$resource, $resource],
+        ];
+    }
+
+    private function createArgumentResolver(): PayloadArgumentResolver
+    {
+        $metadataFactory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $metadataFactory
+            ->create(ResourceImplementation::class)
+            ->willReturn(new ResourceMetadata(
+                ResourceImplementation::class,
+                null,
+                null,
+                [
+                    'update' => [
+                        'method' => 'PUT',
+                    ],
+                    'update_no_deserialize' => [
+                        'method' => 'PUT',
+                        'deserialize' => false,
+                    ],
+                    'update_with_dto' => [
+                        'method' => 'PUT',
+                        'input' => NotResource::class,
+                    ],
+                ],
+                [
+                    'create' => [
+                        'method' => 'POST',
+                    ],
+                ]
+            ));
+
+        $serializerContextBuilder = $this->prophesize(SerializerContextBuilderInterface::class);
+        $serializerContextBuilder
+            ->createFromRequest(
+                Argument::type(Request::class),
+                false,
+                Argument::type('array')
+            )
+            ->will(function (array $arguments) {
+                /** @var Request $request */
+                $request = $arguments[0];
+
+                $context = [
+                    'resource_class' => ResourceImplementation::class,
+                ];
+
+                if ('update_with_dto' === $request->attributes->get('_api_item_operation_name')) {
+                    $context['input'] = NotResource::class;
+                } else {
+                    $context['input'] = null;
+                }
+
+                return $context;
+            });
+
+        return new PayloadArgumentResolver(
+            $metadataFactory->reveal(),
+            $serializerContextBuilder->reveal()
+        );
+    }
+
+    private function createRequest(string $method, array $attributes): Request
+    {
+        $request = Request::create('/foo', $method);
+        $request->attributes->replace($attributes);
+
+        return $request;
+    }
+
+    private function createArgumentMetadata(?string $type = null, bool $isVariadic = false): ArgumentMetadata
+    {
+        return new ArgumentMetadata('foo', $type, $isVariadic, false, null);
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/ArgumentResolver/ResourceImplementation.php
+++ b/tests/Bridge/Symfony/Bundle/ArgumentResolver/ResourceImplementation.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\ArgumentResolver;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+
+/**
+ * @ApiResource
+ */
+class ResourceImplementation implements ResourceInterface
+{
+}

--- a/tests/Bridge/Symfony/Bundle/ArgumentResolver/ResourceInterface.php
+++ b/tests/Bridge/Symfony/Bundle/ArgumentResolver/ResourceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\ArgumentResolver;
+
+interface ResourceInterface
+{
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1388,6 +1388,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.resource.name_collection_factory.annotation',
             'api_platform.metadata.resource.name_collection_factory.yaml',
             'api_platform.metadata.subresource.metadata_factory.annotation',
+            'api_platform.argument_resolver.payload',
             'api_platform.problem.encoder',
             'api_platform.problem.normalizer.constraint_violation_list',
             'api_platform.problem.normalizer.error',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | -
| Doc PR        | -

When creating a custom controller, the argument which is passed the deserialized payload of the request must be named `$data`. This can be very frustrating, especially when you don't know this requirement and you don't understand why your controller is not working properly.

This PR introduces a controller value resolver that allows to use any argument name, as long as its type declaration matches the resource class.