### PR TITLE
Prevent adding Link headers for CORS preflight requets

### DIFF
--- a/src/Mercure/EventListener/AddLinkHeaderListener.php
+++ b/src/Mercure/EventListener/AddLinkHeaderListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Mercure\EventListener;
 
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\CorsTrait;
 use Fig\Link\GenericLinkProvider;
 use Fig\Link\Link;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -25,6 +26,8 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
  */
 final class AddLinkHeaderListener
 {
+    use CorsTrait;
+
     private $resourceMetadataFactory;
     private $hub;
 
@@ -39,22 +42,27 @@ final class AddLinkHeaderListener
      */
     public function onKernelResponse(ResponseEvent $event): void
     {
+        $request = $event->getRequest();
+        // Prevent issues with NelmioCorsBundle
+        if ($this->isPreflightRequest($request)) {
+            return;
+        }
+
         $link = new Link('mercure', $this->hub);
 
-        $attributes = $event->getRequest()->attributes;
         if (
-            null === ($resourceClass = $attributes->get('_api_resource_class')) ||
+            null === ($resourceClass = $request->attributes->get('_api_resource_class')) ||
             false === $this->resourceMetadataFactory->create($resourceClass)->getAttribute('mercure', false)
         ) {
             return;
         }
 
-        if (null === $linkProvider = $attributes->get('_links')) {
-            $attributes->set('_links', new GenericLinkProvider([$link]));
+        if (null === $linkProvider = $request->attributes->get('_links')) {
+            $request->attributes->set('_links', new GenericLinkProvider([$link]));
 
             return;
         }
 
-        $attributes->set('_links', $linkProvider->withLink($link));
+        $request->attributes->set('_links', $linkProvider->withLink($link));
     }
 }

--- a/src/Util/CorsTrait.php
+++ b/src/Util/CorsTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Util;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * CORS utils.
+ *
+ * To be removed when https://github.com/symfony/symfony/pull/34391 wil be merged.
+ *
+ * @internal
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+trait CorsTrait
+{
+    public function isPreflightRequest(Request $request): bool
+    {
+        return $request->isMethod('OPTIONS') && $request->headers->has('Access-Control-Request-Method');
+    }
+}

--- a/tests/Hydra/EventListener/AddLinkHeaderListenerTest.php
+++ b/tests/Hydra/EventListener/AddLinkHeaderListenerTest.php
@@ -50,4 +50,20 @@ class AddLinkHeaderListenerTest extends TestCase
             ['<https://demo.mercure.rocks/hub>; rel="mercure",<http://example.com/docs>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"', new Request([], [], ['_links' => new GenericLinkProvider([new Link('mercure', 'https://demo.mercure.rocks/hub')])])],
         ];
     }
+
+    public function testSkipWhenPreflightRequest(): void
+    {
+        $request = new Request();
+        $request->setMethod('OPTIONS');
+        $request->headers->set('Access-Control-Request-Method', 'POST');
+
+        $event = $this->prophesize(ResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $listener = new AddLinkHeaderListener($urlGenerator->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertFalse($request->attributes->has('_links'));
+    }
 }

--- a/tests/Mercure/EventListener/AddLinkHeaderListenerTest.php
+++ b/tests/Mercure/EventListener/AddLinkHeaderListenerTest.php
@@ -80,4 +80,20 @@ class AddLinkHeaderListenerTest extends TestCase
             [new Request([], [], ['_api_resource_class' => Dummy::class])],
         ];
     }
+
+    public function testSkipWhenPreflightRequest(): void
+    {
+        $request = new Request();
+        $request->setMethod('OPTIONS');
+        $request->headers->set('Access-Control-Request-Method', 'POST');
+
+        $event = $this->prophesize(ResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $resourceMetadataFactory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $listener = new AddLinkHeaderListener($resourceMetadataFactory->reveal(), 'http://example.com/.well-known/mercure');
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertFalse($request->attributes->has('_links'));
+    }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | fixes #3262
| License       | MIT
| Doc PR        | n/a

Preflight requests cannot be accessed in JS, therefore settings the `Link` headers for Hydra and Mercure is useless for these requests Not setting them prevent the issues with invalid URLs being generated. This an alternative fix to #3262.