### PR TITLE
Improve Vulcain support

### DIFF
--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -90,7 +90,7 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
         $data['hydra:member'] = [];
         $iriOnly = $context[self::IRI_ONLY] ?? $this->defaultContext[self::IRI_ONLY];
         foreach ($object as $obj) {
-            $data['hydra:member'][] = $iriOnly ? $this->iriConverter->getIriFromItem($obj) : $this->normalizer->normalize($obj, $format, $context);
+            $data['hydra:member'][] = $iriOnly ? ['@id' => $this->iriConverter->getIriFromItem($obj)] : $this->normalizer->normalize($obj, $format, $context);
         }
 
         $paginated = null;

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -39,16 +39,21 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
     use NormalizerAwareTrait;
 
     public const FORMAT = 'jsonld';
+    public const IRI_ONLY = 'iri_only';
 
     private $contextBuilder;
     private $resourceClassResolver;
     private $iriConverter;
+    private $defaultContext = [
+        self::IRI_ONLY => false,
+    ];
 
-    public function __construct(ContextBuilderInterface $contextBuilder, ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter)
+    public function __construct(ContextBuilderInterface $contextBuilder, ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter, array $defaultContext = [])
     {
         $this->contextBuilder = $contextBuilder;
         $this->resourceClassResolver = $resourceClassResolver;
         $this->iriConverter = $iriConverter;
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     /**
@@ -83,8 +88,9 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
         $data['@type'] = 'hydra:Collection';
 
         $data['hydra:member'] = [];
+        $iriOnly = $context[self::IRI_ONLY] ?? $this->defaultContext[self::IRI_ONLY];
         foreach ($object as $obj) {
-            $data['hydra:member'][] = $this->normalizer->normalize($obj, $format, $context);
+            $data['hydra:member'][] = $iriOnly ? $this->iriConverter->getIriFromItem($obj) : $this->normalizer->normalize($obj, $format, $context);
         }
 
         $paginated = null;

--- a/tests/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionNormalizerTest.php
@@ -368,8 +368,8 @@ class CollectionNormalizerTest extends TestCase
             '@id' => '/foos',
             '@type' => 'hydra:Collection',
             'hydra:member' => [
-                '/foos/1',
-                '/foos/3',
+                ['@id' => '/foos/1'],
+                ['@id' => '/foos/3'],
             ],
             'hydra:totalItems' => 2,
         ], $actual);

--- a/tests/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionNormalizerTest.php
@@ -328,4 +328,50 @@ class CollectionNormalizerTest extends TestCase
             'resource_class' => 'Foo',
         ]);
     }
+
+    public function testNormalizeIriOnlyResourceCollection(): void
+    {
+        $fooOne = new Foo();
+        $fooOne->id = 1;
+        $fooOne->bar = 'baz';
+
+        $fooThree = new Foo();
+        $fooThree->id = 3;
+        $fooThree->bar = 'bzz';
+
+        $data = [$fooOne, $fooThree];
+
+        $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
+        $contextBuilderProphecy->getResourceContextUri(Foo::class)->willReturn('/contexts/Foo');
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($data, Foo::class)->willReturn(Foo::class);
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResourceClass(Foo::class)->willReturn('/foos');
+        $iriConverterProphecy->getIriFromItem($fooOne)->willReturn('/foos/1');
+        $iriConverterProphecy->getIriFromItem($fooThree)->willReturn('/foos/3');
+
+        $delegateNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
+
+        $normalizer = new CollectionNormalizer($contextBuilderProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $iriConverterProphecy->reveal(), [CollectionNormalizer::IRI_ONLY => true]);
+        $normalizer->setNormalizer($delegateNormalizerProphecy->reveal());
+
+        $actual = $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
+            'collection_operation_name' => 'get',
+            'operation_type' => OperationType::COLLECTION,
+            'resource_class' => Foo::class,
+        ]);
+
+        $this->assertSame([
+            '@context' => '/contexts/Foo',
+            '@id' => '/foos',
+            '@type' => 'hydra:Collection',
+            'hydra:member' => [
+                '/foos/1',
+                '/foos/3',
+            ],
+            'hydra:totalItems' => 2,
+        ], $actual);
+    }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

Allows to generate IRIs instead of embedding documents for Hydra collections.

TODO:

* [x] update the JSON-LD context accordingly
