### PR TITLE
Fix symfony 4.4 compat

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -214,6 +214,8 @@
         <service id="api_platform.listener.exception" class="ApiPlatform\Core\EventListener\ExceptionListener">
             <argument>api_platform.action.exception</argument>
             <argument type="service" id="logger" on-invalid="null" />
+            <argument>false</argument>
+            <argument type="service" id="exception_listener" on-invalid="null" />
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-96" />
             <tag name="monolog.logger" channel="request" />

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
-use Symfony\Component\HttpKernel\EventListener\ExceptionListener as BaseExceptionListener;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListener as LegacyExceptionListener;
 
 /**
  * Handles requests errors.
@@ -34,7 +34,7 @@ final class ExceptionListener
         if (class_exists(ErrorListener::class)) {
             $this->exceptionListener = new ErrorListener($controller, $logger, $debug);
         } else {
-            $this->exceptionListener = new BaseExceptionListener($controller, $logger, $debug);
+            $this->exceptionListener = new LegacyExceptionListener($controller, $logger, $debug);
         }
     }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -29,9 +29,9 @@ final class ExceptionListener
 {
     private $exceptionListener;
 
-    public function __construct($controller, LoggerInterface $logger = null, $debug = false)
+    public function __construct($controller, LoggerInterface $logger = null, $debug = false, ErrorListener $errorListener = null)
     {
-        if (class_exists(ErrorListener::class)) {
+        if (null !== $errorListener) {
             $this->exceptionListener = new ErrorListener($controller, $logger, $debug);
         } else {
             $this->exceptionListener = new LegacyExceptionListener($controller, $logger, $debug);

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -19,6 +19,7 @@ use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
@@ -44,7 +45,7 @@ class ExceptionListenerTest extends TestCase
         $eventProphecy->getKernel()->willReturn($kernel);
         $eventProphecy->setResponse(Argument::type(Response::class))->shouldBeCalled();
 
-        $listener = new ExceptionListener('foo:bar');
+        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
         $listener->onKernelException($eventProphecy->reveal());
     }
 
@@ -62,7 +63,7 @@ class ExceptionListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn(new Request());
         $eventProphecy->setResponse(Argument::type(Response::class))->shouldNotBeCalled();
 
-        $listener = new ExceptionListener('foo:bar');
+        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
         $listener->onKernelException($eventProphecy->reveal());
     }
 
@@ -75,7 +76,7 @@ class ExceptionListenerTest extends TestCase
         $eventProphecy->getRequest()->willReturn($request);
         $eventProphecy->setResponse(Argument::type(Response::class))->shouldNotBeCalled();
 
-        $listener = new ExceptionListener('foo:bar');
+        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
         $listener->onKernelException($eventProphecy->reveal());
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes 
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/issues/34509
| License       | MIT
| Doc PR        | 

If is not enough to check for the existence of `Symfony\Component\HttpKernel\EventListener\ErrorListener` to know if we can use it or not on symfony 4.4.

It may have been [removed from the container](https://github.com/symfony/symfony/blob/bfae515d521a421b413cb39e8fae727ffb4ca28b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php#L37).

The new ErrorListener is functionally different to the deprecated one, as the new one [flattens exceptions with the KernelEvents::CONTROLLER_ARGUMENTS event](https://github.com/symfony/symfony/blob/bfae515d521a421b413cb39e8fae727ffb4ca28b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php#L90-L106), and not when the [attributes are added](https://github.com/symfony/symfony/blob/bfae515d521a421b413cb39e8fae727ffb4ca28b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php#L140).

If `ErrorListener` is removed from the container, the exception will never be converted to a flattened exception, causing the wrong Exception type to be passed to the [ExceptionAction](https://github.com/api-platform/core/blob/f4dfa2e86a9300e15c65a7c5acc9dab7975c6421/src/Action/ExceptionAction.php#L53).