### PR TITLE
JSON:API add inclusion of resources from path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Doctrine: Add `nulls_always_first` and `nulls_always_last` to `nulls_comparison` in order filter (#4103)
 * MongoDB: `date_immutable` support (#3940)
 * DataProvider: Add `TraversablePaginator` (#3783)
+* JSON:API: Support inclusion of resources from path (#3288)
 * Swagger UI: Add `swagger_ui_extra_configuration` to Swagger / OpenAPI configuration (#3731)
 
 ## 2.6.3

--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -392,6 +392,452 @@ Feature: JSON API Inclusion of Related Resources
     """
 
   @createSchema
+  Scenario: Request inclusion of resources from path
+    Given there are 1 dummy objects with relatedDummy and its thirdLevel
+    When I send a "GET" request to "/dummies/1?include=relatedDummy.thirdLevel"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+        {
+            "data": {
+                "id": "/dummies/1",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 1,
+                    "name": "Dummy #1",
+                    "alias": "Alias #0",
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedDummy": {
+                        "data": {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/1"
+                        }
+                    }
+                }
+            },
+            "included": [
+                {
+                    "id": "/related_dummies/1",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #1",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 1,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "type": "ThirdLevel",
+                                "id": "/third_levels/1"
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "/third_levels/1",
+                    "type": "ThirdLevel",
+                    "attributes": {
+                        "_id": 1,
+                        "level": 3,
+                        "test": true
+                    }
+                }
+            ]
+       }
+    """
+
+  @createSchema
+  Scenario: Request inclusion of resources from path with collection
+    Given there is a dummy object with 3 relatedDummies and their thirdLevel
+    When I send a "GET" request to "/dummies/1?include=relatedDummies.thirdLevel"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+        {
+            "data": {
+                "id": "/dummies/1",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 1,
+                    "name": "Dummy with relations",
+                    "alias": null,
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/1"
+                            },
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/2"
+                            },
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/3"
+                            }
+                        ]
+                  }
+                }
+            },
+            "included": [
+                {
+                    "id": "/third_levels/1",
+                    "type": "ThirdLevel",
+                    "attributes": {
+                        "_id": 1,
+                        "level": 3,
+                        "test": true
+                    }
+                },
+                {
+                    "id": "/third_levels/2",
+                    "type": "ThirdLevel",
+                    "attributes": {
+                        "_id": 2,
+                        "level": 3,
+                        "test": true
+                    }
+                },
+                {
+                    "id": "/third_levels/3",
+                    "type": "ThirdLevel",
+                    "attributes": {
+                        "_id": 3,
+                        "level": 3,
+                        "test": true
+                    }
+                },
+                {
+                    "id": "/related_dummies/1",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #1",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 1,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "type": "ThirdLevel",
+                                "id": "/third_levels/1"
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "/related_dummies/2",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #2",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 2,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "type": "ThirdLevel",
+                                "id": "/third_levels/2"
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "/related_dummies/3",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #3",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 3,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "type": "ThirdLevel",
+                                "id": "/third_levels/3"
+                            }
+                        }
+                    }
+                }
+            ]
+       }
+    """
+
+  @createSchema
+  Scenario: Do not include the requested resource
+    Given there is a RelatedOwningDummy object with OneToOne relation
+    When I send a "GET" request to "/dummies/1?include=relatedOwningDummy.ownedDummy"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+        {
+            "data": {
+                "id": "/dummies/1",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 1,
+                    "name": "plop",
+                    "alias": null,
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedOwningDummy": {
+                        "data": {
+                            "type": "RelatedOwningDummy",
+                            "id": "/related_owning_dummies/1"
+                        }
+                    }
+                }
+            },
+            "included": [
+                {
+                    "id": "/related_owning_dummies/1",
+                    "type": "RelatedOwningDummy",
+                    "attributes": {
+                        "name": null,
+                        "_id": 1
+                    },
+                    "relationships": {
+                        "ownedDummy": {
+                            "data": {
+                                "type": "Dummy",
+                                "id": "/dummies/1"
+                            }
+                        }
+                    }
+                }
+            ]
+       }
+    """
+
+  @createSchema
+  Scenario: Do not include resources multiple times
+    Given there is a dummy object with 3 relatedDummies with same thirdLevel
+    When I send a "GET" request to "/dummies/1?include=relatedDummies.thirdLevel"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+        {
+            "data": {
+                "id": "/dummies/1",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 1,
+                    "name": "Dummy with relations",
+                    "alias": null,
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/1"
+                            },
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/2"
+                            },
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/3"
+                            }
+                        ]
+                  }
+                }
+            },
+            "included": [
+                {
+                    "id": "/third_levels/1",
+                    "type": "ThirdLevel",
+                    "attributes": {
+                        "_id": 1,
+                        "level": 3,
+                        "test": true
+                    }
+                },
+                {
+                    "id": "/related_dummies/1",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #1",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 1,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "type": "ThirdLevel",
+                                "id": "/third_levels/1"
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "/related_dummies/2",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #2",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 2,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "type": "ThirdLevel",
+                                "id": "/third_levels/1"
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "/related_dummies/3",
+                    "type": "RelatedDummy",
+                    "attributes": {
+                        "name": "RelatedDummy #3",
+                        "dummyDate": null,
+                        "dummyBoolean": null,
+                        "embeddedDummy": {
+                            "dummyName": null,
+                            "dummyBoolean": null,
+                            "dummyDate": null,
+                            "dummyFloat": null,
+                            "dummyPrice": null,
+                            "symfony": null
+                        },
+                        "_id": 3,
+                        "symfony": "symfony",
+                        "age": null
+                    },
+                    "relationships": {
+                        "thirdLevel": {
+                            "data": {
+                                "type": "ThirdLevel",
+                                "id": "/third_levels/1"
+                            }
+                        }
+                    }
+                }
+            ]
+       }
+    """
+
+
+  @createSchema
   Scenario: Request inclusion of a related resources on collection
     Given there are 3 dummy property objects
     When I send a "GET" request to "/dummy_properties?include=group"
@@ -672,5 +1118,222 @@ Feature: JSON API Inclusion of Related Resources
                 "baz": "Baz #2"
             }
         }]
+    }
+    """
+
+  @createSchema
+  Scenario: Request inclusion from path of resource with relation
+    Given there are 3 dummy objects with relatedDummy and its thirdLevel
+    When I send a "GET" request to "/dummies?include=relatedDummy.thirdLevel"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be valid according to the JSON API schema
+    And the JSON should be deep equal to:
+    """
+    {
+        "links": {
+            "self": "/dummies?include=relatedDummy.thirdLevel"
+        },
+        "meta": {
+            "totalItems": 3,
+            "itemsPerPage": 3,
+            "currentPage": 1
+        },
+        "data": [
+            {
+                "id": "/dummies/1",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 1,
+                    "name": "Dummy #1",
+                    "alias": "Alias #2",
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedDummy": {
+                        "data": {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/1"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "/dummies/2",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 2,
+                    "name": "Dummy #2",
+                    "alias": "Alias #1",
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedDummy": {
+                        "data": {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/2"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "/dummies/3",
+                "type": "Dummy",
+                "attributes": {
+                    "description": null,
+                    "dummy": null,
+                    "dummyBoolean": null,
+                    "dummyDate": null,
+                    "dummyFloat": null,
+                    "dummyPrice": null,
+                    "jsonData": [],
+                    "arrayData": [],
+                    "name_converted": null,
+                    "_id": 3,
+                    "name": "Dummy #3",
+                    "alias": "Alias #0",
+                    "foo": null
+                },
+                "relationships": {
+                    "relatedDummy": {
+                        "data": {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/3"
+                        }
+                    }
+                }
+            }
+        ],
+        "included": [
+            {
+                "id": "/third_levels/1",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 1,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
+                "id": "/third_levels/2",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 2,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
+                "id": "/third_levels/3",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 3,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
+                "id": "/related_dummies/1",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "name": "RelatedDummy #1",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "_id": 1,
+                    "symfony": "symfony",
+                    "age": null
+                },
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/1"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "/related_dummies/2",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "name": "RelatedDummy #2",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "_id": 2,
+                    "symfony": "symfony",
+                    "age": null
+                },
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/2"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "/related_dummies/3",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "name": "RelatedDummy #3",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "_id": 3,
+                    "symfony": "symfony",
+                    "age": null
+                },
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/3"
+                        }
+                    }
+                }
+            }
+        ]
     }
     """

--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -393,81 +393,109 @@ Feature: JSON API Inclusion of Related Resources
 
   @createSchema
   Scenario: Request inclusion of resources from path
-    Given there are 1 dummy objects with relatedDummy and its thirdLevel
-    When I send a "GET" request to "/dummies/1?include=relatedDummy.thirdLevel"
+    Given there is a dummy object with a fourth level relation
+    When I send a "GET" request to "/dummies/1?include=relatedDummy.thirdLevel.fourthLevel"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
-        {
-            "data": {
-                "id": "/dummies/1",
-                "type": "Dummy",
-                "attributes": {
-                    "description": null,
-                    "dummy": null,
-                    "dummyBoolean": null,
-                    "dummyDate": null,
-                    "dummyFloat": null,
-                    "dummyPrice": null,
-                    "jsonData": [],
-                    "arrayData": [],
-                    "name_converted": null,
-                    "_id": 1,
-                    "name": "Dummy #1",
-                    "alias": "Alias #0",
-                    "foo": null
+    {
+        "data": {
+            "id": "/dummies/1",
+            "type": "Dummy",
+            "attributes": {
+                "_id": 1,
+                "name": "Dummy with relations",
+                "alias": null,
+                "foo": null,
+                "description": null,
+                "dummy": null,
+                "dummyBoolean": null,
+                "dummyDate": null,
+                "dummyFloat": null,
+                "dummyPrice": null,
+                "jsonData": [],
+                "arrayData": [],
+                "name_converted": null
+            },
+            "relationships": {
+                "relatedDummy": {
+                    "data": {
+                        "type": "RelatedDummy",
+                        "id": "/related_dummies/1"
+                    }
                 },
-                "relationships": {
-                    "relatedDummy": {
-                        "data": {
+                "relatedDummies": {
+                    "data": [
+                        {
                             "type": "RelatedDummy",
                             "id": "/related_dummies/1"
+                        },
+                        {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/2"
+                        }
+                    ]
+                }
+            }
+        },
+        "included": [
+            {
+                "id": "/related_dummies/1",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "_id": 1,
+                    "name": "Hello",
+                    "symfony": "symfony",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "age": null
+                },
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/1"
                         }
                     }
                 }
             },
-            "included": [
-                {
-                    "id": "/related_dummies/1",
-                    "type": "RelatedDummy",
-                    "attributes": {
-                        "name": "RelatedDummy #1",
-                        "dummyDate": null,
-                        "dummyBoolean": null,
-                        "embeddedDummy": {
-                            "dummyName": null,
-                            "dummyBoolean": null,
-                            "dummyDate": null,
-                            "dummyFloat": null,
-                            "dummyPrice": null,
-                            "symfony": null
-                        },
-                        "_id": 1,
-                        "symfony": "symfony",
-                        "age": null
-                    },
-                    "relationships": {
-                        "thirdLevel": {
-                            "data": {
-                                "type": "ThirdLevel",
-                                "id": "/third_levels/1"
-                            }
+            {
+                "id": "/third_levels/1",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 1,
+                    "level": 3,
+                    "test": true
+                },
+                "relationships": {
+                    "fourthLevel": {
+                        "data": {
+                            "type": "FourthLevel",
+                            "id": "/fourth_levels/1"
                         }
                     }
-                },
-                {
-                    "id": "/third_levels/1",
-                    "type": "ThirdLevel",
-                    "attributes": {
-                        "_id": 1,
-                        "level": 3,
-                        "test": true
-                    }
                 }
-            ]
-       }
+            },
+            {
+                "id": "/fourth_levels/1",
+                "type": "FourthLevel",
+                "attributes": {
+                    "_id": 1,
+                    "level": 4
+                }
+            }
+        ]
+    }
     """
 
   @createSchema
@@ -477,160 +505,160 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
-        {
-            "data": {
-                "id": "/dummies/1",
-                "type": "Dummy",
+    {
+        "data": {
+            "id": "/dummies/1",
+            "type": "Dummy",
+            "attributes": {
+                "_id": 1,
+                "name": "Dummy with relations",
+                "alias": null,
+                "foo": null,
+                "description": null,
+                "dummy": null,
+                "dummyBoolean": null,
+                "dummyDate": null,
+                "dummyFloat": null,
+                "dummyPrice": null,
+                "jsonData": [],
+                "arrayData": [],
+                "name_converted": null
+            },
+            "relationships": {
+                "relatedDummies": {
+                    "data": [
+                        {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/1"
+                        },
+                        {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/2"
+                        },
+                        {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/3"
+                        }
+                    ]
+                }
+            }
+        },
+        "included": [
+            {
+                "id": "/related_dummies/1",
+                "type": "RelatedDummy",
                 "attributes": {
-                    "description": null,
-                    "dummy": null,
-                    "dummyBoolean": null,
-                    "dummyDate": null,
-                    "dummyFloat": null,
-                    "dummyPrice": null,
-                    "jsonData": [],
-                    "arrayData": [],
-                    "name_converted": null,
                     "_id": 1,
-                    "name": "Dummy with relations",
-                    "alias": null,
-                    "foo": null
+                    "name": "RelatedDummy #1",
+                    "symfony": "symfony",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "age": null
                 },
                 "relationships": {
-                    "relatedDummies": {
-                        "data": [
-                            {
-                                "type": "RelatedDummy",
-                                "id": "/related_dummies/1"
-                            },
-                            {
-                                "type": "RelatedDummy",
-                                "id": "/related_dummies/2"
-                            },
-                            {
-                                "type": "RelatedDummy",
-                                "id": "/related_dummies/3"
-                            }
-                        ]
-                  }
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/1"
+                        }
+                    }
                 }
             },
-            "included": [
-                {
-                    "id": "/third_levels/1",
-                    "type": "ThirdLevel",
-                    "attributes": {
-                        "_id": 1,
-                        "level": 3,
-                        "test": true
-                    }
-                },
-                {
-                    "id": "/third_levels/2",
-                    "type": "ThirdLevel",
-                    "attributes": {
-                        "_id": 2,
-                        "level": 3,
-                        "test": true
-                    }
-                },
-                {
-                    "id": "/third_levels/3",
-                    "type": "ThirdLevel",
-                    "attributes": {
-                        "_id": 3,
-                        "level": 3,
-                        "test": true
-                    }
-                },
-                {
-                    "id": "/related_dummies/1",
-                    "type": "RelatedDummy",
-                    "attributes": {
-                        "name": "RelatedDummy #1",
-                        "dummyDate": null,
+            {
+                "id": "/third_levels/1",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 1,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
+                "id": "/related_dummies/2",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "_id": 2,
+                    "name": "RelatedDummy #2",
+                    "symfony": "symfony",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
                         "dummyBoolean": null,
-                        "embeddedDummy": {
-                            "dummyName": null,
-                            "dummyBoolean": null,
-                            "dummyDate": null,
-                            "dummyFloat": null,
-                            "dummyPrice": null,
-                            "symfony": null
-                        },
-                        "_id": 1,
-                        "symfony": "symfony",
-                        "age": null
-                    },
-                    "relationships": {
-                        "thirdLevel": {
-                            "data": {
-                                "type": "ThirdLevel",
-                                "id": "/third_levels/1"
-                            }
-                        }
-                    }
-                },
-                {
-                    "id": "/related_dummies/2",
-                    "type": "RelatedDummy",
-                    "attributes": {
-                        "name": "RelatedDummy #2",
                         "dummyDate": null,
-                        "dummyBoolean": null,
-                        "embeddedDummy": {
-                            "dummyName": null,
-                            "dummyBoolean": null,
-                            "dummyDate": null,
-                            "dummyFloat": null,
-                            "dummyPrice": null,
-                            "symfony": null
-                        },
-                        "_id": 2,
-                        "symfony": "symfony",
-                        "age": null
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
                     },
-                    "relationships": {
-                        "thirdLevel": {
-                            "data": {
-                                "type": "ThirdLevel",
-                                "id": "/third_levels/2"
-                            }
-                        }
-                    }
+                    "age": null
                 },
-                {
-                    "id": "/related_dummies/3",
-                    "type": "RelatedDummy",
-                    "attributes": {
-                        "name": "RelatedDummy #3",
-                        "dummyDate": null,
-                        "dummyBoolean": null,
-                        "embeddedDummy": {
-                            "dummyName": null,
-                            "dummyBoolean": null,
-                            "dummyDate": null,
-                            "dummyFloat": null,
-                            "dummyPrice": null,
-                            "symfony": null
-                        },
-                        "_id": 3,
-                        "symfony": "symfony",
-                        "age": null
-                    },
-                    "relationships": {
-                        "thirdLevel": {
-                            "data": {
-                                "type": "ThirdLevel",
-                                "id": "/third_levels/3"
-                            }
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/2"
                         }
                     }
                 }
-            ]
-       }
+            },
+            {
+                "id": "/third_levels/2",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 2,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
+                "id": "/related_dummies/3",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "_id": 3,
+                    "name": "RelatedDummy #3",
+                    "symfony": "symfony",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "age": null
+                },
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/3"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "/third_levels/3",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 3,
+                    "level": 3,
+                    "test": true
+                }
+            }
+        ]
+    }
     """
 
   @createSchema
@@ -640,55 +668,55 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
-        {
-            "data": {
-                "id": "/dummies/1",
-                "type": "Dummy",
+    {
+        "data": {
+            "id": "/dummies/1",
+            "type": "Dummy",
+            "attributes": {
+                "description": null,
+                "dummy": null,
+                "dummyBoolean": null,
+                "dummyDate": null,
+                "dummyFloat": null,
+                "dummyPrice": null,
+                "jsonData": [],
+                "arrayData": [],
+                "name_converted": null,
+                "_id": 1,
+                "name": "plop",
+                "alias": null,
+                "foo": null
+            },
+            "relationships": {
+                "relatedOwningDummy": {
+                    "data": {
+                        "type": "RelatedOwningDummy",
+                        "id": "/related_owning_dummies/1"
+                    }
+                }
+            }
+        },
+        "included": [
+            {
+                "id": "/related_owning_dummies/1",
+                "type": "RelatedOwningDummy",
                 "attributes": {
-                    "description": null,
-                    "dummy": null,
-                    "dummyBoolean": null,
-                    "dummyDate": null,
-                    "dummyFloat": null,
-                    "dummyPrice": null,
-                    "jsonData": [],
-                    "arrayData": [],
-                    "name_converted": null,
-                    "_id": 1,
-                    "name": "plop",
-                    "alias": null,
-                    "foo": null
+                    "name": null,
+                    "_id": 1
                 },
                 "relationships": {
-                    "relatedOwningDummy": {
+                    "ownedDummy": {
                         "data": {
-                            "type": "RelatedOwningDummy",
-                            "id": "/related_owning_dummies/1"
+                            "type": "Dummy",
+                            "id": "/dummies/1"
                         }
                     }
                 }
-            },
-            "included": [
-                {
-                    "id": "/related_owning_dummies/1",
-                    "type": "RelatedOwningDummy",
-                    "attributes": {
-                        "name": null,
-                        "_id": 1
-                    },
-                    "relationships": {
-                        "ownedDummy": {
-                            "data": {
-                                "type": "Dummy",
-                                "id": "/dummies/1"
-                            }
-                        }
-                    }
-                }
-            ]
-       }
+            }
+        ]
+   }
     """
 
   @createSchema
@@ -698,142 +726,142 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
-        {
-            "data": {
-                "id": "/dummies/1",
-                "type": "Dummy",
+    {
+        "data": {
+            "id": "/dummies/1",
+            "type": "Dummy",
+            "attributes": {
+                "_id": 1,
+                "name": "Dummy with relations",
+                "alias": null,
+                "foo": null,
+                "description": null,
+                "dummy": null,
+                "dummyBoolean": null,
+                "dummyDate": null,
+                "dummyFloat": null,
+                "dummyPrice": null,
+                "jsonData": [],
+                "arrayData": [],
+                "name_converted": null
+            },
+            "relationships": {
+                "relatedDummies": {
+                    "data": [
+                        {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/1"
+                        },
+                        {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/2"
+                        },
+                        {
+                            "type": "RelatedDummy",
+                            "id": "/related_dummies/3"
+                        }
+                    ]
+                }
+            }
+        },
+        "included": [
+            {
+                "id": "/related_dummies/1",
+                "type": "RelatedDummy",
                 "attributes": {
-                    "description": null,
-                    "dummy": null,
-                    "dummyBoolean": null,
-                    "dummyDate": null,
-                    "dummyFloat": null,
-                    "dummyPrice": null,
-                    "jsonData": [],
-                    "arrayData": [],
-                    "name_converted": null,
                     "_id": 1,
-                    "name": "Dummy with relations",
-                    "alias": null,
-                    "foo": null
+                    "name": "RelatedDummy #1",
+                    "symfony": "symfony",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "age": null
                 },
                 "relationships": {
-                    "relatedDummies": {
-                        "data": [
-                            {
-                                "type": "RelatedDummy",
-                                "id": "/related_dummies/1"
-                            },
-                            {
-                                "type": "RelatedDummy",
-                                "id": "/related_dummies/2"
-                            },
-                            {
-                                "type": "RelatedDummy",
-                                "id": "/related_dummies/3"
-                            }
-                        ]
-                  }
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/1"
+                        }
+                    }
                 }
             },
-            "included": [
-                {
-                    "id": "/third_levels/1",
-                    "type": "ThirdLevel",
-                    "attributes": {
-                        "_id": 1,
-                        "level": 3,
-                        "test": true
-                    }
-                },
-                {
-                    "id": "/related_dummies/1",
-                    "type": "RelatedDummy",
-                    "attributes": {
-                        "name": "RelatedDummy #1",
-                        "dummyDate": null,
+            {
+                "id": "/third_levels/1",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 1,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
+                "id": "/related_dummies/2",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "_id": 2,
+                    "name": "RelatedDummy #2",
+                    "symfony": "symfony",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
                         "dummyBoolean": null,
-                        "embeddedDummy": {
-                            "dummyName": null,
-                            "dummyBoolean": null,
-                            "dummyDate": null,
-                            "dummyFloat": null,
-                            "dummyPrice": null,
-                            "symfony": null
-                        },
-                        "_id": 1,
-                        "symfony": "symfony",
-                        "age": null
-                    },
-                    "relationships": {
-                        "thirdLevel": {
-                            "data": {
-                                "type": "ThirdLevel",
-                                "id": "/third_levels/1"
-                            }
-                        }
-                    }
-                },
-                {
-                    "id": "/related_dummies/2",
-                    "type": "RelatedDummy",
-                    "attributes": {
-                        "name": "RelatedDummy #2",
                         "dummyDate": null,
-                        "dummyBoolean": null,
-                        "embeddedDummy": {
-                            "dummyName": null,
-                            "dummyBoolean": null,
-                            "dummyDate": null,
-                            "dummyFloat": null,
-                            "dummyPrice": null,
-                            "symfony": null
-                        },
-                        "_id": 2,
-                        "symfony": "symfony",
-                        "age": null
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
                     },
-                    "relationships": {
-                        "thirdLevel": {
-                            "data": {
-                                "type": "ThirdLevel",
-                                "id": "/third_levels/1"
-                            }
-                        }
-                    }
+                    "age": null
                 },
-                {
-                    "id": "/related_dummies/3",
-                    "type": "RelatedDummy",
-                    "attributes": {
-                        "name": "RelatedDummy #3",
-                        "dummyDate": null,
-                        "dummyBoolean": null,
-                        "embeddedDummy": {
-                            "dummyName": null,
-                            "dummyBoolean": null,
-                            "dummyDate": null,
-                            "dummyFloat": null,
-                            "dummyPrice": null,
-                            "symfony": null
-                        },
-                        "_id": 3,
-                        "symfony": "symfony",
-                        "age": null
-                    },
-                    "relationships": {
-                        "thirdLevel": {
-                            "data": {
-                                "type": "ThirdLevel",
-                                "id": "/third_levels/1"
-                            }
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/1"
                         }
                     }
                 }
-            ]
-       }
+            },
+            {
+                "id": "/related_dummies/3",
+                "type": "RelatedDummy",
+                "attributes": {
+                    "_id": 3,
+                    "name": "RelatedDummy #3",
+                    "symfony": "symfony",
+                    "dummyDate": null,
+                    "dummyBoolean": null,
+                    "embeddedDummy": {
+                        "dummyName": null,
+                        "dummyBoolean": null,
+                        "dummyDate": null,
+                        "dummyFloat": null,
+                        "dummyPrice": null,
+                        "symfony": null
+                    },
+                    "age": null
+                },
+                "relationships": {
+                    "thirdLevel": {
+                        "data": {
+                            "type": "ThirdLevel",
+                            "id": "/third_levels/1"
+                        }
+                    }
+                }
+            }
+        ]
+    }
     """
 
 
@@ -1128,7 +1156,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "links": {
@@ -1144,6 +1172,10 @@ Feature: JSON API Inclusion of Related Resources
                 "id": "/dummies/1",
                 "type": "Dummy",
                 "attributes": {
+                    "_id": 1,
+                    "name": "Dummy #1",
+                    "alias": "Alias #2",
+                    "foo": null,
                     "description": null,
                     "dummy": null,
                     "dummyBoolean": null,
@@ -1152,11 +1184,7 @@ Feature: JSON API Inclusion of Related Resources
                     "dummyPrice": null,
                     "jsonData": [],
                     "arrayData": [],
-                    "name_converted": null,
-                    "_id": 1,
-                    "name": "Dummy #1",
-                    "alias": "Alias #2",
-                    "foo": null
+                    "name_converted": null
                 },
                 "relationships": {
                     "relatedDummy": {
@@ -1171,6 +1199,10 @@ Feature: JSON API Inclusion of Related Resources
                 "id": "/dummies/2",
                 "type": "Dummy",
                 "attributes": {
+                    "_id": 2,
+                    "name": "Dummy #2",
+                    "alias": "Alias #1",
+                    "foo": null,
                     "description": null,
                     "dummy": null,
                     "dummyBoolean": null,
@@ -1179,11 +1211,7 @@ Feature: JSON API Inclusion of Related Resources
                     "dummyPrice": null,
                     "jsonData": [],
                     "arrayData": [],
-                    "name_converted": null,
-                    "_id": 2,
-                    "name": "Dummy #2",
-                    "alias": "Alias #1",
-                    "foo": null
+                    "name_converted": null
                 },
                 "relationships": {
                     "relatedDummy": {
@@ -1198,6 +1226,10 @@ Feature: JSON API Inclusion of Related Resources
                 "id": "/dummies/3",
                 "type": "Dummy",
                 "attributes": {
+                    "_id": 3,
+                    "name": "Dummy #3",
+                    "alias": "Alias #0",
+                    "foo": null,
                     "description": null,
                     "dummy": null,
                     "dummyBoolean": null,
@@ -1206,11 +1238,7 @@ Feature: JSON API Inclusion of Related Resources
                     "dummyPrice": null,
                     "jsonData": [],
                     "arrayData": [],
-                    "name_converted": null,
-                    "_id": 3,
-                    "name": "Dummy #3",
-                    "alias": "Alias #0",
-                    "foo": null
+                    "name_converted": null
                 },
                 "relationships": {
                     "relatedDummy": {
@@ -1224,37 +1252,12 @@ Feature: JSON API Inclusion of Related Resources
         ],
         "included": [
             {
-                "id": "/third_levels/1",
-                "type": "ThirdLevel",
-                "attributes": {
-                    "_id": 1,
-                    "level": 3,
-                    "test": true
-                }
-            },
-            {
-                "id": "/third_levels/2",
-                "type": "ThirdLevel",
-                "attributes": {
-                    "_id": 2,
-                    "level": 3,
-                    "test": true
-                }
-            },
-            {
-                "id": "/third_levels/3",
-                "type": "ThirdLevel",
-                "attributes": {
-                    "_id": 3,
-                    "level": 3,
-                    "test": true
-                }
-            },
-            {
                 "id": "/related_dummies/1",
                 "type": "RelatedDummy",
                 "attributes": {
+                    "_id": 1,
                     "name": "RelatedDummy #1",
+                    "symfony": "symfony",
                     "dummyDate": null,
                     "dummyBoolean": null,
                     "embeddedDummy": {
@@ -1265,8 +1268,6 @@ Feature: JSON API Inclusion of Related Resources
                         "dummyPrice": null,
                         "symfony": null
                     },
-                    "_id": 1,
-                    "symfony": "symfony",
                     "age": null
                 },
                 "relationships": {
@@ -1279,10 +1280,21 @@ Feature: JSON API Inclusion of Related Resources
                 }
             },
             {
+                "id": "/third_levels/1",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 1,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
                 "id": "/related_dummies/2",
                 "type": "RelatedDummy",
                 "attributes": {
+                    "_id": 2,
                     "name": "RelatedDummy #2",
+                    "symfony": "symfony",
                     "dummyDate": null,
                     "dummyBoolean": null,
                     "embeddedDummy": {
@@ -1293,8 +1305,6 @@ Feature: JSON API Inclusion of Related Resources
                         "dummyPrice": null,
                         "symfony": null
                     },
-                    "_id": 2,
-                    "symfony": "symfony",
                     "age": null
                 },
                 "relationships": {
@@ -1307,10 +1317,21 @@ Feature: JSON API Inclusion of Related Resources
                 }
             },
             {
+                "id": "/third_levels/2",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 2,
+                    "level": 3,
+                    "test": true
+                }
+            },
+            {
                 "id": "/related_dummies/3",
                 "type": "RelatedDummy",
                 "attributes": {
+                    "_id": 3,
                     "name": "RelatedDummy #3",
+                    "symfony": "symfony",
                     "dummyDate": null,
                     "dummyBoolean": null,
                     "embeddedDummy": {
@@ -1321,8 +1342,6 @@ Feature: JSON API Inclusion of Related Resources
                         "dummyPrice": null,
                         "symfony": null
                     },
-                    "_id": 3,
-                    "symfony": "symfony",
                     "age": null
                 },
                 "relationships": {
@@ -1332,6 +1351,15 @@ Feature: JSON API Inclusion of Related Resources
                             "id": "/third_levels/3"
                         }
                     }
+                }
+            },
+            {
+                "id": "/third_levels/3",
+                "type": "ThirdLevel",
+                "attributes": {
+                    "_id": 3,
+                    "level": 3,
+                    "test": true
                 }
             }
         ]

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -618,6 +618,53 @@ final class DoctrineContext implements Context
     }
 
     /**
+     * @Given there is a dummy object with :nb relatedDummies and their thirdLevel
+     */
+    public function thereIsADummyObjectWithRelatedDummiesAndTheirThirdLevel(int $nb)
+    {
+        $dummy = $this->buildDummy();
+        $dummy->setName('Dummy with relations');
+
+        for ($i = 1; $i <= $nb; ++$i) {
+            $thirdLevel = $this->buildThirdLevel();
+
+            $relatedDummy = $this->buildRelatedDummy();
+            $relatedDummy->setName('RelatedDummy #'.$i);
+            $relatedDummy->setThirdLevel($thirdLevel);
+
+            $dummy->addRelatedDummy($relatedDummy);
+
+            $this->manager->persist($thirdLevel);
+            $this->manager->persist($relatedDummy);
+        }
+        $this->manager->persist($dummy);
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is a dummy object with :nb relatedDummies with same thirdLevel
+     */
+    public function thereIsADummyObjectWithRelatedDummiesWithSameThirdLevel(int $nb)
+    {
+        $dummy = $this->buildDummy();
+        $dummy->setName('Dummy with relations');
+        $thirdLevel = $this->buildThirdLevel();
+
+        for ($i = 1; $i <= $nb; ++$i) {
+            $relatedDummy = $this->buildRelatedDummy();
+            $relatedDummy->setName('RelatedDummy #'.$i);
+            $relatedDummy->setThirdLevel($thirdLevel);
+
+            $dummy->addRelatedDummy($relatedDummy);
+
+            $this->manager->persist($relatedDummy);
+        }
+        $this->manager->persist($thirdLevel);
+        $this->manager->persist($dummy);
+        $this->manager->flush();
+    }
+
+    /**
      * @Given there are :nb dummy objects with embeddedDummy
      */
     public function thereAreDummyObjectsWithEmbeddedDummy(int $nb)


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #2365 
| License       | MIT
| Doc PR        | 

As specified in the JSON:API specs (https://jsonapi.org/format/#fetching-includes): In order to request resources related to other resources, a dot-separated path for each relationship name can be specified

> GET /articles/1?include=comments.author HTTP/1.1
Accept: application/vnd.api+json
