### PR TITLE
Recover compatiblity with symfony/symfony 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "symfony/http-kernel": "^3.4 || ^4.0",
         "symfony/property-access": "^3.4 || ^4.0",
         "symfony/property-info": "^3.4 || ^4.0",
-        "symfony/serializer": "^4.2.6",
-        "symfony/web-link": "^4.1",
+        "symfony/serializer": "^3.4",
+        "symfony/web-link": "^3.4",
         "willdurand/negotiation": "^2.0.3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3296
| License       | MIT

API Platform 2.4 is not compatible with Symfony 3.4 LTS without flex because of conflicts between symfony/symfony and both symfony/web-link and symfony/serializer.

By changing the version constraint to ^3.4 for both the replace definition in symfony/symfony 3.4 LTS with self.version matches again and no conflicts occur.

This pull request doesnt mean to be complete but should provide details about how to fix conflicts with 3.4. Now it should be adapted to dont break Symfony 4 compatibilty.

**I am not very knowledged with composer but it feels it should be required like ^3.4 || ^4.
I didnt manage to do so. Got errors about invalid version string. I would need some help on it.**

The ticket gives more details about the issue and how to reproduce.

