### PR TITLE
Fix serialization of related DTOs

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -40,7 +40,6 @@ final class PublishMercureUpdatesListener
     use ResourceClassInfoTrait;
 
     private $iriConverter;
-    private $resourceMetadataFactory;
     private $serializer;
     private $publisher;
     private $expressionLanguage;

--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Serializer\InputOutputMetadataTrait;
 use ApiPlatform\Core\Util\ResourceClassInfoTrait;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface as SerializerClassMetadataFactoryInterface;
 
@@ -28,6 +29,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface a
  */
 final class SerializerPropertyMetadataFactory implements PropertyMetadataFactoryInterface
 {
+    use InputOutputMetadataTrait;
     use ResourceClassInfoTrait;
 
     private $serializerClassMetadataFactory;
@@ -124,13 +126,15 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
             $relatedClass = $this->resourceClassResolver->getResourceClass(null, $relatedClass);
         }
 
-        $relatedGroups = $this->getClassSerializerGroups($relatedClass);
-
         if (null === $propertyMetadata->isReadableLink()) {
+            $relatedGroups = $this->getClassSerializerGroups($this->getOutputClass($relatedClass) ?? $relatedClass);
+
             $propertyMetadata = $propertyMetadata->withReadableLink(null !== $normalizationGroups && !empty(array_intersect($normalizationGroups, $relatedGroups)));
         }
 
         if (null === $propertyMetadata->isWritableLink()) {
+            $relatedGroups = $this->getClassSerializerGroups($this->getInputClass($relatedClass) ?? $relatedClass);
+
             $propertyMetadata = $propertyMetadata->withWritableLink(null !== $denormalizationGroups && !empty(array_intersect($denormalizationGroups, $relatedGroups)));
         }
 

--- a/src/Metadata/Resource/ToggleableOperationAttributeTrait.php
+++ b/src/Metadata/Resource/ToggleableOperationAttributeTrait.php
@@ -23,7 +23,7 @@ trait ToggleableOperationAttributeTrait
     /**
      * @var ResourceMetadataFactoryInterface|null
      */
-    private $resourceMetadataFactory;
+    protected $resourceMetadataFactory;
 
     private function isOperationAttributeDisabled(array $attributes, string $attribute, bool $default = false, bool $resourceFallback = true): bool
     {

--- a/src/Util/ResourceClassInfoTrait.php
+++ b/src/Util/ResourceClassInfoTrait.php
@@ -34,7 +34,7 @@ trait ResourceClassInfoTrait
     /**
      * @var ResourceMetadataFactoryInterface|null
      */
-    private $resourceMetadataFactory;
+    protected $resourceMetadataFactory;
 
     /**
      * Gets the resource class of the given object.

--- a/src/Validator/EventListener/ValidateListener.php
+++ b/src/Validator/EventListener/ValidateListener.php
@@ -33,7 +33,6 @@ final class ValidateListener
     public const OPERATION_ATTRIBUTE_KEY = 'validate';
 
     private $validator;
-    private $resourceMetadataFactory;
 
     public function __construct(ValidatorInterface $validator, ResourceMetadataFactoryInterface $resourceMetadataFactory)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When serializing a resource that contains a related resource that is configured to always use a DTO, using serialization groups on the DTO doesn't work unless the group is also defined for the related resource it represents:
```yaml
# api_resources.yaml
resources:
    Foo:
        # ...
    Bar:
        # ...
        output: BarDto
```
```yaml
# serialization.yaml
Foo:
    attributes:
        bar:
            groups: [foo]
BarDto:
    attributes:
        id:
            groups: [foo]

# this should not be needed
Bar:
    attributes:
        anyProperty:
            groups: [foo]
```