### PR TITLE
PublishMercureUpdatesListener unable to add custom updates to publish

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
@@ -9,6 +9,7 @@
         <!-- Event listener -->
 
         <service id="api_platform.doctrine.listener.mercure.publish" class="ApiPlatform\Core\Bridge\Doctrine\EventListener\PublishMercureUpdatesListener">
+            <argument type="service" id="ApiPlatform\Core\Mercure\EntitiesToPublish" />
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/mercure.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/mercure.xml
@@ -12,5 +12,6 @@
 
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>
+        <service id="ApiPlatform\Core\Mercure\EntitiesToPublish"/>
     </services>
 </container>

--- a/src/Mercure/EntitiesToPublish.php
+++ b/src/Mercure/EntitiesToPublish.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ *
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+
+namespace ApiPlatform\Core\Mercure;
+
+
+class EntitiesToPublish
+{
+    private $createdEntities;
+    private $updatedEntities;
+    private $deletedEntities;
+
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    public function reset(): void
+    {
+        $this->createdEntities = new \SplObjectStorage();
+        $this->updatedEntities = new \SplObjectStorage();
+        $this->deletedEntities = new \SplObjectStorage();
+    }
+
+    public function addDeletedEntities($entity, $value){
+        $this->deletedEntities[$entity] = $value;
+    }
+
+    public function addUpdatedEntities($entity, $value){
+        $this->updatedEntities[$entity] = $value;
+    }
+
+    public function addCreatedEntities($entity, $value){
+        $this->createdEntities[$entity] = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCreatedEntities()
+    {
+        return $this->createdEntities;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUpdatedEntities()
+    {
+        return $this->updatedEntities;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDeletedEntities()
+    {
+        return $this->deletedEntities;
+    }
+
+    public function getCreatedEntityValue($entity){
+        return $this->createdEntities[$entity];
+    }
+
+    public function getUpdatedEntityValue($entity){
+        return $this->updatedEntities[$entity];
+    }
+
+    public function getDeletedEntityValue($entity){
+        return $this->deletedEntities[$entity];
+    }
+}


### PR DESCRIPTION
I wanted to add custom publish based on different logic ( not for all updates ), there was no way to extend PublishMercureUpdatesListener so I created this commit, following changes are done.

1. Entities to publish is moved to different service.
2. Service ( 1 ) is added as dependency  to PublishMercureUpdatesListener

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | yes
| BC breaks?    | no
| License       | MIT

<!--
Service ApiPlatform\Core\Mercure\EntitiesToPublish can be used to add new entities update / create / delete  to publish via mercure.

following method added on ApiPlatform\Core\Mercure\EntitiesToPublish 

addUpdatedEntities($entity, $target);
addDeletedEntities($entity, $target);
addCreatedEntities($entity, $target);

-->
