### PR TITLE
GraphQl: interface implementation

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -117,6 +117,16 @@ final class ApiResource
     public $subresourceOperations;
 
     /**
+     * @var bool
+     */
+    public $isInterface;
+
+    /**
+     * @var array
+     */
+    public $implements;
+
+    /**
      * @see https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers
      * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
      *

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="api_platform.graphql.resolver.stage.serialize" />
             <argument type="service" id="api_platform.graphql.query_resolver_locator" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.graphql.type_builder" />
         </service>
 
         <service id="api_platform.graphql.resolver.factory.collection" class="ApiPlatform\Core\GraphQl\Resolver\Factory\CollectionResolverFactory" public="false">

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
@@ -54,6 +54,13 @@
             <argument type="service" id="api_platform.metadata.property.name_collection_factory.inherited.inner" />
         </service>
 
+        <service id="api_platform.metadata.property.name_collection_factory.inherited_interface" class="ApiPlatform\Core\Metadata\Property\Factory\InheritedPropertyNameInterfaceCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" decoration-priority="5" public="false">
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory"/>
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory.property_info" />
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory.inherited_interface.inner" />
+        </service>
+
         <service id="api_platform.metadata.property.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.property" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory.cached.inner" />

--- a/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
@@ -132,7 +132,7 @@ final class ItemResolverFactory implements ResolverFactoryInterface
                 throw Error::createLocatedError(sprintf($errorMessage, (new \ReflectionClass($resourceClass))->getShortName(), (new \ReflectionClass($itemClass))->getShortName()), $info->fieldNodes, $info->path);
             }
 
-            $returnType = $this->typeBuilder->getResourceObjectType($resourceClass, $returnItemMetadata, false, $info->operation->operation, null);
+            $returnType = $this->typeBuilder->getResourceObjectType($resourceClass, $returnItemMetadata, false, null, null);
             if ($returnType->implementsInterface($info->returnType)) {
                 return $resourceClass;
             }

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -72,6 +72,10 @@ final class SchemaBuilder implements SchemaBuilderInterface
                     continue;
                 }
 
+                if ($resourceMetadata->isInterface()) {
+                    continue;
+                }
+
                 if ($resourceMetadata->getGraphqlAttribute($operationName, 'item_query')) {
                     $queryFields += $this->fieldsBuilder->getItemQueryFields($resourceClass, $resourceMetadata, $operationName, $value);
 

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -32,6 +32,11 @@ use Symfony\Component\PropertyInfo\Type;
  */
 final class TypeBuilder implements TypeBuilderInterface
 {
+    public const INTERFACE_POSTFIX = 'Interface';
+    public const ITEM_POSTFIX = 'Item';
+    public const COLLECTION_POSTFIX = 'Collection';
+    public const DATA_POSTFIX = 'Data';
+
     private $typesContainer;
     private $defaultFieldResolver;
     private $fieldsBuilderLocator;
@@ -53,6 +58,7 @@ final class TypeBuilder implements TypeBuilderInterface
         if (null !== $mutationName) {
             $shortName = $mutationName.ucfirst($shortName);
         }
+
         if ($input) {
             $shortName .= 'Input';
         } elseif (null !== $mutationName) {
@@ -61,69 +67,41 @@ final class TypeBuilder implements TypeBuilderInterface
             }
             $shortName .= 'Payload';
         }
+
+        if ($resourceMetadata->isInterface()) {
+            $shortName .= self::INTERFACE_POSTFIX;
+        }
+
         if (('item_query' === $queryName || 'collection_query' === $queryName)
             && $resourceMetadata->getGraphqlAttribute('item_query', 'normalization_context', [], true) !== $resourceMetadata->getGraphqlAttribute('collection_query', 'normalization_context', [], true)) {
             if ('item_query' === $queryName) {
-                $shortName .= 'Item';
+                $shortName .= self::ITEM_POSTFIX;
             }
             if ('collection_query' === $queryName) {
-                $shortName .= 'Collection';
+                $shortName .= self::COLLECTION_POSTFIX;
             }
         }
+
         if ($wrapped && null !== $mutationName) {
-            $shortName .= 'Data';
+            $shortName .= self::DATA_POSTFIX;
         }
 
         if ($this->typesContainer->has($shortName)) {
             $resourceObjectType = $this->typesContainer->get($shortName);
-            if (!($resourceObjectType instanceof ObjectType || $resourceObjectType instanceof NonNull)) {
-                throw new \UnexpectedValueException(sprintf('Expected GraphQL type "%s" to be %s.', $shortName, implode('|', [ObjectType::class, NonNull::class])));
+            if (!($resourceObjectType instanceof ObjectType || $resourceObjectType instanceof NonNull || $resourceObjectType instanceof InterfaceType)) {
+                throw new \UnexpectedValueException(sprintf(
+                    'Expected GraphQL type "%s" to be %s.',
+                    $shortName,
+                    implode('|', [ObjectType::class, NonNull::class, InterfaceType::class])
+                ));
             }
 
             return $resourceObjectType;
         }
 
-        $ioMetadata = $resourceMetadata->getGraphqlAttribute($mutationName ?? $queryName, $input ? 'input' : 'output', null, true);
-        if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
-            $resourceClass = $ioMetadata['class'];
-        }
-
-        $wrapData = !$wrapped && null !== $mutationName && !$input && $depth < 1;
-
-        $configuration = [
-            'name' => $shortName,
-            'description' => $resourceMetadata->getDescription(),
-            'resolveField' => $this->defaultFieldResolver,
-            'fields' => function () use ($resourceClass, $resourceMetadata, $input, $mutationName, $queryName, $wrapData, $depth, $ioMetadata) {
-                if ($wrapData) {
-                    $queryNormalizationContext = $resourceMetadata->getGraphqlAttribute($queryName ?? '', 'normalization_context', [], true);
-                    $mutationNormalizationContext = $resourceMetadata->getGraphqlAttribute($mutationName ?? '', 'normalization_context', [], true);
-                    // Use a new type for the wrapped object only if there is a specific normalization context for the mutation.
-                    // If not, use the query type in order to ensure the client cache could be used.
-                    $useWrappedType = $queryNormalizationContext !== $mutationNormalizationContext;
-
-                    return [
-                        lcfirst($resourceMetadata->getShortName()) => $useWrappedType ?
-                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, true, $depth) :
-                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName ?? 'item_query', null, true, $depth),
-                        'clientMutationId' => GraphQLType::string(),
-                    ];
-                }
-
-                $fieldsBuilder = $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder');
-
-                $fields = $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $depth, $ioMetadata);
-
-                if ($input && null !== $mutationName && null !== $mutationArgs = $resourceMetadata->getGraphql()[$mutationName]['args'] ?? null) {
-                    return $fieldsBuilder->resolveResourceArgs($mutationArgs, $mutationName, $resourceMetadata->getShortName()) + ['clientMutationId' => $fields['clientMutationId']];
-                }
-
-                return $fields;
-            },
-            'interfaces' => $wrapData ? [] : [$this->getNodeInterface()],
-        ];
-
-        $resourceObjectType = $input ? GraphQLType::nonNull(new InputObjectType($configuration)) : new ObjectType($configuration);
+        $resourceObjectType = $resourceMetadata->isInterface()
+            ? $this->buildResourceInterfaceType($resourceClass, $shortName, $resourceMetadata, $input, $queryName, $mutationName, $wrapped, $depth)
+            : $this->buildResourceObjectType($resourceClass, $shortName, $resourceMetadata, $input, $queryName, $mutationName, $wrapped, $depth);
         $this->typesContainer->set($shortName, $resourceObjectType);
 
         return $resourceObjectType;
@@ -225,5 +203,142 @@ final class TypeBuilder implements TypeBuilderInterface
     public function isCollection(Type $type): bool
     {
         return $type->isCollection() && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType();
+    }
+
+    private function buildResourceObjectType(?string $resourceClass, string $shortName, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped, int $depth)
+    {
+        $ioMetadata = $resourceMetadata->getGraphqlAttribute($mutationName ?? $queryName, $input ? 'input' : 'output', null, true);
+        if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
+            $resourceClass = $ioMetadata['class'];
+        }
+
+        $wrapData = !$wrapped && null !== $mutationName && !$input && $depth < 1;
+        $interfaces = ($interface = $resourceMetadata->getImplements())
+            ? $this->getInterfaceTypes($interface)
+            : [];
+
+        $configuration = [
+            'name' => $shortName,
+            'description' => $resourceMetadata->getDescription(),
+            'resolveField' => $this->defaultFieldResolver,
+            'fields' => function () use ($resourceClass, $resourceMetadata, $input, $mutationName, $queryName, $wrapData, $depth, $ioMetadata) {
+                if ($wrapData) {
+                    $queryNormalizationContext = $resourceMetadata->getGraphqlAttribute($queryName ?? '', 'normalization_context', [], true);
+                    $mutationNormalizationContext = $resourceMetadata->getGraphqlAttribute($mutationName ?? '', 'normalization_context', [], true);
+                    // Use a new type for the wrapped object only if there is a specific normalization context for the mutation.
+                    // If not, use the query type in order to ensure the client cache could be used.
+                    $useWrappedType = $queryNormalizationContext !== $mutationNormalizationContext;
+
+                    return [
+                        lcfirst($resourceMetadata->getShortName()) => $useWrappedType ?
+                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, true, $depth) :
+                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName ?? 'item_query', null, true, $depth),
+                        'clientMutationId' => GraphQLType::string(),
+                    ];
+                }
+
+                $fieldsBuilder = $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder');
+
+                $fields = $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $depth, $ioMetadata);
+
+                if ($input && null !== $mutationName && null !== $mutationArgs = $resourceMetadata->getGraphql()[$mutationName]['args'] ?? null) {
+                    return $fieldsBuilder->resolveResourceArgs($mutationArgs, $mutationName, $resourceMetadata->getShortName()) + ['clientMutationId' => $fields['clientMutationId']];
+                }
+
+                return $fields;
+            },
+            'interfaces' => $wrapData ? [] : \array_merge([$this->getNodeInterface()], $interfaces),
+        ];
+
+        return $input ? GraphQLType::nonNull(new InputObjectType($configuration)) : new ObjectType($configuration);
+    }
+
+    private function buildResourceInterfaceType(?string $resourceClass, string $shortName, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped, int $depth): ?InterfaceType
+    {
+        static $fieldsBuilder;
+
+        $ioMetadata = $resourceMetadata->getGraphqlAttribute($mutationName ?? $queryName, $input ? 'input' : 'output', null, true);
+        if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
+            $resourceClass = $ioMetadata['class'];
+        }
+
+        $wrapData = !$wrapped && null !== $mutationName && !$input && $depth < 1;
+
+        if ($this->typesContainer->has($shortName)) {
+            $resourceInterface = $this->typesContainer->get($shortName);
+            if (!$resourceInterface instanceof InterfaceType) {
+                throw new \UnexpectedValueException(sprintf('Expected GraphQL type "%s" to be %s.', $shortName, InterfaceType::class));
+            }
+
+            return $resourceInterface;
+        }
+
+        $fieldsBuilder = $fieldsBuilder ?? $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder');
+
+        $resourceInterface = new InterfaceType([
+            'name' => $shortName,
+            'description' => $resourceMetadata->getDescription(),
+            'fields' => function () use ($resourceClass, $resourceMetadata, $input, $mutationName, $queryName, $wrapData, $depth, $ioMetadata, $fieldsBuilder) {
+                if ($wrapData) {
+                    return [
+                        lcfirst($resourceMetadata->getShortName()) => $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, null, true, $depth),
+                    ];
+                }
+
+                return $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, null, $depth, $ioMetadata);
+            },
+            'resolveType' => function ($value, $context, $info) {
+                if (!isset($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY])) {
+                    throw new \UnexpectedValueException('Resource class was not passed. Interface type can not be used.');
+                }
+
+                $shortName = (new \ReflectionClass($value[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]))->getShortName().'Item';
+
+                if (!$this->typesContainer->has($shortName)) {
+                    throw new \UnexpectedValueException("Type with name $shortName can not be found");
+                }
+
+                $type = $this->typesContainer->get($shortName);
+                if (!isset($type->config['interfaces'])) {
+                    throw new \UnexpectedValueException("Type \"$shortName\" doesn't implement any interface.");
+                }
+
+                foreach ($type->config['interfaces'] as $interface) {
+                    $returnType = $info->returnType instanceof WrappingType
+                        ? $info->returnType->getWrappedType()
+                        : $info->returnType;
+
+                    if ($interface === $returnType) {
+                        return $type;
+                    }
+                }
+
+                throw new \UnexpectedValueException("Type \"$type\" must implement interface \"$info->returnType\"");
+            },
+        ]);
+
+        $this->typesContainer->set($shortName, $resourceInterface);
+
+        return $resourceInterface;
+    }
+
+    private function getInterfaceTypes(array $resources): array
+    {
+        $types = [];
+        foreach ($resources as $resourceClass) {
+            try {
+                $reflection = new \ReflectionClass($resourceClass);
+            } catch (\ReflectionException $e) {
+                throw new \UnexpectedValueException("Class $resourceClass can't be found.");
+            }
+
+            $itemTypeName = $reflection->getShortName().self::INTERFACE_POSTFIX;
+            $types[] = isset($this->graphqlTypes[$itemTypeName]) ? [$this->graphqlTypes[$itemTypeName]] : [];
+
+            $collectionTypeName = $reflection->getShortName().self::INTERFACE_POSTFIX.self::COLLECTION_POSTFIX;
+            $types[] = isset($this->graphqlTypes[$collectionTypeName]) ? [$this->graphqlTypes[$collectionTypeName]] : [];
+        }
+
+        return \array_merge(...$types);
     }
 }

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -20,6 +20,7 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as GraphQLType;
+use GraphQL\Type\Definition\WrappingType;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\PropertyInfo\Type;
 

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -203,7 +203,14 @@ final class TypeBuilder implements TypeBuilderInterface
      */
     public function isCollection(Type $type): bool
     {
-        return $type->isCollection() && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType();
+        return ($type->isCollection() && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()) || $this->isArrayOfObjects($type);
+    }
+
+    private function isArrayOfObjects(Type $type): bool
+    {
+        return Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType() &&
+            (null !== $collectionValue = $type->getCollectionValueType()) &&
+            Type::BUILTIN_TYPE_OBJECT === $collectionValue->getBuiltinType();
     }
 
     private function buildResourceObjectType(?string $resourceClass, string $shortName, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped, int $depth)
@@ -215,7 +222,7 @@ final class TypeBuilder implements TypeBuilderInterface
 
         $wrapData = !$wrapped && null !== $mutationName && !$input && $depth < 1;
         $interfaceTypes = ($interfaces = $resourceMetadata->getImplements())
-            ? $this->getInterfaceTypes($interfaces, $queryName === 'collection_query')
+            ? $this->getInterfaceTypes($interfaces)
             : [];
 
         $configuration = [
@@ -326,7 +333,7 @@ final class TypeBuilder implements TypeBuilderInterface
         return $resourceInterface;
     }
 
-    private function getInterfaceTypes(array $resources, bool $isCollection): array
+    private function getInterfaceTypes(array $resources): array
     {
         $interfaceTypes = [];
         foreach ($resources as $resourceClass) {

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -203,14 +203,7 @@ final class TypeBuilder implements TypeBuilderInterface
      */
     public function isCollection(Type $type): bool
     {
-        return ($type->isCollection() && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()) || $this->isArrayOfObjects($type);
-    }
-
-    private function isArrayOfObjects(Type $type): bool
-    {
-        return Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType() &&
-            (null !== $collectionValue = $type->getCollectionValueType()) &&
-            Type::BUILTIN_TYPE_OBJECT === $collectionValue->getBuiltinType();
+        return $type->isCollection() && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType();
     }
 
     private function buildResourceObjectType(?string $resourceClass, string $shortName, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped, int $depth)

--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -61,12 +61,6 @@ final class TypeConverter implements TypeConverterInterface
             case Type::BUILTIN_TYPE_STRING:
                 return GraphQLType::string();
             case Type::BUILTIN_TYPE_ARRAY:
-                if ($type->getCollectionValueType() &&
-                    (null !== $collectionValue = $type->getCollectionValueType()) &&
-                    (Type::BUILTIN_TYPE_OBJECT === $collectionValue->getBuiltinType())
-                ) {
-                    return $this->getResourceType($collectionValue, $input, $queryName, $mutationName, $depth);
-                }
             case Type::BUILTIN_TYPE_ITERABLE:
                 return 'Iterable';
             case Type::BUILTIN_TYPE_OBJECT:

--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -61,6 +61,12 @@ final class TypeConverter implements TypeConverterInterface
             case Type::BUILTIN_TYPE_STRING:
                 return GraphQLType::string();
             case Type::BUILTIN_TYPE_ARRAY:
+                if ($type->getCollectionValueType() &&
+                    (null !== $collectionValue = $type->getCollectionValueType()) &&
+                    (Type::BUILTIN_TYPE_OBJECT === $collectionValue->getBuiltinType())
+                ) {
+                    return $this->getResourceType($collectionValue, $input, $queryName, $mutationName, $depth);
+                }
             case Type::BUILTIN_TYPE_ITERABLE:
                 return 'Iterable';
             case Type::BUILTIN_TYPE_OBJECT:
@@ -105,7 +111,7 @@ final class TypeConverter implements TypeConverterInterface
 
         try {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-            if ([] === ($resourceMetadata->getGraphql() ?? [])) {
+            if (!\array_key_exists($queryName ?? $mutationName, $resourceMetadata->getGraphql() ?? [])) {
                 return null;
             }
         } catch (ResourceClassNotFoundException $e) {

--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -105,7 +105,7 @@ final class TypeConverter implements TypeConverterInterface
 
         try {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
-            if (!\array_key_exists($queryName ?? $mutationName, $resourceMetadata->getGraphql() ?? [])) {
+            if ([] === ($resourceMetadata->getGraphql() ?? [])) {
                 return null;
             }
         } catch (ResourceClassNotFoundException $e) {

--- a/src/Metadata/Property/Factory/InheritedPropertyNameInterfaceCollectionFactory.php
+++ b/src/Metadata/Property/Factory/InheritedPropertyNameInterfaceCollectionFactory.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\Property\Factory;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+
+/**
+ * Creates a property name collection from eventual child inherited properties.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class InheritedPropertyNameInterfaceCollectionFactory implements PropertyNameCollectionFactoryInterface
+{
+    private $resourceNameCollectionFactory;
+    private $decorated;
+    private $resourceMetadata;
+    private $propertyInfo;
+
+    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory,
+                                ResourceMetadataFactoryInterface $resourceMetadata,
+                                PropertyNameCollectionFactoryInterface $propertyInfo,
+                                PropertyNameCollectionFactoryInterface $decorated = null)
+    {
+        $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
+        $this->decorated = $decorated;
+        $this->propertyInfo = $propertyInfo;
+        $this->resourceMetadata = $resourceMetadata;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass, array $options = []): PropertyNameCollection
+    {
+        $propertyNames = [];
+
+        try {
+            $resourceMetadata = $this->resourceMetadata->create($resourceClass);
+        } catch (ResourceClassNotFoundException $e) {
+            $resourceMetadata = null;
+        }
+
+        // Fallback to decorated factory
+        if (!isset($resourceMetadata) || !$resourceMetadata->isInterface()) {
+            return $this->decorated
+                ? $this->decorated->create($resourceClass, $options)
+                : new PropertyNameCollection(array_values($propertyNames));
+        }
+
+        // Inherited from parent
+        if ($this->decorated) {
+            if ($this->decorated instanceof InheritedPropertyNameCollectionFactory) {
+                // InheritedPropertyNameCollectionFactory doesnt work for interfaces
+                foreach ($this->propertyInfo->create($resourceClass, $options) as $propertyName) {
+                    $propertyNames[$propertyName] = (string) $propertyName;
+                }
+            } else {
+                foreach ($this->decorated->create($resourceClass, $options) as $propertyName) {
+                    $propertyNames[$propertyName] = (string) $propertyName;
+                }
+            }
+        }
+
+        foreach ($this->resourceNameCollectionFactory->create() as $knownResourceClass) {
+            if (is_subclass_of($resourceClass, $knownResourceClass)) {
+                foreach ($this->create($knownResourceClass) as $propertyName) {
+                    $propertyNames[$propertyName] = $propertyName;
+                }
+            }
+        }
+
+        return new PropertyNameCollection(array_values($propertyNames));
+    }
+}

--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -87,7 +87,9 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
                 $annotation->collectionOperations,
                 $annotation->attributes,
                 $annotation->subresourceOperations,
-                $annotation->graphql
+                $annotation->graphql,
+                $annotation->isInterface,
+                $annotation->implements
             );
         }
 

--- a/src/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactory.php
@@ -53,10 +53,16 @@ final class AnnotationResourceNameCollectionFactory implements ResourceNameColle
         }
 
         foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories($this->paths) as $className => $reflectionClass) {
-            if ($this->reader->getClassAnnotation($reflectionClass, ApiResource::class)) {
-                $classes[$className] = true;
+            $annotation = $this->reader->getClassAnnotation($reflectionClass, ApiResource::class);
+            if ($annotation) {
+                $classes[$className]['enabled'] = true;
+                $classes[$className]['interface'] = $annotation->isInterface;
             }
         }
+
+        \uasort($classes, static function (array $a, array $b) {
+            return $b['interface'];
+        });
 
         return new ResourceNameCollection(array_keys($classes));
     }

--- a/src/Metadata/Resource/ResourceMetadata.php
+++ b/src/Metadata/Resource/ResourceMetadata.php
@@ -30,8 +30,10 @@ final class ResourceMetadata
     private $subresourceOperations;
     private $graphql;
     private $attributes;
+    private $interface;
+    private $implements;
 
-    public function __construct(string $shortName = null, string $description = null, string $iri = null, array $itemOperations = null, array $collectionOperations = null, array $attributes = null, array $subresourceOperations = null, array $graphql = null)
+    public function __construct(string $shortName = null, string $description = null, string $iri = null, array $itemOperations = null, array $collectionOperations = null, array $attributes = null, array $subresourceOperations = null, array $graphql = null, bool $interface = null, array $implements = null)
     {
         $this->shortName = $shortName;
         $this->description = $description;
@@ -41,6 +43,8 @@ final class ResourceMetadata
         $this->subresourceOperations = $subresourceOperations;
         $this->graphql = $graphql;
         $this->attributes = $attributes;
+        $this->interface = $interface;
+        $this->implements = $implements;
     }
 
     /**
@@ -87,6 +91,16 @@ final class ResourceMetadata
     public function getIri(): ?string
     {
         return $this->iri;
+    }
+
+    public function isInterface(): ?bool
+    {
+        return $this->interface;
+    }
+
+    public function getImplements(): ?array
+    {
+        return $this->implements;
     }
 
     /**


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | #3116
| License       | MIT
| Doc PR        | 

Added interface feature to `Graphql`.

How to use:
```
/**
 * @ApiResource(isInterface=true)
*/
abstract class AA {}

/**
 * @ApiResource(isInterface=true)
*/
abstract class AB {}

/**
 * @ApiResource(
 *     implements={AA::class},
 * )
*/
class A extends AA {}

/**
 * @ApiResource(
 *     implements={AA::class, AB::class},
 * )
*/
class C {}
```

In a scheme you will see that:
- `AAInterface` has two implementations: `A` and `C`;
- `ABInterface` has one implementations: `C`;
- `A` implements one interface `AAInterface`;
- `C` implements two interfaces `AAInterface` and `ABInterface`.

I'm far from thought that my implementation is ready to be merged. Feature was developed in haste because I needed it in my project, but I didnt have time to think about the best architecture.

I'm ready to answer the questions.