### PR TITLE
Improve DX when missing filter class import

### DIFF
--- a/src/Annotation/ApiFilter.php
+++ b/src/Annotation/ApiFilter.php
@@ -57,10 +57,6 @@ final class ApiFilter
             throw new InvalidArgumentException('This annotation needs a value representing the filter class.');
         }
 
-        if (!is_a($options['value'], FilterInterface::class, true)) {
-            throw new InvalidArgumentException(sprintf('The filter class "%s" does not implement "%s". Did you forget a use statement?', $options['value'], FilterInterface::class));
-        }
-
         $this->filterClass = $options['value'];
         unset($options['value']);
 

--- a/src/Util/AnnotationFilterExtractorTrait.php
+++ b/src/Util/AnnotationFilterExtractorTrait.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Util;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
+use ApiPlatform\Core\Api\FilterInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Inflector\Inflector;
 
@@ -135,8 +137,12 @@ trait AnnotationFilterExtractorTrait
      */
     private function generateFilterId(\ReflectionClass $reflectionClass, string $filterClass, string $filterId = null): string
     {
-        $suffix = null !== $filterId ? '_'.$filterId : $filterId;
+        try {
+            $suffix = null !== $filterId ? '_'.$filterId : $filterId;
 
-        return 'annotated_'.Inflector::tableize(str_replace('\\', '', $reflectionClass->getName().(new \ReflectionClass($filterClass))->getName().$suffix));
+            return 'annotated_'.Inflector::tableize(str_replace('\\', '', $reflectionClass->getName().(new \ReflectionClass($filterClass))->getName().$suffix));
+        } catch (\ReflectionException $e) {
+            throw new InvalidArgumentException(sprintf('The filter class "%s" does not implement "%s" in "%s". Did you forget a use statement?', $filterClass, FilterInterface::class, $reflectionClass->getName()));
+        }
     }
 }

--- a/tests/Annotation/ApiFilterTest.php
+++ b/tests/Annotation/ApiFilterTest.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Tests\Annotation;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Tests\Fixtures\DummyFilter;
-use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,14 +28,6 @@ class ApiFilterTest extends TestCase
         $this->expectExceptionMessage('This annotation needs a value representing the filter class.');
 
         new ApiFilter();
-    }
-
-    public function testInvalidFilter()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The filter class "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\Dummy" does not implement "ApiPlatform\\Core\\Api\\FilterInterface". Did you forget a use statement?');
-
-        new ApiFilter(['value' => Dummy::class]);
     }
 
     public function testInvalidProperty()

--- a/tests/Fixtures/DummyEntityInvalidFilter.php
+++ b/tests/Fixtures/DummyEntityInvalidFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use ApiPlatform\Core\Annotation\ApiFilter;
+
+/**
+ * @ApiFilter(SearchFilter::class)
+ */
+class DummyEntityInvalidFilter
+{
+    public $dummyField;
+}

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -17,9 +17,11 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Serializer\Filter\GroupFilter;
 use ApiPlatform\Core\Serializer\Filter\PropertyFilter;
 use ApiPlatform\Core\Tests\Fixtures\DummyEntityFilterAnnotated;
+use ApiPlatform\Core\Tests\Fixtures\DummyEntityInvalidFilter;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Util\AnnotationFilterExtractor;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -81,5 +83,15 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
                 OrderFilter::class,
             ],
         ]);
+    }
+
+    public function testThrowsOnInvalidFilter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The filter class "SearchFilter" does not implement "ApiPlatform\\Core\\Api\\FilterInterface" in "ApiPlatform\Core\Tests\Fixtures\DummyEntityInvalidFilter". Did you forget a use statement?');
+
+        $reflectionClass = new \ReflectionClass(DummyEntityInvalidFilter::class);
+
+        $this->extractor->getFilters($reflectionClass);
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no?
| Deprecations? | no
| Tickets       | - <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | -

Improve DX to get more helpful message when missing import for filter class.

Currently we get:
`The filter class "SearchFilter" does not implement "ApiPlatform\Core\Api\FilterInterface". Did you forget a use statement?`

After this we'd get:

`The filter class "SearchFilter" does not implement "ApiPlatform\Core\Api\FilterInterface" in "ApiPlatform\Core\Tests\Fixtures\DummyEntityInvalidFilter". Did you forget a use statement?`

But this changes behavior a little bit, because now when constructing ApiFilter annotation with invalid class it won't throw directly.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
