### PR TITLE
Check `pagination_use_output_walkers` attribute for graphQl operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.6.4
 
 * Doctrine: Fix purging HTTP cache for unreadable relations (#3441)
+* GraphQL: Manage `pagination_use_output_walkers` and `pagination_fetch_join_collection` for operations (#3311)
 * Swagger UI: Remove Google fonts (#4112)
 
 ## 2.6.3

--- a/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -1043,7 +1043,10 @@ class PaginationExtensionTest extends TestCase
         $this->assertInstanceOf(PaginatorInterface::class, $result);
     }
 
-    public function testGetResultWithFetchJoinCollectionDisabled()
+    /**
+     * @dataProvider fetchJoinCollectionProvider
+     */
+    public function testGetResultWithFetchJoinCollection(array $attributes, array $context, bool $expected)
     {
         $dummyMetadata = new ClassMetadata(Dummy::class);
 
@@ -1064,7 +1067,7 @@ class PaginationExtensionTest extends TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($entityManagerProphecy);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy', null, null, null, null, ['pagination_fetch_join_collection' => false]));
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy', null, null, null, null, $attributes));
 
         $paginationExtension = new PaginationExtension(
             $managerRegistryProphecy->reveal(),
@@ -1072,7 +1075,7 @@ class PaginationExtensionTest extends TestCase
             new Pagination($resourceMetadataFactoryProphecy->reveal())
         );
 
-        $result = $paginationExtension->getResult($queryBuilder, Dummy::class, 'get');
+        $result = $paginationExtension->getResult($queryBuilder, Dummy::class, 'get', $context);
 
         $this->assertInstanceOf(PartialPaginatorInterface::class, $result);
         $this->assertInstanceOf(PaginatorInterface::class, $result);
@@ -1081,7 +1084,17 @@ class PaginationExtensionTest extends TestCase
         $doctrinePaginatorReflectionProperty->setAccessible(true);
 
         $doctrinePaginator = $doctrinePaginatorReflectionProperty->getValue($result);
-        $this->assertFalse($doctrinePaginator->getFetchJoinCollection());
+        $this->assertSame($expected, $doctrinePaginator->getFetchJoinCollection());
+    }
+
+    public function fetchJoinCollectionProvider(): array
+    {
+        return [
+            'collection disabled' => [['pagination_fetch_join_collection' => false], ['collection_operation_name' => 'get'], false],
+            'collection enabled' => [['pagination_fetch_join_collection' => true], ['collection_operation_name' => 'get'], true],
+            'graphql disabled' => [['pagination_fetch_join_collection' => false], ['graphql_operation_name' => 'query'], false],
+            'graphql enabled' => [['pagination_fetch_join_collection' => true], ['graphql_operation_name' => 'query'], true],
+        ];
     }
 
     /**
@@ -1133,7 +1146,10 @@ class PaginationExtensionTest extends TestCase
         $this->assertFalse($doctrinePaginator->getFetchJoinCollection());
     }
 
-    public function testGetResultWithUseOutputWalkersDisabled()
+    /**
+     * @dataProvider fetchUseOutputWalkersProvider
+     */
+    public function testGetResultWithUseOutputWalkers(array $attributes, array $context, bool $expected)
     {
         $dummyMetadata = new ClassMetadata(Dummy::class);
 
@@ -1154,7 +1170,7 @@ class PaginationExtensionTest extends TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($entityManagerProphecy);
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy', null, null, null, null, ['pagination_use_output_walkers' => false]));
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy', null, null, null, null, $attributes));
 
         $paginationExtension = new PaginationExtension(
             $managerRegistryProphecy->reveal(),
@@ -1162,7 +1178,7 @@ class PaginationExtensionTest extends TestCase
             new Pagination($resourceMetadataFactoryProphecy->reveal())
         );
 
-        $result = $paginationExtension->getResult($queryBuilder, Dummy::class, 'get');
+        $result = $paginationExtension->getResult($queryBuilder, Dummy::class, 'get', $context);
 
         $this->assertInstanceOf(PartialPaginatorInterface::class, $result);
         $this->assertInstanceOf(PaginatorInterface::class, $result);
@@ -1171,7 +1187,17 @@ class PaginationExtensionTest extends TestCase
         $doctrinePaginatorReflectionProperty->setAccessible(true);
 
         $doctrinePaginator = $doctrinePaginatorReflectionProperty->getValue($result);
-        $this->assertFalse($doctrinePaginator->getUseOutputWalkers());
+        $this->assertSame($expected, $doctrinePaginator->getUseOutputWalkers());
+    }
+
+    public function fetchUseOutputWalkersProvider(): array
+    {
+        return [
+            'collection disabled' => [['pagination_use_output_walkers' => false], ['collection_operation_name' => 'get'], false],
+            'collection enabled' => [['pagination_use_output_walkers' => true], ['collection_operation_name' => 'get'], true],
+            'graphql disabled' => [['pagination_use_output_walkers' => false], ['graphql_operation_name' => 'query'], false],
+            'graphql enabled' => [['pagination_use_output_walkers' => true], ['graphql_operation_name' => 'query'], true],
+        ];
     }
 
     /**


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3305
| License       | MIT
| Doc PR        |

In a case if we use graphql, we have to check attribute `pagination_use_output_walkers` in graphQl operations too.

I feel that this part can be improved - we have to know the operation type - is it `Rest` or `Graphql`, because I think this is not good to check this attribute in all possible sources blindly.