### PR TITLE
[OpenAPI] Add nullable property description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * GraphQL: Allow to format GraphQL errors based on exceptions (#3063)
 * GraphQL: Add page-based pagination (#3175)
 * OpenAPI: Add PHP default values to the documentation (#2386)
+* OpenAPI: Add nullable schema components properties
  
 ## 2.5.3
 

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -199,7 +199,8 @@ final class SchemaFactory implements SchemaFactoryInterface
                 $className = $valueType->getClassName();
             }
 
-            $valueSchema = $this->typeFactory->getType(new Type($builtinType, $type->isNullable(), $className, $isCollection), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
+            $valueSchema = !$swagger && $type->isNullable() ? ['nullable' => true] : [];
+            $valueSchema += $this->typeFactory->getType(new Type($builtinType, $type->isNullable(), $className, $isCollection), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
         }
 
         $propertySchema = new \ArrayObject($propertySchema + $valueSchema);

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -388,6 +388,7 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'string',
                                 'description' => 'This is a \DateTimeInterface object.',
                                 'format' => 'date-time',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -1998,6 +1999,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'relatedDummy' => new \ArrayObject([
                                 'description' => 'This is a related dummy \o/.',
                                 '$ref' => '#/components/schemas/'.$relatedDummyRef,
+                                'nullable' => true,
                             ]),
                         ],
                     ]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | api-platform/docs#...

While trying to generate a client with [Jane](https://github.com/janephp/janephp), I encountered a missing piece of OpenAPI 3.0 for [nullable properties](https://swagger.io/docs/specification/data-models/data-types/#null). It's useful in order to generate models with nullable getters.

As stated on `src/JsonSchema/SchemaFactory.php:173`: "externalDocs is an OpenAPI specific extension, but JSON Schema allows additional keys, so we always add it" for the property schema. 
Then we could also add the nullable feature. 

Another take, would be to considered each components schema non `required` properties as optional. Therefore, I should make a PR to Jane in order to use non-required properties instead of nullable properties to generate models. But [this is not a desired behaviour on their side](https://github.com/janephp/janephp/issues/100#issuecomment-562044344).