### PR TITLE
[GraphQL] Mercure Subscription Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * MongoDB: Possibility to add execute options (aggregate command fields) for a resource, like `allowDiskUse` (#3144)
 * MongoDB: Mercure support (#3290)
+* GraphQL: Subscription support with Mercure (#3321)
 * GraphQL: Allow to format GraphQL errors based on exceptions (#3063)
 * GraphQL: Add page-based pagination (#3175)
 * OpenAPI: Add PHP default values to the documentation (#2386)

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -17,6 +17,7 @@ default:
             jsonApiSchemaFile: '%paths.base%/tests/Fixtures/JsonSchema/jsonapi.json'
         - 'JsonHalContext':
             schemaFile: '%paths.base%/tests/Fixtures/JsonHal/jsonhal.json'
+        - 'MercureContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
       filters:
@@ -56,6 +57,7 @@ postgres:
             jsonApiSchemaFile: '%paths.base%/tests/Fixtures/JsonSchema/jsonapi.json'
         - 'JsonHalContext':
             schemaFile: '%paths.base%/tests/Fixtures/JsonHal/jsonhal.json'
+        - 'MercureContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
       filters:
@@ -81,6 +83,7 @@ mongodb:
             jsonApiSchemaFile: '%paths.base%/tests/Fixtures/JsonSchema/jsonapi.json'
         - 'JsonHalContext':
             schemaFile: '%paths.base%/tests/Fixtures/JsonHal/jsonhal.json'
+        - 'MercureContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
       filters:
@@ -124,6 +127,7 @@ default-coverage:
             jsonApiSchemaFile: '%paths.base%/tests/Fixtures/JsonSchema/jsonapi.json'
         - 'JsonHalContext':
             schemaFile: '%paths.base%/tests/Fixtures/JsonHal/jsonhal.json'
+        - 'MercureContext'
         - 'CoverageContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'
@@ -149,6 +153,7 @@ mongodb-coverage:
             jsonApiSchemaFile: '%paths.base%/tests/Fixtures/JsonSchema/jsonapi.json'
         - 'JsonHalContext':
             schemaFile: '%paths.base%/tests/Fixtures/JsonHal/jsonhal.json'
+        - 'MercureContext'
         - 'CoverageContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'Behatch\Context\RestContext'

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -37,6 +37,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDtoNoInput as Dummy
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyDtoNoOutput as DummyDtoNoOutputDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyFriend as DummyFriendDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyGroup as DummyGroupDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyMercure as DummyMercureDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyOffer as DummyOfferDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProduct as DummyProductDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyProperty as DummyPropertyDocument;
@@ -93,6 +94,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyDtoNoOutput;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyFriend;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyGroup;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyImmutableDate;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyMercure;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyOffer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProduct;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyProperty;
@@ -1502,6 +1504,27 @@ final class DoctrineContext implements Context
         $this->manager->flush();
     }
 
+    /**
+     * @Given there are :nb dummy mercure objects
+     */
+    public function thereAreDummyMercureObjects(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $relatedDummy = $this->buildRelatedDummy();
+            $relatedDummy->setName('RelatedDummy #'.$i);
+
+            $dummyMercure = $this->buildDummyMercure();
+            $dummyMercure->name = "Dummy Mercure #$i";
+            $dummyMercure->description = 'Description';
+            $dummyMercure->relatedDummy = $relatedDummy;
+
+            $this->manager->persist($relatedDummy);
+            $this->manager->persist($dummyMercure);
+        }
+
+        $this->manager->flush();
+    }
+
     private function isOrm(): bool
     {
         return null !== $this->schemaTool;
@@ -1878,5 +1901,13 @@ final class DoctrineContext implements Context
     private function buildConvertedRelated()
     {
         return $this->isOrm() ? new ConvertedRelated() : new ConvertedRelatedDocument();
+    }
+
+    /**
+     * @return DummyMercure|DummyMercureDocument
+     */
+    private function buildDummyMercure()
+    {
+        return $this->isOrm() ? new DummyMercure() : new DummyMercureDocument();
     }
 }

--- a/features/bootstrap/MercureContext.php
+++ b/features/bootstrap/MercureContext.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Core\Tests\Fixtures\DummyMercurePublisher;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Symfony2Extension\Context\KernelAwareContext;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Mercure\Update;
+
+/**
+ * Context for Mercure.
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class MercureContext implements KernelAwareContext
+{
+    private $kernel;
+
+    public function setKernel(KernelInterface $kernel): void
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @Then the following Mercure update with topics :topics should have been sent:
+     */
+    public function theFollowingMercureUpdateShouldHaveBeenSent(string $topics, PyStringNode $update): void
+    {
+        $topics = explode(',', $topics);
+        $update = json_decode($update->getRaw(), true);
+        /** @var DummyMercurePublisher $publisher */
+        $publisher = $this->kernel->getContainer()->get('mercure.hub.default.publisher');
+
+        /** @var Update $sentUpdate */
+        foreach ($publisher->getUpdates() as $sentUpdate) {
+            $toMatchTopics = count($topics);
+            foreach ($sentUpdate->getTopics() as $sentTopic) {
+                foreach ($topics as $topic) {
+                    if (preg_match("@$topic@", $sentTopic)) {
+                        --$toMatchTopics;
+                    }
+                }
+            }
+
+            if ($toMatchTopics > 0) {
+                continue;
+            }
+
+            if ($sentUpdate->getData() === json_encode($update)) {
+                return;
+            }
+        }
+
+        throw new \RuntimeException('Mercure update has not been sent.');
+    }
+}

--- a/features/graphql/subscription.feature
+++ b/features/graphql/subscription.feature
@@ -1,0 +1,224 @@
+Feature: GraphQL subscription support
+
+  @createSchema
+  Scenario: Introspect subscription type
+    When I send the following GraphQL request:
+    """
+    {
+      __type(name: "Subscription") {
+        fields {
+          name
+          description
+          type {
+            name
+            kind
+          }
+          args {
+            name
+            type {
+              name
+              kind
+              ofType {
+                name
+                kind
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": [
+            "__type"
+          ],
+          "properties": {
+            "__type": {
+              "type": "object",
+              "required": [
+                "fields"
+              ],
+              "properties": {
+                "fields": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "description",
+                      "type",
+                      "args"
+                    ],
+                    "properties": {
+                      "name": {
+                        "pattern": "^update[A-z0-9]+Subscribe"
+                      },
+                      "description": {
+                        "pattern": "^Subscribes to the update event of a [A-z0-9]+.$"
+                      },
+                      "type": {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "kind"
+                        ],
+                        "properties": {
+                          "name": {
+                            "pattern": "^update[A-z0-9]+SubscriptionPayload$"
+                          },
+                          "kind": {
+                            "enum": ["OBJECT"]
+                          }
+                        }
+                      },
+                      "args": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 1,
+                        "items": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "type"
+                            ],
+                            "properties": {
+                              "name": {
+                                "enum": ["input"]
+                              },
+                              "type": {
+                                "type": "object",
+                                "required": [
+                                  "kind",
+                                  "ofType"
+                                ],
+                                "properties": {
+                                  "kind": {
+                                    "enum": ["NON_NULL"]
+                                  },
+                                  "ofType": {
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "kind"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "pattern": "^update[A-z0-9]+SubscriptionInput$"
+                                      },
+                                      "kind": {
+                                        "enum": ["INPUT_OBJECT"]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Subscribe to updates
+    Given there are 2 dummy mercure objects
+    When I send the following GraphQL request:
+    """
+    subscription {
+      updateDummyMercureSubscribe(input: {id: "/dummy_mercures/1", clientSubscriptionId: "myId"}) {
+        dummyMercure {
+          id
+          name
+          relatedDummy {
+            name
+          }
+        }
+        mercureUrl
+        clientSubscriptionId
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.updateDummyMercureSubscribe.dummyMercure.id" should be equal to "/dummy_mercures/1"
+    And the JSON node "data.updateDummyMercureSubscribe.dummyMercure.name" should be equal to "Dummy Mercure #1"
+    And the JSON node "data.updateDummyMercureSubscribe.mercureUrl" should match "@^https://demo.mercure.rocks/hub\?topic=http://example.com/subscriptions/[a-f0-9]+$@"
+    And the JSON node "data.updateDummyMercureSubscribe.clientSubscriptionId" should be equal to "myId"
+
+    When I send the following GraphQL request:
+    """
+    subscription {
+      updateDummyMercureSubscribe(input: {id: "/dummy_mercures/2"}) {
+        dummyMercure {
+          id
+        }
+        mercureUrl
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.updateDummyMercureSubscribe.dummyMercure.id" should be equal to "/dummy_mercures/2"
+    And the JSON node "data.updateDummyMercureSubscribe.mercureUrl" should match "@^https://demo.mercure.rocks/hub\?topic=http://example.com/subscriptions/[a-f0-9]+$@"
+
+  Scenario: Receive Mercure updates with different payloads from subscriptions
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/dummy_mercures/1" with body:
+    """
+    {
+        "name": "Dummy Mercure #1 updated"
+    }
+    """
+    Then the following Mercure update with topics "http://example.com/subscriptions/[a-f0-9]+" should have been sent:
+    """
+    {
+        "dummyMercure": {
+            "id": 1,
+            "name": "Dummy Mercure #1 updated",
+            "relatedDummy": {
+                "name": "RelatedDummy #1"
+            }
+        }
+    }
+    """
+
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/dummy_mercures/2" with body:
+    """
+    {
+        "name": "Dummy Mercure #2 updated"
+    }
+    """
+    Then the following Mercure update with topics "http://example.com/subscriptions/[a-f0-9]+" should have been sent:
+    """
+    {
+        "dummyMercure": {
+            "id": 2
+        }
+    }
+    """

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -31,9 +31,6 @@ parameters:
 		-
 			message: '#Variable \$positionPm might not be defined\.#'
 			path: %currentWorkingDirectory%/src/Util/ClassInfoTrait.php
-		-
-			message: '#Cannot assign offset .+ to bool\.#'
-			path: %currentWorkingDirectory%/src/GraphQl/Serializer/SerializerContextBuilder.php
 		- '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy<(\\?[a-zA-Z0-9_]+)+>::\$[a-zA-Z0-9_]+#'
 		-
 			message: '#Call to an undefined method Doctrine\\Persistence\\ObjectManager::getConnection\(\)#'
@@ -93,6 +90,9 @@ parameters:
 		-
 			message: '#Service "api_platform.iri_converter" is private\.#'
 			path: %currentWorkingDirectory%/src/Bridge/Symfony/Bundle/Test/ApiTestCase.php
+		-
+			message: "#Call to method PHPUnit\\\\Framework\\\\Assert::assertSame\\(\\) with array\\(.+\\) and array\\(.+\\) will always evaluate to false\\.#"
+			path: %currentWorkingDirectory%/tests/Util/SortTraitTest.php
 
 		# Expected, due to optional interfaces
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryCollectionExtensionInterface::applyToCollection\(\) invoked with 5 parameters, 3-4 required\.#'

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -590,6 +590,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         if ($this->isConfigEnabled($container, $config['doctrine_mongodb_odm'])) {
             $loader->load('doctrine_mongodb_odm_mercure_publisher.xml');
         }
+
+        if ($this->isConfigEnabled($container, $config['graphql'])) {
+            $loader->load('graphql_mercure.xml');
+            $container->getDefinition('api_platform.graphql.subscription.mercure_iri_generator')->addArgument($config['mercure']['hub_url'] ?? '%mercure.default_hub%');
+        }
     }
 
     private function registerMessengerConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm_mercure_publisher.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_mongodb_odm_mercure_publisher.xml
@@ -16,6 +16,8 @@
             <argument>%api_platform.formats%</argument>
             <argument type="service" id="messenger.default_bus" on-invalid="ignore" />
             <argument type="service" id="mercure.hub.default.publisher" />
+            <argument type="service" id="api_platform.graphql.subscription.subscription_manager" on-invalid="ignore" />
+            <argument type="service" id="api_platform.graphql.subscription.mercure_iri_generator" on-invalid="ignore" />
 
             <tag name="doctrine_mongodb.odm.event_listener" event="onFlush" />
             <tag name="doctrine_mongodb.odm.event_listener" event="postFlush" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm_mercure_publisher.xml
@@ -16,6 +16,8 @@
             <argument>%api_platform.formats%</argument>
             <argument type="service" id="messenger.default_bus" on-invalid="ignore" />
             <argument type="service" id="mercure.hub.default.publisher" />
+            <argument type="service" id="api_platform.graphql.subscription.subscription_manager" on-invalid="ignore" />
+            <argument type="service" id="api_platform.graphql.subscription.mercure_iri_generator" on-invalid="ignore" />
 
             <tag name="doctrine.event_listener" event="onFlush" />
             <tag name="doctrine.event_listener" event="postFlush" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -40,6 +40,15 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
         </service>
 
+        <service id="api_platform.graphql.resolver.factory.item_subscription" class="ApiPlatform\Core\GraphQl\Resolver\Factory\ItemSubscriptionResolverFactory" public="false">
+            <argument type="service" id="api_platform.graphql.resolver.stage.read" />
+            <argument type="service" id="api_platform.graphql.resolver.stage.security" />
+            <argument type="service" id="api_platform.graphql.resolver.stage.serialize" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.graphql.subscription.subscription_manager" />
+            <argument type="service" id="api_platform.graphql.subscription.mercure_iri_generator" on-invalid="ignore" />
+        </service>
+
         <!-- Resolver Stages -->
 
         <service id="api_platform.graphql.resolver.stage.read" class="ApiPlatform\Core\GraphQl\Resolver\Stage\ReadStage" public="false">
@@ -140,6 +149,7 @@
             <argument type="service" id="api_platform.graphql.resolver.factory.item" />
             <argument type="service" id="api_platform.graphql.resolver.factory.collection" />
             <argument type="service" id="api_platform.graphql.resolver.factory.item_mutation" />
+            <argument type="service" id="api_platform.graphql.resolver.factory.item_subscription" />
             <argument type="service" id="api_platform.filter_locator" />
             <argument type="service" id="api_platform.pagination" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
@@ -240,6 +250,21 @@
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
         </service>
         <service id="ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilderInterface" alias="api_platform.graphql.serializer.context_builder" />
+
+        <!-- Subscription -->
+
+        <service id="api_platform.graphql.subscription.subscription_manager" class="ApiPlatform\Core\GraphQl\Subscription\SubscriptionManager">
+            <argument type="service" id="api_platform.graphql.cache.subscription" />
+            <argument type="service" id="api_platform.graphql.subscription.subscription_identifier_generator" />
+            <argument type="service" id="api_platform.graphql.resolver.stage.serialize" />
+            <argument type="service" id="api_platform.iri_converter" />
+        </service>
+
+        <service id="api_platform.graphql.subscription.subscription_identifier_generator" class="ApiPlatform\Core\GraphQl\Subscription\SubscriptionIdentifierGenerator" />
+
+        <service id="api_platform.graphql.cache.subscription" parent="cache.system" public="false">
+            <tag name="cache.pool" />
+        </service>
 
         <!-- Command -->
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql_mercure.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql_mercure.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="api_platform.graphql.subscription.mercure_iri_generator" class="ApiPlatform\Core\GraphQl\Subscription\MercureSubscriptionIriGenerator">
+            <argument type="service" id="router.request_context" />
+        </service>
+
+    </services>
+
+</container>

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -71,7 +71,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             }
 
             $operationName = $operationName ?? 'collection_query';
-            $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false];
+            $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
             $collection = ($this->readStage)($resourceClass, $rootClass, $operationName, $resolverContext);
             if (!is_iterable($collection)) {

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -70,7 +70,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
                 return null;
             }
 
-            $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true];
+            $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false];
 
             $item = ($this->readStage)($resourceClass, $rootClass, $operationName, $resolverContext);
             if (null !== $item && !\is_object($item)) {

--- a/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
@@ -64,7 +64,7 @@ final class ItemResolverFactory implements ResolverFactoryInterface
             }
 
             $operationName = $operationName ?? 'item_query';
-            $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
+            $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
 
             $item = ($this->readStage)($resourceClass, $rootClass, $operationName, $resolverContext);
             if (null !== $item && !\is_object($item)) {

--- a/src/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactory.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Resolver\Factory;
+
+use ApiPlatform\Core\GraphQl\Resolver\Stage\ReadStageInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Stage\SecurityStageInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Stage\SerializeStageInterface;
+use ApiPlatform\Core\GraphQl\Subscription\MercureSubscriptionIriGeneratorInterface;
+use ApiPlatform\Core\GraphQl\Subscription\SubscriptionManagerInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\ClassInfoTrait;
+use ApiPlatform\Core\Util\CloneTrait;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Creates a function resolving a GraphQL subscription of an item.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class ItemSubscriptionResolverFactory implements ResolverFactoryInterface
+{
+    use ClassInfoTrait;
+    use CloneTrait;
+
+    private $readStage;
+    private $securityStage;
+    private $serializeStage;
+    private $resourceMetadataFactory;
+    private $subscriptionManager;
+    private $mercureSubscriptionIriGenerator;
+
+    public function __construct(ReadStageInterface $readStage, SecurityStageInterface $securityStage, SerializeStageInterface $serializeStage, ResourceMetadataFactoryInterface $resourceMetadataFactory, SubscriptionManagerInterface $subscriptionManager, ?MercureSubscriptionIriGeneratorInterface $mercureSubscriptionIriGenerator)
+    {
+        $this->readStage = $readStage;
+        $this->securityStage = $securityStage;
+        $this->serializeStage = $serializeStage;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->subscriptionManager = $subscriptionManager;
+        $this->mercureSubscriptionIriGenerator = $mercureSubscriptionIriGenerator;
+    }
+
+    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?string $operationName = null): callable
+    {
+        return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operationName) {
+            if (null === $resourceClass || null === $operationName) {
+                return null;
+            }
+
+            $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+
+            $item = ($this->readStage)($resourceClass, $rootClass, $operationName, $resolverContext);
+            if (null !== $item && !\is_object($item)) {
+                throw new \LogicException('Item from read stage should be a nullable object.');
+            }
+            ($this->securityStage)($resourceClass, $operationName, $resolverContext + [
+                'extra_variables' => [
+                    'object' => $item,
+                ],
+            ]);
+
+            $result = ($this->serializeStage)($item, $resourceClass, $operationName, $resolverContext);
+
+            $subscriptionId = $this->subscriptionManager->retrieveSubscriptionId($resolverContext, $result);
+
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+
+            if ($subscriptionId && $resourceMetadata->getAttribute('mercure', false)) {
+                if (!$this->mercureSubscriptionIriGenerator) {
+                    throw new \LogicException('Cannot use Mercure for subscriptions when MercureBundle is not installed. Try running "composer require mercure".');
+                }
+                $result['mercureUrl'] = $this->mercureSubscriptionIriGenerator->generateMercureUrl($subscriptionId);
+            }
+
+            return $result;
+        };
+    }
+}

--- a/src/GraphQl/Resolver/Util/IdentifierTrait.php
+++ b/src/GraphQl/Resolver/Util/IdentifierTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Resolver\Util;
+
+/**
+ * Identifier helper methods.
+ *
+ * @internal
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+trait IdentifierTrait
+{
+    private function getIdentifierFromContext(array $context): ?string
+    {
+        $args = $context['args'];
+
+        if ($context['is_mutation'] || $context['is_subscription']) {
+            return $args['input']['id'] ?? null;
+        }
+
+        return $args['id'] ?? null;
+    }
+}

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -76,8 +76,10 @@ final class ItemNormalizer extends BaseItemNormalizer
             throw new UnexpectedValueException('Expected data to be an array.');
         }
 
-        $data[self::ITEM_RESOURCE_CLASS_KEY] = $this->getObjectClass($object);
-        $data[self::ITEM_IDENTIFIERS_KEY] = $this->identifiersExtractor->getIdentifiersFromItem($object);
+        if (!($context['no_resolver_data'] ?? false)) {
+            $data[self::ITEM_RESOURCE_CLASS_KEY] = $this->getObjectClass($object);
+            $data[self::ITEM_IDENTIFIERS_KEY] = $this->identifiersExtractor->getIdentifiersFromItem($object);
+        }
 
         return $data;
     }

--- a/src/GraphQl/Serializer/ObjectNormalizer.php
+++ b/src/GraphQl/Serializer/ObjectNormalizer.php
@@ -85,8 +85,10 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
             $data['id'] = $this->iriConverter->getIriFromItem($originalResource);
         }
 
-        $data[self::ITEM_RESOURCE_CLASS_KEY] = $this->getObjectClass($originalResource);
-        $data[self::ITEM_IDENTIFIERS_KEY] = $this->identifiersExtractor->getIdentifiersFromItem($originalResource);
+        if (!($context['no_resolver_data'] ?? false)) {
+            $data[self::ITEM_RESOURCE_CLASS_KEY] = $this->getObjectClass($originalResource);
+            $data[self::ITEM_IDENTIFIERS_KEY] = $this->identifiersExtractor->getIdentifiersFromItem($originalResource);
+        }
 
         return $data;
     }

--- a/src/GraphQl/Subscription/MercureSubscriptionIriGenerator.php
+++ b/src/GraphQl/Subscription/MercureSubscriptionIriGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Subscription;
+
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Generates Mercure-related IRIs from a subscription ID.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class MercureSubscriptionIriGenerator implements MercureSubscriptionIriGeneratorInterface
+{
+    private $requestContext;
+    private $hub;
+
+    public function __construct(RequestContext $requestContext, string $hub)
+    {
+        $this->requestContext = $requestContext;
+        $this->hub = $hub;
+    }
+
+    public function generateTopicIri(string $subscriptionId): string
+    {
+        if ('' === $scheme = $this->requestContext->getScheme()) {
+            $scheme = 'https';
+        }
+        if ('' === $host = $this->requestContext->getHost()) {
+            $host = 'api-platform.com';
+        }
+
+        return "$scheme://$host/subscriptions/$subscriptionId";
+    }
+
+    public function generateMercureUrl(string $subscriptionId): string
+    {
+        return $this->hub.'?topic='.$this->generateTopicIri($subscriptionId);
+    }
+}

--- a/src/GraphQl/Subscription/MercureSubscriptionIriGeneratorInterface.php
+++ b/src/GraphQl/Subscription/MercureSubscriptionIriGeneratorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Subscription;
+
+/**
+ * Generates Mercure-related IRIs from a subscription ID.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface MercureSubscriptionIriGeneratorInterface
+{
+    public function generateTopicIri(string $subscriptionId): string;
+
+    public function generateMercureUrl(string $subscriptionId): string;
+}

--- a/src/GraphQl/Subscription/SubscriptionIdentifierGenerator.php
+++ b/src/GraphQl/Subscription/SubscriptionIdentifierGenerator.php
@@ -22,8 +22,10 @@ namespace ApiPlatform\Core\GraphQl\Subscription;
  */
 final class SubscriptionIdentifierGenerator implements SubscriptionIdentifierGeneratorInterface
 {
-    public function generateSubscriptionIdentifier(): string
+    public function generateSubscriptionIdentifier(array $fields): string
     {
-        return bin2hex(random_bytes(16));
+        unset($fields['mercureUrl'], $fields['clientSubscriptionId']);
+
+        return hash('sha256', print_r($fields, true));
     }
 }

--- a/src/GraphQl/Subscription/SubscriptionIdentifierGenerator.php
+++ b/src/GraphQl/Subscription/SubscriptionIdentifierGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Subscription;
+
+/**
+ * Generates an identifier used to identify a subscription.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class SubscriptionIdentifierGenerator implements SubscriptionIdentifierGeneratorInterface
+{
+    public function generateSubscriptionIdentifier(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+}

--- a/src/GraphQl/Subscription/SubscriptionIdentifierGeneratorInterface.php
+++ b/src/GraphQl/Subscription/SubscriptionIdentifierGeneratorInterface.php
@@ -22,5 +22,5 @@ namespace ApiPlatform\Core\GraphQl\Subscription;
  */
 interface SubscriptionIdentifierGeneratorInterface
 {
-    public function generateSubscriptionIdentifier(): string;
+    public function generateSubscriptionIdentifier(array $fields): string;
 }

--- a/src/GraphQl/Subscription/SubscriptionIdentifierGeneratorInterface.php
+++ b/src/GraphQl/Subscription/SubscriptionIdentifierGeneratorInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Subscription;
+
+/**
+ * Generates an identifier used to identify a subscription.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface SubscriptionIdentifierGeneratorInterface
+{
+    public function generateSubscriptionIdentifier(): string;
+}

--- a/src/GraphQl/Subscription/SubscriptionManager.php
+++ b/src/GraphQl/Subscription/SubscriptionManager.php
@@ -69,7 +69,7 @@ final class SubscriptionManager implements SubscriptionManagerInterface
             }
         }
 
-        $subscriptionId = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier();
+        $subscriptionId = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier($fields);
         unset($result['clientSubscriptionId']);
         $subscriptions[] = [$subscriptionId, $fields, $result];
         $subscriptionsCacheItem->set($subscriptions);

--- a/src/GraphQl/Subscription/SubscriptionManager.php
+++ b/src/GraphQl/Subscription/SubscriptionManager.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Subscription;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Stage\SerializeStageInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Util\IdentifierTrait;
+use ApiPlatform\Core\Util\ResourceClassInfoTrait;
+use ApiPlatform\Core\Util\SortTrait;
+use GraphQL\Type\Definition\ResolveInfo;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Manages all the queried subscriptions by creating their ID
+ * and saving to a cache the information needed to publish updated data.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class SubscriptionManager implements SubscriptionManagerInterface
+{
+    use IdentifierTrait;
+    use ResourceClassInfoTrait;
+    use SortTrait;
+
+    private $subscriptionsCache;
+    private $subscriptionIdentifierGenerator;
+    private $serializeStage;
+    private $iriConverter;
+
+    public function __construct(CacheItemPoolInterface $subscriptionsCache, SubscriptionIdentifierGeneratorInterface $subscriptionIdentifierGenerator, SerializeStageInterface $serializeStage, IriConverterInterface $iriConverter)
+    {
+        $this->subscriptionsCache = $subscriptionsCache;
+        $this->subscriptionIdentifierGenerator = $subscriptionIdentifierGenerator;
+        $this->serializeStage = $serializeStage;
+        $this->iriConverter = $iriConverter;
+    }
+
+    public function retrieveSubscriptionId(array $context, ?array $result): ?string
+    {
+        /** @var ResolveInfo $info */
+        $info = $context['info'];
+        $fields = $info->getFieldSelection(PHP_INT_MAX);
+        $this->arrayRecursiveSort($fields, 'ksort');
+        $iri = $this->getIdentifierFromContext($context);
+        if (null === $iri) {
+            return null;
+        }
+        $subscriptionsCacheItem = $this->subscriptionsCache->getItem($this->encodeIriToCacheKey($iri));
+        $subscriptions = [];
+        if ($subscriptionsCacheItem->isHit()) {
+            $subscriptions = $subscriptionsCacheItem->get();
+            foreach ($subscriptions as [$subscriptionId, $subscriptionFields, $subscriptionResult]) {
+                if ($subscriptionFields === $fields) {
+                    return $subscriptionId;
+                }
+            }
+        }
+
+        $subscriptionId = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier();
+        unset($result['clientSubscriptionId']);
+        $subscriptions[] = [$subscriptionId, $fields, $result];
+        $subscriptionsCacheItem->set($subscriptions);
+        $this->subscriptionsCache->save($subscriptionsCacheItem);
+
+        return $subscriptionId;
+    }
+
+    /**
+     * @param object $object
+     */
+    public function getPushPayloads($object): array
+    {
+        $iri = $this->iriConverter->getIriFromItem($object);
+        $subscriptions = $this->getSubscriptionsFromIri($iri);
+
+        $resourceClass = $this->getObjectClass($object);
+
+        $payloads = [];
+        foreach ($subscriptions as [$subscriptionId, $subscriptionFields, $subscriptionResult]) {
+            $resolverContext = ['fields' => $subscriptionFields, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+
+            $data = ($this->serializeStage)($object, $resourceClass, 'update', $resolverContext);
+            unset($data['clientSubscriptionId']);
+
+            if ($data !== $subscriptionResult) {
+                $payloads[] = [$subscriptionId, $data];
+            }
+        }
+
+        return $payloads;
+    }
+
+    /**
+     * @return array<array>
+     */
+    private function getSubscriptionsFromIri(string $iri): array
+    {
+        $subscriptionsCacheItem = $this->subscriptionsCache->getItem($this->encodeIriToCacheKey($iri));
+
+        if ($subscriptionsCacheItem->isHit()) {
+            return $subscriptionsCacheItem->get();
+        }
+
+        return [];
+    }
+
+    private function encodeIriToCacheKey(string $iri): string
+    {
+        return str_replace('/', '_', $iri);
+    }
+}

--- a/src/GraphQl/Subscription/SubscriptionManagerInterface.php
+++ b/src/GraphQl/Subscription/SubscriptionManagerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Subscription;
+
+/**
+ * Manages all the queried subscriptions and creates their ID.
+ *
+ * @experimental
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface SubscriptionManagerInterface
+{
+    public function retrieveSubscriptionId(array $context, ?array $result): ?string;
+
+    public function getPushPayloads($object): array;
+}

--- a/src/GraphQl/Type/FieldsBuilderInterface.php
+++ b/src/GraphQl/Type/FieldsBuilderInterface.php
@@ -45,9 +45,14 @@ interface FieldsBuilderInterface
     public function getMutationFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $mutationName): array;
 
     /**
+     * Gets the subscription fields of the schema.
+     */
+    public function getSubscriptionFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $subscriptionName): array;
+
+    /**
      * Gets the fields of the type of the given resource.
      */
-    public function getResourceObjectTypeFields(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, int $depth, ?array $ioMetadata): array;
+    public function getResourceObjectTypeFields(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, ?string $subscriptionName, int $depth, ?array $ioMetadata): array;
 
     /**
      * Resolve the args of a resource by resolving its types.

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -54,6 +54,7 @@ final class SchemaBuilder implements SchemaBuilderInterface
 
         $queryFields = ['node' => $this->fieldsBuilder->getNodeQueryFields()];
         $mutationFields = [];
+        $subscriptionFields = [];
 
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
@@ -84,6 +85,10 @@ final class SchemaBuilder implements SchemaBuilderInterface
                     continue;
                 }
 
+                if ('update' === $operationName) {
+                    $subscriptionFields += $this->fieldsBuilder->getSubscriptionFields($resourceClass, $resourceMetadata, $operationName);
+                }
+
                 $mutationFields += $this->fieldsBuilder->getMutationFields($resourceClass, $resourceMetadata, $operationName);
             }
         }
@@ -108,6 +113,13 @@ final class SchemaBuilder implements SchemaBuilderInterface
             $schema['mutation'] = new ObjectType([
                 'name' => 'Mutation',
                 'fields' => $mutationFields,
+            ]);
+        }
+
+        if ($subscriptionFields) {
+            $schema['subscription'] = new ObjectType([
+                'name' => 'Subscription',
+                'fields' => $subscriptionFields,
             ]);
         }
 

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -49,16 +49,19 @@ final class TypeBuilder implements TypeBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function getResourceObjectType(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped = false, int $depth = 0): GraphQLType
+    public function getResourceObjectType(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, ?string $subscriptionName, bool $wrapped = false, int $depth = 0): GraphQLType
     {
         $shortName = $resourceMetadata->getShortName();
 
         if (null !== $mutationName) {
             $shortName = $mutationName.ucfirst($shortName);
         }
+        if (null !== $subscriptionName) {
+            $shortName = $subscriptionName.ucfirst($shortName).'Subscription';
+        }
         if ($input) {
             $shortName .= 'Input';
-        } elseif (null !== $mutationName) {
+        } elseif (null !== $mutationName || null !== $subscriptionName) {
             if ($depth > 0) {
                 $shortName .= 'Nested';
             }
@@ -73,7 +76,7 @@ final class TypeBuilder implements TypeBuilderInterface
                 $shortName .= 'Collection';
             }
         }
-        if ($wrapped && null !== $mutationName) {
+        if ($wrapped && (null !== $mutationName || null !== $subscriptionName)) {
             $shortName .= 'Data';
         }
 
@@ -86,36 +89,46 @@ final class TypeBuilder implements TypeBuilderInterface
             return $resourceObjectType;
         }
 
-        $ioMetadata = $resourceMetadata->getGraphqlAttribute($mutationName ?? $queryName, $input ? 'input' : 'output', null, true);
+        $ioMetadata = $resourceMetadata->getGraphqlAttribute($subscriptionName ?? $mutationName ?? $queryName, $input ? 'input' : 'output', null, true);
         if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
             $resourceClass = $ioMetadata['class'];
         }
 
-        $wrapData = !$wrapped && null !== $mutationName && !$input && $depth < 1;
+        $wrapData = !$wrapped && (null !== $mutationName || null !== $subscriptionName) && !$input && $depth < 1;
 
         $configuration = [
             'name' => $shortName,
             'description' => $resourceMetadata->getDescription(),
             'resolveField' => $this->defaultFieldResolver,
-            'fields' => function () use ($resourceClass, $resourceMetadata, $input, $mutationName, $queryName, $wrapData, $depth, $ioMetadata) {
+            'fields' => function () use ($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $subscriptionName, $wrapData, $depth, $ioMetadata) {
                 if ($wrapData) {
                     $queryNormalizationContext = $resourceMetadata->getGraphqlAttribute($queryName ?? '', 'normalization_context', [], true);
-                    $mutationNormalizationContext = $resourceMetadata->getGraphqlAttribute($mutationName ?? '', 'normalization_context', [], true);
-                    // Use a new type for the wrapped object only if there is a specific normalization context for the mutation.
+                    $mutationNormalizationContext = $resourceMetadata->getGraphqlAttribute($mutationName ?? $subscriptionName ?? '', 'normalization_context', [], true);
+                    // Use a new type for the wrapped object only if there is a specific normalization context for the mutation or the subscription.
                     // If not, use the query type in order to ensure the client cache could be used.
                     $useWrappedType = $queryNormalizationContext !== $mutationNormalizationContext;
 
-                    return [
+                    $fields = [
                         lcfirst($resourceMetadata->getShortName()) => $useWrappedType ?
-                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, true, $depth) :
-                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName ?? 'item_query', null, true, $depth),
-                        'clientMutationId' => GraphQLType::string(),
+                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $subscriptionName, true, $depth) :
+                            $this->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName ?? 'item_query', null, null, true, $depth),
                     ];
+
+                    if (null !== $subscriptionName) {
+                        $fields['clientSubscriptionId'] = GraphQLType::string();
+                        if ($resourceMetadata->getAttribute('mercure', false)) {
+                            $fields['mercureUrl'] = GraphQLType::string();
+                        }
+
+                        return $fields;
+                    }
+
+                    return $fields + ['clientMutationId' => GraphQLType::string()];
                 }
 
                 $fieldsBuilder = $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder');
 
-                $fields = $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $depth, $ioMetadata);
+                $fields = $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $subscriptionName, $depth, $ioMetadata);
 
                 if ($input && null !== $mutationName && null !== $mutationArgs = $resourceMetadata->getGraphql()[$mutationName]['args'] ?? null) {
                     return $fieldsBuilder->resolveResourceArgs($mutationArgs, $mutationName, $resourceMetadata->getShortName()) + ['clientMutationId' => $fields['clientMutationId']];

--- a/src/GraphQl/Type/TypeBuilderInterface.php
+++ b/src/GraphQl/Type/TypeBuilderInterface.php
@@ -34,7 +34,7 @@ interface TypeBuilderInterface
      *
      * @return ObjectType|NonNull the object type, possibly wrapped by NonNull
      */
-    public function getResourceObjectType(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, bool $wrapped, int $depth): GraphQLType;
+    public function getResourceObjectType(?string $resourceClass, ResourceMetadata $resourceMetadata, bool $input, ?string $queryName, ?string $mutationName, ?string $subscriptionName, bool $wrapped, int $depth): GraphQLType;
 
     /**
      * Get the interface type of a node.

--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -49,7 +49,7 @@ final class TypeConverter implements TypeConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, string $rootResource, ?string $property, int $depth)
+    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, ?string $subscriptionName, string $resourceClass, string $rootResource, ?string $property, int $depth)
     {
         switch ($type->getBuiltinType()) {
             case Type::BUILTIN_TYPE_BOOL:
@@ -72,7 +72,7 @@ final class TypeConverter implements TypeConverterInterface
                     return GraphQLType::string();
                 }
 
-                return $this->getResourceType($type, $input, $queryName, $mutationName, $depth);
+                return $this->getResourceType($type, $input, $queryName, $mutationName, $subscriptionName, $depth);
             default:
                 return null;
         }
@@ -96,7 +96,7 @@ final class TypeConverter implements TypeConverterInterface
         throw new InvalidArgumentException(sprintf('The type "%s" was not resolved.', $type));
     }
 
-    private function getResourceType(Type $type, bool $input, ?string $queryName, ?string $mutationName, int $depth): ?GraphQLType
+    private function getResourceType(Type $type, bool $input, ?string $queryName, ?string $mutationName, ?string $subscriptionName, int $depth): ?GraphQLType
     {
         $resourceClass = $this->typeBuilder->isCollection($type) && ($collectionValueType = $type->getCollectionValueType()) ? $collectionValueType->getClassName() : $type->getClassName();
         if (null === $resourceClass) {
@@ -113,7 +113,7 @@ final class TypeConverter implements TypeConverterInterface
             return null;
         }
 
-        return $this->typeBuilder->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, false, $depth);
+        return $this->typeBuilder->getResourceObjectType($resourceClass, $resourceMetadata, $input, $queryName, $mutationName, $subscriptionName, false, $depth);
     }
 
     private function resolveAstTypeNode(TypeNode $astTypeNode, string $fromType): ?GraphQLType

--- a/src/GraphQl/Type/TypeConverterInterface.php
+++ b/src/GraphQl/Type/TypeConverterInterface.php
@@ -31,7 +31,7 @@ interface TypeConverterInterface
      *
      * @return string|GraphQLType|null
      */
-    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, string $rootResource, ?string $property, int $depth);
+    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, ?string $subscriptionName, string $resourceClass, string $rootResource, ?string $property, int $depth);
 
     /**
      * Resolves a type written with the GraphQL type system to its object representation.

--- a/src/Util/SortTrait.php
+++ b/src/Util/SortTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Util;
+
+/**
+ * Sort helper methods.
+ *
+ * @internal
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+trait SortTrait
+{
+    private function arrayRecursiveSort(array &$array, callable $sortFunction): void
+    {
+        foreach ($array as &$value) {
+            if (\is_array($value)) {
+                $this->arrayRecursiveSort($value, $sortFunction);
+            }
+        }
+        unset($value);
+        $sortFunction($array);
+    }
+}

--- a/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -18,6 +18,8 @@ use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Bridge\Doctrine\EventListener\PublishMercureUpdatesListener;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\GraphQl\Subscription\MercureSubscriptionIriGeneratorInterface as GraphQlMercureSubscriptionIriGeneratorInterface;
+use ApiPlatform\Core\GraphQl\Subscription\SubscriptionManagerInterface as GraphQlSubscriptionManagerInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\NotAResource;
@@ -113,6 +115,74 @@ class PublishMercureUpdatesListenerTest extends TestCase
 
         $this->assertSame(['http://example.com/dummies/1', 'http://example.com/dummies/2', 'http://example.com/dummies/3', 'http://example.com/dummy_friends/4'], $topics);
         $this->assertSame([[], [], [], ['foo', 'bar']], $targets);
+    }
+
+    public function testPublishGraphQlUpdates(): void
+    {
+        $toUpdate = new Dummy();
+        $toUpdate->setId(2);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class);
+        $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($toUpdate, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2');
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => true, 'normalization_context' => ['groups' => ['foo', 'bar']]]));
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->serialize($toUpdate, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('2');
+
+        $formats = ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']];
+
+        $topics = [];
+        $targets = [];
+        $data = [];
+        $publisher = function (Update $update) use (&$topics, &$targets, &$data): string {
+            $topics = array_merge($topics, $update->getTopics());
+            $targets[] = $update->getTargets();
+            $data[] = $update->getData();
+
+            return 'id';
+        };
+
+        $graphQlSubscriptionManagerProphecy = $this->prophesize(GraphQlSubscriptionManagerInterface::class);
+        $graphQlSubscriptionId = 'subscription-id';
+        $graphQlSubscriptionData = ['data'];
+        $graphQlSubscriptionManagerProphecy->getPushPayloads($toUpdate)->willReturn([[$graphQlSubscriptionId, $graphQlSubscriptionData]]);
+        $graphQlMercureSubscriptionIriGenerator = $this->prophesize(GraphQlMercureSubscriptionIriGeneratorInterface::class);
+        $topicIri = 'subscription-topic-iri';
+        $graphQlMercureSubscriptionIriGenerator->generateTopicIri($graphQlSubscriptionId)->willReturn($topicIri);
+
+        $listener = new PublishMercureUpdatesListener(
+            $resourceClassResolverProphecy->reveal(),
+            $iriConverterProphecy->reveal(),
+            $resourceMetadataFactoryProphecy->reveal(),
+            $serializerProphecy->reveal(),
+            $formats,
+            null,
+            $publisher,
+            $graphQlSubscriptionManagerProphecy->reveal(),
+            $graphQlMercureSubscriptionIriGenerator->reveal()
+        );
+
+        $uowProphecy = $this->prophesize(UnitOfWork::class);
+        $uowProphecy->getScheduledEntityInsertions()->willReturn([])->shouldBeCalled();
+        $uowProphecy->getScheduledEntityUpdates()->willReturn([$toUpdate])->shouldBeCalled();
+        $uowProphecy->getScheduledEntityDeletions()->willReturn([])->shouldBeCalled();
+
+        $emProphecy = $this->prophesize(EntityManagerInterface::class);
+        $emProphecy->getUnitOfWork()->willReturn($uowProphecy->reveal())->shouldBeCalled();
+        $eventArgs = new OnFlushEventArgs($emProphecy->reveal());
+
+        $listener->onFlush($eventArgs);
+        $listener->postFlush();
+
+        $this->assertSame(['http://example.com/dummies/2', 'subscription-topic-iri'], $topics);
+        $this->assertSame([[], []], $targets);
+        $this->assertSame(['2', '["data"]'], $data);
     }
 
     public function testNoPublisher(): void

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -342,6 +342,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.graphql.action.graphql_playground', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.collection', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.item_mutation', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.item_subscription', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.item', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.stage.read', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.stage.security', Argument::type(Definition::class))->shouldNotBeCalled();
@@ -371,7 +372,11 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.graphql.normalizer.validation_exception', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.normalizer.http_exception', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.normalizer.runtime_exception', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.subscription.subscription_manager', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.subscription.subscription_identifier_generator', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.cache.subscription', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.command.export_command', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.subscription.mercure_iri_generator', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.graphql.enabled', true)->shouldNotBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.graphql.enabled', false)->shouldBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.graphql.default_ide', 'graphiql')->shouldNotBeCalled();
@@ -1180,6 +1185,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.resolver.factory.item',
             'api_platform.graphql.resolver.factory.collection',
             'api_platform.graphql.resolver.factory.item_mutation',
+            'api_platform.graphql.resolver.factory.item_subscription',
             'api_platform.graphql.resolver.stage.read',
             'api_platform.graphql.resolver.stage.security',
             'api_platform.graphql.resolver.stage.security_post_denormalize',
@@ -1203,7 +1209,11 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.normalizer.item',
             'api_platform.graphql.normalizer.object',
             'api_platform.graphql.serializer.context_builder',
+            'api_platform.graphql.subscription.subscription_manager',
+            'api_platform.graphql.subscription.subscription_identifier_generator',
+            'api_platform.graphql.cache.subscription',
             'api_platform.graphql.command.export_command',
+            'api_platform.graphql.subscription.mercure_iri_generator',
             'api_platform.hal.encoder',
             'api_platform.hal.normalizer.collection',
             'api_platform.hal.normalizer.entrypoint',
@@ -1365,6 +1375,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->getDefinition('api_platform.mercure.listener.response.add_link_header')->willReturn($definitionDummy);
         $containerBuilderProphecy->getDefinition('api_platform.doctrine.orm.listener.mercure.publish')->willReturn($definitionDummy);
         $containerBuilderProphecy->getDefinition('api_platform.doctrine_mongodb.odm.listener.mercure.publish')->willReturn($definitionDummy);
+        $containerBuilderProphecy->getDefinition('api_platform.graphql.subscription.mercure_iri_generator')->willReturn($definitionDummy);
 
         return $containerBuilderProphecy;
     }

--- a/tests/Fixtures/DummyMercurePublisher.php
+++ b/tests/Fixtures/DummyMercurePublisher.php
@@ -17,8 +17,20 @@ use Symfony\Component\Mercure\Update;
 
 class DummyMercurePublisher
 {
+    private $updates = [];
+
     public function __invoke(Update $update): string
     {
+        $this->updates[] = $update;
+
         return 'dummy';
+    }
+
+    /**
+     * @return array<Update>
+     */
+    public function getUpdates(): array
+    {
+        return $this->updates;
     }
 }

--- a/tests/Fixtures/TestBundle/Document/DummyMercure.php
+++ b/tests/Fixtures/TestBundle/Document/DummyMercure.php
@@ -28,4 +28,19 @@ class DummyMercure
      * @ODM\Id(strategy="INCREMENT", type="integer")
      */
     public $id;
+
+    /**
+     * @ODM\Field(type="string")
+     */
+    public $name;
+
+    /**
+     * @ODM\Field(type="string")
+     */
+    public $description;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument=RelatedDummy::class, storeAs="id", nullable=true)
+     */
+    public $relatedDummy;
 }

--- a/tests/Fixtures/TestBundle/Entity/DummyMercure.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyMercure.php
@@ -26,7 +26,23 @@ class DummyMercure
 {
     /**
      * @ORM\Id
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     public $id;
+
+    /**
+     * @ORM\Column
+     */
+    public $name;
+
+    /**
+     * @ORM\Column
+     */
+    public $description;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="RelatedDummy")
+     */
+    public $relatedDummy;
 }

--- a/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
@@ -36,7 +36,7 @@ final class TypeConverter implements TypeConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, string $resourceClass, string $rootResource, ?string $property, int $depth)
+    public function convertType(Type $type, bool $input, ?string $queryName, ?string $mutationName, ?string $subscriptionName, string $resourceClass, string $rootResource, ?string $property, int $depth)
     {
         if ('dummyDate' === $property
             && \in_array($rootResource, [Dummy::class, DummyDocument::class], true)
@@ -46,7 +46,7 @@ final class TypeConverter implements TypeConverterInterface
             return 'DateTime';
         }
 
-        return $this->defaultTypeConverter->convertType($type, $input, $queryName, $mutationName, $resourceClass, $rootResource, $property, $depth);
+        return $this->defaultTypeConverter->convertType($type, $input, $queryName, $mutationName, $subscriptionName, $resourceClass, $rootResource, $property, $depth);
     }
 
     /**

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -235,6 +235,8 @@ services:
 
     mercure.hub.default.publisher:
         class: ApiPlatform\Core\Tests\Fixtures\DummyMercurePublisher
+        public: true
+        tags: ['messenger.message_handler']
 
     app.serializer.normalizer.override_documentation:
         class: ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\Normalizer\OverrideDocumentationNormalizer

--- a/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -74,7 +74,7 @@ class CollectionResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
         $request = new Request();
         $attributesParameterBagProphecy = $this->prophesize(ParameterBag::class);
@@ -138,7 +138,7 @@ class CollectionResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageCollection = new \stdClass();
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageCollection);
@@ -157,7 +157,7 @@ class CollectionResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageCollection = [new \stdClass()];
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageCollection);

--- a/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemMutationResolverFactoryTest.php
@@ -81,7 +81,7 @@ class ItemMutationResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $readStageItem->field = 'read';
@@ -149,7 +149,7 @@ class ItemMutationResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false];
 
         $readStageItem = [];
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
@@ -168,7 +168,7 @@ class ItemMutationResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $readStageItem->field = 'read';
@@ -209,7 +209,7 @@ class ItemMutationResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $readStageItem->field = 'read';
@@ -249,7 +249,7 @@ class ItemMutationResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $readStageItem->field = 'read';
@@ -301,7 +301,7 @@ class ItemMutationResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $readStageItem->field = 'read';

--- a/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
@@ -73,7 +73,7 @@ class ItemResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
 
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
 
@@ -123,7 +123,7 @@ class ItemResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageItem = [];
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
@@ -142,7 +142,7 @@ class ItemResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageItem = null;
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
@@ -161,7 +161,7 @@ class ItemResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
@@ -180,7 +180,7 @@ class ItemResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
@@ -221,7 +221,7 @@ class ItemResolverFactoryTest extends TestCase
         $source = ['source'];
         $args = ['args'];
         $info = $this->prophesize(ResolveInfo::class)->reveal();
-        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false];
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageItem = new \stdClass();
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);

--- a/tests/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactoryTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Resolver\Factory;
+
+use ApiPlatform\Core\GraphQl\Resolver\Factory\ItemSubscriptionResolverFactory;
+use ApiPlatform\Core\GraphQl\Resolver\Stage\ReadStageInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Stage\SecurityStageInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Stage\SerializeStageInterface;
+use ApiPlatform\Core\GraphQl\Subscription\MercureSubscriptionIriGeneratorInterface;
+use ApiPlatform\Core\GraphQl\Subscription\SubscriptionManagerInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use GraphQL\Type\Definition\ResolveInfo;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class ItemSubscriptionResolverFactoryTest extends TestCase
+{
+    private $itemSubscriptionResolverFactory;
+    private $readStageProphecy;
+    private $securityStageProphecy;
+    private $serializeStageProphecy;
+    private $resourceMetadataFactoryProphecy;
+    private $subscriptionManagerProphecy;
+    private $mercureSubscriptionIriGeneratorProphecy;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->readStageProphecy = $this->prophesize(ReadStageInterface::class);
+        $this->securityStageProphecy = $this->prophesize(SecurityStageInterface::class);
+        $this->serializeStageProphecy = $this->prophesize(SerializeStageInterface::class);
+        $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $this->subscriptionManagerProphecy = $this->prophesize(SubscriptionManagerInterface::class);
+        $this->mercureSubscriptionIriGeneratorProphecy = $this->prophesize(MercureSubscriptionIriGeneratorInterface::class);
+
+        $this->itemSubscriptionResolverFactory = new ItemSubscriptionResolverFactory(
+            $this->readStageProphecy->reveal(),
+            $this->securityStageProphecy->reveal(),
+            $this->serializeStageProphecy->reveal(),
+            $this->resourceMetadataFactoryProphecy->reveal(),
+            $this->subscriptionManagerProphecy->reveal(),
+            $this->mercureSubscriptionIriGeneratorProphecy->reveal()
+        );
+    }
+
+    public function testResolve(): void
+    {
+        $resourceClass = 'stdClass';
+        $rootClass = 'rootClass';
+        $operationName = 'update';
+        $source = ['source'];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+
+        $readStageItem = new \stdClass();
+        $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
+
+        $this->securityStageProphecy->__invoke($resourceClass, $operationName, $resolverContext + [
+            'extra_variables' => [
+                'object' => $readStageItem,
+            ],
+        ])->shouldBeCalled();
+
+        $serializeStageData = ['serialized'];
+        $this->serializeStageProphecy->__invoke($readStageItem, $resourceClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($serializeStageData);
+
+        $subscriptionId = 'subscriptionId';
+        $this->subscriptionManagerProphecy->retrieveSubscriptionId($resolverContext, $serializeStageData)->shouldBeCalled()->willReturn($subscriptionId);
+
+        $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn((new ResourceMetadata())->withAttributes(['mercure' => true]));
+
+        $mercureUrl = 'mercure-url';
+        $this->mercureSubscriptionIriGeneratorProphecy->generateMercureUrl($subscriptionId)->shouldBeCalled()->willReturn($mercureUrl);
+
+        $this->assertSame($serializeStageData + ['mercureUrl' => $mercureUrl], ($this->itemSubscriptionResolverFactory)($resourceClass, $rootClass, $operationName)($source, $args, null, $info));
+    }
+
+    public function testResolveNullResourceClass(): void
+    {
+        $resourceClass = null;
+        $rootClass = 'rootClass';
+        $operationName = 'update';
+        $source = ['source'];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+
+        $this->assertNull(($this->itemSubscriptionResolverFactory)($resourceClass, $rootClass, $operationName)($source, $args, null, $info));
+    }
+
+    public function testResolveNullOperationName(): void
+    {
+        $resourceClass = 'stdClass';
+        $rootClass = 'rootClass';
+        $operationName = null;
+        $source = ['source'];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+
+        $this->assertNull(($this->itemSubscriptionResolverFactory)($resourceClass, $rootClass, $operationName)($source, $args, null, $info));
+    }
+
+    public function testResolveBadReadStageItem(): void
+    {
+        $resourceClass = 'stdClass';
+        $rootClass = 'rootClass';
+        $operationName = 'update';
+        $source = ['source'];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+
+        $readStageItem = [];
+        $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Item from read stage should be a nullable object.');
+
+        ($this->itemSubscriptionResolverFactory)($resourceClass, $rootClass, $operationName)($source, $args, null, $info);
+    }
+
+    public function testResolveNoSubscriptionId(): void
+    {
+        $resourceClass = 'stdClass';
+        $rootClass = 'rootClass';
+        $operationName = 'update';
+        $source = ['source'];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+
+        $readStageItem = new \stdClass();
+        $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->willReturn($readStageItem);
+
+        $serializeStageData = ['serialized'];
+        $this->serializeStageProphecy->__invoke($readStageItem, $resourceClass, $operationName, $resolverContext)->willReturn($serializeStageData);
+
+        $this->subscriptionManagerProphecy->retrieveSubscriptionId($resolverContext, $serializeStageData)->willReturn(null);
+
+        $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn((new ResourceMetadata())->withAttributes(['mercure' => true]));
+
+        $this->mercureSubscriptionIriGeneratorProphecy->generateMercureUrl(Argument::any())->shouldNotBeCalled();
+
+        $this->assertSame($serializeStageData, ($this->itemSubscriptionResolverFactory)($resourceClass, $rootClass, $operationName)($source, $args, null, $info));
+    }
+
+    public function testResolveNoMercureSubscriptionIriGenerator(): void
+    {
+        $resourceClass = 'stdClass';
+        $rootClass = 'rootClass';
+        $operationName = 'update';
+        $source = ['source'];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+
+        $readStageItem = new \stdClass();
+        $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->willReturn($readStageItem);
+
+        $serializeStageData = ['serialized'];
+        $this->serializeStageProphecy->__invoke($readStageItem, $resourceClass, $operationName, $resolverContext)->willReturn($serializeStageData);
+
+        $subscriptionId = 'subscriptionId';
+        $this->subscriptionManagerProphecy->retrieveSubscriptionId($resolverContext, $serializeStageData)->willReturn($subscriptionId);
+
+        $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn((new ResourceMetadata())->withAttributes(['mercure' => true]));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot use Mercure for subscriptions when MercureBundle is not installed. Try running "composer require mercure".');
+
+        $itemSubscriptionResolverFactory = new ItemSubscriptionResolverFactory(
+            $this->readStageProphecy->reveal(),
+            $this->securityStageProphecy->reveal(),
+            $this->serializeStageProphecy->reveal(),
+            $this->resourceMetadataFactoryProphecy->reveal(),
+            $this->subscriptionManagerProphecy->reveal(),
+            null
+        );
+
+        ($itemSubscriptionResolverFactory)($resourceClass, $rootClass, $operationName)($source, $args, null, $info);
+    }
+}

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -101,6 +101,7 @@ class ReadStageTest extends TestCase
         $context = [
             'is_collection' => false,
             'is_mutation' => false,
+            'is_subscription' => false,
             'args' => ['id' => $identifier],
             'info' => $info,
         ];
@@ -132,18 +133,19 @@ class ReadStageTest extends TestCase
     }
 
     /**
-     * @dataProvider itemMutationProvider
+     * @dataProvider itemMutationOrSubscriptionProvider
      *
      * @param object|null $item
      * @param object|null $expectedResult
      */
-    public function testApplyMutation(string $resourceClass, ?string $identifier, $item, bool $throwNotFound, $expectedResult, ?string $expectedExceptionClass = null, ?string $expectedExceptionMessage = null): void
+    public function testApplyMutationOrSubscription(bool $isMutation, bool $isSubscription, string $resourceClass, ?string $identifier, $item, bool $throwNotFound, $expectedResult, ?string $expectedExceptionClass = null, ?string $expectedExceptionMessage = null): void
     {
         $operationName = 'create';
         $info = $this->prophesize(ResolveInfo::class)->reveal();
         $context = [
             'is_collection' => false,
-            'is_mutation' => true,
+            'is_mutation' => $isMutation,
+            'is_subscription' => $isSubscription,
             'args' => ['input' => ['id' => $identifier]],
             'info' => $info,
         ];
@@ -168,15 +170,17 @@ class ReadStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function itemMutationProvider(): array
+    public function itemMutationOrSubscriptionProvider(): array
     {
         $item = new \stdClass();
 
         return [
-            'no identifier' => ['myResource', null, $item, false, null],
-            'identifier' => ['stdClass', 'identifier', $item, false, $item],
-            'identifier bad item' => ['myResource', 'identifier', $item, false, $item, \UnexpectedValueException::class, 'Item "identifier" did not match expected type "shortName".'],
-            'identifier not found' => ['myResource', 'identifier_not_found', $item, true, null, NotFoundHttpException::class, 'Item "identifier_not_found" not found.'],
+            'no identifier' => [true, false, 'myResource', null, $item, false, null],
+            'identifier' => [true, false, 'stdClass', 'identifier', $item, false, $item],
+            'identifier bad item' => [true, false, 'myResource', 'identifier', $item, false, $item, \UnexpectedValueException::class, 'Item "identifier" did not match expected type "shortName".'],
+            'identifier not found' => [true, false, 'myResource', 'identifier_not_found', $item, true, null, NotFoundHttpException::class, 'Item "identifier_not_found" not found.'],
+            'no identifier (subscription)' => [false, true, 'myResource', null, $item, false, null],
+            'identifier (subscription)' => [false, true, 'stdClass', 'identifier', $item, false, $item],
         ];
     }
 
@@ -193,6 +197,7 @@ class ReadStageTest extends TestCase
         $context = [
             'is_collection' => true,
             'is_mutation' => false,
+            'is_subscription' => false,
             'args' => $args,
             'info' => $info,
             'source' => $source,

--- a/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
@@ -64,10 +64,11 @@ class SerializeStageTest extends TestCase
     public function applyDisabledProvider(): array
     {
         return [
-            'item' => [['is_collection' => false, 'is_mutation' => false], false, null],
-            'collection with pagination' => [['is_collection' => true, 'is_mutation' => false], true, ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => null, 'endCursor' => null, 'hasNextPage' => false, 'hasPreviousPage' => false]]],
-            'collection without pagination' => [['is_collection' => true, 'is_mutation' => false], false, []],
-            'mutation' => [['is_collection' => false, 'is_mutation' => true], false, ['clientMutationId' => null]],
+            'item' => [['is_collection' => false, 'is_mutation' => false, 'is_subscription' => false], false, null],
+            'collection with pagination' => [['is_collection' => true, 'is_mutation' => false, 'is_subscription' => false], true, ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => null, 'endCursor' => null, 'hasNextPage' => false, 'hasPreviousPage' => false]]],
+            'collection without pagination' => [['is_collection' => true, 'is_mutation' => false, 'is_subscription' => false], false, []],
+            'mutation' => [['is_collection' => false, 'is_mutation' => true, 'is_subscription' => false], false, ['clientMutationId' => null]],
+            'subscription' => [['is_collection' => false, 'is_mutation' => false, 'is_subscription' => true], false, ['clientSubscriptionId' => null]],
         ];
     }
 
@@ -99,10 +100,11 @@ class SerializeStageTest extends TestCase
         ];
 
         return [
-            'item' => [new \stdClass(), 'item_query', $defaultContext + ['is_collection' => false, 'is_mutation' => false], false, ['normalized_item']],
-            'collection without pagination' => [[new \stdClass(), new \stdClass()], 'collection_query', $defaultContext + ['is_collection' => true, 'is_mutation' => false], false, [['normalized_item'], ['normalized_item']]],
-            'mutation' => [new \stdClass(), 'create', array_merge($defaultContext, ['args' => ['input' => ['clientMutationId' => 'clientMutationId']], 'is_collection' => false, 'is_mutation' => true]), false, ['shortName' => ['normalized_item'], 'clientMutationId' => 'clientMutationId']],
-            'delete mutation' => [new \stdClass(), 'delete', array_merge($defaultContext, ['args' => ['input' => ['id' => 4]], 'is_collection' => false, 'is_mutation' => true]), false, ['shortName' => ['id' => 4], 'clientMutationId' => null]],
+            'item' => [new \stdClass(), 'item_query', $defaultContext + ['is_collection' => false, 'is_mutation' => false, 'is_subscription' => false], false, ['normalized_item']],
+            'collection without pagination' => [[new \stdClass(), new \stdClass()], 'collection_query', $defaultContext + ['is_collection' => true, 'is_mutation' => false, 'is_subscription' => false], false, [['normalized_item'], ['normalized_item']]],
+            'mutation' => [new \stdClass(), 'create', array_merge($defaultContext, ['args' => ['input' => ['clientMutationId' => 'clientMutationId']], 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false]), false, ['shortName' => ['normalized_item'], 'clientMutationId' => 'clientMutationId']],
+            'delete mutation' => [new \stdClass(), 'delete', array_merge($defaultContext, ['args' => ['input' => ['id' => '/iri/4']], 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false]), false, ['shortName' => ['id' => '/iri/4'], 'clientMutationId' => null]],
+            'subscription' => [new \stdClass(), 'update', array_merge($defaultContext, ['args' => ['input' => ['clientSubscriptionId' => 'clientSubscriptionId']], 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true]), false, ['shortName' => ['normalized_item'], 'clientSubscriptionId' => 'clientSubscriptionId']],
         ];
     }
 
@@ -116,6 +118,7 @@ class SerializeStageTest extends TestCase
         $context = [
             'is_collection' => true,
             'is_mutation' => false,
+            'is_subscription' => false,
             'args' => $args,
             'info' => $this->prophesize(ResolveInfo::class)->reveal(),
         ];
@@ -154,7 +157,7 @@ class SerializeStageTest extends TestCase
     {
         $operationName = 'item_query';
         $resourceClass = 'myResource';
-        $context = ['is_collection' => false, 'is_mutation' => false, 'args' => [], 'info' => $this->prophesize(ResolveInfo::class)->reveal()];
+        $context = ['is_collection' => false, 'is_mutation' => false, 'is_subscription' => false, 'args' => [], 'info' => $this->prophesize(ResolveInfo::class)->reveal()];
         $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadata());
 
         $normalizationContext = ['normalization' => true];

--- a/tests/GraphQl/Resolver/Util/IdentifierTraitTest.php
+++ b/tests/GraphQl/Resolver/Util/IdentifierTraitTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Resolver\Util;
+
+use ApiPlatform\Core\GraphQl\Resolver\Util\IdentifierTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class IdentifierTraitTest extends TestCase
+{
+    private function getIdentifierTraitImplementation()
+    {
+        return new class() {
+            use IdentifierTrait {
+                IdentifierTrait::getIdentifierFromContext as public;
+            }
+        };
+    }
+
+    public function testGetIdentifierFromQueryContext(): void
+    {
+        $identifierTrait = $this->getIdentifierTraitImplementation();
+
+        $this->assertEquals('foo', $identifierTrait->getIdentifierFromContext(['args' => ['id' => 'foo'], 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false]));
+    }
+
+    public function testGetIdentifierFromMutationContext(): void
+    {
+        $identifierTrait = $this->getIdentifierTraitImplementation();
+
+        $this->assertEquals('foo', $identifierTrait->getIdentifierFromContext(['args' => ['input' => ['id' => 'foo']], 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false]));
+    }
+
+    public function testGetIdentifierFromSubscriptionContext(): void
+    {
+        $identifierTrait = $this->getIdentifierTraitImplementation();
+
+        $this->assertEquals('foo', $identifierTrait->getIdentifierFromContext(['args' => ['input' => ['id' => 'foo']], 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true]));
+    }
+}

--- a/tests/GraphQl/Subscription/MercureSubscriptionIriGeneratorTest.php
+++ b/tests/GraphQl/Subscription/MercureSubscriptionIriGeneratorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Subscription;
+
+use ApiPlatform\Core\GraphQl\Subscription\MercureSubscriptionIriGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class MercureSubscriptionIriGeneratorTest extends TestCase
+{
+    private $requestContext;
+    private $hubUrl;
+    private $mercureSubscriptionIriGenerator;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->requestContext = new RequestContext('', 'GET', 'example.com');
+        $this->hubUrl = 'https://demo.mercure.rocks/hub';
+        $this->mercureSubscriptionIriGenerator = new MercureSubscriptionIriGenerator($this->requestContext, $this->hubUrl);
+    }
+
+    public function testGenerateTopicIri(): void
+    {
+        $this->assertSame('http://example.com/subscriptions/subscription-id', $this->mercureSubscriptionIriGenerator->generateTopicIri('subscription-id'));
+    }
+
+    public function testGenerateDefaultTopicIri(): void
+    {
+        $mercureSubscriptionIriGenerator = new MercureSubscriptionIriGenerator(new RequestContext('', 'GET', '', ''), $this->hubUrl);
+
+        $this->assertSame('https://api-platform.com/subscriptions/subscription-id', $mercureSubscriptionIriGenerator->generateTopicIri('subscription-id'));
+    }
+
+    public function testGenerateMercureUrl(): void
+    {
+        $this->assertSame("$this->hubUrl?topic=http://example.com/subscriptions/subscription-id", $this->mercureSubscriptionIriGenerator->generateMercureUrl('subscription-id'));
+    }
+}

--- a/tests/GraphQl/Subscription/SubscriptionIdentifierGeneratorTest.php
+++ b/tests/GraphQl/Subscription/SubscriptionIdentifierGeneratorTest.php
@@ -31,10 +31,65 @@ class SubscriptionIdentifierGeneratorTest extends TestCase
         $this->subscriptionIdentifierGenerator = new SubscriptionIdentifierGenerator();
     }
 
+    public function testGenerateSubscriptionIdentifier(): void
+    {
+        $this->assertSame('bf861b4e0edd7766ff61da90c60fdceef2618b595a3628901921d4d8eca555d0', $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier([
+            'dummyMercure' => [
+                'id' => true,
+                'name' => true,
+                'relatedDummy' => [
+                    'name' => true,
+                ],
+            ],
+        ]));
+    }
+
+    public function testGenerateSubscriptionIdentifierFieldsNotIncluded(): void
+    {
+        $subscriptionId = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier([
+            'dummyMercure' => [
+                'id' => true,
+                'name' => true,
+                'relatedDummy' => [
+                    'name' => true,
+                ],
+            ],
+        ]);
+
+        $subscriptionId2 = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier([
+            'dummyMercure' => [
+                'id' => true,
+                'name' => true,
+                'relatedDummy' => [
+                    'name' => true,
+                ],
+            ],
+            'mercureUrl' => true,
+            'clientSubscriptionId' => true,
+        ]);
+
+        $this->assertSame($subscriptionId, $subscriptionId2);
+    }
+
     public function testDifferentGeneratedSubscriptionIdentifiers(): void
     {
-        $subscriptionId = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier();
+        $subscriptionId = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier([
+            'dummyMercure' => [
+                'id' => true,
+                'name' => true,
+                'relatedDummy' => [
+                    'name' => true,
+                ],
+            ],
+        ]);
 
-        $this->assertNotSame($subscriptionId, $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier());
+        $this->assertNotSame($subscriptionId, $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier([
+            'dummyMercure' => [
+                'id' => true,
+                'relatedDummy' => [
+                    'name' => true,
+                ],
+            ],
+        ]));
     }
 }

--- a/tests/GraphQl/Subscription/SubscriptionIdentifierGeneratorTest.php
+++ b/tests/GraphQl/Subscription/SubscriptionIdentifierGeneratorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Subscription;
+
+use ApiPlatform\Core\GraphQl\Subscription\SubscriptionIdentifierGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class SubscriptionIdentifierGeneratorTest extends TestCase
+{
+    private $subscriptionIdentifierGenerator;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->subscriptionIdentifierGenerator = new SubscriptionIdentifierGenerator();
+    }
+
+    public function testDifferentGeneratedSubscriptionIdentifiers(): void
+    {
+        $subscriptionId = $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier();
+
+        $this->assertNotSame($subscriptionId, $this->subscriptionIdentifierGenerator->generateSubscriptionIdentifier());
+    }
+}

--- a/tests/GraphQl/Subscription/SubscriptionManagerTest.php
+++ b/tests/GraphQl/Subscription/SubscriptionManagerTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\GraphQl\Subscription;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\GraphQl\Resolver\Stage\SerializeStageInterface;
+use ApiPlatform\Core\GraphQl\Subscription\SubscriptionIdentifierGeneratorInterface;
+use ApiPlatform\Core\GraphQl\Subscription\SubscriptionManager;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use GraphQL\Type\Definition\ResolveInfo;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class SubscriptionManagerTest extends TestCase
+{
+    private $subscriptionsCacheProphecy;
+    private $subscriptionIdentifierGeneratorProphecy;
+    private $serializeStageProphecy;
+    private $iriConverterProphecy;
+    private $subscriptionManager;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->subscriptionsCacheProphecy = $this->prophesize(CacheItemPoolInterface::class);
+        $this->subscriptionIdentifierGeneratorProphecy = $this->prophesize(SubscriptionIdentifierGeneratorInterface::class);
+        $this->serializeStageProphecy = $this->prophesize(SerializeStageInterface::class);
+        $this->iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $this->subscriptionManager = new SubscriptionManager($this->subscriptionsCacheProphecy->reveal(), $this->subscriptionIdentifierGeneratorProphecy->reveal(), $this->serializeStageProphecy->reveal(), $this->iriConverterProphecy->reveal());
+    }
+
+    public function testRetrieveSubscriptionIdNoIdentifier(): void
+    {
+        $info = $this->prophesize(ResolveInfo::class);
+        $info->getFieldSelection(PHP_INT_MAX)->willReturn([]);
+
+        $context = ['args' => [], 'info' => $info->reveal(), 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+
+        $this->assertNull($this->subscriptionManager->retrieveSubscriptionId($context, null));
+    }
+
+    public function testRetrieveSubscriptionIdNoHit(): void
+    {
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $fields = ['fields'];
+        $infoProphecy->getFieldSelection(PHP_INT_MAX)->willReturn($fields);
+
+        $context = ['args' => ['input' => ['id' => '/foos/34']], 'info' => $infoProphecy->reveal(), 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+        $result = ['result', 'clientSubscriptionId' => 'client-subscription-id'];
+
+        $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
+        $cacheItemProphecy->isHit()->willReturn(false);
+        $subscriptionId = 'subscriptionId';
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->willReturn($subscriptionId);
+        $cacheItemProphecy->set([[$subscriptionId, $fields, ['result']]])->shouldBeCalled();
+        $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
+        $this->subscriptionsCacheProphecy->save($cacheItemProphecy->reveal())->shouldBeCalled();
+
+        $this->assertSame($subscriptionId, $this->subscriptionManager->retrieveSubscriptionId($context, $result));
+    }
+
+    public function testRetrieveSubscriptionIdHitNotCached(): void
+    {
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $fields = ['fields'];
+        $infoProphecy->getFieldSelection(PHP_INT_MAX)->willReturn($fields);
+
+        $context = ['args' => ['input' => ['id' => '/foos/34']], 'info' => $infoProphecy->reveal(), 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+        $result = ['result', 'clientSubscriptionId' => 'client-subscription-id'];
+
+        $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
+        $cacheItemProphecy->isHit()->willReturn(true);
+        $cachedSubscriptions = [
+            ['subscriptionIdFoo', ['fieldsFoo'], ['resultFoo']],
+            ['subscriptionIdBar', ['fieldsBar'], ['resultBar']],
+        ];
+        $cacheItemProphecy->get()->willReturn($cachedSubscriptions);
+        $subscriptionId = 'subscriptionId';
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->willReturn($subscriptionId);
+        $cacheItemProphecy->set(array_merge($cachedSubscriptions, [[$subscriptionId, $fields, ['result']]]))->shouldBeCalled();
+        $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
+        $this->subscriptionsCacheProphecy->save($cacheItemProphecy->reveal())->shouldBeCalled();
+
+        $this->assertSame($subscriptionId, $this->subscriptionManager->retrieveSubscriptionId($context, $result));
+    }
+
+    public function testRetrieveSubscriptionIdHitCached(): void
+    {
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $fields = ['fieldsBar'];
+        $infoProphecy->getFieldSelection(PHP_INT_MAX)->willReturn($fields);
+
+        $context = ['args' => ['input' => ['id' => '/foos/34']], 'info' => $infoProphecy->reveal(), 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+        $result = ['result'];
+
+        $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
+        $cacheItemProphecy->isHit()->willReturn(true);
+        $cacheItemProphecy->get()->willReturn([
+            ['subscriptionIdFoo', ['fieldsFoo'], ['resultFoo']],
+            ['subscriptionIdBar', ['fieldsBar'], ['resultBar']],
+        ]);
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->shouldNotBeCalled();
+        $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
+
+        $this->assertSame('subscriptionIdBar', $this->subscriptionManager->retrieveSubscriptionId($context, $result));
+    }
+
+    public function testRetrieveSubscriptionIdHitCachedDifferentFieldsOrder(): void
+    {
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $fields = [
+            'third' => true,
+            'second' => [
+                'second' => true,
+                'third' => true,
+                'first' => true,
+            ],
+            'first' => true,
+        ];
+        $infoProphecy->getFieldSelection(PHP_INT_MAX)->willReturn($fields);
+
+        $context = ['args' => ['input' => ['id' => '/foos/34']], 'info' => $infoProphecy->reveal(), 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true];
+        $result = ['result'];
+
+        $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
+        $cacheItemProphecy->isHit()->willReturn(true);
+        $cacheItemProphecy->get()->willReturn([
+            ['subscriptionIdFoo', [
+                'first' => true,
+                'second' => [
+                    'first' => true,
+                    'second' => true,
+                    'third' => true,
+                ],
+                'third' => true,
+            ], ['resultFoo']],
+            ['subscriptionIdBar', ['fieldsBar'], ['resultBar']],
+        ]);
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->shouldNotBeCalled();
+        $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
+
+        $this->assertSame('subscriptionIdFoo', $this->subscriptionManager->retrieveSubscriptionId($context, $result));
+    }
+
+    public function testGetPushPayloadsNoHit(): void
+    {
+        $object = new Dummy();
+
+        $this->iriConverterProphecy->getIriFromItem($object)->willReturn('/dummies/2');
+
+        $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
+        $cacheItemProphecy->isHit()->willReturn(false);
+        $this->subscriptionsCacheProphecy->getItem('_dummies_2')->willReturn($cacheItemProphecy->reveal());
+
+        $this->assertSame([], $this->subscriptionManager->getPushPayloads($object));
+    }
+
+    public function testGetPushPayloadsHit(): void
+    {
+        $object = new Dummy();
+
+        $this->iriConverterProphecy->getIriFromItem($object)->willReturn('/dummies/2');
+
+        $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
+        $cacheItemProphecy->isHit()->willReturn(true);
+        $cacheItemProphecy->get()->willReturn([
+            ['subscriptionIdFoo', ['fieldsFoo'], ['resultFoo']],
+            ['subscriptionIdBar', ['fieldsBar'], ['resultBar']],
+        ]);
+        $this->subscriptionsCacheProphecy->getItem('_dummies_2')->willReturn($cacheItemProphecy->reveal());
+
+        $this->serializeStageProphecy->__invoke($object, Dummy::class, 'update', ['fields' => ['fieldsFoo'], 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true])->willReturn(['newResultFoo', 'clientSubscriptionId' => 'client-subscription-id']);
+        $this->serializeStageProphecy->__invoke($object, Dummy::class, 'update', ['fields' => ['fieldsBar'], 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true])->willReturn(['resultBar', 'clientSubscriptionId' => 'client-subscription-id']);
+
+        $this->assertSame([['subscriptionIdFoo', ['newResultFoo']]], $this->subscriptionManager->getPushPayloads($object));
+    }
+}

--- a/tests/GraphQl/Subscription/SubscriptionManagerTest.php
+++ b/tests/GraphQl/Subscription/SubscriptionManagerTest.php
@@ -68,7 +68,7 @@ class SubscriptionManagerTest extends TestCase
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
         $cacheItemProphecy->isHit()->willReturn(false);
         $subscriptionId = 'subscriptionId';
-        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->willReturn($subscriptionId);
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier($fields)->willReturn($subscriptionId);
         $cacheItemProphecy->set([[$subscriptionId, $fields, ['result']]])->shouldBeCalled();
         $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
         $this->subscriptionsCacheProphecy->save($cacheItemProphecy->reveal())->shouldBeCalled();
@@ -93,7 +93,7 @@ class SubscriptionManagerTest extends TestCase
         ];
         $cacheItemProphecy->get()->willReturn($cachedSubscriptions);
         $subscriptionId = 'subscriptionId';
-        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->willReturn($subscriptionId);
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier($fields)->willReturn($subscriptionId);
         $cacheItemProphecy->set(array_merge($cachedSubscriptions, [[$subscriptionId, $fields, ['result']]]))->shouldBeCalled();
         $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
         $this->subscriptionsCacheProphecy->save($cacheItemProphecy->reveal())->shouldBeCalled();
@@ -116,7 +116,7 @@ class SubscriptionManagerTest extends TestCase
             ['subscriptionIdFoo', ['fieldsFoo'], ['resultFoo']],
             ['subscriptionIdBar', ['fieldsBar'], ['resultBar']],
         ]);
-        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->shouldNotBeCalled();
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier($fields)->shouldNotBeCalled();
         $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
 
         $this->assertSame('subscriptionIdBar', $this->subscriptionManager->retrieveSubscriptionId($context, $result));
@@ -153,7 +153,7 @@ class SubscriptionManagerTest extends TestCase
             ], ['resultFoo']],
             ['subscriptionIdBar', ['fieldsBar'], ['resultBar']],
         ]);
-        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier()->shouldNotBeCalled();
+        $this->subscriptionIdentifierGeneratorProphecy->generateSubscriptionIdentifier($fields)->shouldNotBeCalled();
         $this->subscriptionsCacheProphecy->getItem('_foos_34')->shouldBeCalled()->willReturn($cacheItemProphecy->reveal());
 
         $this->assertSame('subscriptionIdFoo', $this->subscriptionManager->retrieveSubscriptionId($context, $result));

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -65,7 +65,7 @@ class SchemaBuilderTest extends TestCase
     /**
      * @dataProvider schemaProvider
      */
-    public function testGetSchema(string $resourceClass, ResourceMetadata $resourceMetadata, ObjectType $expectedQueryType, ?ObjectType $expectedMutationType): void
+    public function testGetSchema(string $resourceClass, ResourceMetadata $resourceMetadata, ObjectType $expectedQueryType, ?ObjectType $expectedMutationType, ?ObjectType $expectedSubscriptionType): void
     {
         $type = $this->prophesize(GraphQLType::class)->reveal();
         $type->name = 'MyType';
@@ -81,6 +81,8 @@ class SchemaBuilderTest extends TestCase
         $this->fieldsBuilderProphecy->getItemQueryFields($resourceClass, $resourceMetadata, 'custom_item_query', ['item_query' => 'item_query_resolver'])->willReturn(['custom_item_query' => ['custom_item_query_fields']]);
         $this->fieldsBuilderProphecy->getCollectionQueryFields($resourceClass, $resourceMetadata, 'custom_collection_query', ['collection_query' => 'collection_query_resolver'])->willReturn(['custom_collection_query' => ['custom_collection_query_fields']]);
         $this->fieldsBuilderProphecy->getMutationFields($resourceClass, $resourceMetadata, 'mutation')->willReturn(['mutation' => ['mutation_fields']]);
+        $this->fieldsBuilderProphecy->getMutationFields($resourceClass, $resourceMetadata, 'update')->willReturn(['mutation' => ['mutation_fields']]);
+        $this->fieldsBuilderProphecy->getSubscriptionFields($resourceClass, $resourceMetadata, 'update')->willReturn(['subscription' => ['subscription_fields']]);
 
         $this->resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([$resourceClass]));
         $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn($resourceMetadata);
@@ -88,6 +90,7 @@ class SchemaBuilderTest extends TestCase
         $schema = $this->schemaBuilder->getSchema();
         $this->assertEquals($expectedQueryType, $schema->getQueryType());
         $this->assertEquals($expectedMutationType, $schema->getMutationType());
+        $this->assertEquals($expectedSubscriptionType, $schema->getSubscriptionType());
         $this->assertEquals($type, $schema->getType('MyType'));
         $this->assertEquals($typeFoo, $schema->getType('Foo'));
     }
@@ -101,7 +104,7 @@ class SchemaBuilderTest extends TestCase
                     'fields' => [
                         'node' => ['node_fields'],
                     ],
-                ]), null,
+                ]), null, null,
             ],
             'item query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['item_query' => []]),
                 new ObjectType([
@@ -110,7 +113,7 @@ class SchemaBuilderTest extends TestCase
                         'node' => ['node_fields'],
                         'query' => ['query_fields'],
                     ],
-                ]), null,
+                ]), null, null,
             ],
             'collection query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['collection_query' => []]),
                 new ObjectType([
@@ -119,7 +122,7 @@ class SchemaBuilderTest extends TestCase
                         'node' => ['node_fields'],
                         'query' => ['query_fields'],
                     ],
-                ]), null,
+                ]), null, null,
             ],
             'custom item query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['custom_item_query' => ['item_query' => 'item_query_resolver']]),
                 new ObjectType([
@@ -128,7 +131,7 @@ class SchemaBuilderTest extends TestCase
                         'node' => ['node_fields'],
                         'custom_item_query' => ['custom_item_query_fields'],
                     ],
-                ]), null,
+                ]), null, null,
             ],
             'custom collection query' => ['resourceClass', (new ResourceMetadata())->withGraphql(['custom_collection_query' => ['collection_query' => 'collection_query_resolver']]),
                 new ObjectType([
@@ -137,7 +140,7 @@ class SchemaBuilderTest extends TestCase
                         'node' => ['node_fields'],
                         'custom_collection_query' => ['custom_collection_query_fields'],
                     ],
-                ]), null,
+                ]), null, null,
             ],
             'mutation' => ['resourceClass', (new ResourceMetadata())->withGraphql(['mutation' => []]),
                 new ObjectType([
@@ -150,6 +153,27 @@ class SchemaBuilderTest extends TestCase
                     'name' => 'Mutation',
                     'fields' => [
                         'mutation' => ['mutation_fields'],
+                    ],
+                ]),
+                null,
+            ],
+            'subscription' => ['resourceClass', (new ResourceMetadata())->withGraphql(['update' => []]),
+                new ObjectType([
+                    'name' => 'Query',
+                    'fields' => [
+                        'node' => ['node_fields'],
+                    ],
+                ]),
+                new ObjectType([
+                    'name' => 'Mutation',
+                    'fields' => [
+                        'mutation' => ['mutation_fields'],
+                    ],
+                ]),
+                new ObjectType([
+                    'name' => 'Subscription',
+                    'fields' => [
+                        'subscription' => ['subscription_fields'],
                     ],
                 ]),
             ],

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -81,7 +81,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, 'item_query', null);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, 'item_query', null, null);
         $this->assertSame('shortName', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -89,7 +89,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('fields', $resourceObjectType->config);
 
         $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
-        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, 'item_query', null, 0, null)->shouldBeCalled();
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, 'item_query', null, null, 0, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $resourceObjectType->config['fields']();
     }
@@ -104,7 +104,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, 'item_query', null);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, 'item_query', null, null);
         $this->assertSame('shortName', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -112,7 +112,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('fields', $resourceObjectType->config);
 
         $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
-        $fieldsBuilderProphecy->getResourceObjectTypeFields('outputClass', $resourceMetadata, false, 'item_query', null, 0, ['class' => 'outputClass'])->shouldBeCalled();
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('outputClass', $resourceMetadata, false, 'item_query', null, null, 0, ['class' => 'outputClass'])->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $resourceObjectType->config['fields']();
     }
@@ -133,7 +133,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, $queryName, null);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, $queryName, null, null);
         $this->assertSame($shortName, $resourceObjectType->name);
     }
 
@@ -170,7 +170,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var NonNull $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, true, null, 'custom');
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, true, null, 'custom', null);
         /** @var InputObjectType $wrappedType */
         $wrappedType = $resourceObjectType->getWrappedType();
         $this->assertInstanceOf(InputObjectType::class, $wrappedType);
@@ -180,7 +180,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
         $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
-        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, true, null, 'custom', 0, null)->shouldBeCalled();
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, true, null, 'custom', null, 0, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $wrappedType->config['fields']();
     }
@@ -195,7 +195,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var NonNull $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, true, null, 'custom');
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, true, null, 'custom', null);
         /** @var InputObjectType $wrappedType */
         $wrappedType = $resourceObjectType->getWrappedType();
         $this->assertInstanceOf(InputObjectType::class, $wrappedType);
@@ -205,7 +205,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
         $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
-        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, true, null, 'custom', 0, null)
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, true, null, 'custom', null, 0, null)
             ->shouldBeCalled()->willReturn(['clientMutationId' => GraphQLType::string()]);
         $fieldsBuilderProphecy->resolveResourceArgs([], 'custom', 'shortName')->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
@@ -221,7 +221,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create');
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create', null);
         $this->assertSame('createShortNamePayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -252,7 +252,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create');
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create', null);
         $this->assertSame('createShortNamePayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -278,7 +278,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
         $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
-        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, 'create', 0, null)->shouldBeCalled();
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, 'create', null, 0, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $wrappedType->config['fields']();
     }
@@ -292,7 +292,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create', false, 1);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, 'create', null, false, 1);
         $this->assertSame('createShortNameNestedPayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -300,7 +300,103 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('fields', $resourceObjectType->config);
 
         $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
-        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, 'create', 1, null)->shouldBeCalled();
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, 'create', null, 1, null)->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $resourceObjectType->config['fields']();
+    }
+
+    public function testGetResourceObjectTypeSubscription(): void
+    {
+        $resourceMetadata = (new ResourceMetadata('shortName', 'description'))->withAttributes(['mercure' => true]);
+        $this->typesContainerProphecy->has('updateShortNameSubscriptionPayload')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('updateShortNameSubscriptionPayload', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, null, 'update');
+        $this->assertSame('updateShortNameSubscriptionPayload', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertSame([], $resourceObjectType->config['interfaces']);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        // Recursive call (not using wrapped type)
+        $this->typesContainerProphecy->has('shortName')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('shortName', Argument::type(ObjectType::class))->shouldBeCalled();
+
+        $fieldsType = $resourceObjectType->config['fields']();
+        $this->assertArrayHasKey('shortName', $fieldsType);
+        $this->assertArrayHasKey('clientSubscriptionId', $fieldsType);
+        $this->assertArrayHasKey('mercureUrl', $fieldsType);
+        $this->assertSame(GraphQLType::string(), $fieldsType['clientSubscriptionId']);
+        $this->assertSame(GraphQLType::string(), $fieldsType['mercureUrl']);
+    }
+
+    public function testGetResourceObjectTypeSubscriptionWrappedType(): void
+    {
+        $resourceMetadata = (new ResourceMetadata('shortName', 'description'))
+            ->withGraphql([
+                'item_query' => ['normalization_context' => ['groups' => ['item_query']]],
+                'update' => ['normalization_context' => ['groups' => ['update']]],
+            ]);
+        $this->typesContainerProphecy->has('updateShortNameSubscriptionPayload')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('updateShortNameSubscriptionPayload', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, null, 'update');
+        $this->assertSame('updateShortNameSubscriptionPayload', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertSame([], $resourceObjectType->config['interfaces']);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        // Recursive call (using wrapped type)
+        $this->typesContainerProphecy->has('updateShortNameSubscriptionPayloadData')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('updateShortNameSubscriptionPayloadData', Argument::type(ObjectType::class))->shouldBeCalled();
+
+        $fieldsType = $resourceObjectType->config['fields']();
+        $this->assertArrayHasKey('shortName', $fieldsType);
+        $this->assertArrayHasKey('clientSubscriptionId', $fieldsType);
+        $this->assertArrayNotHasKey('mercureUrl', $fieldsType);
+        $this->assertSame(GraphQLType::string(), $fieldsType['clientSubscriptionId']);
+
+        /** @var ObjectType $wrappedType */
+        $wrappedType = $fieldsType['shortName'];
+        $this->assertSame('updateShortNameSubscriptionPayloadData', $wrappedType->name);
+        $this->assertSame('description', $wrappedType->description);
+        $this->assertSame($this->defaultFieldResolver, $wrappedType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $wrappedType->config);
+        $this->assertArrayHasKey('fields', $wrappedType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, null, 'update', 0, null)->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $wrappedType->config['fields']();
+    }
+
+    public function testGetResourceObjectTypeSubscriptionNested(): void
+    {
+        $resourceMetadata = (new ResourceMetadata('shortName', 'description'))->withAttributes(['mercure' => true]);
+        $this->typesContainerProphecy->has('updateShortNameSubscriptionNestedPayload')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('updateShortNameSubscriptionNestedPayload', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var ObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, false, null, null, 'update', false, 1);
+        $this->assertSame('updateShortNameSubscriptionNestedPayload', $resourceObjectType->name);
+        $this->assertSame('description', $resourceObjectType->description);
+        $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
+        $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $resourceMetadata, false, null, null, 'update', 1, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $resourceObjectType->config['fields']();
     }

--- a/tests/GraphQl/Type/TypeConverterTest.php
+++ b/tests/GraphQl/Type/TypeConverterTest.php
@@ -63,7 +63,7 @@ class TypeConverterTest extends TestCase
     {
         $this->typeBuilderProphecy->isCollection($type)->willReturn(false);
 
-        $graphqlType = $this->typeConverter->convertType($type, $input, null, null, 'resourceClass', 'rootClass', null, $depth);
+        $graphqlType = $this->typeConverter->convertType($type, $input, null, null, null, 'resourceClass', 'rootClass', null, $depth);
         $this->assertEquals($expectedGraphqlType, $graphqlType);
     }
 
@@ -92,7 +92,7 @@ class TypeConverterTest extends TestCase
         $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(false);
         $this->resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn(new ResourceMetadata());
 
-        $graphqlType = $this->typeConverter->convertType($type, false, null, null, 'resourceClass', 'rootClass', null, 0);
+        $graphqlType = $this->typeConverter->convertType($type, false, null, null, null, 'resourceClass', 'rootClass', null, 0);
         $this->assertNull($graphqlType);
     }
 
@@ -103,7 +103,7 @@ class TypeConverterTest extends TestCase
         $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(false);
         $this->resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willThrow(new ResourceClassNotFoundException());
 
-        $graphqlType = $this->typeConverter->convertType($type, false, null, null, 'resourceClass', 'rootClass', null, 0);
+        $graphqlType = $this->typeConverter->convertType($type, false, null, null, null, 'resourceClass', 'rootClass', null, 0);
         $this->assertNull($graphqlType);
     }
 
@@ -115,9 +115,9 @@ class TypeConverterTest extends TestCase
 
         $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(true);
         $this->resourceMetadataFactoryProphecy->create('dummyValue')->shouldBeCalled()->willReturn($graphqlResourceMetadata);
-        $this->typeBuilderProphecy->getResourceObjectType('dummyValue', $graphqlResourceMetadata, false, null, null, false, 0)->shouldBeCalled()->willReturn($expectedGraphqlType);
+        $this->typeBuilderProphecy->getResourceObjectType('dummyValue', $graphqlResourceMetadata, false, null, null, null, false, 0)->shouldBeCalled()->willReturn($expectedGraphqlType);
 
-        $graphqlType = $this->typeConverter->convertType($type, false, null, null, 'resourceClass', 'rootClass', null, 0);
+        $graphqlType = $this->typeConverter->convertType($type, false, null, null, null, 'resourceClass', 'rootClass', null, 0);
         $this->assertEquals($expectedGraphqlType, $graphqlType);
     }
 

--- a/tests/Util/SortTraitTest.php
+++ b/tests/Util/SortTraitTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Util;
+
+use ApiPlatform\Core\Util\SortTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+class SortTraitTest extends TestCase
+{
+    private function getSortTraitImplementation()
+    {
+        return new class() {
+            use SortTrait {
+                SortTrait::arrayRecursiveSort as public;
+            }
+        };
+    }
+
+    public function testArrayRecursiveSort(): void
+    {
+        $sortTrait = $this->getSortTraitImplementation();
+
+        $array = [
+            'second',
+            [
+                'second',
+                'first',
+            ],
+            'first',
+        ];
+
+        $sortTrait->arrayRecursiveSort($array, 'sort');
+
+        $this->assertSame([
+            'first',
+            'second',
+            [
+                'first',
+                'second',
+            ],
+        ], $array);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3124 
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/1034

[GraphQL Subscriptions](https://github.com/graphql/graphql-spec/blob/master/rfcs/Subscriptions.md) in API Platform will use [Mercure](https://github.com/dunglas/mercure) as the underlying protocol (for the first version) with this PR.

Only the **update** subscription is available. Maybe the delete subscription would be useful too but it could be done later.

A subscription can be done like this:
```graphql
subscription {
  updateDummyMercureSubscribe(input: {id: "/dummy_mercures/1", clientSubscriptionId: "myId"}) {
    dummyMercure {
      id
      name
      relatedDummy {
        name
      }
    }
    mercureUrl
    clientSubscriptionId
  }
}
```

In the JSON response (in `mercureUrl` field), you will receive an URL like this:
`https://demo.mercure.rocks/hub?topic=http://example.com/subscriptions/fc806a60cca4e93544d555912ce8b549`

This URL is used by the Mercure protocol to subscribe to updates by using [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events):
```js
const eventSource = new EventSource(mercureUrl);

// The callback will be called every time an update is published
eventSource.onmessage = e => console.log(e); // do something with the payload
```

To enable subscriptions for a resource, follow the [related Mercure documentation](https://api-platform.com/docs/core/mercure). It mainly consists of adding this annotation:
```php
use ApiPlatform\Core\Annotation\ApiResource;

/**
 * @ApiResource(mercure=true)
 */
class Book
{
    // ...
}
```

You will only receive the update if the payload you have given when subscribing has changed.
To do so, a [Symfony cache](https://symfony.com/doc/current/cache.html) is used to store the subscriptions and their payloads:
`api_platform.graphql.cache.subscription`.
The best way to store the subscriptions is to use an adapter like Redis.

An Apollo transport like this one: https://github.com/CodeCommission/subscriptions-transport-sse could be written later in order to make it work seamlessly with Apollo.