### PR TITLE
Fix ResourceAccessCheckerTest

### DIFF
--- a/tests/Security/ResourceAccessCheckerTest.php
+++ b/tests/Security/ResourceAccessCheckerTest.php
@@ -39,11 +39,15 @@ class ResourceAccessCheckerTest extends TestCase
         $tokenStorageProphecy = $this->prophesize(TokenStorageInterface::class);
 
         $tokenProphecy = $this->prophesize(TokenInterface::class);
+        $token = $tokenProphecy->reveal();
         $tokenProphecy->getUser()->shouldBeCalled();
-        $tokenProphecy->getRoles()->willReturn([])->shouldBeCalled();
-        $tokenProphecy->reveal();
+        if (method_exists($token, 'getRoleNames')) {
+            $tokenProphecy->getRoleNames()->willReturn([])->shouldBeCalled();
+        } else {
+            $tokenProphecy->getRoles()->willReturn([])->shouldBeCalled();
+        }
 
-        $tokenStorageProphecy->getToken()->willReturn($tokenProphecy);
+        $tokenStorageProphecy->getToken()->willReturn($token);
 
         $checker = new ResourceAccessChecker($expressionLanguageProphecy->reveal(), $authenticationTrustResolverProphecy->reveal(), null, $tokenStorageProphecy->reveal());
         $this->assertSame($granted, $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Funny bug!

In the `TokenInterface` (https://github.com/symfony/symfony/blob/v4.4.2/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php), there is a method only defined in the doc block annotation:
```php
 * @method string[] getRoleNames()
```
https://github.com/symfony/symfony/blob/5973dacbd9587d9bf1234dfcb546c3cbdfbc4c9e/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php#L24

Because of the new release of https://github.com/phpDocumentor/ReflectionDocBlock, and particularly this PR: https://github.com/phpDocumentor/ReflectionDocBlock/pull/188, this method is now considered by Prophecy whereas it was not the case before (and it was not the case because... the method has no argument :smile:)!

So in the test we need to mock this method instead because we call `method_exists` on the prophesized token:
https://github.com/api-platform/core/blob/c593d41e080c69b4e68eed76d126df0723398ab8/src/Security/ResourceAccessChecker.php#L84