### PR TITLE
[GraphQL] Better detection of collection types

### DIFF
--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -224,6 +224,6 @@ final class TypeBuilder implements TypeBuilderInterface
      */
     public function isCollection(Type $type): bool
     {
-        return $type->isCollection() && Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType();
+        return $type->isCollection() && ($collectionValueType = $type->getCollectionValueType()) && null !== $collectionValueType->getClassName();
     }
 }

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -384,7 +384,12 @@ class TypeBuilderTest extends TestCase
             [new Type(Type::BUILTIN_TYPE_BOOL), false],
             [new Type(Type::BUILTIN_TYPE_OBJECT), false],
             [new Type(Type::BUILTIN_TYPE_RESOURCE, false, null, false), false],
-            [new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true), true],
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true), false],
+            [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true), false],
+            [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT)), false],
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'className', true), false],
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'className')), true],
+            [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'className')), true],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #https://github.com/api-platform/api-platform/issues/1043 #https://github.com/api-platform/api-platform/issues/836
| License       | MIT
| Doc PR        | N/A

It seems some people were having issues when not using Doctrine and when a resource had a collection property.
In this case, the `DoctrineExtractor` (https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php) is not used and the `PhpDocExtractor` (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php) is used instead.

The best way to detect if a type is a collection is to see if the value type has a classname.

It's a long way from https://github.com/api-platform/core/pull/1746 :sweat_smile: