### PR TITLE
Passing custom doctrine type to addWhereByStrategy

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -168,11 +168,11 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         if (1 === \count($values)) {
             $queryBuilder
                 ->andWhere(sprintf('%s.%s = :%s', $associationAlias, $associationField, $valueParameter))
-                ->setParameter($valueParameter, $values[0]);
+                ->setParameter($valueParameter, $values[0], $doctrineTypeField);
         } else {
             $queryBuilder
                 ->andWhere(sprintf('%s.%s IN (:%s)', $associationAlias, $associationField, $valueParameter))
-                ->setParameter($valueParameter, $values);
+                ->setParameter($valueParameter, $values, $doctrineTypeField);
         }
     }
 

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -92,12 +92,11 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         $caseSensitive = true;
         $metadata = $this->getNestedMetadata($resourceClass, $associations);
 
-        if ($metadata->hasField($field)) {
-            if ('id' === $field) {
-                $values = array_map([$this, 'getIdFromValue'], $values);
-            }
+        $doctrineTypeField = $this->getDoctrineFieldType($property, $resourceClass);
+        $values = array_map([$this, 'getIdFromValue'], $values);
 
-            if (!$this->hasValidValues($values, $this->getDoctrineFieldType($property, $resourceClass))) {
+        if ($metadata->hasField($field)) {
+            if (!$this->hasValidValues($values, $doctrineTypeField)) {
                 $this->logger->notice('Invalid filter ignored', [
                     'exception' => new InvalidArgumentException(sprintf('Values for field "%s" are not valid according to the doctrine type.', $field)),
                 ]);
@@ -114,7 +113,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
             }
 
             if (1 === \count($values)) {
-                $this->addWhereByStrategy($strategy, $queryBuilder, $queryNameGenerator, $alias, $field, $values[0], $caseSensitive);
+                $this->addWhereByStrategy($strategy, $queryBuilder, $queryNameGenerator, $alias, $field, $doctrineTypeField, $values[0], $caseSensitive);
 
                 return;
             }
@@ -140,9 +139,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
             return;
         }
 
-        $values = array_map([$this, 'getIdFromValue'], $values);
         $associationFieldIdentifier = 'id';
-        $doctrineTypeField = $this->getDoctrineFieldType($property, $resourceClass);
 
         if (null !== $this->identifiersExtractor) {
             $associationResourceClass = $metadata->getAssociationTargetClass($field);
@@ -184,7 +181,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
      *
      * @throws InvalidArgumentException If strategy does not exist
      */
-    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, $value, bool $caseSensitive)
+    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, string $fieldType, $value, bool $caseSensitive)
     {
         $wrapCase = $this->createWrapCase($caseSensitive);
         $valueParameter = $queryNameGenerator->generateParameterName($field);
@@ -194,27 +191,27 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
             case self::STRATEGY_EXACT:
                 $queryBuilder
                     ->andWhere(sprintf($wrapCase('%s.%s').' = '.$wrapCase(':%s'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
+                    ->setParameter($valueParameter, $value, $fieldType);
                 break;
             case self::STRATEGY_PARTIAL:
                 $queryBuilder
                     ->andWhere(sprintf($wrapCase('%s.%s').' LIKE '.$wrapCase('CONCAT(\'%%\', :%s, \'%%\')'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
+                    ->setParameter($valueParameter, $value, $fieldType);
                 break;
             case self::STRATEGY_START:
                 $queryBuilder
                     ->andWhere(sprintf($wrapCase('%s.%s').' LIKE '.$wrapCase('CONCAT(:%s, \'%%\')'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
+                    ->setParameter($valueParameter, $value, $fieldType);
                 break;
             case self::STRATEGY_END:
                 $queryBuilder
                     ->andWhere(sprintf($wrapCase('%s.%s').' LIKE '.$wrapCase('CONCAT(\'%%\', :%s)'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
+                    ->setParameter($valueParameter, $value, $fieldType);
                 break;
             case self::STRATEGY_WORD_START:
                 $queryBuilder
                     ->andWhere(sprintf($wrapCase('%1$s.%2$s').' LIKE '.$wrapCase('CONCAT(:%3$s, \'%%\')').' OR '.$wrapCase('%1$s.%2$s').' LIKE '.$wrapCase('CONCAT(\'%% \', :%3$s, \'%%\')'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
+                    ->setParameter($valueParameter, $value, $fieldType);
                 break;
             default:
                 throw new InvalidArgumentException(sprintf('strategy %s does not exist.', $strategy));

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -181,7 +181,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
      *
      * @throws InvalidArgumentException If strategy does not exist
      */
-    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, string $fieldType, $value, bool $caseSensitive)
+    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, $fieldType, $value, bool $caseSensitive)
     {
         $wrapCase = $this->createWrapCase($caseSensitive);
         $valueParameter = $queryNameGenerator->generateParameterName($field);


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When using`uuid_binary_ordered_time` (ramsey/uuid) as PK and then trying to filter list by `association.id`
ORM is not calling`UuidBinaryOrderedTimeType` because type is not passed to QueryBuilder parameters.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
