### PR TITLE
[OpenApi] [Oauth] Fix render oauth when using OpenApi v3

### DIFF
--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -639,7 +639,10 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
 
             $securityDefinitions['oauth'] = [
                 'type' => $this->oauthType,
-                'description' => 'OAuth client_credentials Grant',
+                'description' => sprintf(
+                    'OAuth 2.0 %s Grant',
+                    strtolower(preg_replace('/[A-Z]/', ' \\0', lcfirst($this->oauthFlow)))
+                ),
             ];
 
             if ($v3) {

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -631,14 +631,25 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $security = [];
 
         if ($this->oauthEnabled) {
-            $securityDefinitions['oauth'] = [
-                'type' => $this->oauthType,
-                'description' => 'OAuth client_credentials Grant',
-                'flow' => $this->oauthFlow,
+            $oauthAttributes = [
                 'tokenUrl' => $this->oauthTokenUrl,
                 'authorizationUrl' => $this->oauthAuthorizationUrl,
                 'scopes' => $this->oauthScopes,
             ];
+
+            $securityDefinitions['oauth'] = [
+                'type' => $this->oauthType,
+                'description' => 'OAuth client_credentials Grant',
+            ];
+
+            if ($v3) {
+                $securityDefinitions['oauth']['flows'] = [
+                    $this->oauthFlow => $oauthAttributes,
+                ];
+            } else {
+                $securityDefinitions['oauth']['flow'] = $this->oauthFlow;
+                $securityDefinitions['oauth'] = array_merge($securityDefinitions['oauth'], $oauthAttributes);
+            }
 
             $security[] = ['oauth' => []];
         }

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -492,7 +492,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'securityDefinitions' => [
                 'oauth' => [
                     'type' => 'oauth2',
-                    'description' => 'OAuth client_credentials Grant',
+                    'description' => 'OAuth 2.0 application Grant',
                     'flow' => 'application',
                     'tokenUrl' => '/oauth/v2/token',
                     'authorizationUrl' => '/oauth/v2/auth',

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -483,7 +483,7 @@ class DocumentationNormalizerV3Test extends TestCase
             $legacy ? $nameConverter : null,
             true,
             'oauth2',
-            'application',
+            'authorizationCode',
             '/oauth/v2/token',
             '/oauth/v2/auth',
             ['scope param'],
@@ -554,9 +554,9 @@ class DocumentationNormalizerV3Test extends TestCase
                 'securitySchemes' => [
                     'oauth' => [
                         'type' => 'oauth2',
-                        'description' => 'OAuth client_credentials Grant',
+                        'description' => 'OAuth 2.0 authorization code Grant',
                         'flows' => [
-                            'application' => [
+                            'authorizationCode' => [
                                 'tokenUrl' => '/oauth/v2/token',
                                 'authorizationUrl' => '/oauth/v2/auth',
                                 'scopes' => ['scope param'],

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -555,10 +555,13 @@ class DocumentationNormalizerV3Test extends TestCase
                     'oauth' => [
                         'type' => 'oauth2',
                         'description' => 'OAuth client_credentials Grant',
-                        'flow' => 'application',
-                        'tokenUrl' => '/oauth/v2/token',
-                        'authorizationUrl' => '/oauth/v2/auth',
-                        'scopes' => ['scope param'],
+                        'flows' => [
+                            'application' => [
+                                'tokenUrl' => '/oauth/v2/token',
+                                'authorizationUrl' => '/oauth/v2/auth',
+                                'scopes' => ['scope param'],
+                            ],
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

Following the documentation for Oauth in OAS3 (https://swagger.io/docs/specification/authentication/oauth2/), flows now need to be an array.

This fix turn this
![image](https://user-images.githubusercontent.com/3168281/71641786-c2eead00-2ca1-11ea-91cf-69142e42e560.png)
in this
![image](https://user-images.githubusercontent.com/3168281/71641798-de59b800-2ca1-11ea-862f-d974f50960d8.png)

I kept the current behaviour for swagger v2.