### PR TITLE
#3316: local cache on AbstractItemNormalizer::getAllowedAttributes()

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -50,6 +50,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 {
+    use CacheKeyTrait;
     use ClassInfoTrait;
     use ContextTrait;
     use InputOutputMetadataTrait;
@@ -66,6 +67,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     protected $allowPlainIdentifiers;
     protected $dataTransformers = [];
     protected $localCache = [];
+    protected $allowedAttributesCache = [];
 
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, array $defaultContext = [], iterable $dataTransformers = [], ResourceMetadataFactoryInterface $resourceMetadataFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null)
     {
@@ -354,6 +356,11 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     protected function getAllowedAttributes($classOrObject, array $context, $attributesAsString = false)
     {
         $options = $this->getFactoryOptions($context);
+        $cacheKey = $this->getCacheKey(null, $context);
+
+        if (isset($this->allowedAttributesCache[$cacheKey])) {
+            return $this->allowedAttributesCache[$cacheKey];
+        }
         $propertyNames = $this->propertyNameCollectionFactory->create($context['resource_class'], $options);
 
         $allowedAttributes = [];
@@ -371,7 +378,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             }
         }
 
-        return $allowedAttributes;
+        return $this->allowedAttributesCache[$cacheKey] = $allowedAttributes;
     }
 
     /**

--- a/src/Serializer/CacheKeyTrait.php
+++ b/src/Serializer/CacheKeyTrait.php
@@ -24,10 +24,14 @@ trait CacheKeyTrait
             unset($context[$key]);
         }
         unset($context[self::EXCLUDE_FROM_CACHE_KEY]);
+        unset($context[self::OBJECT_TO_POPULATE]);
         unset($context['cache_key']); // avoid artificially different keys
 
         try {
-            return md5($format.serialize($context));
+            return md5($format.serialize([
+                'context' => $context,
+                'ignored' => $context[self::IGNORED_ATTRIBUTES] ?? $this->defaultContext[self::IGNORED_ATTRIBUTES],
+            ]));
         } catch (\Exception $exception) {
             // The context cannot be serialized, skip the cache
             return false;


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no (performance)
| New feature?  | hmm (performance)
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3316 
| License       | MIT
| Doc PR        | 

The code of getAllowedAttributes is quite heavy and relate on a lot of micro cache, despite being a medium hot path.

Just add a local cache on it, but this is a draft. The cache key only relates on `$options` that I don't think is enough. Relates on `$context` isn't possible because of `$context['cache_Key']`. Should I just remove it and pass ĉontext ?

![image](https://user-images.githubusercontent.com/84887/72207881-05cc3400-349d-11ea-97e0-d6fc18dabd3a.png)
