### PR TITLE
Allow to autoconfigure validation groups generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * GraphQL: Allow to format GraphQL errors based on exceptions (#3063)
 * GraphQL: Add page-based pagination (#3175)
 * OpenAPI: Add PHP default values to the documentation (#2386)
+* Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 
 ## 2.5.x-dev
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -24,6 +24,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter as DoctrineOrmAbstractContextAwareFilter;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Extension\RequestBodySearchCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRestrictionMetadataInterface;
+use ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
@@ -554,8 +555,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     {
         if (interface_exists(ValidatorInterface::class)) {
             $loader->load('validator.xml');
+
+            $container->registerForAutoconfiguration(ValidationGroupsGeneratorInterface::class)
+                ->addTag('api_platform.validation_groups_generator')
+                ->setPublic(true); // this line should be removed in 3.0
             $container->registerForAutoconfiguration(PropertySchemaRestrictionMetadataInterface::class)
-                      ->addTag('api_platform.metadata.property_schema_restriction');
+                ->addTag('api_platform.metadata.property_schema_restriction');
         }
 
         if (!$config['validator']) {

--- a/src/Bridge/Symfony/Validator/ValidationGroupsGeneratorInterface.php
+++ b/src/Bridge/Symfony/Validator/ValidationGroupsGeneratorInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Validator;
+
+use Symfony\Component\Validator\Constraints\GroupSequence;
+
+/**
+ * Generates validation groups for an object.
+ *
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+interface ValidationGroupsGeneratorInterface
+{
+    /**
+     * @param object $object
+     *
+     * @return GroupSequence|string[]
+     */
+    public function __invoke($object);
+}

--- a/src/Bridge/Symfony/Validator/Validator.php
+++ b/src/Bridge/Symfony/Validator/Validator.php
@@ -50,6 +50,10 @@ class Validator implements ValidatorInterface
                 ($service = $this->container->get($validationGroups)) &&
                 \is_callable($service)
             ) {
+                if (!$service instanceof ValidationGroupsGeneratorInterface) {
+                    @trigger_error(sprintf('Using a public validation groups generator service not implementing "%s" is deprecated since 2.6 and will be removed in 3.0.', ValidationGroupsGeneratorInterface::class), E_USER_DEPRECATED);
+                }
+
                 $validationGroups = $service($data);
             } elseif (\is_callable($validationGroups)) {
                 $validationGroups = $validationGroups($data);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -56,6 +56,7 @@ use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\TermFilter;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension;
 use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRestrictionMetadataInterface;
+use ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
@@ -1090,6 +1091,10 @@ class ApiPlatformExtensionTest extends TestCase
             ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
         $this->childDefinitionProphecy->setBindings(['$requestStack' => null])->shouldBeCalledTimes(1);
 
+        $containerBuilderProphecy->registerForAutoconfiguration(ValidationGroupsGeneratorInterface::class)
+            ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
+        $this->childDefinitionProphecy->addTag('api_platform.validation_groups_generator')->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
+
         $containerBuilderProphecy->registerForAutoconfiguration(PropertySchemaRestrictionMetadataInterface::class)
             ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
         $this->childDefinitionProphecy->addTag('api_platform.metadata.property_schema_restriction')->shouldBeCalledTimes(1);
@@ -1384,6 +1389,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->getDefinition('api_platform.doctrine.orm.listener.mercure.publish')->willReturn($definitionDummy);
         $containerBuilderProphecy->getDefinition('api_platform.doctrine_mongodb.odm.listener.mercure.publish')->willReturn($definitionDummy);
         $containerBuilderProphecy->getDefinition('api_platform.graphql.subscription.mercure_iri_generator')->willReturn($definitionDummy);
+        $this->childDefinitionProphecy->setPublic(true)->will(function () {});
 
         return $containerBuilderProphecy;
     }

--- a/tests/Fixtures/TestBundle/Validator/DummyValidationGroupsGenerator.php
+++ b/tests/Fixtures/TestBundle/Validator/DummyValidationGroupsGenerator.php
@@ -13,11 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Validator;
 
+use ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 
-class DummyValidationGroupsGenerator
+final class DummyValidationGroupsGenerator implements ValidationGroupsGeneratorInterface
 {
-    public function __invoke()
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke($object): GroupSequence
     {
         return new GroupSequence(['b', 'a']);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | api-platform/docs#1023

When having many validation groups generators for resources, you need to make every generator as a public service, and this doesn't work with `_instanceof` configuration where you could add a custom marker and make those services public, because symfony doesn't detect that those services are used and removes from container.

This adds `ApiPlatform\Core\Validator\ValidationGroupsGeneratorInterface` so apps can leverage the autoconfiguration + autowiring of those generators. Generators are collected and registered in a custom service locator, but consumers won't need anymore any configuration for them if will implement the interface. For not breaking backwards compatibility left the full service container as a fallback.

TODO:
- [x] Add more tests if needed?
- [x] Make docs PR
