### PR TITLE
Fix class not found schema factory (do not merge)

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -69,7 +69,7 @@ final class SchemaFactory implements SchemaFactoryInterface
     public function buildSchema(string $className, string $format = 'json', string $type = Schema::TYPE_OUTPUT, ?string $operationType = null, ?string $operationName = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
     {
         $schema = $schema ?? new Schema();
-        if (null === $metadata = $this->getMetadata($className, $type, $operationType, $operationName, $serializerContext)) {
+        if (!class_exists($className) || null === $metadata = $this->getMetadata($className, $type, $operationType, $operationName, $serializerContext)) {
             return $schema;
         }
         [$resourceMetadata, $serializerContext, $inputOrOutputClass] = $metadata;
@@ -214,6 +214,7 @@ final class SchemaFactory implements SchemaFactoryInterface
         [$resourceMetadata, $serializerContext, $inputOrOutputClass] = $this->getMetadata($className, $type, $operationType, $operationName, $serializerContext);
 
         $prefix = $resourceMetadata ? $resourceMetadata->getShortName() : (new \ReflectionClass($className))->getShortName();
+
         if (null !== $inputOrOutputClass && $className !== $inputOrOutputClass) {
             $prefix .= ':'.md5($inputOrOutputClass);
         }

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -81,7 +81,7 @@ class Dummy
     public $description;
 
     /**
-     * @var string A dummy
+     * @var self
      *
      * @ORM\Column(nullable=true)
      */

--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -74,4 +74,20 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['bar']);
         $this->assertSame('integer', $definitions[$rootDefinitionKey]['properties']['bar']['type']);
     }
+
+    public function testBuildSchemaForBadClass(): void
+    {
+        $typeFactoryProphecy = $this->prophesize(TypeFactoryInterface::class);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+
+        $schemaFactory = new SchemaFactory($typeFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
+        $resultSchema = $schemaFactory->buildSchema('notaclass');
+
+        $definitions = $resultSchema->getDefinitions();
+
+        $this->assertNull($resultSchema->getRootDefinitionKey());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes 
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | fixed #3344 #3349 #3343
| License       | MIT
| Doc PR        | 

I'm not really sure that we should merge this, it skips wrong classes but there is definitely something more about https://github.com/api-platform/core/issues/3344 that I didn't found yet (class name is `elf` should be `self` and mb that we should just use a reference to the class itself instead of just leaving this error behind).

Attempt to reproduce linked issues: https://github.com/soyuka/self-referencing-metadata-api-platform 