### PR TITLE
take care of the nullable to-many relation in serializer

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -514,11 +514,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         $type = $propertyMetadata->getType();
-        if ($type->isNullable() && is_null($attributeValue)) {
-            
+        if ($type && $type->isNullable() && null === $attributeValue) {
             return null;
         }
-        
+
         if (
             $type &&
             $type->isCollection() &&

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -514,7 +514,11 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         $type = $propertyMetadata->getType();
-
+        if ($type->isNullable() && is_null($attributeValue)) {
+            
+            return null;
+        }
+        
         if (
             $type &&
             $type->isCollection() &&

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -523,7 +523,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $this->resourceClassResolver->isResourceClass($className)
         ) {
             if (!is_iterable($attributeValue)) {
-                if ($type->isNullable() && null === $attributeValue) {
+                if (null === $attributeValue && $type->isNullable()) {
                     return null;
                 }
                 throw new UnexpectedValueException('Unexpected non-iterable value for to-many relation.');

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -514,9 +514,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         $type = $propertyMetadata->getType();
-        if ($type && $type->isNullable() && null === $attributeValue) {
-            return null;
-        }
 
         if (
             $type &&
@@ -526,6 +523,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $this->resourceClassResolver->isResourceClass($className)
         ) {
             if (!is_iterable($attributeValue)) {
+                if ($type->isNullable() && null === $attributeValue) {
+                    return null;
+                }
                 throw new UnexpectedValueException('Unexpected non-iterable value for to-many relation.');
             }
 

--- a/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the API Platform project.
  *
- * (c) Herbin Francois <francois.rb1@gmail.com>
+ * (c) Kévin Dunglas <dunglas@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource
+ */
+class DummyTableNonDoctrineInheritance
+{
+    /**
+     * @var int The id
+     *
+     * @Groups({"default"})
+     */
+    private $id;
+
+    /**
+     * @var string The dummy name
+     *
+     * @Groups({"default"})
+     */
+    private $name;
+
+    /**
+     * @var DummyTableNonDoctrineInheritanceRelated
+     *
+     */
+    private $parent;
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the API Platform project.
  *
- * (c) Kévin Dunglas <dunglas@gmail.com>
+ * (c) Herbin Francois <francois.rb1@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritance.php
@@ -26,18 +26,17 @@ class DummyTableNonDoctrineInheritance
      *
      * @Groups({"default"})
      */
-    private $id;
+    public $id;
 
     /**
      * @var string The dummy name
      *
      * @Groups({"default"})
      */
-    private $name;
+    public $name;
 
     /**
      * @var DummyTableNonDoctrineInheritanceRelated
-     *
      */
-    private $parent;
+    public $parent;
 }

--- a/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritanceRelated.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritanceRelated.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"default"}},
+ *         "denormalization_context"={"groups"={"default"}}
+ *     }
+ * )
+ */
+class DummyTableNonDoctrineInheritanceRelated
+{
+    /**
+     * @var int The id
+     *
+     * @Groups({"default"})
+     */
+    public $id;
+
+    /**
+     * @var DummyTableNonDoctrineInheritance[]|null
+     *
+     * @Groups({"default"})
+     */
+    public $children;
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritanceRelated.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritanceRelated.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the API Platform project.
  *
- * (c) Herbin Francois <francois.rb1@gmail.com>
+ * (c) Kévin Dunglas <dunglas@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritanceRelated.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyTableNonDoctrineInheritanceRelated.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the API Platform project.
  *
- * (c) Kévin Dunglas <dunglas@gmail.com>
+ * (c) Herbin Francois <francois.rb1@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -1140,7 +1140,7 @@ class AbstractItemNormalizerTest extends TestCase
         $propertyMetadata = new PropertyMetadata(
             new Type(Type::BUILTIN_TYPE_ARRAY, true, DummyTableNonDoctrineInheritance::class, true,
                 new Type(Type::BUILTIN_TYPE_INT),
-                new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyTableNonDoctrineInheritance::class),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyTableNonDoctrineInheritance::class)
             ),
             '',
             true
@@ -1202,7 +1202,7 @@ class AbstractItemNormalizerTest extends TestCase
         $propertyMetadata = new PropertyMetadata(
             new Type(Type::BUILTIN_TYPE_ARRAY, false, DummyTableNonDoctrineInheritance::class, true,
                 new Type(Type::BUILTIN_TYPE_INT),
-                new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyTableNonDoctrineInheritance::class),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyTableNonDoctrineInheritance::class)
             ),
             '',
             true

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -32,6 +32,8 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyForAdditionalFields;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyForAdditionalFieldsInput;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritance;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceChild;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableNonDoctrineInheritance;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableNonDoctrineInheritanceRelated;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
@@ -1124,5 +1126,132 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $actualDummy);
 
         $propertyAccessorProphecy->setValue($actualDummy, 'name', 'Dummy')->shouldHaveBeenCalled();
+    }
+
+    public function testNullableToManyRelationProperty()
+    {
+        $dummy = new DummyTableNonDoctrineInheritanceRelated();
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(DummyTableNonDoctrineInheritanceRelated::class, [])->willReturn(
+            new PropertyNameCollection(['children'])
+        )->shouldBeCalled();
+
+        $propertyMetadata = new PropertyMetadata(
+            new Type(Type::BUILTIN_TYPE_ARRAY, true, DummyTableNonDoctrineInheritance::class, true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyTableNonDoctrineInheritance::class),
+            ),
+            '',
+            true
+        );
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy
+            ->create(DummyTableNonDoctrineInheritanceRelated::class, 'children', [])
+            ->willReturn($propertyMetadata)->shouldBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $propertyAccessorProphecy->getValue($dummy, 'children')->willReturn(null)->shouldBeCalled();
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy, DummyTableNonDoctrineInheritanceRelated::class)
+            ->willReturn(DummyTableNonDoctrineInheritanceRelated::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->isResourceClass(DummyTableNonDoctrineInheritance::class)->willReturn(true)->shouldBeCalled();
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(NormalizerInterface::class);
+
+        $normalizer = $this->getMockForAbstractClass(
+            AbstractItemNormalizer::class,
+            [
+                $propertyNameCollectionFactoryProphecy->reveal(),
+                $propertyMetadataFactoryProphecy->reveal(),
+                $iriConverterProphecy->reveal(),
+                $resourceClassResolverProphecy->reveal(),
+                $propertyAccessorProphecy->reveal(),
+                null,
+                null,
+                null,
+                false,
+                [],
+                [],
+                null,
+                false,
+            ]
+        );
+        $normalizer->setSerializer($serializerProphecy->reveal());
+        $this->assertEquals(
+            ['children' => null],
+            $normalizer->normalize($dummy, null, ['resource_class' => DummyTableNonDoctrineInheritanceRelated::class, 'resources' => []])
+        );
+    }
+
+    public function testNotNullableToManyRelationProperty()
+    {
+        $dummy = new DummyTableNonDoctrineInheritanceRelated();
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(DummyTableNonDoctrineInheritanceRelated::class, [])->willReturn(
+            new PropertyNameCollection(['children'])
+        )->shouldBeCalled();
+
+        $propertyMetadata = new PropertyMetadata(
+            new Type(Type::BUILTIN_TYPE_ARRAY, false, DummyTableNonDoctrineInheritance::class, true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyTableNonDoctrineInheritance::class),
+            ),
+            '',
+            true
+        );
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy
+            ->create(DummyTableNonDoctrineInheritanceRelated::class, 'children', [])
+            ->willReturn($propertyMetadata)->shouldBeCalled();
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $propertyAccessorProphecy->getValue($dummy, 'children')->willReturn(null)->shouldBeCalled();
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($dummy, DummyTableNonDoctrineInheritanceRelated::class)
+            ->willReturn(DummyTableNonDoctrineInheritanceRelated::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->isResourceClass(DummyTableNonDoctrineInheritance::class)->willReturn(true)->shouldBeCalled();
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(NormalizerInterface::class);
+
+        $normalizer = $this->getMockForAbstractClass(
+            AbstractItemNormalizer::class,
+            [
+                $propertyNameCollectionFactoryProphecy->reveal(),
+                $propertyMetadataFactoryProphecy->reveal(),
+                $iriConverterProphecy->reveal(),
+                $resourceClassResolverProphecy->reveal(),
+                $propertyAccessorProphecy->reveal(),
+                null,
+                null,
+                null,
+                false,
+                [],
+                [],
+                null,
+                false,
+            ]
+        );
+        $normalizer->setSerializer($serializerProphecy->reveal());
+
+        $this->expectException(UnexpectedValueException::class);
+        $normalizer->normalize(
+            $dummy,
+            null,
+            ['resource_class' => DummyTableNonDoctrineInheritanceRelated::class, 'resources' => []]
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

don't throw UnexpectedValueException('Unexpected non-iterable value for to-many relation.') if the entity property is nullable (and null).
-> for my application, if a to-many relation is set to null, it's because I didn't hydrate that sub-resource.  (i use custom repositories/dataProviders)
