### PR TITLE
Fix first entry is beign skipped when after...

### DIFF
--- a/src/GraphQl/Resolver/Stage/SerializeStage.php
+++ b/src/GraphQl/Resolver/Stage/SerializeStage.php
@@ -125,7 +125,7 @@ final class SerializeStage implements SerializeStageInterface
         $totalItems = $collection->getTotalItems();
         $nbPageItems = $collection->count();
         if (isset($args['after'])) {
-            $after = base64_decode($args['after'], true);
+            $after = '' === $args['after'] ? -1 : base64_decode($args['after'], true);
             if (false === $after) {
                 throw Error::createLocatedError(sprintf('Cursor %s is invalid', $args['after']), $info->fieldNodes, $info->path);
             }


### PR DESCRIPTION
Resolves #3355

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3355 
| License       | MIT
| Doc PR        | None

Fixes issue where graphql parameter `after` is set, but empty string and return skips first value of collection.