### PR TITLE
allow to use output walkers from subresource operations

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -353,6 +353,10 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
             if (null !== $useOutputWalkers = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_use_output_walkers', null, true)) {
                 return $useOutputWalkers;
             }
+
+            if (null !== $useOutputWalkers = $resourceMetadata->getSubresourceOperationAttribute($operationName, 'pagination_use_output_walkers', null, true)) {
+                return $useOutputWalkers;
+            }
         }
 
         /*


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

pagination_use_output_walkers options is not used in case of subresourceOperations.
