### PR TITLE
Ensure that `api:openapi:export` produces JSON with unescaped forward slashes

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -92,7 +92,9 @@ final class SwaggerCommand extends Command
 
         $documentation = new Documentation($this->resourceNameCollectionFactory->create(), $this->apiTitle, $this->apiDescription, $this->apiVersion, $this->apiFormats);
         $data = $this->normalizer->normalize($documentation, DocumentationNormalizer::FORMAT, ['spec_version' => (int) $version, ApiGatewayNormalizer::API_GATEWAY => $input->getOption('api-gateway')]);
-        $content = $input->getOption('yaml') ? Yaml::dump($data, 10, 2, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK) : (json_encode($data, JSON_PRETTY_PRINT) ?: '');
+        $content = $input->getOption('yaml')
+            ? Yaml::dump($data, 10, 2, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK)
+            : (json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: '');
 
         if (!empty($filename = $input->getOption('output')) && \is_string($filename)) {
             file_put_contents($filename, $content);

--- a/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandUnitTest.php
+++ b/tests/Bridge/Symfony/Bundle/Command/SwaggerCommandUnitTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\Command;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Command\SwaggerCommand;
+use ApiPlatform\Core\Documentation\Documentation;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class SwaggerCommandUnitTest extends KernelTestCase
+{
+    /** @var MockObject&NormalizerInterface */
+    private $normalizer;
+
+    /** @var ResourceNameCollectionFactoryInterface&MockObject */
+    private $resources;
+
+    /** @var SwaggerCommand */
+    private $command;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = $this->createMock(NormalizerInterface::class);
+        $this->resources = $this->createMock(ResourceNameCollectionFactoryInterface::class);
+        $this->command = new SwaggerCommand(
+            $this->normalizer,
+            $this->resources,
+            'My API',
+            'I told you already: it is my API',
+            'one-zero-zero'
+        );
+
+        $this->resources->method('create')
+            ->willReturn(new ResourceNameCollection());
+    }
+
+    public function testDocumentationJsonDoesNotUseEscapedSlashes(): void
+    {
+        $this->normalizer->method('normalize')
+            ->with(self::isInstanceOf(Documentation::class))
+            ->willReturn(['a-jsonable-documentation' => 'containing/some/slashes']);
+
+        $output = new BufferedOutput();
+
+        $this->command->run(new ArrayInput([]), $output);
+
+        $jsonOutput = $output->fetch();
+
+        self::assertJson($jsonOutput);
+        self::assertStringNotContainsString('containing\/some\/slashes', $jsonOutput);
+        self::assertStringContainsString('containing/some/slashes', $jsonOutput);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This ensures that the generated OpenAPI schema JSON dump does not contain forward-slashes, such as `"#\/foo\/bar\/MyModel"`, which confuses tooling relying on direct string match in referenced models (most notably, the IntelliJ OpenAPI/Swagger tooling)