### PR TITLE
Add possibility to hydrate input before denormalize

### DIFF
--- a/src/DataTransformer/PreHydrateInputInterface.php
+++ b/src/DataTransformer/PreHydrateInputInterface.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Serializer;
+namespace ApiPlatform\Core\DataTransformer;
 
 interface PreHydrateInputInterface
 {

--- a/src/DataTransformer/PreHydrateInputInterface.php
+++ b/src/DataTransformer/PreHydrateInputInterface.php
@@ -16,9 +16,9 @@ namespace ApiPlatform\Core\DataTransformer;
 interface PreHydrateInputInterface
 {
     /**
-     * @param string $class
+     * @param string $inputClass
      *
      * @return object
      */
-    public function createInput($class, array $context = []);
+    public function createInput($inputClass, array $context = []);
 }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -38,6 +38,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -191,14 +192,11 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 throw new LogicException('Cannot denormalize the input because the injected serializer is not a denormalizer');
             }
             if ($dataTransformer instanceof PreHydrateInputInterface) {
-                $context[static::OBJECT_TO_POPULATE] = $dataTransformer->createInput($inputClass, $context);
+                $context[AbstractNormalizer::OBJECT_TO_POPULATE] = $dataTransformer->createInput($inputClass, $context);
             }
             $denormalizedInput = $this->serializer->denormalize($data, $inputClass, $format, $context);
             if (!\is_object($denormalizedInput)) {
                 throw new \UnexpectedValueException('Expected denormalized input to be an object.');
-            }
-            if ($dataTransformer instanceof PreHydrateInputInterface) {
-                $context[static::OBJECT_TO_POPULATE] = $objectToPopulate;
             }
 
             return $dataTransformer->transform($denormalizedInput, $resourceClass, $dataTransformerContext);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -38,7 +38,6 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
-use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -192,7 +191,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 throw new LogicException('Cannot denormalize the input because the injected serializer is not a denormalizer');
             }
             if ($dataTransformer instanceof PreHydrateInputInterface) {
-                $context[AbstractNormalizer::OBJECT_TO_POPULATE] = $dataTransformer->createInput($inputClass, $context);
+                $context[AbstractObjectNormalizer::OBJECT_TO_POPULATE] = $dataTransformer->createInput($inputClass, $context);
+                $context[AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE] = true;
             }
             $denormalizedInput = $this->serializer->denormalize($data, $inputClass, $format, $context);
             if (!\is_object($denormalizedInput)) {

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -189,9 +189,18 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             if (!$this->serializer instanceof DenormalizerInterface) {
                 throw new LogicException('Cannot denormalize the input because the injected serializer is not a denormalizer');
             }
+            if ($dataTransformer instanceof PreHydrateInputInterface) {
+                $context[static::OBJECT_TO_POPULATE] = $dataTransformer->createInput($inputClass, $context);
+            }
             $denormalizedInput = $this->serializer->denormalize($data, $inputClass, $format, $context);
             if (!\is_object($denormalizedInput)) {
                 throw new \UnexpectedValueException('Expected denormalized input to be an object.');
+            }
+            if ($dataTransformer instanceof PreHydrateInputInterface) {
+                unset($context[static::OBJECT_TO_POPULATE]);
+            }
+            if (null !== $objectToPopulate) {
+                $context[static::OBJECT_TO_POPULATE] = $objectToPopulate;
             }
 
             return $dataTransformer->transform($denormalizedInput, $resourceClass, $dataTransformerContext);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
+use ApiPlatform\Core\DataTransformer\PreHydrateInputInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\InvalidValueException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
@@ -197,9 +198,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 throw new \UnexpectedValueException('Expected denormalized input to be an object.');
             }
             if ($dataTransformer instanceof PreHydrateInputInterface) {
-                unset($context[static::OBJECT_TO_POPULATE]);
-            }
-            if (null !== $objectToPopulate) {
                 $context[static::OBJECT_TO_POPULATE] = $objectToPopulate;
             }
 

--- a/src/Serializer/PreHydrateInputInterface.php
+++ b/src/Serializer/PreHydrateInputInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Serializer;
+
+interface PreHydrateInputInterface
+{
+    /**
+     * @param string $class
+     *
+     * @return object
+     */
+    public function createInput($class, array $context = []);
+}

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -44,7 +44,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
-use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -410,7 +410,8 @@ class AbstractItemNormalizerTest extends TestCase
             'resource_class' => null,
         ]);
         $cleanedContextWithObjectToPopulate = array_merge($cleanedContext, [
-            AbstractNormalizer::OBJECT_TO_POPULATE => $preHydratedDummy,
+            AbstractObjectNormalizer::OBJECT_TO_POPULATE => $preHydratedDummy,
+            AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE => true,
         ]);
 
         $dummyInputDto = new DummyForAdditionalFieldsInput('Dummy Name');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Add an interface to give the possibility to prehydrate input for datatransformer to make it possible to do partial update using input dto.
