### PR TITLE
IsRequired should return true even if not writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.5.5
 
 * GraphQL: Do not allow empty cursor values on `before` or `after`
+* OpenAPI: Fix required fields by keeping them required even if they are not writable to allow valid read types generation on client side (#3381)
 
 ## 2.5.4
 

--- a/src/Metadata/Property/PropertyMetadata.php
+++ b/src/Metadata/Property/PropertyMetadata.php
@@ -134,10 +134,6 @@ final class PropertyMetadata
      */
     public function isRequired(): ?bool
     {
-        if (true === $this->required && false === $this->writable) {
-            return false;
-        }
-
         return $this->required;
     }
 

--- a/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
+++ b/tests/Bridge/NelmioApiDoc/Parser/ApiPlatformParserTest.php
@@ -150,7 +150,7 @@ class ApiPlatformParserTest extends TestCase
         $this->assertEquals([
             'id' => [
                 'dataType' => DataTypes::INTEGER,
-                'required' => false,
+                'required' => true,
                 'description' => 'The id.',
                 'readonly' => true,
             ],
@@ -262,7 +262,7 @@ class ApiPlatformParserTest extends TestCase
         $this->assertEquals([
             'id' => [
                 'dataType' => DataTypes::INTEGER,
-                'required' => false,
+                'required' => true,
                 'description' => 'The id.',
                 'readonly' => true,
             ],
@@ -399,7 +399,7 @@ class ApiPlatformParserTest extends TestCase
                 'children' => [
                     'id' => [
                         'dataType' => DataTypes::INTEGER,
-                        'required' => false,
+                        'required' => true,
                         'description' => null,
                         'readonly' => true,
                     ],

--- a/tests/Metadata/Property/PropertyMetadataTest.php
+++ b/tests/Metadata/Property/PropertyMetadataTest.php
@@ -84,14 +84,14 @@ class PropertyMetadataTest extends TestCase
         $this->assertTrue($newMetadata->isInitializable());
     }
 
-    public function testShouldReturnRequiredFalseWhenRequiredTrueIsSetButMaskedByWritableFalse()
+    public function testShouldReturnRequiredTrueEvenIfWritableFalseSoClientCanAssumeValueCannotBeUndefinedOnReadOperation()
     {
         $metadata = new PropertyMetadata();
 
         $metadata = $metadata->withRequired(true);
         $metadata = $metadata->withWritable(false);
 
-        $this->assertFalse($metadata->isRequired());
+        $this->assertTrue($metadata->isRequired());
     }
 
     public function testShouldReturnPreviouslySetRequiredTrueWhenWritableFalseUnmasked()


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | #3389
| License       | MIT
| Doc PR        | 

While I understand what is the logic under the code I'm removing, I believe this check is wrong because it assumes the property belongs to a schema describing a model for a write operation.

In that case, we *could* say the field is not required because it is not writable.

However, when describing a model for a read operation (e.g. using a group in the `normalizationContext`), we *do* want read-only fields to be marked as required. Otherwise tooling such as code generators will assume the field is nullable.

This is especially happening for all identifiers when auto-generated in the backend. They are always read-only but they are also always required (the client should not assume that the id field may be null).