### PR TITLE
Improve subresources DB query performance by removing a subquery

### DIFF
--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -206,7 +206,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
             $topQueryBuilder->setParameter($placeholder, $value, (string) $classMetadata->getTypeOfField($key));
 
             // Optimization: add where clause for identifiers, but not via a WHERE ... IN ( ...subquery... ).
-            // Instead we use a direct identifier equality clause, to speed thing up when dealing with large tables.
+            // Instead we use a direct identifier equality clause, to speed things up when dealing with large tables.
             // We may do so if there is no more recursion levels from here, and if relation allows it.
             $association = $classMetadata->hasAssociation($previousAssociationProperty) ? $classMetadata->getAssociationMapping($previousAssociationProperty) : [];
             $oneToOneBidirectional = isset($association['inversedBy']) && ClassMetadataInfo::ONE_TO_ONE === $association['type'];

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -205,7 +205,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
             $placeholder = $queryNameGenerator->generateParameterName($key);
             $topQueryBuilder->setParameter($placeholder, $value, (string) $classMetadata->getTypeOfField($key));
 
-            // Optimizaion: add where clause for identifiers, but not via a WHERE ... IN ( ...subquery... ).
+            // Optimization: add where clause for identifiers, but not via a WHERE ... IN ( ...subquery... ).
             // Instead we use a direct identifier equality clause, to speed thing up when dealing with large tables.
             // We may do so if there is no more recursion levels from here, and if relation allows it.
             $association = $classMetadata->hasAssociation($previousAssociationProperty) ? $classMetadata->getAssociationMapping($previousAssociationProperty) : [];

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -198,41 +198,34 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
                 ->from($identifierResourceClass, $alias);
         }
 
-        $lastIdentifer = 1 === $remainingIdentifiers;
-        $association = $classMetadata->hasAssociation($previousAssociationProperty) ? $classMetadata->getAssociationMapping($previousAssociationProperty) : [];
-        $optimizable = $lastIdentifer && (
-                (isset($association['inversedBy']) && ClassMetadataInfo::ONE_TO_ONE === $association['type'])
-                || (isset($association['mappedBy']) && ClassMetadataInfo::ONE_TO_MANY === $association['type'])
-            );
+        $isLeaf = 1 === $remainingIdentifiers;
 
         // Add where clause for identifiers
         foreach ($normalizedIdentifiers as $key => $value) {
             $placeholder = $queryNameGenerator->generateParameterName($key);
-            if ($optimizable) {
-                // Add where clause for identifiers, but not via a WHERE ... IN ( ...subquery... ). Instead we use
-                // a direct identifier equality clause, to speed thing up when dealing with large tables.
-                // We may do so as there is no more recursion levels from here.
-
-                if (ClassMetadataInfo::ONE_TO_ONE === $association['type']) {
-                    $joinAlias = $queryNameGenerator->generateJoinAlias($association['inversedBy']);
-
-                    $previousQueryBuilder->innerJoin("$previousAlias.{$association['inversedBy']}", $joinAlias)
-                        ->andWhere("$joinAlias.$key = :$placeholder");
-                } else {
-                    $previousQueryBuilder->andWhere("IDENTITY($previousAlias) = :$placeholder");
-                }
-            } else {
-                $qb->andWhere("$alias.$key = :$placeholder");
-            }
             $topQueryBuilder->setParameter($placeholder, $value, (string) $classMetadata->getTypeOfField($key));
+
+            // Optimizaion: add where clause for identifiers, but not via a WHERE ... IN ( ...subquery... ).
+            // Instead we use a direct identifier equality clause, to speed thing up when dealing with large tables.
+            // We may do so if there is no more recursion levels from here, and if relation allows it.
+            $association = $classMetadata->hasAssociation($previousAssociationProperty) ? $classMetadata->getAssociationMapping($previousAssociationProperty) : [];
+            $oneToOneBidirectional = isset($association['inversedBy']) && ClassMetadataInfo::ONE_TO_ONE === $association['type'];
+            $oneToManyBidirectional = isset($association['mappedBy']) && ClassMetadataInfo::ONE_TO_MANY === $association['type'];
+            if ($isLeaf && $oneToOneBidirectional) {
+                $joinAlias = $queryNameGenerator->generateJoinAlias($association['inversedBy']);
+
+                return $previousQueryBuilder->innerJoin("$previousAlias.{$association['inversedBy']}", $joinAlias)
+                    ->andWhere("$joinAlias.$key = :$placeholder");
+            }
+            if ($isLeaf && $oneToManyBidirectional) {
+                return $previousQueryBuilder->andWhere("IDENTITY($previousAlias) = :$placeholder");
+            }
+
+            $qb->andWhere("$alias.$key = :$placeholder");
         }
 
         // Recurse queries
         $qb = $this->buildQuery($identifiers, $context, $queryNameGenerator, $qb, $alias, --$remainingIdentifiers, $topQueryBuilder);
-
-        if ($optimizable) {
-            return $previousQueryBuilder;
-        }
 
         return $previousQueryBuilder->andWhere($qb->expr()->in($previousAlias, $qb->getDQL()));
     }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes (kinda) <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | N/A

## Abstract 

This PR try to change DQL queries generated to fetch subresource, to improve performance on large tables.

## Before

The generated SQL to query a subresource uses a `WHERE ... IN ( <subquery> )`, in order to be recursive when subresources also have subresources (introduced by #1608).

The subquery, on large table (at work 4M+ lines), takes a significant amount of time (2-5s), even with the proper SQL indexes (at least on MySQL).

```SQL
SELECT
    DISTINCT c0_.idpurchase AS idpurchase_0,
    c0_.idpurchase AS idpurchase_1
FROM purchase c0_
LEFT JOIN customer c1_ ON c0_.idcustomer = c1_.idcustomer
-- Some other LEFT JOINs
WHERE c0_.idcustomer IN 
(  -- here please notice the usage of a subquery
    SELECT c16_.idcustomer
    FROM customer c16_
    WHERE c16_.idcustomer = :identifier
)
```

## After

This PRs tries to optimize for the common case, having only one level of subresources, by replacing the subquery via a direct `WHERE <identifier> = <identifier-alias>` **only on the last recursion level**. This means it shouldn't break subresources that have subresources, while still improving the query for the nominal cases.

```SQL
SELECT
    DISTINCT c0_.idpurchase AS idpurchase_0,
    c0_.idpurchase AS idpurchase_1
FROM purchase c0_
LEFT JOIN customer c1_ ON c0_.idcustomer = c1_.idcustomer
-- Some other LEFT JOINs
WHERE c0_.idcustomer = :identifier

```

**This significantly reduces the SQL query time, going from 2.45s to 15ms on my e-commerce app.**

## BC & missing things.

I broke the unit tests, mainly the mocking, but also some tests fails as they compare the previously generated query, with the new one (which makes sense). All the Behat tests are green locally though.

I feel out of my depth here, and if someone would help me writing those, ensuring no BC is done, is would be great.

On my side, I run our rather large behat test suite against my fork, and not tests complained about wrong results, so I am fairly confident I haven't introduced some BC.

# TODO

- [x] Fix Behat tests
- [x] Fix PHPUnit tests

