### PR TITLE
Revert "fix getClassType with no readableLink"

### DIFF
--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -99,15 +99,11 @@ final class TypeFactory implements TypeFactoryInterface
             return ['type' => 'string'];
         }
 
-        if (true !== $readableLink) {
-            if ($this->isResourceClass($className)) {
-                return [
-                    'type' => 'string',
-                    'format' => 'iri-reference',
-                ];
-            }
-
-            return ['type' => 'string'];
+        if ($this->isResourceClass($className) && true !== $readableLink) {
+            return [
+                'type' => 'string',
+                'format' => 'iri-reference',
+            ];
         }
 
         $version = $schema->getVersion();

--- a/tests/JsonSchema/TypeFactoryTest.php
+++ b/tests/JsonSchema/TypeFactoryTest.php
@@ -19,7 +19,6 @@ use ApiPlatform\Core\JsonSchema\TypeFactory;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\PropertyInfo\Type;
 
 class TypeFactoryTest extends TestCase
@@ -40,19 +39,8 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'boolean'], new Type(Type::BUILTIN_TYPE_BOOL)];
         yield [['type' => 'string'], new Type(Type::BUILTIN_TYPE_OBJECT)];
         yield [['type' => 'string', 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateTimeImmutable::class)];
-        yield [['type' => 'string', 'format' => 'uuid'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Uuid::class)];
         yield [['type' => 'string'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
-    }
-
-    public function testGetTypeWithSchema(): void
-    {
-        $typeFactory = new TypeFactory();
-        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class);
-        $this->assertSame(
-            ['type' => 'string', 'format' => 'iri-reference'],
-            $typeFactory->getType($type, 'json', null, null, new Schema())
-        );
     }
 
     public function testGetClassType(): void


### PR DESCRIPTION
Reverts api-platform/core#3362

It was an invalid fix.