### PR TITLE
Rename a method in fixture class to avoid "getter" false positive

### DIFF
--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -218,7 +218,7 @@ class Dummy
         return $this->description;
     }
 
-    public function hasRole($role)
+    public function fooBar($baz)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This should fix the failing jobs (`-symfony-next`) with dev packages.