### PR TITLE
Case where Item attribute might be a Nullable to-many relationship

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -522,7 +522,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             ($className = $collectionValueType->getClassName()) &&
             $this->resourceClassResolver->isResourceClass($className)
         ) {
-            if (!$type->isNullable() && null === $attributeValue) {
+            if (null === $attributeValue && !$type->isNullable()) {
                 throw new UnexpectedValueException('Unexpected null value for non-nullable to-many relation.');
             }
             if (null !== $attributeValue && !is_iterable($attributeValue)) {
@@ -542,10 +542,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             ($className = $type->getClassName()) &&
             $this->resourceClassResolver->isResourceClass($className)
         ) {
-            if (!$type->isNullable() && null === $attributeValue) {
+            if (null === $attributeValue && !$type->isNullable()) {
                 throw new UnexpectedValueException('Unexpected null value for non-nullable to-one relation.');
             }
-            if (!\is_object($attributeValue) && null !== $attributeValue) {
+            if (null !== $attributeValue && !\is_object($attributeValue)) {
                 throw new UnexpectedValueException('Unexpected non-object value for to-one relation.');
             }
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -522,6 +522,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             ($className = $collectionValueType->getClassName()) &&
             $this->resourceClassResolver->isResourceClass($className)
         ) {
+            if (!$type->isNullable() && null === $attributeValue) {
+                throw new UnexpectedValueException('Unexpected null value for non-nullable to-many relation.');
+            }
             if (null !== $attributeValue && !is_iterable($attributeValue)) {
                 throw new UnexpectedValueException('Unexpected non-iterable value for to-many relation.');
             }
@@ -539,6 +542,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             ($className = $type->getClassName()) &&
             $this->resourceClassResolver->isResourceClass($className)
         ) {
+            if (!$type->isNullable() && null === $attributeValue) {
+                throw new UnexpectedValueException('Unexpected null value for non-nullable to-one relation.');
+            }
             if (!\is_object($attributeValue) && null !== $attributeValue) {
                 throw new UnexpectedValueException('Unexpected non-object value for to-one relation.');
             }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -522,7 +522,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             ($className = $collectionValueType->getClassName()) &&
             $this->resourceClassResolver->isResourceClass($className)
         ) {
-            if ($attributeValue !== null && !is_iterable($attributeValue)) {
+            if (null !== $attributeValue && !is_iterable($attributeValue)) {
                 throw new UnexpectedValueException('Unexpected non-iterable value for to-many relation.');
             }
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -522,7 +522,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             ($className = $collectionValueType->getClassName()) &&
             $this->resourceClassResolver->isResourceClass($className)
         ) {
-            if (!is_iterable($attributeValue)) {
+            if ($attributeValue !== null && !is_iterable($attributeValue)) {
                 throw new UnexpectedValueException('Unexpected non-iterable value for to-many relation.');
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Case where Item attribute might be a Nullable to-many relationship. Otherwise this IF condition blocks the flow of the execution where it shouldn't.