### PR TITLE
Don't typehint the SchemaFactory decorator by its implementation, but by its interface

### DIFF
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -38,10 +38,13 @@ final class SchemaFactory implements SchemaFactoryInterface
 
     private $schemaFactory;
 
-    public function __construct(BaseSchemaFactory $schemaFactory)
+    public function __construct(SchemaFactoryInterface $schemaFactory)
     {
         $this->schemaFactory = $schemaFactory;
-        $schemaFactory->addDistinctFormat('jsonld');
+
+        if ($schemaFactory instanceof BaseSchemaFactory) {
+            $schemaFactory->addDistinctFormat('jsonld');
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Enable decorating schema factory by it's interface.

The Hydra Json Schema Factory could not be decorated with a custom SchemaFactoryInterface.
The JsonSchemaFactory was used as a default. I've changed the type hint to the interface so everybody can now generate their own SchemaFactory implementations.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
