### PR TITLE
Only save /tmp/phpstan/resultCache.php to cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,12 +162,12 @@ commands:
       - save_cache:
           name: Save PHPStan cache
           paths:
-            - /tmp/phpstan/cache
+            - /tmp/phpstan/resultCache.php
           key: phpstan-{{ .Branch }}-{{ .BuildNum }}
       - save_cache:
           name: Save PHPStan cache
           paths:
-            - /tmp/phpstan/cache
+            - /tmp/phpstan/resultCache.php
           key: phpstan-{{ .Revision }}-{{ .BuildNum }}
   update-project-dependencies:
     steps:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The result cache is a huge win.

CircleCI takes a very long time saving /tmp/phpstan/cache for some reason,
and this cache doesn't affect the run time much anyway.
