### PR TITLE
add missing parameter for swagger normalizer

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -31,6 +31,7 @@
             <argument>%api_platform.formats%</argument>
             <argument>%api_platform.collection.pagination.client_enabled%</argument>
             <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
+            <argument type="collection" />
             <argument>%api_platform.swagger.versions%</argument>
             <tag name="serializer.normalizer" priority="-790" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT

In the service definition for ```ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer``` the parameter ```$defaultContext``` was receiving the value of ```api_platform.swagger.versions```. 
This change just adds an empty array to that parameter.
