### PR TITLE
Add stateless ApiResource attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
 * IriConverter: Fix IRI url double encoding - may cause breaking change as some characters no longer encoded in output (#3552)
 * OpenAPI: **BC** Replace all characters other than `[a-zA-Z0-9\.\-_]` to `.` in definition names to be compliant with OpenAPI 3.0 (#3669)
+* Add stateless ApiResource attribute
 
 ## 2.5.7
 

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -63,6 +63,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("securityPostDenormalize", type="string"),
  *     @Attribute("securityPostDenormalizeMessage", type="string"),
  *     @Attribute("shortName", type="string"),
+ *     @Attribute("stateless", type="bool"),
  *     @Attribute("subresourceOperations", type="array"),
  *     @Attribute("sunset", type="string"),
  *     @Attribute("swaggerContext", type="array"),
@@ -118,6 +119,7 @@ final class ApiResource
         'paginationPartial',
         'paginationViaCursor',
         'routePrefix',
+        'stateless',
         'sunset',
         'swaggerContext',
         'urlGenerationStrategy',
@@ -413,6 +415,13 @@ final class ApiResource
      * @var string
      */
     private $securityPostDenormalizeMessage;
+
+    /**
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $stateless;
 
     /**
      * @see https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -257,6 +257,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             }
         }
 
+        if (!\array_key_exists('stateless', $defaults)) {
+            @trigger_error('Not setting the "api_platform.defaults.stateless" configuration is deprecated since API Platform 2.6 and it will default to `true` in 3.0. You can override this at the operation level if you have stateful operations (highly not recommended).', E_USER_DEPRECATED);
+            $normalizedDefaults['attributes']['stateless'] = false;
+        }
+
         return $normalizedDefaults;
     }
 

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -126,6 +126,7 @@ final class ApiLoader extends Loader
                     [
                         '_controller' => $controller,
                         '_format' => null,
+                        '_stateless' => $operation['stateless'] ?? $resourceMetadata->getAttribute('stateless'),
                         '_api_resource_class' => $operation['resource_class'],
                         '_api_subresource_operation_name' => $operation['route_name'],
                         '_api_subresource_context' => [
@@ -229,6 +230,7 @@ final class ApiLoader extends Loader
             [
                 '_controller' => $controller,
                 '_format' => null,
+                '_stateless' => $operation['stateless'],
                 '_api_resource_class' => $resourceClass,
                 sprintf('_api_%s_operation_name', $operationType) => $operationName,
             ] + ($operation['defaults'] ?? []),

--- a/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/OperationResourceMetadataFactory.php
@@ -59,7 +59,7 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
 
         $collectionOperations = $resourceMetadata->getCollectionOperations();
         if (null === $collectionOperations) {
-            $resourceMetadata = $resourceMetadata->withCollectionOperations($this->createOperations($isAbstract ? ['GET'] : ['GET', 'POST']));
+            $resourceMetadata = $resourceMetadata->withCollectionOperations($this->createOperations($isAbstract ? ['GET'] : ['GET', 'POST'], $resourceMetadata));
         } else {
             $resourceMetadata = $this->normalize(true, $resourceClass, $resourceMetadata, $collectionOperations);
         }
@@ -76,7 +76,7 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
                 }
             }
 
-            $resourceMetadata = $resourceMetadata->withItemOperations($this->createOperations($methods));
+            $resourceMetadata = $resourceMetadata->withItemOperations($this->createOperations($methods, $resourceMetadata));
         } else {
             $resourceMetadata = $this->normalize(false, $resourceClass, $resourceMetadata, $itemOperations);
         }
@@ -91,11 +91,11 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
         return $resourceMetadata;
     }
 
-    private function createOperations(array $methods): array
+    private function createOperations(array $methods, ResourceMetadata $resourceMetadata): array
     {
         $operations = [];
         foreach ($methods as $method) {
-            $operations[strtolower($method)] = ['method' => $method];
+            $operations[strtolower($method)] = ['method' => $method, 'stateless' => $resourceMetadata->getAttribute('stateless')];
         }
 
         return $operations;
@@ -130,6 +130,8 @@ final class OperationResourceMetadataFactory implements ResourceMetadataFactoryI
             if (isset($operation['method'])) {
                 $operation['method'] = strtoupper($operation['method']);
             }
+
+            $operation['stateless'] = $operation['stateless'] ?? $resourceMetadata->getAttribute('stateless');
 
             $newOperations[$operationName] = $operation;
         }

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -26,7 +26,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
 {
     public const SUBRESOURCE_SUFFIX = '_subresource';
     public const FORMAT_SUFFIX = '.{_format}';
-    public const ROUTE_OPTIONS = ['defaults' => [], 'requirements' => [], 'options' => [], 'host' => '', 'schemes' => [], 'condition' => '', 'controller' => null];
+    public const ROUTE_OPTIONS = ['defaults' => [], 'requirements' => [], 'options' => [], 'host' => '', 'schemes' => [], 'condition' => '', 'controller' => null, 'stateless' => null];
 
     private $resourceMetadataFactory;
     private $propertyNameCollectionFactory;

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -158,6 +158,7 @@ class ApiPlatformExtensionTest extends TestCase
         ],
         'defaults' => [
             'attributes' => [],
+            'stateless' => true,
         ],
     ]];
 
@@ -720,7 +721,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->registerForAutoconfiguration(RequestBodySearchCollectionExtensionInterface::class)->willReturn($this->childDefinitionProphecy)->shouldBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.elasticsearch.hosts', ['http://elasticsearch:9200'])->shouldBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.elasticsearch.mapping', [])->shouldBeCalled();
-        $containerBuilderProphecy->setParameter('api_platform.defaults', ['attributes' => []])->shouldBeCalled();
+        $containerBuilderProphecy->setParameter('api_platform.defaults', ['attributes' => ['stateless' => true]])->shouldBeCalled();
 
         $config = self::DEFAULT_CONFIG;
         $config['api_platform']['elasticsearch'] = [
@@ -871,7 +872,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.http_cache.vary' => ['Accept'],
             'api_platform.http_cache.public' => null,
             'api_platform.http_cache.invalidation.max_header_length' => 7500,
-            'api_platform.defaults' => ['attributes' => []],
+            'api_platform.defaults' => ['attributes' => ['stateless' => true]],
             'api_platform.enable_entrypoint' => true,
             'api_platform.enable_docs' => true,
             'api_platform.url_generation_strategy' => 1,
@@ -1175,7 +1176,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.resource_class_directories' => Argument::type('array'),
             'api_platform.validator.serialize_payload_fields' => [],
             'api_platform.elasticsearch.enabled' => false,
-            'api_platform.defaults' => ['attributes' => []],
+            'api_platform.defaults' => ['attributes' => ['stateless' => true]],
         ];
 
         if ($hasSwagger) {

--- a/tests/Fixtures/FileConfigurations/resources.xml
+++ b/tests/Fixtures/FileConfigurations/resources.xml
@@ -53,6 +53,7 @@
             <attribute name="@type">hydra:Operation</attribute>
             <attribute name="@hydra:title">File config Dummy</attribute>
         </attribute>
+        <attribute name="stateless">true</attribute>
 
         <property
                 name="foo"

--- a/tests/Fixtures/FileConfigurations/resources.yml
+++ b/tests/Fixtures/FileConfigurations/resources.yml
@@ -27,6 +27,7 @@ resources:
             hydra_context:
                 '@type': 'hydra:Operation'
                 '@hydra:title': !php/const ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy::HYDRA_TITLE
+            stateless: true
         iri: 'someirischema'
         properties:
             'foo':

--- a/tests/Fixtures/FileConfigurations/single_resource.yml
+++ b/tests/Fixtures/FileConfigurations/single_resource.yml
@@ -25,4 +25,6 @@
         hydra_context:
             '@type': 'hydra:Operation'
             '@hydra:title': 'File config Dummy'
+        stateless: true
     iri: 'someirischema'
+    stateless: true

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -76,6 +76,7 @@ api_platform:
             shared_max_age:                   3600
             vary:                             ['Accept', 'Cookie']
             public:                           true
+        stateless: true
 
 parameters:
     container.autowiring.strict_mode: true

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -45,7 +45,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $this->assertEquals(['foo' => ['bar' => true]], $metadata->getItemOperations());
         $this->assertEquals(['baz' => ['tab' => false]], $metadata->getCollectionOperations());
         $this->assertEquals(['sub' => ['bus' => false]], $metadata->getSubresourceOperations());
-        $this->assertEquals(['a' => 1, 'route_prefix' => '/foobar'], $metadata->getAttributes());
+        $this->assertEquals(['a' => 1, 'route_prefix' => '/foobar', 'stateless' => false], $metadata->getAttributes());
         $this->assertEquals(['foo' => 'bar'], $metadata->getGraphql());
     }
 
@@ -59,6 +59,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
             'attributes' => [
                 'pagination_items_per_page' => 4,
                 'pagination_maximum_items_per_page' => 6,
+                'stateless' => true,
             ],
         ];
 
@@ -81,6 +82,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $this->assertTrue($metadata->getAttribute('pagination_client_enabled'));
         $this->assertEquals(4, $metadata->getAttribute('pagination_items_per_page'));
         $this->assertEquals(10, $metadata->getAttribute('pagination_maximum_items_per_page'));
+        $this->assertTrue($metadata->getAttribute('stateless'));
     }
 
     public function testCreateWithoutAttributes()
@@ -105,6 +107,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
             'subresourceOperations' => ['sub' => ['bus' => false]],
             'attributes' => ['a' => 1, 'route_prefix' => '/foobar'],
             'graphql' => ['foo' => 'bar'],
+            'stateless' => false,
         ];
         $annotationFull = new ApiResource($resourceData);
 

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -302,6 +302,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
             'attributes' => [
                 'pagination_items_per_page' => 4,
                 'pagination_maximum_items_per_page' => 6,
+                'stateless' => true,
             ],
         ];
         $resourceConfiguration = [
@@ -312,6 +313,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
                 'itemOperations' => ['get', 'delete'],
                 'attributes' => [
                     'pagination_maximum_items_per_page' => 10,
+                    'stateless' => false,
                 ],
             ],
         ];
@@ -338,5 +340,6 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals(['get', 'delete'], $metadata->getItemOperations());
         $this->assertEquals(4, $metadata->getAttribute('pagination_items_per_page'));
         $this->assertEquals(10, $metadata->getAttribute('pagination_maximum_items_per_page'));
+        $this->assertFalse($metadata->getAttribute('stateless'));
     }
 }

--- a/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -60,6 +60,7 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
                     '@type' => 'hydra:Operation',
                     '@hydra:title' => 'File config Dummy',
                 ],
+                'stateless' => true,
             ],
         ];
 

--- a/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/OperationResourceMetadataFactoryTest.php
@@ -48,25 +48,29 @@ class OperationResourceMetadataFactoryTest extends TestCase
         yield [new ResourceMetadata(null, null, null, ['get'], [], null, [], []), new ResourceMetadata(null, null, null, $this->getOperations(['get']), [], null, [], [])];
         yield [new ResourceMetadata(null, null, null, ['put'], [], null, [], []), new ResourceMetadata(null, null, null, $this->getOperations(['put']), [], null, [], [])];
         yield [new ResourceMetadata(null, null, null, ['delete'], [], null, [], []), new ResourceMetadata(null, null, null, $this->getOperations(['delete']), [], null, [], [])];
-        yield [new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch']], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch']], [], null, [], [])];
-        yield [new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch']], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch']], [], null, [], []), $jsonapi];
-        yield [new ResourceMetadata(null, null, null, ['untouched' => ['method' => 'GET']], [], null, [], []), new ResourceMetadata(null, null, null, ['untouched' => ['method' => 'GET']], [], null, [], []), $jsonapi];
-        yield [new ResourceMetadata(null, null, null, ['untouched_custom' => ['route_name' => 'custom_route']], [], null, [], []), new ResourceMetadata(null, null, null, ['untouched_custom' => ['route_name' => 'custom_route']], [], null, [], []), $jsonapi];
+        yield [new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch']], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch', 'stateless' => null]], [], null, [], [])];
+        yield [new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch']], [], null, [], []), new ResourceMetadata(null, null, null, ['patch' => ['method' => 'PATCH', 'route_name' => 'patch', 'stateless' => null]], [], null, [], []), $jsonapi];
+        yield [new ResourceMetadata(null, null, null, ['untouched' => ['method' => 'GET']], [], null, [], []), new ResourceMetadata(null, null, null, ['untouched' => ['method' => 'GET', 'stateless' => null]], [], null, [], []), $jsonapi];
+        yield [new ResourceMetadata(null, null, null, ['untouched_custom' => ['route_name' => 'custom_route']], [], null, [], []), new ResourceMetadata(null, null, null, ['untouched_custom' => ['route_name' => 'custom_route', 'stateless' => null]], [], null, [], []), $jsonapi];
+        yield [new ResourceMetadata(null, null, null, ['stateless_operation' => ['method' => 'GET', 'stateless' => true]], [], null, [], []), new ResourceMetadata(null, null, null, ['stateless_operation' => ['method' => 'GET', 'stateless' => true]], [], null, [], []), $jsonapi];
+        yield [new ResourceMetadata(null, null, null, ['statefull_attribute' => ['method' => 'GET']], [], ['stateless' => false], [], []), new ResourceMetadata(null, null, null, ['statefull_attribute' => ['method' => 'GET', 'stateless' => false]], [], ['stateless' => false], [], []), $jsonapi];
 
         // Collection operations
         yield [new ResourceMetadata(null, null, null, [], null, null, [], []), new ResourceMetadata(null, null, null, [], $this->getOperations(['get', 'post']), null, [], [])];
         yield [new ResourceMetadata(null, null, null, [], ['get'], null, [], []), new ResourceMetadata(null, null, null, [], $this->getOperations(['get']), null, [], [])];
         yield [new ResourceMetadata(null, null, null, [], ['post'], null, [], []), new ResourceMetadata(null, null, null, [], $this->getOperations(['post']), null, [], [])];
-        yield [new ResourceMetadata(null, null, null, [], ['options' => ['method' => 'OPTIONS', 'route_name' => 'options']], null, [], []), new ResourceMetadata(null, null, null, [], ['options' => ['route_name' => 'options', 'method' => 'OPTIONS']], null, [], [])];
-        yield [new ResourceMetadata(null, null, null, [], ['untouched' => ['method' => 'GET']], null, [], []), new ResourceMetadata(null, null, null, [], ['untouched' => ['method' => 'GET']], null, [], [])];
-        yield [new ResourceMetadata(null, null, null, [], ['untouched_custom' => ['route_name' => 'custom_route']], null, [], []), new ResourceMetadata(null, null, null, [], ['untouched_custom' => ['route_name' => 'custom_route']], null, [], [])];
+        yield [new ResourceMetadata(null, null, null, [], ['options' => ['method' => 'OPTIONS', 'route_name' => 'options']], null, [], []), new ResourceMetadata(null, null, null, [], ['options' => ['route_name' => 'options', 'method' => 'OPTIONS', 'stateless' => null]], null, [], [])];
+        yield [new ResourceMetadata(null, null, null, [], ['untouched' => ['method' => 'GET']], null, [], []), new ResourceMetadata(null, null, null, [], ['untouched' => ['method' => 'GET', 'stateless' => null]], null, [], [])];
+        yield [new ResourceMetadata(null, null, null, [], ['untouched_custom' => ['route_name' => 'custom_route']], null, [], []), new ResourceMetadata(null, null, null, [], ['untouched_custom' => ['route_name' => 'custom_route', 'stateless' => null]], null, [], [])];
+        yield [new ResourceMetadata(null, null, null, [], ['statefull_operation' => ['method' => 'GET', 'stateless' => false]], null, null, []), new ResourceMetadata(null, null, null, [], ['statefull_operation' => ['method' => 'GET', 'stateless' => false]], null, null, []), $jsonapi];
+        yield [new ResourceMetadata(null, null, null, [], ['stateless_attribute' => ['method' => 'GET']], ['stateless' => true], null, []), new ResourceMetadata(null, null, null, [], ['stateless_attribute' => ['method' => 'GET', 'stateless' => true]], ['stateless' => true], null, []), $jsonapi];
     }
 
     private function getOperations(array $names): array
     {
         $operations = [];
         foreach ($names as $name) {
-            $operations[$name] = ['method' => strtoupper($name)];
+            $operations[$name] = ['method' => strtoupper($name), 'stateless' => null];
         }
 
         return $operations;


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | TODO

In Symfony 5.1, it will be possible to declare routes as stateless (https://github.com/symfony/symfony/pull/35732)
For stateless routes, kernel will either throw an exception (debug enabled) or log a warning (debug disabled) on session usage.

As API Platform shouldn't use session (according to REST architecture constraints), this PR proposes to add an ApiResource attribute in order to declare related routes as stateless: `stateless`

`false` will be the default in order to prevent BC break (and we could set it at `true` in the next major)

One question still remains. API Plateform could be on top of older version of Symfony (4.x, 5.0.x).
How to handle it ?
- Throw an exception saying that this feature isn't supported for that Symfony's version
- Log a warning saying that this feature isn't supported for that Symfony's version
- Do nothing (which is dangerous IMO)

WDYT ?