### PR TITLE
Fix purging HTTP cache for unreadable relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.6.4
 
+* Doctrine: Fix purging HTTP cache for unreadable relations (#3441)
 * Swagger UI: Remove Google fonts (#4112)
 
 ## 2.6.3

--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -125,7 +125,9 @@ final class PurgeHttpCacheListener
     {
         $associationMappings = $em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
         foreach (array_keys($associationMappings) as $property) {
-            $this->addTagsFor($this->propertyAccessor->getValue($entity, $property));
+            if ($this->propertyAccessor->isReadable($entity, $property)) {
+                $this->addTagsFor($this->propertyAccessor->getValue($entity, $property));
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When purging HTTP Cache Tags on Doctrine flush event, API Platform uses Doctrine mapping to determine the tags to purge. When doing so it assumes all mapped associations have a public accessor on the entity but sometimes this is not true and trying to access the value throws an exception.

I assume unreadable associations can be silently ignored as it means the associated entities don't appear in serialized responses which don't have the related tags anyway.