### PR TITLE
add missing parameter for swagger normalizer

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -31,6 +31,7 @@
             <argument>%api_platform.formats%</argument>
             <argument>%api_platform.collection.pagination.client_enabled%</argument>
             <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
+            <argument type="collection" />
             <argument>%api_platform.swagger.versions%</argument>
             <tag name="serializer.normalizer" priority="-790" />
         </service>


### PR DESCRIPTION
add default for the $defaultContext parameter so that swagger.versions parameter is properly sent to the swagger normalizer
rebases https://github.com/api-platform/core/pull/3433