### PR TITLE
Fixed an error where an exception was thrown if the messenger input data has an id field

### DIFF
--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -132,7 +132,10 @@ final class ItemNormalizer extends AbstractItemNormalizer
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         // Avoid issues with proxies if we populated the object
-        if (!isset($context[self::OBJECT_TO_POPULATE]) && isset($data['data']['id'])) {
+        if (!isset($context[self::OBJECT_TO_POPULATE])
+            && isset($data['data']['id'])
+            && !$this->getResourceMetadataAttribute($class, 'messenger', false)
+        ) {
             if (true !== ($context['api_allow_update'] ?? true)) {
                 throw new NotNormalizableValueException('Update is not allowed for this operation.');
             }

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -108,7 +108,10 @@ final class ItemNormalizer extends AbstractItemNormalizer
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         // Avoid issues with proxies if we populated the object
-        if (isset($data['@id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
+        if (isset($data['@id'])
+            && !isset($context[self::OBJECT_TO_POPULATE])
+            && !$this->getResourceMetadataAttribute($class, 'messenger', false)
+        ) {
             if (true !== ($context['api_allow_update'] ?? true)) {
                 throw new NotNormalizableValueException('Update is not allowed for this operation.');
             }

--- a/src/Serializer/InputOutputMetadataTrait.php
+++ b/src/Serializer/InputOutputMetadataTrait.php
@@ -47,4 +47,18 @@ trait InputOutputMetadataTrait
 
         return $metadata->getAttribute($inputOrOutput)['class'] ?? null;
     }
+
+    protected function getResourceMetadataAttribute(string $class, string $key, $default)
+    {
+        if (null === $this->resourceMetadataFactory) {
+            return $default;
+        }
+        try {
+            $metadata = $this->resourceMetadataFactory->create($class);
+        } catch (ResourceClassNotFoundException $e) {
+            return $default;
+        }
+
+        return $metadata->getAttribute($key, $default);
+    }
 }

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -51,7 +51,10 @@ class ItemNormalizer extends AbstractItemNormalizer
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         // Avoid issues with proxies if we populated the object
-        if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
+        if (isset($data['id'])
+            && !isset($context[self::OBJECT_TO_POPULATE])
+            && !$this->getResourceMetadataAttribute($class, 'messenger', false)
+        ) {
             if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {
                 throw new NotNormalizableValueException('Update is not allowed for this operation.');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT

How to reproduce:
```
#api_resources.yaml:
App\Dto\DummyWithIdField:
    attributes:
        messenger: true
        output: false
    collectionOperations:
        post:
            path: '/path/to/dummy'
            status: 202
    itemOperations: {}
```

```
namespace App\Dto;

class DummyWithIdField {
    /** @var string|null */
    public $id;
}
```

```
curl --location --request POST 'https://api.domain.com/path/to/dummy' \
--header 'Content-Type: application/json' \
--data-raw '{"id":"ev_16CHO7Rt6vyOp8ng"}
'
```

The error in response:
```
{
    "@context": "/contexts/Error",
    "@type": "hydra:Error",
    "hydra:title": "An error occurred",
    "hydra:description": "Update is not allowed for this operation.",
    "trace": [
        {
            "namespace": "",
            "short_class": "",
            "class": "",
            "type": "",
            "function": "",
            "file": "vendor/api-platform/core/src/Serializer/ItemNormalizer.php",
            "line": 59,
            "args": []
        },
```
The entire stacktrace https://gist.github.com/karser/9425657bff25da4026591e6af6e227fb