### PR TITLE
Fix error pagination

### DIFF
--- a/features/jsonapi/pagination.feature
+++ b/features/jsonapi/pagination.feature
@@ -36,3 +36,7 @@ Feature: JSON API pagination handling
   Scenario: Get an error when provided page number is not valid
     When I send a "GET" request to "/dummies?page[page]=0"
     Then the response status code should be 400
+    
+  Scenario: Get an error when provided page number is too large
+    When I send a "GET" request to "/dummies?page[page]=9223372036854775807"
+    Then the response status code should be 400

--- a/src/DataProvider/Pagination.php
+++ b/src/DataProvider/Pagination.php
@@ -90,9 +90,9 @@ final class Pagination
         if ($graphql && null !== ($last = $this->getParameterFromContext($context, 'last'))) {
             return ($offset = ($context['count'] ?? 0) - $last) < 0 ? 0 : $offset;
         }
-        
+
         $offset = ($this->getPage($context) - 1) * $limit;
-        
+
         if (!\is_int($offset)) {
             throw new InvalidArgumentException('Page parameter is too large.');
         }

--- a/src/DataProvider/Pagination.php
+++ b/src/DataProvider/Pagination.php
@@ -90,8 +90,14 @@ final class Pagination
         if ($graphql && null !== ($last = $this->getParameterFromContext($context, 'last'))) {
             return ($offset = ($context['count'] ?? 0) - $last) < 0 ? 0 : $offset;
         }
+        
+        $offset = ($this->getPage($context) - 1) * $limit;
+        
+        if (!\is_int($offset)) {
+            throw new InvalidArgumentException('Page parameter is too large.');
+        }
 
-        return ($this->getPage($context) - 1) * $limit;
+        return $offset;
     }
 
     /**


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | n/a


I integrate a schemathesis tool for automatically testing api based on the openapi standard

When setting a large pag value, for example 9223372036854775807, a 500 error is caused

"Return value of ApiPlatform \\ Core \\ DataProvider \\ Pagination :: getOffset () must be of the type integer, float returned"

Added a check for the type of the return value in the getOffset method on Pagination class,

 if the value is outside the scope of int64 (https://www.php.net/manual/en/language.types.integer.php) throw an error "Large page and limit values"
