### PR TITLE
feat: improves iri_only implementation

### DIFF
--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -1588,15 +1588,17 @@ final class DoctrineContext implements Context
     }
 
     /**
-    * @Given there are :nb iriOnlyDummies
-    */
-    public function thereAreIrionlydummies(int $nb)
+     * @Given there are :nb iriOnlyDummies
+     */
+    public function thereAreIriOnlyDummies(int $nb)
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $iriOnlyDummy = $this->buildIriOnlyDummy();
             $iriOnlyDummy->setFoo('bar'.$nb);
             $this->manager->persist($iriOnlyDummy);
         }
+
+        $this->manager->flush();
     }
 
     /**

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -54,6 +54,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\FooDummy as FooDummyDocu
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\FourthLevel as FourthLevelDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Greeting as GreetingDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\InitializeInput as InitializeInputDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\IriOnlyDummy as IriOnlyDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\MaxDepthDummy as MaxDepthDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\NetworkPathDummy as NetworkPathDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\NetworkPathRelationDummy as NetworkPathRelationDummyDocument;
@@ -120,6 +121,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FourthLevel;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Greeting;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\InitializeInput;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\InternalUser;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\IriOnlyDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathRelationDummy;
@@ -1586,6 +1588,18 @@ final class DoctrineContext implements Context
     }
 
     /**
+    * @Given there are :nb iriOnlyDummies
+    */
+    public function thereAreIrionlydummies(int $nb)
+    {
+        for ($i = 1; $i <= $nb; ++$i) {
+            $iriOnlyDummy = $this->buildIriOnlyDummy();
+            $iriOnlyDummy->setFoo('bar'.$nb);
+            $this->manager->persist($iriOnlyDummy);
+        }
+    }
+
+    /**
      * @Given there are :nb absoluteUrlDummy objects with a related absoluteUrlRelationDummy
      */
     public function thereAreAbsoluteUrlDummies(int $nb)
@@ -1865,6 +1879,14 @@ final class DoctrineContext implements Context
     private function buildGreeting()
     {
         return $this->isOrm() ? new Greeting() : new GreetingDocument();
+    }
+
+    /**
+     * @return IriOnlyDummy|IriOnlyDummyDocument
+     */
+    private function buildIriOnlyDummy()
+    {
+        return $this->isOrm() ? new IriOnlyDummy() : new IriOnlyDummyDocument();
     }
 
     /**

--- a/features/jsonld/iri_only.feature
+++ b/features/jsonld/iri_only.feature
@@ -1,9 +1,9 @@
-Feature: JSON-LD using IriOnly parameter
+Feature: JSON-LD using iri_only parameter
   In order to improve Vulcain support
-  As a vulcain user and as a developer
-  I should be able to only get an IRI list when I ask a resource to do so.
+  As a Vulcain user and as a developer
+  I should be able to only get an IRI list when I ask a resource.
 
-  Scenario: Retrieve Dummy's resource context with IriOnly
+  Scenario: Retrieve Dummy's resource context with iri_only
     When I send a "GET" request to "/contexts/IriOnlyDummy"
     Then the response status code should be 200
     And the response should be in JSON
@@ -22,7 +22,7 @@ Feature: JSON-LD using IriOnly parameter
       """
 
   @createSchema
-  Scenario: Retrieve Dummies with an embedded IriOnly context
+  Scenario: Retrieve Dummies with iri_only and jsonld_embed_context
     Given there are 3 iriOnlyDummies
     When I send a "GET" request to "/iri_only_dummies"
     Then the response status code should be 200

--- a/features/jsonld/iri_only.feature
+++ b/features/jsonld/iri_only.feature
@@ -1,0 +1,50 @@
+Feature: JSON-LD using IriOnly parameter
+  In order to improve Vulcain support
+  As a vulcain user and as a developer
+  I should be able to only get an IRI list when I ask a resource to do so.
+
+  Scenario: Retrieve Dummy's resource context with IriOnly
+    When I send a "GET" request to "/contexts/IriOnlyDummy"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+      """
+      {
+          "@context": {
+              "@vocab": "http://example.com/docs.jsonld#",
+              "hydra": "http://www.w3.org/ns/hydra/core#",
+              "hydra:member": {
+                  "@type": "@id"
+              }
+          }
+      }
+      """
+
+  @createSchema
+  Scenario: Retrieve Dummies with an embedded IriOnly context
+    Given there are 3 iriOnlyDummies
+    When I send a "GET" request to "/iri_only_dummies"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+      """
+      {
+          "@context": {
+              "@vocab": "http://example.com/docs.jsonld#",
+              "hydra": "http://www.w3.org/ns/hydra/core#",
+              "hydra:member": {
+                  "@type": "@id"
+              }
+          },
+          "@id": "/iri_only_dummies",
+          "@type": "hydra:Collection",
+          "hydra:member": [
+              "/iri_only_dummies/1",
+              "/iri_only_dummies/2",
+              "/iri_only_dummies/3"
+          ],
+          "hydra:totalItems": 3
+      }
+      """

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -39,21 +39,16 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
     use NormalizerAwareTrait;
 
     public const FORMAT = 'jsonld';
-    public const IRI_ONLY = 'iri_only';
 
     private $contextBuilder;
     private $resourceClassResolver;
     private $iriConverter;
-    private $defaultContext = [
-        self::IRI_ONLY => false,
-    ];
 
-    public function __construct(ContextBuilderInterface $contextBuilder, ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter, array $defaultContext = [])
+    public function __construct(ContextBuilderInterface $contextBuilder, ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter)
     {
         $this->contextBuilder = $contextBuilder;
         $this->resourceClassResolver = $resourceClassResolver;
         $this->iriConverter = $iriConverter;
-        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     /**
@@ -86,11 +81,10 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
         }
 
         $data['@type'] = 'hydra:Collection';
-
         $data['hydra:member'] = [];
-        $iriOnly = $context[self::IRI_ONLY] ?? $this->defaultContext[self::IRI_ONLY];
+        $iriOnly = $context['iri_only'] ?? false;
         foreach ($object as $obj) {
-            $data['hydra:member'][] = $iriOnly ? ['@id' => $this->iriConverter->getIriFromItem($obj)] : $this->normalizer->normalize($obj, $format, $context);
+            $data['hydra:member'][] = $iriOnly ? $this->iriConverter->getIriFromItem($obj) : $this->normalizer->normalize($obj, $format, $context);
         }
 
         if ($object instanceof PaginatorInterface) {

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -39,16 +39,21 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
     use NormalizerAwareTrait;
 
     public const FORMAT = 'jsonld';
+    public const IRI_ONLY = 'iri_only';
 
     private $contextBuilder;
     private $resourceClassResolver;
     private $iriConverter;
+    private $defaultContext = [
+        self::IRI_ONLY => false,
+    ];
 
-    public function __construct(ContextBuilderInterface $contextBuilder, ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter)
+    public function __construct(ContextBuilderInterface $contextBuilder, ResourceClassResolverInterface $resourceClassResolver, IriConverterInterface $iriConverter, array $defaultContext = [])
     {
         $this->contextBuilder = $contextBuilder;
         $this->resourceClassResolver = $resourceClassResolver;
         $this->iriConverter = $iriConverter;
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
     /**
@@ -82,7 +87,7 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
 
         $data['@type'] = 'hydra:Collection';
         $data['hydra:member'] = [];
-        $iriOnly = $context['iri_only'] ?? false;
+        $iriOnly = $context[self::IRI_ONLY] ?? $this->defaultContext[self::IRI_ONLY];
         foreach ($object as $obj) {
             $data['hydra:member'][] = $iriOnly ? $this->iriConverter->getIriFromItem($obj) : $this->normalizer->normalize($obj, $format, $context);
         }

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -95,6 +95,13 @@ final class ContextBuilder implements AnonymousContextBuilderInterface
             return [];
         }
 
+        if ($metadata->getAttribute('normalization_context')['iri_only'] ?? false) {
+            $context = $this->getBaseContext($referenceType);
+            $context['hydra:member']['@type'] = '@id';
+
+            return $context;
+        }
+
         return $this->getResourceContextWithShortname($resourceClass, $referenceType, $shortName);
     }
 

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -95,7 +95,7 @@ final class ContextBuilder implements AnonymousContextBuilderInterface
             return [];
         }
 
-        if ($metadata->getAttribute('normalization_context')['iri_only'] ?? false) {
+        if ($resourceMetadata->getAttribute('normalization_context')['iri_only'] ?? false) {
             $context = $this->getBaseContext($referenceType);
             $context['hydra:member']['@type'] = '@id';
 

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -72,6 +72,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         }
 
         $context['resource_class'] = $attributes['resource_class'];
+        $context['iri_only'] = $resourceMetadata->getAttribute('normalization_context')['iri_only'] ?? false;
         $context['input'] = $resourceMetadata->getTypedOperationAttribute($operationType, $attributes[$operationKey], 'input', null, true);
         $context['output'] = $resourceMetadata->getTypedOperationAttribute($operationType, $attributes[$operationKey], 'output', null, true);
         $context['request_uri'] = $request->getRequestUri();

--- a/tests/Fixtures/TestBundle/Document/IriOnlyDummy.php
+++ b/tests/Fixtures/TestBundle/Document/IriOnlyDummy.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
- * Dummy IriOnly.
+ * Dummy with iri_only.
  *
  * @author Pierre Thibaudeau <pierre.thibaudeau@les-tilleuls.coop>
  *
@@ -45,7 +45,7 @@ class IriOnlyDummy
      */
     private $foo;
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Fixtures/TestBundle/Document/IriOnlyDummy.php
+++ b/tests/Fixtures/TestBundle/Document/IriOnlyDummy.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Dummy IriOnly.
+ *
+ * @author Pierre Thibaudeau <pierre.thibaudeau@les-tilleuls.coop>
+ *
+ * @ApiResource(
+ *     normalizationContext={
+ *         "iri_only"=true,
+ *         "jsonld_embed_context"=true
+ *     }
+ * )
+ * @ODM\Document
+ */
+class IriOnlyDummy
+{
+    /**
+     * @var int The id
+     *
+     * @ODM\Id(strategy="INCREMENT", type="integer")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ODM\Field(type="string")
+     */
+    private $foo;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function setFoo(string $foo): void
+    {
+        $this->foo = $foo;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/IriOnlyDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/IriOnlyDummy.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Dummy IriOnly.
+ * Dummy with iri_only.
  *
  * @author Pierre Thibaudeau <pierre.thibaudeau@les-tilleuls.coop>
  *
@@ -47,7 +47,7 @@ class IriOnlyDummy
      */
     private $foo;
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Fixtures/TestBundle/Entity/IriOnlyDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/IriOnlyDummy.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Dummy IriOnly.
+ *
+ * @author Pierre Thibaudeau <pierre.thibaudeau@les-tilleuls.coop>
+ *
+ * @ApiResource(
+ *     normalizationContext={
+ *         "iri_only"=true,
+ *         "jsonld_embed_context"=true
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class IriOnlyDummy
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    private $foo;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function setFoo(string $foo): void
+    {
+        $this->foo = $foo;
+    }
+}

--- a/tests/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionNormalizerTest.php
@@ -381,7 +381,7 @@ class CollectionNormalizerTest extends TestCase
         ], $actual);
     }
 
-    public function testNormalizeIriOnlyEmbeddedResourceCollection(): void
+    public function testNormalizeIriOnlyEmbedContextResourceCollection(): void
     {
         $fooOne = new Foo();
         $fooOne->id = 1;

--- a/tests/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionNormalizerTest.php
@@ -360,12 +360,12 @@ class CollectionNormalizerTest extends TestCase
 
         $delegateNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
 
-        $normalizer = new CollectionNormalizer($contextBuilderProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $iriConverterProphecy->reveal(), [CollectionNormalizer::IRI_ONLY => true]);
+        $normalizer = new CollectionNormalizer($contextBuilderProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $iriConverterProphecy->reveal());
         $normalizer->setNormalizer($delegateNormalizerProphecy->reveal());
 
         $actual = $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
             'collection_operation_name' => 'get',
-            'operation_type' => OperationType::COLLECTION,
+            'iri_only' => true,
             'resource_class' => Foo::class,
         ]);
 
@@ -374,8 +374,67 @@ class CollectionNormalizerTest extends TestCase
             '@id' => '/foos',
             '@type' => 'hydra:Collection',
             'hydra:member' => [
-                ['@id' => '/foos/1'],
-                ['@id' => '/foos/3'],
+                '/foos/1',
+                '/foos/3',
+            ],
+            'hydra:totalItems' => 2,
+        ], $actual);
+    }
+
+    public function testNormalizeIriOnlyEmbeddedResourceCollection(): void
+    {
+        $fooOne = new Foo();
+        $fooOne->id = 1;
+        $fooOne->bar = 'baz';
+
+        $fooThree = new Foo();
+        $fooThree->id = 3;
+        $fooThree->bar = 'bzz';
+
+        $data = [$fooOne, $fooThree];
+
+        $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
+        $contextBuilderProphecy->getResourceContext(Foo::class)->willReturn([
+            '@vocab' => 'http://localhost:8080/docs.jsonld#',
+            'hydra' => 'http://www.w3.org/ns/hydra/core#',
+            'hydra:member' => [
+                '@type' => '@id',
+            ],
+        ]);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass($data, Foo::class)->willReturn(Foo::class);
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResourceClass(Foo::class)->willReturn('/foos');
+        $iriConverterProphecy->getIriFromItem($fooOne)->willReturn('/foos/1');
+        $iriConverterProphecy->getIriFromItem($fooThree)->willReturn('/foos/3');
+
+        $delegateNormalizerProphecy = $this->prophesize(NormalizerInterface::class);
+
+        $normalizer = new CollectionNormalizer($contextBuilderProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $iriConverterProphecy->reveal());
+        $normalizer->setNormalizer($delegateNormalizerProphecy->reveal());
+
+        $actual = $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
+            'collection_operation_name' => 'get',
+            'iri_only' => true,
+            'jsonld_embed_context' => true,
+            'resource_class' => Foo::class,
+        ]);
+
+        $this->assertSame([
+            '@context' => [
+                '@vocab' => 'http://localhost:8080/docs.jsonld#',
+                'hydra' => 'http://www.w3.org/ns/hydra/core#',
+                'hydra:member' => [
+                    '@type' => '@id',
+                ],
+            ],
+            '@id' => '/foos',
+            '@type' => 'hydra:Collection',
+            'hydra:member' => [
+                '/foos/1',
+                '/foos/3',
             ],
             'hydra:totalItems' => 2,
         ], $actual);

--- a/tests/JsonLd/ContextBuilderTest.php
+++ b/tests/JsonLd/ContextBuilderTest.php
@@ -70,6 +70,25 @@ class ContextBuilderTest extends TestCase
         $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
     }
 
+    public function testIriOnlyResourceContext()
+    {
+        $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity', null, null, null, null, ['normalization_context' => ['iri_only' => true]]));
+        $this->propertyNameCollectionFactoryProphecy->create($this->entityClass)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
+        $this->propertyMetadataFactoryProphecy->create($this->entityClass, 'dummyPropertyA')->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'Dummy property A', true, true, true, true, false, false));
+
+        $contextBuilder = new ContextBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), $this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->urlGeneratorProphecy->reveal());
+
+        $expected = [
+            '@vocab' => '#',
+            'hydra' => 'http://www.w3.org/ns/hydra/core#',
+            'hydra:member' => [
+                '@type' => '@id',
+            ],
+        ];
+
+        $this->assertEquals($expected, $contextBuilder->getResourceContext($this->entityClass));
+    }
+
     public function testResourceContextWithJsonldContext()
     {
         $this->resourceMetadataFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadata('DummyEntity'));

--- a/tests/Serializer/SerializerContextBuilderTest.php
+++ b/tests/Serializer/SerializerContextBuilderTest.php
@@ -58,32 +58,32 @@ class SerializerContextBuilderTest extends TestCase
     {
         $request = Request::create('/foos/1');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['foo' => 'bar', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null];
+        $expected = ['foo' => 'bar', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, true));
 
         $request = Request::create('/foos');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'pot', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['foo' => 'bar', 'collection_operation_name' => 'pot',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null];
+        $expected = ['foo' => 'bar', 'collection_operation_name' => 'pot',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, true));
 
         $request = Request::create('/foos/1');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null];
+        $expected = ['bar' => 'baz', 'item_operation_name' => 'get',  'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
         $request = Request::create('/foos', 'POST');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'post', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'collection_operation_name' => 'post',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => false, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null];
+        $expected = ['bar' => 'baz', 'collection_operation_name' => 'post',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => false, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
         $request = Request::create('/foos', 'PUT');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'put', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'collection_operation_name' => 'put', 'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => true, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null];
+        $expected = ['bar' => 'baz', 'collection_operation_name' => 'put', 'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => true, 'operation_type' => 'collection', 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
         $request = Request::create('/bars/1/foos');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_subresource_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'subresource_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/bars/1/foos', 'operation_type' => 'subresource', 'api_allow_update' => false, 'uri' => 'http://localhost/bars/1/foos', 'output' => null, 'input' => null];
+        $expected = ['bar' => 'baz', 'subresource_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/bars/1/foos', 'operation_type' => 'subresource', 'api_allow_update' => false, 'uri' => 'http://localhost/bars/1/foos', 'output' => null, 'input' => null, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
     }
 
@@ -96,7 +96,7 @@ class SerializerContextBuilderTest extends TestCase
 
     public function testReuseExistingAttributes()
     {
-        $expected = ['bar' => 'baz', 'item_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null];
+        $expected = ['bar' => 'baz', 'item_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/foos/1', 'api_allow_update' => false, 'operation_type' => 'item', 'uri' => 'http://localhost/foos/1', 'output' => null, 'input' => null, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest(Request::create('/foos/1'), false, ['resource_class' => 'Foo', 'item_operation_name' => 'get']));
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT

adds an "iri_only" parameter to the "collectionOperations" annotation. allows the display of resources in IRI list form