### PR TITLE
Remove location header on 2xx responses except for 201 and 202

### DIFF
--- a/src/EventListener/RespondListener.php
+++ b/src/EventListener/RespondListener.php
@@ -83,9 +83,15 @@ final class RespondListener
             $status = $resourceMetadata->getOperationAttribute($attributes, 'status');
         }
 
+        $status = $status ?? self::METHOD_TO_CODE[$request->getMethod()] ?? Response::HTTP_OK;
+
+        if ($request->isMethod('POST') && !\in_array($status, [Response::HTTP_CREATED, Response::HTTP_ACCEPTED], true)) {
+            unset($headers['Location']);
+        }
+
         $event->setResponse(new Response(
             $controllerResult,
-            $status ?? self::METHOD_TO_CODE[$request->getMethod()] ?? Response::HTTP_OK,
+            $status,
             $headers
         ));
     }

--- a/tests/EventListener/RespondListenerTest.php
+++ b/tests/EventListener/RespondListenerTest.php
@@ -78,6 +78,7 @@ class RespondListenerTest extends TestCase
         $this->assertEquals('Accept', $response->headers->get('Vary'));
         $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
+        $this->assertNull($response->headers->get('Location'));
     }
 
     public function testCreate201Response()
@@ -134,6 +135,7 @@ class RespondListenerTest extends TestCase
         $this->assertEquals('Accept', $response->headers->get('Vary'));
         $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
+        $this->assertNull($response->headers->get('Location'));
     }
 
     public function testSetSunsetHeader()


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ??
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Currently when making a POST request that returns a 200 status code with `write` enabled (by default), the location header is returned that make clients like Insomnia consider it as 302.

That's because the `WriteListener` adds the request attribute `_api_write_item_iri` that is then used in the `RespondListener` to set the `Location` header.

Location header for 2xx status code is only valid for 201 and 202 at my knowledge.

From [Wikipedia](https://en.wikipedia.org/wiki/HTTP_location) (not the best reference for this)
```markdown
The HTTP Location header field is returned in responses from an HTTP server under two circumstances:

1) To ask a web browser to load a different web page (URL redirection). In this circumstance, the Location header should be sent with an HTTP status code of 3xx. It is passed as part of the response by a web server when the requested URI has:
  - Moved temporarily;
  - Moved permanently; or
  - Processed a request, e.g. a POSTed form, and is providing the result of that request at a different URI
2) To provide information about the location of a newly created resource. In this circumstance, the Location header should be sent with an HTTP status code of 201 or 202.[1]
```