### PR TITLE
…Do not treat classes implementing \Traversable as collection

### DIFF
--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -45,7 +45,8 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
             throw new InvalidArgumentException('Strict checking is only possible when resource class is specified.');
         }
 
-        $actualClass = \is_object($value) && !$value instanceof \Traversable ? $this->getObjectClass($value) : null;
+        $objectClass = \is_object($value) ? $this->getObjectClass($value) : null;
+        $actualClass = ($objectClass && (!$value instanceof \Traversable || $this->isResourceClass($objectClass))) ? $this->getObjectClass($value) : null;
 
         if (null === $actualClass && null === $resourceClass) {
             throw new InvalidArgumentException('Resource type could not be determined. Resource class must be specified.');

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -90,7 +90,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     public function supportsNormalization($data, $format = null)
     {
-        if (!\is_object($data) || $data instanceof \Traversable) {
+        if (!\is_object($data)) {
             return false;
         }
 

--- a/tests/Api/ResourceClassResolverTest.php
+++ b/tests/Api/ResourceClassResolverTest.php
@@ -88,6 +88,19 @@ class ResourceClassResolverTest extends TestCase
         $this->assertEquals(Dummy::class, $resourceClassResolver->getResourceClass($dummies, Dummy::class));
     }
 
+    public function testGetResourceClassWithTraversable()
+    {
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([\ArrayObject::class]));
+
+        $dummy = new \ArrayObject();
+
+
+        $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
+
+        $this->assertEquals(\ArrayObject::class, $resourceClassResolver->getResourceClass($dummy));
+    }
+
     public function testGetResourceClassWithPaginatorInterfaceAsValue()
     {
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
@@ -119,6 +132,7 @@ class ResourceClassResolverTest extends TestCase
         $this->expectExceptionMessage('Resource type could not be determined. Resource class must be specified.');
 
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection([]));
 
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
 

--- a/tests/Api/ResourceClassResolverTest.php
+++ b/tests/Api/ResourceClassResolverTest.php
@@ -95,7 +95,6 @@ class ResourceClassResolverTest extends TestCase
 
         $dummy = new \ArrayObject();
 
-
         $resourceClassResolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy->reveal());
 
         $this->assertEquals(\ArrayObject::class, $resourceClassResolver->getResourceClass($dummy));


### PR DESCRIPTION
Do not treat classes implementing `\Traversable` as collection if defined as resource

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | #3461
| License       | MIT
| Doc PR        | -

Classes implementing `\Traversable` were always interpreted as Collection by the `ResourceClassResolver `service, based on the fact they implemented the `\Traversable` interface.

Classes that implement this interface will now only be treated as a Collection if they are not explicitly defined as a Resource in the configuration.



<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
