### PR TITLE
[GraphQL] Fix filter arguments order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * GraphQL: Possibility to add a custom description for queries, mutations and subscriptions (#3477, #3514)
 * GraphQL: Support for field name conversion (serialized name) (#3455, #3516)
 * GraphQL: **BC** `operation` is now `operationName` to follow the standard (#3568)
+* GraphQL: **BC** New syntax for the filters' arguments to preserve the order: `order: [{foo: 'asc'}, {bar: 'desc'}]` (#3468)
 * OpenAPI: Add PHP default values to the documentation (#2386)
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -449,6 +449,34 @@ final class DoctrineContext implements Context
     }
 
     /**
+     * @Given there are dummies with similar properties
+     */
+    public function thereAreDummiesWithSimilarProperties()
+    {
+        $dummy1 = $this->buildDummy();
+        $dummy1->setName('foo');
+        $dummy1->setDescription('bar');
+
+        $dummy2 = $this->buildDummy();
+        $dummy2->setName('baz');
+        $dummy2->setDescription('qux');
+
+        $dummy3 = $this->buildDummy();
+        $dummy3->setName('foo');
+        $dummy3->setDescription('qux');
+
+        $dummy4 = $this->buildDummy();
+        $dummy4->setName('baz');
+        $dummy4->setDescription('bar');
+
+        $this->manager->persist($dummy1);
+        $this->manager->persist($dummy2);
+        $this->manager->persist($dummy3);
+        $this->manager->persist($dummy4);
+        $this->manager->flush();
+    }
+
+    /**
      * @Given there are :nb dummyDtoNoInput objects
      */
     public function thereAreDummyDtoNoInputObjects(int $nb)

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -30,7 +30,7 @@ Feature: Collections filtering
     When I send the following GraphQL request:
     """
     {
-      dummies(exists: {relatedDummy: true}) {
+      dummies(exists: [{relatedDummy: true}]) {
         edges {
           node {
             id
@@ -52,7 +52,7 @@ Feature: Collections filtering
     When I send the following GraphQL request:
     """
     {
-      dummies(dummyDate: {after: "2015-04-02"}) {
+      dummies(dummyDate: [{after: "2015-04-02"}]) {
         edges {
           node {
             id
@@ -204,7 +204,7 @@ Feature: Collections filtering
     When I send the following GraphQL request:
     """
     {
-      dummies(order: {relatedDummy__name: "DESC"}) {
+      dummies(order: [{relatedDummy__name: "DESC"}]) {
         edges {
           node {
             name

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -228,7 +228,7 @@ Feature: Collections filtering
     When I send the following GraphQL request:
     """
     {
-      dummies(order: {description: "ASC", name: "ASC"}) {
+      dummies(order: [{description: "ASC"}, {name: "ASC"}]) {
         edges {
           node {
             id

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -223,6 +223,31 @@ Feature: Collections filtering
     And the JSON node "data.dummies.edges[1].node.name" should be equal to "Dummy #1"
 
   @createSchema
+  Scenario: Retrieve a collection ordered correctly given the order of the argument
+    Given there are dummies with similar properties
+    When I send the following GraphQL request:
+    """
+    {
+      dummies(order: {description: "ASC", name: "ASC"}) {
+        edges {
+          node {
+            id
+            name
+            description
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.dummies.edges[0].node.name" should be equal to "baz"
+    And the JSON node "data.dummies.edges[0].node.description" should be equal to "bar"
+    And the JSON node "data.dummies.edges[1].node.name" should be equal to "foo"
+    And the JSON node "data.dummies.edges[1].node.description" should be equal to "bar"
+
+
+  @createSchema
   Scenario: Retrieve a collection filtered using the related search filter with two values and exact strategy
     Given there are 3 dummy objects with relatedDummy
     When  I send the following GraphQL request:

--- a/features/graphql/filters.feature
+++ b/features/graphql/filters.feature
@@ -246,7 +246,6 @@ Feature: Collections filtering
     And the JSON node "data.dummies.edges[1].node.name" should be equal to "foo"
     And the JSON node "data.dummies.edges[1].node.description" should be equal to "bar"
 
-
   @createSchema
   Scenario: Retrieve a collection filtered using the related search filter with two values and exact strategy
     Given there are 3 dummy objects with relatedDummy

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -133,12 +133,12 @@ final class ReadStage implements ReadStageInterface
 
         foreach ($filters as $name => $value) {
             if (\is_array($value)) {
-                if (\is_string($name) && strpos($name, '_list')) {
+                if (strpos($name, '_list')) {
                     $name = substr($name, 0, \strlen($name) - \strlen('_list'));
                 }
 
                 // If the value contains arrays, we need to merge them for the filters to understand this syntax, proper to GraphQL to preserve the order of the arguments.
-                if ($this->isNumericIndexArrayOfArray($value)) {
+                if ($this->isSequentialArrayOfArrays($value)) {
                     if (\count($value[0]) > 1) {
                         $deprecationMessage = "The filter syntax \"$name: {";
                         $filterArgsOld = [];

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -137,8 +137,19 @@ final class ReadStage implements ReadStageInterface
                     $name = substr($name, 0, \strlen($name) - \strlen('_list'));
                 }
 
-                //If the value contains arrays, we need to merge them for the filters to understand this syntax, proper to GraphQL to preserve the order of the arguments.
+                // If the value contains arrays, we need to merge them for the filters to understand this syntax, proper to GraphQL to preserve the order of the arguments.
                 if ($this->isNumericIndexArrayOfArray($value)) {
+                    if (\count($value[0]) > 1) {
+                        $deprecationMessage = "The filter syntax \"$name: {";
+                        $filterArgsOld = [];
+                        $filterArgsNew = [];
+                        foreach ($value[0] as $filterArgName => $filterArgValue) {
+                            $filterArgsOld[] = "$filterArgName: \"$filterArgValue\"";
+                            $filterArgsNew[] = sprintf('{%s: "%s"}', $filterArgName, $filterArgValue);
+                        }
+                        $deprecationMessage .= sprintf('%s}" is deprecated since API Platform 2.6, use the following syntax instead: "%s: [%s]".', implode(', ', $filterArgsOld), $name, implode(', ', $filterArgsNew));
+                        @trigger_error($deprecationMessage, E_USER_DEPRECATED);
+                    }
                     $value = array_merge(...$value);
                 }
                 $filters[$name] = $this->getNormalizedFilters($value);

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -451,10 +451,10 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
             unset($value['#name']);
 
-            $filterArgType = new InputObjectType([
+            $filterArgType = GraphQLType::listOf(new InputObjectType([
                 'name' => $name,
                 'fields' => $this->convertFilterArgsToTypes($value),
-            ]);
+            ]));
 
             $this->typesContainer->set($name, $filterArgType);
 

--- a/src/Util/ArrayTrait.php
+++ b/src/Util/ArrayTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Util;
+
+trait ArrayTrait
+{
+    public function isNumericIndexArrayOfArray(array $array): bool
+    {
+        if (!$this->isSequentialArray($array)) {
+            return false;
+        }
+
+        return $this->arrayContainsOnly($array, gettype([]));
+    }
+
+    public function isSequentialArray(array $array): bool
+    {
+        if ([] === $array) {
+            return false;
+        }
+
+        return array_keys($array) === range(0, \count($array) - 1);
+    }
+
+    public function arrayContainsOnly(array $array, string $type): bool
+    {
+        return $array === array_filter($array, static function ($item) use ($type){
+            return $type === gettype($item);
+        });
+    }
+}

--- a/src/Util/ArrayTrait.php
+++ b/src/Util/ArrayTrait.php
@@ -21,7 +21,7 @@ trait ArrayTrait
             return false;
         }
 
-        return $this->arrayContainsOnly($array, gettype([]));
+        return $this->arrayContainsOnly($array, \gettype([]));
     }
 
     public function isSequentialArray(array $array): bool
@@ -35,8 +35,8 @@ trait ArrayTrait
 
     public function arrayContainsOnly(array $array, string $type): bool
     {
-        return $array === array_filter($array, static function ($item) use ($type){
-            return $type === gettype($item);
+        return $array === array_filter($array, static function ($item) use ($type) {
+            return $type === \gettype($item);
         });
     }
 }

--- a/src/Util/ArrayTrait.php
+++ b/src/Util/ArrayTrait.php
@@ -15,13 +15,13 @@ namespace ApiPlatform\Core\Util;
 
 trait ArrayTrait
 {
-    public function isNumericIndexArrayOfArray(array $array): bool
+    public function isSequentialArrayOfArrays(array $array): bool
     {
         if (!$this->isSequentialArray($array)) {
             return false;
         }
 
-        return $this->arrayContainsOnly($array, \gettype([]));
+        return $this->arrayContainsOnly($array, 'array');
     }
 
     public function isSequentialArray(array $array): bool
@@ -35,7 +35,7 @@ trait ArrayTrait
 
     public function arrayContainsOnly(array $array, string $type): bool
     {
-        return $array === array_filter($array, static function ($item) use ($type) {
+        return $array === array_filter($array, static function ($item) use ($type): bool {
             return $type === \gettype($item);
         });
     }

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -25,6 +25,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use GraphQL\Type\Definition\ResolveInfo;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -32,6 +33,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ReadStageTest extends TestCase
 {
+    use ExpectDeprecationTrait;
     use ProphecyTrait;
 
     /** @var ReadStage */
@@ -230,6 +232,13 @@ class ReadStageTest extends TestCase
                 ['filter_list' => 'filtered', 'filter_field_list' => ['filtered1', 'filtered2'], 'filter.list' => 'filtered', 'filter_field' => ['filtered1', 'filtered2'], 'filter.field' => ['filtered1', 'filtered2']],
                 [],
             ],
+            'with array filter syntax' => [
+                ['filter' => [['filterArg1' => 'filterValue1'], ['filterArg2' => 'filterValue2']]],
+                'myResource',
+                null,
+                ['filter' => ['filterArg1' => 'filterValue1', 'filterArg2' => 'filterValue2']],
+                [],
+            ],
             'with subresource' => [
                 [],
                 'myResource',
@@ -238,5 +247,37 @@ class ReadStageTest extends TestCase
                 ['subresource'],
             ],
         ];
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testApplyCollectionWithDeprecatedFilterSyntax(): void
+    {
+        $operationName = 'collection_query';
+        $resourceClass = 'myResource';
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $fieldName = 'subresource';
+        $info->fieldName = $fieldName;
+        $context = [
+            'is_collection' => true,
+            'is_mutation' => false,
+            'is_subscription' => false,
+            'args' => ['filter' => [['filterArg1' => 'filterValue1', 'filterArg2' => 'filterValue2']]],
+            'info' => $info,
+            'source' => null,
+        ];
+        $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadata());
+
+        $normalizationContext = ['normalization' => true];
+        $this->serializerContextBuilderProphecy->create($resourceClass, $operationName, $context, true)->shouldBeCalled()->willReturn($normalizationContext);
+
+        $this->collectionDataProviderProphecy->getCollection($resourceClass, $operationName, $normalizationContext + ['filters' => ['filter' => ['filterArg1' => 'filterValue1', 'filterArg2' => 'filterValue2']]])->willReturn([]);
+
+        $this->expectDeprecation('The filter syntax "filter: {filterArg1: "filterValue1", filterArg2: "filterValue2"}" is deprecated since API Platform 2.6, use the following syntax instead: "filter: [{filterArg1: "filterValue1"}, {filterArg2: "filterValue2"}]".');
+
+        $result = ($this->readStage)($resourceClass, 'myResource', $operationName, $context);
+
+        $this->assertSame([], $result);
     }
 }

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\NameConverter\CustomCo
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as GraphQLType;
@@ -233,8 +234,8 @@ class FieldsBuilderTest extends TestCase
         $this->filterLocatorProphecy->get('my_filter')->willReturn($filterProphecy->reveal());
         $this->typesContainerProphecy->has('ShortNameFilter_dateField')->willReturn(false);
         $this->typesContainerProphecy->has('ShortNameFilter_parent__child')->willReturn(false);
-        $this->typesContainerProphecy->set('ShortNameFilter_dateField', Argument::type(InputObjectType::class));
-        $this->typesContainerProphecy->set('ShortNameFilter_parent__child', Argument::type(InputObjectType::class));
+        $this->typesContainerProphecy->set('ShortNameFilter_dateField', Argument::type(ListOfType::class));
+        $this->typesContainerProphecy->set('ShortNameFilter_parent__child', Argument::type(ListOfType::class));
 
         $queryFields = $this->fieldsBuilder->getCollectionQueryFields($resourceClass, $resourceMetadata, $queryName, $configuration);
 
@@ -299,8 +300,8 @@ class FieldsBuilderTest extends TestCase
                             ],
                             'boolField' => $graphqlType,
                             'boolField_list' => GraphQLType::listOf($graphqlType),
-                            'parent__child' => new InputObjectType(['name' => 'ShortNameFilter_parent__child', 'fields' => ['related__nested' => $graphqlType]]),
-                            'dateField' => new InputObjectType(['name' => 'ShortNameFilter_dateField', 'fields' => ['before' => $graphqlType]]),
+                            'parent__child' => GraphQLType::listOf(new InputObjectType(['name' => 'ShortNameFilter_parent__child', 'fields' => ['related__nested' => $graphqlType]])),
+                            'dateField' => GraphQLType::listOf(new InputObjectType(['name' => 'ShortNameFilter_dateField', 'fields' => ['before' => $graphqlType]])),
                         ],
                         'resolve' => $resolver,
                         'deprecationReason' => null,
@@ -351,8 +352,8 @@ class FieldsBuilderTest extends TestCase
                             ],
                             'boolField' => $graphqlType,
                             'boolField_list' => GraphQLType::listOf($graphqlType),
-                            'parent__child' => new InputObjectType(['name' => 'ShortNameFilter_parent__child', 'fields' => ['related__nested' => $graphqlType]]),
-                            'dateField' => new InputObjectType(['name' => 'ShortNameFilter_dateField', 'fields' => ['before' => $graphqlType]]),
+                            'parent__child' => GraphQLType::listOf(new InputObjectType(['name' => 'ShortNameFilter_parent__child', 'fields' => ['related__nested' => $graphqlType]])),
+                            'dateField' => GraphQLType::listOf(new InputObjectType(['name' => 'ShortNameFilter_dateField', 'fields' => ['before' => $graphqlType]])),
                         ],
                         'resolve' => $resolver,
                         'deprecationReason' => null,

--- a/tests/ProphecyTrait.php
+++ b/tests/ProphecyTrait.php
@@ -110,9 +110,7 @@ trait ProphecyTrait
         $this->prophecyAssertionsCounted = true;
 
         foreach ($this->prophet->getProphecies() as $objectProphecy) {
-            /**
-             * @var MethodProphecy[] $methodProphecies
-             */
+            /** @var MethodProphecy[] $methodProphecies */
             foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
                 foreach ($methodProphecies as $methodProphecy) {
                     \assert($methodProphecy instanceof MethodProphecy);

--- a/tests/Util/ArrayTraitTest.php
+++ b/tests/Util/ArrayTraitTest.php
@@ -27,39 +27,39 @@ class ArrayTraitTest extends TestCase
         });
     }
 
-    public function testIsSequentialArrayWithEmptyArray()
+    public function testIsSequentialArrayWithEmptyArray(): void
     {
         self::assertFalse($this->arrayTraitClass->isSequentialArray([]));
     }
 
-    public function testIsSequentialArrayWithNonNumericIndex()
+    public function testIsSequentialArrayWithNonNumericIndex(): void
     {
         self::assertFalse($this->arrayTraitClass->isSequentialArray(['foo' => 'bar']));
     }
 
-    public function testIsSequentialArrayWithNumericNonContinuousIndex()
+    public function testIsSequentialArrayWithNumericNonSequentialIndex(): void
     {
         self::assertFalse($this->arrayTraitClass->isSequentialArray([1 => 'bar', 3 => 'foo']));
     }
 
-    public function testIsSequentialArrayWithNumericContinuousIndex()
+    public function testIsSequentialArrayWithNumericSequentialIndex(): void
     {
         self::assertTrue($this->arrayTraitClass->isSequentialArray([0 => 'bar', 1 => 'foo']));
     }
 
-    public function testArrayContainsOnlyWithDifferentTypes()
+    public function testArrayContainsOnlyWithDifferentTypes(): void
     {
-        self::assertFalse($this->arrayTraitClass->arrayContainsOnly([1, 'foo'], \gettype('')));
+        self::assertFalse($this->arrayTraitClass->arrayContainsOnly([1, 'foo'], 'string'));
     }
 
-    public function testArrayContainsOnlyWithSameType()
+    public function testArrayContainsOnlyWithSameType(): void
     {
-        self::assertTrue($this->arrayTraitClass->arrayContainsOnly(['foo', 'bar'], \gettype('')));
+        self::assertTrue($this->arrayTraitClass->arrayContainsOnly(['foo', 'bar'], 'string'));
     }
 
-    public function testIsNumericIndexArrayOfArray()
+    public function testIsSequentialArrayOfArrays(): void
     {
-        self::assertFalse($this->arrayTraitClass->isNumericIndexArrayOfArray([]));
-        self::assertTrue($this->arrayTraitClass->isNumericIndexArrayOfArray([['foo'], ['bar']]));
+        self::assertFalse($this->arrayTraitClass->isSequentialArrayOfArrays([]));
+        self::assertTrue($this->arrayTraitClass->isSequentialArrayOfArrays([['foo'], ['bar']]));
     }
 }

--- a/tests/Util/ArrayTraitTest.php
+++ b/tests/Util/ArrayTraitTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Util;
+
+use ApiPlatform\Core\Util\ArrayTrait;
+use PHPUnit\Framework\TestCase;
+
+class ArrayTraitTest extends TestCase
+{
+    private $arrayTraitClass;
+
+    public function setUp(): void
+    {
+        $this->arrayTraitClass = (new class {
+            use ArrayTrait;
+        });
+    }
+
+    public function testIsSequentialArrayWithEmptyArray()
+    {
+        self::assertFalse($this->arrayTraitClass->isSequentialArray([]));
+    }
+
+    public function testIsSequentialArrayWithNonNumericIndex()
+    {
+        self::assertFalse($this->arrayTraitClass->isSequentialArray(["foo" => "bar"]));
+    }
+
+    public function testIsSequentialArrayWithNumericNonContinuousIndex()
+    {
+        self::assertFalse($this->arrayTraitClass->isSequentialArray([1 => "bar", 3 => 'foo']));
+    }
+
+    public function testIsSequentialArrayWithNumericContinuousIndex()
+    {
+        self::assertTrue($this->arrayTraitClass->isSequentialArray([0 => "bar", 1 => 'foo']));
+    }
+
+    public function testArrayContainsOnlyWithDifferentTypes()
+    {
+        self::assertFalse($this->arrayTraitClass->arrayContainsOnly([1, "foo"], gettype("")));
+    }
+
+    public function testArrayContainsOnlyWithSameType()
+    {
+        self::assertTrue($this->arrayTraitClass->arrayContainsOnly(["foo", "bar"], gettype("")));
+    }
+
+    public function testIsNumericIndexArrayOfArray()
+    {
+        self::assertFalse($this->arrayTraitClass->isNumericIndexArrayOfArray([]));
+        self::assertTrue($this->arrayTraitClass->isNumericIndexArrayOfArray([["foo"], ["bar"]]));
+    }
+}

--- a/tests/Util/ArrayTraitTest.php
+++ b/tests/Util/ArrayTraitTest.php
@@ -20,9 +20,9 @@ class ArrayTraitTest extends TestCase
 {
     private $arrayTraitClass;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        $this->arrayTraitClass = (new class {
+        $this->arrayTraitClass = (new class() {
             use ArrayTrait;
         });
     }
@@ -34,32 +34,32 @@ class ArrayTraitTest extends TestCase
 
     public function testIsSequentialArrayWithNonNumericIndex()
     {
-        self::assertFalse($this->arrayTraitClass->isSequentialArray(["foo" => "bar"]));
+        self::assertFalse($this->arrayTraitClass->isSequentialArray(['foo' => 'bar']));
     }
 
     public function testIsSequentialArrayWithNumericNonContinuousIndex()
     {
-        self::assertFalse($this->arrayTraitClass->isSequentialArray([1 => "bar", 3 => 'foo']));
+        self::assertFalse($this->arrayTraitClass->isSequentialArray([1 => 'bar', 3 => 'foo']));
     }
 
     public function testIsSequentialArrayWithNumericContinuousIndex()
     {
-        self::assertTrue($this->arrayTraitClass->isSequentialArray([0 => "bar", 1 => 'foo']));
+        self::assertTrue($this->arrayTraitClass->isSequentialArray([0 => 'bar', 1 => 'foo']));
     }
 
     public function testArrayContainsOnlyWithDifferentTypes()
     {
-        self::assertFalse($this->arrayTraitClass->arrayContainsOnly([1, "foo"], gettype("")));
+        self::assertFalse($this->arrayTraitClass->arrayContainsOnly([1, 'foo'], \gettype('')));
     }
 
     public function testArrayContainsOnlyWithSameType()
     {
-        self::assertTrue($this->arrayTraitClass->arrayContainsOnly(["foo", "bar"], gettype("")));
+        self::assertTrue($this->arrayTraitClass->arrayContainsOnly(['foo', 'bar'], \gettype('')));
     }
 
     public function testIsNumericIndexArrayOfArray()
     {
         self::assertFalse($this->arrayTraitClass->isNumericIndexArrayOfArray([]));
-        self::assertTrue($this->arrayTraitClass->isNumericIndexArrayOfArray([["foo"], ["bar"]]));
+        self::assertTrue($this->arrayTraitClass->isNumericIndexArrayOfArray([['foo'], ['bar']]));
     }
 }


### PR DESCRIPTION
The InputObjectType doesn't preserve the order of the arguments passed to it and it's the order declared in the service declaration that is used. This can lead to bug when the order of the arguments matter, like with the OrderFilter for example.

The solution is to change the type of the filter argument from InputObjectType to a list of InputObjectType because the order of a list is preserved.

The "old" syntax `order: {foo: asc, bar: desc}` is still "working" (but it's buggy) and the following syntax should be used instead `order: [{foo: 'asc'}, {bar: 'desc'}]`

In the first commit there is a falling behat test that use the current syntax to order a collection across 2 fields, and the order is first apply one the field `name` before the field `description`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | not sur,the build-in filters are still working but I don't know if it can break custom filters
| Deprecations? | not yet, but I think we should find a way to depreciate the "old" syntax on the build-in filter that are buggy because of the order problem
| Tickets       | fixes #2808
| License       | MIT
| Doc PR        | TODO, as the old syntax is still usabled maybe we should add doc on how to use the filters with graphql

Ps: the unit tests are failing but I want to be sure on how preserve the right order and if we should apply the changes for all filter or just for the build-in one because I'm not sure if it can broke something :/
