### PR TITLE
Add default validation groups

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -570,7 +570,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $container->setParameter('api_platform.validator.serialize_payload_fields', $config['validator']['serialize_payload_fields']);
-        $container->setParameter('api_platform.validator.default_groups',  $config['validator']['default_groups']);
+        $container->setParameter('api_platform.validator.default_groups', $config['validator']['default_groups']);
     }
 
     private function registerDataCollectorConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -570,6 +570,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $container->setParameter('api_platform.validator.serialize_payload_fields', $config['validator']['serialize_payload_fields']);
+        $container->setParameter('api_platform.validator.default_groups',  $config['validator']['default_groups']);
     }
 
     private function registerDataCollectorConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -97,6 +97,7 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->variableNode('serialize_payload_fields')->defaultValue([])->info('Enable the serialization of payload fields when a validation error is thrown.')->end()
+                        ->variableNode('default_groups')->defaultValue([])->info('Default validation groups if not filled.')->end()
                     ->end()
                 ->end()
                 ->arrayNode('eager_loading')

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -82,7 +82,7 @@ final class ValidateListener
         } elseif (\is_callable($validationGroups)) {
             $validationGroups = $validationGroups($data);
         }
-        
+
         if ($this->container instanceof SymfonyContainerInterface && empty($validationGroups)) {
             $validationGroups = $this->container->getParameter('api_platform.validator.default_groups');
         }

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -18,9 +18,9 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use ApiPlatform\Core\Validator\EventListener\ValidateListener as MainValidateListener;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 
 /**
  * Validates data.

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -81,6 +81,10 @@ final class ValidateListener
         } elseif (\is_callable($validationGroups)) {
             $validationGroups = $validationGroups($data);
         }
+        
+        if (empty($validationGroups) {
+            $validationGroups = $this->container->getParameter('api_platform.validator.default_groups');
+        }
 
         $violations = $this->validator->validate($data, null, (array) $validationGroups);
         if (0 !== \count($violations)) {

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\Validator\EventListener\ValidateListener as MainValidateLis
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 
 /**
  * Validates data.
@@ -82,7 +83,7 @@ final class ValidateListener
             $validationGroups = $validationGroups($data);
         }
         
-        if (empty($validationGroups)) {
+        if ($this->container instanceof SymfonyContainerInterface && empty($validationGroups)) {
             $validationGroups = $this->container->getParameter('api_platform.validator.default_groups');
         }
 

--- a/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidateListener.php
@@ -82,7 +82,7 @@ final class ValidateListener
             $validationGroups = $validationGroups($data);
         }
         
-        if (empty($validationGroups) {
+        if (empty($validationGroups)) {
             $validationGroups = $this->container->getParameter('api_platform.validator.default_groups');
         }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1139,6 +1139,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.graphql_playground.enabled' => true,
             'api_platform.resource_class_directories' => Argument::type('array'),
             'api_platform.validator.serialize_payload_fields' => [],
+            'api_platform.validator.default_groups' => [],
             'api_platform.elasticsearch.enabled' => false,
             'api_platform.defaults' => ['attributes' => []],
         ];

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -105,6 +105,7 @@ class ConfigurationTest extends TestCase
             'path_segment_name_generator' => 'api_platform.path_segment_name_generator.underscore',
             'validator' => [
                 'serialize_payload_fields' => [],
+                'default_groups' => [],
             ],
             'name_converter' => null,
             'enable_fos_user' => true,


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | not yet

Add an option for default validation groups. It's useful when a bundle has it's own entities, with it's own validations rules with groups and you want to easily take them into account.