### PR TITLE
fix (serializer): returns a 400 HTTP status code instead of 500 on an input type mismatch

### DIFF
--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Exception;
+
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
+
+/**
+ * Invalid Request exception.
+ *
+ * @author Grégoire Hébert <contact@gheb.dev>
+ */
+class InvalidRequestException extends InvalidArgumentException implements RequestExceptionInterface
+{
+}

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\InvalidRequestException;
 use ApiPlatform\Core\Exception\InvalidValueException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -362,7 +363,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         if (!$isValid) {
-            throw new InvalidArgumentException(sprintf('The type of the "%s" attribute must be "%s", "%s" given.', $attribute, $builtinType, \gettype($value)));
+            throw new InvalidRequestException(sprintf('The type of the "%s" attribute must be "%s", "%s" given.', $attribute, $builtinType, \gettype($value)));
         }
     }
 
@@ -374,7 +375,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     protected function denormalizeCollection(string $attribute, PropertyMetadata $propertyMetadata, Type $type, string $className, $value, ?string $format, array $context): array
     {
         if (!\is_array($value)) {
-            throw new InvalidArgumentException(sprintf('The type of the "%s" attribute must be "array", "%s" given.', $attribute, \gettype($value)));
+            throw new InvalidRequestException(sprintf('The type of the "%s" attribute must be "array", "%s" given.', $attribute, \gettype($value)));
         }
 
         $collectionKeyType = $type->getCollectionKeyType();
@@ -383,7 +384,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $values = [];
         foreach ($value as $index => $obj) {
             if (null !== $collectionKeyBuiltinType && !\call_user_func('is_'.$collectionKeyBuiltinType, $index)) {
-                throw new InvalidArgumentException(sprintf('The type of the key "%s" must be "%s", "%s" given.', $index, $collectionKeyBuiltinType, \gettype($index)));
+                throw new InvalidRequestException(sprintf('The type of the key "%s" must be "%s", "%s" given.', $index, $collectionKeyBuiltinType, \gettype($index)));
             }
 
             $values[$index] = $this->denormalizeRelation($attribute, $propertyMetadata, $className, $obj, $format, $this->createChildContext($context, $attribute, $format));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

When a developer sets a non nullable typed property on a resource 
```php
<?php

namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiResource;
use Doctrine\ORM\Mapping as ORM;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @ApiResource
 * @ORM\Entity
 */
class Greeting
{
    /**
     * @var int The entity Id
     *
     * @ORM\Id
     * @ORM\GeneratedValue
     * @ORM\Column(type="integer")
     */
    private $id;

    /**
     * @var string A nice person
     *
     * @ORM\Column
     * @Assert\NotBlank
     */
    public $name = '';

    public function getId(): int
    {
        return $this->id;
    }
}
```

And one sends a post request with a null value
```cli
curl --location --request POST 'https://localhost:8443/greetings' \
--header 'Content-Type: application/json' \
--data-raw '{
	"name": null
}'
```

The response received comes with a 500 (Internal Server Error) http status code.
```
{
    "@context": "/contexts/Error",
    "@type": "hydra:Error",
    "hydra:title": "An error occurred",
    "hydra:description": "The type of the \"name\" attribute must be \"string\", \"NULL\" given.",
    "trace": [ ...
    ]
}
```

But it's not a server error, the configuration is intended.
If the developer wanted to allow null to be used, one would have put the `name` property nullable. Which is not the case. The problem comes from the request itself.
It should have been a 400 (Bad Request) that target the api consuming developer.

And then, The 2 developers could argue that they should have let the property being nullable, but it's not a technical error, it's a design error. Something not related to API Platform itself.

:warning: *Warning*
API consumers relying on the response status to be a 500 will fail.