### PR TITLE
add type factory decorator for elao enum types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/orm": "^2.6.4",
+        "elao/enum": "^1.7",
         "elasticsearch/elasticsearch": "^6.0",
         "friendsofsymfony/user-bundle": "^2.2@dev",
         "guzzlehttp/guzzle": "^6.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -105,6 +105,9 @@ parameters:
 		-
 			message: '#Cannot assign new offset to string\.#'
 			path: src/JsonSchema/SchemaFactory.php
+		-
+			message: '#Class Elao\\Enum\\EnumInterface not found\.#'
+			path: src/JsonSchema/Type/ElaoEnumType.php
 
 		# Expected, due to optional interfaces
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryCollectionExtensionInterface::applyToCollection\(\) invoked with 5 parameters, 3-4 required\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -105,9 +105,6 @@ parameters:
 		-
 			message: '#Cannot assign new offset to string\.#'
 			path: src/JsonSchema/SchemaFactory.php
-		-
-			message: '#Class Elao\\Enum\\EnumInterface not found\.#'
-			path: src/JsonSchema/Type/ElaoEnumType.php
 
 		# Expected, due to optional interfaces
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryCollectionExtensionInterface::applyToCollection\(\) invoked with 5 parameters, 3-4 required\.#'

--- a/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/json_schema.xml
@@ -15,6 +15,10 @@
         </service>
         <service id="ApiPlatform\Core\JsonSchema\TypeFactoryInterface" alias="api_platform.json_schema.type_factory" />
 
+        <service id="api_platform.json_schema.type.elao_enum_type" class="ApiPlatform\Core\JsonSchema\Type\ElaoEnumType" decorates="api_platform.json_schema.type_factory">
+            <argument type="service" id="api_platform.json_schema.type.elao_enum_type.inner" />
+        </service>
+
         <service id="api_platform.json_schema.schema_factory" class="ApiPlatform\Core\JsonSchema\SchemaFactory">
             <argument type="service" id="api_platform.json_schema.type_factory"></argument>
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />

--- a/src/JsonSchema/Type/ElaoEnumType.php
+++ b/src/JsonSchema/Type/ElaoEnumType.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\JsonSchema\Type;
+
+use ApiPlatform\Core\JsonSchema\Schema;
+use ApiPlatform\Core\JsonSchema\TypeFactoryInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class ElaoEnumType implements TypeFactoryInterface
+{
+    /**
+     * @var TypeFactoryInterface
+     */
+    private $decorated;
+
+    /**
+     * @param TypeFactoryInterface $decorated
+     */
+    public function __construct(TypeFactoryInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(Type $type, string $format = 'json', ?bool $readableLink = null, ?array $serializerContext = null, Schema $schema = null): array
+    {
+        if (is_a($enumClass = $type->getClassName(), 'Elao\Enum\EnumInterface', true)) {
+
+            $values = $enumClass::values();
+
+            return [
+                'type' => 'string',
+                'enum' => $values,
+                'example' => reset($values),
+            ];
+        }
+
+        return $this->decorated->getType($type, $format, $readableLink, $serializerContext, $schema);
+    }
+}

--- a/src/JsonSchema/Type/ElaoEnumType.php
+++ b/src/JsonSchema/Type/ElaoEnumType.php
@@ -44,7 +44,7 @@ final class ElaoEnumType implements TypeFactoryInterface
         return [
             'type' => 'string',
             'enum' => $values,
-            'example' => reset($values),
+            'example' => $values[0],
         ];
     }
 }

--- a/src/JsonSchema/Type/ElaoEnumType.php
+++ b/src/JsonSchema/Type/ElaoEnumType.php
@@ -23,9 +23,6 @@ class ElaoEnumType implements TypeFactoryInterface
      */
     private $decorated;
 
-    /**
-     * @param TypeFactoryInterface $decorated
-     */
     public function __construct(TypeFactoryInterface $decorated)
     {
         $this->decorated = $decorated;

--- a/src/JsonSchema/Type/ElaoEnumType.php
+++ b/src/JsonSchema/Type/ElaoEnumType.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the API Platform project.
  *
@@ -14,6 +15,7 @@ namespace ApiPlatform\Core\JsonSchema\Type;
 
 use ApiPlatform\Core\JsonSchema\Schema;
 use ApiPlatform\Core\JsonSchema\TypeFactoryInterface;
+use Elao\Enum\EnumInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 class ElaoEnumType implements TypeFactoryInterface
@@ -33,17 +35,16 @@ class ElaoEnumType implements TypeFactoryInterface
      */
     public function getType(Type $type, string $format = 'json', ?bool $readableLink = null, ?array $serializerContext = null, Schema $schema = null): array
     {
-        if (is_a($enumClass = $type->getClassName(), 'Elao\Enum\EnumInterface', true)) {
-
-            $values = $enumClass::values();
-
-            return [
-                'type' => 'string',
-                'enum' => $values,
-                'example' => reset($values),
-            ];
+        if (!is_a($enumClass = $type->getClassName(), EnumInterface::class, true)) {
+            return $this->decorated->getType($type, $format, $readableLink, $serializerContext, $schema);
         }
 
-        return $this->decorated->getType($type, $format, $readableLink, $serializerContext, $schema);
+        $values = $enumClass::values();
+
+        return [
+            'type' => 'string',
+            'enum' => $values,
+            'example' => reset($values),
+        ];
     }
 }

--- a/src/JsonSchema/Type/ElaoEnumType.php
+++ b/src/JsonSchema/Type/ElaoEnumType.php
@@ -18,7 +18,7 @@ use ApiPlatform\Core\JsonSchema\TypeFactoryInterface;
 use Elao\Enum\EnumInterface;
 use Symfony\Component\PropertyInfo\Type;
 
-class ElaoEnumType implements TypeFactoryInterface
+final class ElaoEnumType implements TypeFactoryInterface
 {
     /**
      * @var TypeFactoryInterface

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1259,6 +1259,7 @@ class ApiPlatformExtensionTest extends TestCase
             $definitions[] = 'api_platform.swagger.command.swagger_command';
             $definitions[] = 'api_platform.swagger.normalizer.api_gateway';
             $definitions[] = 'api_platform.swagger.normalizer.documentation';
+            $definitions[] = 'api_platform.json_schema.type.elao_enum_type';
             $definitions[] = 'api_platform.json_schema.type_factory';
             $definitions[] = 'api_platform.json_schema.schema_factory';
             $definitions[] = 'api_platform.json_schema.json_schema_generate_command';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3432
| License       | MIT

I was not sure about the comparison with "'Elao\Enum\EnumInterface", i would prefer EnumInterface::class but i think adding elao as a dependency is overhead. 

@teohhanhui suggested to move all custom classes like ElaoEnum and RamseyUuid into decorator. If this approach is approved i could do the same for Ramsey.
