### PR TITLE
Improve the RangeFilter DQL query in case the "between" values are equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.5.x-dev
 
 * GraphQL: Do not allow empty cursor values on `before` or `after`
+* Filter: Improve the RangeFilter query in case the values are equals using the between operator
 
 ## 2.5.4
 

--- a/features/doctrine/range_filter.feature
+++ b/features/doctrine/range_filter.feature
@@ -60,6 +60,51 @@ Feature: Range filter on collections
     }
     """
 
+  @createSchema
+  Scenario: Get collection filtered by range (between the same values)
+    Given there are 30 dummy objects with dummyPrice
+    When I send a "GET" request to "/dummies?dummyPrice[between]=12.99..12.99"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/2$"},
+                  {"pattern": "^/dummies/6$"},
+                  {"pattern": "^/dummies/10$"}
+                ]
+              }
+            }
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "uniqueItems": true
+        },
+        "hydra:totalItems": {"type": "number", "minimum": 8, "maximum": 8},
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?dummyPrice%5Bbetween%5D=12.99..12.99"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
   Scenario: Filter by range (between) with invalid format
     When I send a "GET" request to "/dummies?dummyPrice[between]=9.99..12.99..15.99"
     Then the response status code should be 200

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilter.php
@@ -80,6 +80,7 @@ final class RangeFilter extends AbstractFilter implements RangeFilterInterface
 
                 if ($rangeValue[0] === $rangeValue[1]) {
                     $aggregationBuilder->match()->field($matchField)->equals($rangeValue[0]);
+
                     return;
                 }
 

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilter.php
@@ -78,6 +78,11 @@ final class RangeFilter extends AbstractFilter implements RangeFilterInterface
                     return;
                 }
 
+                if ($rangeValue[0] === $rangeValue[1]) {
+                    $aggregationBuilder->match()->field($matchField)->equals($rangeValue[0]);
+                    return;
+                }
+
                 $aggregationBuilder->match()->field($matchField)->gte($rangeValue[0])->lte($rangeValue[1]);
 
                 break;

--- a/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
@@ -85,6 +85,13 @@ class RangeFilter extends AbstractContextAwareFilter implements RangeFilterInter
                     return;
                 }
 
+                if ($rangeValue[0] === $rangeValue[1]) {
+                    $queryBuilder
+                        ->andWhere(sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
+                        ->setParameter($valueParameter, $rangeValue[0]);
+                    return;
+                }
+
                 $queryBuilder
                     ->andWhere(sprintf('%1$s.%2$s BETWEEN :%3$s_1 AND :%3$s_2', $alias, $field, $valueParameter))
                     ->setParameter(sprintf('%s_1', $valueParameter), $rangeValue[0])

--- a/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/RangeFilter.php
@@ -89,6 +89,7 @@ class RangeFilter extends AbstractContextAwareFilter implements RangeFilterInter
                     $queryBuilder
                         ->andWhere(sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
                         ->setParameter($valueParameter, $rangeValue[0]);
+
                     return;
                 }
 

--- a/tests/Bridge/Doctrine/Common/Filter/RangeFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/RangeFilterTestTrait.php
@@ -29,6 +29,14 @@ trait RangeFilterTestTrait
                     ],
                 ],
             ],
+            'between (same values)' => [
+                null,
+                [
+                    'dummyPrice' => [
+                        'between' => '9.99..9.99',
+                    ],
+                ],
+            ],
             'between (too many operands)' => [
                 null,
                 [

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilterTest.php
@@ -453,6 +453,15 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                         ],
                     ],
                 ],
+                'between (same values)' => [
+                    [
+                        [
+                            '$match' => [
+                                'dummyPrice' => 9.99,
+                            ],
+                        ],
+                    ],
+                ],
                 'between (too many operands)' => [
                     [],
                 ],

--- a/tests/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
@@ -343,6 +343,9 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'between' => [
                     sprintf('SELECT o FROM %s o WHERE o.dummyPrice BETWEEN :dummyPrice_p1_1 AND :dummyPrice_p1_2', Dummy::class),
                 ],
+                'between (same values)' => [
+                    sprintf('SELECT o FROM %s o WHERE o.dummyPrice = :dummyPrice_p1', Dummy::class),
+                ],
                 'between (too many operands)' => [
                     sprintf('SELECT o FROM %s o', Dummy::class),
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes 
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Improve the behavior of the RangeFilter filter in case the values of the between operator are equals
In such case, the DQL query is defined with the equals operation




