### PR TITLE
Prevent header Location on POST when status code is not 201 or 30x

### DIFF
--- a/tests/EventListener/RespondListenerTest.php
+++ b/tests/EventListener/RespondListenerTest.php
@@ -80,36 +80,53 @@ class RespondListenerTest extends TestCase
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
     }
 
-    public function testPostCreate200Response()
+    public function testPost200WithoutLocation()
     {
         $kernelProphecy = $this->prophesize(HttpKernelInterface::class);
 
-        $request = new Request([], [], ['_api_respond' => true, '_api_write_item_iri' => '/dummy_entities/1', '_api_item_operation_name' => 'post']);
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get', '_api_respond' => true, '_api_write_item_iri' => '/dummy_entities/1']);
         $request->setMethod('POST');
-        $request->setRequestFormat('xml');
 
         $event = new ViewEvent(
             $kernelProphecy->reveal(),
             $request,
             HttpKernelInterface::MASTER_REQUEST,
-            'foo'
+            'bar'
         );
-
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, ['post' => ['status' => Response::HTTP_OK]]));
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, ['get' => ['status' => Response::HTTP_OK]]));
 
         $listener = new RespondListener($resourceMetadataFactoryProphecy->reveal());
         $listener->onKernelView($event);
 
         $response = $event->getResponse();
-        $this->assertEquals('foo', $response->getContent());
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals('text/xml; charset=utf-8', $response->headers->get('Content-Type'));
-        $this->assertEquals('Accept', $response->headers->get('Vary'));
-        $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
-        $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
         $this->assertFalse($response->headers->has('Location'));
-        $this->assertEquals('/dummy_entities/1', $response->headers->get('Content-Location'));
+        $this->assertSame(Response::HTTP_OK, $event->getResponse()->getStatusCode());
+    }
+
+    public function testPost301WithLocation()
+    {
+        $kernelProphecy = $this->prophesize(HttpKernelInterface::class);
+
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get', '_api_respond' => true, '_api_write_item_iri' => '/dummy_entities/1']);
+        $request->setMethod('POST');
+
+        $event = new ViewEvent(
+            $kernelProphecy->reveal(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            'bar'
+        );
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, ['get' => ['status' => Response::HTTP_MOVED_PERMANENTLY]]));
+
+        $listener = new RespondListener($resourceMetadataFactoryProphecy->reveal());
+        $listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertTrue($response->headers->has('Location'));
+        $this->assertEquals('/dummy_entities/1', $response->headers->get('Location'));
+        $this->assertSame(Response::HTTP_MOVED_PERMANENTLY, $event->getResponse()->getStatusCode());
     }
 
     public function testCreate201Response()
@@ -139,6 +156,7 @@ class RespondListenerTest extends TestCase
         $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
         $this->assertEquals('/dummy_entities/1', $response->headers->get('Location'));
         $this->assertEquals('/dummy_entities/1', $response->headers->get('Content-Location'));
+        $this->assertTrue($response->headers->has('Location'));
     }
 
     public function testCreate204Response()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

When a POST request issues a response with status code 200 setted by API Platform, the client receives 302 status code because of header Location added by RespondListener.

In this case, Safari follows the redirect and the client performs a GET operation on the URL in Location header.

According [PHP doc](https://www.php.net/manual/en/function.header) :

> The second special case is the "Location:" header. Not only does it send this header back to the browser, but it also returns a REDIRECT (302) status code to the browser unless the 201 or a 3xx status code has already been set.

PHP seems overwrite the original status code to 302 when it's not 201 or 30x and Location header exists.

If I force a status code to 201, it works as expected.
