### PR TITLE
Fix wrong link rel value for mercure

### DIFF
--- a/src/Mercure/EventListener/AddLinkHeaderListener.php
+++ b/src/Mercure/EventListener/AddLinkHeaderListener.php
@@ -48,14 +48,14 @@ final class AddLinkHeaderListener
             return;
         }
 
-        $link = new Link('mercure', $this->hub);
-
         if (
             null === ($resourceClass = $request->attributes->get('_api_resource_class')) ||
             false === $this->resourceMetadataFactory->create($resourceClass)->getAttribute('mercure', false)
         ) {
             return;
         }
+
+        $link = new Link('hub', $this->hub);
 
         if (null === $linkProvider = $request->attributes->get('_links')) {
             $request->attributes->set('_links', new GenericLinkProvider([$link]));

--- a/tests/Mercure/EventListener/AddLinkHeaderListenerTest.php
+++ b/tests/Mercure/EventListener/AddLinkHeaderListenerTest.php
@@ -50,8 +50,8 @@ class AddLinkHeaderListenerTest extends TestCase
     public function addProvider(): array
     {
         return [
-            ['<https://demo.mercure.rocks/hub>; rel="mercure"', new Request([], [], ['_api_resource_class' => Dummy::class])],
-            ['<http://example.com/docs>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation",<https://demo.mercure.rocks/hub>; rel="mercure"', new Request([], [], ['_api_resource_class' => Dummy::class, '_links' => new GenericLinkProvider([new Link('http://www.w3.org/ns/hydra/core#apiDocumentation', 'http://example.com/docs')])])],
+            ['<https://demo.mercure.rocks/hub>; rel="hub"', new Request([], [], ['_api_resource_class' => Dummy::class])],
+            ['<http://example.com/docs>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation",<https://demo.mercure.rocks/hub>; rel="hub"', new Request([], [], ['_api_resource_class' => Dummy::class, '_links' => new GenericLinkProvider([new Link('http://www.w3.org/ns/hydra/core#apiDocumentation', 'http://example.com/docs')])])],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | #3499
| License       | MIT
| Doc PR        | ~

Please Note that this change might have an impact on existing applications using this kind of code:

https://github.com/api-platform/client-generator/blob/d5ccc01a3d13894c93e8de7ff6799cd0807e0639/templates/react-common/utils/dataAccess.js#L78

and therefor this line has to change in the same time.