### PR TITLE
Add PHPUnit sqlite dependency in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "willdurand/negotiation": "^2.0.3"
     },
     "require-dev": {
+        "ext-sqlite3": "*",
         "behat/behat": "^3.1",
         "behat/mink": "^1.7",
         "behat/mink-browserkit-driver": "^1.3.1",


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no

## Problem
When I run the phpunit tests `vendor/bin/phpunit` without sqllite extension installed,
Then some tests failed like `ApiPlatformProfilerPanelTest`

## Solution
Add PHPUnit sqlite dependency in composer
```json
"require-dev": {
    "ext-sqlite3": "*"
}
```
