### PR TITLE
Adjust null handling in exported JSON Schema / OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2.7.0
 
-* **BC**: Change `api_platform.listener.request.add_format` priority from 7 to 28 to execute it before firewall (priority 8) (#3599)
-* **BC**: Use `@final` annotation in ORM filters (#4109)
+* **BC** Change `api_platform.listener.request.add_format` priority from 7 to 28 to execute it before firewall (priority 8) (#3599)
+* Doctrine: **BC** Use `@final` annotation in ORM filters (#4109)
+* OpenAPI: **BC** Better nullable handling in JSON Schema / OpenAPI (#3518)
 * Allow defining `exception_to_status` per operation (#3519)
 * Doctrine: Better exception to find which resource is linked to an exception (#3965)
 * Doctrine: Allow mixed type value for date filter (notice if invalid) (#3870)

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -228,7 +228,7 @@ final class SchemaFactory implements SchemaFactoryInterface
                 $className = $valueType->getClassName();
             }
 
-            $valueSchema = $this->typeFactory->getType(new Type($builtinType, $type->isNullable(), $className, $isCollection), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
+            $valueSchema = $this->typeFactory->getType(new Type($builtinType, !$propertyMetadata->isRequired() || $type->isNullable(), $className, $isCollection), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
         }
 
         if (\array_key_exists('type', $propertySchema) && \array_key_exists('$ref', $valueSchema)) {

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -394,14 +394,17 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'minLength' => 3,
                                 'maxLength' => 20,
                                 'pattern' => '^dummyPattern$',
+                                'nullable' => true,
                             ]),
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                             'description' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is an initializable but not writable property.',
+                                'nullable' => true,
                             ]),
                             'dummyDate' => new \ArrayObject([
                                 'nullable' => true,
@@ -567,10 +570,12 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                             'name_converted' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a converted name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -706,6 +711,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -945,6 +951,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -956,6 +963,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'gerard' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a gerard.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -1073,6 +1081,7 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'integer',
                                 'description' => 'This is an id.',
                                 'readOnly' => true,
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -1290,6 +1299,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -1301,6 +1311,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'gerard' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a gerard.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -1520,6 +1531,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -1531,6 +1543,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'gerard' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a gerard.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2072,6 +2085,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2083,6 +2097,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                             'relatedDummy' => new \ArrayObject([
                                 'description' => 'This is a related dummy \o/.',
@@ -2101,6 +2116,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2250,6 +2266,7 @@ class DocumentationNormalizerV3Test extends TestCase
                             'name' => new \ArrayObject([
                                 'description' => 'This is a name.',
                                 'type' => 'string',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2432,6 +2449,7 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'array',
                                 'description' => 'This is a name.',
                                 'items' => ['$ref' => '#/components/schemas/Answer'],
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2444,6 +2462,7 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'array',
                                 'description' => 'This is a name.',
                                 'items' => ['$ref' => '#/components/schemas/Answer'],
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2556,12 +2575,14 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'integer',
                                 'description' => 'This is an id.',
                                 'readOnly' => true,
+                                'nullable' => true,
                             ]),
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
                                 'enum' => ['one', 'two'],
                                 'example' => 'one',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2688,12 +2709,14 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'integer',
                                 'description' => 'This is an id.',
                                 'readOnly' => true,
+                                'nullable' => true,
                             ]),
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
                                 'enum' => ['one', 'two'],
                                 'example' => 'one',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2826,12 +2849,14 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'integer',
                                 'description' => 'This is an id.',
                                 'readOnly' => true,
+                                'nullable' => true,
                             ]),
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
                                 'enum' => ['one', 'two'],
                                 'example' => 'one',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -2968,12 +2993,14 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'integer',
                                 'description' => 'This is an id.',
                                 'readOnly' => true,
+                                'nullable' => true,
                             ]),
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
                                 'enum' => ['one', 'two'],
                                 'example' => 'one',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),
@@ -3212,10 +3239,12 @@ class DocumentationNormalizerV3Test extends TestCase
                                 'type' => 'integer',
                                 'description' => 'This is an id.',
                                 'readOnly' => true,
+                                'nullable' => true,
                             ]),
                             'name' => new \ArrayObject([
                                 'type' => 'string',
                                 'description' => 'This is a name.',
+                                'nullable' => true,
                             ]),
                         ],
                     ]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

https://github.com/api-platform/core/pull/3402/ was a really good start to have a better null handling in exported schema.

But actually we should use required attribute as a condition for nullability.
A non-required property should be nullable.