### PR TITLE
Fixing error for none database identifiers Api ids

### DIFF
--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -217,7 +217,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
                 return $previousQueryBuilder->innerJoin("$previousAlias.{$association['inversedBy']}", $joinAlias)
                     ->andWhere("$joinAlias.$key = :$placeholder");
             }
-            if ($isLeaf && $oneToManyBidirectional) {
+            if ($isLeaf && $oneToManyBidirectional && \in_array($key, $classMetadata->getIdentifier(), true)) {
                 return $previousQueryBuilder->andWhere("IDENTITY($previousAlias) = :$placeholder");
             }
 


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  |no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->

There is an error on sub resources queries when Api platform identifier is not an identifier in database like when using slug but using id as database  identifier.

related to: https://github.com/api-platform/core/pull/3396

**Update:** I guess I should change the target to 2.5 because this error exist there also.
