### PR TITLE
SearchFilter: Refactor code to reduce code duplication and makes it easier to add new strategies to classes inheriting from SearchFilter class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Doctrine: Support for foreign identifiers (#4042)
 * Doctrine: Support for binary UUID in search filter (#3774)
 * Doctrine: Do not add join or lookup for search filter with empty value (#3703)
+* Doctrine: Reduce code duplication in search filter (#3541)
 * JSON Schema: Allow generating documentation when property and method start from "is" (property `isActive` and method `isActive`) (#4064)
 * OpenAPI: Fix missing 422 responses in the documentation (#4086)
 * OpenAPI: Fix error when schema is empty (#4051)

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
@@ -87,12 +87,17 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
             [$matchField, $field, $associations] = $this->addLookupsForNestedProperty($property, $aggregationBuilder, $resourceClass);
         }
 
-        /**
-         * @var MongoDBClassMetadata
-         */
-        $metadata = $this->getNestedMetadata($resourceClass, $associations);
-
         $caseSensitive = true;
+        $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
+
+        // prefixing the strategy with i makes it case insensitive
+        if (0 === strpos($strategy, 'i')) {
+            $strategy = substr($strategy, 1);
+            $caseSensitive = false;
+        }
+
+        /** @var MongoDBClassMetadata */
+        $metadata = $this->getNestedMetadata($resourceClass, $associations);
 
         if ($metadata->hasField($field) && !$metadata->hasAssociation($field)) {
             if ('id' === $field) {
@@ -107,23 +112,9 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
                 return;
             }
 
-            $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
+            $this->addEqualityMatchStrategy($strategy, $aggregationBuilder, $field, $matchField, $values, $caseSensitive, $metadata);
 
-            // prefixing the strategy with i makes it case insensitive
-            if (0 === strpos($strategy, 'i')) {
-                $strategy = substr($strategy, 1);
-                $caseSensitive = false;
-            }
-
-            $inValues = [];
-            foreach ($values as $inValue) {
-                $inValues[] = $this->addEqualityMatchStrategy($strategy, $field, $inValue, $caseSensitive, $metadata);
-            }
-
-            $aggregationBuilder
-                ->match()
-                ->field($matchField)
-                ->in($inValues);
+            return;
         }
 
         // metadata doesn't have the field, nor an association on the field
@@ -132,7 +123,6 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         }
 
         $values = array_map([$this, 'getIdFromValue'], $values);
-        $associationFieldIdentifier = 'id';
         $doctrineTypeField = $this->getDoctrineFieldType($property, $resourceClass);
 
         if (null !== $this->identifiersExtractor) {
@@ -149,23 +139,39 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
             return;
         }
 
-        $aggregationBuilder
-            ->match()
-            ->field($matchField)
-            ->in($values);
+        $this->addEqualityMatchStrategy($strategy, $aggregationBuilder, $field, $matchField, $values, $caseSensitive, $metadata);
     }
 
     /**
      * Add equality match stage according to the strategy.
+     */
+    private function addEqualityMatchStrategy(string $strategy, Builder $aggregationBuilder, string $field, string $matchField, $values, bool $caseSensitive, ClassMetadata $metadata): void
+    {
+        $inValues = [];
+        foreach ($values as $inValue) {
+            $inValues[] = $this->getEqualityMatchStrategyValue($strategy, $field, $inValue, $caseSensitive, $metadata);
+        }
+
+        $aggregationBuilder
+            ->match()
+            ->field($matchField)
+            ->in($inValues);
+    }
+
+    /**
+     * Get equality match value according to the strategy.
      *
      * @throws InvalidArgumentException If strategy does not exist
      *
      * @return Regex|string
      */
-    private function addEqualityMatchStrategy(string $strategy, string $field, $value, bool $caseSensitive, ClassMetadata $metadata)
+    private function getEqualityMatchStrategyValue(string $strategy, string $field, $value, bool $caseSensitive, ClassMetadata $metadata)
     {
         $type = $metadata->getTypeOfField($field);
 
+        if (!MongoDbType::hasType($type)) {
+            return $value;
+        }
         if (MongoDbType::STRING !== $type) {
             return MongoDbType::getType($type)->convertToDatabaseValue($value);
         }

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -543,11 +543,11 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'mixed IRI and entity ID values for relations' => [
-                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummies relatedDummies_a1 WHERE %1$s.relatedDummy IN (:relatedDummy_p1, :relatedDummy_p2) AND relatedDummies_a1.id = :relatedDummies_p4', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummies relatedDummies_a1 WHERE %1$s.relatedDummy IN (:relatedDummy_p1, :relatedDummy_p2) AND relatedDummies_a1.id = :id_p4', $this->alias, Dummy::class),
                     [
                         'relatedDummy_p1' => 1,
                         'relatedDummy_p2' => 2,
-                        'relatedDummies_p4' => 1,
+                        'id_p4' => 1,
                     ],
                     $filterFactory,
                 ],


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#...

All query manipulations are now located in the same method to ease the creation on classes inherited from SearchFilter.

Example:
```
class ExtendedSearchFilter extends SearchFilter
{
    public const STRATEGY_OTHER = 'other';

    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, string $alias, string $field, $fieldType, $values, bool $caseSensitive, string $valueParameter)
    {
        if (self::STRATEGY_OTHER === $strategy) {
            // ...

            return;
        }

        parent::addWhereByStrategy($strategy, $queryBuilder, $alias, $field, $fieldType, $values, $caseSensitive, $valueParameter);
    }
}
```

We will be able to create easily a "not_int" strategy or more complexe cases.