### PR TITLE
Allow a resource Cache-Control HTTP header to be private

### DIFF
--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -76,13 +76,14 @@ final class AddHeadersListener
             $response->setVary(array_diff($this->vary, $response->getVary()), false);
         }
 
+        // if the public-property is defined and not yet set; apply it to the response
         $public = ($resourceCacheHeaders['public'] ?? $this->public);
         if (null !== $public && !$response->headers->hasCacheControlDirective('public')) {
             $public ? $response->setPublic() : $response->setPrivate();
         }
 
-        // s-maxage is only relevant is resource is not marked as "private"
-        if ($public && null !== ($sharedMaxAge = $resourceCacheHeaders['shared_max_age'] ?? $this->sharedMaxAge) && !$response->headers->hasCacheControlDirective('s-maxage')) {
+        // Cache-Control "s-maxage" is only relevant is resource is not marked as "private"
+        if ($public !== false && null !== ($sharedMaxAge = $resourceCacheHeaders['shared_max_age'] ?? $this->sharedMaxAge) && !$response->headers->hasCacheControlDirective('s-maxage')) {
             $response->setSharedMaxAge($sharedMaxAge);
         }
     }

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -76,12 +76,14 @@ final class AddHeadersListener
             $response->setVary(array_diff($this->vary, $response->getVary()), false);
         }
 
-        if (null !== ($sharedMaxAge = $resourceCacheHeaders['shared_max_age'] ?? $this->sharedMaxAge) && !$response->headers->hasCacheControlDirective('s-maxage')) {
-            $response->setSharedMaxAge($sharedMaxAge);
+        $public = ($resourceCacheHeaders['public'] ?? $this->public);
+        if (null !== $public && !$response->headers->hasCacheControlDirective('public')) {
+            $public ? $response->setPublic() : $response->setPrivate();
         }
 
-        if (null !== $this->public && !$response->headers->hasCacheControlDirective('public')) {
-            $this->public ? $response->setPublic() : $response->setPrivate();
+        // s-maxage is only relevant is resource is not marked as "private"
+        if ($public && null !== ($sharedMaxAge = $resourceCacheHeaders['shared_max_age'] ?? $this->sharedMaxAge) && !$response->headers->hasCacheControlDirective('s-maxage')) {
+            $response->setSharedMaxAge($sharedMaxAge);
         }
     }
 }

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -147,10 +147,114 @@ class AddHeadersListenerTest extends TestCase
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
 
-        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], true, $factory->reveal());
+        $listener = new AddHeadersListener(true, 100, 200, [], true, $factory->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));
         $this->assertSame(['Vary-1', 'Vary-2'], $response->getVary());
+    }
+
+    public function testSetHeadersFromResourceMetadataMarkedAsPrivate()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $response = new Response('some content', 200);
+
+        $event = $this->prophesize(ResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $metadata = new ResourceMetadata(null, null, null, null, null, [
+            'cache_headers' => [
+                'max_age' => 123,
+                'public' => false,
+                'shared_max_age' => 456
+            ]
+        ]);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
+
+        $listener = new AddHeadersListener(true, 100, 200, [], true, $factory->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('max-age=123, private', $response->headers->get('Cache-Control'));
+
+        // resource's cache marked as private must not contain s-maxage
+        $this->assertStringNotContainsString("s-maxage", $response->headers->get('Cache-Control'));
+    }
+
+    public function testSetHeadersFromResourceMetadataMarkedAsPublic()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $response = new Response('some content', 200);
+
+        $event = $this->prophesize(ResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $metadata = new ResourceMetadata(null, null, null, null, null, [
+            'cache_headers' => [
+                'max_age' => 123,
+                'public' => true,
+                'shared_max_age' => 456
+            ]
+        ]);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
+
+        $listener = new AddHeadersListener(true, 100, 200, [], true, $factory->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));
+    }
+
+    public function testSetHeadersFromResourceMetadataWithNoPrivacy()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $response = new Response('some content', 200);
+
+        $event = $this->prophesize(ResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $metadata = new ResourceMetadata(null, null, null, null, null, [
+            'cache_headers' => [
+                'max_age' => 123,
+                'shared_max_age' => 456
+            ]
+        ]);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
+
+        $listener = new AddHeadersListener(true, 100, 200, [], true, $factory->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));
+    }
+
+    public function testSetHeadersFromResourceMetadataWithNoPrivacyDefaultsPrivate()
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
+        $response = new Response('some content', 200);
+
+        $event = $this->prophesize(ResponseEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $metadata = new ResourceMetadata(null, null, null, null, null, [
+            'cache_headers' => [
+                'max_age' => 123,
+                'shared_max_age' => 456
+            ]
+        ]);
+        $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
+
+        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], false, $factory->reveal());
+        $listener->onKernelResponse($event->reveal());
+
+        $this->assertSame('max-age=123, private', $response->headers->get('Cache-Control'));
+
+        // resource's cache marked as private must not contain s-maxage
+        $this->assertStringNotContainsString("s-maxage", $response->headers->get('Cache-Control'));
     }
 }

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -147,7 +147,7 @@ class AddHeadersListenerTest extends TestCase
         $factory = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $factory->create(Dummy::class)->willReturn($metadata)->shouldBeCalled();
 
-        $listener = new AddHeadersListener(true, 100, 200, [], true, $factory->reveal());
+        $listener = new AddHeadersListener(true, 100, 200, ['Accept', 'Accept-Encoding'], true, $factory->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('max-age=123, public, s-maxage=456', $response->headers->get('Cache-Control'));


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This change allows to mark a resource as "private" in the cache headers, to avoid having it being cached by shared caching services (Varnish, etc.)

**Example:**
User resources (`/api/user/xxx`) may contain sensitive information that cannot be controlled fine-grained enough with a Vary-header. So these resources should only be cached on the client.

**Configuration:**
```yaml
resources:
  App\Entity\User:
    attributes:
      cache_headers:
        public: false
        shared_max_age: 0 # <- this is ignored as not relevant on private resources
```
