### PR TITLE
Fix: Limit range of PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": "^7.1",
         "doctrine/inflector": "^1.0",
         "fig/link-util": "^1.0",
         "psr/cache": "^1.0",


### PR DESCRIPTION
This PR

* [x] limits the range of PHP versions this package can be installed on

💁‍♂️ We don't know yet if this package will be compatible with PHP 9000, do we?