### PR TITLE
[GraphQL] Allow `id` type in Filter::getDescription()

### DIFF
--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -380,8 +380,12 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
             foreach ($this->filterLocator->get($filterId)->getDescription($resourceClass) as $key => $value) {
                 $nullable = isset($value['required']) ? !$value['required'] : true;
-                $filterType = \in_array($value['type'], Type::$builtinTypes, true) ? new Type($value['type'], $nullable) : new Type('object', $nullable, $value['type']);
-                $graphqlFilterType = $this->convertType($filterType, false, $queryName, $mutationName, null, $resourceClass, $rootResource, $property, $depth);
+                if ($value['type'] instanceof GraphQLType) {
+                    $graphqlFilterType = $value['type'];
+                } else {
+                    $filterType = \in_array($value['type'], Type::$builtinTypes, true) ? new Type($value['type'], $nullable) : new Type('object', $nullable, $value['type']);
+                    $graphqlFilterType = $this->convertType($filterType, false, $queryName, $mutationName, null, $resourceClass, $rootResource, $property, $depth);
+                }
 
                 if ('[]' === substr($key, -2)) {
                     $graphqlFilterType = GraphQLType::listOf($graphqlFilterType);


### PR DESCRIPTION
```php
public function getDescription(string $resourceClass): array
{
    return [
        'someProperty' => [
            'property' => 'someProperty',
            'type' => Type::nonNull(Type::id()), // <-- error
            'description' => 'MyClassName',
        ]
    ];
}
```

The error I got:

```
Argument 3 passed to Symfony\\Component\\PropertyInfo\\Type::__construct() must be of the type string or null, object given
```

P.S. This is a quick fix and I don't have to to investigate how to make a proper pull request with tests covering the added change (sorry).

| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

