### PR TITLE
Support subresource resourceClass resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * GraphQL: **BC** `operation` is now `operationName` to follow the standard (#3568)
 * OpenAPI: Add PHP default values to the documentation (#2386)
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
+* Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
 
 ## 2.5.6
 

--- a/src/Metadata/Extractor/XmlExtractor.php
+++ b/src/Metadata/Extractor/XmlExtractor.php
@@ -120,7 +120,7 @@ final class XmlExtractor extends AbstractExtractor
                 'attributes' => $this->getAttributes($property, 'attribute'),
                 'subresource' => $property->subresource ? [
                     'collection' => $this->phpize($property->subresource, 'collection', 'bool'),
-                    'resourceClass' => $this->phpize($property->subresource, 'resourceClass', 'string'),
+                    'resourceClass' => $this->resolve($this->phpize($property->subresource, 'resourceClass', 'string')),
                     'maxDepth' => $this->phpize($property->subresource, 'maxDepth', 'integer'),
                 ] : null,
             ];

--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -100,6 +100,9 @@ final class YamlExtractor extends AbstractExtractor
             if (!\is_array($propertyValues)) {
                 throw new InvalidArgumentException(sprintf('"%s" setting is expected to be null or an array, %s given in "%s".', $propertyName, \gettype($propertyValues), $path));
             }
+            if (isset($propertyValues['subresource']['resourceClass'])) {
+                $propertyValues['subresource']['resourceClass'] = $this->resolve($propertyValues['subresource']['resourceClass']);
+            }
 
             $this->resources[$resourceName]['properties'][$propertyName] = [
                 'description' => $this->phpize($propertyValues, 'description', 'string'),

--- a/tests/Fixtures/FileConfigurations/resources_with_parameters.xml
+++ b/tests/Fixtures/FileConfigurations/resources_with_parameters.xml
@@ -4,7 +4,11 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="https://api-platform.com/schema/metadata
            https://api-platform.com/schema/metadata/metadata-2.0.xsd">
-    <resource class="%dummy_class%"/>
+    <resource class="%dummy_class%">
+        <property name="relatedOwnedDummy">
+            <subresource resourceClass="%dummy_related_owned_class%" />
+        </property>
+    </resource>
     <resource class="%dummy_class%Bis"/>
     <resource
             class="%file_config_dummy_class%"

--- a/tests/Fixtures/FileConfigurations/resources_with_parameters.yml
+++ b/tests/Fixtures/FileConfigurations/resources_with_parameters.yml
@@ -1,5 +1,8 @@
 resources:
-    '%dummy_class%': ~
+    '%dummy_class%':
+        properties:
+            'relatedOwnedDummy':
+                subresource: { resourceClass: '%dummy_related_owned_class%' }
     '%dummy_class%Bis': ~
     '%file_config_dummy_class%':
         shortName: 'thedummyshortname'

--- a/tests/Metadata/Extractor/ExtractorTestCase.php
+++ b/tests/Metadata/Extractor/ExtractorTestCase.php
@@ -159,6 +159,7 @@ abstract class ExtractorTestCase extends TestCase
     {
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->get('dummy_class')->willReturn(\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy::class);
+        $containerProphecy->getParameter('dummy_related_owned_class')->willReturn(\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedOwnedDummy::class);
         $containerProphecy->get('file_config_dummy_class')->willReturn(\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy::class);
 
         $resources = $this->createExtractor([$this->getResourceWithParametersFile()], $containerProphecy->reveal())->getResources();
@@ -173,7 +174,11 @@ abstract class ExtractorTestCase extends TestCase
                 'subresourceOperations' => null,
                 'graphql' => null,
                 'attributes' => null,
-                'properties' => null,
+                'properties' => [
+                    'relatedOwnedDummy' => [
+                        'resourceClass' => \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedOwnedDummy::class,
+                    ],
+                ],
             ],
             '\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyBis' => [
                 'shortName' => null,
@@ -285,6 +290,7 @@ abstract class ExtractorTestCase extends TestCase
     {
         $containerProphecy = $this->prophesize(SymfonyContainerInterface::class);
         $containerProphecy->getParameter('dummy_class')->willReturn(\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy::class);
+        $containerProphecy->getParameter('dummy_related_owned_class')->willReturn(\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedOwnedDummy::class);
         $containerProphecy->getParameter('file_config_dummy_class')->willReturn(\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy::class);
 
         $resources = $this->createExtractor([$this->getResourceWithParametersFile()], $containerProphecy->reveal())->getResources();
@@ -299,7 +305,11 @@ abstract class ExtractorTestCase extends TestCase
                 'subresourceOperations' => null,
                 'graphql' => null,
                 'attributes' => null,
-                'properties' => null,
+                'properties' => [
+                    'relatedOwnedDummy' => [
+                        'resourceClass' => \ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedOwnedDummy::class,
+                    ],
+                ],
             ],
             '\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyBis' => [
                 'shortName' => null,
@@ -421,7 +431,11 @@ abstract class ExtractorTestCase extends TestCase
                 'subresourceOperations' => null,
                 'graphql' => null,
                 'attributes' => null,
-                'properties' => null,
+                'properties' => [
+                    'relatedOwnedDummy' => [
+                        'resourceClass' => '%dummy_related_owned_class%',
+                    ],
+                ],
             ],
             '%dummy_class%Bis' => [
                 'shortName' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no, more like an improvement
| New feature?  | yes, in a way
| BC breaks?    | no
| Deprecations? | no
| Tickets       | https://github.com/api-platform/core/issues/3559
| License       | MIT
| Doc PR        | n/a

This PR will allow you to define `subresource.resourceClass` as a parameter of the container.

The extractors have support for resolving class names through container defined parameters, but the subResource class did not have support for this, which kind of makes the use of parameters as a flexibility measure a little less useful when you want to use subResources.

