### PR TITLE
Rewrite static access to Inflector as it has been deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "doctrine/inflector": "^1.0",
+        "doctrine/inflector": "^1.4 || ^2.0",
         "fig/link-util": "^1.0",
         "psr/cache": "^1.0",
         "psr/container": "^1.0",

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Annotation;
 
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 
 /**
  * Hydrates attributes from annotation's parameters.
@@ -36,6 +36,8 @@ trait AttributesHydratorTrait
      */
     private function hydrateAttributes(array $values): void
     {
+        $inflector = InflectorFactory::create()->build();
+
         if (isset($values['attributes'])) {
             $this->attributes = $values['attributes'];
             unset($values['attributes']);
@@ -67,7 +69,7 @@ trait AttributesHydratorTrait
                 $this->attributes = [];
             }
 
-            $this->attributes += [Inflector::tableize($key) => $value];
+            $this->attributes += [$inflector->tableize($key) => $value];
         }
     }
 }

--- a/src/Bridge/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
+++ b/src/Bridge/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
@@ -16,7 +16,7 @@ namespace ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory;
 use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 
@@ -48,6 +48,7 @@ final class CatDocumentMetadataFactory implements DocumentMetadataFactoryInterfa
     public function create(string $resourceClass): DocumentMetadata
     {
         $documentMetadata = null;
+        $inflector = InflectorFactory::create()->build();
 
         if ($this->decorated) {
             try {
@@ -64,7 +65,7 @@ final class CatDocumentMetadataFactory implements DocumentMetadataFactoryInterfa
             return $this->handleNotFound($documentMetadata, $resourceClass);
         }
 
-        $index = Inflector::tableize($resourceShortName);
+        $index = $inflector->tableize($resourceShortName);
 
         try {
             $this->client->cat()->indices(['index' => $index]);

--- a/src/Bridge/Symfony/Routing/RouteNameGenerator.php
+++ b/src/Bridge/Symfony/Routing/RouteNameGenerator.php
@@ -16,7 +16,8 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\OperationTypeDeprecationHelper;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 
 /**
  * Generates the Symfony route name associated with an operation name and a resource short name.
@@ -64,8 +65,9 @@ final class RouteNameGenerator
      */
     public static function inflector(string $name, bool $pluralize = true): string
     {
-        $name = Inflector::tableize($name);
+        $inflector = InflectorFactory::create()->build();
+        $name = $inflector->tableize($name);
 
-        return $pluralize ? Inflector::pluralize($name) : $name;
+        return $pluralize ? $inflector->pluralize($name) : $name;
     }
 }

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -21,7 +21,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\NullableType;
 use GraphQL\Type\Definition\Type as GraphQLType;
@@ -113,6 +113,8 @@ final class FieldsBuilder implements FieldsBuilderInterface
      */
     public function getCollectionQueryFields(string $resourceClass, ResourceMetadata $resourceMetadata, string $queryName, array $configuration): array
     {
+        $inflector = InflectorFactory::create()->build();
+
         $shortName = $resourceMetadata->getShortName();
         $fieldName = lcfirst('collection_query' === $queryName ? $shortName : $queryName.$shortName);
         $description = $resourceMetadata->getGraphqlAttribute($queryName, 'description');
@@ -122,7 +124,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
             $args = $this->resolveResourceArgs($configuration['args'] ?? [], $queryName, $shortName);
             $configuration['args'] = $args ?: $configuration['args'] ?? $fieldConfiguration['args'];
 
-            return [Inflector::pluralize($fieldName) => array_merge($fieldConfiguration, $configuration)];
+            return [$inflector->pluralize($fieldName) => array_merge($fieldConfiguration, $configuration)];
         }
 
         return [];

--- a/src/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Operation/DashPathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 
 /**
  * Generate a path name with a dash separator according to a string and whether it's a collection or not.
@@ -27,7 +27,9 @@ final class DashPathSegmentNameGenerator implements PathSegmentNameGeneratorInte
      */
     public function getSegmentName(string $name, bool $collection = true): string
     {
-        return $collection ? $this->dashize(Inflector::pluralize($name)) : $this->dashize($name);
+        $inflector = InflectorFactory::create()->build();
+
+        return $collection ? $this->dashize($inflector->pluralize($name)) : $this->dashize($name);
     }
 
     private function dashize(string $string): string

--- a/src/Operation/UnderscorePathSegmentNameGenerator.php
+++ b/src/Operation/UnderscorePathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 
 /**
  * Generate a path name with an underscore separator according to a string and whether it's a collection or not.
@@ -27,8 +27,9 @@ final class UnderscorePathSegmentNameGenerator implements PathSegmentNameGenerat
      */
     public function getSegmentName(string $name, bool $collection = true): string
     {
-        $name = Inflector::tableize($name);
+        $inflector = InflectorFactory::create()->build();
+        $name = $inflector->tableize($name);
 
-        return $collection ? Inflector::pluralize($name) : $name;
+        return $collection ? $inflector->pluralize($name) : $name;
     }
 }

--- a/src/Util/AnnotationFilterExtractorTrait.php
+++ b/src/Util/AnnotationFilterExtractorTrait.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Util;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 
 /**
  * Generates a service id for a generic filter.
@@ -136,7 +136,8 @@ trait AnnotationFilterExtractorTrait
     private function generateFilterId(\ReflectionClass $reflectionClass, string $filterClass, string $filterId = null): string
     {
         $suffix = null !== $filterId ? '_'.$filterId : $filterId;
+        $inflector = InflectorFactory::create()->build();
 
-        return 'annotated_'.Inflector::tableize(str_replace('\\', '', $reflectionClass->getName().(new \ReflectionClass($filterClass))->getName().$suffix));
+        return 'annotated_'.$inflector->tableize(str_replace('\\', '', $reflectionClass->getName().(new \ReflectionClass($filterClass))->getName().$suffix));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | `doctrine/inflector` raised to `^1.4 \|\| ^2.0` 
| Deprecations? |no
| Tickets       | fixes #2626
| License       | MIT
| Doc PR        | none

`doctrine/inflector` deprecated the use of `Doctrine\Common\Inflector\Inflector` when they released version 2.0 (where the class has been removed).
They suggest to use a factory pattern like this: https://github.com/doctrine/inflector/blob/master/docs/en/index.rst#usage