### PR TITLE
Handle deprecations from Doctrine Inflector

### DIFF
--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Annotation;
 
+use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Hydrates attributes from annotation's parameters.

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Annotation;
 
-use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Util\Inflector;
 
 /**
  * Hydrates attributes from annotation's parameters.

--- a/src/Bridge/Doctrine/Inflector/Inflector.php
+++ b/src/Bridge/Doctrine/Inflector/Inflector.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Doctrine\Inflector;
+
+use Doctrine\Common\Inflector\Inflector as LegacyInflector;
+use Doctrine\Inflector\Inflector as InflectorObject;
+use Doctrine\Inflector\InflectorFactory;
+
+/**
+ * Facade for Doctrine Inflector.
+ *
+ * This class allows us to maintain compatibility with Doctrine Inflector 1.3 and 2.0 at the same time.
+ *
+ * @internal
+ */
+final class Inflector
+{
+    /**
+     * @var InflectorObject
+     */
+    private static $instance;
+
+    private static function getInstance(): InflectorObject
+    {
+        return self::$instance
+            ?? self::$instance = InflectorFactory::create()->build();
+    }
+
+    /**
+     * @see LegacyInflector::tableize()
+     */
+    public static function tableize(string $word): string
+    {
+        return class_exists(InflectorFactory::class) ? self::getInstance()->tableize($word) : LegacyInflector::tableize($word);
+    }
+
+    /**
+     * @see LegacyInflector::pluralize()
+     */
+    public static function pluralize(string $word): string
+    {
+        return class_exists(InflectorFactory::class) ? self::getInstance()->pluralize($word) : LegacyInflector::pluralize($word);
+    }
+}

--- a/src/Bridge/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
+++ b/src/Bridge/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory;
 
+use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use Doctrine\Common\Inflector\Inflector;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 

--- a/src/Bridge/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
+++ b/src/Bridge/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory;
 
-use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\Inflector;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 

--- a/src/Bridge/Symfony/Routing/RouteNameGenerator.php
+++ b/src/Bridge/Symfony/Routing/RouteNameGenerator.php
@@ -15,8 +15,8 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\OperationTypeDeprecationHelper;
-use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Util\Inflector;
 
 /**
  * Generates the Symfony route name associated with an operation name and a resource short name.

--- a/src/Bridge/Symfony/Routing/RouteNameGenerator.php
+++ b/src/Bridge/Symfony/Routing/RouteNameGenerator.php
@@ -15,8 +15,8 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Api\OperationTypeDeprecationHelper;
+use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generates the Symfony route name associated with an operation name and a resource short name.

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Type;
 
+use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\DataProvider\Pagination;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\GraphQl\Resolver\Factory\ResolverFactoryInterface;
@@ -21,7 +22,6 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
-use Doctrine\Common\Inflector\Inflector;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\NullableType;
 use GraphQL\Type\Definition\Type as GraphQLType;

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Type;
 
-use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use ApiPlatform\Core\DataProvider\Pagination;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\GraphQl\Resolver\Factory\ResolverFactoryInterface;
@@ -22,6 +21,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Util\Inflector;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\NullableType;
 use GraphQL\Type\Definition\Type as GraphQLType;

--- a/src/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Operation/DashPathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
+use ApiPlatform\Core\Util\Inflector;
 
 /**
  * Generate a path name with a dash separator according to a string and whether it's a collection or not.

--- a/src/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Operation/DashPathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use Doctrine\Common\Inflector\Inflector;
+use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 
 /**
  * Generate a path name with a dash separator according to a string and whether it's a collection or not.

--- a/src/Operation/UnderscorePathSegmentNameGenerator.php
+++ b/src/Operation/UnderscorePathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use Doctrine\Common\Inflector\Inflector;
+use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 
 /**
  * Generate a path name with an underscore separator according to a string and whether it's a collection or not.

--- a/src/Operation/UnderscorePathSegmentNameGenerator.php
+++ b/src/Operation/UnderscorePathSegmentNameGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Operation;
 
-use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
+use ApiPlatform\Core\Util\Inflector;
 
 /**
  * Generate a path name with an underscore separator according to a string and whether it's a collection or not.

--- a/src/Util/AnnotationFilterExtractorTrait.php
+++ b/src/Util/AnnotationFilterExtractorTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Util;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use Doctrine\Common\Annotations\Reader;
 
 /**

--- a/src/Util/AnnotationFilterExtractorTrait.php
+++ b/src/Util/AnnotationFilterExtractorTrait.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Util;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Inflector\Inflector;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generates a service id for a generic filter.

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Core\Bridge\Doctrine\Inflector;
+namespace ApiPlatform\Core\Util;
 
 use Doctrine\Common\Inflector\Inflector as LegacyInflector;
 use Doctrine\Inflector\Inflector as InflectorObject;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | #2626
| License       | MIT

This is an alternative approach to #3560. Since Doctrine Inflector cannot be bumped to version 1.4 without dropping support for php 7.1, this PR introduces a façade that uses the new API if it's available and falls back to the 1.3 API otherwise.

This change removed a lot of messages from my application's deprecation log.