### PR TITLE
Use operationName instead of operation

### DIFF
--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -129,8 +129,8 @@ final class EntrypointAction
             $variables = \is_array($data['variables']) ? $data['variables'] : $this->decodeVariables($data['variables']);
         }
 
-        if (isset($data['operation'])) {
-            $operation = $data['operation'];
+        if (isset($data['operationName'])) {
+            $operation = $data['operationName'];
         }
 
         return [$query, $operation, $variables];


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | fixes #3566 
| License       | MIT
| Doc PR        | api-platform/docs#...

<!--
The operation name in Data is attempting to pull from operation instead of operationName. Because of this, applications leveraging the StandardServer cannot handle a request with multiple operations (it returns an error saying the operation name is required).

In this PR, I only updated the way the class parses the data on the parseData function.
-->
