### PR TITLE
change operation to OperationName in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * GraphQL: Add page-based pagination (#3175, #3517)
 * GraphQL: Possibility to add a custom description for queries, mutations and subscriptions (#3477, #3514)
 * GraphQL: Support for field name conversion (serialized name) (#3455, #3516)
+* GraphQL: **BC** `operation` is now `operationName` to follow the standard (#3568)
 * OpenAPI: Add PHP default values to the documentation (#2386)
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 
@@ -34,7 +35,6 @@
 * HTTP: Location header is only set on POST with a 201 or between 300 and 400 #3497
 * GraphQL: Do not allow empty cursor values on `before` or `after` #3360
 * Bump versions of Swagger UI, GraphiQL and GraphQL Playground #3510
->>>>>>> 2.5
 
 ## 2.5.4
 

--- a/features/bootstrap/GraphqlContext.php
+++ b/features/bootstrap/GraphqlContext.php
@@ -90,11 +90,11 @@ final class GraphqlContext implements Context
     }
 
     /**
-     * @When I send the GraphQL request with operation :operation
+     * @When I send the GraphQL request with operationName :operationName
      */
-    public function ISendTheGraphqlRequestWithOperation(string $operation)
+    public function ISendTheGraphqlRequestWithOperation(string $operationName)
     {
-        $this->graphqlRequest['operation'] = $operation;
+        $this->graphqlRequest['operationName'] = $operationName;
         $this->sendGraphqlRequest();
     }
 

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -102,13 +102,13 @@ Feature: GraphQL query support
       }
     }
     """
-    And I send the GraphQL request with operation "DummyWithId2"
+    And I send the GraphQL request with operationName "DummyWithId2"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.dummyItem.id" should be equal to "/dummies/2"
     And the JSON node "data.dummyItem.name" should be equal to "Dummy #2"
-    And I send the GraphQL request with operation "DummyWithId1"
+    And I send the GraphQL request with operationName "DummyWithId1"
     And the JSON node "data.dummyItem.name" should be equal to "Dummy #1"
 
   Scenario: Use serialization groups

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -69,13 +69,13 @@ final class EntrypointAction
                 }
             }
 
-            [$query, $operation, $variables] = $this->parseRequest($request);
+            [$query, $operationName, $variables] = $this->parseRequest($request);
             if (null === $query) {
                 throw new BadRequestHttpException('GraphQL query is not valid.');
             }
 
             $executionResult = $this->executor
-                ->executeQuery($this->schemaBuilder->getSchema(), $query, null, null, $variables, $operation)
+                ->executeQuery($this->schemaBuilder->getSchema(), $query, null, null, $variables, $operationName)
                 ->setErrorFormatter([$this->normalizer, 'normalize']);
         } catch (\Exception $exception) {
             $executionResult = (new ExecutionResult(null, [new Error($exception->getMessage(), null, null, null, null, $exception)]))
@@ -91,17 +91,17 @@ final class EntrypointAction
     private function parseRequest(Request $request): array
     {
         $query = $request->query->get('query');
-        $operation = $request->query->get('operationName');
+        $operationName = $request->query->get('operationName');
         if ($variables = $request->query->get('variables', [])) {
             $variables = $this->decodeVariables($variables);
         }
 
         if (!$request->isMethod('POST')) {
-            return [$query, $operation, $variables];
+            return [$query, $operationName, $variables];
         }
 
         if ('json' === $request->getContentType()) {
-            return $this->parseData($query, $operation, $variables, $request->getContent());
+            return $this->parseData($query, $operationName, $variables, $request->getContent());
         }
 
         if ('graphql' === $request->getContentType()) {
@@ -109,16 +109,16 @@ final class EntrypointAction
         }
 
         if ('multipart' === $request->getContentType()) {
-            return $this->parseMultipartRequest($query, $operation, $variables, $request->request->all(), $request->files->all());
+            return $this->parseMultipartRequest($query, $operationName, $variables, $request->request->all(), $request->files->all());
         }
 
-        return [$query, $operation, $variables];
+        return [$query, $operationName, $variables];
     }
 
     /**
      * @throws BadRequestHttpException
      */
-    private function parseData(?string $query, ?string $operation, array $variables, string $jsonContent): array
+    private function parseData(?string $query, ?string $operationName, array $variables, string $jsonContent): array
     {
         if (!\is_array($data = json_decode($jsonContent, true))) {
             throw new BadRequestHttpException('GraphQL data is not valid JSON.');
@@ -133,23 +133,22 @@ final class EntrypointAction
         }
 
         if (isset($data['operationName'])) {
-            $operation = $data['operationName'];
+            $operationName = $data['operationName'];
         }
 
-        return [$query, $operation, $variables];
+        return [$query, $operationName, $variables];
     }
 
     /**
      * @throws BadRequestHttpException
      */
-    private function parseMultipartRequest(?string $query, ?string $operation, array $variables, array $bodyParameters, array $files): array
+    private function parseMultipartRequest(?string $query, ?string $operationName, array $variables, array $bodyParameters, array $files): array
     {
         if ((null === $operations = $bodyParameters['operations'] ?? null) || (null === $map = $bodyParameters['map'] ?? null)) {
             throw new BadRequestHttpException('GraphQL multipart request does not respect the specification.');
         }
 
-        /** @var string $operations */
-        [$query, $operation, $variables] = $this->parseData($query, $operation, $variables, $operations);
+        [$query, $operationName, $variables] = $this->parseData($query, $operationName, $variables, $operations);
 
         /** @var string $map */
         if (!\is_array($decodedMap = json_decode($map, true))) {
@@ -158,7 +157,7 @@ final class EntrypointAction
 
         $variables = $this->applyMapToVariables($decodedMap, $variables, $files);
 
-        return [$query, $operation, $variables];
+        return [$query, $operationName, $variables];
     }
 
     /**

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -91,7 +91,7 @@ final class EntrypointAction
     private function parseRequest(Request $request): array
     {
         $query = $request->query->get('query');
-        $operation = $request->query->get('operation');
+        $operation = $request->query->get('operationName');
         if ($variables = $request->query->get('variables', [])) {
             $variables = $this->decodeVariables($variables);
         }
@@ -132,8 +132,8 @@ final class EntrypointAction
             $variables = \is_array($data['variables']) ? $data['variables'] : $this->decodeVariables($data['variables']);
         }
 
-        if (isset($data['operation'])) {
-            $operation = $data['operation'];
+        if (isset($data['operationName'])) {
+            $operation = $data['operationName'];
         }
 
         return [$query, $operation, $variables];

--- a/tests/GraphQl/Action/EntrypointActionTest.php
+++ b/tests/GraphQl/Action/EntrypointActionTest.php
@@ -58,7 +58,7 @@ class EntrypointActionTest extends TestCase
 
     public function testGetAction(): void
     {
-        $request = new Request(['query' => 'graphqlQuery', 'variables' => '["graphqlVariable"]', 'operation' => 'graphqlOperationName']);
+        $request = new Request(['query' => 'graphqlQuery', 'variables' => '["graphqlVariable"]', 'operationName' => 'graphqlOperationName']);
         $request->setRequestFormat('json');
         $mockedEntrypoint = $this->getEntrypointAction();
 
@@ -67,7 +67,7 @@ class EntrypointActionTest extends TestCase
 
     public function testPostRawAction(): void
     {
-        $request = new Request(['variables' => '["graphqlVariable"]', 'operation' => 'graphqlOperationName'], [], [], [], [], [], 'graphqlQuery');
+        $request = new Request(['variables' => '["graphqlVariable"]', 'operationName' => 'graphqlOperationName'], [], [], [], [], [], 'graphqlQuery');
         $request->setFormat('graphql', 'application/graphql');
         $request->setMethod('POST');
         $request->headers->set('Content-Type', 'application/graphql');
@@ -78,7 +78,7 @@ class EntrypointActionTest extends TestCase
 
     public function testPostJsonAction(): void
     {
-        $request = new Request([], [], [], [], [], [], '{"query": "graphqlQuery", "variables": "[\"graphqlVariable\"]", "operation": "graphqlOperationName"}');
+        $request = new Request([], [], [], [], [], [], '{"query": "graphqlQuery", "variables": "[\"graphqlVariable\"]", "operationName": "graphqlOperationName"}');
         $request->setMethod('POST');
         $request->headers->set('Content-Type', 'application/json');
         $mockedEntrypoint = $this->getEntrypointAction();
@@ -119,14 +119,14 @@ class EntrypointActionTest extends TestCase
 
         return [
             'upload a single file' => [
-                '{"query": "graphqlQuery", "variables": {"file": null}, "operation": "graphqlOperationName"}',
+                '{"query": "graphqlQuery", "variables": {"file": null}, "operationName": "graphqlOperationName"}',
                 '{"file": ["variables.file"]}',
                 ['file' => $file],
                 ['file' => $file],
                 new JsonResponse(['GraphQL']),
             ],
             'upload multiple files' => [
-                '{"query": "graphqlQuery", "variables": {"files": [null, null, null]}, "operation": "graphqlOperationName"}',
+                '{"query": "graphqlQuery", "variables": {"files": [null, null, null]}, "operationName": "graphqlOperationName"}',
                 '{"0": ["variables.files.0"], "1": ["variables.files.1"], "2": ["variables.files.2"]}',
                 [
                     '0' => $file,
@@ -150,7 +150,7 @@ class EntrypointActionTest extends TestCase
                 new Response('{"errors":[{"message":"GraphQL multipart request does not respect the specification.","extensions":{"category":"user","status":400}}]}'),
             ],
             'upload without providing map' => [
-                '{"query": "graphqlQuery", "variables": {"file": null}, "operation": "graphqlOperationName"}',
+                '{"query": "graphqlQuery", "variables": {"file": null}, "operationName": "graphqlOperationName"}',
                 null,
                 ['file' => $file],
                 ['file' => null],
@@ -164,28 +164,28 @@ class EntrypointActionTest extends TestCase
                 new Response('{"errors":[{"message":"GraphQL data is not valid JSON.","extensions":{"category":"user","status":400}}]}'),
             ],
             'upload with invalid map JSON' => [
-                '{"query": "graphqlQuery", "variables": {"file": null}, "operation": "graphqlOperationName"}',
+                '{"query": "graphqlQuery", "variables": {"file": null}, "operationName": "graphqlOperationName"}',
                 '{invalid}',
                 ['file' => $file],
                 ['file' => null],
                 new Response('{"errors":[{"message":"GraphQL multipart request map is not valid JSON.","extensions":{"category":"user","status":400}}]}'),
             ],
             'upload with no file' => [
-                '{"query": "graphqlQuery", "variables": {"file": null}, "operation": "graphqlOperationName"}',
+                '{"query": "graphqlQuery", "variables": {"file": null}, "operationName": "graphqlOperationName"}',
                 '{"file": ["file"]}',
                 [],
                 ['file' => null],
                 new Response('{"errors":[{"message":"GraphQL multipart request file has not been sent correctly.","extensions":{"category":"user","status":400}}]}'),
             ],
             'upload with wrong map' => [
-                '{"query": "graphqlQuery", "variables": {"file": null}, "operation": "graphqlOperationName"}',
+                '{"query": "graphqlQuery", "variables": {"file": null}, "operationName": "graphqlOperationName"}',
                 '{"file": ["file"]}',
                 ['file' => $file],
                 ['file' => null],
                 new Response('{"errors":[{"message":"GraphQL multipart request path in map is invalid.","extensions":{"category":"user","status":400}}]}'),
             ],
             'upload when variable path does not exist' => [
-                '{"query": "graphqlQuery", "variables": {"file": null}, "operation": "graphqlOperationName"}',
+                '{"query": "graphqlQuery", "variables": {"file": null}, "operationName": "graphqlOperationName"}',
                 '{"file": ["variables.wrong"]}',
                 ['file' => $file],
                 ['file' => null],
@@ -217,7 +217,7 @@ class EntrypointActionTest extends TestCase
 
     public function testBadVariablesAction(): void
     {
-        $request = new Request(['query' => 'graphqlQuery', 'variables' => 'graphqlVariable', 'operation' => 'graphqlOperationName']);
+        $request = new Request(['query' => 'graphqlQuery', 'variables' => 'graphqlVariable', 'operationName' => 'graphqlOperationName']);
         $request->setRequestFormat('json');
         $mockedEntrypoint = $this->getEntrypointAction();
 


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | fixes #3566 
| License       | MIT
| Doc PR        | api-platform/docs#...

The operation name in Data is attempting to pull from operation instead of operationName. Because of this, applications leveraging the StandardServer cannot handle a request with multiple operations (it returns an error saying the operation name is required).

In this PR, I only updated the way the class parses the data on the parseData function.
