### PR TITLE
fix: Uuid identifier normalizer should support only strings

### DIFF
--- a/src/Bridge/RamseyUuid/Identifier/Normalizer/UuidNormalizer.php
+++ b/src/Bridge/RamseyUuid/Identifier/Normalizer/UuidNormalizer.php
@@ -43,6 +43,6 @@ final class UuidNormalizer implements DenormalizerInterface
      */
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return is_a($type, UuidInterface::class, true);
+        return \is_string($data) && is_a($type, UuidInterface::class, true);
     }
 }

--- a/tests/Bridge/RamseyUuid/Normalizer/UuidNormalizerTest.php
+++ b/tests/Bridge/RamseyUuid/Normalizer/UuidNormalizerTest.php
@@ -44,4 +44,11 @@ class UuidNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($uuid, Uuid::class));
         $normalizer->denormalize($uuid, Uuid::class);
     }
+
+    public function testDoNotSupportNotString()
+    {
+        $uuid = Uuid::uuid4();
+        $normalizer = new UuidNormalizer();
+        $this->assertFalse($normalizer->supportsDenormalization($uuid, Uuid::class));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | na
| License       | MIT
| Doc PR        | na

The supports method wasn't explicit enough and should not be called with something other then a string.