### PR TITLE
Better handling of relations without Doctrine.

### DIFF
--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -62,6 +62,10 @@ final class TypeConverter implements TypeConverterInterface
                 return GraphQLType::string();
             case Type::BUILTIN_TYPE_ARRAY:
             case Type::BUILTIN_TYPE_ITERABLE:
+                if ($resourceType = $this->getResourceType($type, $input, $queryName, $mutationName, $depth)) {
+                    return $resourceType;
+                }
+
                 return 'Iterable';
             case Type::BUILTIN_TYPE_OBJECT:
                 if ($input && $depth > 0) {

--- a/tests/GraphQl/Type/TypeConverterTest.php
+++ b/tests/GraphQl/Type/TypeConverterTest.php
@@ -120,11 +120,12 @@ class TypeConverterTest extends TestCase
         $this->assertNull($graphqlType);
     }
 
-    public function testConvertTypeResource(): void
+    /**
+     * @dataProvider convertTypeResourceProvider
+     */
+    public function testConvertTypeResource(Type $type, ObjectType $expectedGraphqlType): void
     {
         $graphqlResourceMetadata = (new ResourceMetadata())->withGraphql(['test']);
-        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummyValue'));
-        $expectedGraphqlType = new ObjectType(['name' => 'resourceObjectType']);
 
         $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(true);
         $this->resourceMetadataFactoryProphecy->create('dummyValue')->shouldBeCalled()->willReturn($graphqlResourceMetadata);
@@ -132,6 +133,14 @@ class TypeConverterTest extends TestCase
 
         $graphqlType = $this->typeConverter->convertType($type, false, null, null, 'resourceClass', 'rootClass', null, 0);
         $this->assertEquals($expectedGraphqlType, $graphqlType);
+    }
+
+    public function convertTypeResourceProvider(): array
+    {
+        return [
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummyValue')), new ObjectType(['name' => 'resourceObjectType'])],
+            [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummyValue')), new ObjectType(['name' => 'resourceObjectType'])],
+        ];
     }
 
     /**


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes https://github.com/api-platform/core/issues/3542
| License       | MIT
| Doc PR        | N/A

When Doctrine is not used, the built-in type of a relation is an array
and not an object.