### PR TITLE
Fix/identifier encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * OpenAPI: Add PHP default values to the documentation (#2386)
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
-* Url Encoded IRIs: Fix IRI url encoding
+* IriConverter: Fix IRI url double encoding - may cause breaking change as some characters no longer encoded in output (#3552)
 
 ## 2.5.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * OpenAPI: Add PHP default values to the documentation (#2386)
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
+* Url Encoded IRIs: Fix IRI url encoding
 
 ## 2.5.6
 

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -129,6 +129,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Site;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\SoMany;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Taxon;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ThirdLevel;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\UrlEncodedId;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\User;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\UuidIdentifierDummy;
 use Behat\Behat\Context\Context;
@@ -1051,6 +1052,17 @@ final class DoctrineContext implements Context
         $this->manager->persist($answer);
         $this->manager->persist($question);
 
+        $this->manager->flush();
+        $this->manager->clear();
+    }
+
+    /**
+     * @Given there is a UrlEncodedId resource
+     */
+    public function thereIsAUrlEncodedIdResource()
+    {
+        $urlEncodedIdResource = new UrlEncodedId();
+        $this->manager->persist($urlEncodedIdResource);
         $this->manager->flush();
         $this->manager->clear();
     }

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -67,6 +67,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\SecuredDummy as SecuredD
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\SoMany as SoManyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Taxon as TaxonDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\ThirdLevel as ThirdLevelDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\UrlEncodedId as UrlEncodedIdDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\User as UserDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Address;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Answer;
@@ -1061,7 +1062,7 @@ final class DoctrineContext implements Context
      */
     public function thereIsAUrlEncodedIdResource()
     {
-        $urlEncodedIdResource = new UrlEncodedId();
+        $urlEncodedIdResource = ($this->isOrm() ? new UrlEncodedId() : new UrlEncodedIdDocument());
         $this->manager->persist($urlEncodedIdResource);
         $this->manager->flush();
         $this->manager->clear();

--- a/features/main/table_inheritance.feature
+++ b/features/main/table_inheritance.feature
@@ -538,7 +538,7 @@ Feature: Table inheritance
         },
         "@id": {
           "type": "string",
-          "pattern": "^/resource_interfaces/single%2520item$"
+          "pattern": "^/resource_interfaces/single%20item$"
         },
         "@type": {
           "type": "string",

--- a/features/main/url_encoded_id.feature
+++ b/features/main/url_encoded_id.feature
@@ -1,0 +1,24 @@
+Feature: Allowing resource identifiers with characters that should be URL encoded
+  In order to have a resource with an id with special characters
+  As a client software developer
+  I need to be able to set and retrieve these resources with the URL encoded ID
+
+  @createSchema
+  Scenario Outline: Get a resource whether or not the id is URL encoded
+    Given there is a UrlEncodedId resource
+    And I add "Content-Type" header equal to "application/ld+json"
+    When I send a "GET" request to "<url>"
+    Then the response status code should be 200
+    And the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/UrlEncodedId",
+        "@id": "/url_encoded_ids/encode:id",
+        "@type": "UrlEncodedId",
+        "id": "encode:id"
+    }
+    """
+    Examples:
+      | url                            |
+      | /url_encoded_ids/encode:id     |
+      | /url_encoded_ids/encode%3Aid   |

--- a/features/main/url_encoded_id.feature
+++ b/features/main/url_encoded_id.feature
@@ -13,12 +13,14 @@ Feature: Allowing resource identifiers with characters that should be URL encode
     """
     {
         "@context": "/contexts/UrlEncodedId",
-        "@id": "/url_encoded_ids/encode:id",
+        "@id": "/url_encoded_ids/%25encode:id",
         "@type": "UrlEncodedId",
-        "id": "encode:id"
+        "id": "%encode:id"
     }
     """
     Examples:
-      | url                            |
-      | /url_encoded_ids/encode:id     |
-      | /url_encoded_ids/encode%3Aid   |
+      | url                              |
+      | /url_encoded_ids/%encode:id      |
+      | /url_encoded_ids/%25encode%3Aid  |
+      | /url_encoded_ids/%25encode:id    |
+      | /url_encoded_ids/%encode%3Aid    |

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -182,7 +182,7 @@ final class IriConverter implements IriConverterInterface
         }
 
         if (1 === \count($identifiers)) {
-            return [rawurlencode((string) reset($identifiers))];
+            return [(string) reset($identifiers)];
         }
 
         foreach ($identifiers as $name => $value) {

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -74,6 +74,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null);
         $context = $this->initContext($resourceClass, $context);
+
         $iri = $this->iriConverter->getIriFromItem($object);
         $context['iri'] = $iri;
         $context['api_normalize'] = true;

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -74,7 +74,6 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null);
         $context = $this->initContext($resourceClass, $context);
-
         $iri = $this->iriConverter->getIriFromItem($object);
         $context['iri'] = $iri;
         $context['api_normalize'] = true;

--- a/tests/Fixtures/TestBundle/Document/UrlEncodedId.php
+++ b/tests/Fixtures/TestBundle/Document/UrlEncodedId.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @author Daniel West <daniel@silverback.is>
+ *
+ * Resource with an ID that will be URL encoded
+ *
+ * @ODM\Document
+ *
+ * @ApiResource(
+ *     itemOperations={
+ *         "get"={
+ *             "method"="GET",
+ *             "requirements"={"id"=".+"}
+ *         }
+ *     }
+ * )
+ */
+class UrlEncodedId
+{
+    /**
+     * @ODM\Id(strategy="none")
+     */
+    private $id = '%encode:id';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/UrlEncodedId.php
+++ b/tests/Fixtures/TestBundle/Entity/UrlEncodedId.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\CustomInputDto;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\CustomOutputDto;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Daniel West <daniel@silverback.is>
+ *
+ * Resource with an ID that will be URL encoded
+ *
+ * @ORM\Entity
+ *
+ * @ApiResource(
+ *     itemOperations={
+ *        "get"={
+ *            "method"="GET",
+ *            "requirements"={"id"=".+"}
+ *        }
+ *     }
+ * )
+ */
+class UrlEncodedId
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="string")
+     * @ORM\Id
+     */
+    private $id = 'encode:id';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/UrlEncodedId.php
+++ b/tests/Fixtures/TestBundle/Entity/UrlEncodedId.php
@@ -42,7 +42,7 @@ class UrlEncodedId
      * @ORM\Column(type="string")
      * @ORM\Id
      */
-    private $id = 'encode:id';
+    private $id = '%encode:id';
 
     public function getId()
     {

--- a/tests/Fixtures/TestBundle/Entity/UrlEncodedId.php
+++ b/tests/Fixtures/TestBundle/Entity/UrlEncodedId.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
-use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\CustomInputDto;
-use ApiPlatform\Core\Tests\Fixtures\TestBundle\Dto\CustomOutputDto;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -27,18 +25,16 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ApiResource(
  *     itemOperations={
- *        "get"={
- *            "method"="GET",
- *            "requirements"={"id"=".+"}
- *        }
+ *         "get"={
+ *             "method"="GET",
+ *             "requirements"={"id"=".+"}
+ *         }
  *     }
  * )
  */
 class UrlEncodedId
 {
     /**
-     * @var int The id
-     *
      * @ORM\Column(type="string")
      * @ORM\Id
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       |  fixes #1575
| License       | MIT
| Doc PR        | api-platform/docs#...

It looks as though the url encoding was not necessary and caused duplicate encoding in any case. The example I have tested originally returned `%253A` in place of the colon, which is the percent sign of %3A re-encoding.

This fix removes all URL encoding, it doesn't appear necessary in the IRI converter.

Would this class as a BC change instead of a fix though? Is it better to drill down further and still url encode the IRI once?

From https://github.com/api-platform/core/pull/3552