### PR TITLE
PHPUnits `expectExceptionMessageRegExp` becomes deprecated in Phpunit 9

### DIFF
--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -452,7 +452,7 @@ class ApiPlatformExtensionTest extends TestCase
     public function testResourcesToWatchWithUnsupportedMappingType()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('/Unsupported mapping type in ".+", supported types are XML & YAML\\./');
+        $this->expectExceptionMessageMatches('/Unsupported mapping type in ".+", supported types are XML & YAML\\./');
 
         $config = self::DEFAULT_CONFIG;
         $config['api_platform']['mapping']['paths'] = [__FILE__];

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -261,7 +261,7 @@ class ConfigurationTest extends TestCase
     public function testExceptionToStatusConfigWithInvalidHttpStatusCode($invalidHttpStatusCode)
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/The HTTP status code ".+" is not valid\\./');
+        $this->expectExceptionMessageMatches('/The HTTP status code ".+" is not valid\\./');
 
         $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [
@@ -290,7 +290,7 @@ class ConfigurationTest extends TestCase
     public function testExceptionToStatusConfigWithInvalidHttpStatusCodeValue($invalidHttpStatusCodeValue)
     {
         $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessageRegExp('/Invalid type for path "api_platform\\.exception_to_status\\.Exception". Expected "?int"?, but got "?.+"?\./');
+        $this->expectExceptionMessageMatches('/Invalid type for path "api_platform\\.exception_to_status\\.Exception". Expected "?int"?, but got "?.+"?\./');
 
         $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [
@@ -369,7 +369,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame([2], $config['swagger']['versions']);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/Only the versions .+ are supported. Got .+./');
+        $this->expectExceptionMessageMatches('/Only the versions .+ are supported. Got .+./');
 
         $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [

--- a/tests/GraphQl/Type/Definition/IterableTypeTest.php
+++ b/tests/GraphQl/Type/Definition/IterableTypeTest.php
@@ -43,7 +43,7 @@ class IterableTypeTest extends TestCase
         $iterableType = new IterableType();
 
         $this->expectException(Error::class);
-        $this->expectExceptionMessageRegExp('/`Iterable` cannot represent non iterable value: .+/');
+        $this->expectExceptionMessageMatches('/`Iterable` cannot represent non iterable value: .+/');
 
         $iterableType->serialize('foo');
 
@@ -55,7 +55,7 @@ class IterableTypeTest extends TestCase
         $iterableType = new IterableType();
 
         $this->expectException(Error::class);
-        $this->expectExceptionMessageRegExp('/`Iterable` cannot represent non iterable value: .+/');
+        $this->expectExceptionMessageMatches('/`Iterable` cannot represent non iterable value: .+/');
 
         $iterableType->parseValue('foo');
 

--- a/tests/Metadata/Extractor/YamlExtractorTestCase.php
+++ b/tests/Metadata/Extractor/YamlExtractorTestCase.php
@@ -34,7 +34,7 @@ class YamlExtractorTestCase extends ExtractorTestCase
     public function testParseException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Unable to parse in ".+\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/parse_exception.yml"/');
+        $this->expectExceptionMessageMatches('/Unable to parse in ".+\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/parse_exception.yml"/');
 
         (new YamlExtractor([__DIR__.'/../../Fixtures/FileConfigurations/parse_exception.yml']))->getResources();
     }

--- a/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
@@ -87,7 +87,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     public function testCreateWithInvalidXml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('#.+Element \'\\{https://api-platform.com/schema/metadata\\}foo\': This element is not expected\\..+#');
+        $this->expectExceptionMessageMatches('#.+Element \'\\{https://api-platform.com/schema/metadata\\}foo\': This element is not expected\\..+#');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/propertyinvalid.xml';
 
@@ -203,7 +203,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     public function testCreateWithMalformedResourcesSettingYaml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"resources" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/resourcesinvalid\\.yml"\\./');
+        $this->expectExceptionMessageMatches('/"resources" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/resourcesinvalid\\.yml"\\./');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesinvalid.yml';
 
@@ -213,7 +213,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     public function testCreateWithMalformedPropertiesSettingYaml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"properties" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertiesinvalid\\.yml"\\./');
+        $this->expectExceptionMessageMatches('/"properties" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertiesinvalid\\.yml"\\./');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/propertiesinvalid.yml';
 
@@ -223,7 +223,7 @@ class ExtractorPropertyMetadataFactoryTest extends FileConfigurationMetadataFact
     public function testCreateWithMalformedPropertySettingYaml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"foo" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertyinvalid\\.yml"\\./');
+        $this->expectExceptionMessageMatches('/"foo" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertyinvalid\\.yml"\\./');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/propertyinvalid.yml';
 

--- a/tests/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactoryTest.php
@@ -67,7 +67,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
     public function testCreateWithInvalidXml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('#.+Element \'\\{https://api-platform.com/schema/metadata\\}foo\': This element is not expected\\..+#');
+        $this->expectExceptionMessageMatches('#.+Element \'\\{https://api-platform.com/schema/metadata\\}foo\': This element is not expected\\..+#');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/propertyinvalid.xml';
 
@@ -113,7 +113,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
     public function testCreateWithMalformedResourcesSettingYaml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"resources" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/resourcesinvalid\\.yml"\\./');
+        $this->expectExceptionMessageMatches('/"resources" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/resourcesinvalid\\.yml"\\./');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesinvalid.yml';
 
@@ -123,7 +123,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
     public function testCreateWithMalformedPropertiesSettingYaml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"properties" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertiesinvalid\\.yml"\\./');
+        $this->expectExceptionMessageMatches('/"properties" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertiesinvalid\\.yml"\\./');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/propertiesinvalid.yml';
 
@@ -133,7 +133,7 @@ class ExtractorPropertyNameCollectionFactoryTest extends TestCase
     public function testCreateWithMalformedPropertySettingYaml()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"foo" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertyinvalid\\.yml"\\./');
+        $this->expectExceptionMessageMatches('/"foo" setting is expected to be null or an array, string given in ".+\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/Fixtures\\/FileConfigurations\\/propertyinvalid\\.yml"\\./');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/propertyinvalid.yml';
 

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -260,7 +260,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     public function testCreateWithBadDeclaration()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"ApiPlatform\\\\Core\\\\Tests\\\\Fixtures\\\\TestBundle\\\\Entity\\\\Dummy" setting is expected to be null or an array, string given in ".+\\/Fixtures\\/FileConfigurations\\/bad_declaration\\.yml"\\./');
+        $this->expectExceptionMessageMatches('/"ApiPlatform\\\\Core\\\\Tests\\\\Fixtures\\\\TestBundle\\\\Entity\\\\Dummy" setting is expected to be null or an array, string given in ".+\\/Fixtures\\/FileConfigurations\\/bad_declaration\\.yml"\\./');
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/bad_declaration.yml';
 


### PR DESCRIPTION

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | -//- <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | -//-

PHPUnit `expectExceptionMessageRegExp` becomes deprecated in PHPUnit 9, we should promote `expectExceptionMessageMatches` instead.