### PR TITLE
Allow guzzle 7 in require dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/orm": "^2.6.4",
         "elasticsearch/elasticsearch": "^6.0",
         "friendsofsymfony/user-bundle": "2.2.x-dev#157b53bd7d6c347148a90e723981a43f9c897bf5",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "jangregor/phpstan-prophecy": "^0.6",
         "justinrainbow/json-schema": "^5.2.1",
         "nelmio/api-doc-bundle": "^2.13.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| License       | MIT


Allows guzzle 7 version in require-dev

Left guzzle 6 since from what I see there is a prefer-lowest in ci.