### PR TITLE
Check change tracking deferred for ODM

### DIFF
--- a/src/Bridge/Doctrine/Common/DataPersister.php
+++ b/src/Bridge/Doctrine/Common/DataPersister.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use ApiPlatform\Core\Util\ClassInfoTrait;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager as DoctrineObjectManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 /**
@@ -89,7 +90,7 @@ final class DataPersister implements ContextAwareDataPersisterInterface
     private function isDeferredExplicit(DoctrineObjectManager $manager, $data): bool
     {
         $classMetadata = $manager->getClassMetadata($this->getObjectClass($data));
-        if ($classMetadata instanceof ClassMetadataInfo && method_exists($classMetadata, 'isChangeTrackingDeferredExplicit')) {
+        if (($classMetadata instanceof ClassMetadataInfo || $classMetadata instanceof ClassMetadata) && method_exists($classMetadata, 'isChangeTrackingDeferredExplicit')) {
             return $classMetadata->isChangeTrackingDeferredExplicit();
         }
 

--- a/tests/Bridge/Doctrine/Common/DataPersisterTest.php
+++ b/tests/Bridge/Doctrine/Common/DataPersisterTest.php
@@ -133,7 +133,11 @@ class DataPersisterTest extends TestCase
         $dummy = new Dummy();
 
         $classMetadataInfo = $this->prophesize($metadataClass);
-        $classMetadataInfo->isChangeTrackingDeferredExplicit()->willReturn($deferredExplicit)->shouldBeCalled();
+        if (method_exists($metadataClass, 'isChangeTrackingDeferredExplicit')) {
+            $classMetadataInfo->isChangeTrackingDeferredExplicit()->willReturn($deferredExplicit)->shouldBeCalled();
+        } else {
+            $persisted = false;
+        }
 
         $objectManagerProphecy = $this->prophesize(ObjectManager::class);
         $objectManagerProphecy->getClassMetadata(Dummy::class)->willReturn($classMetadataInfo)->shouldBeCalled();

--- a/tests/Bridge/Doctrine/Common/DataPersisterTest.php
+++ b/tests/Bridge/Doctrine/Common/DataPersisterTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prediction\CallPrediction;
@@ -117,19 +118,21 @@ class DataPersisterTest extends TestCase
     public function getTrackingPolicyParameters()
     {
         return [
-            'deferred explicit' => [true, true],
-            'deferred implicit' => [false, false],
+            'deferred explicit ORM' => [ClassMetadataInfo::class, true, true],
+            'deferred implicit ORM' => [ClassMetadataInfo::class, false, false],
+            'deferred explicit ODM' => [ClassMetadata::class, true, true],
+            'deferred implicit ODM' => [ClassMetadata::class, false, false],
         ];
     }
 
     /**
      * @dataProvider getTrackingPolicyParameters
      */
-    public function testTrackingPolicy($deferredExplicit, $persisted)
+    public function testTrackingPolicy($metadataClass, $deferredExplicit, $persisted)
     {
         $dummy = new Dummy();
 
-        $classMetadataInfo = $this->prophesize(ClassMetadataInfo::class);
+        $classMetadataInfo = $this->prophesize($metadataClass);
         $classMetadataInfo->isChangeTrackingDeferredExplicit()->willReturn($deferredExplicit)->shouldBeCalled();
 
         $objectManagerProphecy = $this->prophesize(ObjectManager::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

`DataPersister` checks change tracking policy before persisting it. It works only with ORM since ODM metadata class is not the same. The aim of this PR is to fix it.