### PR TITLE
Handling GraphQL errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * GraphQL: Subscription support with Mercure (#3321)
 * GraphQL: Allow to format GraphQL errors based on exceptions (#3063)
 * GraphQL: Add page-based pagination (#3175, #3517)
+* GraphQL: Errors thrown from the GraphQL library can now be handled (#3632)
 * GraphQL: Possibility to add a custom description for queries, mutations and subscriptions (#3477, #3514)
 * GraphQL: Support for field name conversion (serialized name) (#3455, #3516)
 * GraphQL: **BC** `operation` is now `operationName` to follow the standard (#3568)
@@ -14,7 +15,6 @@
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
 * IriConverter: Fix IRI url double encoding - may cause breaking change as some characters no longer encoded in output (#3552)
-* GraphQL: Errors thrown from the GraphQL library can now be handled
 
 ## 2.5.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
 * IriConverter: Fix IRI url double encoding - may cause breaking change as some characters no longer encoded in output (#3552)
+* GraphQL: Errors thrown from the GraphQL library can now be handled
 
 ## 2.5.6
 

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -121,7 +121,6 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\InternalUser;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathRelationDummy;
-use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Node;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Order;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Person;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\PersonToPet;
@@ -1542,7 +1541,7 @@ final class DoctrineContext implements Context
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $relatedDummy = $this->buildRelatedDummy();
-            $relatedDummy->setName('RelatedDummy #' . $i);
+            $relatedDummy->setName('RelatedDummy #'.$i);
 
             $dummyMercure = $this->buildDummyMercure();
             $dummyMercure->name = "Dummy Mercure #$i";
@@ -1974,7 +1973,6 @@ final class DoctrineContext implements Context
     private function buildDummyMercure()
     {
         return $this->isOrm() ? new DummyMercure() : new DummyMercureDocument();
-
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -31,6 +31,7 @@ use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
+use ApiPlatform\Core\GraphQl\Error\ErrorHandlerInterface;
 use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
@@ -463,6 +464,8 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             ->addTag('api_platform.graphql.mutation_resolver');
         $container->registerForAutoconfiguration(GraphQlTypeInterface::class)
             ->addTag('api_platform.graphql.type');
+        $container->registerForAutoconfiguration(ErrorHandlerInterface::class)
+            ->addTag('api_platform.graphql.error_handler');
     }
 
     private function registerLegacyBundlesConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -179,6 +179,7 @@
             <argument type="service" id="api_platform.graphql.action.graphiql" />
             <argument type="service" id="api_platform.graphql.action.graphql_playground" />
             <argument type="service" id="serializer" />
+            <argument type="service" id="api_platform.graphql.error_handler" />
             <argument>%kernel.debug%</argument>
             <argument>%api_platform.graphql.graphiql.enabled%</argument>
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
@@ -198,6 +199,8 @@
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
             <argument>%api_platform.title%</argument>
         </service>
+
+        <service id="api_platform.graphql.error_handler" class="ApiPlatform\Core\GraphQl\Error\ErrorHandler" public="false" />
 
         <!-- Serializer -->
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -200,6 +200,8 @@
             <argument>%api_platform.title%</argument>
         </service>
 
+        <!-- Error -->
+
         <service id="api_platform.graphql.error_handler" class="ApiPlatform\Core\GraphQl\Error\ErrorHandler" public="false" />
 
         <!-- Serializer -->

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -39,11 +39,11 @@ final class EntrypointAction
     private $graphiQlAction;
     private $graphQlPlaygroundAction;
     private $normalizer;
+    private $errorHandler;
     private $debug;
     private $graphiqlEnabled;
     private $graphQlPlaygroundEnabled;
     private $defaultIde;
-    private $errorHandler;
 
     public function __construct(SchemaBuilderInterface $schemaBuilder, ExecutorInterface $executor, GraphiQlAction $graphiQlAction, GraphQlPlaygroundAction $graphQlPlaygroundAction, NormalizerInterface $normalizer, ErrorHandlerInterface $errorHandler, bool $debug = false, bool $graphiqlEnabled = false, bool $graphQlPlaygroundEnabled = false, $defaultIde = false)
     {

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -52,11 +52,11 @@ final class EntrypointAction
         $this->graphiQlAction = $graphiQlAction;
         $this->graphQlPlaygroundAction = $graphQlPlaygroundAction;
         $this->normalizer = $normalizer;
+        $this->errorHandler = $errorHandler;
         $this->debug = $debug ? Debug::INCLUDE_DEBUG_MESSAGE | Debug::INCLUDE_TRACE : false;
         $this->graphiqlEnabled = $graphiqlEnabled;
         $this->graphQlPlaygroundEnabled = $graphQlPlaygroundEnabled;
         $this->defaultIde = $defaultIde;
-        $this->errorHandler = $errorHandler;
     }
 
     public function __invoke(Request $request): Response

--- a/src/GraphQl/Error/ErrorHandler.php
+++ b/src/GraphQl/Error/ErrorHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Error;
+
+class ErrorHandler implements ErrorHandlerInterface
+{
+    public function __invoke(array $errors, callable $formatter)
+    {
+        return array_map($formatter, $errors);
+    }
+}

--- a/src/GraphQl/Error/ErrorHandler.php
+++ b/src/GraphQl/Error/ErrorHandler.php
@@ -13,8 +13,18 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Error;
 
+/**
+ * Handles the errors thrown by the GraphQL library by applying the formatter to them (default behavior).
+ *
+ * @experimental
+ *
+ * @author Ollie Harridge <code@oll.ie>
+ */
 class ErrorHandler implements ErrorHandlerInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function __invoke(array $errors, callable $formatter): array
     {
         return array_map($formatter, $errors);

--- a/src/GraphQl/Error/ErrorHandler.php
+++ b/src/GraphQl/Error/ErrorHandler.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\GraphQl\Error;
 
 class ErrorHandler implements ErrorHandlerInterface
 {
-    public function __invoke(array $errors, callable $formatter)
+    public function __invoke(array $errors, callable $formatter): array
     {
         return array_map($formatter, $errors);
     }

--- a/src/GraphQl/Error/ErrorHandlerInterface.php
+++ b/src/GraphQl/Error/ErrorHandlerInterface.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Error;
 
+use GraphQL\Error\Error;
+
 /**
- * A function which passes the errors thrown by the GraphQL library into the formatters.
+ * Handles the errors thrown by the GraphQL library.
+ * It is responsible for applying the formatter to the errors and can be used for filtering or logging them.
  *
  * @experimental
  *
@@ -22,5 +25,8 @@ namespace ApiPlatform\Core\GraphQl\Error;
  */
 interface ErrorHandlerInterface
 {
+    /**
+     * @param Error[] $errors
+     */
     public function __invoke(array $errors, callable $formatter): array;
 }

--- a/src/GraphQl/Error/ErrorHandlerInterface.php
+++ b/src/GraphQl/Error/ErrorHandlerInterface.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\GraphQl\Error;
 
 /**
- *
- * A function which passes the errors thrown by the GraphQL library into the formatters
+ * A function which passes the errors thrown by the GraphQL library into the formatters.
  *
  * @experimental
  *

--- a/src/GraphQl/Error/ErrorHandlerInterface.php
+++ b/src/GraphQl/Error/ErrorHandlerInterface.php
@@ -13,7 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\GraphQl\Error;
 
+/**
+ *
+ * A function which passes the errors thrown by the GraphQL library into the formatters
+ *
+ * @experimental
+ *
+ * @author Ollie Harridge <code@oll.ie>
+ */
 interface ErrorHandlerInterface
 {
-    public function __invoke(array $errors, callable $formatter);
+    public function __invoke(array $errors, callable $formatter): array;
 }

--- a/src/GraphQl/Error/ErrorHandlerInterface.php
+++ b/src/GraphQl/Error/ErrorHandlerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\GraphQl\Error;
+
+interface ErrorHandlerInterface
+{
+    public function __invoke(array $errors, callable $formatter);
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -65,6 +65,7 @@ use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Exception\FilterValidationException;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\GraphQl\Error\ErrorHandlerInterface;
 use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
@@ -393,6 +394,8 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setParameter('api_platform.graphql.graphql_playground.enabled', false)->shouldBeCalled();
         $containerBuilderProphecy->registerForAutoconfiguration(GraphQlTypeInterface::class)->shouldNotBeCalled();
         $this->childDefinitionProphecy->addTag('api_platform.graphql.type')->shouldNotBeCalled();
+        $containerBuilderProphecy->registerForAutoconfiguration(ErrorHandlerInterface::class)->shouldNotBeCalled();
+        $this->childDefinitionProphecy->addTag('api_platform.graphql.error_handler')->shouldNotBeCalled();
         $containerBuilderProphecy->registerForAutoconfiguration(QueryItemResolverInterface::class)->shouldNotBeCalled();
         $containerBuilderProphecy->registerForAutoconfiguration(QueryCollectionResolverInterface::class)->shouldNotBeCalled();
         $this->childDefinitionProphecy->addTag('api_platform.graphql.query_resolver')->shouldNotBeCalled();
@@ -1077,6 +1080,10 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->registerForAutoconfiguration(GraphQlTypeInterface::class)
             ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
         $this->childDefinitionProphecy->addTag('api_platform.graphql.type')->shouldBeCalledTimes(1);
+
+        $containerBuilderProphecy->registerForAutoconfiguration(ErrorHandlerInterface::class)
+            ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);
+        $this->childDefinitionProphecy->addTag('api_platform.graphql.error_handler')->shouldBeCalledTimes(1);
 
         $containerBuilderProphecy->registerForAutoconfiguration(QueryItemResolverInterface::class)
             ->willReturn($this->childDefinitionProphecy)->shouldBeCalledTimes(1);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -342,6 +342,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.graphql.action.entrypoint', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.action.graphiql', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.action.graphql_playground', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.graphql.error_handler', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.collection', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.item_mutation', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.graphql.resolver.factory.item_subscription', Argument::type(Definition::class))->shouldNotBeCalled();
@@ -1195,6 +1196,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.action.entrypoint',
             'api_platform.graphql.action.graphiql',
             'api_platform.graphql.action.graphql_playground',
+            'api_platform.graphql.error_handler',
             'api_platform.graphql.executor',
             'api_platform.graphql.type_builder',
             'api_platform.graphql.fields_builder',

--- a/tests/GraphQl/Action/EntrypointActionTest.php
+++ b/tests/GraphQl/Action/EntrypointActionTest.php
@@ -224,7 +224,6 @@ class EntrypointActionTest extends TestCase
 
         $this->assertEquals(200, $mockedEntrypoint($request)->getStatusCode());
         $this->assertEquals('{"errors":[{"message":"GraphQL variables are not valid JSON.","extensions":{"category":"user","status":400}}]}', $mockedEntrypoint($request)->getContent());
-        $this->assertEquals('{"errors":[{"message":"GraphQL variables are not valid JSON.","extensions":{"category":"user","status":400}}]}', $mockedEntrypoint($request)->getContent());
     }
 
     private function getEntrypointAction(array $variables = ['graphqlVariable']): EntrypointAction

--- a/tests/GraphQl/Action/EntrypointActionTest.php
+++ b/tests/GraphQl/Action/EntrypointActionTest.php
@@ -236,15 +236,15 @@ class EntrypointActionTest extends TestCase
             new HttpExceptionNormalizer(),
             new ErrorNormalizer(),
         ]);
+        $errorHandler = new ErrorHandler();
 
         $executionResultProphecy = $this->prophesize(ExecutionResult::class);
         $executionResultProphecy->toArray(false)->willReturn(['GraphQL']);
         $executionResultProphecy->setErrorFormatter([$normalizer, 'normalize'])->willReturn($executionResultProphecy);
-        $executionResultProphecy->setErrorsHandler(Argument::any())->willReturn($executionResultProphecy);
+        $executionResultProphecy->setErrorsHandler($errorHandler)->willReturn($executionResultProphecy);
         $executorProphecy = $this->prophesize(ExecutorInterface::class);
         $executorProphecy->executeQuery(Argument::is($schema->reveal()), 'graphqlQuery', null, null, $variables, 'graphqlOperationName')->willReturn($executionResultProphecy->reveal());
 
-        $errorHandler = new ErrorHandler();
         $twigProphecy = $this->prophesize(TwigEnvironment::class);
         $routerProphecy = $this->prophesize(RouterInterface::class);
 


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

Porting the functionality from the 2.5.x branch over to master - replaces existing PR #3630 

Errors thrown from the platform are caught by GraphQL and can't be logged or tracked in production environments, making it impossible to track down the cause of errors or use error analysers. This PR allows the errors from GraphQL to be handled by the developers by decorating the ErrorHandler. The errors can either logged (though a service like monolog) or sent to a 3rd party error analyser, like Sentry or NewRelic.