### PR TITLE
Lazy console commands

### DIFF
--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -121,7 +121,6 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\InternalUser;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathRelationDummy;
-use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Node;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Order;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Person;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\PersonToPet;
@@ -1542,7 +1541,7 @@ final class DoctrineContext implements Context
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $relatedDummy = $this->buildRelatedDummy();
-            $relatedDummy->setName('RelatedDummy #' . $i);
+            $relatedDummy->setName('RelatedDummy #'.$i);
 
             $dummyMercure = $this->buildDummyMercure();
             $dummyMercure->name = "Dummy Mercure #$i";
@@ -1974,7 +1973,6 @@ final class DoctrineContext implements Context
     private function buildDummyMercure()
     {
         return $this->isOrm() ? new DummyMercure() : new DummyMercureDocument();
-
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -33,6 +33,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class SwaggerCommand extends Command
 {
+    protected static $defaultName = 'api:openapi:export';
+
     private $normalizer;
     private $resourceNameCollectionFactory;
     private $apiTitle;
@@ -67,7 +69,6 @@ final class SwaggerCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('api:openapi:export')
             ->setAliases(['api:swagger:export'])
             ->setDescription('Dump the OpenAPI documentation')
             ->addOption('yaml', 'y', InputOption::VALUE_NONE, 'Dump the documentation in YAML')

--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -33,8 +33,6 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class SwaggerCommand extends Command
 {
-    protected static $defaultName = 'api:openapi:export';
-
     private $normalizer;
     private $resourceNameCollectionFactory;
     private $apiTitle;
@@ -69,6 +67,7 @@ final class SwaggerCommand extends Command
     protected function configure()
     {
         $this
+            ->setName('api:openapi:export')
             ->setAliases(['api:swagger:export'])
             ->setDescription('Dump the OpenAPI documentation')
             ->addOption('yaml', 'y', InputOption::VALUE_NONE, 'Dump the documentation in YAML')

--- a/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
+++ b/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
@@ -31,6 +31,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class JsonSchemaGenerateCommand extends Command
 {
+    protected static $defaultName = 'api:json-schema:generate';
+
     private $schemaFactory;
     private $formats;
 
@@ -48,7 +50,6 @@ final class JsonSchemaGenerateCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('api:json-schema:generate')
             ->setDescription('Generates the JSON Schema for a resource operation.')
             ->addArgument('resource', InputArgument::REQUIRED, 'The Fully Qualified Class Name (FQCN) of the resource')
             ->addOption('itemOperation', null, InputOption::VALUE_REQUIRED, 'The item operation')


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Type       | improvement

Since Symfony 3.4 console commands can be lazy thanks to a [static name property](https://github.com/symfony/symfony/pull/23887).
This change does not break BC because the BC layer is already [in the base command's constructor](https://github.com/symfony/symfony/pull/23887/files#diff-8e80595663798837db1b033187835535R75).