### PR TITLE
Fix whitespace in namespace

### DIFF
--- a/src/Metadata/Extractor/AbstractExtractor.php
+++ b/src/Metadata/Extractor/AbstractExtractor.php
@@ -119,7 +119,7 @@ abstract class AbstractExtractor implements ExtractorInterface
                 return (string) $resolved;
             }
 
-            throw new\ RuntimeException(sprintf('The container parameter "%s", used in the resource configuration value "%s", must be a string or numeric, but it is of type %s.', $parameter, $value, \gettype($resolved)));
+            throw new \RuntimeException(sprintf('The container parameter "%s", used in the resource configuration value "%s", must be a string or numeric, but it is of type %s.', $parameter, $value, \gettype($resolved)));
         }, $value);
 
         return str_replace('%%', '%', $escapedValue);


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Fix whitespace in namespace token.
If the RFC at https://wiki.php.net/rfc/namespaced_names_as_token gets accepted, then this will cause a parse error in PHP 8.

