### PR TITLE
Update InheritedPropertyNameCollectionFactory.php

### DIFF
--- a/src/Metadata/Property/Factory/InheritedPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/InheritedPropertyNameCollectionFactory.php
@@ -53,7 +53,7 @@ final class InheritedPropertyNameCollectionFactory implements PropertyNameCollec
                 continue;
             }
 
-            if (is_subclass_of($knownResourceClass, $resourceClass)) {
+            if (is_subclass_of($resourceClass, $knownResourceClass)) {
                 foreach ($this->create($knownResourceClass) as $propertyName) {
                     $propertyNames[$propertyName] = $propertyName;
                 }

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -85,12 +85,6 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             $visiting = "$resourceClass $property $subresourceClass";
 
             // Handle maxDepth
-            if ($rootResourceClass === $resourceClass) {
-                $maxDepth = $subresource->getMaxDepth();
-                // reset depth when we return to rootResourceClass
-                $depth = 0;
-            }
-
             if (null !== $maxDepth && $depth >= $maxDepth) {
                 break;
             }
@@ -183,7 +177,11 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
 
             $tree[$operation['route_name']] = $operation;
 
-            $this->computeSubresourceOperations($subresourceClass, $tree, $rootResourceClass, $operation, $visited + [$visiting => true], ++$depth, $maxDepth);
+            // Get the minimum maxDepth between the rootMaxDepth and the maxDepth of the to be visited Subresource
+            $currentMaxDepth = array_filter([$maxDepth, $subresource->getMaxDepth()], 'is_int');
+            $currentMaxDepth = empty($currentMaxDepth) ? null : min($currentMaxDepth);
+
+            $this->computeSubresourceOperations($subresourceClass, $tree, $rootResourceClass, $operation, $visited + [$visiting => true], $depth + 1, $currentMaxDepth);
         }
     }
 }

--- a/tests/Metadata/Property/Factory/InheritedPropertyNameCollectionFactoryTest.php
+++ b/tests/Metadata/Property/Factory/InheritedPropertyNameCollectionFactoryTest.php
@@ -27,7 +27,22 @@ use PHPUnit\Framework\TestCase;
  */
 class InheritedPropertyNameCollectionFactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreateOnParent()
+    {
+        $resourceNameCollectionFactory = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactory->create()->willReturn(new ResourceNameCollection([DummyTableInheritance::class, DummyTableInheritanceChild::class]))->shouldBeCalled();
+
+        $propertyNameCollectionFactory = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory->create(DummyTableInheritance::class, [])->willReturn(new PropertyNameCollection(['name']))->shouldBeCalled();
+        $propertyNameCollectionFactory->create(DummyTableInheritanceChild::class, [])->shouldNotBeCalled();
+
+        $factory = new InheritedPropertyNameCollectionFactory($resourceNameCollectionFactory->reveal(), $propertyNameCollectionFactory->reveal());
+        $metadata = $factory->create(DummyTableInheritance::class);
+
+        $this->assertSame((array) new PropertyNameCollection(['name']), (array) $metadata);
+    }
+
+    public function testCreateOnChild()
     {
         $resourceNameCollectionFactory = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactory->create()->willReturn(new ResourceNameCollection([DummyTableInheritance::class, DummyTableInheritanceChild::class]))->shouldBeCalled();
@@ -37,8 +52,8 @@ class InheritedPropertyNameCollectionFactoryTest extends TestCase
         $propertyNameCollectionFactory->create(DummyTableInheritanceChild::class, [])->willReturn(new PropertyNameCollection(['nickname', '169']))->shouldBeCalled();
 
         $factory = new InheritedPropertyNameCollectionFactory($resourceNameCollectionFactory->reveal(), $propertyNameCollectionFactory->reveal());
-        $metadata = $factory->create(DummyTableInheritance::class);
+        $metadata = $factory->create(DummyTableInheritanceChild::class);
 
-        $this->assertSame((array) $metadata, (array) new PropertyNameCollection(['name', 'nickname', '169']));
+        $this->assertSame((array) new PropertyNameCollection(['nickname', '169', 'name']), (array) $metadata);
     }
 }

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -465,7 +465,7 @@ class SubresourceOperationFactoryTest extends TestCase
     public function testCreateSelfReferencingSubresources()
     {
         /**
-         * DummyEntity -subresource-> DummyEntity -subresource-> DummyEntity ...
+         * DummyEntity -subresource-> DummyEntity --> DummyEntity ...
          */
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('dummyEntity'));
@@ -501,6 +501,83 @@ class SubresourceOperationFactoryTest extends TestCase
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresources.{_format}',
                 'operation_name' => 'subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+        ], $subresourceOperationFactory->create(DummyEntity::class));
+    }
+
+    /**
+     * Test for issue: https://github.com/api-platform/core/issues/2533.
+     */
+    public function testCreateWithDifferentMaxDepthSelfReferencingSubresources()
+    {
+        /**
+         * subresource: maxDepth = 2
+         * secondSubresource: maxDepth = 1
+         * DummyEntity -subresource-> DummyEntity -secondSubresource-> DummyEntity ...
+         * DummyEntity -secondSubresource-> DummyEntity !!!-subresource-> DummyEntity ...
+         */
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('dummyEntity'));
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection(['subresource', 'secondSubresource']));
+
+        $subresourceWithMaxDepthMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false, 2));
+        $secondSubresourceWithMaxDepthMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false, 1));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceWithMaxDepthMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'secondSubresource')->shouldBeCalled()->willReturn($secondSubresourceWithMaxDepthMetadata);
+
+        $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
+        $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresources');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('secondSubresource', false)->shouldBeCalled()->willReturn('second_subresources');
+
+        $subresourceOperationFactory = new SubresourceOperationFactory(
+            $resourceMetadataFactoryProphecy->reveal(),
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $pathSegmentNameGeneratorProphecy->reveal()
+        );
+
+        $this->assertEquals([
+            'api_dummy_entities_subresource_get_subresource' => [
+                'property' => 'subresource',
+                'collection' => false,
+                'resource_class' => DummyEntity::class,
+                'shortNames' => ['dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/subresources.{_format}',
+                'operation_name' => 'subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_subresource_second_subresource_get_subresource' => [
+                'property' => 'secondSubresource',
+                'collection' => false,
+                'resource_class' => DummyEntity::class,
+                'shortNames' => ['dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                    ['subresource', DummyEntity::class, false],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_second_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/subresources/second_subresources.{_format}',
+                'operation_name' => 'subresource_second_subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_second_subresource_get_subresource' => [
+                'property' => 'secondSubresource',
+                'collection' => false,
+                'resource_class' => DummyEntity::class,
+                'shortNames' => ['dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_second_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/second_subresources.{_format}',
+                'operation_name' => 'second_subresource_get_subresource',
             ] + SubresourceOperationFactory::ROUTE_OPTIONS,
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
@@ -649,6 +726,67 @@ class SubresourceOperationFactoryTest extends TestCase
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/root_resource_prefix/dummy_entities/{id}/subresource.{_format}',
                 'operation_name' => 'subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+        ], $subresourceOperationFactory->create(DummyEntity::class));
+    }
+
+    public function testCreateSelfReferencingSubresourcesWithSubresources()
+    {
+        /**
+         * DummyEntity -otherSubresource-> RelatedDummyEntity
+         * DummyEntity -subresource (maxDepth=1) -> DummyEntity -otherSubresource-> RelatedDummyEntity.
+         */
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('dummyEntity'));
+        $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection(['subresource', 'otherSubresource']));
+        $propertyNameCollectionFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection([]));
+
+        $subresource = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false, 1));
+        $otherSubresourceSubresource = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, false));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresource);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'otherSubresource')->shouldBeCalled()->willReturn($otherSubresourceSubresource);
+
+        $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
+        $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresources');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('otherSubresource', false)->shouldBeCalled()->willReturn('other_subresources');
+
+        $subresourceOperationFactory = new SubresourceOperationFactory(
+            $resourceMetadataFactoryProphecy->reveal(),
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $pathSegmentNameGeneratorProphecy->reveal()
+        );
+
+        $this->assertEquals([
+            'api_dummy_entities_subresource_get_subresource' => [
+                'property' => 'subresource',
+                'collection' => false,
+                'resource_class' => DummyEntity::class,
+                'shortNames' => ['dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/subresources.{_format}',
+                'operation_name' => 'subresource_get_subresource',
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+            'api_dummy_entities_other_subresource_get_subresource' => [
+                'property' => 'otherSubresource',
+                'collection' => false,
+                'resource_class' => RelatedDummyEntity::class,
+                'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
+                'identifiers' => [
+                    ['id', DummyEntity::class, true],
+                ],
+                'route_name' => 'api_dummy_entities_other_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/other_subresources.{_format}',
+                'operation_name' => 'other_subresource_get_subresource',
             ] + SubresourceOperationFactory::ROUTE_OPTIONS,
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }


### PR DESCRIPTION
Fix InheritedPropertyNameCollectionFactory to include parent properties and not properties of children. 
Fixes issue https://github.com/api-platform/core/issues/3278

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3278
| License       | MIT
| Doc PR        | api-platform/docs#...

InheritedPropertyNameCollectionFactory should find properties that are inherited from the parent class. Becouse the properties of `is_subclass_of`are switched it instead finds properties for all the children.