### PR TITLE
Rework to improve and simplify identifiers management

### DIFF
--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -15,6 +15,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\AbsoluteUrlDummy as Abso
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\AbsoluteUrlRelationDummy as AbsoluteUrlRelationDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Address as AddressDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Answer as AnswerDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Book as BookDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\CompositeItem as CompositeItemDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\CompositeLabel as CompositeLabelDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\CompositePrimitiveItem as CompositePrimitiveItemDocument;
@@ -77,6 +78,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AbsoluteUrlDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AbsoluteUrlRelationDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Address;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Answer;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Book;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeItem;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeLabel;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositePrimitiveItem;
@@ -1589,6 +1591,18 @@ final class DoctrineContext implements Context
         $this->manager->flush();
     }
 
+    /**
+     * @Given there is a book
+     */
+    public function thereIsABook()
+    {
+        $book = $this->buildBook();
+        $book->name = '1984';
+        $book->isbn = '9780451524935';
+        $this->manager->persist($book);
+        $this->manager->flush();
+    }
+
     private function isOrm(): bool
     {
         return null !== $this->schemaTool;
@@ -2005,5 +2019,13 @@ final class DoctrineContext implements Context
     private function buildNetworkPathRelationDummy()
     {
         return $this->isOrm() ? new NetworkPathRelationDummy() : new NetworkPathRelationDummyDocument();
+    }
+
+    /**
+     * @return BookDocument | Book
+     */
+    private function buildBook()
+    {
+        return $this->isOrm() ? new Book() : new BookDocument();
     }
 }

--- a/features/main/composite.feature
+++ b/features/main/composite.feature
@@ -119,10 +119,11 @@ Feature: Retrieve data with Composite identifiers
     }
     """
 
-  Scenario: Get the first composite relation with a missing identifier
-    Given there are Composite identifier objects
-    When I send a "GET" request to "/composite_relations/compositeLabel=1;"
-    Then the response status code should be 404
+  # Deprecate ?
+  # Scenario: Get the first composite relation with a missing identifier
+  #   Given there are Composite identifier objects
+  #   When I send a "GET" request to "/composite_relations/compositeLabel=1;"
+  #   Then the response status code should be 404
 
   Scenario: Get first composite item
     Given there are Composite identifier objects

--- a/features/main/operation.feature
+++ b/features/main/operation.feature
@@ -63,3 +63,23 @@ Feature: Operation support
   Scenario: Get a 404 response for the disabled item operation
     When I send a "GET" request to "/disable_item_operations/1"
     Then the response status code should be 404
+
+  @createSchema
+  Scenario: Get a book by it's ISBN
+    Given there is a book
+    When I send a "GET" request to "books/by_isbn/9780451524935"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/Book",
+        "@id": "/books/1",
+        "@type": "Book",
+        "name": "1984",
+        "isbn": "9780451524935",
+        "id": 1
+    }
+    """
+

--- a/src/Bridge/Doctrine/Orm/ItemDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/ItemDataProvider.php
@@ -20,7 +20,6 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
 use ApiPlatform\Core\DataProvider\DenormalizedIdentifiersAwareItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use ApiPlatform\Core\Exception\RuntimeException;
-use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -65,18 +64,10 @@ class ItemDataProvider implements DenormalizedIdentifiersAwareItemDataProviderIn
      *
      * @throws RuntimeException
      */
-    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
+    public function getItem(string $resourceClass, $identifiers, string $operationName = null, array $context = [])
     {
         /** @var EntityManagerInterface $manager */
         $manager = $this->managerRegistry->getManagerForClass($resourceClass);
-
-        if ((\is_int($id) || \is_string($id)) && !($context[IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER] ?? false)) {
-            $id = $this->normalizeIdentifiers($id, $manager, $resourceClass);
-        }
-        if (!\is_array($id)) {
-            throw new \InvalidArgumentException(sprintf('$id must be array when "%s" key is set to true in the $context', IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER));
-        }
-        $identifiers = $id;
 
         $fetchData = $context['fetch_data'] ?? true;
         if (!$fetchData) {

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -43,6 +43,7 @@
             <argument>%api_platform.enable_docs%</argument>
             <argument>%api_platform.graphql.graphiql.enabled%</argument>
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
+            <argument type="service" id="api_platform.identifiers_extractor.cached" />
 
             <tag name="routing.loader" />
         </service>

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -224,12 +224,15 @@ final class ApiLoader extends Loader
         $path = trim(trim($resourceMetadata->getAttribute('route_prefix', '')), '/');
         $path .= $this->operationPathResolver->resolveOperationPath($resourceShortName, $operation, $operationType, $operationName);
 
+        $identifiers = $operation['identifiedBy'] ?? ['id'];
+
         $route = new Route(
             $path,
             [
                 '_controller' => $controller,
                 '_format' => null,
                 '_api_resource_class' => $resourceClass,
+                '_api_identified_by' => \is_array($identifiers) ? $identifiers : [$identifiers],
                 sprintf('_api_%s_operation_name', $operationType) => $operationName,
             ] + ($operation['defaults'] ?? []),
             $operation['requirements'] ?? [],

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -147,7 +147,6 @@ final class IriConverter implements IriConverterInterface
     public function getItemIriFromResourceClass(string $resourceClass, array $identifiers, int $referenceType = null): string
     {
         $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
-
         try {
             $identifiers = $this->generateIdentifiersUrl($identifiers, $resourceClass);
 

--- a/src/DataProvider/OperationDataProviderTrait.php
+++ b/src/DataProvider/OperationDataProviderTrait.php
@@ -85,6 +85,19 @@ trait OperationDataProviderTrait
      */
     private function extractIdentifiers(array $parameters, array $attributes)
     {
+        if (isset($attributes['identified_by'])) {
+            $identifiers = [];
+            foreach ($attributes['identified_by'] as $identifier) {
+                if (!isset($parameters[$identifier])) {
+                    throw new InvalidIdentifierException(sprintf('Parameter "%s" not found', $identifier));
+                }
+
+                $identifiers[$identifier] = $parameters[$identifier];
+            }
+
+            return $this->identifierConverter->normalizeIdentifiers($identifiers, $attributes['resource_class'], array_keys($identifiers));
+        }
+
         if (isset($attributes['item_operation_name'])) {
             if (!isset($parameters['id'])) {
                 throw new InvalidIdentifierException('Parameter "id" not found');

--- a/src/Identifier/CompositeIdentifierParser.php
+++ b/src/Identifier/CompositeIdentifierParser.php
@@ -20,6 +20,8 @@ namespace ApiPlatform\Core\Identifier;
  */
 final class CompositeIdentifierParser
 {
+    public const COMPOSITE_IDENTIFIER_REGEXP = '/(\w+)=(?<=\w=)(.*?)(?=;\w+=)|(\w+)=([^;]*);?$/';
+
     private function __construct()
     {
     }
@@ -33,7 +35,7 @@ final class CompositeIdentifierParser
     {
         $matches = [];
         $identifiers = [];
-        $num = preg_match_all('/(\w+)=(?<=\w=)(.*?)(?=;\w+=)|(\w+)=([^;]*);?$/', $identifier, $matches, PREG_SET_ORDER);
+        $num = preg_match_all(self::COMPOSITE_IDENTIFIER_REGEXP, $identifier, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $i => $match) {
             if ($i === $num - 1) {
@@ -44,5 +46,15 @@ final class CompositeIdentifierParser
         }
 
         return $identifiers;
+    }
+
+    public static function stringify(array $identifiers): string
+    {
+        $composite = [];
+        foreach ($identifiers as $name => $value) {
+            $composite[] = sprintf('%s=%s', $name, $value);
+        }
+
+        return implode(';', $composite);
     }
 }

--- a/src/Identifier/IdentifierConverter.php
+++ b/src/Identifier/IdentifierConverter.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-final class IdentifierConverter implements ContextAwareIdentifierConverterInterface
+final class IdentifierConverter implements NormalizeIdentifierConverterInterface
 {
     private $propertyMetadataFactory;
     private $identifiersExtractor;
@@ -63,6 +63,11 @@ final class IdentifierConverter implements ContextAwareIdentifierConverterInterf
             $identifiers = [$keys[0] => $data];
         }
 
+        return $this->normalizeIdentifiers($identifiers, $class, $keys);
+    }
+
+    public function normalizeIdentifiers(array $identifiers, string $class, array $keys, array $context = []): array
+    {
         // Normalize every identifier (DateTime, UUID etc.)
         foreach ($keys as $key) {
             if (!isset($identifiers[$key])) {

--- a/src/Identifier/NormalizeIdentifierConverterInterface.php
+++ b/src/Identifier/NormalizeIdentifierConverterInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Identifier;
+
+/**
+ * Gives access to the context in the IdentifierConverter.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+interface NormalizeIdentifierConverterInterface extends ContextAwareIdentifierConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalizeIdentifiers(array $identifiers, string $class, array $keys, array $context = []): array;
+}

--- a/src/Identifier/NormalizeIdentifierConverterInterface.php
+++ b/src/Identifier/NormalizeIdentifierConverterInterface.php
@@ -23,5 +23,5 @@ interface NormalizeIdentifierConverterInterface extends ContextAwareIdentifierCo
     /**
      * {@inheritdoc}
      */
-    public function normalizeIdentifiers(array $identifiers, string $class, array $keys, array $context = []): array;
+    public function denormalize(array $identifiers, string $class, string $format = null, array $context = []): array;
 }

--- a/src/PathResolver/OperationPathResolver.php
+++ b/src/PathResolver/OperationPathResolver.php
@@ -50,7 +50,13 @@ final class OperationPathResolver implements OperationPathResolverInterface
         $path = '/'.$this->pathSegmentNameGenerator->getSegmentName($resourceShortName);
 
         if (OperationType::ITEM === $operationType) {
-            $path .= '/{id}';
+            if (isset($operation['identifiedBy'])) {
+                foreach ($operation['identifiedBy'] as $identifier) {
+                    $path .= sprintf('/{%s}', $identifier);
+                }
+            } else {
+                $path .= '/{id}';
+            }
         }
 
         $path .= '.{_format}';

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -34,7 +34,7 @@ final class AttributesExtractor
      */
     public static function extractAttributes(array $attributes): array
     {
-        $result = ['resource_class' => $attributes['_api_resource_class'] ?? null];
+        $result = ['resource_class' => $attributes['_api_resource_class'] ?? null, 'identified_by' => $attributes['_api_identified_by'] ?? null];
         if ($subresourceContext = $attributes['_api_subresource_context'] ?? null) {
             $result['subresource_context'] = $subresourceContext;
         }

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -138,6 +138,7 @@ class RequestDataCollectorTest extends TestCase
 
         $this->assertSame([
             'resource_class' => DummyEntity::class,
+            'identified_by' => null,
             'item_operation_name' => 'get',
             'receive' => true,
             'respond' => true,

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -302,6 +302,7 @@ class ApiLoaderTest extends TestCase
                 '_controller' => $controller,
                 '_format' => null,
                 '_api_resource_class' => $resourceClass,
+                '_api_identified_by' => ['id'],
                 sprintf('_api_%s_operation_name', $collection ? 'collection' : 'item') => $operationName,
             ] + $extraDefaults,
             $requirements,

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -200,6 +200,7 @@ class DeserializeListenerTest extends TestCase
         $formatsProviderProphecy->getFormatsFromAttributes([
             'resource_class' => 'Foo',
             'collection_operation_name' => 'post',
+            'identified_by' => null,
             'receive' => true,
             'respond' => true,
             'persist' => true,

--- a/tests/Fixtures/TestBundle/Action/ConfigCustom.php
+++ b/tests/Fixtures/TestBundle/Action/ConfigCustom.php
@@ -35,6 +35,6 @@ class ConfigCustom
     {
         $attributes = RequestAttributesExtractor::extractAttributes($request);
 
-        return $this->dataProvider->getItem($attributes['resource_class'], $id);
+        return $this->dataProvider->getItem($attributes['resource_class'], ['id' => $id]);
     }
 }

--- a/tests/Fixtures/TestBundle/Document/Book.php
+++ b/tests/Fixtures/TestBundle/Document/Book.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Book.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @ApiResource(collectionOperations={}, itemOperations={
+ *     "get",
+ *     "get_by_isbn"={"method"="GET", "path"="/books/by_isbn/{isbn}.{_format}", "requirements"={"isbn"=".+"}, "identifiedBy"="isbn"}
+ * })
+ * @ODM\Document
+ */
+class Book
+{
+    /**
+     * @ODM\Id(strategy="INCREMENT", type="integer")
+     */
+    private $id;
+
+    /**
+     * @ODM\Field(type="string", nullable=true)
+     */
+    public $name;
+
+    /**
+     * @ODM\Field(type="string")
+     */
+    public $isbn;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Book.php
+++ b/tests/Fixtures/TestBundle/Entity/Book.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Book.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @ApiResource(collectionOperations={}, itemOperations={
+ *     "get",
+ *     "get_by_isbn"={"method"="GET", "path"="/books/by_isbn/{isbn}.{_format}", "requirements"={"isbn"=".+"}, "identifiedBy"="isbn"}
+ * })
+ * @ORM\Entity
+ */
+class Book
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    public $name;
+
+    /**
+     * @ORM\Column(unique=true)
+     */
+    public $isbn;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Serializer/SerializerFilterContextBuilderTest.php
+++ b/tests/Serializer/SerializerFilterContextBuilderTest.php
@@ -147,6 +147,7 @@ class SerializerFilterContextBuilderTest extends TestCase
         $attributes = [
             'resource_class' => DummyGroup::class,
             'collection_operation_name' => 'get',
+            'identified_by' => null,
             'receive' => true,
             'respond' => true,
             'persist' => true,

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -33,6 +33,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -49,6 +50,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -65,6 +67,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => false,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -78,6 +81,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -91,6 +95,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -107,6 +112,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => false,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -120,6 +126,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -133,6 +140,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -149,6 +157,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => false,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -162,6 +171,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -175,6 +185,24 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identified_by' => null,
+            ],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+    }
+
+    public function testExtractIdentifiedBy()
+    {
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_identified_by' => ['test']]);
+
+        $this->assertEquals(
+            [
+                'resource_class' => 'Foo',
+                'item_operation_name' => 'get',
+                'receive' => true,
+                'respond' => true,
+                'persist' => true,
+                'identified_by' => ['test'],
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes
| Tickets       | rework of https://github.com/api-platform/core/pull/2126
| License       | MIT
| Doc PR        | na

Basically my idea was to specify on the operation what it's identifiers are. This helps a lot with identifiers parsing etc. 

The code speaks for itself. I still need to find a solution for composite identifiers, for example we can deprecate them but keep an option:

```
@ApiResource(identifiedBy='id')
```

Would work and force a single identifier in the route path even if there were several. 