### PR TITLE
[core] Enable/Disable AddTagsListener

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -27,6 +27,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("accessControlMessage", type="string"),
  *     @Attribute("attributes", type="array"),
  *     @Attribute("cacheHeaders", type="array"),
+ *     @Attribute("cacheInvalidation", type="bool"),
  *     @Attribute("collectionOperations", type="array"),
  *     @Attribute("denormalizationContext", type="array"),
  *     @Attribute("deprecationReason", type="string"),
@@ -87,6 +88,7 @@ final class ApiResource
         'securityPostDenormalize',
         'securityPostDenormalizeMessage',
         'cacheHeaders',
+        'cacheInvalidation',
         'collectionOperations',
         'denormalizationContext',
         'deprecationReason',
@@ -174,6 +176,14 @@ final class ApiResource
      * @var array
      */
     private $cacheHeaders;
+
+    /**
+     * @see https://api-platform.com/docs/core/performance/#enabling-disabling-http-cache-invalidation
+     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
+     *
+     * @var bool
+     */
+    private $cacheInvalidation;
 
     /**
      * @see https://api-platform.com/docs/core/serialization/#using-serialization-groups

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -178,9 +178,6 @@ final class ApiResource
     private $cacheHeaders;
 
     /**
-     * @see https://api-platform.com/docs/core/performance/#enabling-disabling-http-cache-invalidation
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
      * @var bool
      */
     private $cacheInvalidation;

--- a/src/Bridge/Symfony/Bundle/Resources/config/http_cache_tags.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/http_cache_tags.xml
@@ -10,7 +10,7 @@
 
         <service id="api_platform.http_cache.listener.response.add_tags" class="ApiPlatform\Core\HttpCache\EventListener\AddTagsListener">
             <argument type="service" id="api_platform.iri_converter" />
-
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-2" />
         </service>
     </services>

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -58,7 +58,7 @@ final class AddTagsListener
             || !$response->isCacheable()
             || (!$attributes = RequestAttributesExtractor::extractAttributes($request))
             || !$attributes['cache_invalidation']
-            || $this->isOperationAttributeDisabled($attributes, self::OPERATION_ATTRIBUTE_KEY)
+            || $this->isOperationAttributeDisabled($attributes, self::OPERATION_ATTRIBUTE_KEY, false)
         ) {
             return;
         }

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -34,7 +34,7 @@ final class AddTagsListener
 {
     use ToggleableOperationAttributeTrait;
 
-    public const OPERATION_ATTRIBUTE_KEY = 'cache_invalidation';
+    public const OPERATION_ATTRIBUTE_KEY = 'cache_tags_invalidation';
 
     private $iriConverter;
     private $resourceMetadataFactory;
@@ -57,7 +57,7 @@ final class AddTagsListener
             !$request->isMethodCacheable()
             || !$response->isCacheable()
             || (!$attributes = RequestAttributesExtractor::extractAttributes($request))
-            || !$attributes['cache_invalidation']
+            || !$attributes[self::OPERATION_ATTRIBUTE_KEY]
             || $this->isOperationAttributeDisabled($attributes, self::OPERATION_ATTRIBUTE_KEY, false)
         ) {
             return;

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -61,6 +61,7 @@ final class AttributesExtractor
             'receive' => (bool) ($attributes['_api_receive'] ?? true),
             'respond' => (bool) ($attributes['_api_respond'] ?? true),
             'persist' => (bool) ($attributes['_api_persist'] ?? true),
+            'cache_invalidation' => (bool) ($attributes['_api_cache_invalidation'] ?? true),
         ];
 
         return $result;

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -61,7 +61,7 @@ final class AttributesExtractor
             'receive' => (bool) ($attributes['_api_receive'] ?? true),
             'respond' => (bool) ($attributes['_api_respond'] ?? true),
             'persist' => (bool) ($attributes['_api_persist'] ?? true),
-            'cache_invalidation' => (bool) ($attributes['_api_cache_invalidation'] ?? true),
+            'cache_tags_invalidation' => (bool) ($attributes['_api_cache_tags_invalidation'] ?? true),
         ];
 
         return $result;

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -142,6 +142,7 @@ class RequestDataCollectorTest extends TestCase
             'receive' => true,
             'respond' => true,
             'persist' => true,
+            'cache_invalidation' => true,
         ], $dataCollector->getRequestAttributes());
         $this->assertSame(['foo', 'bar'], $dataCollector->getAcceptableContentTypes());
         $this->assertSame(DummyEntity::class, $dataCollector->getResourceClass());

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -142,7 +142,7 @@ class RequestDataCollectorTest extends TestCase
             'receive' => true,
             'respond' => true,
             'persist' => true,
-            'cache_invalidation' => true,
+            'cache_tags_invalidation' => true,
         ], $dataCollector->getRequestAttributes());
         $this->assertSame(['foo', 'bar'], $dataCollector->getAcceptableContentTypes());
         $this->assertSame(DummyEntity::class, $dataCollector->getResourceClass());

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -203,6 +203,7 @@ class DeserializeListenerTest extends TestCase
             'receive' => true,
             'respond' => true,
             'persist' => true,
+            'cache_invalidation' => true,
         ])->willReturn(self::FORMATS)->shouldBeCalled();
 
         $this->doTestDeserializeResourceClassSupportedFormat($method, $populateObject, $formatsProviderProphecy->reveal());

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -203,7 +203,7 @@ class DeserializeListenerTest extends TestCase
             'receive' => true,
             'respond' => true,
             'persist' => true,
-            'cache_invalidation' => true,
+            'cache_tags_invalidation' => true,
         ])->willReturn(self::FORMATS)->shouldBeCalled();
 
         $this->doTestDeserializeResourceClassSupportedFormat($method, $populateObject, $formatsProviderProphecy->reveal());

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -111,7 +111,7 @@ class AddTagsListenerTest extends TestCase
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
-        $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get', '_api_cache_invalidation' => false]);
+        $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get', '_api_cache_tags_invalidation' => false]);
 
         $response = new Response();
         $response->setPublic();
@@ -133,7 +133,7 @@ class AddTagsListenerTest extends TestCase
 
         $resourceMetadata = new ResourceMetadata('Dummy', null, null, [
             'get' => [
-                'cache_invalidation' => false,
+                'cache_tags_invalidation' => false,
             ],
         ]);
 

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -160,17 +160,7 @@ class AddTagsListenerTest extends TestCase
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
-        $resourceMetadata = new ResourceMetadata('Dummy', null, null, [
-            'get' => [
-                'cache_invalidation' => true,
-            ],
-        ]);
-
-        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
-        $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($resourceMetadata);
-
         $request = new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'get']);
-        $request->setMethod('GET');
 
         $response = new Response();
         $response->setPublic();
@@ -180,7 +170,7 @@ class AddTagsListenerTest extends TestCase
         $event->getRequest()->willReturn($request)->shouldBeCalled();
         $event->getResponse()->willReturn($response)->shouldBeCalled();
 
-        $listener = new AddTagsListener($iriConverterProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal());
+        $listener = new AddTagsListener($iriConverterProphecy->reveal());
         $listener->onKernelResponse($event->reveal());
 
         $this->assertSame('/foo,/bar', $response->headers->get('Cache-Tags'));

--- a/tests/Serializer/SerializerFilterContextBuilderTest.php
+++ b/tests/Serializer/SerializerFilterContextBuilderTest.php
@@ -150,6 +150,7 @@ class SerializerFilterContextBuilderTest extends TestCase
             'receive' => true,
             'respond' => true,
             'persist' => true,
+            'cache_invalidation' => true,
         ];
 
         $resourceMetadata = new ResourceMetadata(

--- a/tests/Serializer/SerializerFilterContextBuilderTest.php
+++ b/tests/Serializer/SerializerFilterContextBuilderTest.php
@@ -150,7 +150,7 @@ class SerializerFilterContextBuilderTest extends TestCase
             'receive' => true,
             'respond' => true,
             'persist' => true,
-            'cache_invalidation' => true,
+            'cache_tags_invalidation' => true,
         ];
 
         $resourceMetadata = new ResourceMetadata(

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -33,6 +33,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -49,6 +50,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -65,6 +67,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => false,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -78,6 +81,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -91,6 +95,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -107,6 +112,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => false,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -120,6 +126,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -133,6 +140,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -149,6 +157,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => false,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -162,6 +171,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -175,6 +185,52 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'cache_invalidation' => true,
+            ],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+    }
+
+    public function testExtractAddTags()
+    {
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_cache_invalidation' => '0']);
+
+        $this->assertEquals(
+            [
+                'resource_class' => 'Foo',
+                'item_operation_name' => 'get',
+                'receive' => true,
+                'respond' => true,
+                'persist' => true,
+                'cache_invalidation' => false,
+            ],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_cache_invalidation' => '1']);
+
+        $this->assertEquals(
+            [
+                'resource_class' => 'Foo',
+                'item_operation_name' => 'get',
+                'receive' => true,
+                'respond' => true,
+                'persist' => true,
+                'cache_invalidation' => true,
+            ],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get']);
+
+        $this->assertEquals(
+            [
+                'resource_class' => 'Foo',
+                'item_operation_name' => 'get',
+                'receive' => true,
+                'respond' => true,
+                'persist' => true,
+                'cache_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -33,7 +33,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -50,7 +50,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -67,7 +67,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => false,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -81,7 +81,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -95,7 +95,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -112,7 +112,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => false,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -126,7 +126,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -140,7 +140,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -157,7 +157,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => false,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -171,7 +171,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -185,7 +185,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -193,7 +193,7 @@ class RequestAttributesExtractorTest extends TestCase
 
     public function testExtractAddTags()
     {
-        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_cache_invalidation' => '0']);
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_cache_tags_invalidation' => '0']);
 
         $this->assertEquals(
             [
@@ -202,12 +202,12 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => false,
+                'cache_tags_invalidation' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
 
-        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_cache_invalidation' => '1']);
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_cache_tags_invalidation' => '1']);
 
         $this->assertEquals(
             [
@@ -216,7 +216,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -230,7 +230,7 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
-                'cache_invalidation' => true,
+                'cache_tags_invalidation' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );


### PR DESCRIPTION
Add attribute cache_invalidation in ApiResource

| Q             | A
| ------------- | ---
| Bug fix?      | no 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

My customer uses varnish cache to maximize performance, but for some cases, I need to disable http cache invalidation.

**Proposal**: Enable/Disable AddTagsListener at runtime

It could be done **globally** with something like that:

```php
<?php
// api/src/Entity/Book.php

namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiResource;

/**
 * ...
 * @ApiResource(
 *     cacheInvalidation=false,
 * ...
 * )
 */
class Book
{
    // ...
}
```

It could be disabled **at operation level** with something like that:

```php
<?php
// api/src/Entity/Book.php

namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiResource;

/**
 * ...
 * @ApiResource(
 *     itemOperations={
 *         "get"={
 *             "cache_invalidation"=false,
 *             ...
 *         },
 *     },
 * ...
 * )
 */
class Book
{
    // ...
}
```