### PR TITLE
Avoid Doctrine persistance BC break by adding conflict doctrine/persistence >1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,8 @@
     },
     "conflict": {
         "doctrine/common": "<2.7",
-        "doctrine/mongodb-odm": "<2.0"
+        "doctrine/mongodb-odm": "<2.0",
+        "doctrine/persistence": ">1.3"
     },
     "suggest": {
         "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",


### PR DESCRIPTION
Use Symfony Doctrine brigde namespace instead of Doctrine Common namespace for ManagerRegistry class

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | #3683 [1631](https://github.com/api-platform/api-platform/issues/1631) [37935](https://github.com/symfony/symfony/issues/37935) (symfony issue) [691](https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/691) [667](https://github.com/symfony/maker-bundle/pull/667)
| License       | MIT
| Doc PR        | 

**Description**
Doctrine/persistence 2.0 has changed some namespace like:
Doctrine\Persistence\ManagerRegistry instead of Doctrine\Common\Persistence\ManagerRegistry.
This prevents installing new api-platform using composer.

**How to reproduce**
Create a new Symfony project with composer and add Api-Platform to it:

```
composer create-project symfony/skeleton new-project
cd new-project
composer require api
```
The last command **fail** with the same error message as the [Symfony linked issue](https://github.com/symfony/symfony/issues/37935).

**Additionally**
The pull request was initially addressed in #3684. I rollbacked my changes in favour of @alanpoulain proposal. This caused the pull request to be closed automatically. Even I pushed one new commit into my same branch in my fork, the pull-request didn't reopen.