### PR TITLE
Checking the output option when calculating property metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * OpenAPI: Do not set scheme to oauth2 when generating securitySchemes (#4073)
 * OpenAPI: Fix missing `$ref` when no `type` is used in context (#4076)
 * GraphQL: Fix "Resource class cannot be determined." error when a null iterable field is returned (#4092)
+* Metadata: Check the output class when calculating serializer groups (#3696)
 
 ## 2.6.2
 

--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -209,6 +209,11 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
      */
     private function getClassSerializerGroups(string $class): array
     {
+        $resourceMetadata = $this->resourceMetadataFactory->create($class);
+        if ($outputClass = $resourceMetadata->getAttribute('output')['class'] ?? null) {
+            $class = $outputClass;
+        }
+
         $serializerClassMetadata = $this->serializerClassMetadataFactory->getMetadataFor($class);
 
         $groups = [];

--- a/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\DummyIgnoreProperty;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritance;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceChild;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
@@ -56,19 +57,26 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
     /**
      * @dataProvider groupsProvider
      */
-    public function testCreate($readGroups, $writeGroups)
+    public function testCreate($readGroups, $writeGroups, $relatedOutputClass = null)
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $dummyResourceMetadata = (new ResourceMetadata())
             ->withAttributes([
                 'normalization_context' => [
-                    AbstractNormalizer::GROUPS => $readGroups,
+                    AbstractNormalizer::GROUPS => $readGroups[Dummy::class],
                 ],
                 'denormalization_context' => [
-                    AbstractNormalizer::GROUPS => $writeGroups,
+                    AbstractNormalizer::GROUPS => $writeGroups[Dummy::class],
                 ],
             ]);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($dummyResourceMetadata);
+        $relatedDummyResourceMetadata = new ResourceMetadata();
+        if ($relatedOutputClass) {
+            $relatedDummyResourceMetadata = $relatedDummyResourceMetadata->withAttributes([
+               'output' => ['class' => $relatedOutputClass],
+            ]);
+        }
+        $resourceMetadataFactoryProphecy->create(RelatedDummy::class)->willReturn($relatedDummyResourceMetadata);
 
         $serializerClassMetadataFactoryProphecy = $this->prophesize(SerializerClassMetadataFactoryInterface::class);
         $dummySerializerClassMetadata = new SerializerClassMetadata(Dummy::class);
@@ -88,6 +96,12 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $nameSerializerAttributeMetadata->addGroup('dummy_read');
         $relatedDummySerializerClassMetadata->addAttributeMetadata($nameSerializerAttributeMetadata);
         $serializerClassMetadataFactoryProphecy->getMetadataFor(RelatedDummy::class)->willReturn($relatedDummySerializerClassMetadata);
+        $dummyCarSerializerClassMetadata = new SerializerClassMetadata(DummyCar::class);
+        $nameSerializerAttributeMetadata = new SerializerAttributeMetadata('name');
+        $nameSerializerAttributeMetadata->addGroup('dummy_car_read');
+        $nameSerializerAttributeMetadata->addGroup('dummy_write');
+        $dummyCarSerializerClassMetadata->addAttributeMetadata($nameSerializerAttributeMetadata);
+        $serializerClassMetadataFactoryProphecy->getMetadataFor(DummyCar::class)->willReturn($dummyCarSerializerClassMetadata);
 
         $decoratedProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $fooPropertyMetadata = (new PropertyMetadata())
@@ -120,8 +134,13 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $this->assertInstanceOf(PropertyMetadata::class, $actual[1]);
         $this->assertTrue($actual[1]->isReadable());
         $this->assertTrue($actual[1]->isWritable());
-        $this->assertTrue($actual[1]->isReadableLink());
-        $this->assertFalse($actual[1]->isWritableLink());
+        if ($relatedOutputClass) {
+            $this->assertFalse($actual[1]->isReadableLink());
+            $this->assertTrue($actual[1]->isWritableLink());
+        } else {
+            $this->assertTrue($actual[1]->isReadableLink());
+            $this->assertFalse($actual[1]->isWritableLink());
+        }
 
         $this->assertInstanceOf(PropertyMetadata::class, $actual[2]);
         $this->assertFalse($actual[2]->isReadable());
@@ -131,8 +150,9 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
     public function groupsProvider(): array
     {
         return [
-            [['dummy_read'], ['dummy_write']],
-            ['dummy_read', 'dummy_write'],
+            [[Dummy::class => ['dummy_read']], [Dummy::class => ['dummy_write']]],
+            [[Dummy::class => 'dummy_read'], [Dummy::class => 'dummy_write']],
+            [[Dummy::class => 'dummy_read'], [Dummy::class => 'dummy_write'], DummyCar::class],
         ];
     }
 

--- a/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
@@ -57,23 +57,23 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
     /**
      * @dataProvider groupsProvider
      */
-    public function testCreate($readGroups, $writeGroups, $relatedOutputClass = null)
+    public function testCreate($readGroups, $writeGroups, ?string $relatedOutputClass = null)
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $dummyResourceMetadata = (new ResourceMetadata())
             ->withAttributes([
                 'normalization_context' => [
-                    AbstractNormalizer::GROUPS => $readGroups[Dummy::class],
+                    AbstractNormalizer::GROUPS => $readGroups,
                 ],
                 'denormalization_context' => [
-                    AbstractNormalizer::GROUPS => $writeGroups[Dummy::class],
+                    AbstractNormalizer::GROUPS => $writeGroups,
                 ],
             ]);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($dummyResourceMetadata);
         $relatedDummyResourceMetadata = new ResourceMetadata();
         if ($relatedOutputClass) {
             $relatedDummyResourceMetadata = $relatedDummyResourceMetadata->withAttributes([
-               'output' => ['class' => $relatedOutputClass],
+                'output' => ['class' => $relatedOutputClass],
             ]);
         }
         $resourceMetadataFactoryProphecy->create(RelatedDummy::class)->willReturn($relatedDummyResourceMetadata);
@@ -150,9 +150,9 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
     public function groupsProvider(): array
     {
         return [
-            [[Dummy::class => ['dummy_read']], [Dummy::class => ['dummy_write']]],
-            [[Dummy::class => 'dummy_read'], [Dummy::class => 'dummy_write']],
-            [[Dummy::class => 'dummy_read'], [Dummy::class => 'dummy_write'], DummyCar::class],
+            [['dummy_read'], ['dummy_write']],
+            ['dummy_read', 'dummy_write'],
+            ['dummy_read', 'dummy_write', DummyCar::class],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | this could change behavior for people relying on bug
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

Hi!

Reproducer with instructions here: https://github.com/SymfonyCasts/api-platform/tree/embedded-output-iri-embedded-bug

It's super tricky and subtle. The tl;dr is that when the `readableLink` of `PropertyMetadata` is calculated for an embedded property, it uses the serializer groups from the target resource class when it *should* use the `output=` class (because that is what will actually be serialized).

I didn't include a test (yet) - I'd like some validation that this it the correct place/idea for this.

Thanks!