### PR TITLE
Fix mising @type in output DTO collections

### DIFF
--- a/features/graphql/input_output.feature
+++ b/features/graphql/input_output.feature
@@ -16,7 +16,7 @@ Feature: GraphQL DTO input and output
     }
     """
     Then the response status code should be 201
-    And the JSON should be equal to:
+    And the JSON should be a superset of:
     """
     {
       "@context": {
@@ -43,6 +43,7 @@ Feature: GraphQL DTO input and output
           "relatedToDummyFriend": [],
           "dummyBoolean": null,
           "embeddedDummy": {
+            "@type": "EmbeddableDummy",
             "dummyName": null,
             "dummyBoolean": null,
             "dummyDate": null,

--- a/features/jsonld/input_output.feature
+++ b/features/jsonld/input_output.feature
@@ -69,11 +69,13 @@ Feature: JSON-LD DTO input and output
       "@type": "hydra:Collection",
       "hydra:member": [
         {
+          "@type": "DummyDtoCustom",
           "@id": "/dummy_dto_customs/1",
           "foo": "test",
           "bar": 1
         },
         {
+          "@type": "DummyDtoCustom",
           "@id": "/dummy_dto_customs/2",
           "foo": "test",
           "bar": 2

--- a/features/jsonld/non_resource.feature
+++ b/features/jsonld/non_resource.feature
@@ -12,7 +12,7 @@ Feature: JSON-LD non-resource handling
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
+    And the JSON should be a superset of:
     """
     {
       "@context": "/contexts/ContainNonResource",
@@ -25,11 +25,13 @@ Feature: JSON-LD non-resource handling
         "id": "1-nested",
         "nested": null,
         "notAResource": {
+          "@type": "NotAResource",
           "foo": "f2",
           "bar": "b2"
         }
       },
       "notAResource": {
+        "@type": "NotAResource",
         "foo": "f1",
         "bar": "b1"
       }
@@ -50,13 +52,14 @@ Feature: JSON-LD non-resource handling
     Then the response status code should be 201
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
+    And the JSON should be a superset of:
     """
     {
       "@context": "/contexts/NonRelationResource",
       "@id": "/non_relation_resources/1",
       "@type": "NonRelationResource",
       "relation": {
+        "@type": "NonResourceClass",
         "foo": "test"
       },
       "id": 1

--- a/features/main/operation.feature
+++ b/features/main/operation.feature
@@ -43,16 +43,17 @@ Feature: Operation support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
+    And the JSON should be a superset of:
     """
     {
-        "@context": "/contexts/EmbeddedDummy",
-        "@id": "/embedded_dummies/1",
-        "@type": "EmbeddedDummy",
-        "name": "Dummy #1",
-        "embeddedDummy": {
-            "dummyName": "Dummy #1"
-        }
+      "@context": "/contexts/EmbeddedDummy",
+      "@id": "/embedded_dummies/1",
+      "@type": "EmbeddedDummy",
+      "name": "Dummy #1",
+      "embeddedDummy": {
+      "@type": "EmbeddableDummy",
+        "dummyName": "Dummy #1"
+      }
     }
     """
 

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -402,7 +402,7 @@ Feature: Relations support
     And I send a "GET" request to "/people"
     Then the response status code should be 200
     And the response should be in JSON
-    And the JSON should be equal to:
+    And the JSON should be a superset of:
     """
     {
       "@context": "/contexts/Person",
@@ -415,6 +415,7 @@ Feature: Relations support
           "name": "foo",
           "pets": [
             {
+              "@type": "PersonToPet",
               "pet": {
                 "@id": "/pets/1",
                 "@type": "Pet",

--- a/features/serializer/deserialize_objects_using_constructor.feature
+++ b/features/serializer/deserialize_objects_using_constructor.feature
@@ -21,7 +21,7 @@ Feature: Resource with constructor deserializable
     Then the response status code should be 201
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
+    And the JSON should be a superset of:
     """
     {
       "@context": "/contexts/DummyEntityWithConstructor",
@@ -32,6 +32,7 @@ Feature: Resource with constructor deserializable
       "bar": "world",
       "items": [
         {
+          "@type": "DummyObjectWithoutConstructor",
           "foo": "bar"
         }
       ],

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -126,6 +126,10 @@ final class ContextBuilder implements AnonymousContextBuilderInterface
             '@id' => $context['iri'] ?? '_:'.(\function_exists('spl_object_id') ? spl_object_id($object) : spl_object_hash($object)),
         ];
 
+        if ($context['has_context'] ?? false) {
+            unset($jsonLdContext['@context']);
+        }
+
         // here the object can be different from the resource given by the $context['api_resource'] value
         if (isset($context['api_resource'])) {
             $jsonLdContext['@type'] = $this->resourceMetadataFactory->create($this->getObjectClass($context['api_resource']))->getShortName();

--- a/src/JsonLd/Serializer/JsonLdContextTrait.php
+++ b/src/JsonLd/Serializer/JsonLdContextTrait.php
@@ -49,9 +49,9 @@ trait JsonLdContextTrait
 
     private function createJsonLdContext(AnonymousContextBuilderInterface $contextBuilder, $object, array &$context, array $data = []): array
     {
-        // We're in a collection, just add the IRI if available
+        // We're in a collection, don't add the @context part
         if (isset($context['jsonld_has_context'])) {
-            return isset($context['output']['iri']) ? ['@id' => $context['output']['iri']] : $data;
+            return $contextBuilder->getAnonymousResourceContext($object, ($context['output'] ?? []) + ['api_resource' => $context['api_resource'] ?? null, 'has_context' => true]);
         }
 
         $context['jsonld_has_context'] = true;

--- a/src/JsonLd/Serializer/ObjectNormalizer.php
+++ b/src/JsonLd/Serializer/ObjectNormalizer.php
@@ -79,7 +79,7 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
         $context['api_empty_resource_as_iri'] = true;
 
         $data = $this->decorated->normalize($object, $format, $context);
-        if (!\is_array($data)) {
+        if (!\is_array($data) || !$data) {
             return $data;
         }
 

--- a/tests/JsonLd/ContextBuilderTest.php
+++ b/tests/JsonLd/ContextBuilderTest.php
@@ -197,4 +197,22 @@ class ContextBuilderTest extends TestCase
 
         $this->assertEquals($expected, $contextBuilder->getAnonymousResourceContext($output, ['iri' => '/dummies', 'name' => 'Dummy', 'api_resource' => new Dummy()]));
     }
+
+    public function testAnonymousResourceContextWithApiResourceHavingContext()
+    {
+        $output = new OutputDto();
+        $this->propertyNameCollectionFactoryProphecy->create(OutputDto::class)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
+        $this->propertyMetadataFactoryProphecy->create(OutputDto::class, 'dummyPropertyA')->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'Dummy property A', true, true, true, true, false, false, null, null, []));
+
+        $this->resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata('Dummy'));
+
+        $contextBuilder = new ContextBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataFactoryProphecy->reveal(), $this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->urlGeneratorProphecy->reveal());
+
+        $expected = [
+            '@id' => '/dummies',
+            '@type' => 'Dummy',
+        ];
+
+        $this->assertEquals($expected, $contextBuilder->getAnonymousResourceContext($output, ['iri' => '/dummies', 'name' => 'Dummy', 'api_resource' => new Dummy(), 'has_context' => true]));
+    }
 }

--- a/tests/JsonLd/Serializer/ObjectNormalizerTest.php
+++ b/tests/JsonLd/Serializer/ObjectNormalizerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\JsonLd\Serializer;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\JsonLd\AnonymousContextBuilderInterface;
+use ApiPlatform\Core\JsonLd\Serializer\ObjectNormalizer;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ObjectNormalizerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testNormalize()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('hello');
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(NormalizerInterface::class);
+        $serializerProphecy->normalize($dummy, null, Argument::type('array'))->willReturn(['name' => 'hello']);
+
+        $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
+        $contextBuilderProphecy->getAnonymousResourceContext($dummy, Argument::type('array'))->shouldBeCalled()->willReturn([
+            '@context' => [],
+            '@type' => 'Dummy',
+            '@id' => '_:1234',
+        ]);
+
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(),
+            $iriConverterProphecy->reveal(),
+            $contextBuilderProphecy->reveal()
+        );
+
+        $expected = [
+            '@context' => [],
+            '@id' => '_:1234',
+            '@type' => 'Dummy',
+            'name' => 'hello',
+        ];
+        $this->assertEquals($expected, $normalizer->normalize($dummy));
+    }
+
+    public function testNormalizeEmptyArray()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('hello');
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(NormalizerInterface::class);
+        $serializerProphecy->normalize($dummy, null, Argument::type('array'))->willReturn([]);
+
+        $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
+        $contextBuilderProphecy->getAnonymousResourceContext($dummy, Argument::type('array'))->shouldNotBeCalled();
+
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(),
+            $iriConverterProphecy->reveal(),
+            $contextBuilderProphecy->reveal()
+        );
+
+        $this->assertEquals([], $normalizer->normalize($dummy));
+    }
+
+    public function testNormalizeWithOutput()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('hello');
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1234');
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(NormalizerInterface::class);
+        $serializerProphecy->normalize($dummy, null, Argument::type('array'))->willReturn(['name' => 'hello']);
+
+        $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
+        $contextBuilderProphecy->getAnonymousResourceContext($dummy, ['iri' => '/dummy/1234', 'api_resource' => $dummy])->shouldBeCalled()->willReturn(['@id' => '/dummy/1234', '@type' => 'Dummy', '@context' => []]);
+
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(),
+            $iriConverterProphecy->reveal(),
+            $contextBuilderProphecy->reveal()
+        );
+
+        $expected = [
+            '@context' => [],
+            '@id' => '/dummy/1234',
+            '@type' => 'Dummy',
+            'name' => 'hello',
+        ];
+        $this->assertEquals($expected, $normalizer->normalize($dummy, null, ['api_resource' => $dummy]));
+    }
+
+    public function testNormalizeWithContext()
+    {
+        $dummy = new Dummy();
+        $dummy->setName('hello');
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1234');
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(NormalizerInterface::class);
+        $serializerProphecy->normalize($dummy, null, Argument::type('array'))->willReturn(['name' => 'hello']);
+
+        $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
+        $contextBuilderProphecy->getAnonymousResourceContext($dummy, ['iri' => '/dummy/1234', 'api_resource' => $dummy, 'has_context' => true])->shouldBeCalled()->willReturn(['@id' => '/dummy/1234', '@type' => 'Dummy']);
+
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(),
+            $iriConverterProphecy->reveal(),
+            $contextBuilderProphecy->reveal()
+        );
+
+        $expected = [
+            '@id' => '/dummy/1234',
+            '@type' => 'Dummy',
+            'name' => 'hello',
+        ];
+        $this->assertEquals($expected, $normalizer->normalize($dummy, null, ['api_resource' => $dummy, 'jsonld_has_context' => true]));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes  
| License       | MIT
| Doc PR        | 

The `@type` property was missing from collection using output DTOs.
