### PR TITLE
fix prophecy trait

### DIFF
--- a/tests/ProphecyTrait.php
+++ b/tests/ProphecyTrait.php
@@ -71,6 +71,7 @@ trait ProphecyTrait
 
     /**
      * @postCondition
+     * @after
      */
     protected function verifyProphecyDoubles(): void
     {
@@ -110,7 +111,7 @@ trait ProphecyTrait
 
         foreach ($this->prophet->getProphecies() as $objectProphecy) {
             /**
-             * @var MethodProphecy[] $methodProphecies
+             * @var MethodProphecy[]
              */
             foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
                 foreach ($methodProphecies as $methodProphecy) {

--- a/tests/ProphecyTrait.php
+++ b/tests/ProphecyTrait.php
@@ -111,7 +111,7 @@ trait ProphecyTrait
 
         foreach ($this->prophet->getProphecies() as $objectProphecy) {
             /**
-             * @var MethodProphecy[]
+             * @var MethodProphecy[] $methodProphecies
              */
             foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
                 foreach ($methodProphecies as $methodProphecy) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

annotation `@postCondition` is only available from phpunit ^9.1.

see https://github.com/sebastianbergmann/phpunit/commit/85fefa381541fb3fcbbfe9b5f32be386551cd774