### PR TITLE
Do not add JOINs for Filters without a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Mercure: Do not use data in options when deleting (#4056)
 * Doctrine: Support for foreign identifiers (#4042)
 * Doctrine: Support for binary UUID in search filter (#3774)
+* Doctrine: Do not add join or lookup for search filter with empty value (#3703)
 * JSON Schema: Allow generating documentation when property and method start from "is" (property `isActive` and method `isActive`) (#4064)
 * OpenAPI: Fix missing 422 responses in the documentation (#4086)
 * OpenAPI: Fix error when schema is empty (#4051)

--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
@@ -77,6 +77,11 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 
         $matchField = $field = $property;
 
+        $values = $this->normalizeValues((array) $value, $property);
+        if (null === $values) {
+            return;
+        }
+
         $associations = [];
         if ($this->isPropertyNested($property, $resourceClass)) {
             [$matchField, $field, $associations] = $this->addLookupsForNestedProperty($property, $aggregationBuilder, $resourceClass);
@@ -86,11 +91,6 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
          * @var MongoDBClassMetadata
          */
         $metadata = $this->getNestedMetadata($resourceClass, $associations);
-
-        $values = $this->normalizeValues((array) $value, $property);
-        if (null === $values) {
-            return;
-        }
 
         $caseSensitive = true;
 

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -81,14 +81,14 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
-        $associations = [];
-        if ($this->isPropertyNested($property, $resourceClass)) {
-            [$alias, $field, $associations] = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $resourceClass);
-        }
-
         $values = $this->normalizeValues((array) $value, $property);
         if (null === $values) {
             return;
+        }
+
+        $associations = [];
+        if ($this->isPropertyNested($property, $resourceClass)) {
+            [$alias, $field, $associations] = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $resourceClass);
         }
 
         $metadata = $this->getNestedMetadata($resourceClass, $associations);

--- a/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -466,6 +466,14 @@ trait SearchFilterTestTrait
                     'relatedDummy.symfony' => 'exact',
                 ],
             ],
+            'empty nested property' => [
+                [
+                    'relatedDummy.symfony' => null,
+                ],
+                [
+                    'relatedDummy.symfony' => [],
+                ],
+            ],
         ];
     }
 }

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
@@ -686,6 +686,10 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     ],
                     $filterFactory,
                 ],
+                'empty nested property' => [
+                    [],
+                    $filterFactory,
+                ],
             ]
         );
     }

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -559,6 +559,11 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     ],
                     $filterFactory,
                 ],
+                'empty nested property' => [
+                    sprintf('SELECT %s FROM %s %1$s', $this->alias, Dummy::class),
+                    [],
+                    $filterFactory,
+                ],
             ]
         );
     }


### PR DESCRIPTION
This potentially improves performance significantly with queries that use many filters on nested properties.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | potentially
| Deprecations? | no
| Tickets       | n/a <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | n/a

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
Please note that this change has been poorly tested and this PR must be considered more of a discussion than an actual mergable PR.

In our app we have an Doctrine Entity with multiple associated `ManyToOne` and `ManyToMany` Collections. We have also defined `SearchFilter`s for properties of these Collections in the Annotation for this entity.

While using the GraphQL API, we define the query with all these properties. When the user does not use the filter it will still be defined as `nestedPropertyName: []`. This causes the `JOIN` to be added through (old) lines 83-84. However these JOINs serve no function (?) because (old) line 89 exits the function due to a lack of values. 

In our test joining all these relations even though they are not used makes a very significant performance difference (think 4000ms query vs 90ms in our specific case). Additionally these JOIN's filter out any results that do not have any items in that relation (even if the filter has no value), however I'm not sure that is a feature or a bug.

Regarding not setting the filter in the query in the first place: we aim to have our queries as static as possible only passing in different parameters, it seems that is already supported judging by (old) lines 88-90.

I would love to hear your opinion on this.
