### PR TITLE
Fix definition names to be compliant with OpenAPI 3.0 and JSON Point Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
 * IriConverter: Fix IRI url double encoding - may cause breaking change as some characters no longer encoded in output (#3552)
-* OpenAPI: **BC** Replace all characters other than `^[a-zA-Z0-9\.\-_]+$.` to `.` in definition names to be compliant with OpenAPI 3.0 (#3669)
+* OpenAPI: **BC** Replace all characters other than `[a-zA-Z0-9\.\-_]` to `.` in definition names to be compliant with OpenAPI 3.0 (#3669)
 
 ## 2.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Deprecate using a validation groups generator service not implementing `ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface` (#3346)
 * Subresources: subresource resourceClass can now be defined as a container parameter in XML and Yaml definitions
 * IriConverter: Fix IRI url double encoding - may cause breaking change as some characters no longer encoded in output (#3552)
+* OpenAPI: **BC** Replace all characters other than `^[a-zA-Z0-9\.\-_]+$.` to `.` in definition names to be compliant with OpenAPI 3.0 (#3669)
 
 ## 2.5.7
 

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -95,7 +95,7 @@ Feature: Documentation support
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 6 elements
 
     # Subcollection - check schema
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend:jsonld-fakemanytomany"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany"
 
     # Deprecations
     And the JSON node "paths./dummies.get.deprecated" should not exist

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -255,7 +255,7 @@ final class SchemaFactory implements SchemaFactoryInterface
 
     private function encodeDefinitionName(string $name): string
     {
-        return preg_replace('/^[a-zA-Z0-9.\-_]+$./', '.', $name);
+        return preg_replace('/[^a-zA-Z0-9.\-_]/', '.', $name);
     }
 
     private function getMetadata(string $className, string $type = Schema::TYPE_OUTPUT, ?string $operationType, ?string $operationName, ?array $serializerContext): ?array

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -235,12 +235,12 @@ final class SchemaFactory implements SchemaFactoryInterface
         if (null !== $inputOrOutputClass && $className !== $inputOrOutputClass) {
             $parts = explode('\\', $inputOrOutputClass);
             $shortName = end($parts);
-            $prefix .= ':'.$shortName;
+            $prefix .= '.'.$shortName;
         }
 
         if (isset($this->distinctFormats[$format])) {
             // JSON is the default, and so isn't included in the definition name
-            $prefix .= ':'.$format;
+            $prefix .= '.'.$format;
         }
 
         if (isset($serializerContext[DocumentationNormalizer::SWAGGER_DEFINITION_NAME])) {
@@ -250,7 +250,12 @@ final class SchemaFactory implements SchemaFactoryInterface
             $name = $groups ? sprintf('%s-%s', $prefix, implode('_', $groups)) : $prefix;
         }
 
-        return $name;
+        return $this->encodeDefinitionName($name);
+    }
+
+    private function encodeDefinitionName(string $name): string
+    {
+        return preg_replace('/^[a-zA-Z0-9.\-_]+$./', '.', $name);
     }
 
     private function getMetadata(string $className, string $type = Schema::TYPE_OUTPUT, ?string $operationType, ?string $operationName, ?array $serializerContext): ?array

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -57,7 +57,7 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class);
 
         $this->assertTrue($resultSchema->isDefined());
-        $this->assertEquals(Dummy::class.'.jsonld', $resultSchema->getRootDefinitionKey());
+        $this->assertEquals(str_replace('\\', '.', Dummy::class).'.jsonld', $resultSchema->getRootDefinitionKey());
     }
 
     public function testCustomFormatBuildSchema(): void
@@ -65,7 +65,7 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'json');
 
         $this->assertTrue($resultSchema->isDefined());
-        $this->assertEquals(Dummy::class, $resultSchema->getRootDefinitionKey());
+        $this->assertEquals(str_replace('\\', '.', Dummy::class), $resultSchema->getRootDefinitionKey());
     }
 
     public function testHasRootDefinitionKeyBuildSchema(): void
@@ -74,7 +74,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
-        $this->assertEquals(Dummy::class.'.jsonld', $rootDefinitionKey);
+        $this->assertEquals(str_replace('\\', '.', Dummy::class).'.jsonld', $rootDefinitionKey);
         $this->assertArrayHasKey($rootDefinitionKey, $definitions);
         $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
     }

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -57,7 +57,7 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class);
 
         $this->assertTrue($resultSchema->isDefined());
-        $this->assertEquals(Dummy::class.':jsonld', $resultSchema->getRootDefinitionKey());
+        $this->assertEquals(Dummy::class.'.jsonld', $resultSchema->getRootDefinitionKey());
     }
 
     public function testCustomFormatBuildSchema(): void
@@ -74,7 +74,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
-        $this->assertEquals(Dummy::class.':jsonld', $rootDefinitionKey);
+        $this->assertEquals(Dummy::class.'.jsonld', $rootDefinitionKey);
         $this->assertArrayHasKey($rootDefinitionKey, $definitions);
         $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
     }

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -2779,7 +2779,7 @@ class DocumentationNormalizerV2Test extends TestCase
                                 'schema' => [
                                     'type' => 'array',
                                     'items' => [
-                                        '$ref' => '#/definitions/Dummy:OutputDto',
+                                        '$ref' => '#/definitions/Dummy.OutputDto',
                                     ],
                                 ],
                             ],
@@ -2804,7 +2804,7 @@ class DocumentationNormalizerV2Test extends TestCase
                             201 => [
                                 'description' => 'Dummy resource created',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:OutputDto',
+                                    '$ref' => '#/definitions/Dummy.OutputDto',
                                 ],
                             ],
                             400 => [
@@ -2820,7 +2820,7 @@ class DocumentationNormalizerV2Test extends TestCase
                                 'in' => 'body',
                                 'description' => 'The new Dummy resource',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:InputDto',
+                                    '$ref' => '#/definitions/Dummy.InputDto',
                                 ],
                             ],
                         ],
@@ -2844,7 +2844,7 @@ class DocumentationNormalizerV2Test extends TestCase
                             200 => [
                                 'description' => 'Dummy resource response',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:OutputDto',
+                                    '$ref' => '#/definitions/Dummy.OutputDto',
                                 ],
                             ],
                             404 => [
@@ -2870,7 +2870,7 @@ class DocumentationNormalizerV2Test extends TestCase
                                 'in' => 'body',
                                 'description' => 'The updated Dummy resource',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:InputDto',
+                                    '$ref' => '#/definitions/Dummy.InputDto',
                                 ],
                             ],
                         ],
@@ -2878,7 +2878,7 @@ class DocumentationNormalizerV2Test extends TestCase
                             200 => [
                                 'description' => 'Dummy resource updated',
                                 'schema' => [
-                                    '$ref' => '#/definitions/Dummy:OutputDto',
+                                    '$ref' => '#/definitions/Dummy.OutputDto',
                                 ],
                             ],
                             400 => [
@@ -2892,7 +2892,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ],
             ]),
             'definitions' => new \ArrayObject([
-                'Dummy:OutputDto' => new \ArrayObject([
+                'Dummy.OutputDto' => new \ArrayObject([
                     'type' => 'object',
                     'description' => 'This is a dummy.',
                     'externalDocs' => [
@@ -2910,7 +2910,7 @@ class DocumentationNormalizerV2Test extends TestCase
                         ]),
                     ],
                 ]),
-                'Dummy:InputDto' => new \ArrayObject([
+                'Dummy.InputDto' => new \ArrayObject([
                     'type' => 'object',
                     'description' => 'This is a dummy.',
                     'externalDocs' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | fixes #1969
| License       | MIT
| Doc PR        | api-platform/docs#...

Replaces PR #3669 

From https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#componentsObject
`All the fixed fields declared above are objects that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$.`

Invalid characters will be replaced by `.`. (see https://github.com/api-platform/core/pull/3669#issuecomment-681941187)