### PR TITLE
Create client uses an existing kernel if one is present before the call

### DIFF
--- a/src/Bridge/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Bridge/Symfony/Bundle/Test/ApiTestCase.php
@@ -41,19 +41,24 @@ abstract class ApiTestCase extends KernelTestCase
 
     /**
      * Creates a Client.
+     * In case there is an already booted kernel, that kernel is used and therefore 
+     * the $kernelOptions are ignored.
      *
-     * @param array $kernelOptions  Options to pass to the createKernel method
+     * @param array $kernelOptions  Options to pass to the createKernel method if
+     *                              no kernel is booted before this call
      * @param array $defaultOptions Default options for the requests
      */
     protected static function createClient(array $kernelOptions = [], array $defaultOptions = []): Client
     {
-        $kernel = static::bootKernel($kernelOptions);
+        if (static::$kernel === null) {
+            static::bootKernel($kernelOptions);
+        }
 
         try {
             /**
              * @var Client
              */
-            $client = $kernel->getContainer()->get('test.api_platform.client');
+            $client = static::$kernel->getContainer()->get('test.api_platform.client');
         } catch (ServiceNotFoundException $e) {
             if (!class_exists(AbstractBrowser::class) || !trait_exists(HttpClientTrait::class)) {
                 throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit and HttpClient components are not available. Try running "composer require --dev symfony/browser-kit symfony/http-client".');

--- a/tests/Bridge/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -24,6 +24,27 @@ use PHPUnit\Runner\Version;
 
 class ApiTestCaseTest extends ApiTestCase
 {
+    public function testCreateClientBootsKernelIfNotPresent(): void
+    {
+        $this->assertNull(static::$kernel, "Kernel not booted");
+
+        $this->createClient();
+
+        $this->assertNotNull(static::$kernel, "Kernel booted by createClient()");
+    }
+
+    public function testCreateClientUsesExistingKernelIfPresent(): void
+    {
+        $this->assertNull(static::$kernel, "Kernel not booted");
+
+        $initialKernel = self::bootKernel();
+        $this->assertNotNull(static::$kernel, "Kernel booted successfully");
+
+        $this->createClient();
+
+        $this->assertSame(static::$kernel, $initialKernel, "Kernel not changed by createClient");
+    }
+
     public function testAssertJsonContains(): void
     {
         if (version_compare(Version::id(), '8.0.0', '<')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

As discussed in api-platform/api-platform#1640 the current behavior of `ApiTestCase::createClient()` can lead to problems.
Currently createClient boots a new kernel upon every call. This leads to problems if a kernel was already booted and e.g. used to create entities with Doctrine. In that case `hautelook/alice-bundle::ResetDatabaseTrait()` does not work as expected any more.

So I created a workaround:
createClient() only boots a new kernel if `static::$kernel` isn't defined yet. Otherwise a kernel is already present and there is no need to boot a new one.

