### PR TITLE
Bugfix | Don't try to set `null` values when merging metadata

### DIFF
--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -111,6 +111,10 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
             return $resourceMetadata;
         }
 
+        if (null === $value) {
+            return $resourceMetadata;
+        }
+
         $wither = "with$upperProperty";
 
         return $resourceMetadata->{$wither}($value);

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -34,7 +34,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
     /**
      * @dataProvider getCreateDependencies
      */
-    public function testCreate($reader, $decorated, string $expectedShortName, string $expectedDescription)
+    public function testCreate($reader, $decorated, string $expectedShortName, ?string $expectedDescription)
     {
         $factory = new AnnotationResourceMetadataFactory($reader->reveal(), $decorated ? $decorated->reveal() : null);
         $metadata = $factory->create(Dummy::class);
@@ -62,7 +62,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
 
     public function getCreateDependencies()
     {
-        $annotation = new ApiResource([
+        $resourceData = [
             'shortName' => 'shortName',
             'description' => 'description',
             'iri' => 'http://example.com',
@@ -71,10 +71,11 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
             'subresourceOperations' => ['sub' => ['bus' => false]],
             'attributes' => ['a' => 1, 'route_prefix' => '/foobar'],
             'graphql' => ['foo' => 'bar'],
-        ]);
+        ];
+        $annotationFull = new ApiResource($resourceData);
 
         $reader = $this->prophesize(Reader::class);
-        $reader->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotation)->shouldBeCalled();
+        $reader->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotationFull)->shouldBeCalled();
 
         $decoratedThrow = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedThrow->create(Dummy::class)->willThrow(ResourceClassNotFoundException::class);
@@ -82,10 +83,20 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $decoratedReturn = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedReturn->create(Dummy::class)->willReturn(new ResourceMetadata('hello', 'blabla'))->shouldBeCalled();
 
+        $resourceData['description'] = null;
+        $annotationWithNull = new ApiResource($resourceData);
+
+        $decoratedReturnWithNull = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decoratedReturnWithNull->create(Dummy::class)->willReturn(new ResourceMetadata('hello'))->shouldBeCalled();
+
+        $readerWithNull = $this->prophesize(Reader::class);
+        $readerWithNull->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotationWithNull)->shouldBeCalled();
+
         return [
             [$reader, $decoratedThrow, 'shortName', 'description'],
             [$reader, null, 'shortName', 'description'],
             [$reader, $decoratedReturn, 'hello', 'blabla'],
+            [$readerWithNull, $decoratedReturnWithNull, 'hello', null],
         ];
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT

Fatal error:
```bash
TypeError: Argument 1 passed to ApiPlatform\Core\Metadata\Resource\ResourceMetadata::withDescription() must be of the type string, null given, called in /var/www/vendor/api-platform/core/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php on line 120
```

This was cause when trying to merge two metadata, parent & child ones. By default `ApiPlatform\Core\Annotation\ApiResource` (as well as parent here: `ApiPlatform\Core\Metadata\Resource\ResourceMetadata`) has some of fields marked as default = `null`, when merging right now it's not validated that child has value set, thus due too type-hint it fails with `null` values.

 Dumps (parent + child):
```bash
^ ApiPlatform\Core\Metadata\Resource\ResourceMetadata^ {#9948
  -shortName: "Administrator"
  -description: null
  -iri: null
  -itemOperations: array:3 [
    "get" => []
    "put" => array:1 [
      "denormalization_context" => array:1 [
        "groups" => "admin_user:update"
      ]
    ]
    "delete" => []
  ]
  -collectionOperations: array:2 [
    "get" => []
    "post" => array:1 [
      "validation_groups" => array:2 [
        0 => "sylius"
        1 => "sylius_user_create"
      ]
    ]
  ]
  -subresourceOperations: null
  -graphql: null
  -attributes: array:4 [
    "route_prefix" => "admin"
    "normalization_context" => array:1 [
      "groups" => array:1 [
        0 => "admin_user:read"
      ]
    ]
    "denormalization_context" => array:1 [
      "groups" => array:1 [
        0 => "admin_user:create"
      ]
    ]
    "validation_groups" => "sylius"
  ]
}
```
```bash
ApiPlatform\Core\Annotation\ApiResource^ {#9922
  +collectionOperations: array:2 [
    0 => "get"
    "post" => array:2 [
      "security" => "is_granted('ROLE_ADMIN')"
      "security_message" => "Only admins can add doctors."
    ]
  ]
  +description: null
  +graphql: null
  +iri: null
  +itemOperations: array:2 [
    0 => "get"
    "patch" => array:1 [
      "security" => "is_granted('ROLE_ADMIN') or object == user"
    ]
  ]
  +shortName: null
  +subresourceOperations: null
  -cacheHeaders: null
  -denormalizationContext: null
  -deprecationReason: null
  -elasticsearch: null
  -fetchPartial: null
  -forceEager: null
  -formats: null
  -filters: null
  -hydraContext: null
  -input: null
  -maximumItemsPerPage: null
  -mercure: null
  -messenger: null
  -normalizationContext: null
  -openapiContext: null
  -order: null
  -output: null
  -paginationClientEnabled: null
  -paginationClientItemsPerPage: null
  -paginationClientPartial: null
  -paginationViaCursor: null
  -paginationEnabled: null
  -paginationFetchJoinCollection: null
  -paginationItemsPerPage: null
  -paginationMaximumItemsPerPage: null
  -paginationPartial: null
  -routePrefix: null
  -security: null
  -securityMessage: null
  -securityPostDenormalize: null
  -securityPostDenormalizeMessage: null
  -sunset: null
  -swaggerContext: null
  -validationGroups: null
  +attributes: array:3 [
    "route_prefix" => "%app.security.api_route%"
    "normalization_context" => array:1 [
      "groups" => array:1 [
        0 => "user:read"
      ]
    ]
    "denormalization_context" => array:1 [
      "groups" => array:1 [
        0 => "user:write"
      ]
    ]
  ]
}
```