### PR TITLE
Allow overwriting parent metadata resource informations

### DIFF
--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -107,8 +107,13 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
         $upperProperty = ucfirst($property);
         $getter = "get$upperProperty";
 
-        if (null !== $resourceMetadata->{$getter}()) {
-            return $resourceMetadata;
+        $currentValue = $resourceMetadata->{$getter}();
+        if (null !== $currentValue) {
+            if (null === $value) {
+                $value = $currentValue;
+            } elseif (is_array($currentValue)) {
+                $value = array_merge_recursive($currentValue, $value);
+            }
         }
 
         $wither = "with$upperProperty";

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -34,7 +34,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
     /**
      * @dataProvider getCreateDependencies
      */
-    public function testCreate($reader, $decorated, string $expectedShortName, string $expectedDescription)
+    public function testCreate($reader, $decorated, string $expectedShortName, ?string $expectedDescription)
     {
         $factory = new AnnotationResourceMetadataFactory($reader->reveal(), $decorated ? $decorated->reveal() : null);
         $metadata = $factory->create(Dummy::class);
@@ -62,7 +62,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
 
     public function getCreateDependencies()
     {
-        $annotation = new ApiResource([
+        $resourceData = [
             'shortName' => 'shortName',
             'description' => 'description',
             'iri' => 'http://example.com',
@@ -71,10 +71,11 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
             'subresourceOperations' => ['sub' => ['bus' => false]],
             'attributes' => ['a' => 1, 'route_prefix' => '/foobar'],
             'graphql' => ['foo' => 'bar'],
-        ]);
+        ];
+        $annotationFull = new ApiResource($resourceData);
 
         $reader = $this->prophesize(Reader::class);
-        $reader->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotation)->shouldBeCalled();
+        $reader->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotationFull)->shouldBeCalled();
 
         $decoratedThrow = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedThrow->create(Dummy::class)->willThrow(ResourceClassNotFoundException::class);
@@ -82,10 +83,20 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
         $decoratedReturn = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decoratedReturn->create(Dummy::class)->willReturn(new ResourceMetadata('hello', 'blabla'))->shouldBeCalled();
 
+        $resourceData['description'] = null;
+        $annotationWithNull = new ApiResource($resourceData);
+
+        $decoratedReturnWithNull = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decoratedReturnWithNull->create(Dummy::class)->willReturn(new ResourceMetadata('hello'))->shouldBeCalled();
+
+        $readerWithNull = $this->prophesize(Reader::class);
+        $readerWithNull->getClassAnnotation(Argument::type(\ReflectionClass::class), ApiResource::class)->willReturn($annotationWithNull)->shouldBeCalled();
+
         return [
             [$reader, $decoratedThrow, 'shortName', 'description'],
             [$reader, null, 'shortName', 'description'],
             [$reader, $decoratedReturn, 'hello', 'blabla'],
+            [$readerWithNull, $decoratedReturnWithNull, 'hello', null],
         ];
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes(?)
| New feature?  | yes(?)
| BC breaks?    | no(?)
| Deprecations? | no
| License       | MIT

This is both IMHO bugfix & potentially new feature with BC break (but IMO that BC break is good cause old approach was buggy).

Currently parent resource data is always being selected if set, while child is silently ignored, this changes the approach to allow extending resource change parent data. For example in Sylius predefined resources has `shortName`, but if you extend that model & add own `@ApiResource` it will ignore the setting you try to use **if** it was already set on the extended resource.

If you think it's correct, I will add tests soon to prove the problem & fix.

ps. not sure if this should land in master or be considered as bugfix & go on 2.5...

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
