### PR TITLE
Fixing graphql error when requesting a null array

### DIFF
--- a/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
@@ -60,7 +60,7 @@ final class ItemResolverFactory implements ResolverFactoryInterface
     {
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operationName) {
             // Data already fetched and normalized (field or nested resource)
-            if (isset($source[$info->fieldName])) {
+            if (isset($source[$info->fieldName]) || (\is_array($source) && \array_key_exists($info->fieldName, $source) && null === $source[$info->fieldName] && null === $resourceClass)) {
                 return $source[$info->fieldName];
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3465
| License       | MIT
| Doc PR        | api-platform/docs

This PR fixes graphql error thrown when requesting a property having a null value (notably array).
