### PR TITLE
allow multiple topics mercure

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -253,7 +253,7 @@ final class PublishMercureUpdatesListener
         return $updates;
     }
 
-    private function buildUpdate(string $iri, string $data, array $options): Update
+    private function buildUpdate($iri, string $data, array $options): Update
     {
         if (method_exists(Update::class, 'isPrivate')) {
             return new Update($iri, $data, $options['private'] ?? false, $options['id'] ?? null, $options['type'] ?? null, $options['retry'] ?? null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes ...
| License       | MIT
| Doc PR        | api-platform/docs...

allow multiple topics mercure, the class Update check if $iri is String or Array and after cast as Array. So buildUpdate must not force type String for $iri parameter.

With this change we can set several topics.
