### PR TITLE
Add previous_data to persisters context when available

### DIFF
--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -53,6 +53,10 @@ final class AttributesExtractor
             }
         }
 
+        if ($previousObject = $attributes['previous_data'] ?? null) {
+            $result['previous_data'] = $previousObject;
+        }
+
         if (false === $hasRequestAttributeKey) {
             return [];
         }

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -189,4 +189,22 @@ class RequestAttributesExtractorTest extends TestCase
     {
         $this->assertEmpty(RequestAttributesExtractor::extractAttributes(new Request([], [], ['_api_resource_class' => 'Foo'])));
     }
+
+    public function testExtractPreviousDataAttributes()
+    {
+        $object = new \stdClass();
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', 'previous_data' => $object]);
+
+        $this->assertEquals(
+            [
+                'resource_class' => 'Foo',
+                'item_operation_name' => 'get',
+                'receive' => true,
+                'respond' => true,
+                'persist' => true,
+                'previous_data' => $object,
+            ],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+    }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3751
| License       | MIT
| Doc PR        | 

Expose the previous_data attribute into DataPersisters context.
ref https://github.com/api-platform/core/issues/3751#issuecomment-706753166
