### PR TITLE
[2.5] Fix CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "symfony/http-client": "^4.3 || ^5.0",
         "symfony/mercure-bundle": "*",
         "symfony/messenger": "^4.3 || ^5.0",
-        "symfony/phpunit-bridge": "dev-master",
+        "symfony/phpunit-bridge": "5.x-dev",
         "symfony/routing": "^3.4 || ^4.3 || ^5.0",
         "symfony/security-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/security-core": "^4.3 || ^5.0",


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


Make the 2.5 pipeline green again. That was likely due to the master branch being removed from the symfony/phpunit-bridge