### PR TITLE
Escape search terms before using them in a Regex

### DIFF
--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
@@ -166,20 +166,24 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
     {
         $type = $metadata->getTypeOfField($field);
 
+        if (MongoDbType::STRING !== $type) {
+            return MongoDbType::getType($type)->convertToDatabaseValue($value);
+        }
+
+        $quotedValue = preg_quote($value);
+
         switch ($strategy) {
-            case MongoDbType::STRING !== $type:
-                return MongoDbType::getType($type)->convertToDatabaseValue($value);
             case null:
             case self::STRATEGY_EXACT:
-                return $caseSensitive ? $value : new Regex("^$value$", 'i');
+                return $caseSensitive ? $value : new Regex("^$quotedValue$", 'i');
             case self::STRATEGY_PARTIAL:
-                return new Regex($value, $caseSensitive ? '' : 'i');
+                return new Regex($quotedValue, $caseSensitive ? '' : 'i');
             case self::STRATEGY_START:
-                return new Regex("^$value", $caseSensitive ? '' : 'i');
+                return new Regex("^$quotedValue", $caseSensitive ? '' : 'i');
             case self::STRATEGY_END:
-                return new Regex("$value$", $caseSensitive ? '' : 'i');
+                return new Regex("$quotedValue$", $caseSensitive ? '' : 'i');
             case self::STRATEGY_WORD_START:
-                return new Regex("(^$value.*|.*\s$value.*)", $caseSensitive ? '' : 'i');
+                return new Regex("(^$quotedValue.*|.*\s$quotedValue.*)", $caseSensitive ? '' : 'i');
             default:
                 throw new InvalidArgumentException(sprintf('strategy %s does not exist.', $strategy));
         }

--- a/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -200,6 +200,15 @@ trait SearchFilterTestTrait
                     'name' => 'exact',
                 ],
             ],
+            'exact (case insensitive, with special characters)' => [
+                [
+                    'id' => null,
+                    'name' => 'iexact',
+                ],
+                [
+                    'name' => 'exact (special)',
+                ],
+            ],
             'exact (multiple values)' => [
                 [
                     'id' => null,

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
@@ -305,6 +305,20 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     ],
                     $filterFactory,
                 ],
+                'exact (case insensitive, with special characters)' => [
+                    [
+                        [
+                            '$match' => [
+                                'name' => [
+                                    '$in' => [
+                                        new Regex('^exact \(special\)$', 'i'),
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    $filterFactory,
+                ],
                 'exact (multiple values)' => [
                     [
                         [

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -384,6 +384,11 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     ['name_p1' => 'exact'],
                     $filterFactory,
                 ],
+                'exact (case insensitive, with special characters)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) = LOWER(:name_p1)', $this->alias, Dummy::class),
+                    ['name_p1' => 'exact (special)'],
+                    $filterFactory,
+                ],
                 'exact (multiple values)' => [
                     sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN (:name_p1)', $this->alias, Dummy::class),
                     [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes: search terms no longer need or support explicit escaping, and consequently, regex special characters no longer behave like they're special.
| Deprecations? | no
| Tickets       | Fixes #3754
| License       | MIT
| Doc PR        | N/A