### PR TITLE
Try to fix master pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,9 +765,6 @@ jobs:
           composer remove --dev --no-progress --no-update --ansi \
             doctrine/mongodb-odm \
             doctrine/mongodb-odm-bundle \
-      - name: Require Symfony Uid
-        if: (!startsWith(matrix.php, '7.1'))
-        run: composer require symfony/uid:^5.1 --dev --no-progress --ansi
       - name: Update project dependencies
         run: |
           mkdir -p /tmp/api-platform/core/vendor
@@ -891,8 +888,6 @@ jobs:
         run: |
           composer global require --prefer-dist --no-progress --no-suggest --ansi \
             symfony/flex
-      - name: Require Symfony Uid
-        run: composer require symfony/uid --dev --no-progress --ansi
       - name: Update project dependencies
         run: |
           mkdir -p /tmp/api-platform/core/vendor


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

-
We might want to skip the installation of symfony/uid for legacy tests completely. The rationale behind this is that we can't install this package when the symfony requirement is limited to `^3.4 | ^4.0` only.
