### PR TITLE
Fix openApi when no data provided

### DIFF
--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -29,6 +29,6 @@ final class Paths
 
     public function getPaths(): array
     {
-        return $this->paths;
+        return $this->paths ?? [];
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

![Capture d’écran 2020-10-13 à 22 46 14](https://user-images.githubusercontent.com/47118498/95921722-173ac780-0db2-11eb-9fd0-6b03e0b9c1f1.png)

Found this bug on a brand new Symfony project while trying to check the Open Api documentation while no Entity was created yet with `"api-platform/core": "2.6.x-dev"`
