### PR TITLE
fix OpenApi operation servers/security

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -77,7 +77,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     {
         $baseUrl = $context[self::BASE_URL] ?? '/';
         $info = new Model\Info($this->openApiOptions->getTitle(), $this->openApiOptions->getVersion(), trim($this->openApiOptions->getDescription()));
-        $servers = '/' === $baseUrl || '' === $baseUrl ? [] : [new Model\Server($baseUrl)];
+        $servers = '/' === $baseUrl || '' === $baseUrl ? [new Model\Server('/')] : [new Model\Server($baseUrl)];
         $paths = new Model\Paths();
         $links = [];
         $schemas = [];
@@ -216,8 +216,8 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                 $requestBody,
                 isset($operation['openapi_context']['callbacks']) ? new \ArrayObject($operation['openapi_context']['callbacks']) : null,
                 $operation['openapi_context']['deprecated'] ?? (bool) $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'deprecation_reason', false, true),
-                $operation['openapi_context']['security'] ?? [],
-                $operation['openapi_context']['servers'] ?? []
+                $operation['openapi_context']['security'] ?? null,
+                $operation['openapi_context']['servers'] ?? null
             ));
 
             $paths->addPath($path, $pathItem);

--- a/src/OpenApi/Model/Operation.php
+++ b/src/OpenApi/Model/Operation.php
@@ -30,7 +30,7 @@ final class Operation
     private $servers;
     private $externalDocs;
 
-    public function __construct(string $operationId = null, array $tags = [], array $responses = [], string $summary = '', string $description = '', ExternalDocumentation $externalDocs = null, array $parameters = [], RequestBody $requestBody = null, \ArrayObject $callbacks = null, bool $deprecated = false, array $security = [], array $servers = [])
+    public function __construct(string $operationId = null, array $tags = [], array $responses = [], string $summary = '', string $description = '', ExternalDocumentation $externalDocs = null, array $parameters = [], RequestBody $requestBody = null, \ArrayObject $callbacks = null, bool $deprecated = false, ?array $security = null, ?array $servers = null)
     {
         $this->tags = $tags;
         $this->summary = $summary;
@@ -103,12 +103,12 @@ final class Operation
         return $this->deprecated;
     }
 
-    public function getSecurity(): array
+    public function getSecurity(): ?array
     {
         return $this->security;
     }
 
-    public function getServers(): array
+    public function getServers(): ?array
     {
         return $this->servers;
     }
@@ -193,7 +193,7 @@ final class Operation
         return $clone;
     }
 
-    public function withSecurity(array $security): self
+    public function withSecurity(?array $security = null): self
     {
         $clone = clone $this;
         $clone->security = $security;
@@ -201,7 +201,7 @@ final class Operation
         return $clone;
     }
 
-    public function withServers(array $servers): self
+    public function withServers(?array $servers = null): self
     {
         $clone = clone $this;
         $clone->servers = $servers;

--- a/src/OpenApi/Model/PathItem.php
+++ b/src/OpenApi/Model/PathItem.php
@@ -32,7 +32,7 @@ final class PathItem
     private $servers;
     private $parameters;
 
-    public function __construct(string $ref = null, string $summary = null, string $description = null, Operation $get = null, Operation $put = null, Operation $post = null, Operation $delete = null, Operation $options = null, Operation $head = null, Operation $patch = null, Operation $trace = null, array $servers = [], array $parameters = [])
+    public function __construct(string $ref = null, string $summary = null, string $description = null, Operation $get = null, Operation $put = null, Operation $post = null, Operation $delete = null, Operation $options = null, Operation $head = null, Operation $patch = null, Operation $trace = null, ?array $servers = null, array $parameters = [])
     {
         $this->ref = $ref;
         $this->summary = $summary;
@@ -104,7 +104,7 @@ final class PathItem
         return $this->trace;
     }
 
-    public function getServers(): array
+    public function getServers(): ?array
     {
         return $this->servers;
     }
@@ -202,7 +202,7 @@ final class PathItem
         return $clone;
     }
 
-    public function withServers(array $servers): self
+    public function withServers(?array $servers = null): self
     {
         $clone = clone $this;
         $clone->servers = $servers;

--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -24,7 +24,6 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     public const FORMAT = 'json';
-    public const OPEN_API_PRESERVE_EMPTY_OBJECTS = 'open_api_preserve_empty_objects';
     private const EXTENSION_PROPERTIES_KEY = 'extensionProperties';
 
     private $decorated;

--- a/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
+++ b/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
@@ -68,7 +68,7 @@ class OpenApiNormalizerTest extends TestCase
             ],
             [
                 'get' => ['method' => 'GET'] + self::OPERATION_FORMATS,
-                'post' => ['method' => 'POST'] + self::OPERATION_FORMATS,
+                'post' => ['method' => 'POST', 'openapi_context' => ['security' => [], 'servers' => ['url' => '/test']]] + self::OPERATION_FORMATS,
             ],
             []
         );
@@ -154,5 +154,11 @@ class OpenApiNormalizerTest extends TestCase
         $this->assertArrayNotHasKey('termsOfService', $openApiAsArray['info']);
         $this->assertArrayNotHasKey('paths', $openApiAsArray['paths']);
         $this->assertArrayHasKey('/dummies/{id}', $openApiAsArray['paths']);
+        $this->assertArrayNotHasKey('servers', $openApiAsArray['paths']['/dummies/{id}']['get']);
+        $this->assertArrayNotHasKey('security', $openApiAsArray['paths']['/dummies/{id}']['get']);
+
+        // Security can be disabled per-operation using an empty array
+        $this->assertEquals([], $openApiAsArray['paths']['/dummies']['post']['security']);
+        $this->assertEquals(['url' => '/test'], $openApiAsArray['paths']['/dummies']['post']['servers']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | na
| License       | MIT
| Doc PR        | na

This fixes:
  ~~- ability to normalize OpenApi v3 using `/docs.json`~~ (will be in another patch #3759)
  - removes `servers` on operations when it's empty to fix the swagger-ui bug :
![20201014_10h38m05s_grim](https://user-images.githubusercontent.com/1321971/95967664-cc9a6900-0e0c-11eb-99a4-f11d9fbf8b80.png)
  - Allows to specify `security` as an empty array on an `openapi_context` to remove previously enabled security. 
