### PR TITLE
fix identifiers do not denormalize the same identifier twice

### DIFF
--- a/src/Identifier/IdentifierConverter.php
+++ b/src/Identifier/IdentifierConverter.php
@@ -80,6 +80,7 @@ final class IdentifierConverter implements ContextAwareIdentifierConverterInterf
 
                 try {
                     $identifiers[$key] = $identifierDenormalizer->denormalize($identifiers[$key], $type);
+                    break;
                 } catch (InvalidIdentifierException $e) {
                     throw new InvalidIdentifierException(sprintf('Identifier "%s" could not be denormalized.', $key), $e->getCode(), $e);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | na
| License       | MIT
| Doc PR        | na

Currently the identifier denormalization loops continues when an identifier is denormalized. This causes issues if you want to denormalize an identifier and if it then gets denormalized again.  