### PR TITLE
Configurable asset package

### DIFF
--- a/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -61,11 +61,12 @@ final class SwaggerUiAction
     private $graphQlPlaygroundEnabled;
     private $swaggerVersions;
     private $swaggerUiAction;
+    private $assetPackage;
 
     /**
      * @param int[] $swaggerVersions
      */
-    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, TwigEnvironment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', $formats = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [], bool $showWebby = true, bool $swaggerUiEnabled = false, bool $reDocEnabled = false, bool $graphqlEnabled = false, bool $graphiQlEnabled = false, bool $graphQlPlaygroundEnabled = false, array $swaggerVersions = [2, 3], OpenApiSwaggerUiAction $swaggerUiAction = null)
+    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, TwigEnvironment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', $formats = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [], bool $showWebby = true, bool $swaggerUiEnabled = false, bool $reDocEnabled = false, bool $graphqlEnabled = false, bool $graphiQlEnabled = false, bool $graphQlPlaygroundEnabled = false, array $swaggerVersions = [2, 3], OpenApiSwaggerUiAction $swaggerUiAction = null, $assetPackage = null)
     {
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -91,6 +92,7 @@ final class SwaggerUiAction
         $this->graphQlPlaygroundEnabled = $graphQlPlaygroundEnabled;
         $this->swaggerVersions = $swaggerVersions;
         $this->swaggerUiAction = $swaggerUiAction;
+        $this->assetPackage = $assetPackage;
 
         if (null === $this->swaggerUiAction) {
             @trigger_error(sprintf('The use of "%s" is deprecated since API Platform 2.6, use "%s" instead.', __CLASS__, OpenApiSwaggerUiAction::class), E_USER_DEPRECATED);
@@ -143,6 +145,7 @@ final class SwaggerUiAction
             'graphqlEnabled' => $this->graphqlEnabled,
             'graphiQlEnabled' => $this->graphiQlEnabled,
             'graphQlPlaygroundEnabled' => $this->graphQlPlaygroundEnabled,
+            'assetPackage' => $this->assetPackage,
         ];
 
         $swaggerContext = ['spec_version' => $request->query->getInt('spec_version', $this->swaggerVersions[0] ?? 2)];

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -217,6 +217,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         if ($config['name_converter']) {
             $container->setAlias('api_platform.name_converter', $config['name_converter']);
         }
+        $container->setParameter('api_platform.asset_package', $config['asset_package']);
         $container->setParameter('api_platform.defaults', $this->normalizeDefaults($config['defaults'] ?? []));
     }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -92,6 +92,7 @@ final class Configuration implements ConfigurationInterface
                     ->info('Specify the default operation path resolver to use for generating resources operations path.')
                 ->end()
                 ->scalarNode('name_converter')->defaultNull()->info('Specify a name converter to use.')->end()
+                ->scalarNode('asset_package')->defaultNull()->info('Specify an asset package name to use.')->end()
                 ->scalarNode('path_segment_name_generator')->defaultValue('api_platform.path_segment_name_generator.underscore')->info('Specify a path name generator to use.')->end()
                 ->booleanNode('allow_plain_identifiers')->defaultFalse()->info('Allow plain identifiers, for example "id" instead of "@id" when denormalizing a relation.')->end()
                 ->arrayNode('validator')

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger-ui.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger-ui.xml
@@ -37,6 +37,7 @@
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
             <argument>%api_platform.swagger.versions%</argument>
             <argument type="service" id="api_platform.swagger_ui.action" />
+            <argument>%api_platform.asset_package%</argument>
         </service>
 
         <service id="api_platform.swagger_ui.context" class="ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiContext">
@@ -46,6 +47,7 @@
             <argument>%api_platform.graphql.enabled%</argument>
             <argument>%api_platform.graphql.graphiql.enabled%</argument>
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
+            <argument>%api_platform.asset_package%</argument>
         </service>
 
         <service id="api_platform.swagger_ui.action" class="ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiAction" public="true">

--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -6,11 +6,11 @@
 
     {% block stylesheet %}
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700">
-        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/swagger-ui/swagger-ui.css') }}">
-        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/style.css') }}">
+        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/swagger-ui/swagger-ui.css', assetPackage) }}">
+        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/style.css', assetPackage) }}">
     {% endblock %}
 
-    {% set oauth_data = {'oauth': swagger_data.oauth|merge({'redirectUrl' : absolute_url(asset('bundles/apiplatform/swagger-ui/oauth2-redirect.html')) })} %}
+    {% set oauth_data = {'oauth': swagger_data.oauth|merge({'redirectUrl' : absolute_url(asset('bundles/apiplatform/swagger-ui/oauth2-redirect.html', assetPackage)) })} %}
     {# json_encode(65) is for JSON_UNESCAPED_SLASHES|JSON_HEX_TAG to avoid JS XSS #}
     <script id="swagger-data" type="application/json">{{ swagger_data|merge(oauth_data)|json_encode(65)|raw }}</script>
 </head>
@@ -50,12 +50,12 @@
     </defs>
 </svg>
 <header>
-    <a id="logo" href="https://api-platform.com"><img src="{{ asset('bundles/apiplatform/logo-header.svg') }}" alt="API Platform"></a>
+    <a id="logo" href="https://api-platform.com"><img src="{{ asset('bundles/apiplatform/logo-header.svg', assetPackage) }}" alt="API Platform"></a>
 </header>
 
 {% if showWebby %}
-    <div class="web"><img src="{{ asset('bundles/apiplatform/web.png') }}"></div>
-    <div class="webby"><img src="{{ asset('bundles/apiplatform/webby.png') }}"></div>
+    <div class="web"><img src="{{ asset('bundles/apiplatform/web.png', assetPackage) }}"></div>
+    <div class="webby"><img src="{{ asset('bundles/apiplatform/webby.png', assetPackage) }}"></div>
 {% endif %}
 
 <div id="swagger-ui" class="api-platform"></div>
@@ -82,12 +82,12 @@
 
 {% block javascript %}
     {% if (reDocEnabled and not swaggerUiEnabled) or (reDocEnabled and 're_doc' == active_ui) %}
-        <script src="{{ asset('bundles/apiplatform/redoc/redoc.standalone.js') }}"></script>
-        <script src="{{ asset('bundles/apiplatform/init-redoc-ui.js') }}"></script>
+        <script src="{{ asset('bundles/apiplatform/redoc/redoc.standalone.js', assetPackage) }}"></script>
+        <script src="{{ asset('bundles/apiplatform/init-redoc-ui.js', assetPackage) }}"></script>
     {% else %}
-        <script src="{{ asset('bundles/apiplatform/swagger-ui/swagger-ui-bundle.js') }}"></script>
-        <script src="{{ asset('bundles/apiplatform/swagger-ui/swagger-ui-standalone-preset.js') }}"></script>
-        <script src="{{ asset('bundles/apiplatform/init-swagger-ui.js') }}"></script>
+        <script src="{{ asset('bundles/apiplatform/swagger-ui/swagger-ui-bundle.js', assetPackage) }}"></script>
+        <script src="{{ asset('bundles/apiplatform/swagger-ui/swagger-ui-standalone-preset.js', assetPackage) }}"></script>
+        <script src="{{ asset('bundles/apiplatform/init-swagger-ui.js', assetPackage) }}"></script>
     {% endif %}
 {% endblock %}
 

--- a/src/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
@@ -70,6 +70,7 @@ final class SwaggerUiAction
             'graphqlEnabled' => $this->swaggerUiContext->isGraphQlEnabled(),
             'graphiQlEnabled' => $this->swaggerUiContext->isGraphiQlEnabled(),
             'graphQlPlaygroundEnabled' => $this->swaggerUiContext->isGraphQlPlaygroundEnabled(),
+            'assetPackage' => $this->swaggerUiContext->getAssetPackage(),
         ];
 
         $swaggerData = [

--- a/src/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiContext.php
+++ b/src/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiContext.php
@@ -21,8 +21,9 @@ final class SwaggerUiContext
     private $graphQlEnabled;
     private $graphiQlEnabled;
     private $graphQlPlaygroundEnabled;
+    private $assetPackage;
 
-    public function __construct(bool $swaggerUiEnabled = false, bool $showWebby = true, bool $reDocEnabled = false, bool $graphQlEnabled = false, bool $graphiQlEnabled = false, bool $graphQlPlaygroundEnabled = false)
+    public function __construct(bool $swaggerUiEnabled = false, bool $showWebby = true, bool $reDocEnabled = false, bool $graphQlEnabled = false, bool $graphiQlEnabled = false, bool $graphQlPlaygroundEnabled = false, $assetPackage = null)
     {
         $this->swaggerUiEnabled = $swaggerUiEnabled;
         $this->showWebby = $showWebby;
@@ -30,6 +31,7 @@ final class SwaggerUiContext
         $this->graphQlEnabled = $graphQlEnabled;
         $this->graphiQlEnabled = $graphiQlEnabled;
         $this->graphQlPlaygroundEnabled = $graphQlPlaygroundEnabled;
+        $this->assetPackage = $assetPackage;
     }
 
     public function isSwaggerUiEnabled(): bool
@@ -60,5 +62,10 @@ final class SwaggerUiContext
     public function isGraphQlPlaygroundEnabled(): bool
     {
         return $this->graphQlPlaygroundEnabled;
+    }
+
+    public function getAssetPackage(): ?string
+    {
+        return $this->assetPackage;
     }
 }

--- a/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
+++ b/tests/Bridge/Symfony/Bundle/Action/SwaggerUiActionTest.php
@@ -174,6 +174,7 @@ class SwaggerUiActionTest extends TestCase
             'graphqlEnabled' => false,
             'graphiQlEnabled' => false,
             'graphQlPlaygroundEnabled' => false,
+            'assetPackage' => null,
             'swagger_data' => [
                 'url' => '/url',
                 'spec' => self::SPEC,

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -872,6 +872,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.http_cache.vary' => ['Accept'],
             'api_platform.http_cache.public' => null,
             'api_platform.http_cache.invalidation.max_header_length' => 7500,
+            'api_platform.asset_package' => null,
             'api_platform.defaults' => ['attributes' => ['stateless' => true]],
             'api_platform.enable_entrypoint' => true,
             'api_platform.enable_docs' => true,
@@ -1176,6 +1177,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.resource_class_directories' => Argument::type('array'),
             'api_platform.validator.serialize_payload_fields' => [],
             'api_platform.elasticsearch.enabled' => false,
+            'api_platform.asset_package' => null,
             'api_platform.defaults' => ['attributes' => ['stateless' => true]],
         ];
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -206,6 +206,7 @@ class ConfigurationTest extends TestCase
             ],
             'allow_plain_identifiers' => false,
             'resource_class_directories' => [],
+            'asset_package' => null,
         ], $config);
     }
 

--- a/tests/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiActionTest.php
+++ b/tests/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiActionTest.php
@@ -169,6 +169,7 @@ class SwaggerUiActionTest extends TestCase
             'graphqlEnabled' => false,
             'graphiQlEnabled' => false,
             'graphQlPlaygroundEnabled' => false,
+            'assetPackage' => null,
             'swagger_data' => [
                 'url' => '/url',
                 'spec' => self::SPEC,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3760
| License       | MIT
| Doc PR        | api-platform/docs#1186

This PR introduces a new config parameter: `asset_package`

It enables the users to specify a custom asset package ([as in Symfony framework](https://symfony.com/doc/4.4/reference/configuration/framework.html#packages)) to be used by the Swagger UI template.
In this way, we have more fine-grained control over the asset url generations.

The new parameter is optional with a `null` default value. It results in the same `asset(...)` twig function calls as it was before.

----

Example usage of the new parameter:

```yaml
# config/packages/api_platform.yaml
api_platform:
    asset_package: 'api_platform'
```

and the corresponding symfony framework setup example:

```yaml
# config/packages/framework.yaml
framework:
    # ...
    assets:
        base_path: '/custom_base_path' # the default
        packages:
            api_platform:
                base_path: '/'
```