### PR TITLE
Check for the existence of a getter for the ID

### DIFF
--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -48,10 +48,8 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
             }
         }
 
-        $isInterface = interface_exists($resourceClass);
-
         if (
-            !property_exists($resourceClass, $property) && !$isInterface ||
+            $this->doesIdentifierExist($resourceClass, $property) ||
             null === ($propertyMetadata = $this->extractor->getResources()[$resourceClass]['properties'][$property] ?? null)
         ) {
             return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
@@ -148,5 +146,30 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
         }
 
         return new SubresourceMetadata($resourceClass, $isCollection, $maxDepth);
+    }
+
+
+    /**
+     * @param string $resourceClass
+     * @param string $property
+     *
+     * @return bool
+     */
+    private function doesIdentifierExist(string $resourceClass, string $property): bool
+    {
+        if (interface_exists($resourceClass)) {
+            return false;
+        }
+
+        if (property_exists($resourceClass, $property)) {
+            return true;
+        }
+
+        $getter = 'get' . ucfirst($property);
+        if (method_exists($resourceClass, $getter)) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | tbc (will update if this PR is acceptable)

This is a draft proposal for discussion, before a do the work to update the tests & docs.

I had the requirement to use Value Objects from another package as resources in my API, however because the value object I was using was a wrapper around another class with the ID property, and simply had a getter for that, API didn't like it, as it checks for the existence of the property by that field name, rather than allowing for getters to access it as a virtual ID property.  This PR checks for the existence of a getter method (either `get{Property}()` or `{property}()`) and will use this if available, rather than requiring the actual property exists.

This may have further reaching consequences which I've not come across yet, so I'm open to having to expand on this change to support this, if it's acceptable to make this change to the codebase, so please can you provide feedback on whether you'd like this or not.

If acceptable, I will update the tests and documentation as well.

Still to do, if PR is wanted…

* [ ] Update tests
* [ ] Add PR to add details to docs
* [ ] Update CHANGELOG