### PR TITLE
Slash baseUrl only from IRI beginning

### DIFF
--- a/src/Bridge/Symfony/Routing/Router.php
+++ b/src/Bridge/Symfony/Routing/Router.php
@@ -71,7 +71,10 @@ final class Router implements RouterInterface, UrlGeneratorInterface
     public function match($pathInfo)
     {
         $baseContext = $this->router->getContext();
-        $pathInfo = str_replace($baseContext->getBaseUrl(), '', $pathInfo);
+        $baseUrl = $baseContext->getBaseUrl();
+        if ($baseUrl === substr($pathInfo, 0, \strlen($baseUrl))) {
+            $pathInfo = substr($pathInfo, \strlen($baseUrl));
+        }
 
         $request = Request::create($pathInfo, 'GET', [], [], [], ['HTTP_HOST' => $baseContext->getHost()]);
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3775
| License       | MIT
| Doc PR        | 

I made a comparison before slashing the first baseUrl from IRI as security check, maybe it can be removed. I used substr as it is faster than preg_replace.