### PR TITLE
[DEFAULT ORDER] #1246: Support default order for a specific custom operation

### DIFF
--- a/features/main/default_order.feature
+++ b/features/main/default_order.feature
@@ -117,3 +117,115 @@ Feature: Default order
       }
     }
     """
+
+  Scenario: Override custom order asc
+    When I send a "GET" request to "/custom_collection_asc_foos?itemsPerPage=10"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Foo",
+      "@id": "/foos",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/foos/5",
+          "@type": "Foo",
+          "id": 5,
+          "name": "Balbo",
+          "bar": "Amet"
+        },
+        {
+          "@id": "/foos/3",
+          "@type": "Foo",
+          "id": 3,
+          "name": "Ephesian",
+          "bar": "Dolor"
+        },
+        {
+          "@id": "/foos/1",
+          "@type": "Foo",
+          "id": 1,
+          "name": "Hawsepipe",
+          "bar": "Lorem"
+        },
+        {
+          "@id": "/foos/4",
+          "@type": "Foo",
+          "id": 4,
+          "name": "Separativeness",
+          "bar": "Sit"
+        },
+        {
+          "@id": "/foos/2",
+          "@type": "Foo",
+          "id": 2,
+          "name": "Sthenelus",
+          "bar": "Ipsum"
+        }
+      ],
+      "hydra:totalItems": 5,
+      "hydra:view": {
+        "@id": "/custom_collection_asc_foos?itemsPerPage=10",
+        "@type": "hydra:PartialCollectionView"
+      }
+    }
+    """
+
+  Scenario: Override custom order desc
+    When I send a "GET" request to "/custom_collection_desc_foos?itemsPerPage=10"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Foo",
+      "@id": "/foos",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/foos/2",
+          "@type": "Foo",
+          "id": 2,
+          "name": "Sthenelus",
+          "bar": "Ipsum"
+        },
+        {
+          "@id": "/foos/4",
+          "@type": "Foo",
+          "id": 4,
+          "name": "Separativeness",
+          "bar": "Sit"
+        },
+        {
+          "@id": "/foos/1",
+          "@type": "Foo",
+          "id": 1,
+          "name": "Hawsepipe",
+          "bar": "Lorem"
+        },
+        {
+          "@id": "/foos/3",
+          "@type": "Foo",
+          "id": 3,
+          "name": "Ephesian",
+          "bar": "Dolor"
+        },
+        {
+          "@id": "/foos/5",
+          "@type": "Foo",
+          "id": 5,
+          "name": "Balbo",
+          "bar": "Amet"
+        }
+      ],
+      "hydra:totalItems": 5,
+      "hydra:view": {
+        "@id": "/custom_collection_desc_foos?itemsPerPage=10",
+        "@type": "hydra:PartialCollectionView"
+      }
+    }
+    """

--- a/src/Bridge/Doctrine/MongoDbOdm/Extension/OrderExtension.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Extension/OrderExtension.php
@@ -16,8 +16,8 @@ namespace ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Extension;
 use ApiPlatform\Core\Bridge\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\PropertyHelperTrait as MongoDbOdmPropertyHelperTrait;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * Applies selected ordering while querying resource collection.
@@ -53,7 +53,11 @@ final class OrderExtension implements AggregationCollectionExtensionInterface
         $classMetaData = $this->getClassMetadata($resourceClass);
         $identifiers = $classMetaData->getIdentifier();
         if (null !== $this->resourceMetadataFactory) {
-            $defaultOrder = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('order');
+            $defaultOrder = $this->resourceMetadataFactory->create($resourceClass)
+                   ->getCollectionOperationAttribute($operationName, 'order', [], true);
+            if (empty($defaultOrder)) {
+                $defaultOrder = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('order');
+            }
             if (\is_array($defaultOrder)) {
                 foreach ($defaultOrder as $field => $order) {
                     if (\is_int($field)) {

--- a/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
@@ -51,7 +51,11 @@ final class OrderExtension implements ContextAwareQueryCollectionExtensionInterf
         $classMetaData = $queryBuilder->getEntityManager()->getClassMetadata($resourceClass);
         $identifiers = $classMetaData->getIdentifier();
         if (null !== $this->resourceMetadataFactory) {
-            $defaultOrder = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('order');
+            $defaultOrder = $this->resourceMetadataFactory->create($resourceClass)
+                   ->getCollectionOperationAttribute($operationName, 'order', [], true);
+            if (empty($defaultOrder)) {
+                $defaultOrder = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('order');
+            }
             if (\is_array($defaultOrder)) {
                 foreach ($defaultOrder as $field => $order) {
                     if (\is_int($field)) {

--- a/tests/Fixtures/TestBundle/Document/Foo.php
+++ b/tests/Fixtures/TestBundle/Document/Foo.php
@@ -30,6 +30,11 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  *         "collection_query"={"pagination_enabled"=false},
  *         "create",
  *         "delete"
+ *     },
+ *     collectionOperations={
+ *         "get",
+ *         "get_desc_custom"={"method"="GET", "path"="custom_collection_desc_foos", "order"={"name"="DESC"}},
+ *         "get_asc_custom"={"method"="GET", "path"="custom_collection_asc_foos", "order"={ "name"="ASC"}},
  *     }
  * )
  * @ODM\Document

--- a/tests/Fixtures/TestBundle/Entity/Foo.php
+++ b/tests/Fixtures/TestBundle/Entity/Foo.php
@@ -30,6 +30,11 @@ use Doctrine\ORM\Mapping as ORM;
  *         "collection_query"={"pagination_enabled"=false},
  *         "create",
  *         "delete"
+ *     },
+ *     collectionOperations={
+ *         "get",
+ *         "get_desc_custom"={"method"="GET", "path"="custom_collection_desc_foos", "order"={"name"="DESC"}},
+ *         "get_asc_custom"={"method"="GET", "path"="custom_collection_asc_foos", "order"={ "name"="ASC"}},
  *     }
  * )
  * @ORM\Entity


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       |  #1321
| License       | MIT
| Doc PR        | api-platform/docs#1195

Currently, the `default-order` impact all the defined collection operations, so, it is not possible to have two different custom operations with different `default-order` configurations.

The idea is to support both, the definition of an order in a global way and also in a more specific way.

For example:
```yaml
resources:
    attributes:
        order: ["foo", "ASC"]
    App\Entity\Book:
        collectionOperations:
            get_desc:
               method: GET
               path: /books/desc
               order: ["name", "DESC"]
               normalization_context:
                    groups: ['group1']
            get_asc:
               method: GET
               path: /books/asc
               order: ["name", "ASC"]
               normalization_context:
                    groups: ['group2']
            get_another:
               method: GET
               path: /books/another
               normalization_context:
                    groups: ['group3']
```
* `order: ["name", "DESC"]` will be applied on *get_desc* operation.
* `order: ["name", "ASC"]` will be applied on *get_asc* operation.
* `order: order: ["foo", "ASC"]` will be applied on *get_another* operation.

This will allow to have a parent generic configuration and others more specific child configuration.