### PR TITLE
Allow to search on multiple values on every strategies

### DIFF
--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -272,6 +272,47 @@ Feature: Search filter on collections
     }
     """
 
+  Scenario: Search collection by name (partial multiple values)
+    Given there are 30 dummy objects
+    When I send a "GET" request to "/dummies?name[]=2&name[]=3"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And print last JSON response
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/2$"},
+                  {"pattern": "^/dummies/3$"},
+                  {"pattern": "^/dummies/12$"}
+                ]
+              }
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?name%5B%5D=2&name%5B%5D=3"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
   Scenario: Search collection by name (partial case insensitive)
     When I send a "GET" request to "/dummies?dummy=somedummytest1"
     Then the response status code should be 200
@@ -339,6 +380,45 @@ Feature: Search filter on collections
     }
     """
 
+  Scenario: Search collection by alias (start multiple values)
+    When I send a "GET" request to "/dummies?description[]=Sma&description[]=Not"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/1$"},
+                  {"pattern": "^/dummies/2$"},
+                  {"pattern": "^/dummies/3$"}
+                ]
+              }
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?description%5B%5D=Sma&description%5B%5D=Not"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
   @sqlite
   Scenario: Search collection by description (word_start)
     When I send a "GET" request to "/dummies?description=smart"
@@ -372,6 +452,46 @@ Feature: Search filter on collections
           "type": "object",
           "properties": {
             "@id": {"pattern": "^/dummies\\?description=smart"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  @sqlite
+  Scenario: Search collection by description (word_start multiple values)
+    When I send a "GET" request to "/dummies?description[]=smart&description[]=so"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/1$"},
+                  {"pattern": "^/dummies/2$"},
+                  {"pattern": "^/dummies/3$"}
+                ]
+              }
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/dummies\\?description%5B%5D=smart&description%5B%5D=so"},
             "@type": {"pattern": "^hydra:PartialCollectionView$"}
           }
         }

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -89,7 +89,6 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
             return;
         }
 
-        $caseSensitive = true;
         $metadata = $this->getNestedMetadata($resourceClass, $associations);
 
         if ($metadata->hasField($field)) {
@@ -105,6 +104,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
                 return;
             }
 
+            $caseSensitive = true;
             $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
 
             // prefixing the strategy with i makes it case insensitive
@@ -113,26 +113,9 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
                 $caseSensitive = false;
             }
 
-            if (1 === \count($values)) {
-                $this->addWhereByStrategy($strategy, $queryBuilder, $queryNameGenerator, $alias, $field, $values[0], $caseSensitive);
+            $this->addWhereByStrategy($strategy, $queryBuilder, $queryNameGenerator, $alias, $field, $values, $caseSensitive);
 
-                return;
-            }
-
-            if (self::STRATEGY_EXACT !== $strategy) {
-                $this->logger->notice('Invalid filter ignored', [
-                    'exception' => new InvalidArgumentException(sprintf('"%s" strategy selected for "%s" property, but only "%s" strategy supports multiple values', $strategy, $property, self::STRATEGY_EXACT)),
-                ]);
-
-                return;
-            }
-
-            $wrapCase = $this->createWrapCase($caseSensitive);
-            $valueParameter = $queryNameGenerator->generateParameterName($field);
-
-            $queryBuilder
-                ->andWhere(sprintf($wrapCase('%s.%s').' IN (:%s)', $alias, $field, $valueParameter))
-                ->setParameter($valueParameter, $caseSensitive ? $values : array_map('strtolower', $values));
+            return;
         }
 
         // metadata doesn't have the field, nor an association on the field
@@ -158,23 +141,21 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
             return;
         }
 
-        $association = $field;
-        $valueParameter = $queryNameGenerator->generateParameterName($association);
-        if ($metadata->isCollectionValuedAssociation($association)) {
-            $associationAlias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $alias, $association);
+        $associationAlias = $alias;
+        $associationField = $field;
+        $valueParameter = $queryNameGenerator->generateParameterName($associationField);
+        if ($metadata->isCollectionValuedAssociation($associationField)) {
+            $associationAlias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $alias, $associationField);
             $associationField = $associationFieldIdentifier;
-        } else {
-            $associationAlias = $alias;
-            $associationField = $field;
         }
 
         if (1 === \count($values)) {
             $queryBuilder
-                ->andWhere(sprintf('%s.%s = :%s', $associationAlias, $associationField, $valueParameter))
+                ->andWhere($queryBuilder->expr()->eq($associationAlias.'.'.$associationField, ':'.$valueParameter))
                 ->setParameter($valueParameter, $values[0]);
         } else {
             $queryBuilder
-                ->andWhere(sprintf('%s.%s IN (:%s)', $associationAlias, $associationField, $valueParameter))
+                ->andWhere($queryBuilder->expr()->in($associationAlias.'.'.$associationField, ':'.$valueParameter))
                 ->setParameter($valueParameter, $values);
         }
     }
@@ -184,41 +165,70 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
      *
      * @throws InvalidArgumentException If strategy does not exist
      */
-    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, $value, bool $caseSensitive)
+    protected function addWhereByStrategy(string $strategy, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, $values, bool $caseSensitive)
     {
-        $wrapCase = $this->createWrapCase($caseSensitive);
-        $valueParameter = $queryNameGenerator->generateParameterName($field);
-
-        switch ($strategy) {
-            case null:
-            case self::STRATEGY_EXACT:
-                $queryBuilder
-                    ->andWhere(sprintf($wrapCase('%s.%s').' = '.$wrapCase(':%s'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
-                break;
-            case self::STRATEGY_PARTIAL:
-                $queryBuilder
-                    ->andWhere(sprintf($wrapCase('%s.%s').' LIKE '.$wrapCase('CONCAT(\'%%\', :%s, \'%%\')'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
-                break;
-            case self::STRATEGY_START:
-                $queryBuilder
-                    ->andWhere(sprintf($wrapCase('%s.%s').' LIKE '.$wrapCase('CONCAT(:%s, \'%%\')'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
-                break;
-            case self::STRATEGY_END:
-                $queryBuilder
-                    ->andWhere(sprintf($wrapCase('%s.%s').' LIKE '.$wrapCase('CONCAT(\'%%\', :%s)'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
-                break;
-            case self::STRATEGY_WORD_START:
-                $queryBuilder
-                    ->andWhere(sprintf($wrapCase('%1$s.%2$s').' LIKE '.$wrapCase('CONCAT(:%3$s, \'%%\')').' OR '.$wrapCase('%1$s.%2$s').' LIKE '.$wrapCase('CONCAT(\'%% \', :%3$s, \'%%\')'), $alias, $field, $valueParameter))
-                    ->setParameter($valueParameter, $value);
-                break;
-            default:
-                throw new InvalidArgumentException(sprintf('strategy %s does not exist.', $strategy));
+        if (!\is_array($values)) {
+            $values = [$values];
         }
+
+        $wrapCase = $this->createWrapCase($caseSensitive);
+        $valueParameter = ':'.$queryNameGenerator->generateParameterName($field);
+        $aliasedField = sprintf('%s.%s', $alias, $field);
+
+        if (null == $strategy || self::STRATEGY_EXACT == $strategy) {
+            if (1 == \count($values)) {
+                $queryBuilder
+                    ->andWhere($queryBuilder->expr()->eq($wrapCase($aliasedField), $wrapCase($valueParameter)))
+                    ->setParameter($valueParameter, $values[0]);
+
+                return;
+            }
+
+            $queryBuilder
+                ->andWhere($queryBuilder->expr()->in($wrapCase($aliasedField), $valueParameter))
+                ->setParameter($valueParameter, $caseSensitive ? $values : array_map('strtolower', $values));
+
+            return;
+        }
+
+        $ors = [];
+        $parameters = [];
+        foreach ($values as $key => $value) {
+            $keyValueParameter = sprintf('%s_%s', $valueParameter, $key);
+            $parameters[$caseSensitive ? $value : strtolower($value)] = $keyValueParameter;
+
+            switch ($strategy) {
+                case self::STRATEGY_PARTIAL:
+                    $ors[] = $queryBuilder->expr()->like(
+                        $wrapCase($aliasedField),
+                        $wrapCase((string) $queryBuilder->expr()->concat("'%'", $keyValueParameter, "'%'"))
+                    );
+                    break;
+                case self::STRATEGY_START:
+                    $ors[] = $queryBuilder->expr()->like(
+                        $wrapCase($aliasedField),
+                        $wrapCase((string) $queryBuilder->expr()->concat($keyValueParameter, "'%'"))
+                    );
+                    break;
+                case self::STRATEGY_END:
+                    $ors[] = $queryBuilder->expr()->like(
+                        $wrapCase($aliasedField),
+                        $wrapCase((string) $queryBuilder->expr()->concat("'%'", $keyValueParameter))
+                    );
+                    break;
+                case self::STRATEGY_WORD_START:
+                    $ors[] = $queryBuilder->expr()->orX(
+                        $queryBuilder->expr()->like($wrapCase($aliasedField), $wrapCase((string) $queryBuilder->expr()->concat($keyValueParameter, "'%'"))),
+                        $queryBuilder->expr()->like($wrapCase($aliasedField), $wrapCase((string) $queryBuilder->expr()->concat("'% '", $keyValueParameter, "'%'")))
+                    );
+                    break;
+                default:
+                    throw new InvalidArgumentException(sprintf('strategy %s does not exist.', $strategy));
+            }
+        }
+
+        $queryBuilder->andWhere($queryBuilder->expr()->orX(...$ors));
+        array_walk($parameters, [$queryBuilder, 'setParameter']);
     }
 
     /**

--- a/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -264,6 +264,30 @@ trait SearchFilterTestTrait
                     'name' => 'partial',
                 ],
             ],
+            'partial (multiple values)' => [
+                [
+                    'id' => null,
+                    'name' => 'partial',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'SENSitive',
+                    ],
+                ],
+            ],
+            'partial (multiple values; case insensitive)' => [
+                [
+                    'id' => null,
+                    'name' => 'ipartial',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'inSENSitive',
+                    ],
+                ],
+            ],
             'start' => [
                 [
                     'id' => null,
@@ -280,6 +304,30 @@ trait SearchFilterTestTrait
                 ],
                 [
                     'name' => 'partial',
+                ],
+            ],
+            'start (multiple values)' => [
+                [
+                    'id' => null,
+                    'name' => 'start',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'SENSitive',
+                    ],
+                ],
+            ],
+            'start (multiple values; case insensitive)' => [
+                [
+                    'id' => null,
+                    'name' => 'istart',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'inSENSitive',
+                    ],
                 ],
             ],
             'end' => [
@@ -300,6 +348,30 @@ trait SearchFilterTestTrait
                     'name' => 'partial',
                 ],
             ],
+            'end (multiple values)' => [
+                [
+                    'id' => null,
+                    'name' => 'end',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'SENSitive',
+                    ],
+                ],
+            ],
+            'end (multiple values; case insensitive)' => [
+                [
+                    'id' => null,
+                    'name' => 'iend',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'inSENSitive',
+                    ],
+                ],
+            ],
             'word_start' => [
                 [
                     'id' => null,
@@ -316,6 +388,30 @@ trait SearchFilterTestTrait
                 ],
                 [
                     'name' => 'partial',
+                ],
+            ],
+            'word_start (multiple values)' => [
+                [
+                    'id' => null,
+                    'name' => 'word_start',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'SENSitive',
+                    ],
+                ],
+            ],
+            'word_start (multiple values; case insensitive)' => [
+                [
+                    'id' => null,
+                    'name' => 'iword_start',
+                ],
+                [
+                    'name' => [
+                        'CaSE',
+                        'inSENSitive',
+                    ],
                 ],
             ],
             'invalid value for relation' => [

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -385,7 +385,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'exact (multiple values)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN (:name_p1)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN(:name_p1)', $this->alias, Dummy::class),
                     [
                         'name_p1' => [
                             'CaSE',
@@ -395,7 +395,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'exact (multiple values; case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) IN (:name_p1)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) IN(:name_p1)', $this->alias, Dummy::class),
                     [
                         'name_p1' => [
                             'case',
@@ -415,43 +415,107 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'partial' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1, \'%%\')', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0, \'%%\')', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'partial (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1, \'%%\'))', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\'))', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
+                    $filterFactory,
+                ],
+                'partial (multiple values)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%%\', :name_p1_1, \'%%\')', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'CaSE',
+                        'name_p1_1' => 'SENSitive',
+                    ],
+                    $filterFactory,
+                ],
+                'partial (multiple values; case insensitive)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'case',
+                        'name_p1_1' => 'insensitive',
+                    ],
                     $filterFactory,
                 ],
                 'start' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1, \'%%\')', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\')', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'start (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1, \'%%\'))', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\'))', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
+                    $filterFactory,
+                ],
+                'start (multiple values)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(:name_p1_1, \'%%\')', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'CaSE',
+                        'name_p1_1' => 'SENSitive',
+                    ],
+                    $filterFactory,
+                ],
+                'start (multiple values; case insensitive)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'case',
+                        'name_p1_1' => 'insensitive',
+                    ],
                     $filterFactory,
                 ],
                 'end' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1)', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0)', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'end (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1))', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0))', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
+                    $filterFactory,
+                ],
+                'end (multiple values)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0) OR %1$s.name LIKE CONCAT(\'%%\', :name_p1_1)', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'CaSE',
+                        'name_p1_1' => 'SENSitive',
+                    ],
+                    $filterFactory,
+                ],
+                'end (multiple values; case insensitive)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0)) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1))', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'case',
+                        'name_p1_1' => 'insensitive',
+                    ],
                     $filterFactory,
                 ],
                 'word_start' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1, \'%%\')', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_0, \'%%\')', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'word_start (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1, \'%%\'))', $this->alias, Dummy::class),
-                    ['name_p1' => 'partial'],
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_0, \'%%\'))', $this->alias, Dummy::class),
+                    ['name_p1_0' => 'partial'],
+                    $filterFactory,
+                ],
+                'word_start (multiple values)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE (%1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_0, \'%%\')) OR (%1$s.name LIKE CONCAT(:name_p1_1, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'CaSE',
+                        'name_p1_1' => 'SENSitive',
+                    ],
+                    $filterFactory,
+                ],
+                'word_start (multiple values; case insensitive)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE (LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_0, \'%%\'))) OR (LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_1, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_1, \'%%\')))', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'case',
+                        'name_p1_1' => 'insensitive',
+                    ],
                     $filterFactory,
                 ],
                 'invalid value for relation' => [
@@ -478,7 +542,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'mixed IRI and entity ID values for relations' => [
-                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummies relatedDummies_a1 WHERE %1$s.relatedDummy IN (:relatedDummy_p1) AND relatedDummies_a1.id = :relatedDummies_p2', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummies relatedDummies_a1 WHERE %1$s.relatedDummy IN(:relatedDummy_p1) AND relatedDummies_a1.id = :relatedDummies_p2', $this->alias, Dummy::class),
                     [
                         'relatedDummy_p1' => [1, 2],
                         'relatedDummies_p2' => 1,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3782
| License       | MIT

**Description**  
For now the SearchFilter accept many values only with the "exact" strategy: https://github.com/api-platform/core/blob/master/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php#L122
This is a limitation and we could make it possible to search partially many values.

With many values, the exact strategy adds a WHERE IN clause. 
Doing the same for the partial, start, end and word_start we could add LIKE OK LIKE [...] clause.

**Example**  

```php
/**
 * @ApiFilter(SearchFilter::class, properties={"email": "partial"})
 */
class Contact 
{
    private $email;
}
```

```yaml
Contact:
    john:
        email: "john@company.com"
    jane:
        email: "jane@ext-company.com"
```

Requesting `/contacts?email[]=@company.com&email[]=@ext-company.com` would return john and jane.

**Todo:**
 - [ ] Update CHANGELOG.md file if this is validated
