### PR TITLE
Search Filter: Allow aliasing of properties, allow explicit strategy selection

### DIFF
--- a/src/Bridge/Doctrine/Common/Filter/SearchFilterInterface.php
+++ b/src/Bridge/Doctrine/Common/Filter/SearchFilterInterface.php
@@ -45,4 +45,33 @@ interface SearchFilterInterface
      * @var string Finds fields that are starting with the word
      */
     public const STRATEGY_WORD_START = 'word_start';
+
+    /**
+     * All avaliable strategies.
+     */
+    public const STRATEGIES = [
+        self::STRATEGY_EXACT,
+        self::STRATEGY_PARTIAL,
+        self::STRATEGY_START,
+        self::STRATEGY_END,
+        self::STRATEGY_WORD_START,
+        'i'.self::STRATEGY_EXACT,
+        'i'.self::STRATEGY_PARTIAL,
+        'i'.self::STRATEGY_START,
+        'i'.self::STRATEGY_END,
+        'i'.self::STRATEGY_WORD_START,
+    ];
+
+    public const STRATEGIES_MAP = [
+        self::STRATEGY_EXACT => true,
+        self::STRATEGY_PARTIAL => true,
+        self::STRATEGY_START => true,
+        self::STRATEGY_END => true,
+        self::STRATEGY_WORD_START => true,
+        'i'.self::STRATEGY_EXACT => true,
+        'i'.self::STRATEGY_PARTIAL => true,
+        'i'.self::STRATEGY_START => true,
+        'i'.self::STRATEGY_END => true,
+        'i'.self::STRATEGY_WORD_START => true,
+    ];
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no (should we add them?)
| Tickets       | fixes #2310, fixes #3606, fixes #2351
| License       | MIT
| Doc PR        | TODO

**Note: This PR is still WIP, I've submitted it to discuss it while I'm working on it**

**TODO:**
- [ ] Documentation
- [ ] Extend changes to MongoDB SearchFilter

This PR adds 2 new features to the standard SearchFilter, while keeping backwards compatibilty.

## Feature 1: Property aliasing
The name used in the query param is now decoupled from the actual resource property name, this allows to define aliases for nested properties as well. I've used the syntax described here (https://github.com/api-platform/core/issues/3606)

Example:
```php

@ApiFilter(SearchFilter::class, properties: {
  "aliasedName" : {"property": "name", "defaultStrategy": "exact"},
  "aliasedNestedProperty" : {"property": "relatedDummy.name", "defaultStrategy": "exact"},
})
class Dummy() {
    /**
     * @ORM\Column
     */
    private $name;
    /**
     * @var RelatedDummy A related dummy
     * @ORM\ManyToOne(targetEntity="RelatedDummy")
     */
    public $relatedDummy;
}
```
If no `property` is defined, the filter assumes that the key in the properties array corresponds to the actual property name.
If no strategy is defined (`defaultStrategy` key), `exact` is assumed.
I used `defaultStrategy` instead of `strategy` because of feature2 (see below).

With this, users can do the following:

`GET /api/dummies?aliasedName=test`
This performs exact match with the property `name`

`GET /api/dummies?aliasedNestedProperty=test`
This performs exact match with the property `relatedDummy.name`

Old SearchFilter definitions in the form ```"<property>": "<strategy>"```  correspond to the following new definition 
```<property>: {"property": "<property>", "defaultStrategy": "<strategy>"}```

## Feature 2: Explicit strategy request
Using the same entity definition as before, developers can now do the following:

`GET /api/dummies?aliasedName=test`
This performs exact match with the property `name`

`GET /api/dummies?aliasedName[partial]=test`
This performs partial match with the property `name`

And so on for `start`, `end`, `word_start` and their case insensitive versions. I've used the syntax proposed in #2351 which seemed good to me.
If no strategy is provided explicitly, the `defaultStrategy` is used.

## Testing
I've added ~10 tests to test for both aliasing and explicit strategy selection. I've also kept all previous tests on the SearchFilter.

## Points of discussion

* Does this seem like a good improvement for the SearchFilter functionality? By looking at #2351 it seemed to me that some work could be done on the filter. If you think 
* Should we deprecate the old SearchFilter properties syntax?
* Should this be expanded to the ODM version of the Search Filter?
* I'm seeing some issues related to automated tests. More precisely, several tests are failing at `Require Symfony UID` with `Cannot update only a partial set of packages without a lock file present.` which seems unrelated to my changes, do you have any idea into how I could fix this? Thanks.

Let me know your thoughts!