### PR TITLE
Use serialized_name in Swagger UI Links section

### DIFF
--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -61,6 +61,11 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
             return $propertyMetadata;
         }
 
+        $serializerMetadataAttributes = $this->serializerClassMetadataFactory->getMetadataFor($resourceClass)->getAttributesMetadata();
+        if (!empty($serializerMetadataAttributes[$property]) && null !== ($serializedName = $serializerMetadataAttributes[$property]->getSerializedName())) {
+            $propertyMetadata = $propertyMetadata->withSerializedName($serializedName);
+        }
+
         $propertyMetadata = $this->transformReadWrite($propertyMetadata, $resourceClass, $property, $normalizationGroups, $denormalizationGroups);
 
         return $this->transformLinkStatus($propertyMetadata, $normalizationGroups, $denormalizationGroups);

--- a/src/Metadata/Property/PropertyMetadata.php
+++ b/src/Metadata/Property/PropertyMetadata.php
@@ -35,8 +35,9 @@ final class PropertyMetadata
     private $attributes;
     private $subresource;
     private $initializable;
+    private $serializedName;
 
-    public function __construct(Type $type = null, string $description = null, bool $readable = null, bool $writable = null, bool $readableLink = null, bool $writableLink = null, bool $required = null, bool $identifier = null, string $iri = null, $childInherited = null, array $attributes = null, SubresourceMetadata $subresource = null, bool $initializable = null)
+    public function __construct(Type $type = null, string $description = null, bool $readable = null, bool $writable = null, bool $readableLink = null, bool $writableLink = null, bool $required = null, bool $identifier = null, string $iri = null, $childInherited = null, array $attributes = null, SubresourceMetadata $subresource = null, bool $initializable = null, string $serializedName = null)
     {
         $this->type = $type;
         $this->description = $description;
@@ -51,6 +52,7 @@ final class PropertyMetadata
         $this->attributes = $attributes;
         $this->subresource = $subresource;
         $this->initializable = $initializable;
+        $this->serializedName = $serializedName;
     }
 
     /**
@@ -340,6 +342,25 @@ final class PropertyMetadata
     {
         $metadata = clone $this;
         $metadata->initializable = $initializable;
+
+        return $metadata;
+    }
+
+    /**
+     * Gets custom serialized name of this property.
+     */
+    public function getSerializedName(): ?string
+    {
+        return $this->serializedName;
+    }
+
+    /**
+     * Returns a new instance with the given serialized name.
+     */
+    public function withSerializedName(string $serializedName = null): self
+    {
+        $metadata = clone $this;
+        $metadata->serializedName = $serializedName;
 
         return $metadata;
     }

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -793,6 +793,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
                 continue;
             }
 
+            $propertyName = $propertyMetadata->getSerializedName() ?? $propertyName;
             $linkObject['parameters'][$propertyName] = sprintf('$response.body#/%s', $propertyName);
             $identifiers[] = $propertyName;
         }
@@ -801,7 +802,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             return [];
         }
         $linkObject['operationId'] = $operationId;
-        $linkObject['description'] = 1 === \count($identifiers) ? sprintf('The `%1$s` value returned in the response can be used as the `%1$s` parameter in `GET %2$s`.', $identifiers[0], $path) : sprintf('The values returned in the response can be used in `GET %s`.', $path);
+        $linkObject['description'] = 1 === \count($identifiers) ? sprintf('The `%1$s` value returned in the response can be used as the `id` parameter in `GET %2$s`.', $identifiers[0], $path) : sprintf('The values returned in the response can be used in `GET %s`.', $path);
 
         return $linkObject;
     }

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -802,7 +802,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             return [];
         }
         $linkObject['operationId'] = $operationId;
-        $linkObject['description'] = 1 === \count($identifiers) ? sprintf('The `%1$s` value returned in the response can be used as the `id` parameter in `GET %2$s`.', $identifiers[0], $path) : sprintf('The values returned in the response can be used in `GET %s`.', $path);
+        $linkObject['description'] = 1 === \count($identifiers) ? sprintf('The `%1$s` value returned in the response can be used as the `%1$s` parameter in `GET %2$s`.', $identifiers[0], $path) : sprintf('The values returned in the response can be used in `GET %s`.', $path);
 
         return $linkObject;
     }

--- a/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
@@ -83,6 +83,9 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $dummySerializerClassMetadata->addAttributeMetadata($relatedDummySerializerAttributeMetadata);
         $nameConvertedSerializerAttributeMetadata = new SerializerAttributeMetadata('nameConverted');
         $dummySerializerClassMetadata->addAttributeMetadata($nameConvertedSerializerAttributeMetadata);
+        $nameSerializedSerializerAttributeMetadata = new SerializerAttributeMetadata('nameSerialized');
+        $nameSerializedSerializerAttributeMetadata->setSerializedName('name_serialized');
+        $dummySerializerClassMetadata->addAttributeMetadata($nameSerializedSerializerAttributeMetadata);
         $serializerClassMetadataFactoryProphecy->getMetadataFor(Dummy::class)->willReturn($dummySerializerClassMetadata);
         $relatedDummySerializerClassMetadata = new SerializerClassMetadata(RelatedDummy::class);
         $idSerializerAttributeMetadata = new SerializerAttributeMetadata('id');
@@ -105,6 +108,9 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $nameConvertedPropertyMetadata = (new PropertyMetadata())
             ->withType(new Type(Type::BUILTIN_TYPE_STRING, true));
         $decoratedProphecy->create(Dummy::class, 'nameConverted', [])->willReturn($nameConvertedPropertyMetadata);
+        $nameSerializedPropertyMetadata = (new PropertyMetadata())
+            ->withType(new Type(Type::BUILTIN_TYPE_STRING, true));
+        $decoratedProphecy->create(Dummy::class, 'nameSerialized', [])->willReturn($nameSerializedPropertyMetadata);
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
@@ -116,6 +122,7 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $actual[] = $serializerPropertyMetadataFactory->create(Dummy::class, 'foo');
         $actual[] = $serializerPropertyMetadataFactory->create(Dummy::class, 'relatedDummy');
         $actual[] = $serializerPropertyMetadataFactory->create(Dummy::class, 'nameConverted');
+        $actual[] = $serializerPropertyMetadataFactory->create(Dummy::class, 'nameSerialized');
 
         $this->assertInstanceOf(PropertyMetadata::class, $actual[0]);
         $this->assertFalse($actual[0]->isReadable());
@@ -130,6 +137,9 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $this->assertInstanceOf(PropertyMetadata::class, $actual[2]);
         $this->assertFalse($actual[2]->isReadable());
         $this->assertFalse($actual[2]->isWritable());
+
+        $this->assertInstanceOf(PropertyMetadata::class, $actual[3]);
+        $this->assertEquals($actual[3]->getSerializedName(), 'name_serialized');
     }
 
     public function groupsProvider(): array

--- a/tests/Metadata/Property/PropertyMetadataTest.php
+++ b/tests/Metadata/Property/PropertyMetadataTest.php
@@ -82,6 +82,10 @@ class PropertyMetadataTest extends TestCase
         $newMetadata = $metadata->withInitializable(true);
         $this->assertNotSame($metadata, $newMetadata);
         $this->assertTrue($newMetadata->isInitializable());
+
+        $newMetadata = $metadata->withSerializedName('foo');
+        $this->assertNotSame($metadata, $newMetadata);
+        $this->assertEquals('foo', $newMetadata->getSerializedName());
     }
 
     public function testShouldReturnRequiredFalseWhenRequiredTrueIsSetButMaskedByWritableFalse()

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -3218,7 +3218,7 @@ class DocumentationNormalizerV3Test extends TestCase
                                     'GetDummyItem' => [
                                         'operationId' => 'getDummyItem',
                                         'parameters' => ['code' => '$response.body#/code'],
-                                        'description' => 'The `code` value returned in the response can be used as the `id` parameter in `GET /dummies/{id}`.',
+                                        'description' => 'The `code` value returned in the response can be used as the `code` parameter in `GET /dummies/{id}`.',
                                     ],
                                 ],
                             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3788 
| License       | MIT
| Doc PR        |

Show [custom serialized_name](https://symfony.com/blog/new-in-symfony-4-2-simpler-custom-serialized-names) if set from Resource attributes in Swagger UI Links section instead original Resource property.