### PR TITLE
Allow method/property to return false

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -136,9 +136,6 @@ final class PublishMercureUpdatesListener
         }
 
         $options = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('mercure', false);
-        if (false === $options) {
-            return;
-        }
 
         if (\is_string($options)) {
             if (null === $this->expressionLanguage) {
@@ -146,6 +143,10 @@ final class PublishMercureUpdatesListener
             }
 
             $options = $this->expressionLanguage->evaluate($options, ['object' => $entity]);
+        }
+
+        if (false === $options) {
+            return;
         }
 
         if (true === $options) {


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes<!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3681
| License       | MIT
| Doc PR        | api-platform/docs#...

When using a method or property (like [this example](https://api-platform.com/docs/core/mercure/#dispatching-private-updates-authorized-mode) from the documentation) you can't return `false` right now.

Currently, this example:
```
<?php
// api/src/Entity/Book.php

namespace App\Entity;

use ApiPlatform\Core\Annotation\ApiResource;
use Doctrine\ORM\Mapping as ORM;
/**
 * @ApiResource(mercure="object.mercureOptions()")
 */
class Book
{
    /**
     * @ORM\Column(type="string")
     */
    private $foo;

    public function mercureOptions()
    {
        if ($this->foo !== 'bar') {
            return false;
        }

        return ['private' => false];
    }

```

will give an error message:
> The value of the "mercure" attribute of the "Book" resource class must be a boolean, an array of options or an expression returning this array, "boolean" given.'

This 'must be boolean (..), "boolean" given' is very confusing.

With this PR, this example will work.