### PR TITLE
Lazy load remaining commands

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/OpenApiCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/OpenApiCommand.php
@@ -29,6 +29,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class OpenApiCommand extends Command
 {
+    protected static $defaultName = 'api:openapi:export';
+
     private $openApiFactory;
     private $normalizer;
 
@@ -45,7 +47,6 @@ final class OpenApiCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('api:openapi:export')
             ->setDescription('Dump the Open API documentation')
             ->addOption('yaml', 'y', InputOption::VALUE_NONE, 'Dump the documentation in YAML')
             ->addOption('output', 'o', InputOption::VALUE_OPTIONAL, 'Write output to file')

--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -33,6 +33,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class SwaggerCommand extends Command
 {
+    protected static $defaultName = 'api:swagger:export';
+
     private $normalizer;
     private $resourceNameCollectionFactory;
     private $apiTitle;
@@ -67,7 +69,6 @@ final class SwaggerCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('api:swagger:export')
             ->setDescription('Dump the Swagger v2 documentation')
             ->addOption('yaml', 'y', InputOption::VALUE_NONE, 'Dump the documentation in YAML')
             ->addOption('spec-version', null, InputOption::VALUE_OPTIONAL, sprintf('OpenAPI version to use (%s)', implode(' or ', $this->swaggerVersions)), $this->swaggerVersions[0] ?? 2)


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/c
| License       | MIT
| Doc PR        | n/c

Some commands are already lazy loaded, but when profiling a command execution using Blackfire, I found this.