### PR TITLE
[JSON Schema] Add base Hydra properties to collection items definition

### DIFF
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -31,10 +31,12 @@ final class SchemaFactory implements SchemaFactoryInterface
         'type' => 'string',
     ];
     private const BASE_PROPS = [
-        '@context' => self::BASE_PROP,
         '@id' => self::BASE_PROP,
         '@type' => self::BASE_PROP,
     ];
+    private const BASE_ROOT_PROPS = [
+        '@context' => self::BASE_PROP,
+    ] + self::BASE_PROPS;
 
     private $schemaFactory;
 
@@ -59,9 +61,12 @@ final class SchemaFactory implements SchemaFactoryInterface
 
         $definitions = $schema->getDefinitions();
         if ($key = $schema->getRootDefinitionKey()) {
-            $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
+            $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);
 
             return $schema;
+        }
+        if ($key = $schema->getItemsDefinitionKey()) {
+            $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
         }
 
         if (($schema['type'] ?? '') === 'array') {

--- a/src/JsonSchema/Schema.php
+++ b/src/JsonSchema/Schema.php
@@ -100,11 +100,20 @@ final class Schema extends \ArrayObject
             return null;
         }
 
-        // strlen('#/definitions/') = 14
-        // strlen('#/components/schemas/') = 21
-        $prefix = self::VERSION_OPENAPI === $this->version ? 21 : 14;
+        return $this->removeDefinitionKeyPrefix($this['$ref']);
+    }
 
-        return substr($this['$ref'], $prefix);
+    /**
+     * Returns the name of the items definition, if defined.
+     */
+    public function getItemsDefinitionKey(): ?string
+    {
+        $ref = $this['items']['$ref'] ?? null;
+        if (null === $ref) {
+            return null;
+        }
+
+        return $this->removeDefinitionKeyPrefix($ref);
     }
 
     /**
@@ -113,5 +122,14 @@ final class Schema extends \ArrayObject
     public function isDefined(): bool
     {
         return isset($this['$ref']) || isset($this['type']);
+    }
+
+    private function removeDefinitionKeyPrefix(string $definitionKey): string
+    {
+        // strlen('#/definitions/') = 14
+        // strlen('#/components/schemas/') = 21
+        $prefix = self::VERSION_OPENAPI === $this->version ? 21 : 14;
+
+        return substr($definitionKey, $prefix);
     }
 }

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -77,6 +77,10 @@ class SchemaFactoryTest extends TestCase
         $this->assertEquals(Dummy::class.':jsonld', $rootDefinitionKey);
         $this->assertArrayHasKey($rootDefinitionKey, $definitions);
         $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
+        $properties = $resultSchema['definitions'][$rootDefinitionKey]['properties'];
+        $this->assertArrayHasKey('@context', $properties);
+        $this->assertArrayHasKey('@type', $properties);
+        $this->assertArrayHasKey('@id', $properties);
     }
 
     public function testSchemaTypeBuildSchema(): void
@@ -89,6 +93,10 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('hydra:totalItems', $resultSchema['properties']);
         $this->assertArrayHasKey('hydra:view', $resultSchema['properties']);
         $this->assertArrayHasKey('hydra:search', $resultSchema['properties']);
+        $properties = $resultSchema['definitions'][Dummy::class.':jsonld']['properties'];
+        $this->assertArrayNotHasKey('@context', $properties);
+        $this->assertArrayHasKey('@type', $properties);
+        $this->assertArrayHasKey('@id', $properties);
 
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, null, null, null, true);
 
@@ -98,5 +106,9 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('hydra:totalItems', $resultSchema['properties']);
         $this->assertArrayHasKey('hydra:view', $resultSchema['properties']);
         $this->assertArrayHasKey('hydra:search', $resultSchema['properties']);
+        $properties = $resultSchema['definitions'][Dummy::class.':jsonld']['properties'];
+        $this->assertArrayNotHasKey('@context', $properties);
+        $this->assertArrayHasKey('@type', $properties);
+        $this->assertArrayHasKey('@id', $properties);
     }
 }

--- a/tests/JsonSchema/SchemaTest.php
+++ b/tests/JsonSchema/SchemaTest.php
@@ -31,6 +31,19 @@ class SchemaTest extends TestCase
         $this->assertSame('Foo', $schema->getRootDefinitionKey());
     }
 
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testCollectionJsonSchemaVersion(string $version, string $ref): void
+    {
+        $schema = new Schema($version);
+        $schema['items']['$ref'] = $ref;
+
+        $this->assertInstanceOf(\ArrayObject::class, $schema);
+        $this->assertSame($version, $schema->getVersion());
+        $this->assertSame('Foo', $schema->getItemsDefinitionKey());
+    }
+
     public function versionProvider(): iterable
     {
         yield [Schema::VERSION_JSON_SCHEMA, '#/definitions/Foo'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR is part of a set of PR whose purpose is to make the assertions `assertMatchesResourceItemJsonSchema` and `assertMatchesResourceCollectionJsonSchema` work correctly.
The PR are:
- https://github.com/api-platform/core/pull/3803 (this one)
- https://github.com/api-platform/core/pull/3804
- https://github.com/api-platform/core/pull/3806
- https://github.com/api-platform/core/pull/3807

It adds the base Hydra properties (`@id`, `@type`) to collection items definition in the JSON Schema.

Before:
```json
{
   "$schema":"http:\/\/json-schema.org\/draft-07\/schema#",
   "type":"object",
   "definitions":{
      "Application:jsonld":{
         "type":"object",
         "description":"",
         "properties":{
            "id":{
               "readOnly":true,
               "type":"integer"
            },
            "name":{
               "type":"string"
            }
         }
      }
   },
   "properties":{
      "hydra:member":{
         "type":"array",
         "items":{
            "$ref":"#\/definitions\/Application:jsonld"
         }
      },
      "hydra:totalItems":{
         "type":"integer",
         "minimum":0
      },
      "hydra:view":{
         "type":"object",
         "properties":{
            "@id":{
               "type":"string",
               "format":"iri-reference"
            },
            "@type":{
               "type":"string"
            },
            "hydra:first":{
               "type":"string",
               "format":"iri-reference"
            },
            "hydra:last":{
               "type":"string",
               "format":"iri-reference"
            },
            "hydra:next":{
               "type":"string",
               "format":"iri-reference"
            }
         }
      },
      "hydra:search":{
         "type":"object",
         "properties":{
            "@type":{
               "type":"string"
            },
            "hydra:template":{
               "type":"string"
            },
            "hydra:variableRepresentation":{
               "type":"string"
            },
            "hydra:mapping":{
               "type":"array",
               "items":{
                  "type":"object",
                  "properties":{
                     "@type":{
                        "type":"string"
                     },
                     "variable":{
                        "type":"string"
                     },
                     "property":{
                        "type":"string"
                     },
                     "required":{
                        "type":"boolean"
                     }
                  }
               }
            }
         }
      }
   },
   "required":[
      "hydra:member"
   ]
}
```

After:
```json
{
   "$schema":"http:\/\/json-schema.org\/draft-07\/schema#",
   "type":"object",
   "definitions":{
      "Application:jsonld":{
         "type":"object",
         "description":"",
         "properties":{
            "@id":{
               "readOnly":true,
               "type":"string"
            },
            "@type":{
               "readOnly":true,
               "type":"string"
            },
            "id":{
               "readOnly":true,
               "type":"integer"
            },
            "name":{
               "type":"string"
            }
         }
      }
   },
   "properties":{
      "hydra:member":{
         "type":"array",
         "items":{
            "$ref":"#\/definitions\/Application:jsonld"
         }
      },
      "hydra:totalItems":{
         "type":"integer",
         "minimum":0
      },
      "hydra:view":{
         "type":"object",
         "properties":{
            "@id":{
               "type":"string",
               "format":"iri-reference"
            },
            "@type":{
               "type":"string"
            },
            "hydra:first":{
               "type":"string",
               "format":"iri-reference"
            },
            "hydra:last":{
               "type":"string",
               "format":"iri-reference"
            },
            "hydra:next":{
               "type":"string",
               "format":"iri-reference"
            }
         }
      },
      "hydra:search":{
         "type":"object",
         "properties":{
            "@type":{
               "type":"string"
            },
            "hydra:template":{
               "type":"string"
            },
            "hydra:variableRepresentation":{
               "type":"string"
            },
            "hydra:mapping":{
               "type":"array",
               "items":{
                  "type":"object",
                  "properties":{
                     "@type":{
                        "type":"string"
                     },
                     "variable":{
                        "type":"string"
                     },
                     "property":{
                        "type":"string"
                     },
                     "required":{
                        "type":"boolean"
                     }
                  }
               }
            }
         }
      }
   },
   "required":[
      "hydra:member"
   ]
}
```