### PR TITLE
[JSON Schema] Add `additionalProperties` (false) to the generated JSON schema

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -96,13 +96,7 @@ parameters:
 			path: tests/GraphQl/Type/TypesContainerTest.php
 		# https://github.com/phpstan/phpstan/issues/2999
 		-
-			message: '#ArrayObject<string, string> does not accept true\.#'
-			path: src/JsonSchema/SchemaFactory.php
-		-
-			message: '#ArrayObject<string, string> does not accept array<string, mixed>\.#'
-			path: src/JsonSchema/SchemaFactory.php
-		-
-			message: '#Cannot assign new offset to string\.#'
+			message: '#ArrayObject<string, bool\|string> does not accept array<string, mixed>\.#'
 			path: src/JsonSchema/SchemaFactory.php
 
 		# Expected, due to optional interfaces

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -109,7 +109,7 @@ final class SchemaFactory implements SchemaFactoryInterface
             return $schema;
         }
 
-        $definition = new \ArrayObject(['type' => 'object']);
+        $definition = new \ArrayObject(['type' => 'object', 'additionalProperties' => false]);
         $definitions[$definitionName] = $definition;
         if (null !== $resourceMetadata && null !== $description = $resourceMetadata->getDescription()) {
             $definition['description'] = $description;

--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -73,6 +73,7 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey($rootDefinitionKey, $definitions);
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
+        $this->assertFalse($definitions[$rootDefinitionKey]['additionalProperties']);
         $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
         $this->assertArrayHasKey('foo', $definitions[$rootDefinitionKey]['properties']);
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['foo']);
@@ -136,6 +137,7 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey($rootDefinitionKey, $definitions);
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
+        $this->assertFalse($definitions[$rootDefinitionKey]['additionalProperties']);
         $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
         $this->assertArrayHasKey('alias', $definitions[$rootDefinitionKey]['properties']);
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['alias']);

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -327,6 +327,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -461,6 +462,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'properties' => [
                         'name' => new \ArrayObject([
@@ -573,6 +575,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'properties' => [
                         'name' => new \ArrayObject([
@@ -765,6 +768,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -776,6 +780,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $ref => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -963,6 +968,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -974,6 +980,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $ref => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1062,6 +1069,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy-Read' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1235,6 +1243,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1246,6 +1255,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Dummy-dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1421,6 +1431,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1432,6 +1443,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Dummy-dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1608,6 +1620,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2001,6 +2014,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2012,6 +2026,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $ref => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2027,6 +2042,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $relatedDummyRef => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a related dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/RelatedDummy'],
                     'properties' => [
@@ -2136,6 +2152,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'properties' => [
                         'name' => new \ArrayObject([
@@ -2295,6 +2312,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Question' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a question.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Question'],
                     'properties' => [
@@ -2307,6 +2325,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Answer' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is an answer.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Answer'],
                     'properties' => [
@@ -2390,6 +2409,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2490,6 +2510,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2685,6 +2706,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2893,6 +2915,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy:300dcd476cef011532fb0ca7683395d7' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => [
                         'url' => 'http://schema.example.com/Dummy',
@@ -2911,6 +2934,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Dummy:b4f76c1a44965bd401aa23bb37618acc' => new \ArrayObject([
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'description' => 'This is a dummy.',
                     'externalDocs' => [
                         'url' => 'http://schema.example.com/Dummy',

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -370,6 +370,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -540,6 +541,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'properties' => [
                             'name' => new \ArrayObject([
@@ -674,6 +676,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'properties' => [
                             'name' => new \ArrayObject([
@@ -905,6 +908,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -916,6 +920,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     $ref => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1027,6 +1032,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy-Read' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1238,6 +1244,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1249,6 +1256,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     'Dummy-dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1461,6 +1469,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1472,6 +1481,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     'Dummy-dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1991,6 +2001,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2002,6 +2013,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     $ref => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2020,6 +2032,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     $relatedDummyRef => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a related dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/RelatedDummy'],
                         'properties' => [
@@ -2165,6 +2178,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'properties' => [
                             'name' => new \ArrayObject([
@@ -2337,6 +2351,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Question' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a question.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Question'],
                         'properties' => [
@@ -2349,6 +2364,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     'Answer' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is an answer.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Answer'],
                         'properties' => [
@@ -2456,6 +2472,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2583,6 +2600,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2716,6 +2734,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2853,6 +2872,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -3090,6 +3110,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
+                        'additionalProperties' => false,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR is part of a set of PR whose purpose is to make the assertions `assertMatchesResourceItemJsonSchema` and `assertMatchesResourceCollectionJsonSchema` work correctly.
The PR are:
- https://github.com/api-platform/core/pull/3803
- https://github.com/api-platform/core/pull/3804 (this one)
- https://github.com/api-platform/core/pull/3806
- https://github.com/api-platform/core/pull/3807

It add `additionalProperties` (to false) to the definitions in order to not validate a schema if the validated object has additional properties (it could be another resource in this case).