### PR TITLE
[JSON Schema] Use validation groups for property metadata in JSON Schema factory

### DIFF
--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -99,6 +99,7 @@ class SchemaFactoryTest extends TestCase
                 'normalization_context' => [
                     'groups' => 'overridden_operation_dummy_put',
                 ],
+                'validation_groups' => ['validation_groups_dummy_put'],
             ],
         ], [], [
             'normalization_context' => [
@@ -107,21 +108,22 @@ class SchemaFactoryTest extends TestCase
         ]));
 
         $serializerGroup = 'overridden_operation_dummy_put';
+        $validationGroups = 'validation_groups_dummy_put';
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(OverriddenOperationDummy::class, Argument::allOf(
             Argument::type('array'),
-            Argument::withEntry('serializer_groups', [$serializerGroup])
+            Argument::allOf(Argument::withEntry('serializer_groups', [$serializerGroup]), Argument::withEntry('validation_groups', [$validationGroups]))
         ))->willReturn(new PropertyNameCollection(['alias', 'description']));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(OverriddenOperationDummy::class, 'alias', Argument::allOf(
             Argument::type('array'),
-            Argument::withEntry('serializer_groups', [$serializerGroup])
+            Argument::allOf(Argument::withEntry('serializer_groups', [$serializerGroup]), Argument::withEntry('validation_groups', [$validationGroups]))
         ))->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), null, true));
         $propertyMetadataFactoryProphecy->create(OverriddenOperationDummy::class, 'description', Argument::allOf(
             Argument::type('array'),
-            Argument::withEntry('serializer_groups', [$serializerGroup])
+            Argument::allOf(Argument::withEntry('serializer_groups', [$serializerGroup]), Argument::withEntry('validation_groups', [$validationGroups]))
         ))->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), null, true));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR is part of a set of PR whose purpose is to make the assertions `assertMatchesResourceItemJsonSchema` and `assertMatchesResourceCollectionJsonSchema` work correctly.
The PR are:
- https://github.com/api-platform/core/pull/3803
- https://github.com/api-platform/core/pull/3804
- https://github.com/api-platform/core/pull/3806 (this one)
- https://github.com/api-platform/core/pull/3807

It uses the validation groups when creating the property metadata. The aim is to use correctly the `ValidatorPropertyMetadataFactory`, mainly to receive correctly the `required` attribute:
https://github.com/api-platform/core/blob/8e58a986970dc3abe1fa994f6849631ad77e09a1/src/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php#L97-L99