### PR TITLE
fix: use getArrayCopy for assertMatchesJsonSchema

### DIFF
--- a/src/Bridge/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Bridge/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -113,14 +113,14 @@ trait ApiTestAssertionsTrait
     {
         $schema = self::getSchemaFactory()->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, OperationType::COLLECTION, $operationName);
 
-        static::assertMatchesJsonSchema($schema);
+        static::assertMatchesJsonSchema($schema->getArrayCopy());
     }
 
     public static function assertMatchesResourceItemJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld'): void
     {
         $schema = self::getSchemaFactory()->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, OperationType::ITEM, $operationName);
 
-        static::assertMatchesJsonSchema($schema);
+        static::assertMatchesJsonSchema($schema->getArrayCopy());
     }
 
     private static function getHttpClient(Client $newClient = null): ?Client


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR is part of a set of PR whose purpose is to make the assertions `assertMatchesResourceItemJsonSchema` and `assertMatchesResourceCollectionJsonSchema` work correctly.
The PR are:
- https://github.com/api-platform/core/pull/3803
- https://github.com/api-platform/core/pull/3804
- https://github.com/api-platform/core/pull/3806
- https://github.com/api-platform/core/pull/3807 (this one)

Without doing this, the refs are not correctly expanded and the value is not correctly validated against the JSON Schema.
It's because of this line:
https://github.com/justinrainbow/json-schema/blob/fa4d2d3c1e40a222ded125b679891086c9a6c7d6/src/JsonSchema/SchemaStorage.php#L99

It seems that `property_exists` on an `ArrayObject` is not considering a key as a property.
See: https://3v4l.org/60Mbh