### PR TITLE
[ValidationException] Allow customization of validation error status code

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -674,7 +674,7 @@ Feature: GraphQL mutation support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "errors[0].extensions.status" should be equal to "400"
+    And the JSON node "errors[0].extensions.status" should be equal to "422"
     And the JSON node "errors[0].message" should be equal to "name: This value should not be blank."
     And the JSON node "errors[0].extensions.violations" should exist
     And the JSON node "errors[0].extensions.violations[0].path" should be equal to "name"

--- a/features/hal/problem.feature
+++ b/features/hal/problem.feature
@@ -10,7 +10,7 @@ Feature: Error handling valid according to RFC 7807 (application/problem+json)
     """
     {}
     """
-    Then the response status code should be 400
+    Then the response status code should be 422
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
     And the JSON should be equal to:

--- a/features/hydra/error.feature
+++ b/features/hydra/error.feature
@@ -9,7 +9,7 @@ Feature: Error handling
     """
     {}
     """
-    Then the response status code should be 400
+    Then the response status code should be 422
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be equal to:

--- a/features/jsonapi/errors.feature
+++ b/features/jsonapi/errors.feature
@@ -18,7 +18,7 @@ Feature: JSON API error handling
       }
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 422
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
     And the JSON should be equal to:
@@ -49,7 +49,7 @@ Feature: JSON API error handling
       }
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 422
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
     And the JSON should be equal to:

--- a/features/main/validation.feature
+++ b/features/main/validation.feature
@@ -24,7 +24,7 @@ Feature: Using validations groups
       "code": "My Dummy"
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 422
     And the response should be in JSON
     And the JSON should be equal to:
     """
@@ -52,7 +52,7 @@ Feature: Using validations groups
       "code": "My Dummy"
     }
     """
-    Then the response status code should be 400
+    Then the response status code should be 422
     And the response should be in JSON
     And the JSON should be equal to:
     """

--- a/features/security/send_security_headers.feature
+++ b/features/security/send_security_headers.feature
@@ -27,7 +27,7 @@ Feature: Send security header
     """
     {"name": ""}
     """
-    Then the response status code should be 400
+    Then the response status code should be 422
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the header "X-Content-Type-Options" should be equal to "nosniff"
     And the header "X-Frame-Options" should be equal to "deny"

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -202,6 +202,7 @@
         <service id="api_platform.listener.exception.validation" class="ApiPlatform\Core\Bridge\Symfony\Validator\EventListener\ValidationExceptionListener">
             <argument type="service" id="api_platform.serializer" />
             <argument>%api_platform.error_formats%</argument>
+            <argument>%api_platform.exception_to_status%</argument>
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -239,6 +239,8 @@
         </service>
 
         <service id="api_platform.graphql.normalizer.validation_exception" class="ApiPlatform\Core\GraphQl\Serializer\Exception\ValidationExceptionNormalizer">
+            <argument>%api_platform.exception_to_status%</argument>
+
             <tag name="serializer.normalizer" priority="-780" />
         </service>
 

--- a/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -47,7 +47,7 @@ final class ValidationExceptionListener
             return;
         }
         $exceptionClass = \get_class($exception);
-        $statusCode = Response::HTTP_BAD_REQUEST;
+        $statusCode = Response::HTTP_UNPROCESSABLE_ENTITY;
 
         foreach ($this->exceptionToStatus as $class => $status) {
             if (is_a($exceptionClass, $class, true)) {

--- a/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -28,11 +28,13 @@ final class ValidationExceptionListener
 {
     private $serializer;
     private $errorFormats;
+    private $exceptionToStatus;
 
-    public function __construct(SerializerInterface $serializer, array $errorFormats)
+    public function __construct(SerializerInterface $serializer, array $errorFormats, array $exceptionToStatus = [])
     {
         $this->serializer = $serializer;
         $this->errorFormats = $errorFormats;
+        $this->exceptionToStatus = $exceptionToStatus;
     }
 
     /**
@@ -44,12 +46,22 @@ final class ValidationExceptionListener
         if (!$exception instanceof ValidationException) {
             return;
         }
+        $exceptionClass = get_class($exception);
+        $statusCode = Response::HTTP_BAD_REQUEST;
+
+        foreach ($this->exceptionToStatus as $class => $status) {
+            if (is_a($exceptionClass, $class, true)) {
+                $statusCode = $status;
+
+                break;
+            }
+        }
 
         $format = ErrorFormatGuesser::guessErrorFormat($event->getRequest(), $this->errorFormats);
 
         $event->setResponse(new Response(
                 $this->serializer->serialize($exception->getConstraintViolationList(), $format['key']),
-                Response::HTTP_BAD_REQUEST,
+                $statusCode,
                 [
                     'Content-Type' => sprintf('%s; charset=utf-8', $format['value'][0]),
                     'X-Content-Type-Options' => 'nosniff',

--- a/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -46,7 +46,7 @@ final class ValidationExceptionListener
         if (!$exception instanceof ValidationException) {
             return;
         }
-        $exceptionClass = get_class($exception);
+        $exceptionClass = \get_class($exception);
         $statusCode = Response::HTTP_BAD_REQUEST;
 
         foreach ($this->exceptionToStatus as $class => $status) {

--- a/tests/Bridge/Symfony/Validator/EventListener/ValidationExceptionListenerTest.php
+++ b/tests/Bridge/Symfony/Validator/EventListener/ValidationExceptionListenerTest.php
@@ -57,7 +57,7 @@ class ValidationExceptionListenerTest extends TestCase
         $response = $event->getResponse();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($exceptionJson, $response->getContent());
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
         $this->assertSame('application/ld+json; charset=utf-8', $response->headers->get('Content-Type'));
         $this->assertSame('nosniff', $response->headers->get('X-Content-Type-Options'));
         $this->assertSame('deny', $response->headers->get('X-Frame-Options'));

--- a/tests/GraphQl/Serializer/Exception/ValidationExceptionNormalizerTest.php
+++ b/tests/GraphQl/Serializer/Exception/ValidationExceptionNormalizerTest.php
@@ -48,7 +48,7 @@ class ValidationExceptionNormalizerTest extends TestCase
 
         $normalizedError = $this->validationExceptionNormalizer->normalize($error);
         $this->assertSame($exceptionMessage, $normalizedError['message']);
-        $this->assertSame(400, $normalizedError['extensions']['status']);
+        $this->assertSame(422, $normalizedError['extensions']['status']);
         $this->assertSame('user', $normalizedError['extensions']['category']);
         $this->assertArrayHasKey('violations', $normalizedError['extensions']);
         $this->assertSame([


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no 
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  
| License       | MIT
| Doc PR |  api-platform/docs#1206

In general, I think it's a good practice to use *400 Bad Request* http status code when the request body is malformed (i.e. incorrect syntax in the payload or invalid parameters in the URL) and  use *422 Unprocessable Entity*  when the query is semantically incorrect.

According to the RFC https://tools.ietf.org/html/rfc4918#section-11.2 the code 422 seems to me to be much more appropriate and specific in a case of data validation failure.
Cause the server understands the content type of the request entity and the syntax of the request entity is correct but was unable to process the data because its semantically erroneous.

The idea, is to give the hand to configure the status code for the ValidationException under `exception_to_status` section, just like this :

```yaml
api_platform:
    exception_to_status:
        ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY

```
Any way, just let me know if this requires to add some unit tests or some documentation, (if it'is an interesting idea).
Best regards,