### PR TITLE
Add version to json+ld docs endpoint output

### DIFF
--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -35,6 +35,7 @@ Feature: Documentation support
     And the JSON node "hydra:description" should contain "This is a test API."
     And the JSON node "hydra:description" should contain "Made with love"
     And the JSON node "hydra:entrypoint" should be equal to "/"
+    And the JSON node "version" should be equal to "0.0.0"
     # Supported classes
     And the Hydra class "The API entrypoint" exists
     And the Hydra class "A constraint violation" exists

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -519,6 +519,10 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             $doc['hydra:description'] = $object->getDescription();
         }
 
+        if ('' !== $object->getVersion()) {
+            $doc['version'] = $object->getVersion();
+        }
+
         $doc['hydra:entrypoint'] = $this->urlGenerator->generate('api_entrypoint');
         $doc['hydra:supportedClass'] = $classes;
 

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -144,6 +144,7 @@ class DocumentationNormalizerTest extends TestCase
             '@type' => 'hydra:ApiDocumentation',
             'hydra:title' => 'Test Api',
             'hydra:description' => 'test ApiGerard',
+            'version' => '0.0.0',
             'hydra:supportedClass' => [
                 [
                     '@id' => '#dummy',
@@ -450,6 +451,7 @@ class DocumentationNormalizerTest extends TestCase
             '@type' => 'hydra:ApiDocumentation',
             'hydra:title' => 'Test Api',
             'hydra:description' => 'test ApiGerard',
+            'version' => '0.0.0',
             'hydra:entrypoint' => '/',
             'hydra:supportedClass' => [
                 [


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tickets       | #3809
| License       | MIT
| Doc PR        | n/a

I consider this a bug fix as the plain json output will provide the API version in the `info.version` node. This was missing in the extended ld+json output.

I've also updated tests. I'm happy to make adjustments to the target branch or the json node path as appropriate.