### PR TITLE
[JSON Schema] Manage correctly nullability

### DIFF
--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -161,6 +161,17 @@ final class TypeFactory implements TypeFactoryInterface
             ];
         }
 
+        if ($schema && Schema::VERSION_JSON_SCHEMA === $schema->getVersion()) {
+            return array_merge(
+                $jsonSchema,
+                [
+                    'type' => \is_array($jsonSchema['type'])
+                        ? array_merge($jsonSchema['type'], ['null'])
+                        : [$jsonSchema['type'], 'null'],
+                ]
+            );
+        }
+
         return array_merge($jsonSchema, ['nullable' => true]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Following https://github.com/api-platform/core/pull/3402 and the list of PR from https://github.com/api-platform/core/pull/3807.

In order to validate correctly nullable data against the generated JSON Schema (using `assertMatchesResourceItemJsonSchema` and `assertMatchesResourceCollectionJsonSchema`), the schema needs to be compliant with the specification for nullability:

```json
{"type": ["string", "null"]}
```

However OpenAPI < 3.1 doesn't understand this syntax (OpenAPI 3.1 will at least! https://github.com/OAI/OpenAPI-Specification/releases/tag/3.1.0-rc0) and only understands:

```json
{"type": "string", "nullable": true}
```

That's why we need a condition when the schema is generated for JSON Schema only.

@Ocramius you may be interested.