### PR TITLE
Parameter for pagination cannot be arrays

### DIFF
--- a/src/DataProvider/Pagination.php
+++ b/src/DataProvider/Pagination.php
@@ -265,6 +265,17 @@ final class Pagination
     private function getParameterFromContext(array $context, string $parameterName, $default = null)
     {
         $filters = $context['filters'] ?? [];
+        $parameterAsArray = explode('.', $parameterName);
+        if (count($parameterAsArray) > 1) {
+            foreach ($parameterAsArray as $key => $parameter) {
+                if (! isset ($filters[$parameterAsArray[$key]])) {
+                    break;
+                }
+                $filters = $filters[$parameterAsArray[$key]];
+            }
+
+            return ! is_array($filters) ? $filters : $default;
+        }
 
         return \array_key_exists($parameterName, $filters) ? $filters[$parameterName] : $default;
     }

--- a/tests/DataProvider/PaginationTest.php
+++ b/tests/DataProvider/PaginationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+
+namespace ApiPlatform\Core\Tests\DataProvider;
+
+use ApiPlatform\Core\DataProvider\Pagination;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Arnaud POINTET <arnaud.pointet@gmail.com>
+ */
+class PaginationTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testPaginationParameterNameIsAString()
+    {
+        $resourceMetadataProphesize = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $options = [
+            'page_parameter_name' => 'test_page_parameter'
+        ];
+
+        $pagination = new Pagination($resourceMetadataProphesize->reveal(), $options);
+        $result = $pagination->getPagination(null, null, [
+            'filters' => [
+                'test_page_parameter' => 50
+            ]
+        ]);
+
+        $this->assertEquals(50, $result[0]);
+    }
+
+    public function testPaginationParameterNameIsAnArray()
+    {
+        $resourceMetadataProphesize = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $options = [
+            'page_parameter_name' => 'pagination.test_page_parameter'
+        ];
+
+        $pagination = new Pagination($resourceMetadataProphesize->reveal(), $options);
+        $result = $pagination->getPagination(null, null, [
+            'filters' => [
+                'pagination' => [
+                    'test_page_parameter' => 50
+                ]
+            ]
+        ]);
+
+        $this->assertEquals(50, $result[0]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Today when you try to use an array for client pagination parameters the system return the default value

For example if in the configuration file you set items_per_page_parameter_name: 'pagination.perpage' it will find in the context the value pagination[perpage]