### PR TITLE
 Rework to improve and simplify identifiers management

### DIFF
--- a/features/main/custom_identifier.feature
+++ b/features/main/custom_identifier.feature
@@ -101,3 +101,21 @@ Feature: Using custom identifier on resource
     When I send a "DELETE" request to "/custom_identifier_dummies/1"
     Then the response status code should be 204
     And the response should be empty
+
+  @createSchema
+  Scenario: Get a resource
+    Given there is a custom multiple identifier dummy
+    When I send a "GET" request to "/custom_multiple_identifier_dummies/1/2"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/CustomMultipleIdentifierDummy",
+      "@id": "/custom_multiple_identifier_dummies/1/2",
+      "@type": "CustomMultipleIdentifierDummy",
+      "firstId": 1,
+      "secondId": 2,
+      "name": "Orwell"
+    }
+    """

--- a/features/main/operation.feature
+++ b/features/main/operation.feature
@@ -64,3 +64,22 @@ Feature: Operation support
   Scenario: Get a 404 response for the disabled item operation
     When I send a "GET" request to "/disable_item_operations/1"
     Then the response status code should be 404
+
+  @createSchema
+  Scenario: Get a book by its ISBN
+    Given there is a book
+    When I send a "GET" request to "books/by_isbn/9780451524935"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+        "@context": "/contexts/Book",
+        "@id": "/books/1",
+        "@type": "Book",
+        "name": "1984",
+        "isbn": "9780451524935",
+        "id": 1
+    }
+    """

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -28,6 +28,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("attributes", type="array"),
  *     @Attribute("cacheHeaders", type="array"),
  *     @Attribute("collectionOperations", type="array"),
+ *     @Attribute("compositeIdentifier", type="bool"),
  *     @Attribute("denormalizationContext", type="array"),
  *     @Attribute("deprecationReason", type="string"),
  *     @Attribute("description", type="string"),
@@ -217,7 +218,8 @@ final class ApiResource
         ?string $sunset = null,
         ?array $swaggerContext = null,
         ?array $validationGroups = null,
-        ?int $urlGenerationStrategy = null
+        ?int $urlGenerationStrategy = null,
+        ?bool $compositeIdentifier = null
     ) {
         if (!\is_array($description)) { // @phpstan-ignore-line Doctrine annotations support
             [$publicProperties, $configurableAttributes] = self::getConfigMetadata();

--- a/src/Bridge/Doctrine/MongoDbOdm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/SubresourceDataProvider.php
@@ -121,8 +121,16 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
 
         $topAggregationBuilder = $topAggregationBuilder ?? $previousAggregationBuilder;
 
-        [$identifier, $identifierResourceClass] = $context['identifiers'][$remainingIdentifiers - 1];
-        $previousAssociationProperty = $context['identifiers'][$remainingIdentifiers][0] ?? $context['property'];
+        if (\is_string(key($context['identifiers']))) {
+            $contextIdentifiers = array_keys($context['identifiers']);
+            $identifier = $contextIdentifiers[$remainingIdentifiers - 1];
+            $identifierResourceClass = $context['identifiers'][$identifier][0];
+            $previousAssociationProperty = $contextIdentifiers[$remainingIdentifiers] ?? $context['property'];
+        } else {
+            @trigger_error('Identifiers should match the convention introduced in ADR 0001-resource-identifiers, this behavior will be removed in 3.0.', E_USER_DEPRECATED);
+            [$identifier, $identifierResourceClass] = $context['identifiers'][$remainingIdentifiers - 1];
+            $previousAssociationProperty = $context['identifiers'][$remainingIdentifiers][0] ?? $context['property'];
+        }
 
         $manager = $this->managerRegistry->getManagerForClass($identifierResourceClass);
         if (!$manager instanceof DocumentManager) {

--- a/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
+++ b/src/Bridge/Doctrine/Orm/SubresourceDataProvider.php
@@ -130,8 +130,16 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
 
         $topQueryBuilder = $topQueryBuilder ?? $previousQueryBuilder;
 
-        [$identifier, $identifierResourceClass] = $context['identifiers'][$remainingIdentifiers - 1];
-        $previousAssociationProperty = $context['identifiers'][$remainingIdentifiers][0] ?? $context['property'];
+        if (\is_string(key($context['identifiers']))) {
+            $contextIdentifiers = array_keys($context['identifiers']);
+            $identifier = $contextIdentifiers[$remainingIdentifiers - 1];
+            $identifierResourceClass = $context['identifiers'][$identifier][0];
+            $previousAssociationProperty = $contextIdentifiers[$remainingIdentifiers] ?? $context['property'];
+        } else {
+            @trigger_error('Identifiers should match the convention introduced in ADR 0001-resource-identifiers, this behavior will be removed in 3.0.', E_USER_DEPRECATED);
+            [$identifier, $identifierResourceClass] = $context['identifiers'][$remainingIdentifiers - 1];
+            $previousAssociationProperty = $context['identifiers'][$remainingIdentifiers][0] ?? $context['property'];
+        }
 
         $manager = $this->managerRegistry->getManagerForClass($identifierResourceClass);
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -43,6 +43,7 @@
             <argument>%api_platform.enable_docs%</argument>
             <argument>%api_platform.graphql.graphiql.enabled%</argument>
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
+            <argument type="service" id="api_platform.identifiers_extractor.cached"></argument>
 
             <tag name="routing.loader" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -289,6 +289,7 @@
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="service" id="api_platform.path_segment_name_generator" />
+            <argument type="service" id="api_platform.identifiers_extractor.cached" />
         </service>
 
         <service id="api_platform.subresource_operation_factory.cached" class="ApiPlatform\Core\Operation\Factory\CachedSubresourceOperationFactory" decorates="api_platform.subresource_operation_factory" decoration-priority="-10" public="false">

--- a/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
@@ -45,6 +45,7 @@
             <argument>%api_platform.formats%</argument>
             <argument type="service" id="api_platform.openapi.options" />
             <argument type="service" id="api_platform.pagination_options" />
+            <argument type="service" id="api_platform.identifiers_extractor.cached" />
         </service>
         <service id="ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface" alias="api_platform.openapi.factory" />
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
@@ -42,10 +42,10 @@
             <argument type="service" id="api_platform.operation_path_resolver" />
             <argument type="service" id="api_platform.filter_locator" />
             <argument type="service" id="api_platform.subresource_operation_factory" />
+            <argument type="service" id="api_platform.identifiers_extractor.cached" />
             <argument>%api_platform.formats%</argument>
             <argument type="service" id="api_platform.openapi.options" />
             <argument type="service" id="api_platform.pagination_options" />
-            <argument type="service" id="api_platform.identifiers_extractor.cached" />
         </service>
         <service id="ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface" alias="api_platform.openapi.factory" />
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml
@@ -33,6 +33,7 @@
             <argument>%api_platform.collection.pagination.enabled_parameter_name%</argument>
             <argument type="collection" />
             <argument>%api_platform.swagger.versions%</argument>
+            <argument type="service" id="api_platform.identifiers_extractor.cached" />
             <tag name="serializer.normalizer" priority="-790" />
         </service>
 

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\OperationType;
-use ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractorInterface;
 use ApiPlatform\Core\Exception\InvalidResourceException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
@@ -58,6 +57,7 @@ final class ApiLoader extends Loader
     private $graphQlPlaygroundEnabled;
     private $entrypointEnabled;
     private $docsEnabled;
+    private $identifiersExtractor;
 
     public function __construct(KernelInterface $kernel, ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, OperationPathResolverInterface $operationPathResolver, ContainerInterface $container, array $formats, array $resourceClassDirectories = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $graphqlEnabled = false, bool $entrypointEnabled = true, bool $docsEnabled = true, bool $graphiQlEnabled = false, bool $graphQlPlaygroundEnabled = false, IdentifiersExtractorInterface $identifiersExtractor = null)
     {
@@ -76,11 +76,6 @@ final class ApiLoader extends Loader
         $this->graphQlPlaygroundEnabled = $graphQlPlaygroundEnabled;
         $this->entrypointEnabled = $entrypointEnabled;
         $this->docsEnabled = $docsEnabled;
-
-        if (null === $identifiersExtractor) {
-            @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.6 and will not be possible anymore in API Platform 3', IdentifierExtractorInterface::class), E_USER_DEPRECATED);
-        }
-
         $this->identifiersExtractor = $identifiersExtractor;
     }
 
@@ -136,7 +131,7 @@ final class ApiLoader extends Loader
                         '_format' => null,
                         '_stateless' => $operation['stateless'] ?? $resourceMetadata->getAttribute('stateless'),
                         '_api_resource_class' => $operation['resource_class'],
-                        '_api_identified_by' => $operation['identified_by'],
+                        '_api_identifiers' => $operation['identifiers'],
                         '_api_has_composite_identifier' => false,
                         '_api_subresource_operation_name' => $operation['route_name'],
                         '_api_subresource_context' => [
@@ -232,8 +227,8 @@ final class ApiLoader extends Loader
             }
         }
 
-        $operation['identified_by'] = (array) ($operation['identified_by'] ?? $resourceMetadata->getAttribute('identified_by', $this->identifiersExtractor ? $this->identifiersExtractor->getIdentifiersFromResourceClass($resourceClass) : ['id']));
-        $operation['has_composite_identifier'] = \count($operation['identified_by']) > 1 ? $resourceMetadata->getAttribute('composite_identifier', true) : false;
+        $operation['identifiers'] = (array) ($operation['identifiers'] ?? $resourceMetadata->getAttribute('identifiers', $this->identifiersExtractor ? $this->identifiersExtractor->getIdentifiersFromResourceClass($resourceClass) : ['id']));
+        $operation['has_composite_identifier'] = \count($operation['identifiers']) > 1 ? $resourceMetadata->getAttribute('composite_identifier', true) : false;
         $path = trim(trim($resourceMetadata->getAttribute('route_prefix', '')), '/');
         $path .= $this->operationPathResolver->resolveOperationPath($resourceShortName, $operation, $operationType, $operationName);
 
@@ -244,7 +239,7 @@ final class ApiLoader extends Loader
                 '_format' => null,
                 '_stateless' => $operation['stateless'],
                 '_api_resource_class' => $resourceClass,
-                '_api_identified_by' => $operation['identified_by'],
+                '_api_identifiers' => $operation['identifiers'],
                 '_api_has_composite_identifier' => $operation['has_composite_identifier'],
                 sprintf('_api_%s_operation_name', $operationType) => $operationName,
             ] + ($operation['defaults'] ?? []),

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -26,6 +26,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
 use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Identifier\CompositeIdentifierParser;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -60,11 +61,7 @@ final class IriConverter implements IriConverterInterface
         $this->subresourceDataProvider = $subresourceDataProvider;
         $this->identifierConverter = $identifierConverter;
         $this->resourceClassResolver = $resourceClassResolver;
-
-        if (null === $identifiersExtractor) {
-            @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3', IdentifiersExtractorInterface::class), E_USER_DEPRECATED);
-            $this->identifiersExtractor = new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, $propertyAccessor ?? PropertyAccess::createPropertyAccessor());
-        }
+        $this->identifiersExtractor = $identifiersExtractor ?: new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, $propertyAccessor ?? PropertyAccess::createPropertyAccessor());
         $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
 

--- a/src/Bridge/Symfony/Routing/RouteNameResolver.php
+++ b/src/Bridge/Symfony/Routing/RouteNameResolver.php
@@ -67,8 +67,8 @@ final class RouteNameResolver implements RouteNameResolverInterface
         $subresources = array_keys($context['subresource_resources']);
         $currentSubresources = [];
 
-        foreach ($currentContext['identifiers'] as $identifierContext) {
-            $currentSubresources[] = $identifierContext[1];
+        foreach ($currentContext['identifiers'] as [$class]) {
+            $currentSubresources[] = $class;
         }
 
         return $currentSubresources === $subresources;

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -172,7 +172,7 @@ final class ReadStage implements ReadStageInterface
         $resolvedIdentifiers = [];
         $rootIdentifiers = array_keys($rootResolvedFields);
         foreach ($rootIdentifiers as $rootIdentifier) {
-            $resolvedIdentifiers[] = [$rootIdentifier, $rootResolvedClass];
+            $resolvedIdentifiers[$rootIdentifier] = [$rootResolvedClass, $rootIdentifier];
         }
 
         return $this->subresourceDataProvider->getSubresource($subresourceClass, $rootResolvedFields, $normalizationContext + [

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -236,7 +236,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         if (null !== $this->subresourceOperationFactory) {
             foreach ($this->subresourceOperationFactory->create($resourceClass) as $operationId => $operation) {
                 $subresourceMetadata = $this->resourceMetadataFactory->create($operation['resource_class']);
-                $propertyMetadata = $this->propertyMetadataFactory->create(end($operation['identifiers'])[1], $operation['property']);
+                $propertyMetadata = $this->propertyMetadataFactory->create(end($operation['identifiers'])[0], $operation['property']);
                 $hydraOperations[] = $this->getHydraOperation($resourceClass, $subresourceMetadata, $operation['route_name'], $operation, "#{$subresourceMetadata->getShortName()}", OperationType::SUBRESOURCE, $propertyMetadata->getSubresource());
             }
         }

--- a/src/Identifier/CompositeIdentifierParser.php
+++ b/src/Identifier/CompositeIdentifierParser.php
@@ -20,6 +20,8 @@ namespace ApiPlatform\Core\Identifier;
  */
 final class CompositeIdentifierParser
 {
+    public const COMPOSITE_IDENTIFIER_REGEXP = '/(\w+)=(?<=\w=)(.*?)(?=;\w+=)|(\w+)=([^;]*);?$/';
+
     private function __construct()
     {
     }
@@ -33,7 +35,7 @@ final class CompositeIdentifierParser
     {
         $matches = [];
         $identifiers = [];
-        $num = preg_match_all('/(\w+)=(?<=\w=)(.*?)(?=;\w+=)|(\w+)=([^;]*);?$/', $identifier, $matches, PREG_SET_ORDER);
+        $num = preg_match_all(self::COMPOSITE_IDENTIFIER_REGEXP, $identifier, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $i => $match) {
             if ($i === $num - 1) {
@@ -44,5 +46,18 @@ final class CompositeIdentifierParser
         }
 
         return $identifiers;
+    }
+
+    /**
+     * Renders composite identifiers to string using: key=value;key2=value2.
+     */
+    public static function stringify(array $identifiers): string
+    {
+        $composite = [];
+        foreach ($identifiers as $name => $value) {
+            $composite[] = sprintf('%s=%s', $name, $value);
+        }
+
+        return implode(';', $composite);
     }
 }

--- a/src/Identifier/ContextAwareIdentifierConverterInterface.php
+++ b/src/Identifier/ContextAwareIdentifierConverterInterface.php
@@ -23,5 +23,5 @@ interface ContextAwareIdentifierConverterInterface extends IdentifierConverterIn
     /**
      * {@inheritdoc}
      */
-    public function convert(string $data, string $class, array $context = []): array;
+    public function convert($data, string $class, array $context = []): array;
 }

--- a/src/Identifier/IdentifierConverter.php
+++ b/src/Identifier/IdentifierConverter.php
@@ -51,11 +51,11 @@ final class IdentifierConverter implements ContextAwareIdentifierConverterInterf
     public function convert($data, string $class, array $context = []): array
     {
         if (!\is_array($data)) {
-            @trigger_error(sprintf('Not using an array as the first argument of "%s->convert" is deprecated since API Platform 2.6 and will not be possible anymore in API Platform 3', IdentifierExtractorInterface::class), E_USER_DEPRECATED);
-            $data = [$data];
+            @trigger_error(sprintf('Not using an array as the first argument of "%s->convert" is deprecated since API Platform 2.6 and will not be possible anymore in API Platform 3', self::class), E_USER_DEPRECATED);
+            $data = ['id' => $data];
         }
 
-        $identifiers = [];
+        $identifiers = $data;
         foreach ($data as $identifier => $value) {
             if (null === $type = $this->getIdentifierType($class, $identifier)) {
                 continue;

--- a/src/Identifier/IdentifierConverterInterface.php
+++ b/src/Identifier/IdentifierConverterInterface.php
@@ -28,6 +28,8 @@ interface IdentifierConverterInterface
     public const HAS_IDENTIFIER_CONVERTER = 'has_identifier_converter';
 
     /**
+     * Takes an array of strings representing identifiers and transform their values to the expected type.
+     *
      * @param string $data  Identifier to convert to php values
      * @param string $class The class to which the identifiers belong
      *
@@ -35,5 +37,5 @@ interface IdentifierConverterInterface
      *
      * @return array Indexed by identifiers properties with their values denormalized
      */
-    public function convert(string $data, string $class): array;
+    public function convert($data, string $class): array;
 }

--- a/src/Identifier/IdentifierConverterInterface.php
+++ b/src/Identifier/IdentifierConverterInterface.php
@@ -30,7 +30,7 @@ interface IdentifierConverterInterface
     /**
      * Takes an array of strings representing identifiers and transform their values to the expected type.
      *
-     * @param string $data  Identifier to convert to php values
+     * @param mixed  $data  Identifier to convert to php values
      * @param string $class The class to which the identifiers belong
      *
      * @throws InvalidIdentifierException

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -109,7 +109,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             if (null === $parentOperation) {
                 $identifiers = (array) $rootResourceMetadata->getAttribute('identifiers');
                 $rootShortname = $rootResourceMetadata->getShortName();
-                $identifier = array_key_first($identifiers) ?: $identifiers[0];
+                $identifier = \is_string($key = array_key_first($identifiers)) ? $key : $identifiers[0];
                 $operation['identifiers'][$identifier] = [$rootResourceClass, $identifiers[$identifier][1] ?? $identifier, true];
                 $operation['operation_name'] = sprintf(
                     '%s_%s%s',
@@ -147,7 +147,7 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
             } else {
                 $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
                 $identifiers = (array) $resourceMetadata->getAttribute('identifiers', null === $this->identifiersExtractor ? ['id'] : $this->identifiersExtractor->getIdentifiersFromResourceClass($resourceClass));
-                $identifier = array_key_first($identifiers) ?: $identifiers[0];
+                $identifier = \is_string($key = array_key_first($identifiers)) ? $key : $identifiers[0];
                 $operation['identifiers'] = $parentOperation['identifiers'];
                 $operation['identifiers'][$parentOperation['property']] = [$resourceClass, $identifiers[$identifier][1] ?? $identifier, $isLastItem ? true : $parentOperation['collection']];
 

--- a/src/PathResolver/OperationPathResolver.php
+++ b/src/PathResolver/OperationPathResolver.php
@@ -50,7 +50,13 @@ final class OperationPathResolver implements OperationPathResolverInterface
         $path = '/'.$this->pathSegmentNameGenerator->getSegmentName($resourceShortName);
 
         if (OperationType::ITEM === $operationType) {
-            $path .= '/{id}';
+            if (isset($operation['identified_by']) && (\count($operation['identified_by']) <= 1 || false === ($operation['has_composite_identifier'] ?? true))) {
+                foreach ($operation['identified_by'] as $identifier) {
+                    $path .= sprintf('/{%s}', $identifier);
+                }
+            } else {
+                $path .= '/{id}';
+            }
         }
 
         $path .= '.{_format}';

--- a/src/PathResolver/OperationPathResolver.php
+++ b/src/PathResolver/OperationPathResolver.php
@@ -50,9 +50,9 @@ final class OperationPathResolver implements OperationPathResolverInterface
         $path = '/'.$this->pathSegmentNameGenerator->getSegmentName($resourceShortName);
 
         if (OperationType::ITEM === $operationType) {
-            if (isset($operation['identified_by']) && (\count($operation['identified_by']) <= 1 || false === ($operation['has_composite_identifier'] ?? true))) {
-                foreach ($operation['identified_by'] as $identifier) {
-                    $path .= sprintf('/{%s}', $identifier);
+            if (isset($operation['identifiers']) && (\count($operation['identifiers']) <= 1 || false === ($operation['has_composite_identifier'] ?? true))) {
+                foreach ($operation['identifiers'] as $parameterName => $identifier) {
+                    $path .= sprintf('/{%s}', \is_string($parameterName) ? $parameterName : $identifier);
                 }
             } else {
                 $path .= '/{id}';

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -85,12 +85,12 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         if (isset($attributes['subresource_context'])) {
             $context['subresource_identifiers'] = [];
 
-            foreach ($attributes['subresource_context']['identifiers'] as $key => [$id, $resourceClass]) {
+            foreach ($attributes['subresource_context']['identifiers'] as $parameterName => [$resourceClass]) {
                 if (!isset($context['subresource_resources'][$resourceClass])) {
                     $context['subresource_resources'][$resourceClass] = [];
                 }
 
-                $context['subresource_identifiers'][$id] = $context['subresource_resources'][$resourceClass][$id] = $request->attributes->get($id);
+                $context['subresource_identifiers'][$parameterName] = $context['subresource_resources'][$resourceClass][$parameterName] = $request->attributes->get($parameterName);
             }
         }
 

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Swagger\Serializer;
 use ApiPlatform\Core\Api\FilterCollection;
 use ApiPlatform\Core\Api\FilterLocatorTrait;
 use ApiPlatform\Core\Api\FormatsProviderInterface;
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\OperationAwareFormatsProviderInterface;
 use ApiPlatform\Core\Api\OperationMethodResolverInterface;
 use ApiPlatform\Core\Api\OperationType;
@@ -99,6 +100,8 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         ApiGatewayNormalizer::API_GATEWAY => false,
     ];
 
+    private $identifiersExtractor;
+
     /**
      * @param SchemaFactoryInterface|ResourceClassResolverInterface|null $jsonSchemaFactory
      * @param ContainerInterface|FilterCollection|null                   $filterLocator
@@ -106,7 +109,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
      * @param mixed|null                                                 $jsonSchemaTypeFactory
      * @param int[]                                                      $swaggerVersions
      */
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, $jsonSchemaFactory = null, $jsonSchemaTypeFactory = null, OperationPathResolverInterface $operationPathResolver = null, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, bool $oauthEnabled = false, string $oauthType = '', string $oauthFlow = '', string $oauthTokenUrl = '', string $oauthAuthorizationUrl = '', array $oauthScopes = [], array $apiKeys = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $paginationEnabled = true, string $paginationPageParameterName = 'page', bool $clientItemsPerPage = false, string $itemsPerPageParameterName = 'itemsPerPage', $formats = [], bool $paginationClientEnabled = false, string $paginationClientEnabledParameterName = 'pagination', array $defaultContext = [], array $swaggerVersions = [2, 3])
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, $jsonSchemaFactory = null, $jsonSchemaTypeFactory = null, OperationPathResolverInterface $operationPathResolver = null, UrlGeneratorInterface $urlGenerator = null, $filterLocator = null, NameConverterInterface $nameConverter = null, bool $oauthEnabled = false, string $oauthType = '', string $oauthFlow = '', string $oauthTokenUrl = '', string $oauthAuthorizationUrl = '', array $oauthScopes = [], array $apiKeys = [], SubresourceOperationFactoryInterface $subresourceOperationFactory = null, bool $paginationEnabled = true, string $paginationPageParameterName = 'page', bool $clientItemsPerPage = false, string $itemsPerPageParameterName = 'itemsPerPage', $formats = [], bool $paginationClientEnabled = false, string $paginationClientEnabledParameterName = 'pagination', array $defaultContext = [], array $swaggerVersions = [2, 3], IdentifiersExtractorInterface $identifiersExtractor = null)
     {
         if ($jsonSchemaTypeFactory instanceof OperationMethodResolverInterface) {
             @trigger_error(sprintf('Passing an instance of %s to %s() is deprecated since version 2.5 and will be removed in 3.0.', OperationMethodResolverInterface::class, __METHOD__), E_USER_DEPRECATED);
@@ -167,6 +170,12 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $this->defaultContext[self::SPEC_VERSION] = $swaggerVersions[0] ?? 2;
 
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
+
+        if (null === $identifiersExtractor) {
+            @trigger_error(sprintf('Not injecting "%s" is deprecated since API Platform 2.6 and will not be possible anymore in API Platform 3', IdentifierExtractorInterface::class), E_USER_DEPRECATED);
+        }
+
+        $this->identifiersExtractor = $identifiersExtractor;
     }
 
     /**
@@ -182,6 +191,9 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
 
         foreach ($object->getResourceNameCollection() as $resourceClass) {
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+            if ($this->identifiersExtractor) {
+                $resourceMetadata = $resourceMetadata->withAttributes(($resourceMetadata->getAttributes() ?: []) + ['identified_by' => $this->identifiersExtractor->getIdentifiersFromResourceClass($resourceClass)]);
+            }
             $resourceShortName = $resourceMetadata->getShortName();
 
             // Items needs to be parsed first to be able to reference the lines from the collection operation
@@ -341,7 +353,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $outputResourseShortName = $resourceMetadata->getItemOperations()[$operationName]['output']['name'] ?? $resourceShortName;
         $pathOperation['summary'] ?? $pathOperation['summary'] = sprintf('Retrieves a %s resource.', $outputResourseShortName);
 
-        $pathOperation = $this->addItemOperationParameters($v3, $pathOperation);
+        $pathOperation = $this->addItemOperationParameters($v3, $pathOperation, $operationType, $operationName, $resourceMetadata);
 
         $successResponse = ['description' => sprintf('%s resource response', $outputResourseShortName)];
         [$successResponse] = $this->addSchemas($v3, $successResponse, $definitions, $resourceClass, $operationType, $operationName, $mimeTypes);
@@ -487,7 +499,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $pathOperation['summary'] ?? $pathOperation['summary'] = sprintf('Creates a %s resource.', $resourceShortName);
 
         if (OperationType::ITEM === $operationType) {
-            $pathOperation = $this->addItemOperationParameters($v3, $pathOperation);
+            $pathOperation = $this->addItemOperationParameters($v3, $pathOperation, $operationType, $operationName, $resourceMetadata);
         }
 
         $successResponse = ['description' => sprintf('%s resource created', $resourceShortName)];
@@ -515,7 +527,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
 
         $pathOperation['summary'] ?? $pathOperation['summary'] = sprintf('Replaces the %s resource.', $resourceShortName);
 
-        $pathOperation = $this->addItemOperationParameters($v3, $pathOperation);
+        $pathOperation = $this->addItemOperationParameters($v3, $pathOperation, $operationType, $operationName, $resourceMetadata);
 
         $successResponse = ['description' => sprintf('%s resource updated', $resourceShortName)];
         [$successResponse] = $this->addSchemas($v3, $successResponse, $definitions, $resourceClass, $operationType, $operationName, $responseMimeTypes);
@@ -577,18 +589,32 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             '404' => ['description' => 'Resource not found'],
         ];
 
-        return $this->addItemOperationParameters($v3, $pathOperation);
+        return $this->addItemOperationParameters($v3, $pathOperation, $operationType, $operationName, $resourceMetadata);
     }
 
-    private function addItemOperationParameters(bool $v3, \ArrayObject $pathOperation): \ArrayObject
+    private function addItemOperationParameters(bool $v3, \ArrayObject $pathOperation, string $operationType, string $operationName, ResourceMetadata $resourceMetadata): \ArrayObject
     {
-        $parameter = [
-            'name' => 'id',
-            'in' => 'path',
-            'required' => true,
-        ];
-        $v3 ? $parameter['schema'] = ['type' => 'string'] : $parameter['type'] = 'string';
-        $pathOperation['parameters'] ?? $pathOperation['parameters'] = [$parameter];
+        $identifiers = (array) $resourceMetadata
+                ->getTypedOperationAttribute(OperationType::ITEM, $operationName, 'identified_by', ['id'], true);
+        $hasCompositeIdentifiers = \count($identifiers) > 1 ? $resourceMetadata->getAttribute('composite_identifier', true) : false;
+
+        if ($hasCompositeIdentifiers) {
+            $identifiers = ['id'];
+        }
+
+        if (!($pathOperation['parameters'] ?? null)) {
+            $pathOperation['parameters'] = [];
+        }
+
+        foreach ($identifiers as $identifier) {
+            $parameter = [
+                'name' => $identifier,
+                'in' => 'path',
+                'required' => true,
+            ];
+            $v3 ? $parameter['schema'] = ['type' => 'string'] : $parameter['type'] = 'string';
+            $pathOperation['parameters'][] = $parameter;
+        }
 
         return $pathOperation;
     }

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -598,7 +598,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             $identifiers = ['id'];
         }
 
-        if (!($pathOperation['parameters'] ?? null)) {
+        if (!isset($pathOperation['parameters'])) {
             $pathOperation['parameters'] = [];
         }
 

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -34,7 +34,7 @@ final class AttributesExtractor
      */
     public static function extractAttributes(array $attributes): array
     {
-        $result = ['resource_class' => $attributes['_api_resource_class'] ?? null];
+        $result = ['resource_class' => $attributes['_api_resource_class'] ?? null, 'identified_by' => $attributes['_api_identified_by'] ?? null, 'has_composite_identifier' => $attributes['_api_has_composite_identifier'] ?? false];
         if ($subresourceContext = $attributes['_api_subresource_context'] ?? null) {
             $result['subresource_context'] = $subresourceContext;
         }

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -34,10 +34,22 @@ final class AttributesExtractor
      */
     public static function extractAttributes(array $attributes): array
     {
-        $result = ['resource_class' => $attributes['_api_resource_class'] ?? null, 'identified_by' => $attributes['_api_identified_by'] ?? null, 'has_composite_identifier' => $attributes['_api_has_composite_identifier'] ?? false];
+        $result = ['resource_class' => $attributes['_api_resource_class'] ?? null, 'has_composite_identifier' => $attributes['_api_has_composite_identifier'] ?? false];
         if ($subresourceContext = $attributes['_api_subresource_context'] ?? null) {
             $result['subresource_context'] = $subresourceContext;
         }
+
+        // Normalizing identifiers tuples
+        $identifiers = [];
+        foreach (($attributes['_api_identifiers'] ?? ['id']) as $parameterName => $identifiedBy) {
+            if (\is_string($identifiedBy)) {
+                $identifiers[$identifiedBy] = [$result['resource_class'], $identifiedBy];
+            } else {
+                $identifiers[$parameterName] = $identifiedBy;
+            }
+        }
+
+        $result['identifiers'] = $identifiers;
 
         if (null === $result['resource_class']) {
             return [];

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -1673,6 +1673,7 @@ final class DoctrineContext implements Context
         $related = $this->buildRelatedDummy();
         $dummy->setRelated($related);
         $this->manager->persist($related);
+        $this->manager->persist($dummy);
         $this->manager->flush();
     }
 

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\AbsoluteUrlDummy as Abso
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\AbsoluteUrlRelationDummy as AbsoluteUrlRelationDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Address as AddressDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Answer as AnswerDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Book as BookDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\CompositeItem as CompositeItemDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\CompositeLabel as CompositeLabelDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\CompositePrimitiveItem as CompositePrimitiveItemDocument;
@@ -28,6 +29,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\ConvertedOwner as Conver
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\ConvertedRelated as ConvertedRelatedDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\ConvertedString as ConvertedStringDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Customer as CustomerDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\CustomMultipleIdentifierDummy as CustomMultipleIdentifierDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Dummy as DummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyAggregateOffer as DummyAggregateOfferDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\DummyCar as DummyCarDocument;
@@ -82,6 +84,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AbsoluteUrlDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AbsoluteUrlRelationDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Address;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Answer;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Book;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeItem;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeLabel;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositePrimitiveItem;
@@ -93,6 +96,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConvertedOwner;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConvertedRelated;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ConvertedString;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Customer;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CustomMultipleIdentifierDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyAggregateOffer;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
@@ -1669,6 +1673,31 @@ final class DoctrineContext implements Context
         $related = $this->buildRelatedDummy();
         $dummy->setRelated($related);
         $this->manager->persist($related);
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is a book
+     */
+    public function thereIsABook()
+    {
+        $book = $this->buildBook();
+        $book->name = '1984';
+        $book->isbn = '9780451524935';
+        $this->manager->persist($book);
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is a custom multiple identifier dummy
+     */
+    public function thereIsACustomMultipleIdentifierDummy()
+    {
+        $dummy = $this->buildCustomMultipleIdentifierDummy();
+        $dummy->setName('Orwell');
+        $dummy->setFirstId(1);
+        $dummy->setSecondId(2);
+
         $this->manager->persist($dummy);
         $this->manager->flush();
     }
@@ -2113,5 +2142,21 @@ final class DoctrineContext implements Context
     private function buildPatchDummyRelation()
     {
         return $this->isOrm() ? new PatchDummyRelation() : new PatchDummyRelationDocument();
+    }
+
+    /**
+     * @return BookDocument | Book
+     */
+    private function buildBook()
+    {
+        return $this->isOrm() ? new Book() : new BookDocument();
+    }
+
+    /**
+     * @return CustomMultipleIdentifierDummy | CustomMultipleIdentifierDummyDocument
+     */
+    private function buildCustomMultipleIdentifierDummy()
+    {
+        return $this->isOrm() ? new CustomMultipleIdentifierDummy() : new CustomMultipleIdentifierDummyDocument();
     }
 }

--- a/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
@@ -43,12 +43,14 @@ use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 class SubresourceDataProviderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
     use ProphecyTrait;
 
     private function assertIdentifierManagerMethodCalls($managerProphecy)
@@ -172,7 +174,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $dataProvider = new SubresourceDataProvider($managerRegistryProphecy->reveal(), $propertyNameCollectionFactory, $propertyMetadataFactory);
 
-        $context = ['property' => 'relatedDummies', 'identifiers' => [['id', Dummy::class]], 'collection' => true, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
+        $context = ['property' => 'relatedDummies', 'identifiers' => ['id' => [Dummy::class, 'id']], 'collection' => true, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
 
         $this->assertEquals([], $dataProvider->getSubresource(RelatedDummy::class, ['id' => ['id' => 1]], $context));
     }
@@ -266,7 +268,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $dataProvider = new SubresourceDataProvider($managerRegistryProphecy->reveal(), $propertyNameCollectionFactory, $propertyMetadataFactory);
 
-        $context = ['property' => 'thirdLevel', 'identifiers' => [['id', Dummy::class], ['relatedDummies', RelatedDummy::class]], 'collection' => false, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
+        $context = ['property' => 'thirdLevel', 'identifiers' => ['id' => [Dummy::class, 'id'], 'relatedDummies' => [RelatedDummy::class, 'id']], 'collection' => false, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
 
         $this->assertEquals($result, $dataProvider->getSubresource(ThirdLevel::class, ['id' => ['id' => 1], 'relatedDummies' => ['id' => 1]], $context));
     }
@@ -322,7 +324,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $dataProvider = new SubresourceDataProvider($managerRegistryProphecy->reveal(), $propertyNameCollectionFactory, $propertyMetadataFactory);
 
-        $context = ['property' => 'ownedDummy', 'identifiers' => [['id', Dummy::class]], 'collection' => false, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
+        $context = ['property' => 'ownedDummy', 'identifiers' => ['id' => [Dummy::class, 'id']], 'collection' => false, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
 
         $this->assertEquals([], $dataProvider->getSubresource(RelatedOwningDummy::class, ['id' => ['id' => 1]], $context));
     }
@@ -382,7 +384,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $dataProvider = new SubresourceDataProvider($managerRegistryProphecy->reveal(), $propertyNameCollectionFactory, $propertyMetadataFactory, [$extensionProphecy->reveal()]);
 
-        $context = ['property' => 'relatedDummies', 'identifiers' => [['id', Dummy::class]], 'collection' => true, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
+        $context = ['property' => 'relatedDummies', 'identifiers' => ['id' => [Dummy::class, 'id']], 'collection' => true, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
 
         $this->assertEquals([], $dataProvider->getSubresource(RelatedDummy::class, ['id' => ['id' => 1]], $context));
     }
@@ -426,6 +428,7 @@ class SubresourceDataProviderTest extends TestCase
      */
     public function testGetSubSubresourceItemLegacy()
     {
+        $this->expectDeprecation('Identifiers should match the convention introduced in ADR 0001-resource-identifiers, this behavior will be removed in 3.0.');
         $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
         $identifiers = ['id'];
         $funcProphecy = $this->prophesize(Func::class);
@@ -605,7 +608,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $dataProvider = new SubresourceDataProvider($managerRegistryProphecy->reveal(), $propertyNameCollectionFactory, $propertyMetadataFactory);
 
-        $context = ['property' => 'id', 'identifiers' => [['id', Dummy::class, true], ['relatedDummies', RelatedDummy::class, true]], 'collection' => false, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
+        $context = ['property' => 'id', 'identifiers' => ['id' => [Dummy::class, 'id', true], 'relatedDummies' => [RelatedDummy::class, 'id', true]], 'collection' => false, IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true];
 
         $this->assertEquals($result, $dataProvider->getSubresource(RelatedDummy::class, ['id' => ['id' => 1], 'relatedDummies' => ['id' => 2]], $context));
     }

--- a/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataCollector/RequestDataCollectorTest.php
@@ -142,6 +142,8 @@ class RequestDataCollectorTest extends TestCase
 
         $this->assertSame([
             'resource_class' => DummyEntity::class,
+            'has_composite_identifier' => false,
+            'identifiers' => ['id' => [DummyEntity::class, 'id']],
             'item_operation_name' => 'get',
             'receive' => true,
             'respond' => true,
@@ -282,7 +284,7 @@ class RequestDataCollectorTest extends TestCase
                 }
             },
         ]));
-        $itemDataProvider->getItem('', '', null, ['item_context']);
+        $itemDataProvider->getItem('', [], null, ['item_context']);
 
         return $itemDataProvider;
     }

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Bridge\Symfony\Routing;
 
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Bridge\Symfony\Routing\ApiLoader;
 use ApiPlatform\Core\Exception\InvalidResourceException;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -50,6 +51,7 @@ class ApiLoaderTest extends TestCase
     {
         $resourceMetadata = new ResourceMetadata();
         $resourceMetadata = $resourceMetadata->withShortName('dummy');
+        $resourceMetadata = $resourceMetadata->withAttributes(['identifiers' => 'id']);
         //default operation based on OperationResourceMetadataFactory
         $resourceMetadata = $resourceMetadata->withItemOperations([
             'get' => ['method' => 'GET', 'requirements' => ['id' => '\d+'], 'defaults' => ['my_default' => 'default_value', '_controller' => 'should_not_be_overriden'], 'stateless' => null],
@@ -105,7 +107,7 @@ class ApiLoaderTest extends TestCase
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', DummyEntity::class, true]], 'collection' => true, 'operationId' => 'api_dummies_subresources_get_subresource'], [], ['_stateless' => true]),
+            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => ['id' => [DummyEntity::class, 'id', true]], 'collection' => true, 'operationId' => 'api_dummies_subresources_get_subresource'], [], ['_stateless' => true]),
             $routeCollection->get('api_dummies_subresources_get_subresource')
         );
     }
@@ -119,7 +121,7 @@ class ApiLoaderTest extends TestCase
             'put' => ['method' => 'PUT', 'stateless' => null],
             'delete' => ['method' => 'DELETE', 'stateless' => null],
         ]);
-        $resourceMetadata = $resourceMetadata->withAttributes(['route_prefix' => '/foobar-prefix']);
+        $resourceMetadata = $resourceMetadata->withAttributes(['route_prefix' => '/foobar-prefix', 'identifiers' => 'id']);
 
         $routeCollection = $this->getApiLoaderWithResourceMetadata($resourceMetadata)->load(null);
 
@@ -200,32 +202,32 @@ class ApiLoaderTest extends TestCase
         $routeCollection = $this->getApiLoaderWithResourceMetadata($resourceMetadata, true)->load(null);
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', DummyEntity::class, true]], 'collection' => true, 'operationId' => 'api_dummies_subresources_get_subresource']),
+            $this->getSubresourceRoute('/dummies/{id}/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_dummies_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => ['id' => [DummyEntity::class, 'id', true]], 'collection' => true, 'operationId' => 'api_dummies_subresources_get_subresource']),
             $routeCollection->get('api_dummies_subresources_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_recursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', RelatedDummyEntity::class, true], ['recursivesubresource', DummyEntity::class, false]], 'collection' => true, 'operationId' => 'api_related_dummies_recursivesubresource_subresources_get_subresource']),
+            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_recursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => ['id' => [RelatedDummyEntity::class, 'id', true], 'recursivesubresource' => [DummyEntity::class, 'id', false]], 'collection' => true, 'operationId' => 'api_related_dummies_recursivesubresource_subresources_get_subresource']),
             $routeCollection->get('api_related_dummies_recursivesubresource_subresources_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource.{_format}', 'dummy_controller', DummyEntity::class, 'api_related_dummies_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => [['id', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'api_related_dummies_recursivesubresource_get_subresource']),
+            $this->getSubresourceRoute('/related_dummies/{id}/recursivesubresource.{_format}', 'dummy_controller', DummyEntity::class, 'api_related_dummies_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => ['id' => [RelatedDummyEntity::class, 'id', true]], 'collection' => false, 'operationId' => 'api_related_dummies_recursivesubresource_get_subresource']),
             $routeCollection->get('api_related_dummies_recursivesubresource_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/dummies/{id}/subresources/{subresource}/recursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_dummies_subresources_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => [['id', DummyEntity::class, true], ['subresource', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'api_dummies_subresources_recursivesubresource_get_subresource']),
+            $this->getSubresourceRoute('/dummies/{id}/subresources/{subresource}/recursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_dummies_subresources_recursivesubresource_get_subresource', ['property' => 'recursivesubresource', 'identifiers' => ['id' => [DummyEntity::class, 'id', true], 'subresource' => [RelatedDummyEntity::class, 'id', true]], 'collection' => false, 'operationId' => 'api_dummies_subresources_recursivesubresource_get_subresource']),
             $routeCollection->get('api_dummies_subresources_recursivesubresource_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => [['id', RelatedDummyEntity::class, true], ['secondrecursivesubresource', DummyEntity::class, false]], 'collection' => true, 'operationId' => 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource']),
+            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource/subresources.{_format}', 'api_platform.action.get_subresource', RelatedDummyEntity::class, 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource', ['property' => 'subresource', 'identifiers' => ['id' => [RelatedDummyEntity::class, 'id', true], 'secondrecursivesubresource' => [DummyEntity::class, 'id', false]], 'collection' => true, 'operationId' => 'api_related_dummies_secondrecursivesubresource_subresources_get_subresource']),
             $routeCollection->get('api_related_dummies_secondrecursivesubresource_subresources_get_subresource')
         );
 
         $this->assertEquals(
-            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_related_dummies_secondrecursivesubresource_get_subresource', ['property' => 'secondrecursivesubresource', 'identifiers' => [['id', RelatedDummyEntity::class, true]], 'collection' => false, 'operationId' => 'api_related_dummies_secondrecursivesubresource_get_subresource']),
+            $this->getSubresourceRoute('/related_dummies/{id}/secondrecursivesubresource.{_format}', 'api_platform.action.get_subresource', DummyEntity::class, 'api_related_dummies_secondrecursivesubresource_get_subresource', ['property' => 'secondrecursivesubresource', 'identifiers' => ['id' => [RelatedDummyEntity::class, 'id', true]], 'collection' => false, 'operationId' => 'api_related_dummies_secondrecursivesubresource_get_subresource']),
             $routeCollection->get('api_related_dummies_secondrecursivesubresource_get_subresource')
         );
     }
@@ -301,9 +303,13 @@ class ApiLoaderTest extends TestCase
 
         $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
 
-        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), new UnderscorePathSegmentNameGenerator());
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+        $identifiersExtractor = $identifiersExtractorProphecy->reveal();
 
-        return new ApiLoader($kernelProphecy->reveal(), $resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactory, $operationPathResolver, $containerProphecy->reveal(), ['jsonld' => ['application/ld+json']], [], $subresourceOperationFactory, false, true, true, false, false);
+        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), new UnderscorePathSegmentNameGenerator(), $identifiersExtractor);
+
+        return new ApiLoader($kernelProphecy->reveal(), $resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactory, $operationPathResolver, $containerProphecy->reveal(), ['jsonld' => ['application/ld+json']], [], $subresourceOperationFactory, false, true, true, false, false, $identifiersExtractor);
     }
 
     private function getRoute(string $path, string $controller, string $resourceClass, string $operationName, array $methods, bool $collection = false, array $requirements = [], array $extraDefaults = ['_stateless' => null], array $options = [], string $host = '', array $schemes = [], string $condition = ''): Route
@@ -314,6 +320,8 @@ class ApiLoaderTest extends TestCase
                 '_controller' => $controller,
                 '_format' => null,
                 '_api_resource_class' => $resourceClass,
+                '_api_identifiers' => ['id'],
+                '_api_has_composite_identifier' => false,
                 sprintf('_api_%s_operation_name', $collection ? 'collection' : 'item') => $operationName,
             ] + $extraDefaults,
             $requirements,
@@ -335,6 +343,8 @@ class ApiLoaderTest extends TestCase
                 '_api_resource_class' => $resourceClass,
                 '_api_subresource_operation_name' => $operationName,
                 '_api_subresource_context' => $context,
+                '_api_identifiers' => $context['identifiers'],
+                '_api_has_composite_identifier' => false,
             ] + $extraDefaults,
             $requirements,
             [],

--- a/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
+++ b/tests/Bridge/Symfony/Routing/RouteNameResolverTest.php
@@ -172,12 +172,12 @@ class RouteNameResolverTest extends TestCase
         $routeCollection->add('a_some_subresource_route', new Route('/a/some/item/path/{id}', [
             '_api_resource_class' => 'AppBundle\Entity\User',
             '_api_subresource_operation_name' => 'some_other_item_op',
-            '_api_subresource_context' => ['identifiers' => [[1, 'bar']]],
+            '_api_subresource_context' => ['identifiers' => ['id' => ['Bar', 'id']]],
         ]));
         $routeCollection->add('b_some_subresource_route', new Route('/b/some/item/path/{id}', [
             '_api_resource_class' => 'AppBundle\Entity\User',
             '_api_subresource_operation_name' => 'some_item_op',
-            '_api_subresource_context' => ['identifiers' => [[1, 'foo']]],
+            '_api_subresource_context' => ['identifiers' => ['id' => ['Foo', 'id']]],
         ]));
         $routeCollection->add('some_collection_route', new Route('/some/collection/path', [
             '_api_resource_class' => 'AppBundle\Entity\User',
@@ -188,7 +188,7 @@ class RouteNameResolverTest extends TestCase
         $routerProphecy->getRouteCollection()->willReturn($routeCollection);
 
         $routeNameResolver = new RouteNameResolver($routerProphecy->reveal());
-        $actual = $routeNameResolver->getRouteName('AppBundle\Entity\User', OperationType::SUBRESOURCE, ['subresource_resources' => ['foo' => 1]]);
+        $actual = $routeNameResolver->getRouteName('AppBundle\Entity\User', OperationType::SUBRESOURCE, ['subresource_resources' => ['Foo' => 1]]);
 
         $this->assertSame('b_some_subresource_route', $actual);
     }

--- a/tests/EventListener/DeserializeListenerTest.php
+++ b/tests/EventListener/DeserializeListenerTest.php
@@ -200,13 +200,7 @@ class DeserializeListenerTest extends TestCase
     public function testLegacyDeserializeResourceClassSupportedFormat(string $method, bool $populateObject): void
     {
         $formatsProviderProphecy = $this->prophesize(FormatsProviderInterface::class);
-        $formatsProviderProphecy->getFormatsFromAttributes([
-            'resource_class' => 'Foo',
-            'collection_operation_name' => 'post',
-            'receive' => true,
-            'respond' => true,
-            'persist' => true,
-        ])->willReturn(self::FORMATS)->shouldBeCalled();
+        $formatsProviderProphecy->getFormatsFromAttributes(Argument::type('array'))->willReturn(self::FORMATS)->shouldBeCalled();
 
         $this->doTestDeserializeResourceClassSupportedFormat($method, $populateObject, $formatsProviderProphecy->reveal());
     }

--- a/tests/Fixtures/TestBundle/Document/Book.php
+++ b/tests/Fixtures/TestBundle/Document/Book.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Book.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @ApiResource(collectionOperations={}, itemOperations={
+ *     "get",
+ *     "get_by_isbn"={"method"="GET", "path"="/books/by_isbn/{isbn}.{_format}", "requirements"={"isbn"=".+"}, "identifiers"="isbn"}
+ * })
+ * @ODM\Document
+ */
+class Book
+{
+    /**
+     * @ODM\Id(strategy="INCREMENT", type="integer")
+     */
+    private $id;
+
+    /**
+     * @ODM\Field(type="string", nullable=true)
+     */
+    public $name;
+
+    /**
+     * @ODM\Field(type="string")
+     */
+    public $isbn;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/CustomMultipleIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Document/CustomMultipleIdentifierDummy.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Custom Identifier Dummy.
+ *
+ * @ApiResource(compositeIdentifier=false)
+ * @ODM\Document
+ */
+class CustomMultipleIdentifierDummy
+{
+    /**
+     * @var int The custom identifier
+     *
+     * @ODM\Id(strategy="NONE", type="integer")
+     */
+    private $firstId;
+
+    /**
+     * @var int The custom identifier
+     *
+     * @ApiProperty(identifier=true)
+     * @ODM\Field(type="integer")
+     */
+    private $secondId;
+
+    /**
+     * @var string The dummy name
+     *
+     * @ODM\Field(type="string")
+     */
+    private $name;
+
+    public function getFirstId(): int
+    {
+        return $this->firstId;
+    }
+
+    public function setFirstId(int $firstId)
+    {
+        $this->firstId = $firstId;
+    }
+
+    public function getSecondId(): int
+    {
+        return $this->secondId;
+    }
+
+    public function setSecondId(int $secondId)
+    {
+        $this->secondId = $secondId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/SlugParentDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SlugParentDummy.php
@@ -23,7 +23,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * Custom Identifier Dummy With Subresource.
  *
- * @ApiResource
+ * @ApiResource(attributes={"identifiers"="slug"})
  * @ODM\Document
  */
 class SlugParentDummy

--- a/tests/Fixtures/TestBundle/Entity/Book.php
+++ b/tests/Fixtures/TestBundle/Entity/Book.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Book.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @ApiResource(collectionOperations={}, itemOperations={
+ *     "get",
+ *     "get_by_isbn"={"method"="GET", "path"="/books/by_isbn/{isbn}.{_format}", "requirements"={"isbn"=".+"}, "identifiers"="isbn"}
+ * })
+ * @ORM\Entity
+ */
+class Book
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    public $name;
+
+    /**
+     * @ORM\Column(unique=true)
+     */
+    public $isbn;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/CustomMultipleIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomMultipleIdentifierDummy.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Custom Identifier Dummy.
+ *
+ * @ApiResource(compositeIdentifier=false)
+ * @ORM\Entity
+ */
+class CustomMultipleIdentifierDummy
+{
+    /**
+     * @var int The custom identifier
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $firstId;
+
+    /**
+     * @var int The custom identifier
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $secondId;
+
+    /**
+     * @var string The dummy name
+     *
+     * @ORM\Column(length=30)
+     */
+    private $name;
+
+    public function getFirstId(): int
+    {
+        return $this->firstId;
+    }
+
+    public function setFirstId(int $firstId)
+    {
+        $this->firstId = $firstId;
+    }
+
+    public function getSecondId(): int
+    {
+        return $this->secondId;
+    }
+
+    public function setSecondId(int $secondId)
+    {
+        $this->secondId = $secondId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/SlugParentDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SlugParentDummy.php
@@ -23,7 +23,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Custom Identifier Dummy With Subresource.
  *
- * @ApiResource
+ * @ApiResource(attributes={"identifiers"="slug"})
  * @ORM\Entity
  */
 class SlugParentDummy

--- a/tests/Fixtures/TestBundle/Model/ProductInterface.php
+++ b/tests/Fixtures/TestBundle/Model/ProductInterface.php
@@ -21,6 +21,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @ApiResource(
  *     shortName="Product",
+ *     attributes={"identifiers"="code"},
  *     normalizationContext={
  *         "groups"={"product_read"},
  *     },

--- a/tests/Fixtures/TestBundle/Model/TaxonInterface.php
+++ b/tests/Fixtures/TestBundle/Model/TaxonInterface.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ApiResource(
+ *     attributes={"identifiers"="code"},
  *     shortName="Taxon",
  *     normalizationContext={
  *         "groups"={"taxon_read"},

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -212,7 +212,7 @@ class ReadStageTest extends TestCase
         $normalizationContext = ['normalization' => true];
         $this->serializerContextBuilderProphecy->create($resourceClass, $operationName, $context, true)->shouldBeCalled()->willReturn($normalizationContext);
 
-        $this->subresourceDataProviderProphecy->getSubresource($resourceClass, ['id' => 3], $normalizationContext + ['filters' => $expectedFilters, 'property' => $fieldName, 'identifiers' => [['id', $resourceClass]], 'collection' => true], $operationName)->willReturn(['subresource']);
+        $this->subresourceDataProviderProphecy->getSubresource($resourceClass, ['id' => 3], $normalizationContext + ['filters' => $expectedFilters, 'property' => $fieldName, 'identifiers' => ['id' => [$resourceClass, 'id']], 'collection' => true], $operationName)->willReturn(['subresource']);
 
         $this->collectionDataProviderProphecy->getCollection($resourceClass, $operationName, $normalizationContext + ['filters' => $expectedFilters])->willReturn([]);
 

--- a/tests/Hydra/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Hydra/Serializer/DocumentationNormalizerTest.php
@@ -95,7 +95,7 @@ class DocumentationNormalizerTest extends TestCase
                 'resource_class' => 'relatedDummy',
                 'shortNames' => ['relatedDummy'],
                 'identifiers' => [
-                    ['id', 'dummy', true],
+                    'id' => ['dummy', 'id', true],
                 ],
                 'route_name' => 'api_dummies_subresource_get_related_dummy',
                 'path' => '/dummies/{id}/related_dummy.{_format}',

--- a/tests/Identifier/CompositeIdentifierParserTest.php
+++ b/tests/Identifier/CompositeIdentifierParserTest.php
@@ -41,4 +41,27 @@ class CompositeIdentifierParserTest extends TestCase
             'foo=test=bar;bar=' => ['foo' => 'test=bar', 'bar' => ''],
         ]]];
     }
+
+    /**
+     * @dataProvider compositeIdentifiers
+     */
+    public function testStringify(array $identifiers)
+    {
+        foreach ($identifiers as $string => $arr) {
+            $this->assertEquals(CompositeIdentifierParser::stringify($arr), $string);
+        }
+    }
+
+    public function compositeIdentifiers(): array
+    {
+        return [[[
+            'a=bd;dc=d' => ['a' => 'bd', 'dc' => 'd'],
+            'a=b;c=d foo;d23i=e' => ['a' => 'b', 'c' => 'd foo', 'd23i' => 'e'],
+            'a=1;c=2;d=10-30-24' => ['a' => '1', 'c' => '2', 'd' => '10-30-24'],
+            'a=test;b=bar;foo;c=123' => ['a' => 'test', 'b' => 'bar;foo', 'c' => '123'],
+            'foo=test=bar;;bar=bazzz' => ['foo' => 'test=bar;', 'bar' => 'bazzz'],
+            'foo=test=bar;bar=;test=foo' => ['foo' => 'test=bar', 'bar' => '', 'test' => 'foo'],
+            'foo=test=bar;bar=' => ['foo' => 'test=bar', 'bar' => ''],
+        ]]];
+    }
 }

--- a/tests/Identifier/IdentifierConverterTest.php
+++ b/tests/Identifier/IdentifierConverterTest.php
@@ -32,6 +32,8 @@ class IdentifierConverterTest extends TestCase
 
     public function testCompositeIdentifier()
     {
+        $this->markTestSkipped('This behavior is now external to the identifier converter.');
+        /** @phpstan-ignore-next-line */
         $identifier = 'a=1;c=2;d=2015-04-05';
         $class = 'Dummy';
 
@@ -58,7 +60,7 @@ class IdentifierConverterTest extends TestCase
 
     public function testSingleDateIdentifier()
     {
-        $identifier = '2015-04-05';
+        $identifier = ['funkyid' => '2015-04-05'];
         $class = 'Dummy';
 
         $dateIdentifierPropertyMetadata = (new PropertyMetadata())->withIdentifier(true)->withType(new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateTime::class));
@@ -77,7 +79,7 @@ class IdentifierConverterTest extends TestCase
 
     public function testIntegerIdentifier()
     {
-        $identifier = '42';
+        $identifier = ['id' => '42'];
         $class = 'Dummy';
 
         $integerIdentifierPropertyMetadata = (new PropertyMetadata())->withIdentifier(true)->withType(new Type(Type::BUILTIN_TYPE_INT));

--- a/tests/OpenApi/Factory/OpenApiFactoryTest.php
+++ b/tests/OpenApi/Factory/OpenApiFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\OpenApi\Factory;
 
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Bridge\Symfony\Routing\RouterOperationPathResolver;
 use ApiPlatform\Core\DataProvider\PaginationOptions;
 use ApiPlatform\Core\JsonSchema\Schema;
@@ -148,6 +149,9 @@ class OpenApiFactoryTest extends TestCase
         $schemaFactory = new SchemaFactory($typeFactory, $resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $typeFactory->setSchemaFactory($schemaFactory);
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $factory = new OpenApiFactory(
             $resourceNameCollectionFactoryProphecy->reveal(),
             $resourceMetadataFactory,
@@ -158,6 +162,7 @@ class OpenApiFactoryTest extends TestCase
             $operationPathResolver,
             $filterLocatorProphecy->reveal(),
             $subresourceOperationFactoryProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal(),
             [],
             new Options('Test API', 'This is a test API.', '1.2.3', true, 'oauth2', 'authorizationCode', '/oauth/v2/token', '/oauth/v2/auth', '/oauth/v2/refresh', ['scope param'], [
                 'header' => [
@@ -525,6 +530,9 @@ class OpenApiFactoryTest extends TestCase
         $schemaFactory = new SchemaFactory($typeFactory, $resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $typeFactory->setSchemaFactory($schemaFactory);
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $factory = new OpenApiFactory(
             $resourceNameCollectionFactoryProphecy->reveal(),
             $resourceMetadataFactory,
@@ -535,6 +543,7 @@ class OpenApiFactoryTest extends TestCase
             $operationPathResolver,
             $filterLocatorProphecy->reveal(),
             $subresourceOperationFactoryProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal(),
             [],
             new Options('Test API', 'This is a test API.', '1.2.3', true, 'oauth2', 'authorizationCode', '/oauth/v2/token', '/oauth/v2/auth', '/oauth/v2/refresh', ['scope param'], [
                 'header' => [
@@ -614,7 +623,11 @@ class OpenApiFactoryTest extends TestCase
         $propertyNameCollectionFactory = $propertyNameCollectionFactoryProphecy->reveal();
         $propertyMetadataFactory = $propertyMetadataFactoryProphecy->reveal();
 
-        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new UnderscorePathSegmentNameGenerator());
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+        $identifiersExtractor = $identifiersExtractorProphecy->reveal();
+
+        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new UnderscorePathSegmentNameGenerator(), $identifiersExtractor);
 
         $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $resourceNameCollectionFactoryProphecy->create()->shouldBeCalled()->willReturn(new ResourceNameCollection([Question::class, Answer::class]));
@@ -634,6 +647,7 @@ class OpenApiFactoryTest extends TestCase
             $operationPathResolver,
             $filterLocatorProphecy->reveal(),
             $subresourceOperationFactory,
+            $identifiersExtractor,
             ['jsonld' => ['application/ld+json']],
             new Options('Test API', 'This is a test API.', '1.2.3', true, 'oauth2', 'authorizationCode', '/oauth/v2/token', '/oauth/v2/auth', '/oauth/v2/refresh', ['scope param'], [
                 'header' => [

--- a/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
+++ b/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\OpenApi\Serializer;
 
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\DataProvider\PaginationOptions;
 use ApiPlatform\Core\JsonSchema\SchemaFactory;
 use ApiPlatform\Core\JsonSchema\TypeFactory;
@@ -95,6 +96,9 @@ class OpenApiNormalizerTest extends TestCase
         $schemaFactory = new SchemaFactory($typeFactory, $resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $typeFactory->setSchemaFactory($schemaFactory);
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $factory = new OpenApiFactory(
             $resourceNameCollectionFactoryProphecy->reveal(),
             $resourceMetadataFactory,
@@ -105,6 +109,7 @@ class OpenApiNormalizerTest extends TestCase
             $operationPathResolver,
             $filterLocatorProphecy->reveal(),
             $subresourceOperationFactoryProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal(),
             [],
             new Options('Test API', 'This is a test API.', '1.2.3', true, 'oauth2', 'authorizationCode', '/oauth/v2/token', '/oauth/v2/auth', '/oauth/v2/refresh', ['scope param'], [
                 'header' => [

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Operation\Factory;
 
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
@@ -27,6 +28,7 @@ use ApiPlatform\Core\Tests\Fixtures\DummyValidatedEntity;
 use ApiPlatform\Core\Tests\Fixtures\RelatedDummyEntity;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
@@ -62,7 +64,10 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
         $pathSegmentNameGeneratorProphecy->getSegmentName('anotherSubresource', false)->shouldBeCalled()->willReturn('another_subresource');
 
-        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $pathSegmentNameGeneratorProphecy->reveal());
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
+        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $pathSegmentNameGeneratorProphecy->reveal(), $identifiersExtractorProphecy->reveal());
 
         $this->assertEquals([
             'api_dummy_entities_subresource_get_subresource' => [
@@ -71,7 +76,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource.{_format}',
@@ -83,8 +88,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity', 'relatedDummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subresource', RelatedDummyEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subresource' => [RelatedDummyEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource.{_format}',
@@ -96,9 +101,9 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subresource', RelatedDummyEntity::class, false],
-                    ['anotherSubresource', DummyEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subresource' => [RelatedDummyEntity::class, 'id', false],
+                    'anotherSubresource' => [DummyEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource/subcollections.{_format}',
@@ -110,7 +115,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections.{_format}',
@@ -122,8 +127,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity', 'relatedDummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subcollection', RelatedDummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subcollection' => [RelatedDummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections/{subcollection}/another_subresource.{_format}',
@@ -135,9 +140,9 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subcollection', RelatedDummyEntity::class, true],
-                    ['anotherSubresource', DummyEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subcollection' => [RelatedDummyEntity::class, 'id', true],
+                    'anotherSubresource' => [DummyEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subcollections/{subcollection}/another_subresource/subresource.{_format}',
@@ -180,7 +185,10 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
         $pathSegmentNameGeneratorProphecy->getSegmentName('anotherSubresource', false)->shouldBeCalled()->willReturn('another_subresource');
 
-        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $pathSegmentNameGeneratorProphecy->reveal());
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
+        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $pathSegmentNameGeneratorProphecy->reveal(), $identifiersExtractorProphecy->reveal());
 
         $this->assertEquals([
             'api_dummy_entities_subresource_get_subresource' => [
@@ -189,7 +197,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource.{_format}',
@@ -201,8 +209,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity', 'relatedDummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subresource', RelatedDummyEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subresource' => [RelatedDummyEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource.{_format}',
@@ -214,9 +222,9 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subresource', RelatedDummyEntity::class, false],
-                    ['anotherSubresource', DummyEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subresource' => [RelatedDummyEntity::class, 'id', false],
+                    'anotherSubresource' => [DummyEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_another_subresource_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/another_subresource/subcollections.{_format}',
@@ -228,7 +236,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_get_subresource',
                 'path' => '/dummy_entities/{id}/foobars',
@@ -240,8 +248,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity', 'relatedDummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subcollection', RelatedDummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subcollection' => [RelatedDummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_foobar.{_format}',
@@ -253,9 +261,9 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subcollection', RelatedDummyEntity::class, true],
-                    ['anotherSubresource', DummyEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subcollection' => [RelatedDummyEntity::class, 'id', true],
+                    'anotherSubresource' => [DummyEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_subcollections_another_subresource_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/foobars/{subcollection}/another_foobar/subresource.{_format}',
@@ -286,11 +294,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresource');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
                 $resourceMetadataFactoryProphecy->reveal(),
                 $propertyNameCollectionFactoryProphecy->reveal(),
                 $propertyMetadataFactoryProphecy->reveal(),
-                $pathSegmentNameGeneratorProphecy->reveal()
+                $pathSegmentNameGeneratorProphecy->reveal(),
+                $identifiersExtractorProphecy->reveal()
         );
 
         $this->assertEquals([
@@ -300,7 +312,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource.{_format}',
@@ -346,11 +358,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('secondSubresource', false)->shouldBeCalled()->willReturn('second_subresources');
         $pathSegmentNameGeneratorProphecy->getSegmentName('moreSubresource', false)->shouldBeCalled()->willReturn('mode_subresources');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $pathSegmentNameGeneratorProphecy->reveal()
+            $pathSegmentNameGeneratorProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal()
         );
 
         $this->assertEquals([
@@ -360,7 +376,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresources.{_format}',
@@ -372,7 +388,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyValidatedEntity::class,
                 'shortNames' => ['dummyValidatedEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_second_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/second_subresources.{_format}',
@@ -384,8 +400,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyValidatedEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['secondSubresource', DummyValidatedEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'secondSubresource' => [DummyValidatedEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_second_subresource_more_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/second_subresources/mode_subresources.{_format}',
@@ -430,11 +446,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresources');
         $pathSegmentNameGeneratorProphecy->getSegmentName('secondSubresource', false)->shouldBeCalled()->willReturn('second_subresources');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $pathSegmentNameGeneratorProphecy->reveal()
+            $pathSegmentNameGeneratorProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal()
         );
 
         $this->assertEquals([
@@ -444,7 +464,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresources.{_format}',
@@ -456,7 +476,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyValidatedEntity::class,
                 'shortNames' => ['dummyValidatedEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_second_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/second_subresources.{_format}',
@@ -485,11 +505,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresources');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $pathSegmentNameGeneratorProphecy->reveal()
+            $pathSegmentNameGeneratorProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal()
         );
 
         $this->assertEquals([
@@ -499,7 +523,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresources.{_format}',
@@ -537,11 +561,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresources');
         $pathSegmentNameGeneratorProphecy->getSegmentName('secondSubresource', false)->shouldBeCalled()->willReturn('second_subresources');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $pathSegmentNameGeneratorProphecy->reveal()
+            $pathSegmentNameGeneratorProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal()
         );
 
         $this->assertEquals([
@@ -551,7 +579,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresources.{_format}',
@@ -563,8 +591,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subresource', DummyEntity::class, false],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subresource' => [DummyEntity::class, 'id', false],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_second_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresources/second_subresources.{_format}',
@@ -576,7 +604,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_second_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/second_subresources.{_format}',
@@ -606,11 +634,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', true)->shouldBeCalled()->willReturn('subresource');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
                 $resourceMetadataFactoryProphecy->reveal(),
                 $propertyNameCollectionFactoryProphecy->reveal(),
                 $propertyMetadataFactoryProphecy->reveal(),
-                $pathSegmentNameGeneratorProphecy->reveal()
+                $pathSegmentNameGeneratorProphecy->reveal(),
+                $identifiersExtractorProphecy->reveal()
         );
 
         $result = $subresourceOperationFactory->create(DummyEntity::class);
@@ -621,7 +653,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresources_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource.{_format}',
@@ -633,8 +665,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity', 'relatedDummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
-                    ['subresource', RelatedDummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
+                    'subresource' => [RelatedDummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresources_item_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource/{subresource}.{_format}',
@@ -664,11 +696,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresource');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
                 $resourceMetadataFactoryProphecy->reveal(),
                 $propertyNameCollectionFactoryProphecy->reveal(),
                 $propertyMetadataFactoryProphecy->reveal(),
-                $pathSegmentNameGeneratorProphecy->reveal()
+                $pathSegmentNameGeneratorProphecy->reveal(),
+                $identifiersExtractorProphecy->reveal()
         );
 
         $result = $subresourceOperationFactory->create(DummyEntity::class);
@@ -679,7 +715,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresource.{_format}',
@@ -710,11 +746,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresource');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $pathSegmentNameGeneratorProphecy->reveal()
+            $pathSegmentNameGeneratorProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal()
         );
 
         $this->assertEquals([
@@ -724,7 +764,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/root_resource_prefix/dummy_entities/{id}/subresource.{_format}',
@@ -759,11 +799,15 @@ class SubresourceOperationFactoryTest extends TestCase
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresources');
         $pathSegmentNameGeneratorProphecy->getSegmentName('otherSubresource', false)->shouldBeCalled()->willReturn('other_subresources');
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $subresourceOperationFactory = new SubresourceOperationFactory(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
-            $pathSegmentNameGeneratorProphecy->reveal()
+            $pathSegmentNameGeneratorProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal()
         );
 
         $this->assertEquals([
@@ -773,7 +817,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => DummyEntity::class,
                 'shortNames' => ['dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/subresources.{_format}',
@@ -785,7 +829,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'resource_class' => RelatedDummyEntity::class,
                 'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
                 'identifiers' => [
-                    ['id', DummyEntity::class, true],
+                    'id' => [DummyEntity::class, 'id', true],
                 ],
                 'route_name' => 'api_dummy_entities_other_subresource_get_subresource',
                 'path' => '/dummy_entities/{id}/other_subresources.{_format}',

--- a/tests/PathResolver/OperationPathResolverTest.php
+++ b/tests/PathResolver/OperationPathResolverTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\PathResolver;
+
+use ApiPlatform\Core\Api\OperationType;
+use ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator;
+use ApiPlatform\Core\PathResolver\OperationPathResolver;
+use PHPUnit\Framework\TestCase;
+
+class OperationPathResolverTest extends TestCase
+{
+    public function testResolveItemOperationPath()
+    {
+        $operationPathResolver = new OperationPathResolver(new UnderscorePathSegmentNameGenerator());
+        $this->assertEquals('/foos/{id}.{_format}', $operationPathResolver->resolveOperationPath('Foo', [], OperationType::ITEM, 'get'));
+    }
+
+    public function testResolveItemOperationPathIdentifiedBy()
+    {
+        $operationPathResolver = new OperationPathResolver(new UnderscorePathSegmentNameGenerator());
+        $this->assertSame('/short_names/{isbn}.{_format}', $operationPathResolver->resolveOperationPath('ShortName', ['identifiers' => ['isbn']], OperationType::ITEM, 'get'));
+    }
+}

--- a/tests/Serializer/SerializerContextBuilderTest.php
+++ b/tests/Serializer/SerializerContextBuilderTest.php
@@ -99,6 +99,11 @@ class SerializerContextBuilderTest extends TestCase
         $request->attributes->replace(['_api_resource_class' => 'FooWithPatch', '_api_item_operation_name' => 'patch', '_api_format' => 'json', '_api_mime_type' => 'application/json']);
         $expected = ['item_operation_name' => 'patch', 'resource_class' => 'FooWithPatch', 'request_uri' => '/foowithpatch/1', 'operation_type' => 'item', 'api_allow_update' => true, 'uri' => 'http://localhost/foowithpatch/1', 'output' => null, 'input' => null, 'deep_object_to_populate' => true, 'skip_null_values' => true, 'iri_only' => false];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
+
+        $request = Request::create('/bars/1/foos');
+        $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_subresource_operation_name' => 'get', '_api_format' => 'xml', '_api_mime_type' => 'text/xml', '_api_subresource_context' => ['identifiers' => ['id' => ['Foo', 'id']]], 'id' => '1']);
+        $expected = ['bar' => 'baz', 'subresource_operation_name' => 'get', 'resource_class' => 'Foo', 'request_uri' => '/bars/1/foos', 'operation_type' => 'subresource', 'api_allow_update' => false, 'uri' => 'http://localhost/bars/1/foos', 'output' => null, 'input' => null, 'iri_only' => false, 'subresource_identifiers' => ['id' => '1'], 'subresource_resources' => ['Foo' => ['id' => '1']]];
+        $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
     }
 
     public function testThrowExceptionOnInvalidRequest()

--- a/tests/Serializer/SerializerFilterContextBuilderTest.php
+++ b/tests/Serializer/SerializerFilterContextBuilderTest.php
@@ -150,6 +150,10 @@ class SerializerFilterContextBuilderTest extends TestCase
         $attributes = [
             'resource_class' => DummyGroup::class,
             'collection_operation_name' => 'get',
+            'identifiers' => [
+                'id' => [DummyGroup::class, 'id'],
+            ],
+            'has_composite_identifier' => false,
             'receive' => true,
             'respond' => true,
             'persist' => true,

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Swagger\Serializer;
 
 use ApiPlatform\Core\Api\FilterCollection;
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\OperationAwareFormatsProviderInterface;
 use ApiPlatform\Core\Api\OperationMethodResolverInterface;
 use ApiPlatform\Core\Api\OperationType;
@@ -50,6 +51,7 @@ use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -65,6 +67,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 class DocumentationNormalizerV2Test extends TestCase
 {
     use ProphecyTrait;
+    use ExpectDeprecationTrait;
 
     private const OPERATION_FORMATS = [
         'input_formats' => ['jsonld' => ['application/ld+json']],
@@ -73,10 +76,11 @@ class DocumentationNormalizerV2Test extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing an instance of ApiPlatform\Core\Api\UrlGeneratorInterface to ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer::__construct() is deprecated since version 2.1 and will be removed in 3.0.
      */
     public function testLegacyConstruct(): void
     {
+        $this->expectDeprecation('Passing an instance of ApiPlatform\Core\Api\UrlGeneratorInterface to ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer::__construct() is deprecated since version 2.1 and will be removed in 3.0.');
+
         $normalizer = new DocumentationNormalizer(
             $this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(),
             $this->prophesize(PropertyNameCollectionFactoryInterface::class)->reveal(),
@@ -142,13 +146,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             $operationMethodResolver,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -409,6 +437,9 @@ class DocumentationNormalizerV2Test extends TestCase
             $typeFactory->setSchemaFactory($schemaFactory);
         }
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -424,7 +455,19 @@ class DocumentationNormalizerV2Test extends TestCase
             'application',
             '/oauth/v2/token',
             '/oauth/v2/auth',
-            ['scope param']
+            ['scope param'],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -521,6 +564,9 @@ class DocumentationNormalizerV2Test extends TestCase
             ],
         ];
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -537,7 +583,18 @@ class DocumentationNormalizerV2Test extends TestCase
             '',
             '',
             [],
-            $apiKeysConfiguration
+            $apiKeysConfiguration,
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -648,13 +705,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -848,13 +929,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1025,13 +1130,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1123,13 +1252,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1311,13 +1464,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1491,13 +1668,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1721,7 +1922,26 @@ class DocumentationNormalizerV2Test extends TestCase
             null,
             $this->prophesize(OperationPathResolverInterface::class)->reveal(),
             null,
-            new \ArrayObject()
+            new \ArrayObject(),
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $this->prophesize(IdentifiersExtractorInterface::class)->reveal()
         );
     }
 
@@ -1732,13 +1952,37 @@ class DocumentationNormalizerV2Test extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3');
@@ -1768,13 +2012,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1810,13 +2078,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1894,13 +2186,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2081,6 +2397,9 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2089,7 +2408,26 @@ class DocumentationNormalizerV2Test extends TestCase
             null,
             $operationPathResolver,
             null,
-            $filterLocator
+            $filterLocator,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2227,7 +2565,13 @@ class DocumentationNormalizerV2Test extends TestCase
         $propertyNameCollectionFactory = $propertyNameCollectionFactoryProphecy->reveal();
         $propertyMetadataFactory = $propertyMetadataFactoryProphecy->reveal();
 
-        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new UnderscorePathSegmentNameGenerator());
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
+        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new UnderscorePathSegmentNameGenerator(), $identifiersExtractorProphecy->reveal());
+
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactory,
@@ -2251,7 +2595,12 @@ class DocumentationNormalizerV2Test extends TestCase
             'page',
             false,
             'itemsPerPage',
-            $formatsProvider ?? ['json' => ['application/json'], 'csv' => ['text/csv']]
+            $formatsProvider ?? ['json' => ['application/json'], 'csv' => ['text/csv']],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2365,13 +2714,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2456,13 +2829,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2577,6 +2974,9 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new OperationPathResolver(new UnderscorePathSegmentNameGenerator());
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2598,7 +2998,12 @@ class DocumentationNormalizerV2Test extends TestCase
             'page',
             false,
             'itemsPerPage',
-            $formatProvider
+            $formatProvider,
+            false,
+            'pagination',
+            [],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2771,13 +3176,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            '',
+            [],
+            [],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2977,13 +3406,37 @@ class DocumentationNormalizerV2Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
             $propertyMetadataFactoryProphecy->reveal(),
             null,
             null,
-            $operationPathResolver
+            $operationPathResolver,
+            null,
+            null,
+            null,
+            false,
+            '',
+            '',
+            '',
+            '',
+            [],
+            [],
+            null,
+            true,
+            'page',
+            false,
+            'itemsPerPage',
+            [],
+            false,
+            '',
+            [],
+            [],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $result = $normalizer->normalize($documentation, DocumentationNormalizer::FORMAT);

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Swagger\Serializer;
 
 use ApiPlatform\Core\Api\FilterCollection;
+use ApiPlatform\Core\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Core\Api\OperationAwareFormatsProviderInterface;
 use ApiPlatform\Core\Api\OperationMethodResolverInterface;
 use ApiPlatform\Core\Api\OperationType;
@@ -120,6 +121,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -145,7 +149,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -477,6 +483,9 @@ class DocumentationNormalizerV3Test extends TestCase
             $typeFactory->setSchemaFactory($schemaFactory);
         }
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactory,
             $propertyNameCollectionFactory,
@@ -502,7 +511,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -611,6 +622,9 @@ class DocumentationNormalizerV3Test extends TestCase
             ],
         ];
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -636,7 +650,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -752,6 +768,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -777,7 +796,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -968,6 +989,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -993,7 +1017,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1090,6 +1116,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -1115,7 +1144,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1315,6 +1346,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -1340,7 +1374,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1615,7 +1651,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $this->prophesize(IdentifiersExtractorInterface::class)->reveal()
         );
     }
 
@@ -1625,6 +1663,7 @@ class DocumentationNormalizerV3Test extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
@@ -1651,7 +1690,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $documentation = new Documentation(new ResourceNameCollection([Dummy::class]), 'Test API', 'This is a test API.', '1.2.3');
@@ -1685,6 +1726,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -1710,7 +1754,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1745,6 +1791,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -1770,7 +1819,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -1847,6 +1898,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -1872,7 +1926,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2074,6 +2130,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2099,7 +2158,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2256,7 +2317,13 @@ class DocumentationNormalizerV3Test extends TestCase
         $propertyNameCollectionFactory = $propertyNameCollectionFactoryProphecy->reveal();
         $propertyMetadataFactory = $propertyMetadataFactoryProphecy->reveal();
 
-        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new UnderscorePathSegmentNameGenerator());
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
+        $subresourceOperationFactory = new SubresourceOperationFactory($resourceMetadataFactory, $propertyNameCollectionFactory, $propertyMetadataFactory, new UnderscorePathSegmentNameGenerator(), $identifiersExtractorProphecy->reveal());
+
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
 
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactory,
@@ -2283,7 +2350,9 @@ class DocumentationNormalizerV3Test extends TestCase
             $formatProvider ?? [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2407,6 +2476,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2432,7 +2504,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2522,6 +2596,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2547,7 +2624,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2651,6 +2730,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2676,7 +2758,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2789,6 +2873,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2814,7 +2901,9 @@ class DocumentationNormalizerV3Test extends TestCase
             [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [
@@ -2943,6 +3032,9 @@ class DocumentationNormalizerV3Test extends TestCase
 
         $operationPathResolver = new OperationPathResolver(new UnderscorePathSegmentNameGenerator());
 
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
         $normalizer = new DocumentationNormalizer(
             $resourceMetadataFactoryProphecy->reveal(),
             $propertyNameCollectionFactoryProphecy->reveal(),
@@ -2967,7 +3059,9 @@ class DocumentationNormalizerV3Test extends TestCase
             $formatsProvider ?? [],
             false,
             'pagination',
-            ['spec_version' => 3]
+            ['spec_version' => 3],
+            [2, 3],
+            $identifiersExtractorProphecy->reveal()
         );
 
         $expected = [

--- a/tests/Util/RequestAttributesExtractorTest.php
+++ b/tests/Util/RequestAttributesExtractorTest.php
@@ -33,6 +33,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -49,6 +51,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -65,6 +69,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => false,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -78,6 +84,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -91,6 +99,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -107,6 +117,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => false,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -120,6 +132,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -133,6 +147,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -149,6 +165,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => false,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -162,6 +180,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -175,6 +195,8 @@ class RequestAttributesExtractorTest extends TestCase
                 'receive' => true,
                 'respond' => true,
                 'persist' => true,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );
@@ -203,6 +225,26 @@ class RequestAttributesExtractorTest extends TestCase
                 'respond' => true,
                 'persist' => true,
                 'previous_data' => $object,
+                'identifiers' => ['id' => ['Foo', 'id']],
+                'has_composite_identifier' => false,
+            ],
+            RequestAttributesExtractor::extractAttributes($request)
+        );
+    }
+
+    public function testExtractIdentifiers()
+    {
+        $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_item_operation_name' => 'get', '_api_identifiers' => ['test'], '_api_has_composite_identifier' => true]);
+
+        $this->assertEquals(
+            [
+                'resource_class' => 'Foo',
+                'item_operation_name' => 'get',
+                'receive' => true,
+                'respond' => true,
+                'persist' => true,
+                'identifiers' => ['test' => ['Foo', 'test']],
+                'has_composite_identifier' => true,
             ],
             RequestAttributesExtractor::extractAttributes($request)
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | adaptation of https://github.com/api-platform/core/pull/3664 with proper depreciation  also fixes https://github.com/api-platform/api-platform/issues/1518 and others
| License       | MIT
| Doc PR        | TBD

Move logic of identifiers extractor upwards, use only identifier converter downwards

TODO: 
- [x] fix tests
- [ ] open another PR that deprecates plain identifiers in favor of a documented normalizer 
- [x] Document the work to be done on 3.0 

**When removing deprecations on 3.0 we should:**
- rename IdentifierDenormalizer to IdentifierConverter
- remove the use of the symfony DenormalizerInterface for Identifier/Normalizers as their job is slightly different from normalizers in which they just convert the type from string to integer, boolean etc. 
- remove IdentifiersExtractor from IriConverter and every data provider that may use it. 
- remove IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER 

The diff at https://github.com/api-platform/core/pull/3664/files can be used as a reference. 