### PR TITLE
fix warning for preloading AbstractPaginator class

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -28,6 +28,9 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+// Help opcache.preload discover always-needed symbols
+class_exists(AbstractPaginator::class);
+
 /**
  * Applies pagination on the Doctrine query for resource collection when enabled.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This pull requests should fix a php warning when opcache preload is active:
<pre><code>PHP Warning:  Can't preload unlinked class class@anonymous: Unknown parent ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\AbstractPaginator in /app/vendor/api-platform/core/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php on line 178</code></pre>

This fix uses the solution of https://github.com/symfony/symfony/pull/38533.