### PR TITLE
Specify AdditionalProperties according to allow_extra_attributes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -92,10 +92,6 @@ parameters:
 		-
 			message: '#Service "test" is not registered in the container\.#'
 			path: tests/GraphQl/Type/TypesContainerTest.php
-		# https://github.com/phpstan/phpstan/issues/2999
-		-
-			message: '#ArrayObject<string, bool\|string> does not accept array<string, mixed>\.#'
-			path: src/JsonSchema/SchemaFactory.php
 
 		# Expected, due to optional interfaces
 		- '#Method ApiPlatform\\Core\\Bridge\\Doctrine\\Orm\\Extension\\QueryCollectionExtensionInterface::applyToCollection\(\) invoked with 5 parameters, 3-4 required\.#'

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -109,7 +109,7 @@ final class SchemaFactory implements SchemaFactoryInterface
             return $schema;
         }
 
-        $definition = new \ArrayObject(['type' => 'object', 'additionalProperties' => false]);
+        $definition = new \ArrayObject(['type' => 'object', 'additionalProperties' => $serializerContext[AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES] ?? true]);
         $definitions[$definitionName] = $definition;
         if (null !== $resourceMetadata && null !== $description = $resourceMetadata->getDescription()) {
             $definition['description'] = $description;

--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -30,6 +30,7 @@ use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
 class SchemaFactoryTest extends TestCase
 {
@@ -73,7 +74,7 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey($rootDefinitionKey, $definitions);
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
-        $this->assertFalse($definitions[$rootDefinitionKey]['additionalProperties']);
+        $this->assertTrue($definitions[$rootDefinitionKey]['additionalProperties']);
         $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
         $this->assertArrayHasKey('foo', $definitions[$rootDefinitionKey]['properties']);
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['foo']);
@@ -98,6 +99,7 @@ class SchemaFactoryTest extends TestCase
             'put' => [
                 'normalization_context' => [
                     'groups' => 'overridden_operation_dummy_put',
+                    AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
                 ],
                 'validation_groups' => ['validation_groups_dummy_put'],
             ],

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -128,7 +128,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 'custom' => ['method' => 'GET', 'path' => '/foo', 'status' => '202'] + self::OPERATION_FORMATS,
                 'custom2' => ['method' => 'POST', 'path' => '/foo'] + self::OPERATION_FORMATS,
             ],
-            ['pagination_client_items_per_page' => true]
+            ['pagination_client_items_per_page' => true, 'normalization_context' => [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]]
         );
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($dummyMetadata);
@@ -462,7 +462,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'properties' => [
                         'name' => new \ArrayObject([
@@ -575,7 +575,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'properties' => [
                         'name' => new \ArrayObject([
@@ -768,7 +768,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -780,7 +780,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $ref => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -968,7 +968,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -980,7 +980,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $ref => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1069,7 +1069,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy-Read' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1243,7 +1243,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1255,7 +1255,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Dummy-dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1431,7 +1431,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1443,7 +1443,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Dummy-dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -1620,7 +1620,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2014,7 +2014,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2026,7 +2026,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $ref => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2042,7 +2042,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 $relatedDummyRef => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a related dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/RelatedDummy'],
                     'properties' => [
@@ -2152,7 +2152,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'properties' => [
                         'name' => new \ArrayObject([
@@ -2312,7 +2312,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Question' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a question.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Question'],
                     'properties' => [
@@ -2325,7 +2325,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Answer' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is an answer.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Answer'],
                     'properties' => [
@@ -2409,7 +2409,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2510,7 +2510,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2706,7 +2706,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                     'properties' => [
@@ -2915,7 +2915,7 @@ class DocumentationNormalizerV2Test extends TestCase
             'definitions' => new \ArrayObject([
                 'Dummy:300dcd476cef011532fb0ca7683395d7' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => [
                         'url' => 'http://schema.example.com/Dummy',
@@ -2934,7 +2934,7 @@ class DocumentationNormalizerV2Test extends TestCase
                 ]),
                 'Dummy:b4f76c1a44965bd401aa23bb37618acc' => new \ArrayObject([
                     'type' => 'object',
-                    'additionalProperties' => false,
+                    'additionalProperties' => true,
                     'description' => 'This is a dummy.',
                     'externalDocs' => [
                         'url' => 'http://schema.example.com/Dummy',

--- a/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV3Test.php
@@ -107,7 +107,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'custom' => ['method' => 'GET', 'path' => '/foo'] + self::OPERATION_FORMATS,
                 'custom2' => ['method' => 'POST', 'path' => '/foo'] + self::OPERATION_FORMATS,
             ],
-            ['pagination_client_items_per_page' => true]
+            ['pagination_client_items_per_page' => true, 'normalization_context' => [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]]
         );
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn($dummyMetadata);
@@ -541,7 +541,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'properties' => [
                             'name' => new \ArrayObject([
@@ -676,7 +676,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'properties' => [
                             'name' => new \ArrayObject([
@@ -908,7 +908,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -920,7 +920,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     $ref => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1032,7 +1032,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy-Read' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1244,7 +1244,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1256,7 +1256,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     'Dummy-dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1469,7 +1469,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -1481,7 +1481,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     'Dummy-dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2001,7 +2001,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2013,7 +2013,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     $ref => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2032,7 +2032,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     $relatedDummyRef => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a related dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/RelatedDummy'],
                         'properties' => [
@@ -2178,7 +2178,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'properties' => [
                             'name' => new \ArrayObject([
@@ -2351,7 +2351,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Question' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a question.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Question'],
                         'properties' => [
@@ -2364,7 +2364,7 @@ class DocumentationNormalizerV3Test extends TestCase
                     ]),
                     'Answer' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is an answer.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Answer'],
                         'properties' => [
@@ -2472,7 +2472,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2600,7 +2600,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2734,7 +2734,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -2872,7 +2872,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [
@@ -3110,7 +3110,7 @@ class DocumentationNormalizerV3Test extends TestCase
                 'schemas' => new \ArrayObject([
                     'Dummy' => new \ArrayObject([
                         'type' => 'object',
-                        'additionalProperties' => false,
+                        'additionalProperties' => true,
                         'description' => 'This is a dummy.',
                         'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
                         'properties' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | fixes https://github.com/api-platform/core/issues/3382
| License       | MIT
| Doc PR        | todo?

According to https://github.com/api-platform/core/pull/3388 additionalProperties should respect the normalization context allow_extra_attributes value. Adds up to https://github.com/api-platform/core/pull/3804. 