### PR TITLE
JsonLd context fix format issue

### DIFF
--- a/src/JsonLd/Action/ContextAction.php
+++ b/src/JsonLd/Action/ContextAction.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\JsonLd\Action;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -48,6 +49,13 @@ final class ContextAction
      */
     public function __invoke(string $shortName): array
     {
+        $pathParts = pathinfo($shortName);
+
+        if (($pathParts['extension'] ?? null) && 'jsonld' !== $pathParts['extension']) {
+            throw new BadRequestHttpException();
+        }
+        $shortName = $pathParts['filename'];
+
         if ('Entrypoint' === $shortName) {
             return ['@context' => $this->contextBuilder->getEntrypointContext()];
         }

--- a/tests/JsonLd/Action/ContextActionTest.php
+++ b/tests/JsonLd/Action/ContextActionTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -81,5 +82,33 @@ class ContextActionTest extends TestCase
             new ResourceMetadata('gerard', 'gerard', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST'], 'custom' => ['method' => 'GET', 'path' => '/foo'], 'custom2' => ['method' => 'POST', 'path' => '/foo']], [])
         );
         $contextAction('dummy');
+    }
+
+    public function testContextActionWithFormatThrown()
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection(['gerard']));
+        $contextAction = new ContextAction($contextBuilderProphecy->reveal(), $resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal());
+
+        $contextAction('dummy.html');
+    }
+
+    public function testContextActionWithResourceClassAndFormat()
+    {
+        $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
+        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->create()->willReturn(new ResourceNameCollection(['dummy']));
+        $contextAction = new ContextAction($contextBuilderProphecy->reveal(), $resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal());
+        $contextBuilderProphecy->getResourceContext('dummy')->willReturn(['/dummies']);
+
+        $resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn(
+            new ResourceMetadata('dummy', 'dummy', '#dummy', ['get' => ['method' => 'GET'], 'put' => ['method' => 'PUT']], ['get' => ['method' => 'GET'], 'post' => ['method' => 'POST'], 'custom' => ['method' => 'GET', 'path' => '/foo'], 'custom2' => ['method' => 'POST', 'path' => '/foo']], [])
+        );
+        $this->assertEquals(['@context' => ['/dummies']], $contextAction('dummy.jsonld'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       |  maybe reported?
| License       | MIT
| Doc PR        | na

The `api_jsonld_context` route specifies a format but using it makes a 404 not found.

```
  api_jsonld_context                                                                                     ANY        ANY      ANY    /contexts/{shortName}.{_format} 
```

Let's interpret the format in the ContextAction and handle it properly.
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
