### PR TITLE
CI: Set-env is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Enable code coverage
         if: matrix.coverage
-        run: echo '::set-env name=COVERAGE::1'
+        run: echo "COVERAGE=1" >> $GITHUB_ENV
       - name: Remove Doctrine MongoDB ODM
         if: (startsWith(matrix.php, '7.1') || startsWith(matrix.php, 'rc'))
         run: |
@@ -222,7 +222,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Enable code coverage
         if: matrix.coverage
-        run: echo '::set-env name=COVERAGE::1'
+        run: echo "COVERAGE=1" >> $GITHUB_ENV
       - name: Remove Doctrine MongoDB ODM
         if: startsWith(matrix.php, '7.1')
         run: |

--- a/tests/JsonLd/Serializer/ObjectNormalizerTest.php
+++ b/tests/JsonLd/Serializer/ObjectNormalizerTest.php
@@ -48,8 +48,8 @@ class ObjectNormalizerTest extends TestCase
             '@id' => '_:1234',
         ]);
 
-        $normalizer = new ObjectNormalizer( // @phpstan-ignore-line
-            $serializerProphecy->reveal(),
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(), // @phpstan-ignore-line
             $iriConverterProphecy->reveal(),
             $contextBuilderProphecy->reveal()
         );
@@ -77,8 +77,8 @@ class ObjectNormalizerTest extends TestCase
         $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
         $contextBuilderProphecy->getAnonymousResourceContext($dummy, Argument::type('array'))->shouldNotBeCalled();
 
-        $normalizer = new ObjectNormalizer( // @phpstan-ignore-line
-            $serializerProphecy->reveal(),
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(),  // @phpstan-ignore-line
             $iriConverterProphecy->reveal(),
             $contextBuilderProphecy->reveal()
         );
@@ -101,8 +101,8 @@ class ObjectNormalizerTest extends TestCase
         $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
         $contextBuilderProphecy->getAnonymousResourceContext($dummy, ['iri' => '/dummy/1234', 'api_resource' => $dummy])->shouldBeCalled()->willReturn(['@id' => '/dummy/1234', '@type' => 'Dummy', '@context' => []]);
 
-        $normalizer = new ObjectNormalizer( // @phpstan-ignore-line
-            $serializerProphecy->reveal(),
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(), // @phpstan-ignore-line
             $iriConverterProphecy->reveal(),
             $contextBuilderProphecy->reveal()
         );
@@ -131,8 +131,8 @@ class ObjectNormalizerTest extends TestCase
         $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
         $contextBuilderProphecy->getAnonymousResourceContext($dummy, ['iri' => '/dummy/1234', 'api_resource' => $dummy, 'has_context' => true])->shouldBeCalled()->willReturn(['@id' => '/dummy/1234', '@type' => 'Dummy']);
 
-        $normalizer = new ObjectNormalizer( // @phpstan-ignore-line
-            $serializerProphecy->reveal(),
+        $normalizer = new ObjectNormalizer(
+            $serializerProphecy->reveal(), // @phpstan-ignore-line
             $iriConverterProphecy->reveal(),
             $contextBuilderProphecy->reveal()
         );


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
