### PR TITLE
OpenAPI - make all info model fields configurable

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -106,6 +106,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerCommonConfiguration($container, $config, $loader, $formats, $patchFormats, $errorFormats);
         $this->registerMetadataConfiguration($container, $config, $loader);
         $this->registerOAuthConfiguration($container, $config);
+        $this->registerOpenApiConfiguration($container, $config);
         $this->registerSwaggerConfiguration($container, $config, $loader);
         $this->registerJsonApiConfiguration($formats, $loader);
         $this->registerJsonLdHydraConfiguration($container, $formats, $loader, $config['enable_docs']);
@@ -708,6 +709,16 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         if (isset($bundles['SecurityBundle'])) {
             $loader->load('security.xml');
         }
+    }
+
+    private function registerOpenApiConfiguration(ContainerBuilder $container, array $config): void
+    {
+        $container->setParameter('api_platform.openapi.termsOfService', $config['openapi']['termsOfService']);
+        $container->setParameter('api_platform.openapi.contact.name', $config['openapi']['contact']['name']);
+        $container->setParameter('api_platform.openapi.contact.url', $config['openapi']['contact']['url']);
+        $container->setParameter('api_platform.openapi.contact.email', $config['openapi']['contact']['email']);
+        $container->setParameter('api_platform.openapi.license.name', $config['openapi']['license']['name']);
+        $container->setParameter('api_platform.openapi.license.url', $config['openapi']['license']['url']);
     }
 
     private function buildDeprecationArgs(string $version, string $message): array

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -201,6 +201,7 @@ final class Configuration implements ConfigurationInterface
         $this->addMercureSection($rootNode);
         $this->addMessengerSection($rootNode);
         $this->addElasticsearchSection($rootNode);
+        $this->addOpenApiSection($rootNode);
 
         $this->addExceptionToStatusSection($rootNode);
 
@@ -460,6 +461,34 @@ final class Configuration implements ConfigurationInterface
                                     ->scalarNode('index')->defaultNull()->end()
                                     ->scalarNode('type')->defaultValue(DocumentMetadata::DEFAULT_TYPE)->end()
                                 ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addOpenApiSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('openapi')
+                    ->addDefaultsIfNotSet()
+                        ->children()
+                        ->arrayNode('contact')
+                        ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('name')->defaultNull()->info('The identifying name of the contact person/organization.')->end()
+                                ->scalarNode('url')->defaultNull()->info('The URL pointing to the contact information. MUST be in the format of a URL.')->end()
+                                ->scalarNode('email')->defaultNull()->info('The email address of the contact person/organization. MUST be in the format of an email address.')->end()
+                            ->end()
+                        ->end()
+                        ->scalarNode('termsOfService')->defaultNull()->info('A URL to the Terms of Service for the API. MUST be in the format of a URL.')->end()
+                        ->arrayNode('license')
+                        ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('name')->defaultNull()->info('The license name used for the API.')->end()
+                                ->scalarNode('url')->defaultNull()->info('URL to the license used for the API. MUST be in the format of a URL.')->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
@@ -23,6 +23,12 @@
             <argument>%api_platform.oauth.refreshUrl%</argument>
             <argument>%api_platform.oauth.scopes%</argument>
             <argument>%api_platform.swagger.api_keys%</argument>
+            <argument>%api_platform.openapi.contact.name%</argument>
+            <argument>%api_platform.openapi.contact.url%</argument>
+            <argument>%api_platform.openapi.contact.email%</argument>
+            <argument>%api_platform.openapi.termsOfService%</argument>
+            <argument>%api_platform.openapi.license.name%</argument>
+            <argument>%api_platform.openapi.license.url%</argument>
         </service>
         <service id="ApiPlatform\Core\OpenApi\Options" alias="api_platform.openapi.options" />
 

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -77,7 +77,9 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     public function __invoke(array $context = []): OpenApi
     {
         $baseUrl = $context[self::BASE_URL] ?? '/';
-        $info = new Model\Info($this->openApiOptions->getTitle(), $this->openApiOptions->getVersion(), trim($this->openApiOptions->getDescription()));
+        $contact = null === $this->openApiOptions->getContactUrl() || null === $this->openApiOptions->getContactEmail() ? null : new Model\Contact($this->openApiOptions->getContactName(), $this->openApiOptions->getContactUrl(), $this->openApiOptions->getContactEmail());
+        $license = null === $this->openApiOptions->getLicenseName() ? null : new Model\License($this->openApiOptions->getLicenseName(), $this->openApiOptions->getLicenseUrl());
+        $info = new Model\Info($this->openApiOptions->getTitle(), $this->openApiOptions->getVersion(), trim($this->openApiOptions->getDescription()), $this->openApiOptions->getTermsOfService(), $contact, $license);
         $servers = '/' === $baseUrl || '' === $baseUrl ? [new Model\Server('/')] : [new Model\Server($baseUrl)];
         $paths = new Model\Paths();
         $links = [];

--- a/src/OpenApi/Model/Contact.php
+++ b/src/OpenApi/Model/Contact.php
@@ -21,29 +21,29 @@ final class Contact
     private $url;
     private $email;
 
-    public function __construct(string $name = '', string $url = '', string $email = '')
+    public function __construct(string $name = null, string $url = null, string $email = null)
     {
         $this->name = $name;
         $this->url = $url;
         $this->email = $email;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getUrl(): string
+    public function getUrl(): ?string
     {
         return $this->url;
     }
 
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
-    public function withName(string $name): self
+    public function withName(?string $name): self
     {
         $clone = clone $this;
         $clone->name = $name;
@@ -51,7 +51,7 @@ final class Contact
         return $clone;
     }
 
-    public function withUrl(string $url): self
+    public function withUrl(?string $url): self
     {
         $clone = clone $this;
         $clone->url = $url;
@@ -59,7 +59,7 @@ final class Contact
         return $clone;
     }
 
-    public function withEmail(string $email): self
+    public function withEmail(?string $email): self
     {
         $clone = clone $this;
         $clone->email = $email;

--- a/src/OpenApi/Model/License.php
+++ b/src/OpenApi/Model/License.php
@@ -20,7 +20,7 @@ final class License
     private $name;
     private $url;
 
-    public function __construct(string $name, string $url)
+    public function __construct(string $name, string $url = null)
     {
         $this->name = $name;
         $this->url = $url;
@@ -31,7 +31,7 @@ final class License
         return $this->name;
     }
 
-    public function getUrl(): string
+    public function getUrl(): ?string
     {
         return $this->url;
     }
@@ -44,7 +44,7 @@ final class License
         return $clone;
     }
 
-    public function withUrl(string $url): self
+    public function withUrl(?string $url): self
     {
         $clone = clone $this;
         $clone->url = $url;

--- a/src/OpenApi/Options.php
+++ b/src/OpenApi/Options.php
@@ -26,8 +26,14 @@ final class Options
     private $oAuthRefreshUrl;
     private $oAuthScopes;
     private $apiKeys;
+    private $contactName;
+    private $contactUrl;
+    private $contactEmail;
+    private $termsOfService;
+    private $licenseName;
+    private $licenseUrl;
 
-    public function __construct(string $title, string $description = '', string $version = '', bool $oAuthEnabled = false, string $oAuthType = '', string $oAuthFlow = '', string $oAuthTokenUrl = '', string $oAuthAuthorizationUrl = '', string $oAuthRefreshUrl = '', array $oAuthScopes = [], array $apiKeys = [])
+    public function __construct(string $title, string $description = '', string $version = '', bool $oAuthEnabled = false, string $oAuthType = '', string $oAuthFlow = '', string $oAuthTokenUrl = '', string $oAuthAuthorizationUrl = '', string $oAuthRefreshUrl = '', array $oAuthScopes = [], array $apiKeys = [], string $contactName = null, string $contactUrl = null, string $contactEmail = null, string $termsOfService = null, string $licenseName = null, string $licenseUrl = null)
     {
         $this->title = $title;
         $this->description = $description;
@@ -40,6 +46,12 @@ final class Options
         $this->oAuthRefreshUrl = $oAuthRefreshUrl;
         $this->oAuthScopes = $oAuthScopes;
         $this->apiKeys = $apiKeys;
+        $this->contactName = $contactName;
+        $this->contactUrl = $contactUrl;
+        $this->contactEmail = $contactEmail;
+        $this->termsOfService = $termsOfService;
+        $this->licenseName = $licenseName;
+        $this->licenseUrl = $licenseUrl;
     }
 
     public function getTitle(): string
@@ -95,5 +107,35 @@ final class Options
     public function getApiKeys(): array
     {
         return $this->apiKeys;
+    }
+
+    public function getContactName(): ?string
+    {
+        return $this->contactName;
+    }
+
+    public function getContactUrl(): ?string
+    {
+        return $this->contactUrl;
+    }
+
+    public function getContactEmail(): ?string
+    {
+        return $this->contactEmail;
+    }
+
+    public function getTermsOfService(): ?string
+    {
+        return $this->termsOfService;
+    }
+
+    public function getLicenseName(): ?string
+    {
+        return $this->licenseName;
+    }
+
+    public function getLicenseUrl(): ?string
+    {
+        return $this->licenseUrl;
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1142,6 +1142,12 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.elasticsearch.enabled' => false,
             'api_platform.asset_package' => null,
             'api_platform.defaults' => ['attributes' => ['stateless' => true]],
+            'api_platform.openapi.termsOfService' => null,
+            'api_platform.openapi.contact.name' => null,
+            'api_platform.openapi.contact.url' => null,
+            'api_platform.openapi.contact.email' => null,
+            'api_platform.openapi.license.name' => null,
+            'api_platform.openapi.license.url' => null,
         ];
 
         if ($hasSwagger) {

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -207,6 +207,18 @@ class ConfigurationTest extends TestCase
             'allow_plain_identifiers' => false,
             'resource_class_directories' => [],
             'asset_package' => null,
+            'openapi' => [
+                'contact' => [
+                    'name' => null,
+                    'url' => null,
+                    'email' => null,
+                ],
+                'termsOfService' => null,
+                'license' => [
+                    'name' => null,
+                    'url' => null,
+                ],
+            ],
         ], $config);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | Not yet

Enables the configuration of ToS, Contact and License in the SwaggerUI. 

I wasnt sure about the contact model. All properties there have a default value which is not needed imho, contact e.g. also works if you only set one field. I think it would be better to make them nullable so they are not serialized at all.
