### PR TITLE
Remove unuseful private properties from ApiResource

### DIFF
--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -77,55 +77,6 @@ final class ApiProperty
     public $identifier;
 
     /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $deprecationReason;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $fetchable;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $fetchEager;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $jsonldContext;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $openapiContext;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $push;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $swaggerContext;
-
-    /**
      * @throws InvalidArgumentException
      */
     public function __construct(array $values = [])

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -25,22 +25,16 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  * @Attributes(
  *     @Attribute("accessControl", type="string"),
  *     @Attribute("accessControlMessage", type="string"),
- *     @Attribute("attributes", type="array"),
  *     @Attribute("cacheHeaders", type="array"),
- *     @Attribute("collectionOperations", type="array"),
  *     @Attribute("denormalizationContext", type="array"),
  *     @Attribute("deprecationReason", type="string"),
- *     @Attribute("description", type="string"),
  *     @Attribute("elasticsearch", type="bool"),
  *     @Attribute("fetchPartial", type="bool"),
  *     @Attribute("forceEager", type="bool"),
  *     @Attribute("formats", type="array"),
  *     @Attribute("filters", type="string[]"),
- *     @Attribute("graphql", type="array"),
  *     @Attribute("hydraContext", type="array"),
  *     @Attribute("input", type="mixed"),
- *     @Attribute("iri", type="string"),
- *     @Attribute("itemOperations", type="array"),
  *     @Attribute("mercure", type="mixed"),
  *     @Attribute("messenger", type="mixed"),
  *     @Attribute("normalizationContext", type="array"),
@@ -62,8 +56,6 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("securityMessage", type="string"),
  *     @Attribute("securityPostDenormalize", type="string"),
  *     @Attribute("securityPostDenormalizeMessage", type="string"),
- *     @Attribute("shortName", type="string"),
- *     @Attribute("subresourceOperations", type="array"),
  *     @Attribute("sunset", type="string"),
  *     @Attribute("swaggerContext", type="array"),
  *     @Attribute("validationGroups", type="mixed")
@@ -115,275 +107,6 @@ final class ApiResource
      * @var array
      */
     public $subresourceOperations;
-
-    /**
-     * @see https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $cacheHeaders;
-
-    /**
-     * @see https://api-platform.com/docs/core/serialization/#using-serialization-groups
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $denormalizationContext;
-
-    /**
-     * @see https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $deprecationReason;
-
-    /**
-     * @see https://api-platform.com/docs/core/elasticsearch/
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $elasticsearch;
-
-    /**
-     * @see https://api-platform.com/docs/core/performance/#fetch-partial
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $fetchPartial;
-
-    /**
-     * @see https://api-platform.com/docs/core/performance/#force-eager
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $forceEager;
-
-    /**
-     * @see https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $formats;
-
-    /**
-     * @see https://api-platform.com/docs/core/filters/#doctrine-orm-and-mongodb-odm-filters
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string[]
-     */
-    private $filters;
-
-    /**
-     * @see https://api-platform.com/docs/core/extending-jsonld-context/#hydra
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string[]
-     */
-    private $hydraContext;
-
-    /**
-     * @see https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string|false
-     */
-    private $input;
-
-    /**
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var int
-     *
-     * @deprecated - Use $paginationMaximumItemsPerPage instead
-     */
-    private $maximumItemsPerPage;
-
-    /**
-     * @see https://api-platform.com/docs/core/mercure
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     */
-    private $mercure;
-
-    /**
-     * @see https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool|string
-     */
-    private $messenger;
-
-    /**
-     * @see https://api-platform.com/docs/core/serialization/#using-serialization-groups
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $normalizationContext;
-
-    /**
-     * @see https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $openapiContext;
-
-    /**
-     * @see https://api-platform.com/docs/core/default-order/#overriding-default-order
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $order;
-
-    /**
-     * @see https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string|false
-     */
-    private $output;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationClientEnabled;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource-3
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationClientItemsPerPage;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource-6
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationClientPartial;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#cursor-based-pagination
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $paginationViaCursor;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#for-a-specific-resource
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationEnabled;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#controlling-the-behavior-of-the-doctrine-orm-paginator
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationFetchJoinCollection;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#changing-the-number-of-items-per-page
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var int
-     */
-    private $paginationItemsPerPage;
-
-    /**
-     * @see https://api-platform.com/docs/core/pagination/#changing-maximum-items-per-page
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var int
-     */
-    private $paginationMaximumItemsPerPage;
-
-    /**
-     * @see https://api-platform.com/docs/core/performance/#partial-pagination
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var bool
-     */
-    private $paginationPartial;
-
-    /**
-     * @see https://api-platform.com/docs/core/operations/#prefixing-all-routes-of-all-operations
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $routePrefix;
-
-    /**
-     * @see https://api-platform.com/docs/core/security
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $security;
-
-    /**
-     * @see https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $securityMessage;
-
-    /**
-     * @see https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $securityPostDenormalize;
-
-    /**
-     * @see https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $securityPostDenormalizeMessage;
-
-    /**
-     * @see https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var string
-     */
-    private $sunset;
-
-    /**
-     * @see https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     *
-     * @var array
-     */
-    private $swaggerContext;
-
-    /**
-     * @see https://api-platform.com/docs/core/validation/#using-validation-groups
-     * @see https://github.com/Haehnchen/idea-php-annotation-plugin/issues/112
-     */
-    private $validationGroups;
 
     /**
      * @throws InvalidArgumentException

--- a/src/Annotation/AttributesHydratorTrait.php
+++ b/src/Annotation/AttributesHydratorTrait.php
@@ -54,11 +54,7 @@ trait AttributesHydratorTrait
 
         foreach ($values as $key => $value) {
             $key = (string) $key;
-            if (!property_exists($this, $key)) {
-                throw new InvalidArgumentException(sprintf('Unknown property "%s" on annotation "%s".', $key, self::class));
-            }
-
-            if ((new \ReflectionProperty($this, $key))->isPublic()) {
+            if (property_exists($this, $key) && (new \ReflectionProperty($this, $key))->isPublic()) {
                 $this->{$key} = $value;
                 continue;
             }

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Annotation;
 
 use ApiPlatform\Core\Annotation\ApiResource;
-use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Tests\Fixtures\AnnotatedClass;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
@@ -130,18 +129,6 @@ class ApiResourceTest extends TestCase
             'security_post_denormalize_message' => 'You are not bar.',
             'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => ['Custom-Vary-1', 'Custom-Vary-2']],
         ], $resource->attributes);
-    }
-
-    public function testConstructWithInvalidAttribute()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown property "invalidAttribute" on annotation "ApiPlatform\\Core\\Annotation\\ApiResource".');
-
-        new ApiResource([
-            'shortName' => 'shortName',
-            'routePrefix' => '/foo',
-            'invalidAttribute' => 'exception',
-        ]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Since https://github.com/Haehnchen/idea-php-annotation-plugin/commit/7a75efc63ffada9eeeb3b228def62aeaff9e0a45 is merged, there is no need to have private properties anymore (see https://github.com/api-platform/core/pull/1788).