### PR TITLE
Chunk headers to comply with Varnish max length

### DIFF
--- a/src/HttpCache/VarnishPurger.php
+++ b/src/HttpCache/VarnishPurger.php
@@ -24,14 +24,18 @@ use GuzzleHttp\ClientInterface;
  */
 final class VarnishPurger implements PurgerInterface
 {
+    private const DEFAULT_VARNISH_MAX_HEADER_LENGTH = 8000;
+
     private $clients;
+    private $maxHeaderLength;
 
     /**
      * @param ClientInterface[] $clients
      */
-    public function __construct(array $clients)
+    public function __construct(array $clients, int $maxHeaderLength = self::DEFAULT_VARNISH_MAX_HEADER_LENGTH)
     {
         $this->clients = $clients;
+        $this->maxHeaderLength = $maxHeaderLength;
     }
 
     /**
@@ -48,10 +52,42 @@ final class VarnishPurger implements PurgerInterface
             return sprintf('(^|\,)%s($|\,)', preg_quote($iri));
         }, $iris);
 
-        $regex = \count($parts) > 1 ? sprintf('(%s)', implode(')|(', $parts)) : array_shift($parts);
+        foreach ($this->chunkRegexParts($parts) as $regex) {
+            $this->banRegex($regex);
+        }
+    }
 
+    private function banRegex(string $regex): void
+    {
         foreach ($this->clients as $client) {
             $client->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => $regex]]);
         }
+    }
+
+    private function chunkRegexParts(array $parts): iterable
+    {
+        if (1 === \count($parts)) {
+            yield $parts[0];
+
+            return;
+        }
+
+        $concatenatedParts = sprintf('(%s)', implode(")\n(", $parts));
+
+        if (\strlen($concatenatedParts) <= $this->maxHeaderLength) {
+            yield str_replace("\n", '|', $concatenatedParts);
+
+            return;
+        }
+
+        $lastSeparator = strrpos(substr($concatenatedParts, 0, $this->maxHeaderLength + 1), "\n");
+
+        $chunk = substr($concatenatedParts, 0, $lastSeparator);
+
+        yield str_replace("\n", '|', $chunk);
+
+        $nextParts = \array_slice($parts, substr_count($chunk, "\n") + 1);
+
+        yield from $this->chunkRegexParts($nextParts);
     }
 }

--- a/tests/HttpCache/VarnishPurgerTest.php
+++ b/tests/HttpCache/VarnishPurgerTest.php
@@ -16,8 +16,12 @@ namespace ApiPlatform\Core\Tests\HttpCache;
 use ApiPlatform\Core\HttpCache\VarnishPurger;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response;
+use LogicException;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -48,5 +52,102 @@ class VarnishPurgerTest extends TestCase
 
         $purger = new VarnishPurger([$clientProphecy1->reveal()]);
         $purger->purge([]);
+    }
+
+    /**
+     * @dataProvider provideChunkHeaderCases
+     */
+    public function testItChunksHeaderToAvoidHittingVarnishLimit(int $maxHeaderLength, array $iris, array $regexesToSend)
+    {
+        $client = new class() implements ClientInterface {
+            public $sentRegexes = [];
+
+            public function send(RequestInterface $request, array $options = []): ResponseInterface
+            {
+                throw new LogicException('Not implemented');
+            }
+
+            public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
+            {
+                throw new LogicException('Not implemented');
+            }
+
+            public function request($method, $uri, array $options = []): ResponseInterface
+            {
+                $this->sentRegexes[] = $options['headers']['ApiPlatform-Ban-Regex'];
+
+                return new Response();
+            }
+
+            public function requestAsync($method, $uri, array $options = []): PromiseInterface
+            {
+                throw new LogicException('Not implemented');
+            }
+
+            public function getConfig($option = null)
+            {
+                throw new LogicException('Not implemented');
+            }
+        };
+
+        $purger = new VarnishPurger([$client], $maxHeaderLength);
+        $purger->purge($iris);
+
+        self::assertSame($regexesToSend, $client->sentRegexes);
+    }
+
+    public function provideChunkHeaderCases()
+    {
+        yield 'few iris' => [
+            50,
+            ['/foo', '/bar'],
+            ['((^|\,)/foo($|\,))|((^|\,)/bar($|\,))'],
+        ];
+
+        yield 'iris to generate a header with exactly the maximum length' => [
+            56,
+            ['/foo', '/bar', '/baz'],
+            ['((^|\,)/foo($|\,))|((^|\,)/bar($|\,))|((^|\,)/baz($|\,))'],
+        ];
+
+        yield 'iris to generate a header with exactly the maximum length and a smaller one' => [
+            37,
+            ['/foo', '/bar', '/baz'],
+            [
+                '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))',
+                '(^|\,)/baz($|\,)',
+            ],
+        ];
+
+        yield 'with last iri too long to be part of the same header' => [
+            50,
+            ['/foo', '/bar', '/some-longer-tag'],
+            [
+                '((^|\,)/foo($|\,))|((^|\,)/bar($|\,))',
+                '(^|\,)/some\-longer\-tag($|\,)',
+            ],
+        ];
+
+        yield 'iris to have five headers' => [
+            50,
+            ['/foo/1', '/foo/2', '/foo/3', '/foo/4', '/foo/5', '/foo/6', '/foo/7', '/foo/8', '/foo/9', '/foo/10'],
+            [
+                '((^|\,)/foo/1($|\,))|((^|\,)/foo/2($|\,))',
+                '((^|\,)/foo/3($|\,))|((^|\,)/foo/4($|\,))',
+                '((^|\,)/foo/5($|\,))|((^|\,)/foo/6($|\,))',
+                '((^|\,)/foo/7($|\,))|((^|\,)/foo/8($|\,))',
+                '((^|\,)/foo/9($|\,))|((^|\,)/foo/10($|\,))',
+            ],
+        ];
+
+        yield 'with varnish default limit' => [
+            8000,
+            array_fill(0, 1000, '/foo'),
+            [
+                implode('|', array_fill(0, 421, '((^|\,)/foo($|\,))')),
+                implode('|', array_fill(0, 421, '((^|\,)/foo($|\,))')),
+                implode('|', array_fill(0, 158, '((^|\,)/foo($|\,))')),
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3168 and #1856
| License       | MIT
| Doc PR        | -

This PR chunks the regex to send it in separate requests to avoid `400 Bad Request` responses from Varnish when the maximum header length is exceeded. The default limit is 8000 for now since it's Varnish's default value, but that could be easily made configurable in another iteration (maybe for next minor release instead of 2.5?).