### PR TITLE
Deep object update consistency

### DIFF
--- a/features/main/patch.feature
+++ b/features/main/patch.feature
@@ -28,3 +28,34 @@ Feature: Sending PATCH requets
     {"name": null}
     """
     Then the JSON node "name" should not exist
+
+  @createSchema
+  Scenario: Patch the relation
+    Given there is a PatchDummyRelation
+    When I add "Content-Type" header equal to "application/merge-patch+json"
+    And I send a "PATCH" request to "/patch_dummy_relations/1" with body:
+    """
+    {
+      "related": {
+        "symfony": "A new name"
+      }
+    }
+    """
+    Then print last JSON response
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/PatchDummyRelation",
+      "@id": "/patch_dummy_relations/1",
+      "@type": "PatchDummyRelation",
+      "related": {
+        "@id": "/related_dummies/1",
+        "@type": "https://schema.org/Product",
+        "id": 1,
+        "symfony": "A new name"
+      }
+    }
+    """

--- a/features/main/patch.feature
+++ b/features/main/patch.feature
@@ -41,7 +41,6 @@ Feature: Sending PATCH requets
       }
     }
     """
-    Then print last JSON response
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -577,6 +577,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $attributeValue = null;
         }
 
+        if ($context['api_denormalize'] ?? false) {
+            return $attributeValue;
+        }
+
         $type = $propertyMetadata->getType();
 
         if (

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -66,7 +66,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
                 $context['api_allow_update'] = \in_array($method = $request->getMethod(), ['PUT', 'PATCH'], true);
 
                 if ($context['api_allow_update'] && 'PATCH' === $method) {
-                    $context[AbstractItemNormalizer::DEEP_OBJECT_TO_POPULATE] = $context[AbstractItemNormalizer::DEEP_OBJECT_TO_POPULATE] ?? true;
+                    $context['deep_object_to_populate'] = $context['deep_object_to_populate'] ?? true;
                 }
             }
 
@@ -108,7 +108,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         // TODO: We should always use `skip_null_values` but changing this would be a BC break, for now use it only when `merge-patch+json` is activated on a Resource
         foreach ($resourceMetadata->getItemOperations() as $operation) {
             if ('PATCH' === ($operation['method'] ?? '') && \in_array('application/merge-patch+json', $operation['input_formats']['json'] ?? [], true)) {
-                $context[AbstractItemNormalizer::SKIP_NULL_VALUES] = true;
+                $context['skip_null_values'] = true;
 
                 break;
             }

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -61,6 +61,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\MaxDepthDummy as MaxDept
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\NetworkPathDummy as NetworkPathDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\NetworkPathRelationDummy as NetworkPathRelationDummyDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Order as OrderDocument;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\PatchDummyRelation as PatchDummyRelationDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Person as PersonDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\PersonToPet as PersonToPetDocument;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\Pet as PetDocument;
@@ -128,6 +129,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\NetworkPathRelationDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Order;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\PatchDummyRelation;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Person;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\PersonToPet;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Pet;
@@ -1658,6 +1660,19 @@ final class DoctrineContext implements Context
         $this->manager->flush();
     }
 
+    /**
+     * @Given there is a PatchDummyRelation
+     */
+    public function thereIsAPatchDummyRelation()
+    {
+        $dummy = $this->buildPatchDummyRelation();
+        $related = $this->buildRelatedDummy();
+        $dummy->setRelated($related);
+        $this->manager->persist($related);
+        $this->manager->persist($dummy);
+        $this->manager->flush();
+    }
+
     private function isOrm(): bool
     {
         return null !== $this->schemaTool;
@@ -2090,5 +2105,13 @@ final class DoctrineContext implements Context
     private function buildInitializeInput()
     {
         return $this->isOrm() ? new InitializeInput() : new InitializeInputDocument();
+    }
+
+    /**
+     * @return PatchDummyRelation|PatchDummyRelationDocument
+     */
+    private function buildPatchDummyRelation()
+    {
+        return $this->isOrm() ? new PatchDummyRelation() : new PatchDummyRelationDocument();
     }
 }

--- a/tests/Fixtures/TestBundle/Document/PatchDummyRelation.php
+++ b/tests/Fixtures/TestBundle/Document/PatchDummyRelation.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"chicago"}},
+ *         "denormalization_context"={"groups"={"chicago"}},
+ *     },
+ *     itemOperations={
+ *         "get",
+ *         "patch"={"input_formats"={"json"={"application/merge-patch+json"}, "jsonapi"}}
+ *     }
+ * )
+ * @ODM\Document
+ */
+class PatchDummyRelation
+{
+    /**
+     * @ODM\Id(strategy="INCREMENT", type="integer")
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument=RelatedDummy::class)
+     * @Groups({"chicago"})
+     */
+    protected $related;
+
+    public function getRelated()
+    {
+        return $this->related;
+    }
+
+    public function setRelated(RelatedDummy $relatedDummy)
+    {
+        $this->related = $relatedDummy;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/PatchDummyRelation.php
+++ b/tests/Fixtures/TestBundle/Entity/PatchDummyRelation.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @ApiResource(
+ *     attributes={
+ *         "normalization_context"={"groups"={"chicago"}},
+ *         "denormalization_context"={"groups"={"chicago"}},
+ *     },
+ *     itemOperations={
+ *         "get",
+ *         "patch"={"input_formats"={"json"={"application/merge-patch+json"}, "jsonapi"}}
+ *     }
+ * )
+ * @ORM\Entity
+ */
+class PatchDummyRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="RelatedDummy")
+     * @Groups({"chicago"})
+     */
+    protected $related;
+
+    public function getRelated()
+    {
+        return $this->related;
+    }
+
+    public function setRelated(RelatedDummy $relatedDummy)
+    {
+        $this->related = $relatedDummy;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3087 
| License       | MIT
| Doc PR        | Should add one for `skip_null_values`

This PR fixes inconsistencies when updating deep objects. In an update context, we should always set the `deep_object_to_populate`, at least for the `application/merge-patch+json` content type. 
Note that this fixes incoherent behavior for PATCH when updating nested resources. 

Also, now we support `deep_object_to_populate` and this fixes #3087. Users can enable it via the `denormalization_context` if needed. 

Many thanks @Toflar for reporting this and helping me get to the bottom of this!