### PR TITLE
Update composer.json to support PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/property-info": "^3.4 || ^4.4 || ^5.1",
         "symfony/serializer": "^4.4 || ^5.1",
         "symfony/web-link": "^4.4 || ^5.1",
-        "willdurand/negotiation": "^2.0.3 || 3.0.x-dev"
+        "willdurand/negotiation": "^2.0.3 || ^3.0"
     },
     "require-dev": {
         "behat/behat": "^3.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3854
| License       | MIT

Changed the version string for `willdurand/negotiation` to `^2.0.3 || ^3.0` to allow PHP 8.0