### PR TITLE
Add the violation code to the violation properties

### DIFF
--- a/features/hal/problem.feature
+++ b/features/hal/problem.feature
@@ -22,7 +22,8 @@ Feature: Error handling valid according to RFC 7807 (application/problem+json)
       "violations": [
         {
           "propertyPath": "name",
-          "message": "This value should not be blank."
+          "message": "This value should not be blank.",
+          "code": "c1051bb4-d103-4f74-8988-acbcafc7fdc3"
         }
       ]
     }

--- a/features/hydra/error.feature
+++ b/features/hydra/error.feature
@@ -22,7 +22,8 @@ Feature: Error handling
       "violations": [
         {
           "propertyPath": "name",
-          "message": "This value should not be blank."
+          "message": "This value should not be blank.",
+          "code": "c1051bb4-d103-4f74-8988-acbcafc7fdc3"
         }
       ]
     }

--- a/features/main/validation.feature
+++ b/features/main/validation.feature
@@ -36,7 +36,8 @@ Feature: Using validations groups
       "violations": [
          {
              "propertyPath": "name",
-             "message": "This value should not be null."
+             "message": "This value should not be null.",
+             "code": "ad32d13f-c3d4-423b-909a-857b961eb720"
          }
       ]
     }
@@ -64,7 +65,8 @@ Feature: Using validations groups
       "violations": [
          {
              "propertyPath": "title",
-             "message": "This value should not be null."
+             "message": "This value should not be null.",
+             "code": "ad32d13f-c3d4-423b-909a-857b961eb720"
          }
       ]
     }

--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -63,6 +63,7 @@ abstract class AbstractConstraintViolationListNormalizer implements NormalizerIn
             $violationData = [
                 'propertyPath' => $this->nameConverter ? $this->nameConverter->normalize($violation->getPropertyPath(), $class, static::FORMAT) : $violation->getPropertyPath(),
                 'message' => $violation->getMessage(),
+                'code' => $violation->getCode(),
             ];
 
             $constraint = $violation->getConstraint();

--- a/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
@@ -62,7 +62,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $constraint = new NotNull();
         $constraint->payload = ['severity' => 'warning', 'anotherField2' => 'aValue'];
         $list = new ConstraintViolationList([
-            new ConstraintViolation('a', 'b', [], 'c', 'd', 'e', null, null, $constraint),
+            new ConstraintViolation('a', 'b', [], 'c', 'd', 'e', null, 'f24bdbad0becef97a6887238aa58221c', $constraint),
             new ConstraintViolation('1', '2', [], '3', '4', '5'),
         ]);
 
@@ -75,10 +75,12 @@ class ConstraintViolationNormalizerTest extends TestCase
                 [
                     'propertyPath' => '_d',
                     'message' => 'a',
+                    'code' => 'f24bdbad0becef97a6887238aa58221c',
                 ],
                 [
                     'propertyPath' => '_4',
                     'message' => '1',
+                    'code' => null,
                 ],
             ],
         ];

--- a/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
@@ -53,7 +53,7 @@ class ConstraintViolationNormalizerTest extends TestCase
         $constraint = new NotNull();
         $constraint->payload = ['severity' => 'warning', 'anotherField2' => 'aValue'];
         $list = new ConstraintViolationList([
-            new ConstraintViolation('a', 'b', [], 'c', 'd', 'e', null, null, $constraint),
+            new ConstraintViolation('a', 'b', [], 'c', 'd', 'e', null, 'f24bdbad0becef97a6887238aa58221c', $constraint),
             new ConstraintViolation('1', '2', [], '3', '4', '5'),
         ]);
 
@@ -65,6 +65,7 @@ class ConstraintViolationNormalizerTest extends TestCase
                 [
                     'propertyPath' => '_d',
                     'message' => 'a',
+                    'code' => 'f24bdbad0becef97a6887238aa58221c',
                     'payload' => [
                         'severity' => 'warning',
                     ],
@@ -72,6 +73,7 @@ class ConstraintViolationNormalizerTest extends TestCase
                 [
                     'propertyPath' => '_4',
                     'message' => '1',
+                    'code' => null,
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | potentially
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Unnecessary

When returning the list of violations, in some context it is better to rely on a violation code/identifier rather than the message itself. The Symfony Validator already provides such a feature (although may not be enforced by all custom constraints), so we can directly take advantage of it.

If you're fine with the idea I'll look into finishing this PR

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
