### PR TITLE
Add missing note about the default behavior of the PATCH method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,7 @@ For compatibility reasons with Symfony 5.2 and PHP 8, we do not test anymore the
 
 * Add an HTTP client dedicated to functional API testing (#2608)
 * Add PATCH support (#2895)  
-  Note: with PATCH, responses will skip null values. As this may break on some endpoints, you need to manually [add the `merge-patch+json` format](https://api-platform.com/docs/core/content-negotiation/#configuring-patch-formats) to enable PATCH support. This will be the default behavior in API Platform 3.
+  Note: with JSON Merge Patch, responses will skip null values. As this may break on some endpoints, you need to manually [add the `merge-patch+json` format](https://api-platform.com/docs/core/content-negotiation/#configuring-patch-formats) to enable PATCH support. This will be the default behavior in API Platform 3.
 * Add a command to generate json schemas `api:json-schema:generate` (#2996)
 * Add infrastructure to generate a JSON Schema from a Resource `ApiPlatform\Core\JsonSchema\SchemaFactoryInterface` (#2983)
 * Replaces `access_control` by `security` and adds a `security_post_denormalize` attribute (#2992)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,7 +231,8 @@ For compatibility reasons with Symfony 5.2 and PHP 8, we do not test anymore the
 ## 2.5.0 beta 1
 
 * Add an HTTP client dedicated to functional API testing (#2608)
-* Add PATCH support (#2895)
+* Add PATCH support (#2895)  
+  Note: with patch, responses will skip null values. As this may break on some endpoints, to enable patch support you need to manually [add the `merge-patch+json` format](https://api-platform.com/docs/core/content-negotiation/#configuring-patch-formats). This will be the default behavior in API Platform 3.
 * Add a command to generate json schemas `api:json-schema:generate` (#2996)
 * Add infrastructure to generate a JSON Schema from a Resource `ApiPlatform\Core\JsonSchema\SchemaFactoryInterface` (#2983)
 * Replaces `access_control` by `security` and adds a `security_post_denormalize` attribute (#2992)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,7 @@ For compatibility reasons with Symfony 5.2 and PHP 8, we do not test anymore the
 
 * Add an HTTP client dedicated to functional API testing (#2608)
 * Add PATCH support (#2895)  
-  Note: with patch, responses will skip null values. As this may break on some endpoints, to enable patch support you need to manually [add the `merge-patch+json` format](https://api-platform.com/docs/core/content-negotiation/#configuring-patch-formats). This will be the default behavior in API Platform 3.
+  Note: with PATCH, responses will skip null values. As this may break on some endpoints, you need to manually [add the `merge-patch+json` format](https://api-platform.com/docs/core/content-negotiation/#configuring-patch-formats) to enable PATCH support. This will be the default behavior in API Platform 3.
 * Add a command to generate json schemas `api:json-schema:generate` (#2996)
 * Add infrastructure to generate a JSON Schema from a Resource `ApiPlatform\Core\JsonSchema\SchemaFactoryInterface` (#2983)
 * Replaces `access_control` by `security` and adds a `security_post_denormalize` attribute (#2992)


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| Docs fix | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3335 <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | N/D

Adding a note to the v2.5.0-beta1 about the default PATCH behavior and how to override it.
