### PR TITLE
[Elasticsearch] inject denormalization context into `Paginator` to have access to serialization groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.0
+
+* Elasticsearch: The `Paginator` class constructor now receives the denormalization context to support denormalizing documents using serialization groups. This change may cause potential **BC** breaks for existing applications as denormalization was previously done without serialization groups.
+
 ## 2.6.0
 
 * Display the API Platform's version in the debug-bar

--- a/src/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
@@ -116,7 +116,8 @@ final class CollectionDataProvider implements ContextAwareCollectionDataProvider
             $documents,
             $resourceClass,
             $limit,
-            $offset
+            $offset,
+            $context
         );
     }
 }

--- a/src/Bridge/Elasticsearch/DataProvider/Paginator.php
+++ b/src/Bridge/Elasticsearch/DataProvider/Paginator.php
@@ -33,14 +33,16 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
     private $limit;
     private $offset;
     private $cachedDenormalizedDocuments = [];
+    private $denormalizationContext = [];
 
-    public function __construct(DenormalizerInterface $denormalizer, array $documents, string $resourceClass, int $limit, int $offset)
+    public function __construct(DenormalizerInterface $denormalizer, array $documents, string $resourceClass, int $limit, int $offset, array $denormalizationContext = [])
     {
         $this->denormalizer = $denormalizer;
         $this->documents = $documents;
         $this->resourceClass = $resourceClass;
         $this->limit = $limit;
         $this->offset = $offset;
+        $this->denormalizationContext = $denormalizationContext;
     }
 
     /**
@@ -102,6 +104,8 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
      */
     public function getIterator(): \Traversable
     {
+        $denormalizationContext = array_merge([AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true], $this->denormalizationContext);
+
         foreach ($this->documents['hits']['hits'] ?? [] as $document) {
             $cacheKey = isset($document['_index'], $document['_type'], $document['_id']) ? md5("${document['_index']}_${document['_type']}_${document['_id']}") : null;
 
@@ -112,7 +116,7 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
                     $document,
                     $this->resourceClass,
                     ItemNormalizer::FORMAT,
-                    [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true]
+                    $denormalizationContext
                 );
 
                 if ($cacheKey) {

--- a/tests/Bridge/Elasticsearch/DataProvider/CollectionDataProviderTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/CollectionDataProviderTest.php
@@ -92,6 +92,10 @@ class CollectionDataProviderTest extends TestCase
 
     public function testGetCollection()
     {
+        $context = [
+            'groups' => ['custom'],
+        ];
+
         $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);
         $documentMetadataFactoryProphecy->create(Foo::class)->willReturn(new DocumentMetadata('foo'))->shouldBeCalled();
 
@@ -159,7 +163,7 @@ class CollectionDataProviderTest extends TestCase
             ->shouldBeCalled();
 
         $requestBodySearchCollectionExtensionProphecy = $this->prophesize(RequestBodySearchCollectionExtensionInterface::class);
-        $requestBodySearchCollectionExtensionProphecy->applyToCollection([], Foo::class, null, [])->wilLReturn([])->shouldBeCalled();
+        $requestBodySearchCollectionExtensionProphecy->applyToCollection([], Foo::class, 'get', $context)->willReturn([])->shouldBeCalled();
 
         $collectionDataProvider = new CollectionDataProvider(
             $clientProphecy->reveal(),
@@ -172,8 +176,8 @@ class CollectionDataProviderTest extends TestCase
         );
 
         self::assertEquals(
-            new Paginator($denormalizer, $documents, Foo::class, 2, 0),
-            $collectionDataProvider->getCollection(Foo::class)
+            new Paginator($denormalizer, $documents, Foo::class, 2, 0, $context),
+            $collectionDataProvider->getCollection(Foo::class, 'get', $context)
         );
     }
 }

--- a/tests/Bridge/Elasticsearch/DataProvider/PaginatorTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/PaginatorTest.php
@@ -178,11 +178,11 @@ class PaginatorTest extends TestCase
 
         foreach ($documents['hits']['hits'] as $document) {
             $denormalizerProphecy
-                ->denormalize($document, Foo::class, ItemNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])
+                ->denormalize($document, Foo::class, ItemNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true, 'groups' => ['custom']])
                 ->willReturn($this->denormalizeFoo($document['_source']));
         }
 
-        return new Paginator($denormalizerProphecy->reveal(), $documents, Foo::class, $limit, $offset);
+        return new Paginator($denormalizerProphecy->reveal(), $documents, Foo::class, $limit, $offset, ['groups' => ['custom']]);
     }
 
     private function denormalizeFoo(array $fooDocument): Foo


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | probably yes...
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

This patch enables the Elasticsearch paginator to receive the serialization context so that documents can be denormalized to objects using the serialization groups.
