### PR TITLE
fix: set stateless to false by default and remove the deprecation

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -260,11 +260,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $normalizedDefaults['attributes'][$option] = $value;
         }
 
-        if (!\array_key_exists('stateless', $defaults)) {
-            @trigger_error('Not setting the "api_platform.defaults.stateless" configuration is deprecated since API Platform 2.6 and it will default to `true` in 3.0. You can override this at the operation level if you have stateful operations (highly not recommended).', E_USER_DEPRECATED);
-            $normalizedDefaults['attributes']['stateless'] = false;
-        }
-
         return $normalizedDefaults;
     }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -155,7 +155,6 @@ class ApiPlatformExtensionTest extends TestCase
         ],
         'defaults' => [
             'attributes' => [],
-            'stateless' => true,
         ],
     ]];
 
@@ -684,7 +683,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->registerForAutoconfiguration(RequestBodySearchCollectionExtensionInterface::class)->willReturn($this->childDefinitionProphecy)->shouldBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.elasticsearch.hosts', ['http://elasticsearch:9200'])->shouldBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.elasticsearch.mapping', [])->shouldBeCalled();
-        $containerBuilderProphecy->setParameter('api_platform.defaults', ['attributes' => ['stateless' => true]])->shouldBeCalled();
+        $containerBuilderProphecy->setParameter('api_platform.defaults', ['attributes' => []])->shouldBeCalled();
 
         $config = self::DEFAULT_CONFIG;
         $config['api_platform']['elasticsearch'] = [
@@ -836,7 +835,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.http_cache.public' => null,
             'api_platform.http_cache.invalidation.max_header_length' => 7500,
             'api_platform.asset_package' => null,
-            'api_platform.defaults' => ['attributes' => ['stateless' => true]],
+            'api_platform.defaults' => ['attributes' => []],
             'api_platform.enable_entrypoint' => true,
             'api_platform.enable_docs' => true,
             'api_platform.url_generation_strategy' => 1,
@@ -1141,7 +1140,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.validator.serialize_payload_fields' => [],
             'api_platform.elasticsearch.enabled' => false,
             'api_platform.asset_package' => null,
-            'api_platform.defaults' => ['attributes' => ['stateless' => true]],
+            'api_platform.defaults' => ['attributes' => []],
             'api_platform.openapi.termsOfService' => null,
             'api_platform.openapi.contact.name' => null,
             'api_platform.openapi.contact.url' => null,

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -66,11 +66,6 @@ api_platform:
     collection:
         order_parameter_name:          'order'
         order:                         'ASC'
-        pagination:
-            client_enabled:            true
-            client_items_per_page:     true
-            client_partial:            true
-            items_per_page:            3
     exception_to_status:
         Symfony\Component\Serializer\Exception\ExceptionInterface: !php/const Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST
         ApiPlatform\Core\Exception\InvalidArgumentException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST
@@ -89,7 +84,6 @@ api_platform:
             shared_max_age:                   3600
             vary:                             ['Accept', 'Cookie']
             public:                           true
-        stateless: true
 
 parameters:
     container.autowiring.strict_mode: true


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | n/a
| Tickets       | https://github.com/api-platform/core/pull/3436, https://github.com/api-platform/api-platform/pull/1703, https://github.com/symfony/recipes/pull/853
| License       | MIT
| Doc PR        | n/a

It's not possible to enable `stateless` by default because it conflicts with the default configuration of the Symfony firewall. Let's disable this option in the bundle, and enable it in the distribution.