### PR TITLE
Make "hydra:mapping" item's property nullable

### DIFF
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -121,7 +121,10 @@ final class SchemaFactory implements SchemaFactoryInterface
                                 'properties' => [
                                     '@type' => ['type' => 'string'],
                                     'variable' => ['type' => 'string'],
-                                    'property' => ['type' => 'string', 'nullable' => true],
+                                    'property' => [
+                                        'nullable' => true,
+                                        'anyOf' => [['type' => 'string'], ['type' => 'null']],
+                                    ],
                                     'required' => ['type' => 'boolean'],
                                 ],
                             ],

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -123,7 +123,7 @@ final class SchemaFactory implements SchemaFactoryInterface
                                     'variable' => ['type' => 'string'],
                                     'property' => [
                                         'nullable' => true,
-                                        'anyOf' => [['type' => 'string'], ['type' => 'null']],
+                                        'type' => ['string', 'null'],
                                     ],
                                     'required' => ['type' => 'boolean'],
                                 ],

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -74,15 +74,15 @@ final class SchemaFactory implements SchemaFactoryInterface
             $items = $schema['items'];
             unset($schema['items']);
 
+            $nullableStringDefinition = ['type' => 'string'];
+
             switch ($schema->getVersion()) {
                 case Schema::VERSION_JSON_SCHEMA:
-                    $mappingPropDefinition = ['type' => ['string', 'null']];
+                    $nullableStringDefinition = ['type' => ['string', 'null']];
                     break;
                 case Schema::VERSION_OPENAPI:
-                    $mappingPropDefinition = ['type' => 'string', 'nullable' => true];
+                    $nullableStringDefinition = ['type' => 'string', 'nullable' => true];
                     break;
-                default:
-                    $mappingPropDefinition = ['type' => 'string'];
             }
 
             $schema['type'] = 'object';
@@ -132,7 +132,7 @@ final class SchemaFactory implements SchemaFactoryInterface
                                 'properties' => [
                                     '@type' => ['type' => 'string'],
                                     'variable' => ['type' => 'string'],
-                                    'property' => $mappingPropDefinition,
+                                    'property' => $nullableStringDefinition,
                                     'required' => ['type' => 'boolean'],
                                 ],
                             ],

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -74,6 +74,17 @@ final class SchemaFactory implements SchemaFactoryInterface
             $items = $schema['items'];
             unset($schema['items']);
 
+            switch ($schema->getVersion()) {
+                case Schema::VERSION_JSON_SCHEMA:
+                    $mappingPropDefinition = ['type' => ['string', 'null']];
+                    break;
+                case Schema::VERSION_OPENAPI:
+                    $mappingPropDefinition = ['type' => 'string', 'nullable' => true];
+                    break;
+                default:
+                    $mappingPropDefinition = ['type' => 'string'];
+            }
+
             $schema['type'] = 'object';
             $schema['properties'] = [
                 'hydra:member' => [
@@ -121,10 +132,7 @@ final class SchemaFactory implements SchemaFactoryInterface
                                 'properties' => [
                                     '@type' => ['type' => 'string'],
                                     'variable' => ['type' => 'string'],
-                                    'property' => [
-                                        'nullable' => true,
-                                        'type' => ['string', 'null'],
-                                    ],
+                                    'property' => $mappingPropDefinition,
                                     'required' => ['type' => 'boolean'],
                                 ],
                             ],

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -121,7 +121,7 @@ final class SchemaFactory implements SchemaFactoryInterface
                                 'properties' => [
                                     '@type' => ['type' => 'string'],
                                     'variable' => ['type' => 'string'],
-                                    'property' => ['type' => 'string'],
+                                    'property' => ['type' => 'string', 'nullable' => true],
                                     'required' => ['type' => 'boolean'],
                                 ],
                             ],


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

## Context

My entites have the following filter, to select properties. Parameter name have been overrode.
` * @ApiFilter(PropertyFilter::class, arguments={"parameterName": "fields"})`

And I got the following error in my tests, using `assertMatchesResourceCollectionJsonSchema` assertion

```
   │             ...
   │             3 => Array &9 (
   │                 '@type' => 'IriTemplateMapping'
   │                 'variable' => 'fields[]'
   │                 'property' => null
   │                 'required' => false
   │             )
   │             ...
   │     )
   │ ) matches the provided JSON Schema.
   │ hydra:search.hydra:mapping[3].property: NULL value found, but a string is required
```