### PR TITLE
Introduce `PaginatorFactoryInterface` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
 * DTO: Improve Input/Output support (#3231)
 * Data Persisters: Add `previous_data` to the context passed to persisters when available (#3752)
 * Data Persister: Add a `ResumableDataPersisterInterface` that allows to call multiple persisters (#3912)
+* Data Providers: Add `PaginatorFactoryInterface` interface.
 * Debug: Display API Platform's version in the debug bar (#3235)
 * Docs: Make `asset_package` configurable (#3764)
 * Doctrine: Allow searching on multiple values on every strategies (#3786)
 * Elasticsearch: The `Paginator` class constructor now receives the denormalization context to support denormalizing documents using serialization groups. This change may cause potential **BC** breaks for existing applications as denormalization was previously done without serialization groups.
+* Elasticsearch: The `CollectionDataProvider` class constructor now receives a concrete `PaginatorFactoryInterface` instance that is responsible for creating the concrete `PaginatorInterface` instance. This change enables more flexibility allowing applications to inject their custom implementation of `PaginatorFactoryInterface` dependency to produce a custom implementation of the `PaginatorInterface` interface. 
 * GraphQL: **BC** New syntax for the filters' arguments to preserve the order: `order: [{foo: 'asc'}, {bar: 'desc'}]` (#3468)
 * GraphQL: **BC** `operation` is now `operationName` to follow the standard (#3568)
 * GraphQL: **BC** `paginationType` is now `pagination_type` (#3614)

--- a/src/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
@@ -116,6 +116,6 @@ final class CollectionDataProvider implements ContextAwareCollectionDataProvider
             'body' => $body,
         ]);
 
-        return $this->paginatorFactory->createPaginator($documents, $limit, $offset, array_merge(['resourceClass' => $resourceClass], $context));
+        return $this->paginatorFactory->createPaginator($documents, $limit, $offset, $context + ['resource_class' => $resourceClass]);
     }
 }

--- a/src/Bridge/Elasticsearch/DataProvider/PaginatorFactory.php
+++ b/src/Bridge/Elasticsearch/DataProvider/PaginatorFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Elasticsearch\DataProvider;
+
+use ApiPlatform\Core\DataProvider\PaginatorFactoryInterface;
+use ApiPlatform\Core\DataProvider\PaginatorInterface;
+use ApiPlatform\Core\Exception\RuntimeException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class PaginatorFactory implements PaginatorFactoryInterface
+{
+    private $denormalizer;
+
+    public function __construct(DenormalizerInterface $denormalizer)
+    {
+        $this->denormalizer = $denormalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createPaginator($subject, int $limit, int $offset, array $context = []): PaginatorInterface
+    {
+        $resourceClass = $context['resourceClass'] ?? null;
+
+        if (null === $resourceClass) {
+            throw new RuntimeException('The given context array is missing the "resourceClass" key.');
+        }
+
+        return new Paginator(
+            $this->denormalizer,
+            $subject,
+            $resourceClass,
+            $limit,
+            $offset,
+            $context
+        );
+    }
+}

--- a/src/Bridge/Elasticsearch/DataProvider/PaginatorFactory.php
+++ b/src/Bridge/Elasticsearch/DataProvider/PaginatorFactory.php
@@ -32,10 +32,10 @@ final class PaginatorFactory implements PaginatorFactoryInterface
      */
     public function createPaginator($subject, int $limit, int $offset, array $context = []): PaginatorInterface
     {
-        $resourceClass = $context['resourceClass'] ?? null;
+        $resourceClass = $context['resource_class'] ?? null;
 
         if (null === $resourceClass) {
-            throw new RuntimeException('The given context array is missing the "resourceClass" key.');
+            throw new RuntimeException('The given context array is missing the "resource_class" key.');
         }
 
         return new Paginator(

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -74,12 +74,16 @@
             <argument type="service" id="api_platform.elasticsearch.client" />
             <argument type="service" id="api_platform.elasticsearch.metadata.document.metadata_factory" />
             <argument type="service" id="api_platform.elasticsearch.identifier_extractor" />
-            <argument type="service" id="serializer" />
+            <argument type="service" id="api_platform.elasticsearch.paginator_factory" />
             <argument type="service" id="api_platform.pagination" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="tagged" tag="api_platform.elasticsearch.request_body_search_extension.collection" />
 
             <tag name="api_platform.collection_data_provider" priority="5" />
+        </service>
+
+        <service id="api_platform.elasticsearch.paginator_factory" class="ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\PaginatorFactory" public="false">
+            <argument type="service" id="serializer" />
         </service>
 
         <service id="api_platform.elasticsearch.request_body_search_extension.filter" public="false" abstract="true">

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -74,10 +74,11 @@
             <argument type="service" id="api_platform.elasticsearch.client" />
             <argument type="service" id="api_platform.elasticsearch.metadata.document.metadata_factory" />
             <argument type="service" id="api_platform.elasticsearch.identifier_extractor" />
-            <argument type="service" id="api_platform.elasticsearch.paginator_factory" />
+            <argument type="service" id="serializer" />
             <argument type="service" id="api_platform.pagination" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="tagged" tag="api_platform.elasticsearch.request_body_search_extension.collection" />
+            <argument type="service" id="api_platform.elasticsearch.paginator_factory" />
 
             <tag name="api_platform.collection_data_provider" priority="5" />
         </service>

--- a/src/DataProvider/PaginatorFactoryInterface.php
+++ b/src/DataProvider/PaginatorFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\DataProvider;
+
+use ApiPlatform\Core\Exception\ExceptionInterface;
+
+interface PaginatorFactoryInterface
+{
+    /**
+     * Creates a new {@see PaginatorInterface} concrete instance.
+     *
+     * @param mixed                $subject The subject to paginate (array, ORM query, etc.)
+     * @param int                  $limit   The maximum number of records to fetch
+     * @param int                  $offset  The starting index from which to fetch the records
+     * @param array<string, mixed> $context The associative array context for the paginator
+     *
+     * @throws ExceptionInterface Whenever something wrong occurs
+     */
+    public function createPaginator($subject, int $limit, int $offset, array $context = []): PaginatorInterface;
+}

--- a/tests/Bridge/Elasticsearch/DataProvider/CollectionDataProviderTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/CollectionDataProviderTest.php
@@ -102,7 +102,7 @@ class CollectionDataProviderTest extends TestCase
     {
         $context = [
             'groups' => ['custom'],
-            'resourceClass' => Foo::class,
+            'resource_class' => Foo::class,
         ];
 
         $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);
@@ -196,7 +196,7 @@ class CollectionDataProviderTest extends TestCase
     {
         $context = [
             'groups' => ['custom'],
-            'resourceClass' => Foo::class,
+            'resource_class' => Foo::class,
         ];
 
         $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);

--- a/tests/Bridge/Elasticsearch/DataProvider/PaginatorFactoryTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/PaginatorFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Elasticsearch\DataProvider;
+
+use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Paginator;
+use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\PaginatorFactory;
+use ApiPlatform\Core\DataProvider\PaginatorFactoryInterface;
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class PaginatorFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var PaginatorFactory
+     */
+    private $paginatorFactory;
+
+    public function testConstruct()
+    {
+        $this->assertInstanceOf(PaginatorFactoryInterface::class, $this->paginatorFactory);
+    }
+
+    public function testCreatePaginator()
+    {
+        $paginator = $this->paginatorFactory->createPaginator([], 10, 0, ['resourceClass' => Foo::class]);
+
+        $this->assertInstanceOf(Paginator::class, $paginator);
+    }
+
+    public function testCreatePaginatorFailsWhenResourceClassAttributeIsMissing()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The given context array is missing the "resourceClass" key.');
+
+        $this->paginatorFactory->createPaginator([], 10, 0, ['resourceClass' => null]);
+    }
+
+    protected function setUp(): void
+    {
+        $this->paginatorFactory = new PaginatorFactory($this->prophesize(DenormalizerInterface::class)->reveal());
+    }
+}

--- a/tests/Bridge/Elasticsearch/DataProvider/PaginatorFactoryTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/PaginatorFactoryTest.php
@@ -38,7 +38,7 @@ final class PaginatorFactoryTest extends TestCase
 
     public function testCreatePaginator()
     {
-        $paginator = $this->paginatorFactory->createPaginator([], 10, 0, ['resourceClass' => Foo::class]);
+        $paginator = $this->paginatorFactory->createPaginator([], 10, 0, ['resource_class' => Foo::class]);
 
         $this->assertInstanceOf(Paginator::class, $paginator);
     }
@@ -46,9 +46,9 @@ final class PaginatorFactoryTest extends TestCase
     public function testCreatePaginatorFailsWhenResourceClassAttributeIsMissing()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The given context array is missing the "resourceClass" key.');
+        $this->expectExceptionMessage('The given context array is missing the "resource_class" key.');
 
-        $this->paginatorFactory->createPaginator([], 10, 0, ['resourceClass' => null]);
+        $this->paginatorFactory->createPaginator([], 10, 0, ['resource_class' => null]);
     }
 
     protected function setUp(): void

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -666,6 +666,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.normalizer.item', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.item_data_provider', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.collection_data_provider', Argument::type(Definition::class))->shouldBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.paginator_factory', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.request_body_search_extension.filter', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.request_body_search_extension.constant_score_filter', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.request_body_search_extension.sort_filter', Argument::type(Definition::class))->shouldBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/1239

This MR introduces a new generic `PaginatorFactoryInterface` interface enabling for more flexibility for collection data providers to produce `PaginatorInterface` instance.

For example, this is mainly useful for the Elasticsearch implementation when applications need to embed more information that just the records to be paginated into the paginator. That's the case when using Elasticsearch `aggregations` (or faceting in other words) system. Having a factory enables to construct a `AggregatedPaginatorFactory` class that produces `AggregatedPaginator` instances. The later will contain the documents to be paginated but also the returned `aggregated` data from Elasticsearch. Finally, by implementing a custom normalizer (ie. `AggregatedCollectionNormalizer`) and checking the concrete type of the paginator, the normalizer can append the aggregated data alongside the collection of documents in the JSON response.
