### PR TITLE
Fix tests with serialization groups

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -254,7 +254,7 @@ final class SchemaFactory implements SchemaFactoryInterface
 
         return [
             $resourceMetadata,
-            $serializerContext ?? $this->getSerializerContext($resourceMetadata, $type, $operationType, $operationName),
+            array_merge($serializerContext ?? [], $this->getSerializerContext($resourceMetadata, $type, $operationType, $operationName)),
             $this->getValidationGroups($resourceMetadata, $operationType, $operationName),
             $inputOrOutput['class'],
         ];


### PR DESCRIPTION
…ceItemJsonSchema with serialization groups

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3881
| License       | MIT


The serialization context parameter added in src/Bridge/Symfony/Bundle/Test/ApiTestAssertionsTrait.php avoid extra_attributes but breaks serialization groups schema.

Serialization context is now merge in SchemaFactory