### PR TITLE
Fix passing tags to purge

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -103,7 +103,7 @@ final class PurgeHttpCacheListener
             return;
         }
 
-        $this->purger->purge($this->tags);
+        $this->purger->purge(array_values($this->tags));
         $this->tags = [];
     }
 

--- a/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -56,7 +56,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $toDeleteNoPurge->setId(5);
 
         $purgerProphecy = $this->prophesize(PurgerInterface::class);
-        $purgerProphecy->purge(['/dummies' => '/dummies', '/dummies/1' => '/dummies/1', '/dummies/2' => '/dummies/2', '/dummies/3' => '/dummies/3', '/dummies/4' => '/dummies/4'])->shouldBeCalled();
+        $purgerProphecy->purge(['/dummies', '/dummies/1', '/dummies/2', '/dummies/3', '/dummies/4'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
@@ -99,7 +99,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $dummy->setId(1);
 
         $purgerProphecy = $this->prophesize(PurgerInterface::class);
-        $purgerProphecy->purge(['/dummies' => '/dummies', '/dummies/1' => '/dummies/1', '/related_dummies/old' => '/related_dummies/old', '/related_dummies/new' => '/related_dummies/new'])->shouldBeCalled();
+        $purgerProphecy->purge(['/dummies', '/dummies/1', '/related_dummies/old', '/related_dummies/new'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();

--- a/tests/HttpCache/VarnishPurgerTest.php
+++ b/tests/HttpCache/VarnishPurgerTest.php
@@ -98,6 +98,18 @@ class VarnishPurgerTest extends TestCase
 
     public function provideChunkHeaderCases()
     {
+        yield 'no iri' => [
+            50,
+            [],
+            [],
+        ];
+
+        yield 'one iri' => [
+            50,
+            ['/foo'],
+            ['(^|\,)/foo($|\,)'],
+        ];
+
         yield 'few iris' => [
             50,
             ['/foo', '/bar'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | #3893
| License       | MIT
| Doc PR        | -

`PurgerInterface::purge($iris)` expects `string[]` and never used string keys from the `$iris` argument anyway.