### PR TITLE
allow absence of token for sf authentication manager

### DIFF
--- a/tests/Security/ResourceAccessCheckerTest.php
+++ b/tests/Security/ResourceAccessCheckerTest.php
@@ -76,23 +76,11 @@ class ResourceAccessCheckerTest extends TestCase
     public function testExpressionLanguageNotInstalled()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The "symfony/expression-language" library must be installed to use the "security".');
+        $this->expectExceptionMessage('The "symfony/expression-language" library must be installed to use the "security" attribute.');
 
         $authenticationTrustResolverProphecy = $this->prophesize(AuthenticationTrustResolverInterface::class);
         $tokenStorageProphecy = $this->prophesize(TokenStorageInterface::class);
         $tokenStorageProphecy->getToken()->willReturn($this->prophesize(TokenInterface::class)->willImplement(Serializable::class)->reveal());
-
-        $checker = new ResourceAccessChecker(null, $authenticationTrustResolverProphecy->reveal(), null, $tokenStorageProphecy->reveal());
-        $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")');
-    }
-
-    public function testNotBehindAFirewall()
-    {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The current token must be set to use the "security" attribute (is the URL behind a firewall?).');
-
-        $authenticationTrustResolverProphecy = $this->prophesize(AuthenticationTrustResolverInterface::class);
-        $tokenStorageProphecy = $this->prophesize(TokenStorageInterface::class);
 
         $checker = new ResourceAccessChecker(null, $authenticationTrustResolverProphecy->reveal(), null, $tokenStorageProphecy->reveal());
         $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")');


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#...

Anonymous users don't exist anymore when using the Symfony Authentication manager (No token in token storage, which doesn't necessarily mean you're not behind a firewall)

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
