### PR TITLE
Try to fix CI errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build/
 /composer.lock
 /composer.phar
+/phpstan.neon
 /phpunit.xml
 /swagger.json
 /swagger.yaml

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -96,6 +96,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => true,
         ],
+        'phpdoc_no_alias_tag' => false, // Set the rule to true when https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5357 is fixed
         'phpdoc_order' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_var_annotation_correct_order' => true,

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -27,7 +27,7 @@ use Doctrine\Inflector\InflectorFactory;
 final class Inflector
 {
     /**
-     * @var InflectorObject
+     * @var InflectorObject|null
      */
     private static $instance;
 
@@ -38,18 +38,18 @@ final class Inflector
     }
 
     /**
-     * @see LegacyInflector::tableize()
+     * @see InflectorObject::tableize()
      */
     public static function tableize(string $word): string
     {
-        return class_exists(InflectorFactory::class) ? self::getInstance()->tableize($word) : LegacyInflector::tableize($word);
+        return class_exists(LegacyInflector::class) ? LegacyInflector::tableize($word) : self::getInstance()->tableize($word);
     }
 
     /**
-     * @see LegacyInflector::pluralize()
+     * @see InflectorObject::pluralize()
      */
     public static function pluralize(string $word): string
     {
-        return class_exists(InflectorFactory::class) ? self::getInstance()->pluralize($word) : LegacyInflector::pluralize($word);
+        return class_exists(LegacyInflector::class) ? LegacyInflector::pluralize($word) : self::getInstance()->pluralize($word);
     }
 }

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -18,7 +18,6 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\TestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Doctrine\Common\Inflector\Inflector;
-use Doctrine\Inflector\InflectorFactory;
 use FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -54,7 +53,7 @@ class AppKernel extends Kernel
 
         // patch for old versions of Doctrine Inflector, to delete when we'll drop support for v1
         // see https://github.com/doctrine/inflector/issues/147#issuecomment-628807276
-        if (!class_exists(InflectorFactory::class)) {
+        if (class_exists(Inflector::class)) {
             Inflector::rules('plural', ['/taxon/i' => 'taxa']);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no (I hope)
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

About CS errors, I suspect a bug in PHP-CS-Fixer 2.17. I am waiting for their opinion: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5357.

~About PHPStan errors, I applied the fix from https://github.com/api-platform/core/pull/3886. I'm not sure if the new thrown exception might be a BC break.~