### PR TITLE
Add the @Ignore annotation support

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -11,6 +11,7 @@ default:
         - 'ApiPlatform\Core\Tests\Behat\HttpCacheContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonApiContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonHalContext'
+        - 'ApiPlatform\Core\Tests\Behat\XmlContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
@@ -45,6 +46,7 @@ postgres:
         - 'ApiPlatform\Core\Tests\Behat\HttpCacheContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonApiContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonHalContext'
+        - 'ApiPlatform\Core\Tests\Behat\XmlContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
@@ -64,6 +66,7 @@ mongodb:
         - 'ApiPlatform\Core\Tests\Behat\HttpCacheContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonApiContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonHalContext'
+        - 'ApiPlatform\Core\Tests\Behat\XmlContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
@@ -98,6 +101,7 @@ default-coverage:
         - 'ApiPlatform\Core\Tests\Behat\JsonApiContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonHalContext'
         - 'ApiPlatform\Core\Tests\Behat\CoverageContext'
+        - 'ApiPlatform\Core\Tests\Behat\XmlContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
 
@@ -117,6 +121,7 @@ mongodb-coverage:
         - 'ApiPlatform\Core\Tests\Behat\JsonApiContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonHalContext'
         - 'ApiPlatform\Core\Tests\Behat\CoverageContext'
+        - 'ApiPlatform\Core\Tests\Behat\XmlContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-foundation": "^4.4 || ^5.1",
         "symfony/http-kernel": "^4.4 || ^5.1",
         "symfony/property-access": "^3.4.19 || ^4.4 || ^5.1",
-        "symfony/property-info": "^3.4 || ^4.4 || ^5.1",
+        "symfony/property-info": "^3.4 || ^4.4 || ^5.2.x-dev#516cbda5788a37f393df6f0dfd19c25eb926784b",
         "symfony/serializer": "^4.4 || ^5.1",
         "symfony/web-link": "^4.4 || ^5.1",
         "willdurand/negotiation": "^2.0.3 || ^3.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-foundation": "^4.4 || ^5.1",
         "symfony/http-kernel": "^4.4 || ^5.1",
         "symfony/property-access": "^3.4.19 || ^4.4 || ^5.1",
-        "symfony/property-info": "^3.4 || ^4.4 || ^5.2.x-dev#516cbda5788a37f393df6f0dfd19c25eb926784b",
+        "symfony/property-info": "^3.4 || ^4.4 || ^5.2.1",
         "symfony/serializer": "^4.4 || ^5.1",
         "symfony/web-link": "^4.4 || ^5.1",
         "willdurand/negotiation": "^2.0.3 || ^3.0"

--- a/features/doctrine/search_filter.feature
+++ b/features/doctrine/search_filter.feature
@@ -19,7 +19,7 @@ Feature: Search filter on collections
     Given there is a DummyCar entity with related colors
     When I send a "GET" request to "/dummy_cars?colors.prop=red"
     Then the response status code should be 200
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
       "@context": "/contexts/DummyCar",
@@ -81,19 +81,7 @@ Feature: Search filter on collections
         "hydra:mapping": [
           {
             "@type": "IriTemplateMapping",
-            "variable": "availableAt[after]",
-            "property": "availableAt",
-            "required": false
-          },
-          {
-            "@type": "IriTemplateMapping",
             "variable": "availableAt[before]",
-            "property": "availableAt",
-            "required": false
-          },
-          {
-            "@type": "IriTemplateMapping",
-            "variable": "availableAt[strictly_after]",
             "property": "availableAt",
             "required": false
           },
@@ -105,26 +93,20 @@ Feature: Search filter on collections
           },
           {
             "@type": "IriTemplateMapping",
+            "variable": "availableAt[after]",
+            "property": "availableAt",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "availableAt[strictly_after]",
+            "property": "availableAt",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
             "variable": "canSell",
             "property": "canSell",
-            "required": false
-          },
-          {
-            "@type": "IriTemplateMapping",
-            "variable": "colors",
-            "property": "colors",
-            "required": false
-          },
-          {
-            "@type": "IriTemplateMapping",
-            "variable": "colors.prop",
-            "property": "colors.prop",
-            "required": false
-          },
-          {
-            "@type": "IriTemplateMapping",
-            "variable": "colors[]",
-            "property": "colors",
             "required": false
           },
           {
@@ -147,8 +129,20 @@ Feature: Search filter on collections
           },
           {
             "@type": "IriTemplateMapping",
-            "variable": "name",
-            "property": "name",
+            "variable": "colors.prop",
+            "property": "colors.prop",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "colors",
+            "property": "colors",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "colors[]",
+            "property": "colors",
             "required": false
           },
           {
@@ -185,6 +179,12 @@ Feature: Search filter on collections
             "@type": "IriTemplateMapping",
             "variable": "uuid[]",
             "property": "uuid",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "name",
+            "property": "name",
             "required": false
           }
         ]
@@ -278,7 +278,6 @@ Feature: Search filter on collections
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And print last JSON response
     And the JSON should be valid according to this schema:
     """
     {

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -71,12 +71,56 @@ Feature: GraphQL introspection support
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.type1.description" should be equal to "Dummy Product."
-    And the JSON node "data.type1.fields[1].type.name" should be equal to "DummyAggregateOfferConnection"
-    And the JSON node "data.type2.fields[0].name" should be equal to "edges"
-    And the JSON node "data.type2.fields[0].type.ofType.name" should be equal to "DummyAggregateOfferEdge"
-    And the JSON node "data.type3.fields[0].name" should be equal to "node"
-    And the JSON node "data.type3.fields[1].name" should be equal to "cursor"
-    And the JSON node "data.type3.fields[0].type.name" should be equal to "DummyAggregateOffer"
+    And the JSON node "data.type1.fields" should contain:
+    """
+    {
+      "name":"offers",
+      "type":{
+        "name":"DummyAggregateOfferConnection",
+        "kind":"OBJECT",
+        "ofType":null
+      }
+    }
+    """
+    And the JSON node "data.type2.fields" should contain:
+    """
+    {
+      "name":"edges",
+      "type":{
+        "name":null,
+        "kind":"LIST",
+        "ofType":{
+          "name":"DummyAggregateOfferEdge",
+          "kind":"OBJECT"
+        }
+      }
+    }
+    """
+    And the JSON node "data.type3.fields" should contain:
+    """
+    {
+      "name":"node",
+      "type":{
+        "name":"DummyAggregateOffer",
+        "kind":"OBJECT",
+        "ofType":null
+      }
+    }
+    """
+    And the JSON node "data.type3.fields" should contain:
+    """
+    {
+      "name":"cursor",
+      "type":{
+        "name":null,
+        "kind":"NON_NULL",
+        "ofType":{
+          "name":"String",
+          "kind":"SCALAR"
+        }
+      }
+    }
+    """
 
   Scenario: Introspect types with different serialization groups for item_query and collection_query
     When I send the following GraphQL request:
@@ -201,7 +245,7 @@ Feature: GraphQL introspection support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
       "data": {
@@ -286,8 +330,17 @@ Feature: GraphQL introspection support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.__type.fields[9].name" should be equal to "jsonData"
-    And the JSON node "data.__type.fields[9].type.name" should be equal to "Iterable"
+    And the JSON node "data.__type.fields" should contain:
+    """
+    {
+      "name":"jsonData",
+      "type":{
+        "name":"Iterable",
+        "kind":"SCALAR",
+        "ofType":null
+      }
+    }
+    """
 
   Scenario: Retrieve entity - using serialization groups - fields
     When I send the following GraphQL request:
@@ -420,13 +473,52 @@ Feature: GraphQL introspection support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.typeCreatePayload.fields" should have 2 elements
-    And the JSON node "data.typeCreatePayload.fields[0].name" should be equal to "dummyProperty"
-    And the JSON node "data.typeCreatePayload.fields[0].type.name" should be equal to "createDummyPropertyPayloadData"
-    And the JSON node "data.typeCreatePayload.fields[1].name" should be equal to "clientMutationId"
-    And the JSON node "data.typeCreatePayloadData.fields[3].name" should be equal to "group"
-    And the JSON node "data.typeCreatePayloadData.fields[3].type.name" should be equal to "createDummyGroupNestedPayload"
-    And the JSON node "data.typeCreateNestedPayload.fields[0].name" should be equal to "id"
+    And the JSON node "data.typeCreatePayload.fields" should be equal to:
+    """
+    [
+      {
+        "name":"dummyProperty",
+        "type":{
+          "name":"createDummyPropertyPayloadData",
+          "kind":"OBJECT",
+          "ofType":null
+        }
+      },
+      {
+        "name":"clientMutationId",
+        "type":{
+          "name":"String",
+          "kind":"SCALAR",
+          "ofType":null
+        }
+      }
+    ]
+    """
+    And the JSON node "data.typeCreatePayloadData.fields" should contain:
+    """
+    {
+      "name":"group",
+      "type":{
+        "name":"createDummyGroupNestedPayload",
+        "kind":"OBJECT",
+        "ofType":null
+      }
+    }
+    """
+    And the JSON node "data.typeCreateNestedPayload.fields" should contain:
+    """
+    {
+      "name":"id",
+      "type":{
+        "name":null,
+        "kind":"NON_NULL",
+        "ofType":{
+          "name":"ID",
+          "kind":"SCALAR"
+        }
+      }
+    }
+    """
 
   Scenario: Retrieve a type name through a GraphQL query
     Given there are 4 dummy objects with relatedDummy

--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -14,7 +14,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "data": {
@@ -56,7 +56,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "data": {
@@ -86,7 +86,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "data": {
@@ -123,7 +123,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "data": {
@@ -158,7 +158,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "data": {
@@ -238,7 +238,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "data": {
@@ -328,7 +328,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
         {
             "data": {
@@ -398,7 +398,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "links": {
@@ -510,7 +510,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "links": {
@@ -602,7 +602,7 @@ Feature: JSON API Inclusion of Related Resources
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be valid according to the JSON API schema
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
         "links": {

--- a/features/main/composite.feature
+++ b/features/main/composite.feature
@@ -11,7 +11,7 @@ Feature: Retrieve data with Composite identifiers
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be deep equal to:
+    And the JSON should be equal to:
     """
     {
       "@context": "/contexts/CompositeItem",

--- a/features/main/content_negotiation.feature
+++ b/features/main/content_negotiation.feature
@@ -15,7 +15,8 @@ Feature: Content Negotiation support
     """
     Then the response status code should be 201
     And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
-    And the response should be equal to
+    And the response should be in XML
+    And the XML should be equal to:
     """
     <?xml version="1.0"?>
     <response><description/><dummy/><dummyBoolean/><dummyDate/><dummyFloat/><dummyPrice/><relatedDummy/><relatedDummies/><jsonData/><arrayData/><name_converted/><relatedOwnedDummy/><relatedOwningDummy/><id>1</id><name>XML!</name><alias/><foo/></response>
@@ -26,7 +27,8 @@ Feature: Content Negotiation support
     And I send a "GET" request to "/dummies"
     Then the response status code should be 200
     And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
-    And the response should be equal to
+    And the response should be in XML
+    And the XML should be equal to:
     """
     <?xml version="1.0"?>
     <response><item key="0"><description/><dummy/><dummyBoolean/><dummyDate/><dummyFloat/><dummyPrice/><relatedDummy/><relatedDummies/><jsonData/><arrayData/><name_converted/><relatedOwnedDummy/><relatedOwningDummy/><id>1</id><name>XML!</name><alias/><foo/></item></response>
@@ -36,7 +38,8 @@ Feature: Content Negotiation support
     When I send a "GET" request to "/dummies.xml"
     Then the response status code should be 200
     And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
-    And the response should be equal to
+    And the response should be in XML
+    And the XML should be equal to:
     """
     <?xml version="1.0"?>
     <response><item key="0"><description/><dummy/><dummyBoolean/><dummyDate/><dummyFloat/><dummyPrice/><relatedDummy/><relatedDummies/><jsonData/><arrayData/><name_converted/><relatedOwnedDummy/><relatedOwningDummy/><id>1</id><name>XML!</name><alias/><foo/></item></response>
@@ -82,7 +85,8 @@ Feature: Content Negotiation support
     """
     Then the response status code should be 201
     And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
-    And the response should be equal to
+    And the response should be in XML
+    And the XML should be equal to:
     """
     <?xml version="1.0"?>
     <response><description/><dummy/><dummyBoolean/><dummyDate/><dummyFloat/><dummyPrice/><relatedDummy/><relatedDummies/><jsonData/><arrayData/><name_converted/><relatedOwnedDummy/><relatedOwningDummy/><id>2</id><name>Sent in JSON</name><alias/><foo/></response>
@@ -134,7 +138,8 @@ Feature: Content Negotiation support
     """
     Then the response status code should be 201
     And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
-    And the response should be equal to
+    And the response should be in XML
+    And the XML should be equal to:
     """
     <?xml version="1.0"?>
     <response><id>1</id><name>Kevin</name></response>

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -193,45 +193,45 @@ Feature: Subresource support
     }
     """
 
-  Scenario: Get the subresource relation item
-    When I send a "GET" request to "/dummies/1/related_dummies/2"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/RelatedDummy",
-      "@id": "/related_dummies/2",
-      "@type": "https://schema.org/Product",
-      "id": 2,
-      "name": null,
-      "symfony": "symfony",
-      "dummyDate": null,
-      "thirdLevel": {
-        "@id": "/third_levels/1",
-        "@type": "ThirdLevel",
-        "fourthLevel": "/fourth_levels/1"
-      },
-      "relatedToDummyFriend": [],
-      "dummyBoolean": null,
-      "embeddedDummy": [],
-      "age": null
-    }
-    """
+#  Scenario: Get the subresource relation item
+#    When I send a "GET" request to "/dummies/1/related_dummies/2"
+#    Then the response status code should be 200
+#    And the response should be in JSON
+#    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+#    And the JSON should be equal to:
+#    """
+#    {
+#      "@context": "/contexts/RelatedDummy",
+#      "@id": "/related_dummies/2",
+#      "@type": "https://schema.org/Product",
+#      "id": 2,
+#      "name": null,
+#      "symfony": "symfony",
+#      "dummyDate": null,
+#      "thirdLevel": {
+#        "@id": "/third_levels/1",
+#        "@type": "ThirdLevel",
+#        "fourthLevel": "/fourth_levels/1"
+#      },
+#      "relatedToDummyFriend": [],
+#      "dummyBoolean": null,
+#      "embeddedDummy": [],
+#      "age": null
+#    }
+#    """
 
-  Scenario: Create a dummy with a relation that is a subresource
-    When I add "Content-Type" header equal to "application/ld+json"
-    And I send a "POST" request to "/dummies" with body:
-    """
-    {
-      "name": "Dummy with relations",
-      "relatedDummy": "/dummies/1/related_dummies/2"
-    }
-    """
-    Then the response status code should be 201
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+#  Scenario: Create a dummy with a relation that is a subresource
+#    When I add "Content-Type" header equal to "application/ld+json"
+#    And I send a "POST" request to "/dummies" with body:
+#    """
+#    {
+#      "name": "Dummy with relations",
+#      "relatedDummy": "/dummies/1/related_dummies/2"
+#    }
+#    """
+#    Then the response status code should be 201
+#    And the response should be in JSON
+#    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
   Scenario: Get the embedded relation subresource item at the third level
     When I send a "GET" request to "/dummies/1/related_dummies/1/third_level"
@@ -355,7 +355,7 @@ Feature: Subresource support
     """
     {
       "@context": "/contexts/Dummy",
-      "@id": "/dummies/3",
+      "@id": "/dummies/2",
       "@type": "Dummy",
       "description": null,
       "dummy": null,
@@ -370,7 +370,7 @@ Feature: Subresource support
       "name_converted": null,
       "relatedOwnedDummy": "/related_owned_dummies/1",
       "relatedOwningDummy": null,
-      "id": 3,
+      "id": 2,
       "name": "plop",
       "alias": null,
       "foo": null
@@ -387,7 +387,7 @@ Feature: Subresource support
     """
     {
       "@context": "/contexts/Dummy",
-      "@id": "/dummies/4",
+      "@id": "/dummies/3",
       "@type": "Dummy",
       "description": null,
       "dummy": null,
@@ -402,7 +402,7 @@ Feature: Subresource support
       "name_converted": null,
       "relatedOwnedDummy": null,
       "relatedOwningDummy": "/related_owning_dummies/1",
-      "id": 4,
+      "id": 3,
       "name": "plop",
       "alias": null,
       "foo": null

--- a/features/main/subresource.feature
+++ b/features/main/subresource.feature
@@ -193,45 +193,45 @@ Feature: Subresource support
     }
     """
 
-#  Scenario: Get the subresource relation item
-#    When I send a "GET" request to "/dummies/1/related_dummies/2"
-#    Then the response status code should be 200
-#    And the response should be in JSON
-#    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-#    And the JSON should be equal to:
-#    """
-#    {
-#      "@context": "/contexts/RelatedDummy",
-#      "@id": "/related_dummies/2",
-#      "@type": "https://schema.org/Product",
-#      "id": 2,
-#      "name": null,
-#      "symfony": "symfony",
-#      "dummyDate": null,
-#      "thirdLevel": {
-#        "@id": "/third_levels/1",
-#        "@type": "ThirdLevel",
-#        "fourthLevel": "/fourth_levels/1"
-#      },
-#      "relatedToDummyFriend": [],
-#      "dummyBoolean": null,
-#      "embeddedDummy": [],
-#      "age": null
-#    }
-#    """
+  Scenario: Get the subresource relation item
+    When I send a "GET" request to "/dummies/1/related_dummies/2"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/RelatedDummy",
+      "@id": "/related_dummies/2",
+      "@type": "https://schema.org/Product",
+      "id": 2,
+      "name": null,
+      "symfony": "symfony",
+      "dummyDate": null,
+      "thirdLevel": {
+        "@id": "/third_levels/1",
+        "@type": "ThirdLevel",
+        "fourthLevel": "/fourth_levels/1"
+      },
+      "relatedToDummyFriend": [],
+      "dummyBoolean": null,
+      "embeddedDummy": [],
+      "age": null
+    }
+    """
 
-#  Scenario: Create a dummy with a relation that is a subresource
-#    When I add "Content-Type" header equal to "application/ld+json"
-#    And I send a "POST" request to "/dummies" with body:
-#    """
-#    {
-#      "name": "Dummy with relations",
-#      "relatedDummy": "/dummies/1/related_dummies/2"
-#    }
-#    """
-#    Then the response status code should be 201
-#    And the response should be in JSON
-#    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+  Scenario: Create a dummy with a relation that is a subresource
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": "Dummy with relations",
+      "relatedDummy": "/dummies/1/related_dummies/2"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
   Scenario: Get the embedded relation subresource item at the third level
     When I send a "GET" request to "/dummies/1/related_dummies/1/third_level"
@@ -344,71 +344,6 @@ Feature: Subresource support
     }
     """
 
-
-  Scenario: The OneToOne subresource should be accessible from owned side
-    Given there is a RelatedOwnedDummy object with OneToOne relation
-    When I send a "GET" request to "/related_owned_dummies/1/owning_dummy"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/Dummy",
-      "@id": "/dummies/2",
-      "@type": "Dummy",
-      "description": null,
-      "dummy": null,
-      "dummyBoolean": null,
-      "dummyDate": null,
-      "dummyFloat": null,
-      "dummyPrice": null,
-      "relatedDummy": null,
-      "relatedDummies": [],
-      "jsonData": [],
-      "arrayData": [],
-      "name_converted": null,
-      "relatedOwnedDummy": "/related_owned_dummies/1",
-      "relatedOwningDummy": null,
-      "id": 2,
-      "name": "plop",
-      "alias": null,
-      "foo": null
-    }
-    """
-
-  Scenario: The OneToOne subresource should be accessible from owning side
-    Given there is a RelatedOwningDummy object with OneToOne relation
-    When I send a "GET" request to "/related_owning_dummies/1/owned_dummy"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/Dummy",
-      "@id": "/dummies/3",
-      "@type": "Dummy",
-      "description": null,
-      "dummy": null,
-      "dummyBoolean": null,
-      "dummyDate": null,
-      "dummyFloat": null,
-      "dummyPrice": null,
-      "relatedDummy": null,
-      "relatedDummies": [],
-      "jsonData": [],
-      "arrayData": [],
-      "name_converted": null,
-      "relatedOwnedDummy": null,
-      "relatedOwningDummy": "/related_owning_dummies/1",
-      "id": 3,
-      "name": "plop",
-      "alias": null,
-      "foo": null
-    }
-    """
-
   Scenario: Recursive resource
     When I send a "GET" request to "/dummy_products/2"
     Then the response status code should be 200
@@ -429,5 +364,71 @@ Feature: Subresource support
         "/dummy_products/1"
       ],
       "parent": null
+    }
+    """
+
+  @createSchema
+  Scenario: The OneToOne subresource should be accessible from owned side
+    Given there is a RelatedOwnedDummy object with OneToOne relation
+    When I send a "GET" request to "/related_owned_dummies/1/owning_dummy"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
+      "description": null,
+      "dummy": null,
+      "dummyBoolean": null,
+      "dummyDate": null,
+      "dummyFloat": null,
+      "dummyPrice": null,
+      "relatedDummy": null,
+      "relatedDummies": [],
+      "jsonData": [],
+      "arrayData": [],
+      "name_converted": null,
+      "relatedOwnedDummy": "/related_owned_dummies/1",
+      "relatedOwningDummy": null,
+      "id": 1,
+      "name": "plop",
+      "alias": null,
+      "foo": null
+    }
+    """
+
+  @createSchema
+  Scenario: The OneToOne subresource should be accessible from owning side
+    Given there is a RelatedOwningDummy object with OneToOne relation
+    When I send a "GET" request to "/related_owning_dummies/1/owned_dummy"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies/1",
+      "@type": "Dummy",
+      "description": null,
+      "dummy": null,
+      "dummyBoolean": null,
+      "dummyDate": null,
+      "dummyFloat": null,
+      "dummyPrice": null,
+      "relatedDummy": null,
+      "relatedDummies": [],
+      "jsonData": [],
+      "arrayData": [],
+      "name_converted": null,
+      "relatedOwnedDummy": null,
+      "relatedOwningDummy": "/related_owning_dummies/1",
+      "id": 1,
+      "name": "plop",
+      "alias": null,
+      "foo": null
     }
     """

--- a/src/Bridge/Symfony/PropertyInfo/Metadata/Property/PropertyInfoPropertyNameCollectionFactory.php
+++ b/src/Bridge/Symfony/PropertyInfo/Metadata/Property/PropertyInfoPropertyNameCollectionFactory.php
@@ -38,7 +38,7 @@ final class PropertyInfoPropertyNameCollectionFactory implements PropertyNameCol
      */
     public function create(string $resourceClass, array $options = []): PropertyNameCollection
     {
-        $properties = $this->propertyInfo->getProperties($resourceClass, $options);
+        $properties = $this->propertyInfo->getProperties($resourceClass, $options + ['serializer_groups' => null]);
 
         return new PropertyNameCollection($properties ?? []);
     }

--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Util\ResourceClassInfoTrait;
+use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface as SerializerClassMetadataFactoryInterface;
 
 /**
@@ -66,24 +67,26 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
     }
 
     /**
-     * Sets readable/writable based on matching normalization/denormalization groups.
+     * Sets readable/writable based on matching normalization/denormalization groups and property's ignorance.
      *
      * A false value is never reset as it could be unreadable/unwritable for other reasons.
-     * If normalization/denormalization groups are not specified, the property is implicitly readable/writable.
+     * If normalization/denormalization groups are not specified and the property is not ignored, the property is implicitly readable/writable.
      *
      * @param string[]|null $normalizationGroups
      * @param string[]|null $denormalizationGroups
      */
     private function transformReadWrite(PropertyMetadata $propertyMetadata, string $resourceClass, string $propertyName, array $normalizationGroups = null, array $denormalizationGroups = null): PropertyMetadata
     {
-        $groups = $this->getPropertySerializerGroups($resourceClass, $propertyName);
+        $serializerAttributeMetadata = $this->getSerializerAttributeMetadata($resourceClass, $propertyName);
+        $groups = $serializerAttributeMetadata ? $serializerAttributeMetadata->getGroups() : [];
+        $ignored = $serializerAttributeMetadata && method_exists($serializerAttributeMetadata, 'isIgnored') ? $serializerAttributeMetadata->isIgnored() : false;
 
         if (false !== $propertyMetadata->isReadable()) {
-            $propertyMetadata = $propertyMetadata->withReadable(null === $normalizationGroups || !empty(array_intersect($normalizationGroups, $groups)));
+            $propertyMetadata = $propertyMetadata->withReadable(!$ignored && (null === $normalizationGroups || array_intersect($normalizationGroups, $groups)));
         }
 
         if (false !== $propertyMetadata->isWritable()) {
-            $propertyMetadata = $propertyMetadata->withWritable(null === $denormalizationGroups || !empty(array_intersect($denormalizationGroups, $groups)));
+            $propertyMetadata = $propertyMetadata->withWritable(!$ignored && (null === $denormalizationGroups || array_intersect($denormalizationGroups, $groups)));
         }
 
         return $propertyMetadata;
@@ -178,22 +181,17 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
         ];
     }
 
-    /**
-     * Gets the serializer groups defined on a property.
-     *
-     * @return string[]
-     */
-    private function getPropertySerializerGroups(string $class, string $property): array
+    private function getSerializerAttributeMetadata(string $class, string $attribute): ?AttributeMetadataInterface
     {
         $serializerClassMetadata = $this->serializerClassMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            if ($property === $serializerAttributeMetadata->getName()) {
-                return $serializerAttributeMetadata->getGroups();
+            if ($attribute === $serializerAttributeMetadata->getName()) {
+                return $serializerAttributeMetadata;
             }
         }
 
-        return [];
+        return null;
     }
 
     /**

--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -149,7 +149,10 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
                 $identifiers = (array) $resourceMetadata->getAttribute('identifiers', null === $this->identifiersExtractor ? ['id'] : $this->identifiersExtractor->getIdentifiersFromResourceClass($resourceClass));
                 $identifier = \is_string($key = array_key_first($identifiers)) ? $key : $identifiers[0];
                 $operation['identifiers'] = $parentOperation['identifiers'];
-                $operation['identifiers'][$parentOperation['property']] = [$resourceClass, $identifiers[$identifier][1] ?? $identifier, $isLastItem ? true : $parentOperation['collection']];
+
+                if (!isset($operation['identifiers'][$parentOperation['property']])) {
+                    $operation['identifiers'][$parentOperation['property']] = [$resourceClass, $identifiers[$identifier][1] ?? $identifier, $isLastItem ? true : $parentOperation['collection']];
+                }
 
                 $operation['operation_name'] = str_replace(
                     'get'.self::SUBRESOURCE_SUFFIX,

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -356,19 +356,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $options = $this->getFactoryOptions($context);
         $propertyNames = $this->propertyNameCollectionFactory->create($context['resource_class'], $options);
 
-        $attributesMetadata = $this->classMetadataFactory ?
-            $this->classMetadataFactory->getMetadataFor($context['resource_class'])->getAttributesMetadata() :
-            null;
-
         $allowedAttributes = [];
         foreach ($propertyNames as $propertyName) {
-            if (
-                null != $attributesMetadata && \array_key_exists($propertyName, $attributesMetadata) &&
-                method_exists($attributesMetadata[$propertyName], 'isIgnored') &&
-                $attributesMetadata[$propertyName]->isIgnored()) {
-                continue;
-            }
-
             $propertyMetadata = $this->propertyMetadataFactory->create($context['resource_class'], $propertyName, $options);
 
             if (

--- a/tests/Behat/XmlContext.php
+++ b/tests/Behat/XmlContext.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Behat;
+
+use Behat\Gherkin\Node\PyStringNode;
+use Behatch\Context\XmlContext as BaseXmlContext;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+
+final class XmlContext extends BaseXmlContext
+{
+    private $xmlEncoder;
+
+    public function __construct()
+    {
+        $this->xmlEncoder = new XmlEncoder();
+    }
+
+    /**
+     * @Then the XML should be equal to:
+     */
+    public function theXmlShouldBeEqualTo(PyStringNode $content): void
+    {
+        $expected = $this->xmlEncoder->decode((string) $content, 'xml');
+        $actual = $this->xmlEncoder->decode($actualXml = $this->getSession()->getPage()->getContent(), 'xml');
+
+        $this->assertEquals(
+            $expected,
+            $actual,
+            "The XML is equal to:\n{$actualXml}"
+        );
+    }
+}

--- a/tests/Fixtures/DummyIgnoreProperty.php
+++ b/tests/Fixtures/DummyIgnoreProperty.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+class DummyIgnoreProperty
+{
+    public $visibleWithoutGroup;
+
+    /**
+     * @Groups({"dummy"})
+     */
+    public $visibleWithGroup;
+
+    /**
+     * @Groups({"dummy"})
+     * @Ignore
+     */
+    public $ignored;
+}

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -33,6 +33,7 @@ class RelatedDummy extends ParentDummy
 {
     /**
      * @ApiProperty(writable=false)
+     * @ApiSubresource
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -33,7 +33,6 @@ class RelatedDummy extends ParentDummy
 {
     /**
      * @ApiProperty(writable=false)
-     * @ApiSubresource
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")

--- a/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/SerializerPropertyMetadataFactoryTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\SerializerPropertyMetadataFactory
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\DummyIgnoreProperty;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritance;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceChild;
@@ -26,6 +27,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata as SerializerAttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata as SerializerClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface as SerializerClassMetadataFactoryInterface;
@@ -82,9 +84,6 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $dummySerializerClassMetadata->addAttributeMetadata($nameConvertedSerializerAttributeMetadata);
         $serializerClassMetadataFactoryProphecy->getMetadataFor(Dummy::class)->willReturn($dummySerializerClassMetadata);
         $relatedDummySerializerClassMetadata = new SerializerClassMetadata(RelatedDummy::class);
-        $idSerializerAttributeMetadata = new SerializerAttributeMetadata('id');
-        $idSerializerAttributeMetadata->addGroup('dummy_read');
-        $relatedDummySerializerClassMetadata->addAttributeMetadata($idSerializerAttributeMetadata);
         $nameSerializerAttributeMetadata = new SerializerAttributeMetadata('name');
         $nameSerializerAttributeMetadata->addGroup('dummy_read');
         $relatedDummySerializerClassMetadata->addAttributeMetadata($nameSerializerAttributeMetadata);
@@ -160,5 +159,50 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
         $actual = $serializerPropertyMetadataFactory->create(DummyTableInheritance::class, 'nickname');
 
         $this->assertEquals($actual->getChildInherited(), DummyTableInheritanceChild::class);
+    }
+
+    public function testCreateWithIgnoredProperty(): void
+    {
+        // symfony/serializer < 5.1
+        if (!class_exists(Ignore::class)) {
+            self::markTestSkipped();
+        }
+
+        $dummyIgnorePropertyResourceMetadata = (new ResourceMetadata())
+            ->withAttributes([
+                'normalization_context' => [AbstractNormalizer::GROUPS => ['dummy']],
+                'denormalization_context' => [AbstractNormalizer::GROUPS => ['dummy']],
+            ]);
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(DummyIgnoreProperty::class)->willReturn($dummyIgnorePropertyResourceMetadata);
+
+        $ignoredSerializerAttributeMetadata = new SerializerAttributeMetadata('ignored');
+        $ignoredSerializerAttributeMetadata->addGroup('dummy');
+        $ignoredSerializerAttributeMetadata->addGroup('dummy');
+        $ignoredSerializerAttributeMetadata->setIgnore(true);
+
+        $dummyIgnorePropertySerializerClassMetadata = new SerializerClassMetadata(DummyIgnoreProperty::class);
+        $dummyIgnorePropertySerializerClassMetadata->addAttributeMetadata($ignoredSerializerAttributeMetadata);
+
+        $serializerClassMetadataFactoryProphecy = $this->prophesize(SerializerClassMetadataFactoryInterface::class);
+        $serializerClassMetadataFactoryProphecy->getMetadataFor(DummyIgnoreProperty::class)->willReturn($dummyIgnorePropertySerializerClassMetadata);
+
+        $ignoredPropertyMetadata = (new PropertyMetadata())->withType(new Type(Type::BUILTIN_TYPE_STRING, true));
+
+        $decoratedProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $decoratedProphecy->create(DummyIgnoreProperty::class, 'ignored', [])->willReturn($ignoredPropertyMetadata);
+
+        $serializerPropertyMetadataFactory = new SerializerPropertyMetadataFactory(
+            $resourceMetadataFactoryProphecy->reveal(),
+            $serializerClassMetadataFactoryProphecy->reveal(),
+            $decoratedProphecy->reveal(),
+            $this->prophesize(ResourceClassResolverInterface::class)->reveal()
+        );
+
+        $result = $serializerPropertyMetadataFactory->create(DummyIgnoreProperty::class, 'ignored');
+
+        self::assertFalse($result->isReadable());
+        self::assertFalse($result->isWritable());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #1566
| License       | MIT
| Doc PR        | n/a

This PR is an alternative to #3820 & #3907 and adds the `@Ignore` annotation support in accordance with https://github.com/symfony/symfony/pull/28744.