### PR TITLE
Restore composite identifier denormalization

### DIFF
--- a/src/DataProvider/OperationDataProviderTrait.php
+++ b/src/DataProvider/OperationDataProviderTrait.php
@@ -106,7 +106,7 @@ trait OperationDataProviderTrait
                         throw new InvalidIdentifierException(sprintf('Expected %d identifiers, got %d', $identifiersNumber, $currentIdentifiersNumber));
                     }
 
-                    return $identifiers;
+                    return $this->identifierConverter->convert($identifiers, $attributes['resource_class']);
                 }
 
                 // TODO: Subresources tuple may have a third item representing if it is a "collection", this behavior will be removed in 3.0

--- a/tests/Identifier/IdentifierConverterTest.php
+++ b/tests/Identifier/IdentifierConverterTest.php
@@ -32,9 +32,12 @@ class IdentifierConverterTest extends TestCase
 
     public function testCompositeIdentifier()
     {
-        $this->markTestSkipped('This behavior is now external to the identifier converter.');
-        /** @phpstan-ignore-next-line */
-        $identifier = 'a=1;c=2;d=2015-04-05';
+        $identifiers = [
+            'a' => '1',
+            'c' => '2',
+            'd' => '2015-04-05',
+        ];
+
         $class = 'Dummy';
 
         $integerPropertyMetadata = (new PropertyMetadata())->withIdentifier(true)->withType(new Type(Type::BUILTIN_TYPE_INT));
@@ -53,7 +56,7 @@ class IdentifierConverterTest extends TestCase
 
         $identifierDenormalizer = new IdentifierConverter($identifiersExtractor->reveal(), $propertyMetadataFactory->reveal(), $identifierDenormalizers);
 
-        $result = $identifierDenormalizer->convert($identifier, $class);
+        $result = $identifierDenormalizer->convert($identifiers, $class);
         $this->assertEquals(['a' => 1, 'c' => '2', 'd' => new \DateTime('2015-04-05')], $result);
         $this->assertSame(1, $result['a']);
     }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fi
| License       | MIT
| Doc PR        | 

Fixes a regression in 2.6 where composite identifiers are not denormalized correctly anymore
There was an existing test that was supposed to avoid such regression but it was marked as skipped during a refactoring unfortunately.
https://github.com/api-platform/core/blob/ed59e8df62a50e57eb2bbb3b8cdaefcfd241dcb5/tests/Identifier/IdentifierConverterTest.php#L33-L59


Not sure what would be the best place to test this now if needed, ping @soyuka 