### PR TITLE
Fix OpenApi spec security must be an array

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -105,10 +105,24 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         $securityRequirements = [];
 
         foreach (array_keys($securitySchemes) as $key) {
-            $securityRequirements[$key] = [];
+            $securityRequirements[] = [$key => []];
         }
 
-        return new OpenApi($info, $servers, $paths, new Model\Components(new \ArrayObject($schemas), new \ArrayObject(), new \ArrayObject(), new \ArrayObject(), new \ArrayObject(), new \ArrayObject(), new \ArrayObject($securitySchemes)), $securityRequirements);
+        return new OpenApi(
+            $info,
+            $servers,
+            $paths,
+            new Model\Components(
+                new \ArrayObject($schemas),
+                new \ArrayObject(),
+                new \ArrayObject(),
+                new \ArrayObject(),
+                new \ArrayObject(),
+                new \ArrayObject(),
+                new \ArrayObject($securitySchemes)
+            ),
+            $securityRequirements
+        );
     }
 
     /**

--- a/tests/OpenApi/Factory/OpenApiFactoryTest.php
+++ b/tests/OpenApi/Factory/OpenApiFactoryTest.php
@@ -232,6 +232,12 @@ class OpenApiFactoryTest extends TestCase
             'query' => new Model\SecurityScheme('apiKey', 'Value for the key query parameter.', 'key', 'query'),
         ]));
 
+        $this->assertSame([
+            ['oauth' => []],
+            ['header' => []],
+            ['query' => []],
+        ], $openApi->getSecurity());
+
         $paths = $openApi->getPaths();
         $dummiesPath = $paths->getPath('/dummies');
         $this->assertNotNull($dummiesPath);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | -

Fixes `security` in OpenAPI spec which must be an array.
