### PR TITLE
Allow arbitrary extension property types

### DIFF
--- a/src/OpenApi/Model/ExtensionTrait.php
+++ b/src/OpenApi/Model/ExtensionTrait.php
@@ -17,7 +17,7 @@ trait ExtensionTrait
 {
     private $extensionProperties = [];
 
-    public function withExtensionProperty(string $key, string $value)
+    public function withExtensionProperty(string $key, $value)
     {
         if (0 !== strpos($key, 'x-')) {
             $key = 'x-'.$key;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no (well, sort of)
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

Do not limit the extension property to strings only. E.g. for [redoc](https://github.com/Redocly/redoc) you can specifiy an array for the logo information. I need to be able to write this:

```php
$info = $openApi->getInfo();
$info = $info->withExtensionProperty('x-logo', ['url' => 'assets/logo.svg']);
$openApi = $openApi->withInfo($info);
```

Also see https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-logo.
