### PR TITLE
DataProvider/Persister register interfaces for autowiring

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/data_persister.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/data_persister.xml
@@ -9,6 +9,7 @@
             <argument type="tagged" tag="api_platform.data_persister" />
         </service>
         <service id="ApiPlatform\Core\DataPersister\DataPersisterInterface" alias="api_platform.data_persister" />
+        <service id="ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface" alias="api_platform.data_persister" />
     </services>
 
 </container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
@@ -44,6 +44,8 @@
         </service>
         <service id="ApiPlatform\Core\DataProvider\PaginationOptions" alias="api_platform.pagination_options" />
 
+        <service id="ApiPlatform\Core\DataProvider\DenormalizedIdentifiersAwareItemDataProviderInterface" alias="api_platform.item_data_provider" />
+        <service id="ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface" alias="api_platform.collection_data_provider" />
     </services>
 
 </container>


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | na
| License       | MIT
| Doc PR        | documentation references those interfaces

Added `DenormalizedIdentifiersAwareItemDataProviderInterface`,  `ContextAwareCollectionDataProviderInterface` and `ContextAwareDataPersisterInterface` as aliases. 