### PR TITLE
Make sure both, description and summary are generated

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -232,7 +232,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                 $operationId,
                 $operation['openapi_context']['tags'] ?? (OperationType::SUBRESOURCE === $operationType ? $operation['shortNames'] : [$resourceShortName]),
                 $responses,
-                $operation['openapi_context']['summary'] ?? '',
+                $operation['openapi_context']['summary'] ?? $this->getPathDescription($resourceShortName, $method, $operationType),
                 $operation['openapi_context']['description'] ?? $this->getPathDescription($resourceShortName, $method, $operationType),
                 isset($operation['openapi_context']['externalDocs']) ? new ExternalDocumentation($operation['openapi_context']['externalDocs']['description'] ?? null, $operation['openapi_context']['externalDocs']['url']) : null,
                 $parameters,

--- a/tests/OpenApi/Factory/OpenApiFactoryTest.php
+++ b/tests/OpenApi/Factory/OpenApiFactoryTest.php
@@ -256,7 +256,7 @@ class OpenApiFactoryTest extends TestCase
                     ]))),
                 ])),
             ],
-            '',
+            'Retrieves the collection of Dummy resources.',
             'Retrieves the collection of Dummy resources.',
             null,
             [
@@ -289,7 +289,7 @@ class OpenApiFactoryTest extends TestCase
                 ),
                 '400' => new Model\Response('Invalid input'),
             ],
-            '',
+            'Creates a Dummy resource.',
             'Creates a Dummy resource.',
             null,
             [],
@@ -320,7 +320,7 @@ class OpenApiFactoryTest extends TestCase
                 ),
                 '404' => new Model\Response('Resource not found'),
             ],
-            '',
+            'Retrieves a Dummy resource.',
             'Retrieves a Dummy resource.',
             null,
             [new Model\Parameter('id', 'path', 'Resource identifier', true, false, false, ['type' => 'string'])]
@@ -341,7 +341,7 @@ class OpenApiFactoryTest extends TestCase
                 '400' => new Model\Response('Invalid input'),
                 '404' => new Model\Response('Resource not found'),
             ],
-            '',
+            'Replaces the Dummy resource.',
             'Replaces the Dummy resource.',
             null,
             [new Model\Parameter('id', 'path', 'Resource identifier', true, false, false, ['type' => 'string'])],
@@ -361,7 +361,7 @@ class OpenApiFactoryTest extends TestCase
                 '204' => new Model\Response('Dummy resource deleted'),
                 '404' => new Model\Response('Resource not found'),
             ],
-            '',
+            'Removes the Dummy resource.',
             'Removes the Dummy resource.',
             null,
             [new Model\Parameter('id', 'path', 'Resource identifier', true, false, false, ['type' => 'string'])]
@@ -374,7 +374,7 @@ class OpenApiFactoryTest extends TestCase
             [
                 '404' => new Model\Response('Resource not found'),
             ],
-            '',
+            'Dummy',
             'Custom description',
             null,
             [new Model\Parameter('id', 'path', 'Resource identifier', true, false, false, ['type' => 'string'])]
@@ -397,7 +397,7 @@ class OpenApiFactoryTest extends TestCase
                 '400' => new Model\Response('Invalid input'),
                 '404' => new Model\Response('Resource not found'),
             ],
-            '',
+            'Replaces the Dummy resource.',
             'Replaces the Dummy resource.',
             null,
             [new Model\Parameter('id', 'path', 'Resource identifier', true, false, false, ['type' => 'string'])],
@@ -423,7 +423,7 @@ class OpenApiFactoryTest extends TestCase
                     ])),
                 ])),
             ],
-            '',
+            'Retrieves the collection of Dummy resources.',
             'Retrieves the collection of Dummy resources.',
             null,
             [
@@ -467,7 +467,7 @@ class OpenApiFactoryTest extends TestCase
                     ])),
                 ])),
             ],
-            '',
+            'Retrieves the collection of Dummy resources.',
             'Retrieves the collection of Dummy resources.',
             null,
             [
@@ -683,7 +683,7 @@ class OpenApiFactoryTest extends TestCase
                     ])
                 ),
             ],
-            '',
+            'Retrieves a Question resource.',
             'Retrieves a Question resource.',
             null,
             [new Model\Parameter('id', 'path', 'Question identifier', true, false, false, ['type' => 'string'])]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Up until now, `summary` has also been autogenerated (see e.g. https://github.com/api-platform/core/blob/2.5/src/Swagger/Serializer/DocumentationNormalizer.php#L327 or just search for `summary` there :)). It's also the one preferred by some JS tools like redoc for the navigation. I think there's nothing wrong in providing a good default for both, `description` as well as `summary`. You can always override them if you want to.