### PR TITLE
feat: Ability to use an identifier on non-resources

### DIFF
--- a/features/jsonld/non_resource.feature
+++ b/features/jsonld/non_resource.feature
@@ -12,7 +12,7 @@ Feature: JSON-LD non-resource handling
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be a superset of:
+    And the JSON should be equal to:
     """
     {
       "@context": "/contexts/ContainNonResource",
@@ -26,12 +26,14 @@ Feature: JSON-LD non-resource handling
         "nested": null,
         "notAResource": {
           "@type": "NotAResource",
+          "@id": "_:7e075feb68a66b8e398bd5ec1ac0bf90",
           "foo": "f2",
           "bar": "b2"
         }
       },
       "notAResource": {
         "@type": "NotAResource",
+        "@id": "_:82a2e6df651246c369ba0176220d8102",
         "foo": "f1",
         "bar": "b1"
       }

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -396,6 +396,7 @@ Feature: Relations support
     }
     """
 
+  @createSchema
   Scenario: Issue #1222
     Given there are people having pets
     When I add "Content-Type" header equal to "application/ld+json"

--- a/tests/Fixtures/NotAResource.php
+++ b/tests/Fixtures/NotAResource.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\Fixtures;
 
+use ApiPlatform\Core\Annotation\ApiProperty;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
@@ -22,6 +23,11 @@ use Symfony\Component\Serializer\Annotation\Groups;
  */
 class NotAResource
 {
+    /**
+     * @ApiProperty(identifier=true)
+     */
+    private $id;
+
     /**
      * @Groups("contain_non_resource")
      */
@@ -36,6 +42,11 @@ class NotAResource
     {
         $this->foo = $foo;
         $this->bar = $bar;
+    }
+
+    public function getId(): string
+    {
+        return md5($this->foo.$this->bar);
     }
 
     public function getFoo()


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | kinda
| New feature?  | kinda
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3941
| License       | MIT
| Doc PR        | na

This re-uses our `ApiProperty(identifier=true)` and enables its use on classes that are not resources. It helps in the id generation that may not be desirable. 