### PR TITLE
Also pass the object to the resource access checker in the serializer

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -398,7 +398,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $propertyMetadata = $this->propertyMetadataFactory->create($context['resource_class'], $attribute, $options);
         $security = $propertyMetadata->getAttribute('security');
         if ($this->resourceAccessChecker && $security) {
-            return $this->resourceAccessChecker->isGranted($attribute, $security);
+            return $this->resourceAccessChecker->isGranted($context['resource_class'], $security, [
+                'object' => $classOrObject,
+            ]);
         }
 
         return true;

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -230,7 +230,11 @@ class AbstractItemNormalizerTest extends TestCase
         $resourceClassResolverProphecy->getResourceClass($dummy, null)->willReturn(SecuredDummy::class);
 
         $resourceAccessChecker = $this->prophesize(ResourceAccessCheckerInterface::class);
-        $resourceAccessChecker->isGranted('adminOnlyProperty', 'is_granted(\'ROLE_ADMIN\')')->willReturn(false);
+        $resourceAccessChecker->isGranted(
+            SecuredDummy::class,
+            'is_granted(\'ROLE_ADMIN\')',
+            ['object' => $dummy]
+        )->willReturn(false);
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | sort of
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In #3503 @GregoireHebert introduced support for the `security` attribute on an api property.
I found that this is very useful to me because I can get rid of my own normalizer. However, my permission system depends not only on roles but you can have different roles per organisation. This in turn means, it depends on the object.
The object itself is already passed on in e.g. the DenyAccessListener (https://github.com/api-platform/core/blob/master/src/Security/EventListener/DenyAccessListener.php#L100) so we should also have it here.

By introducing that, I was able to super conveniently restrict access to a certain property by registering my own custom expression language function. It now looks like this ❤️ : 

```php
    /**
     * @ApiProperty(security="user_has_role_for_organisation('ROLE_OWNER', object)")
     */
    private $stuff;
```

Regarding docs, I guess I could expand a bit on what Frédéric already wrote in https://github.com/api-platform/docs/pull/1000.
