### PR TITLE
fix: only display hydra:next when the item total is strictly greater …

### DIFF
--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -113,7 +113,7 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Norm
                 $data['hydra:view']['hydra:previous'] = IriHelper::createIri($parsed['parts'], $parsed['parameters'], $this->pageParameterName, $currentPage - 1.);
             }
 
-            if (null !== $lastPage && $currentPage < $lastPage || null === $lastPage && $pageTotalItems >= $itemsPerPage) {
+            if (null !== $lastPage && $currentPage < $lastPage || null === $lastPage && $pageTotalItems > $itemsPerPage) {
                 $data['hydra:view']['hydra:next'] = IriHelper::createIri($parsed['parts'], $parsed['parameters'], $this->pageParameterName, $currentPage + 1.);
             }
         }

--- a/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
+++ b/tests/Hydra/Serializer/PartialCollectionViewNormalizerTest.php
@@ -79,7 +79,6 @@ class PartialCollectionViewNormalizerTest extends TestCase
                     '@id' => '/?_page=3',
                     '@type' => 'hydra:PartialCollectionView',
                     'hydra:previous' => '/?_page=2',
-                    'hydra:next' => '/?_page=4',
                 ],
             ],
             $this->normalizePaginator(true)


### PR DESCRIPTION
…than the number of items per page

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When the number of items per page is equal to the number of items present in the collection, the page found in the "hydra:next" field will return an empty collection. The "hydra:next" field should therefore only be displayed when the number of items present in the collection is strictly greater than the number of items per page.
