### PR TITLE
fix: defaults when using attributes

### DIFF
--- a/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/AnnotationResourceMetadataFactory.php
@@ -88,7 +88,15 @@ final class AnnotationResourceMetadataFactory implements ResourceMetadataFactory
 
     private function createMetadata(ApiResource $annotation, ResourceMetadata $parentResourceMetadata = null): ResourceMetadata
     {
-        $attributes = (null === $annotation->attributes && [] === $this->defaults['attributes']) ? null : (array) $annotation->attributes + $this->defaults['attributes'];
+        $attributes = null;
+        if (null !== $annotation->attributes || [] !== $this->defaults['attributes']) {
+            $attributes = (array) $annotation->attributes;
+            foreach ($this->defaults['attributes'] as $key => $value) {
+                if (!isset($attributes[$key])) {
+                    $attributes[$key] = $value;
+                }
+            }
+        }
 
         if (!$parentResourceMetadata) {
             return new ResourceMetadata(

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
@@ -59,7 +59,15 @@ final class ExtractorResourceMetadataFactory implements ResourceMetadataFactoryI
         $resource['itemOperations'] = $resource['itemOperations'] ?? $this->defaults['item_operations'] ?? null;
         $resource['collectionOperations'] = $resource['collectionOperations'] ?? $this->defaults['collection_operations'] ?? null;
         $resource['graphql'] = $resource['graphql'] ?? $this->defaults['graphql'] ?? null;
-        $resource['attributes'] = (null === $resource['attributes'] && [] === $this->defaults['attributes']) ? null : (array) $resource['attributes'] + $this->defaults['attributes'];
+
+        if (null !== $resource['attributes'] || [] !== $this->defaults['attributes']) {
+            $resource['attributes'] = (array) $resource['attributes'];
+            foreach ($this->defaults['attributes'] as $key => $value) {
+                if (!isset($resource['attributes'][$key])) {
+                    $resource['attributes'][$key] = $value;
+                }
+            }
+        }
 
         return $this->update($parentResourceMetadata ?: new ResourceMetadata(), $resource);
     }

--- a/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceMetadataFactoryTest.php
@@ -80,6 +80,7 @@ class AnnotationResourceMetadataFactoryTest extends TestCase
             'attributes' => [
                 'pagination_client_enabled' => true,
                 'pagination_maximum_items_per_page' => 10,
+                'stateless' => null,
             ],
         ]);
         $reader = $this->prophesize(Reader::class);

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -312,6 +312,7 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
                 'subresourceOperations' => null,
                 'itemOperations' => ['get', 'delete'],
                 'attributes' => [
+                    'pagination_items_per_page' => null,
                     'pagination_maximum_items_per_page' => 10,
                     'stateless' => false,
                 ],


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes n/a
| License       | MIT
| Doc PR        | n/a

Defaults aren't applied properly when using attributes, because the default value is null.

TODO:

* [x] Add a test