### PR TITLE
Fix the denormalization of \DateTime(Immutable) for ES documents

### DIFF
--- a/features/elasticsearch/read.feature
+++ b/features/elasticsearch/read.feature
@@ -20,6 +20,7 @@ Feature: Retrieve from Elasticsearch
       "age": 31,
       "firstName": "Kilian",
       "lastName": "Jornet",
+      "registeredAt": "2009-09-01T00:00:00+00:00",
       "tweets": [
         {
           "@id": "/tweets/f36a0026-0635-4865-86a6-5adb21d94d64",

--- a/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractorInterface;
 use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Exception\NonUniqueIdentifierException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
-use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer;
+use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
@@ -101,7 +101,7 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
             return null;
         }
 
-        $item = $this->denormalizer->denormalize($document, $resourceClass, ItemNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true]);
+        $item = $this->denormalizer->denormalize($document, $resourceClass, DocumentNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true]);
         if (!\is_object($item) && null !== $item) {
             throw new \UnexpectedValueException('Expected item to be an object or null.');
         }

--- a/src/Bridge/Elasticsearch/DataProvider/Paginator.php
+++ b/src/Bridge/Elasticsearch/DataProvider/Paginator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Elasticsearch\DataProvider;
 
-use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer;
+use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -115,7 +115,7 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
                 $object = $this->denormalizer->denormalize(
                     $document,
                     $this->resourceClass,
-                    ItemNormalizer::FORMAT,
+                    DocumentNormalizer::FORMAT,
                     $denormalizationContext
                 );
 

--- a/src/Bridge/Elasticsearch/Serializer/DocumentNormalizer.php
+++ b/src/Bridge/Elasticsearch/Serializer/DocumentNormalizer.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Elasticsearch\Serializer;
+
+use ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractorInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+/**
+ * Document denormalizer for Elasticsearch.
+ *
+ * @experimental
+ *
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
+ */
+final class DocumentNormalizer extends ObjectNormalizer
+{
+    public const FORMAT = 'elasticsearch';
+
+    private $identifierExtractor;
+
+    public function __construct(IdentifierExtractorInterface $identifierExtractor, ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = [])
+    {
+        parent::__construct($classMetadataFactory, $nameConverter, $propertyAccessor, $propertyTypeExtractor, $classDiscriminatorResolver, $objectClassResolver, $defaultContext);
+
+        $this->identifierExtractor = $identifierExtractor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        return self::FORMAT === $format && parent::supportsDenormalization($data, $type, $format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        if (\is_string($data['_id'] ?? null) && \is_array($data['_source'] ?? null)) {
+            $data = $this->populateIdentifier($data, $class)['_source'];
+        }
+
+        return parent::denormalize($data, $class, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null): bool
+    {
+        // prevent the use of lower priority normalizers (e.g. serializer.normalizer.object) for this format
+        return self::FORMAT === $format;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws LogicException
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        throw new LogicException(sprintf('%s is a write-only format.', self::FORMAT));
+    }
+
+    /**
+     * Populates the resource identifier with the document identifier if not present in the original JSON document.
+     */
+    private function populateIdentifier(array $data, string $class): array
+    {
+        $identifier = $this->identifierExtractor->getIdentifierFromResourceClass($class);
+        $identifier = null === $this->nameConverter ? $identifier : $this->nameConverter->normalize($identifier, $class, self::FORMAT);
+
+        if (!isset($data['_source'][$identifier])) {
+            $data['_source'][$identifier] = $data['_id'];
+        }
+
+        return $data;
+    }
+}

--- a/src/Bridge/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Bridge/Elasticsearch/Serializer/ItemNormalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Elasticsearch\Serializer;
 
-use ApiPlatform\Core\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -32,48 +32,78 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
 
     public function __construct(NormalizerInterface $decorated)
     {
-        if (!$decorated instanceof DenormalizerInterface) {
-            throw new InvalidArgumentException(sprintf('The decorated normalizer must be an instance of "%s".', DenormalizerInterface::class));
-        }
-
-        if (!$decorated instanceof SerializerAwareInterface) {
-            throw new InvalidArgumentException(sprintf('The decorated normalizer must be an instance of "%s".', SerializerAwareInterface::class));
-        }
-
-        if (!$decorated instanceof CacheableSupportsMethodInterface) {
-            throw new InvalidArgumentException(sprintf('The decorated normalizer must be an instance of "%s".', CacheableSupportsMethodInterface::class));
-        }
-
         $this->decorated = $decorated;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @throws LogicException
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        if (!$this->decorated instanceof CacheableSupportsMethodInterface) {
+            throw new LogicException(sprintf('The decorated normalizer must be an instance of "%s".', CacheableSupportsMethodInterface::class));
+        }
+
         return $this->decorated->hasCacheableSupportsMethod();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @throws LogicException
+     */
     public function denormalize($data, $type, $format = null, array $context = [])
     {
+        if (!$this->decorated instanceof DenormalizerInterface) {
+            throw new LogicException(sprintf('The decorated normalizer must be an instance of "%s".', DenormalizerInterface::class));
+        }
+
         return $this->decorated->denormalize($data, $type, $format, $context);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @throws LogicException
+     */
     public function supportsDenormalization($data, $type, $format = null)
     {
+        if (!$this->decorated instanceof DenormalizerInterface) {
+            throw new LogicException(sprintf('The decorated normalizer must be an instance of "%s".', DenormalizerInterface::class));
+        }
+
         return DocumentNormalizer::FORMAT !== $format && $this->decorated->supportsDenormalization($data, $type, $format);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function normalize($object, $format = null, array $context = [])
     {
         return $this->decorated->normalize($object, $format, $context);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function supportsNormalization($data, $format = null)
     {
         return DocumentNormalizer::FORMAT !== $format && $this->decorated->supportsNormalization($data, $format);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @throws LogicException
+     */
     public function setSerializer(SerializerInterface $serializer)
     {
+        if (!$this->decorated instanceof SerializerAwareInterface) {
+            throw new LogicException(sprintf('The decorated normalizer must be an instance of "%s".', SerializerAwareInterface::class));
+        }
+
         $this->decorated->setSerializer($serializer);
     }
 }

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -48,7 +48,11 @@
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
         </service>
 
-        <service id="api_platform.elasticsearch.normalizer.item" class="ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer" public="false">
+        <service id="api_platform.elasticsearch.normalizer.item" class="ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer" decorates="api_platform.serializer.normalizer.item" public="false">
+            <argument type="service" id="api_platform.elasticsearch.normalizer.item.inner" />
+        </service>
+
+        <service id="api_platform.elasticsearch.normalizer.document" class="ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer" public="false">
             <argument type="service" id="api_platform.elasticsearch.identifier_extractor" />
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument type="service" id="api_platform.elasticsearch.name_converter.inner_fields" />
@@ -56,8 +60,8 @@
             <argument type="service" id="property_info" on-invalid="ignore" />
             <argument type="service" id="serializer.mapping.class_discriminator_resolver" on-invalid="ignore" />
 
-            <!-- Run before serializer.normalizer.json_serializable -->
-            <tag name="serializer.normalizer" priority="-890" />
+            <!-- Run after serializer.normalizer.data_uri but before serializer.normalizer.object -->
+            <tag name="serializer.normalizer" priority="-922" />
         </service>
 
         <service id="api_platform.elasticsearch.item_data_provider" class="ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\ItemDataProvider" public="false">

--- a/tests/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
@@ -19,7 +19,7 @@ use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Exception\NonUniqueIdentifierException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
-use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer;
+use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
@@ -116,7 +116,7 @@ class ItemDataProviderTest extends TestCase
         $clientProphecy->get(['index' => 'foo', 'type' => DocumentMetadata::DEFAULT_TYPE, 'id' => '1'])->willReturn($document)->shouldBeCalled();
 
         $denormalizerProphecy = $this->prophesize(DenormalizerInterface::class);
-        $denormalizerProphecy->denormalize($document, Foo::class, ItemNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])->willReturn($foo)->shouldBeCalled();
+        $denormalizerProphecy->denormalize($document, Foo::class, DocumentNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])->willReturn($foo)->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
 

--- a/tests/Bridge/Elasticsearch/DataProvider/PaginatorTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/PaginatorTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Tests\Bridge\Elasticsearch\DataProvider;
 
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Paginator;
-use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer;
+use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer;
 use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo;
 use ApiPlatform\Core\Tests\ProphecyTrait;
@@ -178,7 +178,7 @@ class PaginatorTest extends TestCase
 
         foreach ($documents['hits']['hits'] as $document) {
             $denormalizerProphecy
-                ->denormalize($document, Foo::class, ItemNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true, 'groups' => ['custom']])
+                ->denormalize($document, Foo::class, DocumentNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true, 'groups' => ['custom']])
                 ->willReturn($this->denormalizeFoo($document['_source']));
         }
 

--- a/tests/Bridge/Elasticsearch/Serializer/DocumentNormalizerTest.php
+++ b/tests/Bridge/Elasticsearch/Serializer/DocumentNormalizerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class DocumentNormalizerTest extends TestCase
+final class DocumentNormalizerTest extends TestCase
 {
     use ProphecyTrait;
 

--- a/tests/Bridge/Elasticsearch/Serializer/DocumentNormalizerTest.php
+++ b/tests/Bridge/Elasticsearch/Serializer/DocumentNormalizerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Elasticsearch\Serializer;
+
+use ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractorInterface;
+use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class DocumentNormalizerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testConstruct()
+    {
+        $itemNormalizer = new DocumentNormalizer($this->prophesize(IdentifierExtractorInterface::class)->reveal());
+
+        self::assertInstanceOf(DenormalizerInterface::class, $itemNormalizer);
+        self::assertInstanceOf(NormalizerInterface::class, $itemNormalizer);
+    }
+
+    public function testSupportsDenormalization()
+    {
+        $document = [
+            '_index' => 'test',
+            '_type' => '_doc',
+            '_id' => '1',
+            '_version' => 1,
+            'found' => true,
+            '_source' => [
+                'id' => 1,
+                'name' => 'Caroline',
+                'bar' => 'Chaverot',
+            ],
+        ];
+
+        $itemNormalizer = new DocumentNormalizer($this->prophesize(IdentifierExtractorInterface::class)->reveal());
+
+        self::assertTrue($itemNormalizer->supportsDenormalization($document, Foo::class, DocumentNormalizer::FORMAT));
+        self::assertFalse($itemNormalizer->supportsDenormalization($document, Foo::class, 'text/coffee'));
+    }
+
+    public function testDenormalize()
+    {
+        $document = [
+            '_index' => 'test',
+            '_type' => '_doc',
+            '_id' => '1',
+            '_version' => 1,
+            'found' => true,
+            '_source' => [
+                'name' => 'Caroline',
+                'bar' => 'Chaverot',
+            ],
+        ];
+
+        $identifierExtractorProphecy = $this->prophesize(IdentifierExtractorInterface::class);
+        $identifierExtractorProphecy->getIdentifierFromResourceClass(Foo::class)->willReturn('id')->shouldBeCalled();
+
+        $normalizer = new DocumentNormalizer($identifierExtractorProphecy->reveal());
+
+        $expectedFoo = new Foo();
+        $expectedFoo->setName('Caroline');
+        $expectedFoo->setBar('Chaverot');
+
+        self::assertEquals($expectedFoo, $normalizer->denormalize($document, Foo::class, DocumentNormalizer::FORMAT));
+    }
+
+    public function testSupportsNormalization()
+    {
+        $itemNormalizer = new DocumentNormalizer($this->prophesize(IdentifierExtractorInterface::class)->reveal());
+
+        self::assertTrue($itemNormalizer->supportsNormalization(new Foo(), DocumentNormalizer::FORMAT));
+    }
+
+    public function testNormalize()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('%s is a write-only format.', DocumentNormalizer::FORMAT));
+
+        (new DocumentNormalizer($this->prophesize(IdentifierExtractorInterface::class)->reveal()))->normalize(new Foo(), DocumentNormalizer::FORMAT);
+    }
+}

--- a/tests/Bridge/Elasticsearch/Serializer/ItemNormalizerTest.php
+++ b/tests/Bridge/Elasticsearch/Serializer/ItemNormalizerTest.php
@@ -15,9 +15,9 @@ namespace ApiPlatform\Core\Tests\Bridge\Elasticsearch\Serializer;
 
 use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer;
 use ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer;
-use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -44,20 +44,12 @@ final class ItemNormalizerTest extends TestCase
         );
     }
 
-    /** @dataProvider decoratedNormalizerProvider */
-    public function testConstruct(NormalizerInterface $normalizer, ?string $exception): void
+    public function testConstruct(): void
     {
-        if (null !== $exception) {
-            $this->expectException(InvalidArgumentException::class);
-            $this->expectExceptionMessage($exception);
-        }
-
-        $itemNormalizer = new ItemNormalizer($normalizer);
-
-        self::assertInstanceOf(NormalizerInterface::class, $itemNormalizer);
-        self::assertInstanceOf(DenormalizerInterface::class, $itemNormalizer);
-        self::assertInstanceOf(SerializerAwareInterface::class, $itemNormalizer);
-        self::assertInstanceOf(CacheableSupportsMethodInterface::class, $itemNormalizer);
+        self::assertInstanceOf(NormalizerInterface::class, $this->itemNormalizer);
+        self::assertInstanceOf(DenormalizerInterface::class, $this->itemNormalizer);
+        self::assertInstanceOf(SerializerAwareInterface::class, $this->itemNormalizer);
+        self::assertInstanceOf(CacheableSupportsMethodInterface::class, $this->itemNormalizer);
     }
 
     public function testHasCacheableSupportsMethod(): void
@@ -106,38 +98,35 @@ final class ItemNormalizerTest extends TestCase
         $this->itemNormalizer->setSerializer($serializer);
     }
 
-    public function decoratedNormalizerProvider(): iterable
+    public function testHasCacheableSupportsMethodWithDecoratedNormalizerNotAnInstanceOfCacheableSupportsMethodInterface(): void
     {
-        yield [
-            $this->prophesize(NormalizerInterface::class)->reveal(),
-            sprintf('The decorated normalizer must be an instance of "%s".', DenormalizerInterface::class),
-        ];
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('The decorated normalizer must be an instance of "%s".', CacheableSupportsMethodInterface::class));
 
-        yield [
-            $this
-                ->prophesize(NormalizerInterface::class)
-                ->willImplement(DenormalizerInterface::class)
-                ->reveal(),
-            sprintf('The decorated normalizer must be an instance of "%s".', SerializerAwareInterface::class),
-        ];
+        (new ItemNormalizer($this->prophesize(NormalizerInterface::class)->reveal()))->hasCacheableSupportsMethod();
+    }
 
-        yield [
-            $this
-                ->prophesize(NormalizerInterface::class)
-                ->willImplement(DenormalizerInterface::class)
-                ->willImplement(SerializerAwareInterface::class)
-                ->reveal(),
-            sprintf('The decorated normalizer must be an instance of "%s".', CacheableSupportsMethodInterface::class),
-        ];
+    public function testDenormalizeWithDecoratedNormalizerNotAnInstanceOfDenormalizerInterface(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('The decorated normalizer must be an instance of "%s".', DenormalizerInterface::class));
 
-        yield [
-            $this
-                ->prophesize(NormalizerInterface::class)
-                ->willImplement(DenormalizerInterface::class)
-                ->willImplement(SerializerAwareInterface::class)
-                ->willImplement(CacheableSupportsMethodInterface::class)
-                ->reveal(),
-            null,
-        ];
+        (new ItemNormalizer($this->prophesize(NormalizerInterface::class)->reveal()))->denormalize('foo', 'string');
+    }
+
+    public function testSupportsDenormalizationWithDecoratedNormalizerNotAnInstanceOfDenormalizerInterface(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('The decorated normalizer must be an instance of "%s".', DenormalizerInterface::class));
+
+        (new ItemNormalizer($this->prophesize(NormalizerInterface::class)->reveal()))->supportsDenormalization('foo', 'string');
+    }
+
+    public function testSetSerializerWithDecoratedNormalizerNotAnInstanceOfSerializerAwareInterface(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('The decorated normalizer must be an instance of "%s".', SerializerAwareInterface::class));
+
+        (new ItemNormalizer($this->prophesize(NormalizerInterface::class)->reveal()))->setSerializer($this->prophesize(SerializerInterface::class)->reveal());
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -664,6 +664,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.metadata.document.metadata_factory.cached', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.identifier_extractor', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.name_converter.inner_fields', Argument::type(Definition::class))->shouldBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.normalizer.document', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.normalizer.item', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.item_data_provider', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.collection_data_provider', Argument::type(Definition::class))->shouldBeCalled();

--- a/tests/Fixtures/Elasticsearch/Fixtures/user.json
+++ b/tests/Fixtures/Elasticsearch/Fixtures/user.json
@@ -5,6 +5,7 @@
     "age": 31,
     "firstName": "Kilian",
     "lastName": "Jornet",
+    "registeredAt": "2009-09-01",
     "tweets": [
       {
         "id": "f36a0026-0635-4865-86a6-5adb21d94d64",
@@ -29,6 +30,7 @@
     "age": 32,
     "firstName": "Francois",
     "lastName": "D'Haene",
+    "registeredAt": "2014-08-01",
     "tweets": [
       {
         "id": "5bc245d7-df50-4e2d-b26b-823e73372183",
@@ -48,6 +50,7 @@
     "age": 30,
     "firstName": "Xavier",
     "lastName": "Thevenard",
+    "registeredAt": "2013-09-02",
     "tweets": [
       {
         "id": "86c41446-31d6-48a4-96e7-73e84ea283d3",
@@ -62,6 +65,7 @@
     "age": 35,
     "firstName": "Anton",
     "lastName": "Krupicka",
+    "registeredAt": "2014-07-01",
     "tweets": [
       {
         "id": "ce73f15a-8c96-46fe-8999-392460feb61b",
@@ -81,6 +85,7 @@
     "age": 28,
     "firstName": "Jim",
     "lastName": "Walmsley",
+    "registeredAt": "2011-07-01",
     "tweets": [
       {
         "id": "0cfe3d33-6116-416b-8c50-3b8319331998",
@@ -95,6 +100,7 @@
     "age": 30,
     "firstName": "Zach",
     "lastName": "Miller",
+    "registeredAt": "2017-03-01",
     "tweets": [
       {
         "id": "1c9e0545-1b37-4a9a-83e0-30400d0b354e",
@@ -119,6 +125,7 @@
     "age": 42,
     "firstName": "Caroline",
     "lastName": "Chaverot",
+    "registeredAt": "2013-11-01",
     "tweets": [
       {
         "id": "6d82a76c-8ba2-4e78-9ab3-6a456e4470c3",
@@ -138,6 +145,7 @@
     "age": 42,
     "firstName": "Nuria",
     "lastName": "Picas",
+    "registeredAt": "2012-12-01",
     "tweets": [
       {
         "id": "dcaef1db-225d-442b-960e-5de6984a44be",
@@ -157,6 +165,7 @@
     "age": 32,
     "firstName": "Emelie",
     "lastName": "Forsberg",
+    "registeredAt": "2012-07-01",
     "tweets": [
       {
         "id": "6947ce52-c85d-4786-a587-3966a936842b",
@@ -176,6 +185,7 @@
     "age": 37,
     "firstName": "Anna",
     "lastName": "Frost",
+    "registeredAt": "2010-07-01",
     "tweets": [
       {
         "id": "9de3308c-6f82-4a57-a33c-4e3cd5d5a3f6",
@@ -195,6 +205,7 @@
     "age": 34,
     "firstName": "Rory",
     "lastName": "Bosio",
+    "registeredAt": "2013-09-05",
     "tweets": []
   },
   {
@@ -203,6 +214,7 @@
     "age": 29,
     "firstName": "Ruth",
     "lastName": "Croft",
+    "registeredAt": "2015-02-01",
     "tweets": [
       {
         "id": "3a1d02fa-2347-41ff-80ef-ed9b9c0efea9",

--- a/tests/Fixtures/Elasticsearch/Mappings/tweet.json
+++ b/tests/Fixtures/Elasticsearch/Mappings/tweet.json
@@ -1,39 +1,37 @@
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "id": {
-          "type": "keyword"
-        },
-        "author": {
-          "properties": {
-            "id": {
-              "type": "keyword"
-            },
-            "gender": {
-              "type": "keyword"
-            },
-            "age": {
-              "type": "integer"
-            },
-            "firstName": {
-              "type": "text"
-            },
-            "lastName": {
-              "type": "text"
-            }
-          },
-          "dynamic": "strict"
-        },
-        "date": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss"
-        },
-        "message": {
-          "type": "text"
-        }
+    "properties": {
+      "id": {
+        "type": "keyword"
       },
-      "dynamic": "strict"
-    }
+      "author": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "gender": {
+            "type": "keyword"
+          },
+          "age": {
+            "type": "integer"
+          },
+          "firstName": {
+            "type": "text"
+          },
+          "lastName": {
+            "type": "text"
+          }
+        },
+        "dynamic": "strict"
+      },
+      "date": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
+      },
+      "message": {
+        "type": "text"
+      }
+    },
+    "dynamic": "strict"
   }
 }

--- a/tests/Fixtures/Elasticsearch/Mappings/tweet.json
+++ b/tests/Fixtures/Elasticsearch/Mappings/tweet.json
@@ -1,37 +1,39 @@
 {
   "mappings": {
-    "properties": {
-      "id": {
-        "type": "keyword"
-      },
-      "author": {
-        "properties": {
-          "id": {
-            "type": "keyword"
-          },
-          "gender": {
-            "type": "keyword"
-          },
-          "age": {
-            "type": "integer"
-          },
-          "firstName": {
-            "type": "text"
-          },
-          "lastName": {
-            "type": "text"
-          }
+    "_doc": {
+      "properties": {
+        "id": {
+          "type": "keyword"
         },
-        "dynamic": "strict"
+        "author": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "gender": {
+              "type": "keyword"
+            },
+            "age": {
+              "type": "integer"
+            },
+            "firstName": {
+              "type": "text"
+            },
+            "lastName": {
+              "type": "text"
+            }
+          },
+          "dynamic": "strict"
+        },
+        "date": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss"
+        },
+        "message": {
+          "type": "text"
+        }
       },
-      "date": {
-        "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss"
-      },
-      "message": {
-        "type": "text"
-      }
-    },
-    "dynamic": "strict"
+      "dynamic": "strict"
+    }
   }
 }

--- a/tests/Fixtures/Elasticsearch/Mappings/user.json
+++ b/tests/Fixtures/Elasticsearch/Mappings/user.json
@@ -1,38 +1,44 @@
 {
   "mappings": {
-    "properties": {
-      "id": {
-        "type": "keyword"
-      },
-      "gender": {
-        "type": "keyword"
-      },
-      "age": {
-        "type": "integer"
-      },
-      "firstName": {
-        "type": "text"
-      },
-      "lastName": {
-        "type": "text"
-      },
-      "tweets": {
-        "type": "nested",
-        "properties": {
-          "id": {
-            "type": "keyword"
-          },
-          "date": {
-            "type": "date",
-            "format": "yyyy-MM-dd HH:mm:ss"
-          },
-          "message": {
-            "type": "text"
-          }
+    "_doc": {
+      "properties": {
+        "id": {
+          "type": "keyword"
         },
-        "dynamic": "strict"
-      }
-    },
-    "dynamic": "strict"
+        "gender": {
+          "type": "keyword"
+        },
+        "age": {
+          "type": "integer"
+        },
+        "firstName": {
+          "type": "text"
+        },
+        "lastName": {
+          "type": "text"
+        },
+        "registeredAt": {
+          "type": "date",
+          "format": "yyyy-MM-dd"
+        },
+        "tweets": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "date": {
+              "type": "date",
+              "format": "yyyy-MM-dd HH:mm:ss"
+            },
+            "message": {
+              "type": "text"
+            }
+          },
+          "dynamic": "strict"
+        }
+      },
+      "dynamic": "strict"
+    }
   }
 }

--- a/tests/Fixtures/Elasticsearch/Mappings/user.json
+++ b/tests/Fixtures/Elasticsearch/Mappings/user.json
@@ -1,40 +1,38 @@
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "id": {
-          "type": "keyword"
-        },
-        "gender": {
-          "type": "keyword"
-        },
-        "age": {
-          "type": "integer"
-        },
-        "firstName": {
-          "type": "text"
-        },
-        "lastName": {
-          "type": "text"
-        },
-        "tweets": {
-          "type": "nested",
-          "properties": {
-            "id": {
-              "type": "keyword"
-            },
-            "date": {
-              "type": "date",
-              "format": "yyyy-MM-dd HH:mm:ss"
-            },
-            "message": {
-              "type": "text"
-            }
-          },
-          "dynamic": "strict"
-        }
+    "properties": {
+      "id": {
+        "type": "keyword"
       },
-      "dynamic": "strict"
-    }
+      "gender": {
+        "type": "keyword"
+      },
+      "age": {
+        "type": "integer"
+      },
+      "firstName": {
+        "type": "text"
+      },
+      "lastName": {
+        "type": "text"
+      },
+      "tweets": {
+        "type": "nested",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "date": {
+            "type": "date",
+            "format": "yyyy-MM-dd HH:mm:ss"
+          },
+          "message": {
+            "type": "text"
+          }
+        },
+        "dynamic": "strict"
+      }
+    },
+    "dynamic": "strict"
   }
 }

--- a/tests/Fixtures/Elasticsearch/Model/Tweet.php
+++ b/tests/Fixtures/Elasticsearch/Model/Tweet.php
@@ -73,12 +73,12 @@ class Tweet
         $this->author = $author;
     }
 
-    public function getDate(): ?\DateTimeInterface
+    public function getDate(): ?\DateTimeImmutable
     {
         return $this->date;
     }
 
-    public function setDate(\DateTimeInterface $date): void
+    public function setDate(\DateTimeImmutable $date): void
     {
         $this->date = $date;
     }

--- a/tests/Fixtures/Elasticsearch/Model/User.php
+++ b/tests/Fixtures/Elasticsearch/Model/User.php
@@ -59,6 +59,11 @@ class User
     /**
      * @Groups({"user:read"})
      */
+    private $registeredAt;
+
+    /**
+     * @Groups({"user:read"})
+     */
     private $tweets = [];
 
     public function getId(): ?string
@@ -109,6 +114,16 @@ class User
     public function setLastName(string $lastName): void
     {
         $this->lastName = $lastName;
+    }
+
+    public function getRegisteredAt(): ?\DateTimeInterface
+    {
+        return $this->registeredAt;
+    }
+
+    public function setRegisteredAt(\DateTimeInterface $registeredAt): void
+    {
+        $this->registeredAt = $registeredAt;
     }
 
     public function getTweets(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | fixes #3908  fixes #3170 <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | n/A

This PR:
* Reverts the priority of the Elasticsearch documents normalizer from `-890` to `-922`.
* Introduces an item normalizer decorator that prevents the default `ApiPlatform\Core\Serializer\ItemNormalizer` from taking over for the `elasticsearch` format because of priorities when the bridge is enabled.
* Renames the `ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer` class to `ApiPlatform\Core\Bridge\Elasticsearch\Serializer\DocumentNormalizer` so that the role of the denormalizer is more explicit: to transform Elasticsearch documents into PHP objects. **This is a BC break however the class is marked as experimental.** Because of this, it might be better to apply this fix to `3.0`.

