### PR TITLE
fix #3980 TraceableDataPersister supports called without context

### DIFF
--- a/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
+++ b/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
@@ -73,7 +73,7 @@ final class TraceableChainDataPersister implements ContextAwareDataPersisterInte
         $found = false;
         foreach ($this->persisters as $persister) {
             if (
-                ($this->persistersResponse[\get_class($persister)] = $found ? false : $persister->supports($data))
+                ($this->persistersResponse[\get_class($persister)] = $found ? false : $persister->supports($data, $context))
                 &&
                 !($persister instanceof ResumableDataPersisterInterface && $persister->resumable()) && !$found
             ) {

--- a/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
@@ -60,6 +60,16 @@ class TraceableChainDataPersisterTest extends TestCase
         $this->assertSame($expected, array_values($result));
     }
 
+    public function testSupports() {
+        $context = ['ok' => true];
+        $persister = $this->prophesize(DataPersisterInterface::class);
+        $persister->supports('', $context)->willReturn(true)->shouldBeCalled();
+        $chain = new ChainDataPersister([$persister->reveal()]);
+        $persister->persist('', $context)->shouldBeCalled();
+        $dataPersister = new TraceableChainDataPersister($chain);
+        $dataPersister->persist('',$context);
+    }
+
     public function dataPersisterProvider(): iterable
     {
         yield [
@@ -163,7 +173,7 @@ class TraceableChainDataPersisterTest extends TestCase
                     public function remove($data)
                     {
                     }
-                },
+                }
             ]),
             [true, false, true],
         ];

--- a/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
@@ -67,7 +67,7 @@ class TraceableChainDataPersisterTest extends TestCase
         $chain = new ChainDataPersister([$persister->reveal()]);
         $persister->persist('', $context)->shouldBeCalled();
         $dataPersister = new TraceableChainDataPersister($chain);
-        $dataPersister->persist('',$context);
+        $dataPersister->persist('', $context);
     }
 
     public function dataPersisterProvider(): iterable


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3980 
| License       | MIT
| Doc PR        | api-platform/docs#...

fix #3980 TraceableDataPersister supports called without context