### PR TITLE
Fix #3979 identifier chain not breaking after denormalizing

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -275,11 +275,11 @@
         </service>
 
         <service id="api_platform.identifier.integer" class="ApiPlatform\Core\Identifier\Normalizer\IntegerDenormalizer" public="false">
-            <tag name="api_platform.identifier.denormalizer" />
+            <tag name="api_platform.identifier.denormalizer" priority="-100" />
         </service>
 
         <service id="api_platform.identifier.date_normalizer" class="ApiPlatform\Core\Identifier\Normalizer\DateTimeIdentifierDenormalizer" public="false">
-            <tag name="api_platform.identifier.denormalizer" />
+            <tag name="api_platform.identifier.denormalizer" priority="-100" />
         </service>
 
         <!-- Subresources -->

--- a/src/Bridge/Symfony/Bundle/Resources/config/ramsey_uuid.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/ramsey_uuid.xml
@@ -6,7 +6,7 @@
 
     <services>
         <service id="api_platform.identifier.uuid_normalizer" class="ApiPlatform\Core\Bridge\RamseyUuid\Identifier\Normalizer\UuidNormalizer" public="false">
-            <tag name="api_platform.identifier.denormalizer" />
+            <tag name="api_platform.identifier.denormalizer" priority="-100" />
         </service>
 
         <service id="api_platform.serializer.uuid_denormalizer" class="ApiPlatform\Core\Bridge\RamseyUuid\Serializer\UuidDenormalizer" public="false">

--- a/src/Identifier/IdentifierConverter.php
+++ b/src/Identifier/IdentifierConverter.php
@@ -69,6 +69,7 @@ final class IdentifierConverter implements ContextAwareIdentifierConverterInterf
 
                 try {
                     $identifiers[$identifier] = $identifierTransformer->denormalize($value, $type);
+                    break;
                 } catch (InvalidIdentifierException $e) {
                     throw new InvalidIdentifierException(sprintf('Identifier "%s" could not be denormalized.', $identifier), $e->getCode(), $e);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3979 
| License       | MIT
| Doc PR        | na

- lower priority of our identifier denormalizer for better DX
- break the chain of normalizers when an identifier transformer is found
