### PR TITLE
Fix #3982 maxDepth property of the ApiSubresource annotation not working

### DIFF
--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -42,6 +42,6 @@ final class ApiSubresource
 
             return;
         }
-        $this->maxDepth = $maxDepth['maxDepth'];
+        $this->maxDepth = $maxDepth['maxDepth'] ?? null;
     }
 }

--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -20,10 +20,20 @@ namespace ApiPlatform\Core\Annotation;
  *
  * @Annotation
  * @Target({"METHOD", "PROPERTY"})
+ * @Attributes (
+ *     @Attribute("maxDepth", type="int"),
+ * )
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
 final class ApiSubresource
 {
+    use AttributesHydratorTrait;
+
+    /**
+     * @var array<string, array>
+     */
+    private static $deprecatedAttributes = [];
+
     /**
      * @var int
      */
@@ -37,5 +47,7 @@ final class ApiSubresource
         if (!\is_array($maxDepth)) { // @phpstan-ignore-line
             $this->maxDepth = $maxDepth;
         }
+
+        $this->hydrateAttributes($maxDepth);
     }
 }

--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -33,15 +33,14 @@ final class ApiSubresource
     public $maxDepth;
 
     /**
-     * @param int|array $maxDepth
+     * @param int $maxDepth
      */
     public function __construct($maxDepth = null)
     {
-        if (!\is_array($maxDepth)) {
+        if (!\is_array($maxDepth)) { // @phpstan-ignore-line
             $this->maxDepth = $maxDepth;
-
-            return;
+        } else {
+            $this->maxDepth = $maxDepth['maxDepth'] ?? null;
         }
-        $this->maxDepth = $maxDepth['maxDepth'] ?? null;
     }
 }

--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -27,39 +27,21 @@ namespace ApiPlatform\Core\Annotation;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
 final class ApiSubresource
 {
-    use AttributesHydratorTrait;
-
-    /**
-     * @var array<string, array>
-     */
-    private static $deprecatedAttributes = [];
-
     /**
      * @var int
      */
     public $maxDepth;
 
     /**
-     * @param int $maxDepth
+     * @param int|array $maxDepth
      */
-    public function __construct(
-        $maxDepth = null,
-        // attributes
-        ?array $attributes = null
-    ) {
-        if (!\is_array($maxDepth)) { // @phpstan-ignore-line
-            [$publicProperties, $configurableAttributes] = self::getConfigMetadata();
+    public function __construct($maxDepth = null)
+    {
+        if (!\is_array($maxDepth)) {
+            $this->maxDepth = $maxDepth;
 
-            foreach ($publicProperties as $prop => $_) {
-                $this->{$prop} = ${$prop};
-            }
-
-            $maxDepth = [];
-            foreach ($configurableAttributes as $attribute => $_) {
-                $maxDepth[$attribute] = ${$attribute};
-            }
+            return;
         }
-
-        $this->hydrateAttributes($maxDepth ?? []);
+        $this->maxDepth = $maxDepth['maxDepth'];
     }
 }

--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -46,8 +46,10 @@ final class ApiSubresource
     {
         if (!\is_array($maxDepth)) { // @phpstan-ignore-line
             $this->maxDepth = $maxDepth;
+
+            $maxDepth = [];
         }
 
-        $this->hydrateAttributes($maxDepth);
+        $this->hydrateAttributes($maxDepth ?? []);
     }
 }

--- a/src/Annotation/ApiSubresource.php
+++ b/src/Annotation/ApiSubresource.php
@@ -20,7 +20,7 @@ namespace ApiPlatform\Core\Annotation;
  *
  * @Annotation
  * @Target({"METHOD", "PROPERTY"})
- * @Attributes (
+ * @Attributes(
  *     @Attribute("maxDepth", type="int"),
  * )
  */
@@ -42,12 +42,22 @@ final class ApiSubresource
     /**
      * @param int $maxDepth
      */
-    public function __construct($maxDepth = null)
-    {
+    public function __construct(
+        $maxDepth = null,
+        // attributes
+        ?array $attributes = null
+    ) {
         if (!\is_array($maxDepth)) { // @phpstan-ignore-line
-            $this->maxDepth = $maxDepth;
+            [$publicProperties, $configurableAttributes] = self::getConfigMetadata();
+
+            foreach ($publicProperties as $prop => $_) {
+                $this->{$prop} = ${$prop};
+            }
 
             $maxDepth = [];
+            foreach ($configurableAttributes as $attribute => $_) {
+                $maxDepth[$attribute] = ${$attribute};
+            }
         }
 
         $this->hydrateAttributes($maxDepth ?? []);

--- a/tests/Annotation/ApiSubresourceTest.php
+++ b/tests/Annotation/ApiSubresourceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Annotation;
+
+use ApiPlatform\Core\Annotation\ApiSubresource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ApiSubresourceTest extends TestCase
+{
+    public function testAssignation()
+    {
+        $property = new ApiSubresource();
+        $property->maxDepth = 1;
+        $property->attributes = ['foo' => 'bar'];
+
+        $this->assertEquals(1, $property->maxDepth);
+        $this->assertEquals(['foo' => 'bar'], $property->attributes);
+    }
+
+    public function testConstruct()
+    {
+        $property = new ApiSubresource([
+            'maxDepth' => null,
+            'attributes' => ['unknown' => 'unknown', 'max_depth' => 1],
+        ]);
+        $this->assertEquals([
+            'max_depth' => 1,
+            'unknown' => 'unknown',
+        ], $property->attributes);
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testConstructAttribute()
+    {
+        $property = eval(<<<'PHP'
+return new \ApiPlatform\Core\Annotation\ApiSubresource(
+    maxDepth: null,
+    attributes: ['unknown' => 'unknown', 'max_depth' => 1]
+);
+PHP
+        );
+
+        $this->assertEquals([
+            'max_depth' => 1,
+            'unknown' => 'unknown',
+        ], $property->attributes);
+    }
+}

--- a/tests/Annotation/ApiSubresourceTest.php
+++ b/tests/Annotation/ApiSubresourceTest.php
@@ -31,7 +31,7 @@ class ApiSubresourceTest extends TestCase
 
     public function testConstruct()
     {
-        $property = new ApiSubresource([
+        $property = new ApiSubresource([ // @phpstan-ignore-line
             'maxDepth' => 1,
         ]);
         $this->assertEquals(1, $property->maxDepth);

--- a/tests/Annotation/ApiSubresourceTest.php
+++ b/tests/Annotation/ApiSubresourceTest.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Annotation\ApiSubresource;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Cody Banman <crbanman@gmail.com>
  */
 class ApiSubresourceTest extends TestCase
 {
@@ -25,22 +25,16 @@ class ApiSubresourceTest extends TestCase
     {
         $property = new ApiSubresource();
         $property->maxDepth = 1;
-        $property->attributes = ['foo' => 'bar'];
 
         $this->assertEquals(1, $property->maxDepth);
-        $this->assertEquals(['foo' => 'bar'], $property->attributes);
     }
 
     public function testConstruct()
     {
         $property = new ApiSubresource([
-            'maxDepth' => null,
-            'attributes' => ['unknown' => 'unknown', 'max_depth' => 1],
+            'maxDepth' => 1,
         ]);
-        $this->assertEquals([
-            'max_depth' => 1,
-            'unknown' => 'unknown',
-        ], $property->attributes);
+        $this->assertEquals(1, $property->maxDepth);
     }
 
     /**
@@ -50,15 +44,10 @@ class ApiSubresourceTest extends TestCase
     {
         $property = eval(<<<'PHP'
 return new \ApiPlatform\Core\Annotation\ApiSubresource(
-    maxDepth: null,
-    attributes: ['unknown' => 'unknown', 'max_depth' => 1]
+    maxDepth: 1
 );
 PHP
         );
-
-        $this->assertEquals([
-            'max_depth' => 1,
-            'unknown' => 'unknown',
-        ], $property->attributes);
+        $this->assertEquals(1, $property->maxDepth);
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3982 
| License       | MIT
| Doc PR        | n/a

- fix the issue with the `maxDepth` parameter of the `ApiSubresource` not working