### PR TITLE
Allow mapping.paths override bundles configs

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -311,7 +311,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
     private function getResourcesToWatch(ContainerBuilder $container, array $config): array
     {
-        $paths = array_unique(array_merge($config['mapping']['paths'], $this->getBundlesResourcesPaths($container, $config)));
+        $paths = array_unique(array_merge($this->getBundlesResourcesPaths($container, $config), $config['mapping']['paths']));
 
         // Flex structure (only if nothing specified)
         $projectDir = $container->getParameter('kernel.project_dir');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Right now third party bundle's config is load after project's own resources definitions (ie `api_platform.mapping.paths`), and therefore vendor's config always override the project's own.

I suggest we change the load order to allow user to override 3rd party settings.

