### PR TITLE
Fix Swagger link in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ It natively supports popular open formats including [JSON for Linked Data (JSON-
 Build a working and fully-featured CRUD API in minutes. Leverage the awesome features of the tool to develop complex and
 high performance API-first projects. Extend or override everything you want.
 
-[![GitHub Actions](https://github.com/api-platform/core/workflows/CI/badge.svg?branch=master)](https://github.com/api-platform/core/actions?query=workflow%3ACI+branch%3Amaster)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/grwuyprts3wdqx5l/branch/master?svg=true)](https://ci.appveyor.com/project/dunglas/dunglasapibundle/branch/master)
-[![Codecov](https://codecov.io/gh/api-platform/core/branch/master/graph/badge.svg)](https://codecov.io/gh/api-platform/core/branch/master)
+[![GitHub Actions](https://github.com/api-platform/core/workflows/CI/badge.svg?branch=main)](https://github.com/api-platform/core/actions?query=workflow%3ACI+branch%3Amain)
+[![Codecov](https://codecov.io/gh/api-platform/core/branch/main/graph/badge.svg)](https://codecov.io/gh/api-platform/core/branch/main)
 [![SymfonyInsight](https://insight.symfony.com/projects/92d78899-946c-4282-89a3-ac92344f9a93/mini.svg)](https://insight.symfony.com/projects/92d78899-946c-4282-89a3-ac92344f9a93)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/api-platform/core/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/api-platform/core/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/api-platform/core/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/api-platform/core/?branch=main)
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.6.x-dev"
+            "dev-main": "2.7.x-dev"
         },
         "symfony": {
             "require": "^3.4 || ^4.4 || ^5.1"

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -148,7 +148,7 @@ final class ApiResource
      * @param bool|array   $mercure                        https://api-platform.com/docs/core/mercure
      * @param bool         $messenger                      https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
      * @param array        $normalizationContext           https://api-platform.com/docs/core/serialization/#using-serialization-groups
-     * @param array        $openapiContext                 https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
+     * @param array        $openapiContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
      * @param array        $order                          https://api-platform.com/docs/core/default-order/#overriding-default-order
      * @param string|false $output                         https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
      * @param bool         $paginationClientEnabled        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
@@ -167,7 +167,7 @@ final class ApiResource
      * @param string       $securityPostDenormalizeMessage https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
      * @param bool         $stateless
      * @param string       $sunset                         https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
-     * @param array        $swaggerContext                 https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
+     * @param array        $swaggerContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
      * @param array        $validationGroups               https://api-platform.com/docs/core/validation/#using-validation-groups
      * @param int          $urlGenerationStrategy
      *


### PR DESCRIPTION
Fixing the link "https://api-platform.com/docs/core/swagger/" that leads to a 404