### PR TITLE
Sort resources and schemas in OpenApi docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,9 +522,9 @@ jobs:
       - name: Update project dependencies
         run: |
           composer update --no-interaction --no-progress --ansi
-          composer why doctrine/reflection
-      # - name: Require Symfony Uid
-      #   run: composer require symfony/uid --dev --no-interaction --no-progress --ansi
+          # composer why doctrine/reflection
+      - name: Require Symfony Uid
+        run: composer require symfony/uid --dev --no-interaction --no-progress --ansi
       - name: Install PHPUnit
         run: vendor/bin/simple-phpunit --version
       - name: Clear test app cache

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ It natively supports popular open formats including [JSON for Linked Data (JSON-
 Build a working and fully-featured CRUD API in minutes. Leverage the awesome features of the tool to develop complex and
 high performance API-first projects. Extend or override everything you want.
 
-[![GitHub Actions](https://github.com/api-platform/core/workflows/CI/badge.svg?branch=master)](https://github.com/api-platform/core/actions?query=workflow%3ACI+branch%3Amaster)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/grwuyprts3wdqx5l/branch/master?svg=true)](https://ci.appveyor.com/project/dunglas/dunglasapibundle/branch/master)
-[![Codecov](https://codecov.io/gh/api-platform/core/branch/master/graph/badge.svg)](https://codecov.io/gh/api-platform/core/branch/master)
+[![GitHub Actions](https://github.com/api-platform/core/workflows/CI/badge.svg?branch=main)](https://github.com/api-platform/core/actions?query=workflow%3ACI+branch%3Amain)
+[![Codecov](https://codecov.io/gh/api-platform/core/branch/main/graph/badge.svg)](https://codecov.io/gh/api-platform/core/branch/main)
 [![SymfonyInsight](https://insight.symfony.com/projects/92d78899-946c-4282-89a3-ac92344f9a93/mini.svg)](https://insight.symfony.com/projects/92d78899-946c-4282-89a3-ac92344f9a93)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/api-platform/core/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/api-platform/core/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/api-platform/core/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/api-platform/core/?branch=main)
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.6.x-dev"
+            "dev-main": "2.7.x-dev"
         },
         "symfony": {
             "require": "^3.4 || ^4.4 || ^5.1"

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -148,7 +148,7 @@ final class ApiResource
      * @param bool|array   $mercure                        https://api-platform.com/docs/core/mercure
      * @param bool         $messenger                      https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
      * @param array        $normalizationContext           https://api-platform.com/docs/core/serialization/#using-serialization-groups
-     * @param array        $openapiContext                 https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
+     * @param array        $openapiContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
      * @param array        $order                          https://api-platform.com/docs/core/default-order/#overriding-default-order
      * @param string|false $output                         https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
      * @param bool         $paginationClientEnabled        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
@@ -167,7 +167,7 @@ final class ApiResource
      * @param string       $securityPostDenormalizeMessage https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
      * @param bool         $stateless
      * @param string       $sunset                         https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
-     * @param array        $swaggerContext                 https://api-platform.com/docs/core/swagger/#using-the-openapi-and-swagger-contexts
+     * @param array        $swaggerContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
      * @param array        $validationGroups               https://api-platform.com/docs/core/validation/#using-validation-groups
      * @param int          $urlGenerationStrategy
      *

--- a/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
+++ b/src/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersister.php
@@ -73,7 +73,7 @@ final class TraceableChainDataPersister implements ContextAwareDataPersisterInte
         $found = false;
         foreach ($this->persisters as $persister) {
             if (
-                ($this->persistersResponse[\get_class($persister)] = $found ? false : $persister->supports($data))
+                ($this->persistersResponse[\get_class($persister)] = $found ? false : $persister->supports($data, $context))
                 &&
                 !($persister instanceof ResumableDataPersisterInterface && $persister->resumable()) && !$found
             ) {

--- a/src/OpenApi/Model/Components.php
+++ b/src/OpenApi/Model/Components.php
@@ -38,6 +38,8 @@ final class Components
         $this->securitySchemes = $securitySchemes;
         $this->links = $links;
         $this->callbacks = $callbacks;
+
+        $this->schemas->ksort();
     }
 
     public function getSchemas(): ?\ArrayObject

--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\OpenApi\Model;
 
 final class Paths
 {
-    private $paths;
+    private $paths = [];
 
     public function addPath(string $path, PathItem $pathItem)
     {
@@ -29,6 +29,8 @@ final class Paths
 
     public function getPaths(): array
     {
-        return $this->paths ?? [];
+        ksort($this->paths);
+
+        return $this->paths;
     }
 }

--- a/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
@@ -60,6 +60,16 @@ class TraceableChainDataPersisterTest extends TestCase
         $this->assertSame($expected, array_values($result));
     }
 
+    public function testSupports() {
+        $context = ['ok' => true];
+        $persister = $this->prophesize(DataPersisterInterface::class);
+        $persister->supports('', $context)->willReturn(true)->shouldBeCalled();
+        $chain = new ChainDataPersister([$persister->reveal()]);
+        $persister->persist('', $context)->shouldBeCalled();
+        $dataPersister = new TraceableChainDataPersister($chain);
+        $dataPersister->persist('', $context);
+    }
+
     public function dataPersisterProvider(): iterable
     {
         yield [
@@ -163,7 +173,7 @@ class TraceableChainDataPersisterTest extends TestCase
                     public function remove($data)
                     {
                     }
-                },
+                }
             ]),
             [true, false, true],
         ];

--- a/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
+++ b/tests/Bridge/Symfony/Bundle/DataPersister/TraceableChainDataPersisterTest.php
@@ -60,7 +60,8 @@ class TraceableChainDataPersisterTest extends TestCase
         $this->assertSame($expected, array_values($result));
     }
 
-    public function testSupports() {
+    public function testSupports()
+    {
         $context = ['ok' => true];
         $persister = $this->prophesize(DataPersisterInterface::class);
         $persister->supports('', $context)->willReturn(true)->shouldBeCalled();
@@ -173,7 +174,7 @@ class TraceableChainDataPersisterTest extends TestCase
                     public function remove($data)
                     {
                     }
-                }
+                },
             ]),
             [true, false, true],
         ];


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3996  <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | 

This is a very minor bug fix. With the introduction of the OpenApi models in version 2.6, the resources and the schemas were no more sorted in the ascending order as before. This PR sorts the resources (paths) and the schemas.