### PR TITLE
Allow to set openapi_context on subresourceOperations

### DIFF
--- a/src/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Operation/Factory/SubresourceOperationFactory.php
@@ -184,6 +184,10 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
                 }
             }
 
+            if (isset($subresourceOperation['openapi_context'])) {
+                $operation['openapi_context'] = $subresourceOperation['openapi_context'];
+            }
+
             foreach (self::ROUTE_OPTIONS as $routeOption => $defaultValue) {
                 $operation[$routeOption] = $subresourceOperation[$routeOption] ?? $defaultValue;
             }

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -837,4 +837,61 @@ class SubresourceOperationFactoryTest extends TestCase
             ] + SubresourceOperationFactory::ROUTE_OPTIONS,
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }
+
+    public function testCreateWithOpenapiContext()
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
+        $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn((new ResourceMetadata('dummyEntity'))->withSubresourceOperations([
+            'subresource_get_subresource' => [
+                'openapi_context' => [
+                    'summary' => 'Get related dummy entities',
+                    'tags' => ['Dummy'],
+                ]
+            ]
+        ]));
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection(['subresource']));
+        $propertyNameCollectionFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new PropertyNameCollection([]));
+
+        $subresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, false));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadata);
+
+        $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
+        $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresources');
+
+        $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
+        $identifiersExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);
+
+        $subresourceOperationFactory = new SubresourceOperationFactory(
+            $resourceMetadataFactoryProphecy->reveal(),
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $pathSegmentNameGeneratorProphecy->reveal(),
+            $identifiersExtractorProphecy->reveal()
+        );
+
+        $this->assertEquals([
+            'api_dummy_entities_subresource_get_subresource' => [
+                'property' => 'subresource',
+                'collection' => false,
+                'resource_class' => RelatedDummyEntity::class,
+                'shortNames' => ['relatedDummyEntity', 'dummyEntity'],
+                'identifiers' => [
+                    'id' => [DummyEntity::class, 'id', true],
+                ],
+                'route_name' => 'api_dummy_entities_subresource_get_subresource',
+                'path' => '/dummy_entities/{id}/subresources.{_format}',
+                'operation_name' => 'subresource_get_subresource',
+                'openapi_context' => [
+                    'summary' => 'Get related dummy entities',
+                    'tags' => ['Dummy'],
+                ]
+            ] + SubresourceOperationFactory::ROUTE_OPTIONS,
+        ], $subresourceOperationFactory->create(DummyEntity::class));
+    }
 }

--- a/tests/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -847,8 +847,8 @@ class SubresourceOperationFactoryTest extends TestCase
                 'openapi_context' => [
                     'summary' => 'Get related dummy entities',
                     'tags' => ['Dummy'],
-                ]
-            ]
+                ],
+            ],
         ]));
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -890,7 +890,7 @@ class SubresourceOperationFactoryTest extends TestCase
                 'openapi_context' => [
                     'summary' => 'Get related dummy entities',
                     'tags' => ['Dummy'],
-                ]
+                ],
             ] + SubresourceOperationFactory::ROUTE_OPTIONS,
         ], $subresourceOperationFactory->create(DummyEntity::class));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3573
| License       | MIT
| Doc PR        | api-platform/docs#...

It is not possible to set `openapi_context` on subresource operations right now.
With this PR the openapi_context property on the subresource operation with be copied within SubresourceOperationFactory  and afterwards used in OpenApiFactory.
This allows to override tags, summary and more as described [here](https://api-platform.com/docs/core/openapi/#changing-operations-in-the-openapi-documentation).

Example use case:
```php
use ApiPlatform\Core\Annotation\ApiResource;
use ApiPlatform\Core\Annotation\ApiSubresource;

/**
 * @ApiResource(
 *   subresourceOperations={
 *     "answer_get_subresource"={
 *       "openapi_context"={
 *         "summary"="My custom answer summary",
 *         "tags"={"My Answer"},
 *       }
 *     }
 *   }
 * )
 */
class Question {
    /**
     * @ApiSubresource
     */
    public Answer $answer;
}

/**
 * @ApiResource()
 */
class Answer {}
```

Note that the operation id is without the resource prefix, which will hopefully be fixed in #3458.

