### PR TITLE
Update resource metadata if new config is given

### DIFF
--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
@@ -87,23 +87,23 @@ final class ExtractorResourceMetadataFactory implements ResourceMetadataFactoryI
     }
 
     /**
-     * Update resource metadata if new config is given
+     * Update resource metadata if new config is given.
      */
     private function update(ResourceMetadata $resourceMetadata, array $metadata): ResourceMetadata
     {
         foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'graphql', 'attributes'] as $property) {
-            $propertyData = $metadata[$property];
-            $parentPropertyData = $resourceMetadata->{'get'.ucfirst($property)}();
+            $propertyMetadata = $metadata[$property];
+            $parentPropertyMetadata = $resourceMetadata->{'get'.ucfirst($property)}();
 
-            if (null === $propertyData) {
+            if (null === $propertyMetadata) {
                 continue;
             }
 
-            if (is_array($parentPropertyData) && is_array($propertyData)) {
-                $propertyData = array_merge($parentPropertyData, $propertyData);
+            if (\is_array($parentPropertyMetadata) && \is_array($propertyMetadata)) {
+                $propertyMetadata = array_merge($parentPropertyMetadata, $propertyMetadata);
             }
 
-            $resourceMetadata = $resourceMetadata->{'with'.ucfirst($property)}($propertyData);
+            $resourceMetadata = $resourceMetadata->{'with'.ucfirst($property)}($propertyMetadata);
         }
 
         return $resourceMetadata;

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
@@ -87,16 +87,23 @@ final class ExtractorResourceMetadataFactory implements ResourceMetadataFactoryI
     }
 
     /**
-     * Creates a new instance of metadata if the property is not already set.
+     * Update resource metadata if new config is given
      */
     private function update(ResourceMetadata $resourceMetadata, array $metadata): ResourceMetadata
     {
         foreach (['shortName', 'description', 'iri', 'itemOperations', 'collectionOperations', 'subresourceOperations', 'graphql', 'attributes'] as $property) {
-            if (null === $metadata[$property] || null !== $resourceMetadata->{'get'.ucfirst($property)}()) {
+            $propertyData = $metadata[$property];
+            $parentPropertyData = $resourceMetadata->{'get'.ucfirst($property)}();
+
+            if (null === $propertyData) {
                 continue;
             }
 
-            $resourceMetadata = $resourceMetadata->{'with'.ucfirst($property)}($metadata[$property]);
+            if (is_array($parentPropertyData) && is_array($propertyData)) {
+                $propertyData = array_merge($parentPropertyData, $propertyData);
+            }
+
+            $resourceMetadata = $resourceMetadata->{'with'.ucfirst($property)}($propertyData);
         }
 
         return $resourceMetadata;

--- a/tests/Fixtures/FileConfigurations/resources.xml
+++ b/tests/Fixtures/FileConfigurations/resources.xml
@@ -23,6 +23,7 @@
             <collectionOperation name="my_collection_op">
                 <attribute name="method">POST</attribute>
                 <attribute name="path">the/collection/path</attribute>
+                <attribute name="status">201</attribute>
             </collectionOperation>
         </collectionOperations>
         <subresourceOperations>

--- a/tests/Fixtures/FileConfigurations/resources.yml
+++ b/tests/Fixtures/FileConfigurations/resources.yml
@@ -12,6 +12,7 @@ resources:
             my_collection_op:
                 method: 'POST'
                 path: 'the/collection/path'
+                status: '201'
         subresourceOperations:
             my_collection_subresource:
                 path: 'the/subresource/path'

--- a/tests/Fixtures/FileConfigurations/resourcesoverride.xml
+++ b/tests/Fixtures/FileConfigurations/resourcesoverride.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
+    <resource class="ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy" description="New description">
+        <itemOperations>
+            <itemOperation name="my_op_name">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">the/path</attribute>
+            </itemOperation>
+        </itemOperations>
+        <collectionOperations>
+            <collectionOperation name="my_collection_op">
+                <attribute name="method">POST</attribute>
+                <attribute name="status">200</attribute>
+            </collectionOperation>
+        </collectionOperations>
+    </resource>
+</resources>

--- a/tests/Fixtures/FileConfigurations/resourcesoverride.yml
+++ b/tests/Fixtures/FileConfigurations/resourcesoverride.yml
@@ -1,0 +1,11 @@
+resources:
+    'ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy':
+        description: New description
+        itemOperations:
+            my_op_name:
+                method: 'GET'
+                path: 'the/path'
+        collectionOperations:
+            my_collection_op:
+                method: 'POST'
+                status: '200'

--- a/tests/Fixtures/FileConfigurations/single_resource.yml
+++ b/tests/Fixtures/FileConfigurations/single_resource.yml
@@ -10,6 +10,7 @@
         my_collection_op:
             method: 'POST'
             path: 'the/collection/path'
+            status: '201'
     subresourceOperations:
         my_collection_subresource:
             path: 'the/subresource/path'

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -164,6 +164,23 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
     }
 
     /**
+     * @dataProvider overrideOperationsResourceMetadataProvider
+     */
+    public function testXmlOverrideExistingParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata)
+    {
+        $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesoverride.xml';
+
+        $decorated = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decorated->create(FileConfigDummy::class)->willReturn($this->resourceMetadataProvider()[0][0])->shouldBeCalled();
+
+        $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new XmlExtractor([$configPath]), $decorated->reveal());
+
+        $resourceMetadata = $resourceMetadataFactory->create(FileConfigDummy::class);
+
+        $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
+    }
+
+    /**
      * @dataProvider resourceMetadataProvider
      */
     public function testYamlCreateResourceMetadata(ResourceMetadata $expectedResourceMetadata)
@@ -243,6 +260,23 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
 
         $decorated = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $decorated->create(FileConfigDummy::class)->willReturn($expectedResourceMetadata)->shouldBeCalled();
+
+        $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new YamlExtractor([$configPath]), $decorated->reveal());
+
+        $resourceMetadata = $resourceMetadataFactory->create(FileConfigDummy::class);
+
+        $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
+    }
+
+    /**
+     * @dataProvider overrideOperationsResourceMetadataProvider
+     */
+    public function testYamlOverrideExistingParentResourceMetadataFactory(ResourceMetadata $expectedResourceMetadata)
+    {
+        $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesoverride.yml';
+
+        $decorated = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decorated->create(FileConfigDummy::class)->willReturn($this->resourceMetadataProvider()[0][0])->shouldBeCalled();
 
         $resourceMetadataFactory = new ExtractorResourceMetadataFactory(new YamlExtractor([$configPath]), $decorated->reveal());
 

--- a/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -111,4 +111,22 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
 
         return [[$resourceMetadata]];
     }
+
+    public function overrideOperationsResourceMetadataProvider()
+    {
+        $resourceMetadata = $this->resourceMetadataProvider()[0][0];
+
+        $resourceMetadata = $resourceMetadata->withDescription('New description');
+
+        $resourceMetadata = $resourceMetadata->withItemOperations([
+            'my_op_name' => ['method' => 'GET', 'path' => 'the/path'],
+            'my_other_op_name' => ['method' => 'POST'],
+        ]);
+
+        $resourceMetadata = $resourceMetadata->withCollectionOperations([
+            'my_collection_op' => ['method' => 'POST', 'status' => '200'],
+        ]);
+
+        return [[$resourceMetadata]];
+    }
 }

--- a/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
+++ b/tests/Metadata/Resource/Factory/FileConfigurationMetadataFactoryProvider.php
@@ -36,7 +36,7 @@ abstract class FileConfigurationMetadataFactoryProvider extends TestCase
                 'my_other_op_name' => ['method' => 'POST'],
             ],
             'collectionOperations' => [
-                'my_collection_op' => ['method' => 'POST', 'path' => 'the/collection/path'],
+                'my_collection_op' => ['method' => 'POST', 'path' => 'the/collection/path', 'status' => '201'],
             ],
             'subresourceOperations' => [
                 'my_collection_subresource' => ['path' => 'the/subresource/path'],


### PR DESCRIPTION
If a resource is being defined twice, allow the later one to override the previous one.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

If a resource is being defined twice, allow the later one to override the previous one.

This is useful when resources is predefined by a 3rd party library, eg Sylius.