### PR TITLE
Add the ability to customize multiple status codes based on the validation exception

### DIFF
--- a/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Bridge/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Symfony\Validator\EventListener;
 
-use ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException;
+use ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ConstraintViolationListAwareExceptionInterface;
 use ApiPlatform\Core\Util\ErrorFormatGuesser;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -43,7 +43,7 @@ final class ValidationExceptionListener
     public function onKernelException(ExceptionEvent $event): void
     {
         $exception = method_exists($event, 'getThrowable') ? $event->getThrowable() : $event->getException(); // @phpstan-ignore-line
-        if (!$exception instanceof ValidationException) {
+        if (!$exception instanceof ConstraintViolationListAwareExceptionInterface) {
             return;
         }
         $exceptionClass = \get_class($exception);

--- a/src/Bridge/Symfony/Validator/Exception/ConstraintViolationListAwareExceptionInterface.php
+++ b/src/Bridge/Symfony/Validator/Exception/ConstraintViolationListAwareExceptionInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Validator\Exception;
+
+use ApiPlatform\Core\Exception\ExceptionInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * An exception which has a constraint violation list.
+ */
+interface ConstraintViolationListAwareExceptionInterface extends ExceptionInterface
+{
+    /**
+     * Gets constraint violations related to this exception.
+     */
+    public function getConstraintViolationList(): ConstraintViolationListInterface;
+}

--- a/src/Bridge/Symfony/Validator/Exception/ValidationException.php
+++ b/src/Bridge/Symfony/Validator/Exception/ValidationException.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ValidationException extends BaseValidationException
+final class ValidationException extends BaseValidationException implements ConstraintViolationListAwareExceptionInterface
 {
     private $constraintViolationList;
 
@@ -32,9 +32,6 @@ final class ValidationException extends BaseValidationException
         parent::__construct($message ?: $this->__toString(), $code, $previous);
     }
 
-    /**
-     * Gets constraint violations related to this exception.
-     */
     public function getConstraintViolationList(): ConstraintViolationListInterface
     {
         return $this->constraintViolationList;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This PR introduces a new `ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ConstraintViolationListAwareExceptionInterface` which adds the ability to have a close management of status code on validation exceptions.
