### PR TITLE
Serialize openapi properly fix #3997

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
@@ -5,27 +5,24 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="api_platform.openapi.object_normalizer" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
-            <argument>null</argument>
-            <argument>null</argument>
-            <argument type="service" id="api_platform.property_accessor"/>
-            <argument type="service" id="api_platform.property_info"/>
-            <call method="setSerializer">
-                <argument type="service" id="api_platform.openapi.serializer"/>
-            </call>
-        </service>
-
-        <service id="api_platform.openapi.serializer" class="Symfony\Component\Serializer\Serializer" public="false">
-            <argument type="collection">
-                <argument type="service" id="api_platform.openapi.object_normalizer" />
-            </argument>
-            <argument type="collection">
-                <argument type="service" id="serializer.encoder.json" />
-            </argument>
-        </service>
-
         <service id="api_platform.openapi.normalizer" class="ApiPlatform\Core\OpenApi\Serializer\OpenApiNormalizer" public="false">
-            <argument type="service" id="api_platform.openapi.object_normalizer"/>
+            <argument type="service">
+                <service class="Symfony\Component\Serializer\Serializer">
+                    <argument type="collection">
+                        <argument type="service">
+                            <service class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer">
+                                <argument>null</argument>
+                                <argument>null</argument>
+                                <argument type="service" id="api_platform.property_accessor"/>
+                                <argument type="service" id="api_platform.property_info"/>
+                            </service>
+                        </argument>
+                    </argument>
+                    <argument type="collection">
+                        <argument type="service" id="serializer.encoder.json" />
+                    </argument>
+                </service>
+            </argument>
 
             <!-- Just after the DocumentationNormalizer see swagger.xml -->
             <tag name="serializer.normalizer" priority="-795" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/openapi.xml
@@ -5,8 +5,28 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="api_platform.openapi.object_normalizer" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
+            <argument>null</argument>
+            <argument>null</argument>
+            <argument type="service" id="api_platform.property_accessor"/>
+            <argument type="service" id="api_platform.property_info"/>
+            <call method="setSerializer">
+                <argument type="service" id="api_platform.openapi.serializer"/>
+            </call>
+        </service>
+
+        <service id="api_platform.openapi.serializer" class="Symfony\Component\Serializer\Serializer" public="false">
+            <argument type="collection">
+                <argument type="service" id="api_platform.openapi.object_normalizer" />
+            </argument>
+            <argument type="collection">
+                <argument type="service" id="serializer.encoder.json" />
+            </argument>
+        </service>
+
         <service id="api_platform.openapi.normalizer" class="ApiPlatform\Core\OpenApi\Serializer\OpenApiNormalizer" public="false">
-            <argument type="service" id="serializer.normalizer.object" />
+            <argument type="service" id="api_platform.openapi.object_normalizer"/>
+
             <!-- Just after the DocumentationNormalizer see swagger.xml -->
             <tag name="serializer.normalizer" priority="-795" />
         </service>

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1329,8 +1329,6 @@ class ApiPlatformExtensionTest extends TestCase
             $definitions[] = 'api_platform.swagger.normalizer.api_gateway';
             $definitions[] = 'api_platform.swagger.normalizer.documentation';
             $definitions[] = 'api_platform.openapi.options';
-            $definitions[] = 'api_platform.openapi.object_normalizer';
-            $definitions[] = 'api_platform.openapi.serializer';
             $definitions[] = 'api_platform.openapi.normalizer';
             $definitions[] = 'api_platform.openapi.normalizer.api_gateway';
             $definitions[] = 'api_platform.openapi.factory';

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1335,6 +1335,10 @@ class ApiPlatformExtensionTest extends TestCase
             $definitions[] = 'api_platform.openapi.command';
             $definitions[] = 'api_platform.swagger_ui.context';
             $definitions[] = 'api_platform.swagger_ui.action';
+
+            $containerBuilderProphecy->setDefinition(Argument::that(static function ($arg) {
+                return 0 === strpos($arg, '.');
+            }), Argument::type(Definition::class))->shouldBeCalled();
         }
 
         // has jsonld

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1335,10 +1335,6 @@ class ApiPlatformExtensionTest extends TestCase
             $definitions[] = 'api_platform.openapi.command';
             $definitions[] = 'api_platform.swagger_ui.context';
             $definitions[] = 'api_platform.swagger_ui.action';
-
-            $containerBuilderProphecy->setDefinition(Argument::that(static function ($arg) {
-                return 0 === strpos($arg, '.');
-            }), Argument::type(Definition::class))->shouldBeCalled();
         }
 
         // has jsonld
@@ -1365,6 +1361,13 @@ class ApiPlatformExtensionTest extends TestCase
             $definitions[] = 'api_platform.jsonld.normalizer.item';
             $definitions[] = 'api_platform.jsonld.normalizer.object';
         }
+
+        // Ignore inlined services
+        $containerBuilderProphecy->setDefinition(Argument::that(static function (string $arg) {
+            return 0 === strpos($arg, '.');
+        }), Argument::type(Definition::class))->should(function () {
+            return true;
+        });
 
         foreach ($definitions as $definition) {
             $containerBuilderProphecy->setDefinition($definition, Argument::type(Definition::class))->shouldBeCalled();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1329,6 +1329,8 @@ class ApiPlatformExtensionTest extends TestCase
             $definitions[] = 'api_platform.swagger.normalizer.api_gateway';
             $definitions[] = 'api_platform.swagger.normalizer.documentation';
             $definitions[] = 'api_platform.openapi.options';
+            $definitions[] = 'api_platform.openapi.object_normalizer';
+            $definitions[] = 'api_platform.openapi.serializer';
             $definitions[] = 'api_platform.openapi.normalizer';
             $definitions[] = 'api_platform.openapi.normalizer.api_gateway';
             $definitions[] = 'api_platform.openapi.factory';

--- a/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
+++ b/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
@@ -185,5 +185,7 @@ class OpenApiNormalizerTest extends TestCase
 
         // Make sure things are sorted
         $this->assertEquals(array_keys($openApiAsArray['paths']), ['/dummies', '/dummies/{id}', '/zorros', '/zorros/{id}']);
+        // Test name converter doesn't rename this property
+        $this->assertArrayHasKey('requestBody', $openApiAsArray['paths']['/dummies']['post']);
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3997 
| License       | MIT
| Doc PR        | na

When adding a name converter some properties of OpenAPI were serialized without respecting the specification causing issues. This fixes it.