### PR TITLE
Fix #4024 identifiers with multiple classes

### DIFF
--- a/src/DataProvider/OperationDataProviderTrait.php
+++ b/src/DataProvider/OperationDataProviderTrait.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\DataProvider;
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Identifier\CompositeIdentifierParser;
+use ApiPlatform\Core\Identifier\ContextAwareIdentifierConverterInterface;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 
 /**
@@ -106,7 +107,7 @@ trait OperationDataProviderTrait
                         throw new InvalidIdentifierException(sprintf('Expected %d identifiers, got %d', $identifiersNumber, $currentIdentifiersNumber));
                     }
 
-                    return $this->identifierConverter->convert($identifiers, $attributes['resource_class']);
+                    return $this->identifierConverter->convert($identifiers, $identifiedBy[0]);
                 }
 
                 // TODO: Subresources tuple may have a third item representing if it is a "collection", this behavior will be removed in 3.0
@@ -118,6 +119,10 @@ trait OperationDataProviderTrait
             }
 
             $identifiers[$parameterName] = $parameters[$parameterName];
+        }
+
+        if ($this->identifierConverter instanceof ContextAwareIdentifierConverterInterface) {
+            return $this->identifierConverter->convert($identifiers, $attributes['resource_class'], ['identifiers' => $identifiersKeys]);
         }
 
         return $this->identifierConverter->convert($identifiers, $attributes['resource_class']);

--- a/src/Identifier/IdentifierConverter.php
+++ b/src/Identifier/IdentifierConverter.php
@@ -56,8 +56,9 @@ final class IdentifierConverter implements ContextAwareIdentifierConverterInterf
         }
 
         $identifiers = $data;
-        foreach ($data as $identifier => $value) {
-            if (null === $type = $this->getIdentifierType($class, $identifier)) {
+
+        foreach ($data as $parameter => $value) {
+            if (null === $type = $this->getIdentifierType($context['identifiers'][$parameter][0] ?? $class, $context['identifiers'][$parameter][1] ?? $parameter)) {
                 continue;
             }
 
@@ -68,10 +69,10 @@ final class IdentifierConverter implements ContextAwareIdentifierConverterInterf
                 }
 
                 try {
-                    $identifiers[$identifier] = $identifierTransformer->denormalize($value, $type);
+                    $identifiers[$parameter] = $identifierTransformer->denormalize($value, $type);
                     break;
                 } catch (InvalidIdentifierException $e) {
-                    throw new InvalidIdentifierException(sprintf('Identifier "%s" could not be denormalized.', $identifier), $e->getCode(), $e);
+                    throw new InvalidIdentifierException(sprintf('Identifier "%s" could not be denormalized.', $parameter), $e->getCode(), $e);
                 }
             }
         }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tickets       | fixes #4024
| License       | MIT
| Doc PR        | na.

IdentifierConverter was missing the context to map identifiers to the correct classes. 