### PR TITLE
Properties need to be allowed by Symfony's serializer at the same time

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -374,7 +374,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         // Gets allowed attributes using serialization groups
         $groupAllowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
 
-        if (is_array($groupAllowedAttributes)) {
+        if (\is_array($groupAllowedAttributes)) {
             // Attributes need to be allowed by both API Resource and serialization groups at the same time
             return array_intersect($allowedAttributes, $groupAllowedAttributes);
         }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -371,7 +371,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             }
         }
 
-        return $allowedAttributes;
+        // Attributes need to be allowed by Symfony's serializer at the same time
+        return array_intersect($allowedAttributes, parent::getAllowedAttributes($classOrObject, $context, $attributesAsString));
     }
 
     /**

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -371,8 +371,15 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             }
         }
 
-        // Attributes need to be allowed by Symfony's serializer at the same time
-        return array_intersect($allowedAttributes, parent::getAllowedAttributes($classOrObject, $context, $attributesAsString));
+        // Gets allowed attributes using serialization groups
+        $groupAllowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
+
+        if (is_array($groupAllowedAttributes)) {
+            // Attributes need to be allowed by both API Resource and serialization groups at the same time
+            return array_intersect($allowedAttributes, $groupAllowedAttributes);
+        }
+
+        return $allowedAttributes;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#...

### The Problem

- Properties defined in Api Platform's resource cannot be hide by Symfony's serialization group
- Properties's visibility can be defined in both api resource and serializer config. This lead to confusion and unexpected behaviour. 

### The Solution

- Call `parent::getAllowedAttributes()` in `ApiPlatform\Core\Serializer\AbstractItemNormalizer`.
- But this will change the behaviour of ApiPlatform completely, this will force developer to well define their property in Serializer. Not sure is it something you want to merge easily. 
