### PR TITLE
Fix getStyle, getName, getIn return type to be consistent with construct.

### DIFF
--- a/src/OpenApi/Model/Parameter.php
+++ b/src/OpenApi/Model/Parameter.php
@@ -56,12 +56,12 @@ final class Parameter
         }
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getIn(): ?string
+    public function getIn(): string
     {
         return $this->in;
     }
@@ -91,7 +91,7 @@ final class Parameter
         return $this->schema;
     }
 
-    public function getStyle(): string
+    public function getStyle(): ?string
     {
         return $this->style;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

When I put some custom documentation in my project with openapi_context I have the following error:

> The method "ApiPlatform\Core\OpenApi\Model\Parameter::getStyle()" returned "null", but expected type "string". Did you forget to initialize a property or to make the return type nullable using "?string"?

When I check this class, I can see that there are some errors in return type definition. (Maybe adding attribute type definition could help phpstan to detect this kind of problems ?)

Fix getStyle, getName, getIn return type to be consistent with construct.