### PR TITLE
update phpdoc ItemDataProviderInterface::getItem()

### DIFF
--- a/src/DataProvider/ItemDataProviderInterface.php
+++ b/src/DataProvider/ItemDataProviderInterface.php
@@ -25,7 +25,7 @@ interface ItemDataProviderInterface
     /**
      * Retrieves an item.
      *
-     * @param array|int|string $id
+     * @param array|int|object|string $id
      *
      * @throws ResourceClassNotSupportedException
      *


### PR DESCRIPTION
`ItemDataProviderInterface::getItem()` `$id` argument could also be an `object`

eg: an item with an identifier of type `Ramsey\Uuid\UuidInterface`

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

<!--
In a project I use [ramsey/uuid-doctrine](https://github.com/ramsey/uuid-doctrine) for my Models identifiers. In its related custom dataprovider, the getItem() $id argument is a `Ramsey\Uuid\UuidInterface` instance. But the phpdoc says that the $id @param is `array`, `int` or `string` only.
-->
