### PR TITLE
Fix openapi schema sort

### DIFF
--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -54,10 +54,8 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
                 continue;
             }
 
-            if ('schemas' === $key) {
-                if ($value) {
-                    ksort($value);
-                }
+            if ('schemas' === $key && \is_array($value)) {
+                ksort($value);
             }
 
             // Side effect of using getPaths(): Paths which itself contains the array


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #4047
| License       | MIT
| Doc PR        | na

Fixes schemas sort as it's an ArrayObject not an array.