### PR TITLE
Mercure: deletion with custom method sends the full data

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -191,6 +191,8 @@ final class PublishMercureUpdatesListener
         }
 
         if ('deletedObjects' === $property) {
+            // if it's a deletion, ignore 'data' provided
+            unset($options['data']);
             $this->deletedObjects[(object) [
                 'id' => $this->iriConverter->getIriFromItem($object),
                 'iri' => $this->iriConverter->getIriFromItem($object, UrlGeneratorInterface::ABS_URL),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3969 
| License       | MIT
| Doc PR        | api-platform/docs#...

When using Mercure and when an entity is deleted, APIP evaluates how to retrieve entity properties.
If we use a custom method with `@ApiResource(mercure="object.mercureOptions()")` the data provided by this function is used, with no regard if we are posting, updating or deleting the entity.
If the custom function returns `data`, in case of a deletion, the data is still sent.

See bug report to fully understand what's wrong.
