### PR TITLE
fix(mercure): do not use data options when deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.3
+
+* Mercure: Do not use data in options when deleting (#4056)
+
 ## 2.6.2
 
 * Validation: properties regex pattern is now compliant with ECMA 262 (#4027)

--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -213,7 +213,7 @@ final class PublishMercureUpdatesListener
             // and I'm not a fond of this approach.
             $iri = $options['topics'] ?? $object->iri;
             /** @var string $data */
-            $data = $options['data'] ?? json_encode(['@id' => $object->id]);
+            $data = json_encode(['@id' => $object->id]);
         } else {
             $resourceClass = $this->getObjectClass($object);
             $context = $options['normalization_context'] ?? $this->resourceMetadataFactory->create($resourceClass)->getAttribute('normalization_context', []);

--- a/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -146,6 +146,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $toDelete->setId(3);
         $toDeleteExpressionLanguage = new DummyFriend();
         $toDeleteExpressionLanguage->setId(4);
+        $toDeleteMercureOptions = new DummyOffer();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class);
@@ -167,12 +168,14 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $iriConverterProphecy->getIriFromItem($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions)->willReturn('/dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_offers/5')->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => true, 'normalization_context' => ['groups' => ['foo', 'bar']]]));
         $resourceMetadataFactoryProphecy->create(DummyCar::class)->willReturn(new ResourceMetadata());
         $resourceMetadataFactoryProphecy->create(DummyFriend::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => ['private' => true, 'retry' => 10]]));
-        $resourceMetadataFactoryProphecy->create(DummyOffer::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => ['topics' => 'http://example.com/custom_topics/1', 'normalization_context' => ['groups' => ['baz']]]]));
+        $resourceMetadataFactoryProphecy->create(DummyOffer::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => ['topics' => 'http://example.com/custom_topics/1', 'data' => 'mercure_custom_data', 'normalization_context' => ['groups' => ['baz']]]]));
         $resourceMetadataFactoryProphecy->create(DummyMercure::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => ['topics' => ['/dummies/1', '/users/3'], 'normalization_context' => ['groups' => ['baz']]]]));
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
@@ -186,10 +189,12 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $topics = [];
         $private = [];
         $retry = [];
-        $publisher = function (Update $update) use (&$topics, &$private, &$retry): string {
+        $data = [];
+        $publisher = function (Update $update) use (&$topics, &$private, &$retry, &$data): string {
             $topics = array_merge($topics, $update->getTopics());
             $private[] = $update->isPrivate();
             $retry[] = $update->getRetry();
+            $data[] = $update->getData();
 
             return 'id';
         };
@@ -207,7 +212,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $uowProphecy = $this->prophesize(UnitOfWork::class);
         $uowProphecy->getScheduledEntityInsertions()->willReturn([$toInsert, $toInsertNotResource])->shouldBeCalled();
         $uowProphecy->getScheduledEntityUpdates()->willReturn([$toUpdate, $toUpdateNoMercureAttribute, $toUpdateMercureOptions, $toUpdateMercureTopicOptions])->shouldBeCalled();
-        $uowProphecy->getScheduledEntityDeletions()->willReturn([$toDelete, $toDeleteExpressionLanguage])->shouldBeCalled();
+        $uowProphecy->getScheduledEntityDeletions()->willReturn([$toDelete, $toDeleteExpressionLanguage, $toDeleteMercureOptions])->shouldBeCalled();
 
         $emProphecy = $this->prophesize(EntityManagerInterface::class);
         $emProphecy->getUnitOfWork()->willReturn($uowProphecy->reveal())->shouldBeCalled();
@@ -216,9 +221,10 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $listener->onFlush($eventArgs);
         $listener->postFlush();
 
-        $this->assertSame(['http://example.com/dummies/1', 'http://example.com/dummies/2', 'http://example.com/custom_topics/1', '/dummies/1', '/users/3', 'http://example.com/dummies/3', 'http://example.com/dummy_friends/4'], $topics);
-        $this->assertSame([false, false, false, false, false, true], $private);
-        $this->assertSame([null, null, null, null, null, 10], $retry);
+        $this->assertSame(['1', '2', 'mercure_custom_data', 'mercure_options', '{"@id":"\/dummies\/3"}', '{"@id":"\/dummy_friends\/4"}', '{"@id":"\/dummy_offers\/5"}'], $data);
+        $this->assertSame(['http://example.com/dummies/1', 'http://example.com/dummies/2', 'http://example.com/custom_topics/1', '/dummies/1', '/users/3', 'http://example.com/dummies/3', 'http://example.com/dummy_friends/4', 'http://example.com/custom_topics/1'], $topics);
+        $this->assertSame([false, false, false, false, false, true, false], $private);
+        $this->assertSame([null, null, null, null, null, 10, null], $retry);
     }
 
     public function testPublishGraphQlUpdates(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #3969 
| License       | MIT
| Doc PR        | N/A

Supersedes https://github.com/api-platform/core/pull/4054.

> When using Mercure and when an entity is deleted, APIP evaluates how to retrieve entity properties.
> If we use a custom method with `@ApiResource(mercure="object.mercureOptions()")` the data provided by this function is used, with no regard if we are posting, updating or deleting the entity.
> If the custom function returns `data`, in case of a deletion, the data is still sent.
> 
> See bug report to fully understand what's wrong.