### PR TITLE
WIP: Don't always change DELETE response codes to 204

### DIFF
--- a/src/EventListener/RespondListener.php
+++ b/src/EventListener/RespondListener.php
@@ -77,6 +77,10 @@ final class RespondListener
 
         $status = $status ?? self::METHOD_TO_CODE[$request->getMethod()] ?? Response::HTTP_OK;
 
+        if (Response::HTTP_NO_CONTENT === $status && $controllerResult) {
+            $status = Response::HTTP_OK;
+        }
+
         if ($request->attributes->has('_api_write_item_iri')) {
             $headers['Content-Location'] = $request->attributes->get('_api_write_item_iri');
 

--- a/tests/EventListener/RespondListenerTest.php
+++ b/tests/EventListener/RespondListenerTest.php
@@ -151,7 +151,7 @@ class RespondListenerTest extends TestCase
         $this->assertTrue($response->headers->has('Location'));
     }
 
-    public function testCreate204Response()
+    public function testCreate200ResponseFromDeleteWithBody()
     {
         $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('xml');
@@ -169,6 +169,31 @@ class RespondListenerTest extends TestCase
 
         $response = $event->getResponse();
         $this->assertEquals('foo', $response->getContent());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals('text/xml; charset=utf-8', $response->headers->get('Content-Type'));
+        $this->assertEquals('Accept', $response->headers->get('Vary'));
+        $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
+        $this->assertEquals('deny', $response->headers->get('X-Frame-Options'));
+    }
+
+    public function testCreate204ResponseFromDeleteWithoutBody()
+    {
+        $request = new Request([], [], ['_api_respond' => true]);
+        $request->setRequestFormat('xml');
+        $request->setMethod('DELETE');
+
+        $event = new ViewEvent(
+            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            ''
+        );
+
+        $listener = new RespondListener();
+        $listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertEquals('', $response->getContent());
         $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertEquals('text/xml; charset=utf-8', $response->headers->get('Content-Type'));
         $this->assertEquals('Accept', $response->headers->get('Vary'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

`RespondListener` convert a string returned by a controller into a response. To reach that, it tries to guess the status code. For a response tied to a DELETE request, the status code is always 204.

But according to [rfc 7231 section 4.3.5](https://tools.ietf.org/html/rfc7231#section-4.3.5), a response with a body can be returned when a DELETE request is received. So in this case, the status code should be 200 instead.

This PR tries to fix that.