### PR TITLE
Use a null token when using the authenticator manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.6.3
 
+* Security: Use a `NullToken` when using the new authenticator manager in the resource access checker (#4067)
 * Mercure: Do not use data in options when deleting (#4056)
 * Doctrine: Support for foreign identifiers
 * SchemaFactory: Allow generating documentation when property and method start from "is" (property `isActive` and method `isActive`)

--- a/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Bridge/Symfony/Bundle/ApiPlatformBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DeprecateMercurePublisherPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
@@ -53,5 +54,6 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new DeprecateMercurePublisherPass());
         $container->addCompilerPass(new MetadataAwareNameConverterPass());
         $container->addCompilerPass(new TestClientPass());
+        $container->addCompilerPass(new AuthenticatorManagerPass());
     }
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AuthenticatorManagerPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AuthenticatorManagerPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Checks if the new authenticator manager exists.
+ *
+ * @internal
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class AuthenticatorManagerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->has('security.authenticator.manager')) {
+            $container->getDefinition('api_platform.security.resource_access_checker')->setArgument(5, false);
+        }
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Bridge/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DeprecateMercurePublisherPass;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
@@ -50,6 +51,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(DeprecateMercurePublisherPass::class))->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(MetadataAwareNameConverterPass::class))->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(TestClientPass::class))->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(AuthenticatorManagerPass::class))->shouldBeCalled();
 
         $bundle = new ApiPlatformBundle();
         $bundle->build($containerProphecy->reveal());

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AuthenticatorManagerPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AuthenticatorManagerPassTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class AuthenticatorManagerPassTest extends TestCase
+{
+    private $containerBuilderProphecy;
+    private $authenticatorManagerPass;
+
+    protected function setUp(): void
+    {
+        $this->containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $this->authenticatorManagerPass = new AuthenticatorManagerPass();
+    }
+
+    public function testConstruct(): void
+    {
+        self::assertInstanceOf(CompilerPassInterface::class, $this->authenticatorManagerPass);
+    }
+
+    public function testProcessWithoutAuthenticatorManager(): void
+    {
+        $this->containerBuilderProphecy->has('security.authenticator.manager')->willReturn(false);
+        $this->containerBuilderProphecy->getDefinition('api_platform.security.resource_access_checker')->shouldNotBeCalled();
+
+        $this->authenticatorManagerPass->process($this->containerBuilderProphecy->reveal());
+    }
+
+    public function testProcess(): void
+    {
+        $this->containerBuilderProphecy->has('security.authenticator.manager')->willReturn(true);
+        $authenticatorManagerDefinitionProphecy = $this->prophesize(Definition::class);
+        $this->containerBuilderProphecy->getDefinition('api_platform.security.resource_access_checker')->willReturn($authenticatorManagerDefinitionProphecy->reveal());
+        $authenticatorManagerDefinitionProphecy->setArgument(5, false)->shouldBeCalledOnce();
+
+        $this->authenticatorManagerPass->process($this->containerBuilderProphecy->reveal());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #4055, fix #3922
| License       | MIT
| Doc PR        | N/A

Rework of https://github.com/api-platform/core/pull/3899.

Throw back the exception if the new authenticator manager is not used (like https://github.com/symfony/symfony/blob/494ef421c554a78b38c6779c4b7deb9a20d89923/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php#L52).

Use the `NullToken` if the new authenticator manager is used and if there is no token in order to use the variables in the `security` attribute (see also https://github.com/symfony/symfony/pull/37620).