### PR TITLE
Fix missing $ref in OpenApi documentation (#4009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Mercure: Do not use data in options when deleting (#4056)
 * Doctrine: Support for foreign identifiers
 * SchemaFactory: Allow generating documentation when property and method start from "is" (property `isActive` and method `isActive`)
+* OpenApi: Fix missing `$ref` (#4076)
 
 ## 2.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Mercure: Do not use data in options when deleting (#4056)
 * Doctrine: Support for foreign identifiers
 * SchemaFactory: Allow generating documentation when property and method start from "is" (property `isActive` and method `isActive`)
-* OpenApi: Fix missing `$ref` (#4076)
+* OpenAPI: Fix missing `$ref` when no `type` is used in context (#4076)
 
 ## 2.6.2
 

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -226,7 +226,7 @@ final class SchemaFactory implements SchemaFactoryInterface
             $valueSchema = $this->typeFactory->getType(new Type($builtinType, $type->isNullable(), $className, $isCollection), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
         }
 
-        if (\count($propertySchema) > 0 && \array_key_exists('$ref', $valueSchema)) {
+        if (\array_key_exists('type', $propertySchema) && \array_key_exists('$ref', $valueSchema)) {
             $propertySchema = new \ArrayObject($propertySchema);
         } else {
             $propertySchema = new \ArrayObject($propertySchema + $valueSchema);

--- a/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
+++ b/tests/Swagger/Serializer/DocumentationNormalizerV2Test.php
@@ -2133,7 +2133,7 @@ class DocumentationNormalizerV2Test extends TestCase
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, Argument::allOf(
             Argument::type('array'),
             Argument::withEntry('serializer_groups', $groups)
-        ))->willReturn(new PropertyNameCollection(['name', 'relatedDummy']));
+        ))->willReturn(new PropertyNameCollection(['name', 'relatedDummy', 'relatedDummyWithCustomOpenApiContextType']));
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, Argument::type('array'))->willReturn(new PropertyNameCollection(['name']));
         $propertyNameCollectionFactoryProphecy->create(RelatedDummy::class, Argument::allOf(
             Argument::type('array'),
@@ -2170,6 +2170,7 @@ class DocumentationNormalizerV2Test extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', Argument::type('array'))->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'This is a name.', true, true, true, true, false, false, null, null, []));
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy', Argument::type('array'))->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, true, RelatedDummy::class), 'This is a related dummy \o/.', true, true, true, true, false, false, null, null, []));
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummyWithCustomOpenApiContextType', Argument::type('array'))->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, true, RelatedDummy::class), 'This is a related dummy with type string \o/.', true, true, true, true, false, false, null, null, ['swagger_context' => ['type' => 'string']]));
         $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'name', Argument::type('array'))->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'This is a name.', true, true, true, true, false, false, null, null, []));
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
@@ -2339,6 +2340,11 @@ class DocumentationNormalizerV2Test extends TestCase
                         ]),
                         'relatedDummy' => new \ArrayObject([
                             'description' => 'This is a related dummy \o/.',
+                            '$ref' => '#/definitions/'.$relatedDummyRef,
+                        ]),
+                        'relatedDummyWithCustomOpenApiContextType' => new \ArrayObject([
+                            'description' => 'This is a related dummy with type string \o/.',
+                            'type' => 'string',
                         ]),
                     ],
                 ]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #4009
| License       | MIT
| Doc PR        | 

In https://github.com/api-platform/core/pull/3957 a change got introduced that unintentionally removed `$ref`'s from the OpenApi documentation in some cases. The PR changed an existing test without adding a new one.

`$propertySchema` is filled with the `type` that gets passed in the `@ApiProperty()` `openapi_context` or `swagger_context` attribute. So in the previous PR it was thought that whenever `$propertySchema` contains _something_ it was certainly filled because someone tried to define their own type and we shouldn't add a `$ref`. However `$propertySchema` is also filled with `description` whenever a description exists.

So at the moment when you add a description to your method, you lose the `$ref`.

This PR makes sure the `$ref` is only removed when a `$propertySchema['type']` is set.

I've also updated the test with a property that has the `swagger_context` with a `type` set.