### PR TITLE
Add nulls_always_first and nulls_always_last to nulls_comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * MongoDB: `date_immutable` support (#3940)
 * DataProvider: Add `TraversablePaginator` (#3783)
 * Swagger UI: Add `swagger_ui_extra_configuration` to Swagger / OpenAPI configuration (#3731)
+* OrderFilter: Add `nulls_always_first` and `nulls_always_last` to `nulls_comparison` (#4103)
 
 ## 2.6.3
 

--- a/src/Bridge/Doctrine/Common/Filter/OrderFilterInterface.php
+++ b/src/Bridge/Doctrine/Common/Filter/OrderFilterInterface.php
@@ -24,6 +24,8 @@ interface OrderFilterInterface
 {
     public const DIRECTION_ASC = 'ASC';
     public const DIRECTION_DESC = 'DESC';
+    public const NULLS_ALWAYS_FIRST = 'nulls_always_first';
+    public const NULLS_ALWAYS_LAST = 'nulls_always_last';
     public const NULLS_SMALLEST = 'nulls_smallest';
     public const NULLS_LARGEST = 'nulls_largest';
     public const NULLS_DIRECTION_MAP = [

--- a/src/Bridge/Doctrine/Common/Filter/OrderFilterInterface.php
+++ b/src/Bridge/Doctrine/Common/Filter/OrderFilterInterface.php
@@ -24,10 +24,10 @@ interface OrderFilterInterface
 {
     public const DIRECTION_ASC = 'ASC';
     public const DIRECTION_DESC = 'DESC';
-    public const NULLS_ALWAYS_FIRST = 'nulls_always_first';
-    public const NULLS_ALWAYS_LAST = 'nulls_always_last';
     public const NULLS_SMALLEST = 'nulls_smallest';
     public const NULLS_LARGEST = 'nulls_largest';
+    public const NULLS_ALWAYS_FIRST = 'nulls_always_first';
+    public const NULLS_ALWAYS_LAST = 'nulls_always_last';
     public const NULLS_DIRECTION_MAP = [
         self::NULLS_SMALLEST => [
             'ASC' => 'ASC',

--- a/src/Bridge/Doctrine/Common/Filter/OrderFilterInterface.php
+++ b/src/Bridge/Doctrine/Common/Filter/OrderFilterInterface.php
@@ -37,5 +37,13 @@ interface OrderFilterInterface
             'ASC' => 'DESC',
             'DESC' => 'ASC',
         ],
+        self::NULLS_ALWAYS_FIRST => [
+            'ASC' => 'ASC',
+            'DESC' => 'ASC',
+        ],
+        self::NULLS_ALWAYS_LAST => [
+            'ASC' => 'DESC',
+            'DESC' => 'DESC',
+        ],
     ];
 }

--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -103,7 +103,11 @@ class OrderFilter extends AbstractContextAwareFilter implements OrderFilterInter
         }
 
         if (null !== $nullsComparison = $this->properties[$property]['nulls_comparison'] ?? null) {
-            $nullsDirection = self::NULLS_DIRECTION_MAP[$nullsComparison][$direction];
+            if (\in_array($nullsComparison, [self::NULLS_ALWAYS_FIRST, self::NULLS_ALWAYS_LAST], true)) {
+                $nullsDirection = self::NULLS_ALWAYS_FIRST === $nullsComparison ? 'ASC' : 'DESC';
+            } else {
+                $nullsDirection = self::NULLS_DIRECTION_MAP[$nullsComparison][$direction];
+            }
 
             $nullRankHiddenField = sprintf('_%s_%s_null_rank', $alias, $field);
 

--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -103,11 +103,7 @@ class OrderFilter extends AbstractContextAwareFilter implements OrderFilterInter
         }
 
         if (null !== $nullsComparison = $this->properties[$property]['nulls_comparison'] ?? null) {
-            if (\in_array($nullsComparison, [self::NULLS_ALWAYS_FIRST, self::NULLS_ALWAYS_LAST], true)) {
-                $nullsDirection = self::NULLS_ALWAYS_FIRST === $nullsComparison ? 'ASC' : 'DESC';
-            } else {
-                $nullsDirection = self::NULLS_DIRECTION_MAP[$nullsComparison][$direction];
-            }
+            $nullsDirection = self::NULLS_DIRECTION_MAP[$nullsComparison][$direction];
 
             $nullRankHiddenField = sprintf('_%s_%s_null_rank', $alias, $field);
 

--- a/tests/Bridge/Doctrine/Common/Filter/OrderFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/OrderFilterTestTrait.php
@@ -232,6 +232,62 @@ trait OrderFilterTestTrait
                     ],
                 ],
             ],
+            'nulls_always_first (asc)' => [
+                [
+                    'dummyDate' => [
+                        'nulls_comparison' => 'nulls_always_first',
+                    ],
+                    'name' => null,
+                ],
+                [
+                    'order' => [
+                        'dummyDate' => 'asc',
+                        'name' => 'desc',
+                    ],
+                ],
+            ],
+            'nulls_always_first (desc)' => [
+                [
+                    'dummyDate' => [
+                        'nulls_comparison' => 'nulls_always_first',
+                    ],
+                    'name' => null,
+                ],
+                [
+                    'order' => [
+                        'dummyDate' => 'desc',
+                        'name' => 'desc',
+                    ],
+                ],
+            ],
+            'nulls_always_last (asc)' => [
+                [
+                    'dummyDate' => [
+                        'nulls_comparison' => 'nulls_always_last',
+                    ],
+                    'name' => null,
+                ],
+                [
+                    'order' => [
+                        'dummyDate' => 'asc',
+                        'name' => 'desc',
+                    ],
+                ],
+            ],
+            'nulls_always_last (desc)' => [
+                [
+                    'dummyDate' => [
+                        'nulls_comparison' => 'nulls_always_last',
+                    ],
+                    'name' => null,
+                ],
+                [
+                    'order' => [
+                        'dummyDate' => 'desc',
+                        'name' => 'desc',
+                    ],
+                ],
+            ],
             'not having order should not throw a deprecation (select unchanged)' => [
                 [
                     'id' => null,

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/OrderFilterTest.php
@@ -436,6 +436,70 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     ],
                     $orderFilterFactory,
                 ],
+                'nulls_always_first (asc)' => [
+                    [
+                        [
+                            '$sort' => [
+                                'dummyDate' => 1,
+                            ],
+                        ],
+                        [
+                            '$sort' => [
+                                'dummyDate' => 1,
+                                'name' => -1,
+                            ],
+                        ],
+                    ],
+                    $orderFilterFactory,
+                ],
+                'nulls_always_first (desc)' => [
+                    [
+                        [
+                            '$sort' => [
+                                'dummyDate' => -1,
+                            ],
+                        ],
+                        [
+                            '$sort' => [
+                                'dummyDate' => -1,
+                                'name' => -1,
+                            ],
+                        ],
+                    ],
+                    $orderFilterFactory,
+                ],
+                'nulls_always_last (asc)' => [
+                    [
+                        [
+                            '$sort' => [
+                                'dummyDate' => 1,
+                            ],
+                        ],
+                        [
+                            '$sort' => [
+                                'dummyDate' => 1,
+                                'name' => -1,
+                            ],
+                        ],
+                    ],
+                    $orderFilterFactory,
+                ],
+                'nulls_always_last (desc)' => [
+                    [
+                        [
+                            '$sort' => [
+                                'dummyDate' => -1,
+                            ],
+                        ],
+                        [
+                            '$sort' => [
+                                'dummyDate' => -1,
+                                'name' => -1,
+                            ],
+                        ],
+                    ],
+                    $orderFilterFactory,
+                ],
                 'not having order should not throw a deprecation (select unchanged)' => [
                     [],
                     $orderFilterFactory,

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -265,6 +265,26 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                     null,
                     $orderFilterFactory,
                 ],
+                'nulls_always_first (asc)' => [
+                    sprintf('SELECT o, CASE WHEN o.dummyDate IS NULL THEN 0 ELSE 1 END AS HIDDEN _o_dummyDate_null_rank FROM %s o ORDER BY _o_dummyDate_null_rank ASC, o.dummyDate ASC, o.name DESC', Dummy::class),
+                    null,
+                    $orderFilterFactory,
+                ],
+                'nulls_always_first (desc)' => [
+                    sprintf('SELECT o, CASE WHEN o.dummyDate IS NULL THEN 0 ELSE 1 END AS HIDDEN _o_dummyDate_null_rank FROM %s o ORDER BY _o_dummyDate_null_rank ASC, o.dummyDate DESC, o.name DESC', Dummy::class),
+                    null,
+                    $orderFilterFactory,
+                ],
+                'nulls_always_last (asc)' => [
+                    sprintf('SELECT o, CASE WHEN o.dummyDate IS NULL THEN 0 ELSE 1 END AS HIDDEN _o_dummyDate_null_rank FROM %s o ORDER BY _o_dummyDate_null_rank DESC, o.dummyDate ASC, o.name DESC', Dummy::class),
+                    null,
+                    $orderFilterFactory,
+                ],
+                'nulls_always_last (desc)' => [
+                    sprintf('SELECT o, CASE WHEN o.dummyDate IS NULL THEN 0 ELSE 1 END AS HIDDEN _o_dummyDate_null_rank FROM %s o ORDER BY _o_dummyDate_null_rank DESC, o.dummyDate DESC, o.name DESC', Dummy::class),
+                    null,
+                    $orderFilterFactory,
+                ],
                 'not having order should not throw a deprecation (select unchanged)' => [
                     sprintf('SELECT o FROM %s o', Dummy::class),
                     null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | (no issue)
| License       | MIT
| Doc PR        | api-platform/docs#1297

Add `nulls_always_first` and `nulls_always_last` to `nulls_comparison` of the `OrderFilter`. This allows to always sort in `null` values first or last, independent of the current order. 

This is useful for UIs with optional fields; displaying empty fields might not be useful to the user. Sorting these always last, independent of the chosen ordering, is the expected behavior.

Given something like

```
/**
 * @ApiResource(order={"number": "ASC"})
 * @ApiFilter(
 *     OrderFilter::class,
 *     properties={
 *         "number": {
 *             "nulls_comparison": OrderFilter::NULLS_ALWAYS_LAST
 *         }
 *     }
 * )
 */
 ```

will result in an ordering like

```
1
4
NULL
NULL
```