### PR TITLE
Handle sequentially validator constraints when generating property metadata

### DIFF
--- a/src/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
@@ -30,6 +30,7 @@ use Symfony\Component\Validator\Constraints\Isbn;
 use Symfony\Component\Validator\Constraints\Issn;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Sequentially;
 use Symfony\Component\Validator\Constraints\Time;
 use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Constraints\Uuid;
@@ -170,11 +171,15 @@ final class ValidatorPropertyMetadataFactory implements PropertyMetadataFactoryI
             }
 
             foreach ($validatorPropertyMetadata->findConstraints($validationGroup) as $propertyConstraint) {
-                $constraints[] = $propertyConstraint;
+                if ($propertyConstraint instanceof Sequentially) {
+                    $constraints[] = $propertyConstraint->getNestedContraints();
+                } else {
+                    $constraints[] = [$propertyConstraint];
+                }
             }
         }
 
-        return $constraints;
+        return array_merge([], ...$constraints);
     }
 
     /**

--- a/tests/Fixtures/DummySequentiallyValidatedEntity.php
+++ b/tests/Fixtures/DummySequentiallyValidatedEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummySequentiallyValidatedEntity
+{
+    /**
+     * @var string
+     *
+     * @Assert\Sequentially({
+     *     @Assert\Length(min=1, max=32),
+     *     @Assert\Regex(pattern="/^[a-z]$/")
+     * })
+     */
+    public $dummy;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | -

Currently property metadata from validator constraints (length/regex etc.) is only taken when these constraints are applied directly. Since Symfony 5.1 there is Sequentially constraint which allows to validate as a group sequence but much easier. But api platform doesn't take them because they're nested inside the Sequentially constraint.

~~I have updated to include all nested constraints from the Composite, but maybe that's too wide?
Also not sure about that maybe constraint flattening should be recursive?~~
