### PR TITLE
Fix denormalization of basic property-types in XML and CSV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,16 +446,20 @@ jobs:
         php:
           - '7.4'
       fail-fast: false
+    services:
+      mysql:
+        image: mariadb:10.5.9
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: api_platform_test
+        ports:
+          - 3306:3306
     env:
       APP_ENV: mysql
       DATABASE_URL: mysql://root:root@127.0.0.1/api_platform_test
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup mysql
-        run: |
-          sudo systemctl start mysql.service
-          sudo mysql -u root -proot -e "CREATE DATABASE api_platform_test"
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,7 @@ jobs:
       - name: Clear test app cache
         run: tests/Fixtures/app/console cache:clear --ansi
       - name: Run Behat tests
-        run: vendor/bin/behat --out=std --format=progress --profile=default --no-interaction
+        run: vendor/bin/behat --out=std --format=progress --profile=default --no-interaction --tags '~@!mysql'
 
   mongodb:
     name: PHPUnit + Behat (PHP ${{ matrix.php }}) (MongoDB)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## 2.6.4
 
+* Serializer: Fix denormalization of basic property-types in XML and CSV (#3191)
 * Doctrine: Fix purging HTTP cache for unreadable relations (#3441)
+* Doctrine: Revert #3774 support for binary UUID in search filter (#4134)
 * GraphQL: Partial pagination support (#3223)
 * GraphQL: Manage `pagination_use_output_walkers` and `pagination_fetch_join_collection` for operations (#3311)
 * Swagger UI: Remove Google fonts (#4112)
-* Doctrine: Revert #3774 support for binary UUID in search filter (#4134) 
 
 ## 2.6.3
 

--- a/features/main/content_negotiation.feature
+++ b/features/main/content_negotiation.feature
@@ -22,7 +22,7 @@ Feature: Content Negotiation support
     <response><description/><dummy/><dummyBoolean/><dummyDate/><dummyFloat/><dummyPrice/><relatedDummy/><relatedDummies/><jsonData/><arrayData/><name_converted/><relatedOwnedDummy/><relatedOwningDummy/><id>1</id><name>XML!</name><alias/><foo/></response>
     """
 
-  Scenario:  Retrieve a collection in XML
+  Scenario: Retrieve a collection in XML
     When I add "Accept" header equal to "text/xml"
     And I send a "GET" request to "/dummies"
     Then the response status code should be 200
@@ -34,7 +34,7 @@ Feature: Content Negotiation support
     <response><item key="0"><description/><dummy/><dummyBoolean/><dummyDate/><dummyFloat/><dummyPrice/><relatedDummy/><relatedDummies/><jsonData/><arrayData/><name_converted/><relatedOwnedDummy/><relatedOwningDummy/><id>1</id><name>XML!</name><alias/><foo/></item></response>
     """
 
-  Scenario:  Retrieve a collection in XML using the .xml URL
+  Scenario: Retrieve a collection in XML using the .xml URL
     When I send a "GET" request to "/dummies.xml"
     Then the response status code should be 200
     And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
@@ -45,7 +45,7 @@ Feature: Content Negotiation support
     <response><item key="0"><description/><dummy/><dummyBoolean/><dummyDate/><dummyFloat/><dummyPrice/><relatedDummy/><relatedDummies/><jsonData/><arrayData/><name_converted/><relatedOwnedDummy/><relatedOwningDummy/><id>1</id><name>XML!</name><alias/><foo/></item></response>
     """
 
-  Scenario:  Retrieve a collection in JSON
+  Scenario: Retrieve a collection in JSON
     When I add "Accept" header equal to "application/json"
     And I send a "GET" request to "/dummies"
     Then the response status code should be 200

--- a/features/xml/deserialization.feature
+++ b/features/xml/deserialization.feature
@@ -1,0 +1,76 @@
+Feature: XML Deserialization
+  In order to use the API with XML
+  As a client software developer
+  I need to be able to deserialize XML data
+
+  Background:
+    Given I add "Accept" header equal to "application/xml"
+    And I add "Content-Type" header equal to "application/xml"
+
+  @createSchema
+  Scenario: Posting an XML resource with a string value
+    When I send a "POST" request to "/resource_with_strings" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithString>
+      <myStringField>string</myStringField>
+    </ResourceWithString>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
+
+  Scenario Outline: Posting an XML resource with a boolean value
+    When I send a "POST" request to "/resource_with_booleans" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithBoolean>
+      <myBooleanField><value></myBooleanField>
+    </ResourceWithBoolean>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
+  Examples:
+    | value |
+    | true  |
+    | false |
+    | 1     |
+    | 0     |
+
+  Scenario Outline: Posting an XML resource with an integer value
+    When I send a "POST" request to "/resource_with_integers" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithInteger>
+      <myIntegerField><value></myIntegerField>
+    </ResourceWithInteger>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
+  Examples:
+    | value |
+    | 42    |
+    | -6    |
+    | 1     |
+    | 0     |
+
+  @!mysql
+  Scenario Outline: Posting an XML resource with a float value
+    When I send a "POST" request to "/resource_with_floats" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ResourceWithFloat>
+      <myFloatField><value></myFloatField>
+    </ResourceWithFloat>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"
+  Examples:
+    | value |
+    | 3.14  |
+    | NaN   |
+    | INF   |
+    | -INF  |

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -31,6 +31,8 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -770,6 +772,51 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             unset($context['resource_class']);
 
             return $this->serializer->denormalize($value, $className, $format, $context);
+        }
+
+        /* From @see AbstractObjectNormalizer::validateAndDenormalize() */
+        // In XML and CSV all basic datatypes are represented as strings, it is e.g. not possible to determine,
+        // if a value is meant to be a string, float, int or a boolean value from the serialized representation.
+        // That's why we have to transform the values, if one of these non-string basic datatypes is expected.
+        if (\is_string($value) && (XmlEncoder::FORMAT === $format || CsvEncoder::FORMAT === $format)) {
+            if ('' === $value && $type->isNullable() && \in_array($type->getBuiltinType(), [Type::BUILTIN_TYPE_BOOL, Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT], true)) {
+                return null;
+            }
+
+            switch ($type->getBuiltinType()) {
+                case Type::BUILTIN_TYPE_BOOL:
+                    // according to https://www.w3.org/TR/xmlschema-2/#boolean, valid representations are "false", "true", "0" and "1"
+                    if ('false' === $value || '0' === $value) {
+                        $value = false;
+                    } elseif ('true' === $value || '1' === $value) {
+                        $value = true;
+                    } else {
+                        throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be bool ("%s" given).', $attribute, $className, $value));
+                    }
+                    break;
+                case Type::BUILTIN_TYPE_INT:
+                    if (ctype_digit($value) || ('-' === $value[0] && ctype_digit(substr($value, 1)))) {
+                        $value = (int) $value;
+                    } else {
+                        throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be int ("%s" given).', $attribute, $className, $value));
+                    }
+                    break;
+                case Type::BUILTIN_TYPE_FLOAT:
+                    if (is_numeric($value)) {
+                        return (float) $value;
+                    }
+
+                    switch ($value) {
+                        case 'NaN':
+                            return \NAN;
+                        case 'INF':
+                            return \INF;
+                        case '-INF':
+                            return -\INF;
+                        default:
+                            throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be float ("%s" given).', $attribute, $className, $value));
+                    }
+            }
         }
 
         if ($context[static::DISABLE_TYPE_ENFORCEMENT] ?? false) {

--- a/tests/Fixtures/TestBundle/Document/ResourceWithBoolean.php
+++ b/tests/Fixtures/TestBundle/Document/ResourceWithBoolean.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ApiResource
+ * @ODM\Document
+ */
+class ResourceWithBoolean
+{
+    /**
+     * @var int The id
+     *
+     * @ODM\Id(strategy="INCREMENT", type="int")
+     */
+    private $id;
+
+    /**
+     * @var bool
+     *
+     * @ODM\Field(type="bool")
+     */
+    private $myBooleanField = false;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyBooleanField(): bool
+    {
+        return $this->myBooleanField;
+    }
+
+    public function setMyBooleanField(bool $myBooleanField): void
+    {
+        $this->myBooleanField = $myBooleanField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/ResourceWithFloat.php
+++ b/tests/Fixtures/TestBundle/Document/ResourceWithFloat.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ApiResource
+ * @ODM\Document
+ */
+class ResourceWithFloat
+{
+    /**
+     * @var int The id
+     *
+     * @ODM\Id(strategy="INCREMENT", type="int")
+     */
+    private $id;
+
+    /**
+     * @var float
+     *
+     * @ODM\Field(type="float")
+     */
+    private $myFloatField = 0.0;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyFloatField(): float
+    {
+        return $this->myFloatField;
+    }
+
+    public function setMyFloatField(float $myFloatField): void
+    {
+        $this->myFloatField = $myFloatField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/ResourceWithInteger.php
+++ b/tests/Fixtures/TestBundle/Document/ResourceWithInteger.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ApiResource
+ * @ODM\Document
+ */
+class ResourceWithInteger
+{
+    /**
+     * @var int The id
+     *
+     * @ODM\Id(strategy="INCREMENT", type="int")
+     */
+    private $id;
+
+    /**
+     * @var int
+     *
+     * @ODM\Field(type="int")
+     */
+    private $myIntegerField = 0;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyIntegerField(): int
+    {
+        return $this->myIntegerField;
+    }
+
+    public function setMyIntegerField(int $myIntegerField): void
+    {
+        $this->myIntegerField = $myIntegerField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/ResourceWithString.php
+++ b/tests/Fixtures/TestBundle/Document/ResourceWithString.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ApiResource
+ * @ODM\Document
+ */
+class ResourceWithString
+{
+    /**
+     * @var int The id
+     *
+     * @ODM\Id(strategy="INCREMENT", type="int")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ODM\Field(type="string")
+     */
+    private $myStringField = '';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyStringField(): string
+    {
+        return $this->myStringField;
+    }
+
+    public function setMyStringField(string $myStringField): void
+    {
+        $this->myStringField = $myStringField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithBoolean.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithBoolean.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithBoolean
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
+    private $myBooleanField = false;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyBooleanField(): bool
+    {
+        return $this->myBooleanField;
+    }
+
+    public function setMyBooleanField(bool $myBooleanField): void
+    {
+        $this->myBooleanField = $myBooleanField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithFloat.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithFloat.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithFloat
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var float
+     *
+     * @ORM\Column(type="float")
+     */
+    private $myFloatField = 0.0;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyFloatField(): float
+    {
+        return $this->myFloatField;
+    }
+
+    public function setMyFloatField(float $myFloatField): void
+    {
+        $this->myFloatField = $myFloatField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithInteger.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithInteger.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithInteger
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     */
+    private $myIntegerField = 0;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyIntegerField(): int
+    {
+        return $this->myIntegerField;
+    }
+
+    public function setMyIntegerField(int $myIntegerField): void
+    {
+        $this->myIntegerField = $myIntegerField;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ResourceWithString.php
+++ b/tests/Fixtures/TestBundle/Entity/ResourceWithString.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity
+ */
+class ResourceWithString
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    private $myStringField = '';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMyStringField(): string
+    {
+        return $this->myStringField;
+    }
+
+    public function setMyStringField(string $myStringField): void
+    {
+        $this->myStringField = $myStringField;
+    }
+}

--- a/tests/Fixtures/app/config/config_mysql.yml
+++ b/tests/Fixtures/app/config/config_mysql.yml
@@ -3,7 +3,7 @@ imports:
 
 parameters:
     env(DATABASE_URL): mysql://root:@localhost/api_platform_test
-    env(MYSQL_VERSION): '5.7'
+    env(MYSQL_VERSION): 'mariadb-10.5.9'
 
 doctrine:
     dbal:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes https://github.com/api-platform/api-platform/issues/1299
| License       | MIT
| Doc PR        | N/A

Replace https://github.com/api-platform/core/pull/3191.

> This PR fixes an issue where by posting XML content throws errors when a field has a non string primitive type because the XML encoder can only normalize primitive values as strings. This means that post create and update requests fail. This PR adds some additional behaviour where by the AbstractItemNormalizer will cast valid strings as the correct type.

This PR mirrors the Symfony equivalent: https://github.com/symfony/symfony/pull/33850.