### PR TITLE
Fix #2928: do not override Vary headers already set in the Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * GraphQL: Partial pagination support (#3223)
 * GraphQL: Manage `pagination_use_output_walkers` and `pagination_fetch_join_collection` for operations (#3311)
 * Swagger UI: Remove Google fonts (#4112)
+* Doctrine: Revert #3774 support for binary UUID in search filter (#4134) 
+* Do not override Vary headers already set in the Response 
 
 ## 2.6.3
 

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -74,10 +74,9 @@ final class AddHeadersListener
             $response->setMaxAge($maxAge);
         }
 
-        if (isset($resourceCacheHeaders['vary'])) {
-            $response->setVary($resourceCacheHeaders['vary']);
-        } elseif (null !== $this->vary) {
-            $response->setVary(array_diff($this->vary, $response->getVary()), false);
+        $vary = $resourceCacheHeaders['vary'] ?? $this->vary;
+        if (null !== $vary) {
+            $response->setVary(array_diff($vary, $response->getVary()), false);
         }
 
         // if the public-property is defined and not yet set; apply it to the response

--- a/tests/HttpCache/EventListener/AddHeadersListenerTest.php
+++ b/tests/HttpCache/EventListener/AddHeadersListenerTest.php
@@ -162,7 +162,7 @@ class AddHeadersListenerTest extends TestCase
         $listener->onKernelResponse($event);
 
         $this->assertSame('max-age=123, public, s-maxage=456, stale-if-error=70, stale-while-revalidate=928', $response->headers->get('Cache-Control'));
-        $this->assertSame(['Vary-1', 'Vary-2'], $response->getVary());
+        $this->assertSame(['Accept', 'Cookie', 'Vary-1', 'Vary-2'], $response->getVary());
     }
 
     public function testSetHeadersFromResourceMetadataMarkedAsPrivate()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #2928 
| License       | MIT