### PR TITLE
Add oneOf property schema restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.6.4
 
 * Serializer: Fix denormalization of basic property-types in XML and CSV (#3191)
+* JSON Schema: Manage Sequentially and AtLeastOneOf constraints when generating property metadata (#4139 and #4147)
 * Doctrine: Fix purging HTTP cache for unreadable relations (#3441)
 * Doctrine: Revert #3774 support for binary UUID in search filter (#4134)
 * GraphQL: Partial pagination support (#3223)

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -21,6 +21,11 @@
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>
 
+        <service id="api_platform.metadata.property_schema.one_of_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaOneOfRestriction" public="false">
+            <argument type="tagged" tag="api_platform.metadata.property_schema_restriction" />
+            <tag name="api_platform.metadata.property_schema_restriction"/>
+        </service>
+
         <service id="api_platform.metadata.property_schema.regex_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRegexRestriction" public="false">
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>

--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestriction.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\AtLeastOneOf;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class PropertySchemaOneOfRestriction implements PropertySchemaRestrictionMetadataInterface
+{
+    /**
+     * @var iterable<PropertySchemaRestrictionMetadataInterface>
+     */
+    private $restrictionsMetadata;
+
+    /**
+     * @param iterable<PropertySchemaRestrictionMetadataInterface> $restrictionsMetadata
+     */
+    public function __construct(iterable $restrictionsMetadata = [])
+    {
+        $this->restrictionsMetadata = $restrictionsMetadata;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param AtLeastOneOf $constraint
+     */
+    public function create(Constraint $constraint, PropertyMetadata $propertyMetadata): array
+    {
+        $oneOfConstraints = $constraint->getNestedContraints();
+        $oneOfRestrictions = [];
+
+        foreach ($oneOfConstraints as $oneOfConstraint) {
+            foreach ($this->restrictionsMetadata as $restrictionMetadata) {
+                if ($restrictionMetadata->supports($oneOfConstraint, $propertyMetadata) && !empty($oneOfRestriction = $restrictionMetadata->create($oneOfConstraint, $propertyMetadata))) {
+                    $oneOfRestrictions[] = $oneOfRestriction;
+                }
+            }
+        }
+
+        if (!empty($oneOfRestrictions)) {
+            return ['oneOf' => $oneOfRestrictions];
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Constraint $constraint, PropertyMetadata $propertyMetadata): bool
+    {
+        return $constraint instanceof AtLeastOneOf;
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1333,6 +1333,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.property.metadata_factory.annotation',
             'api_platform.metadata.property.metadata_factory.validator',
             'api_platform.metadata.property_schema.length_restriction',
+            'api_platform.metadata.property_schema.one_of_restriction',
             'api_platform.metadata.property_schema.regex_restriction',
             'api_platform.metadata.property_schema.format_restriction',
             'api_platform.metadata.property.metadata_factory.yaml',

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestrictionTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestrictionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaLengthRestriction;
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaOneOfRestriction;
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRegexRestriction;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\AtLeastOneOf;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Positive;
+
+/**
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class PropertySchemaOneOfRestrictionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $propertySchemaOneOfRestriction;
+
+    protected function setUp(): void
+    {
+        $this->propertySchemaOneOfRestriction = new PropertySchemaOneOfRestriction([
+            new PropertySchemaLengthRestriction(),
+            new PropertySchemaRegexRestriction(),
+        ]);
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(Constraint $constraint, PropertyMetadata $propertyMetadata, bool $expectedResult): void
+    {
+        if (!class_exists(AtLeastOneOf::class)) {
+            self::markTestSkipped();
+        }
+
+        self::assertSame($expectedResult, $this->propertySchemaOneOfRestriction->supports($constraint, $propertyMetadata));
+    }
+
+    public function supportsProvider(): \Generator
+    {
+        yield 'supported' => [new AtLeastOneOf(['constraints' => []]), new PropertyMetadata(), true];
+
+        yield 'not supported' => [new Positive(), new PropertyMetadata(), false];
+    }
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(Constraint $constraint, PropertyMetadata $propertyMetadata, array $expectedResult): void
+    {
+        if (!class_exists(AtLeastOneOf::class)) {
+            self::markTestSkipped();
+        }
+
+        self::assertSame($expectedResult, $this->propertySchemaOneOfRestriction->create($constraint, $propertyMetadata));
+    }
+
+    public function createProvider(): \Generator
+    {
+        yield 'empty' => [new AtLeastOneOf(['constraints' => []]), new PropertyMetadata(), []];
+
+        yield 'not supported constraints' => [new AtLeastOneOf(['constraints' => [new Positive(), new Length(['min' => 3])]]), new PropertyMetadata(), []];
+
+        yield 'one supported constraint' => [new AtLeastOneOf(['constraints' => [new Positive(), new Length(['min' => 3])]]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), [
+            'oneOf' => [['minLength' => 3]],
+        ]];
+    }
+}

--- a/tests/Fixtures/DummyAtLeastOneOfValidatedEntity.php
+++ b/tests/Fixtures/DummyAtLeastOneOfValidatedEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummyAtLeastOneOfValidatedEntity
+{
+    /**
+     * @var string
+     *
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Regex("/#/"),
+     *     @Assert\Length(min=10)
+     * })
+     */
+    public $dummy;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Following https://github.com/api-platform/core/pull/4139.

Add `PropertySchemaOneOfRestriction` to transform the [AtLeastOneOf](https://symfony.com/doc/current/reference/constraints/AtLeastOneOf.html) validation constraint into [oneOf](https://json-schema.org/understanding-json-schema/reference/combining.html#oneof) JSON Schema restriction.