### PR TITLE
Manage Ulid in format property schema restriction

### DIFF
--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormat.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormat.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Ip;
+use Symfony\Component\Validator\Constraints\Ulid;
 use Symfony\Component\Validator\Constraints\Uuid;
 
 /**
@@ -39,6 +40,10 @@ class PropertySchemaFormat implements PropertySchemaRestrictionMetadataInterface
             return ['format' => 'uuid'];
         }
 
+        if ($constraint instanceof Ulid) {
+            return ['format' => 'ulid'];
+        }
+
         if ($constraint instanceof Ip) {
             if ($constraint->version === $constraint::V4) {
                 return ['format' => 'ipv4'];
@@ -57,6 +62,6 @@ class PropertySchemaFormat implements PropertySchemaRestrictionMetadataInterface
     {
         $schema = $propertyMetadata->getSchema();
 
-        return empty($schema['format']);
+        return empty($schema['format']) && ($constraint instanceof Email || $constraint instanceof Uuid || $constraint instanceof Ulid || $constraint instanceof Ip);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Add [Ulid](https://symfony.com/doc/current/reference/constraints/Ulid.html) management in the `PropertySchemaFormat`.