### PR TITLE
Fix order filter with embedded and nulls comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: intl, bcmath, curl, openssl, mbstring 
           ini-values: memory_limit=-1
-          tools: pecl, composer, php-cs-fixer
+          tools: pecl, composer, php-cs-fixer:2.18.4
           coverage: none
       - name: Run PHP-CS-Fixer fix
         run: php-cs-fixer fix --dry-run --diff --ansi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * JSON Schema: Manage Sequentially and AtLeastOneOf constraints when generating property metadata (#4139 and #4147)
 * Doctrine: Fix purging HTTP cache for unreadable relations (#3441)
 * Doctrine: Revert #3774 support for binary UUID in search filter (#4134)
+* Doctrine: Fix order filter when using embedded and nulls comparison (#4151)
 * GraphQL: Partial pagination support (#3223)
 * GraphQL: Manage `pagination_use_output_walkers` and `pagination_fetch_join_collection` for operations (#3311)
 * Swagger UI: Remove Google fonts (#4112)

--- a/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/OrderFilter.php
@@ -105,7 +105,7 @@ class OrderFilter extends AbstractContextAwareFilter implements OrderFilterInter
         if (null !== $nullsComparison = $this->properties[$property]['nulls_comparison'] ?? null) {
             $nullsDirection = self::NULLS_DIRECTION_MAP[$nullsComparison][$direction];
 
-            $nullRankHiddenField = sprintf('_%s_%s_null_rank', $alias, $field);
+            $nullRankHiddenField = sprintf('_%s_%s_null_rank', $alias, str_replace('.', '_', $field));
 
             $queryBuilder->addSelect(sprintf('CASE WHEN %s.%s IS NULL THEN 0 ELSE 1 END AS HIDDEN %s', $alias, $field, $nullRankHiddenField));
             $queryBuilder->addOrderBy($nullRankHiddenField, $nullsDirection);

--- a/tests/Bridge/Doctrine/Common/Filter/OrderFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/OrderFilterTestTrait.php
@@ -249,7 +249,7 @@ trait OrderFilterTestTrait
                     'order' => ['relatedDummy.name' => 'ASC'],
                 ],
             ],
-            'embeddable' => [
+            'embedded' => [
                 [
                     'embeddedDummy.dummyName' => 'ASC',
                 ],
@@ -257,7 +257,7 @@ trait OrderFilterTestTrait
                     'order' => ['embeddedDummy.dummyName' => 'ASC'],
                 ],
             ],
-            'embeddable_nulls_comparison' => [
+            'embedded with nulls_comparison' => [
                 [
                     'embeddedDummy.dummyName' => [
                         'nulls_comparison' => 'nulls_largest',
@@ -265,7 +265,7 @@ trait OrderFilterTestTrait
                 ],
                 [
                     'order' => [
-                        'embeddedDummy.dummyName' => 'asc',
+                        'embeddedDummy.dummyName' => 'ASC',
                     ],
                 ],
             ],

--- a/tests/Bridge/Doctrine/Common/Filter/OrderFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/OrderFilterTestTrait.php
@@ -249,6 +249,26 @@ trait OrderFilterTestTrait
                     'order' => ['relatedDummy.name' => 'ASC'],
                 ],
             ],
+            'embeddable' => [
+                [
+                    'embeddedDummy.dummyName' => 'ASC',
+                ],
+                [
+                    'order' => ['embeddedDummy.dummyName' => 'ASC'],
+                ],
+            ],
+            'embeddable_nulls_comparison' => [
+                [
+                    'embeddedDummy.dummyName' => [
+                        'nulls_comparison' => 'nulls_largest',
+                    ],
+                ],
+                [
+                    'order' => [
+                        'embeddedDummy.dummyName' => 'asc',
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/OrderFilterTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Doctrine\MongoDbOdm\Filter;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\OrderFilter;
 use ApiPlatform\Core\Test\DoctrineMongoDbOdmFilterTestCase;
 use ApiPlatform\Core\Tests\Bridge\Doctrine\Common\Filter\OrderFilterTestTrait;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Document\EmbeddedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\NameConverter\CustomConverter;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -460,6 +461,28 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                         ],
                     ],
                     $orderFilterFactory,
+                ],
+                'embedded' => [
+                    [
+                        [
+                            '$sort' => [
+                                'embeddedDummy.dummyName' => 1,
+                            ],
+                        ],
+                    ],
+                    $orderFilterFactory,
+                    EmbeddedDummy::class,
+                ],
+                'embedded with nulls_comparison' => [
+                    [
+                        [
+                            '$sort' => [
+                                'embeddedDummy.dummyName' => 1,
+                            ],
+                        ],
+                    ],
+                    $orderFilterFactory,
+                    EmbeddedDummy::class,
                 ],
             ]
         );

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -20,7 +20,6 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\NameConverter\CustomConverter;
 use Doctrine\Persistence\ManagerRegistry;
-use phpDocumentor\Reflection\Types\Boolean;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -388,13 +387,13 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                     null,
                     $orderFilterFactory,
                 ],
-                'embeddable' => [
+                'embedded' => [
                     sprintf('SELECT o FROM %s o ORDER BY o.embeddedDummy.dummyName ASC', EmbeddedDummy::class),
                     null,
                     $orderFilterFactory,
                     EmbeddedDummy::class,
                 ],
-                'embeddable_nulls_comparison' => [
+                'embedded with nulls_comparison' => [
                     sprintf('SELECT o, CASE WHEN o.embeddedDummy.dummyName IS NULL THEN 0 ELSE 1 END AS HIDDEN _o_embeddedDummy_dummyName_null_rank FROM %s o ORDER BY _o_embeddedDummy_dummyName_null_rank DESC, o.embeddedDummy.dummyName ASC', EmbeddedDummy::class),
                     null,
                     $orderFilterFactory,

--- a/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -17,8 +17,10 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Core\Test\DoctrineOrmFilterTestCase;
 use ApiPlatform\Core\Tests\Bridge\Doctrine\Common\Filter\OrderFilterTestTrait;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\EmbeddedDummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Serializer\NameConverter\CustomConverter;
 use Doctrine\Persistence\ManagerRegistry;
+use phpDocumentor\Reflection\Types\Boolean;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -181,6 +183,117 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 ],
             ],
         ], $filter->getDescription($this->resourceClass));
+
+        $this->assertEquals([
+            'order[id]' => [
+                'property' => 'id',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[name]' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[dummyDate]' => [
+                'property' => 'dummyDate',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[embeddedDummy.dummyName]' => [
+                'property' => 'embeddedDummy.dummyName',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[embeddedDummy.dummyBoolean]' => [
+                'property' => 'embeddedDummy.dummyBoolean',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[embeddedDummy.dummyDate]' => [
+                'property' => 'embeddedDummy.dummyDate',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[embeddedDummy.dummyFloat]' => [
+                'property' => 'embeddedDummy.dummyFloat',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[embeddedDummy.dummyPrice]' => [
+                'property' => 'embeddedDummy.dummyPrice',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+            'order[embeddedDummy.symfony]' => [
+                'property' => 'embeddedDummy.symfony',
+                'type' => 'string',
+                'required' => false,
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'asc',
+                        'desc',
+                    ],
+                ],
+            ],
+        ], $filter->getDescription(EmbeddedDummy::class));
     }
 
     public function provideApplyTestData(): array
@@ -274,6 +387,18 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                     sprintf('SELECT o FROM %s o LEFT JOIN o.relatedDummy relatedDummy_a1 ORDER BY relatedDummy_a1.name ASC', Dummy::class),
                     null,
                     $orderFilterFactory,
+                ],
+                'embeddable' => [
+                    sprintf('SELECT o FROM %s o ORDER BY o.embeddedDummy.dummyName ASC', EmbeddedDummy::class),
+                    null,
+                    $orderFilterFactory,
+                    EmbeddedDummy::class,
+                ],
+                'embeddable_nulls_comparison' => [
+                    sprintf('SELECT o, CASE WHEN o.embeddedDummy.dummyName IS NULL THEN 0 ELSE 1 END AS HIDDEN _o_embeddedDummy_dummyName_null_rank FROM %s o ORDER BY _o_embeddedDummy_dummyName_null_rank DESC, o.embeddedDummy.dummyName ASC', EmbeddedDummy::class),
+                    null,
+                    $orderFilterFactory,
+                    EmbeddedDummy::class,
                 ],
             ]
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes<!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | Fixes #4144 Fixes #3440
| License       | MIT
| Doc PR        | Feature already documented here: Order Filter (Sorting) > [Comparing with Null Values](https://api-platform.com/docs/core/filters/#comparing-with-null-values)

### Description

**Comparing with Null Values doesn't work with embeddable.**

Thanks @vsalvans who found the issue in #3440.

### Todo

- [X] Always add tests and ensure they pass. (PhpUnit)
- [ ] Always add tests and ensure they pass. (Behat)
- [ ] Update CHANGELOG.md file
- [ ] Add test for mondoDB ?

## Help wanted

### Issue n°1: Is there a better way to add a test for this bug ?

I wrote a lot of PhpUnits Tests code. First, I started to test the correct behavior of OrderFilter regarding embaddables. I modified `\ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy` to add a `public $embeddedDummy;` property.
By doing this, I was able to add a new test scenario under `\ApiPlatform\Core\Tests\Bridge\Doctrine\Common\Filter\OrderFilterTestTrait::provideApplyTestArguments` : 
```
'embeddable_nulls_comparison' => [
    [
        'embeddedDummy.dummyName' => [
            'nulls_comparison' => 'nulls_largest',
        ],
    ],
    [
        'order' => [
            'embeddedDummy.dummyName' => 'asc',
        ],
    ],
],
```
Unfortunatly, adding a new property created several new entries in the API documentation which led me writing a lot of code for all other tests (eg: BooleanFilterTest, RangeFilterTest, etc...). Regarding the impacts in the tests (see above), I am not convinced it is the best way to go. Should I create more isolated tests specific to embeddable somewhere else ?

### Issue n°2: behat tests fails

While all PhpUnit tests succeed, the behats tests fail. The first failing scenario is creating a new Dummy resource using GraphQL. The reason is that to create a new Dummy entity, it now needs the missing part of  `public $embeddedDummy;` in the payload.
This encourages me thinking this is not the best way to go.

```
001 Scenario: Create an item with a subresource                                     # features/graphql/mutation.feature:428
      And the JSON node "data.createDummy.dummy.id" should be equal to "/dummies/2" # features/graphql/mutation.feature:451
        Failed to evaluate expression 'data.createDummy.dummy.id' (Exception)

```

### Issue n°3: I didn't write tests for mongoDB, but tests are green.

Am I missing something here ? Also, I never used mongoDB, and I'm not even sure the bug affect this database.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
-->
