### PR TITLE
Correctly deserialize a collection with one element in XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.6.4
 
 * Serializer: Fix denormalization of basic property-types in XML and CSV (#3191)
+* Serializer: Fix denormalization of collection with one element in XML (#4154)
 * JSON Schema: Manage Sequentially and AtLeastOneOf constraints when generating property metadata (#4139 and #4147)
 * Doctrine: Fix purging HTTP cache for unreadable relations (#3441)
 * Doctrine: Revert #3774 support for binary UUID in search filter (#4134)

--- a/features/xml/deserialization.feature
+++ b/features/xml/deserialization.feature
@@ -74,3 +74,19 @@ Feature: XML Deserialization
     | NaN   |
     | INF   |
     | -INF  |
+
+  Scenario: Posting an XML resource with a collection with only one element
+    When I send a "POST" request to "/dummy_properties" with body:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <DummyProperty>
+      <groups>
+        <DummyGroup>
+          <foo>bar</foo>
+        </DummyGroup>
+      </groups>
+    </DummyProperty>
+    """
+    Then the response status code should be 201
+    And the response should be in XML
+    And the header "Content-Type" should be equal to "application/xml; charset=utf-8"

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -727,9 +727,18 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $value;
         }
 
+        $collectionValueType = method_exists(Type::class, 'getCollectionValueTypes') ? ($type->getCollectionValueTypes()[0] ?? null) : $type->getCollectionValueType();
+
+        /* From @see AbstractObjectNormalizer::validateAndDenormalize() */
+        // Fix a collection that contains the only one element
+        // This is special to xml format only
+        if ('xml' === $format && null !== $collectionValueType && (!\is_array($value) || !\is_int(key($value)))) {
+            $value = [$value];
+        }
+
         if (
             $type->isCollection() &&
-            null !== ($collectionValueType = method_exists(Type::class, 'getCollectionValueTypes') ? ($type->getCollectionValueTypes()[0] ?? null) : $type->getCollectionValueType()) &&
+            null !== $collectionValueType &&
             null !== ($className = $collectionValueType->getClassName()) &&
             $this->resourceClassResolver->isResourceClass($className)
         ) {
@@ -752,7 +761,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if (
             $type->isCollection() &&
-            null !== ($collectionValueType = method_exists(Type::class, 'getCollectionValueTypes') ? ($type->getCollectionValueTypes()[0] ?? null) : $type->getCollectionValueType()) &&
+            null !== $collectionValueType &&
             null !== ($className = $collectionValueType->getClassName())
         ) {
             if (!$this->serializer instanceof DenormalizerInterface) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR mirrors the Symfony equivalents:
- https://github.com/symfony/symfony/pull/27326
- https://github.com/symfony/symfony/pull/33733

It fixes the denormalization of XML collection with only one element.