### PR TITLE
Add support for generating property schema with Range restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* JSON Schema: Add support for generating property schema with Range restriction (#4158)
 * JSON Schema: Add support for generating property schema with Unique restriction (#4159)
 * **BC**: Change `api_platform.listener.request.add_format` priority from 7 to 28 to execute it before firewall (priority 8) (#3599)
 * **BC**: Use `@final` annotation in ORM filters (#4109)

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -26,6 +26,10 @@
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>
 
+        <service id="api_platform.metadata.property_schema.range_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRangeRestriction" public="false">
+            <tag name="api_platform.metadata.property_schema_restriction"/>
+        </service>
+
         <service id="api_platform.metadata.property_schema.regex_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRegexRestriction" public="false">
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>

--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Range;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+final class PropertySchemaRangeRestriction implements PropertySchemaRestrictionMetadataInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function create(Constraint $constraint, PropertyMetadata $propertyMetadata): array
+    {
+        $restriction = [];
+
+        if (isset($constraint->min) && is_numeric($constraint->min)) {
+            $restriction['minimum'] = $constraint->min;
+        }
+
+        if (isset($constraint->max) && is_numeric($constraint->max)) {
+            $restriction['maximum'] = $constraint->max;
+        }
+
+        return $restriction;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Constraint $constraint, PropertyMetadata $propertyMetadata): bool
+    {
+        return $constraint instanceof Range && null !== ($type = $propertyMetadata->getType()) && \in_array($type->getBuiltinType(), [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT], true);
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1337,6 +1337,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.property.metadata_factory.validator',
             'api_platform.metadata.property_schema.length_restriction',
             'api_platform.metadata.property_schema.one_of_restriction',
+            'api_platform.metadata.property_schema.range_restriction',
             'api_platform.metadata.property_schema.regex_restriction',
             'api_platform.metadata.property_schema.format_restriction',
             'api_platform.metadata.property_schema.unique_restriction',

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestrictionTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestrictionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRangeRestriction;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Range;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+final class PropertySchemaRangeRestrictionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $propertySchemaRangeRestriction;
+
+    protected function setUp(): void
+    {
+        $this->propertySchemaRangeRestriction = new PropertySchemaRangeRestriction();
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(Constraint $constraint, PropertyMetadata $propertyMetadata, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaRangeRestriction->supports($constraint, $propertyMetadata));
+    }
+
+    public function supportsProvider(): \Generator
+    {
+        yield 'supported int' => [new Range(['min' => 1, 'max' => 10]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), true];
+        yield 'supported float' => [new Range(['min' => 1, 'max' => 10]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), true];
+
+        yield 'not supported constraint' => [new Length(['min' => 1]), new PropertyMetadata(), false];
+        yield 'not supported type' => [new Range(['min' => 1]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), false];
+    }
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(Constraint $constraint, PropertyMetadata $propertyMetadata, array $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaRangeRestriction->create($constraint, $propertyMetadata));
+    }
+
+    public function createProvider(): \Generator
+    {
+        yield 'int min' => [new Range(['min' => 1]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), ['minimum' => 1]];
+        yield 'int max' => [new Range(['max' => 10]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), ['maximum' => 10]];
+
+        yield 'float min' => [new Range(['min' => 1.5]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), ['minimum' => 1.5]];
+        yield 'float max' => [new Range(['max' => 10.5]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), ['maximum' => 10.5]];
+    }
+}

--- a/tests/Fixtures/DummyRangeValidatedEntity.php
+++ b/tests/Fixtures/DummyRangeValidatedEntity.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummyRangeValidatedEntity
+{
+    /**
+     * @var int
+     *
+     * @Assert\Range(min=1)
+     */
+    public $dummyIntMin;
+
+    /**
+     * @var int
+     *
+     * @Assert\Range(max=10)
+     */
+    public $dummyIntMax;
+
+    /**
+     * @var int
+     *
+     * @Assert\Range(min=1, max=10)
+     */
+    public $dummyIntMinMax;
+
+    /**
+     * @var float
+     *
+     * @Assert\Range(min=1.5)
+     */
+    public $dummyFloatMin;
+
+    /**
+     * @var float
+     *
+     * @Assert\Range(max=10.5)
+     */
+    public $dummyFloatMax;
+
+    /**
+     * @var float
+     *
+     * @Assert\Range(min=1.5, max=10.5)
+     */
+    public $dummyFloatMinMax;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Add a `PropertySchemaRangeRestriction` to transform for integers and floats [Range](https://symfony.com/doc/current/reference/constraints/Range.html) validation constraint into `minimum`/`maximum` JSON Schema restriction.

