### PR TITLE
Add support for generating property schema with Choice restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* JSON Schema: Add support for generating property schema with Choice restriction (#4162)
 * JSON Schema: Add support for generating property schema with Range restriction (#4158)
 * JSON Schema: Add support for generating property schema with Unique restriction (#4159)
 * **BC**: Change `api_platform.listener.request.add_format` priority from 7 to 28 to execute it before firewall (priority 8) (#3599)

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -17,6 +17,10 @@
             <argument type="tagged" tag="api_platform.metadata.property_schema_restriction" />
         </service>
 
+        <service id="api_platform.metadata.property_schema.choice_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaChoiceRestriction" public="false">
+            <tag name="api_platform.metadata.property_schema_restriction"/>
+        </service>
+
         <service id="api_platform.metadata.property_schema.length_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaLengthRestriction" public="false">
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>

--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Choice;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+final class PropertySchemaChoiceRestriction implements PropertySchemaRestrictionMetadataInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param Choice $constraint
+     */
+    public function create(Constraint $constraint, PropertyMetadata $propertyMetadata): array
+    {
+        $choices = [];
+
+        if (\is_callable($choices = $constraint->callback)) {
+            $choices = $choices();
+        } elseif (\is_array($constraint->choices)) {
+            $choices = $constraint->choices;
+        }
+
+        if (!$choices) {
+            return [];
+        }
+
+        $restriction = [];
+
+        if (!$constraint->multiple) {
+            $restriction['enum'] = $choices;
+
+            return $restriction;
+        }
+
+        $restriction['type'] = 'array';
+        $restriction['items'] = ['type' => Type::BUILTIN_TYPE_STRING === $propertyMetadata->getType()->getBuiltinType() ? 'string' : 'number', 'enum' => $choices];
+
+        if (null !== $constraint->min) {
+            $restriction['minItems'] = $constraint->min;
+        }
+
+        if (null !== $constraint->max) {
+            $restriction['maxItems'] = $constraint->max;
+        }
+
+        return $restriction;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Constraint $constraint, PropertyMetadata $propertyMetadata): bool
+    {
+        return $constraint instanceof Choice && null !== ($type = $propertyMetadata->getType()) && \in_array($type->getBuiltinType(), [Type::BUILTIN_TYPE_STRING, Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT], true);
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1335,6 +1335,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.extractor.yaml',
             'api_platform.metadata.property.metadata_factory.annotation',
             'api_platform.metadata.property.metadata_factory.validator',
+            'api_platform.metadata.property_schema.choice_restriction',
             'api_platform.metadata.property_schema.length_restriction',
             'api_platform.metadata.property_schema.one_of_restriction',
             'api_platform.metadata.property_schema.range_restriction',

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestrictionTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestrictionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaChoiceRestriction;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Positive;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+final class PropertySchemaChoiceRestrictionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $propertySchemaChoiceRestriction;
+
+    protected function setUp(): void
+    {
+        $this->propertySchemaChoiceRestriction = new PropertySchemaChoiceRestriction();
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(Constraint $constraint, PropertyMetadata $propertyMetadata, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaChoiceRestriction->supports($constraint, $propertyMetadata));
+    }
+
+    public function supportsProvider(): \Generator
+    {
+        yield 'supported' => [new Choice(['choices' => ['a', 'b']]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), true];
+
+        yield 'not supported constraint' => [new Positive(), new PropertyMetadata(), false];
+        yield 'not supported type' => [new Choice(['choices' => [new \stdClass(), new \stdClass()]]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT)), false];
+    }
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(Constraint $constraint, PropertyMetadata $propertyMetadata, array $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaChoiceRestriction->create($constraint, $propertyMetadata));
+    }
+
+    public function createProvider(): \Generator
+    {
+        yield 'single string choice' => [new Choice(['choices' => ['a', 'b']]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), ['enum' => ['a', 'b']]];
+        yield 'multi string choice' => [new Choice(['choices' => ['a', 'b'], 'multiple' => true]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ['a', 'b']]]];
+        yield 'multi string choice min' => [new Choice(['choices' => ['a', 'b'], 'multiple' => true, 'min' => 2]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ['a', 'b']], 'minItems' => 2]];
+        yield 'multi string choice max' => [new Choice(['choices' => ['a', 'b', 'c', 'd'], 'multiple' => true, 'max' => 4]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ['a', 'b', 'c', 'd']], 'maxItems' => 4]];
+        yield 'multi string choice min/max' => [new Choice(['choices' => ['a', 'b', 'c', 'd'], 'multiple' => true, 'min' => 2, 'max' => 4]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ['a', 'b', 'c', 'd']], 'minItems' => 2, 'maxItems' => 4]];
+
+        yield 'single int choice' => [new Choice(['choices' => [1, 2]]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), ['enum' => [1, 2]]];
+        yield 'multi int choice' => [new Choice(['choices' => [1, 2], 'multiple' => true]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1, 2]]]];
+        yield 'multi int choice min' => [new Choice(['choices' => [1, 2], 'multiple' => true, 'min' => 2]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1, 2]], 'minItems' => 2]];
+        yield 'multi int choice max' => [new Choice(['choices' => [1, 2, 3, 4], 'multiple' => true, 'max' => 4]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1, 2, 3, 4]], 'maxItems' => 4]];
+        yield 'multi int choice min/max' => [new Choice(['choices' => [1, 2, 3, 4], 'multiple' => true, 'min' => 2, 'max' => 4]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1, 2, 3, 4]], 'minItems' => 2, 'maxItems' => 4]];
+
+        yield 'single float choice' => [new Choice(['choices' => [1.1, 2.2]]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), ['enum' => [1.1, 2.2]]];
+        yield 'multi float choice' => [new Choice(['choices' => [1.1, 2.2], 'multiple' => true]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1.1, 2.2]]]];
+        yield 'multi float choice min' => [new Choice(['choices' => [1.1, 2.2], 'multiple' => true, 'min' => 2]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1.1, 2.2]], 'minItems' => 2]];
+        yield 'multi float choice max' => [new Choice(['choices' => [1.1, 2.2, 3.3, 4.4], 'multiple' => true, 'max' => 4]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1.1, 2.2, 3.3, 4.4]], 'maxItems' => 4]];
+        yield 'multi float choice min/max' => [new Choice(['choices' => [1.1, 2.2, 3.3, 4.4], 'multiple' => true, 'min' => 2, 'max' => 4]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_FLOAT)), ['type' => 'array', 'items' => ['type' => 'number', 'enum' => [1.1, 2.2, 3.3, 4.4]], 'minItems' => 2, 'maxItems' => 4]];
+
+        yield 'single choice callback' => [new Choice(['callback' => [ChoiceCallback::class, 'getChoices']]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), ['enum' => ['a', 'b', 'c', 'd']]];
+        yield 'multi choice callback' => [new Choice(['callback' => [ChoiceCallback::class, 'getChoices'], 'multiple' => true]), new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING)), ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ['a', 'b', 'c', 'd']]]];
+    }
+}
+
+final class ChoiceCallback
+{
+    public static function getChoices(): array
+    {
+        return ['a', 'b', 'c', 'd'];
+    }
+}

--- a/tests/Fixtures/DummyValidatedChoiceEntity.php
+++ b/tests/Fixtures/DummyValidatedChoiceEntity.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummyValidatedChoiceEntity
+{
+    /**
+     * @var string
+     *
+     * @Assert\Choice(choices={"a", "b"})
+     */
+    public $dummySingleChoice;
+
+    /**
+     * @var string
+     *
+     * @Assert\Choice(callback={DummyValidatedChoiceEntity::class, "getChoices"})
+     */
+    public $dummySingleChoiceCallback;
+
+    /**
+     * @var string[]
+     *
+     * @Assert\Choice(choices={"a", "b"}, multiple=true)
+     */
+    public $dummyMultiChoice;
+
+    /**
+     * @var string[]
+     *
+     * @Assert\Choice(callback={DummyValidatedChoiceEntity::class, "getChoices"}, multiple=true)
+     */
+    public $dummyMultiChoiceCallback;
+
+    /**
+     * @var string[]
+     *
+     * @Assert\Choice(choices={"a", "b", "c", "d"}, multiple=true, min=2)
+     */
+    public $dummyMultiChoiceMin;
+
+    /**
+     * @var string[]
+     *
+     * @Assert\Choice(choices={"a", "b", "c", "d"}, multiple=true, max=4)
+     */
+    public $dummyMultiChoiceMax;
+
+    /**
+     * @var string[]
+     *
+     * @Assert\Choice(choices={"a", "b", "c", "d"}, multiple=true, min=2, max=4)
+     */
+    public $dummyMultiChoiceMinMax;
+
+    public static function getChoices(): array
+    {
+        return ['a', 'b', 'c', 'd'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Add a `PropertySchemaChoiceRestriction` to transform [Choice](https://symfony.com/doc/current/reference/constraints/Choice.html) validation constraint into these schemas:

`@Assert\Choice(choices={"choice1", "choice2"})`
```json
{
  "enum": ["choice1", "choice2"]
}
```
`@Assert\Choice(choices={"choice1", "choice2"}, multiple=true)`
```json
{
  "type": "array",
  "items": { "enum": ["choice1", "choice2"] }
}
```

`@Assert\Choice(choices={"choice1", "choice2", "choice3", "choice4"}, multiple=true, min=2, max=4)`
```json
{
  "type": "array",
  "items": { "enum": ["choice1", "choice2", "choice3", "choice4"] },
  "minItems": 2,
  "maxItems": 4
}
```

