### PR TITLE
Add an option to disable query parameter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* Validator: Add an option to disable query parameter validation (#4165)
 * JSON Schema: Add support for generating property schema with Choice restriction (#4162)
 * JSON Schema: Add support for generating property schema with Range restriction (#4158)
 * JSON Schema: Add support for generating property schema with Unique restriction (#4159)

--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -71,6 +71,7 @@ use ApiPlatform\Core\Exception\InvalidArgumentException;
  *     @Attribute("urlGenerationStrategy", type="int"),
  *     @Attribute("validationGroups", type="mixed"),
  *     @Attribute("exceptionToStatus", type="array"),
+ *     @Attribute("queryParameterValidationEnabled", type="bool")
  * )
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
@@ -132,46 +133,47 @@ final class ApiResource
 
     /**
      * @param string       $description
-     * @param array        $collectionOperations           https://api-platform.com/docs/core/operations
-     * @param array        $graphql                        https://api-platform.com/docs/core/graphql
-     * @param array        $itemOperations                 https://api-platform.com/docs/core/operations
-     * @param array        $subresourceOperations          https://api-platform.com/docs/core/subresources
-     * @param array        $cacheHeaders                   https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers
-     * @param array        $denormalizationContext         https://api-platform.com/docs/core/serialization/#using-serialization-groups
-     * @param string       $deprecationReason              https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
-     * @param bool         $elasticsearch                  https://api-platform.com/docs/core/elasticsearch/
-     * @param bool         $fetchPartial                   https://api-platform.com/docs/core/performance/#fetch-partial
-     * @param bool         $forceEager                     https://api-platform.com/docs/core/performance/#force-eager
-     * @param array        $formats                        https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
-     * @param string[]     $filters                        https://api-platform.com/docs/core/filters/#doctrine-orm-and-mongodb-odm-filters
-     * @param string[]     $hydraContext                   https://api-platform.com/docs/core/extending-jsonld-context/#hydra
-     * @param string|false $input                          https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
-     * @param bool|array   $mercure                        https://api-platform.com/docs/core/mercure
-     * @param bool         $messenger                      https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
-     * @param array        $normalizationContext           https://api-platform.com/docs/core/serialization/#using-serialization-groups
-     * @param array        $openapiContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
-     * @param array        $order                          https://api-platform.com/docs/core/default-order/#overriding-default-order
-     * @param string|false $output                         https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
-     * @param bool         $paginationClientEnabled        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
-     * @param bool         $paginationClientItemsPerPage   https://api-platform.com/docs/core/pagination/#for-a-specific-resource-3
-     * @param bool         $paginationClientPartial        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-6
-     * @param array        $paginationViaCursor            https://api-platform.com/docs/core/pagination/#cursor-based-pagination
-     * @param bool         $paginationEnabled              https://api-platform.com/docs/core/pagination/#for-a-specific-resource
-     * @param bool         $paginationFetchJoinCollection  https://api-platform.com/docs/core/pagination/#controlling-the-behavior-of-the-doctrine-orm-paginator
-     * @param int          $paginationItemsPerPage         https://api-platform.com/docs/core/pagination/#changing-the-number-of-items-per-page
-     * @param int          $paginationMaximumItemsPerPage  https://api-platform.com/docs/core/pagination/#changing-maximum-items-per-page
-     * @param bool         $paginationPartial              https://api-platform.com/docs/core/performance/#partial-pagination
-     * @param string       $routePrefix                    https://api-platform.com/docs/core/operations/#prefixing-all-routes-of-all-operations
-     * @param string       $security                       https://api-platform.com/docs/core/security
-     * @param string       $securityMessage                https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
-     * @param string       $securityPostDenormalize        https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
-     * @param string       $securityPostDenormalizeMessage https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
+     * @param array        $collectionOperations            https://api-platform.com/docs/core/operations
+     * @param array        $graphql                         https://api-platform.com/docs/core/graphql
+     * @param array        $itemOperations                  https://api-platform.com/docs/core/operations
+     * @param array        $subresourceOperations           https://api-platform.com/docs/core/subresources
+     * @param array        $cacheHeaders                    https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers
+     * @param array        $denormalizationContext          https://api-platform.com/docs/core/serialization/#using-serialization-groups
+     * @param string       $deprecationReason               https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
+     * @param bool         $elasticsearch                   https://api-platform.com/docs/core/elasticsearch/
+     * @param bool         $fetchPartial                    https://api-platform.com/docs/core/performance/#fetch-partial
+     * @param bool         $forceEager                      https://api-platform.com/docs/core/performance/#force-eager
+     * @param array        $formats                         https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
+     * @param string[]     $filters                         https://api-platform.com/docs/core/filters/#doctrine-orm-and-mongodb-odm-filters
+     * @param string[]     $hydraContext                    https://api-platform.com/docs/core/extending-jsonld-context/#hydra
+     * @param string|false $input                           https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
+     * @param bool|array   $mercure                         https://api-platform.com/docs/core/mercure
+     * @param bool         $messenger                       https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
+     * @param array        $normalizationContext            https://api-platform.com/docs/core/serialization/#using-serialization-groups
+     * @param array        $openapiContext                  https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param array        $order                           https://api-platform.com/docs/core/default-order/#overriding-default-order
+     * @param string|false $output                          https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
+     * @param bool         $paginationClientEnabled         https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
+     * @param bool         $paginationClientItemsPerPage    https://api-platform.com/docs/core/pagination/#for-a-specific-resource-3
+     * @param bool         $paginationClientPartial         https://api-platform.com/docs/core/pagination/#for-a-specific-resource-6
+     * @param array        $paginationViaCursor             https://api-platform.com/docs/core/pagination/#cursor-based-pagination
+     * @param bool         $paginationEnabled               https://api-platform.com/docs/core/pagination/#for-a-specific-resource
+     * @param bool         $paginationFetchJoinCollection   https://api-platform.com/docs/core/pagination/#controlling-the-behavior-of-the-doctrine-orm-paginator
+     * @param int          $paginationItemsPerPage          https://api-platform.com/docs/core/pagination/#changing-the-number-of-items-per-page
+     * @param int          $paginationMaximumItemsPerPage   https://api-platform.com/docs/core/pagination/#changing-maximum-items-per-page
+     * @param bool         $paginationPartial               https://api-platform.com/docs/core/performance/#partial-pagination
+     * @param string       $routePrefix                     https://api-platform.com/docs/core/operations/#prefixing-all-routes-of-all-operations
+     * @param string       $security                        https://api-platform.com/docs/core/security
+     * @param string       $securityMessage                 https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
+     * @param string       $securityPostDenormalize         https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
+     * @param string       $securityPostDenormalizeMessage  https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
      * @param bool         $stateless
-     * @param string       $sunset                         https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
-     * @param array        $swaggerContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
-     * @param array        $validationGroups               https://api-platform.com/docs/core/validation/#using-validation-groups
+     * @param string       $sunset                          https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
+     * @param array        $swaggerContext                  https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param array        $validationGroups                https://api-platform.com/docs/core/validation/#using-validation-groups
      * @param int          $urlGenerationStrategy
-     * @param array        $exceptionToStatus              https://api-platform.com/docs/core/errors/#fine-grained-configuration
+     * @param array        $exceptionToStatus               https://api-platform.com/docs/core/errors/#fine-grained-configuration
+     * @param bool         $queryParameterValidationEnabled
      *
      * @throws InvalidArgumentException
      */
@@ -222,7 +224,8 @@ final class ApiResource
         ?array $validationGroups = null,
         ?int $urlGenerationStrategy = null,
         ?bool $compositeIdentifier = null,
-        ?array $exceptionToStatus = null
+        ?array $exceptionToStatus = null,
+        ?bool $queryParameterValidationEnabled = null
     ) {
         if (!\is_array($description)) { // @phpstan-ignore-line Doctrine annotations support
             [$publicProperties, $configurableAttributes] = self::getConfigMetadata();

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -624,6 +624,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $container->setParameter('api_platform.validator.serialize_payload_fields', $config['validator']['serialize_payload_fields']);
+        $container->setParameter('api_platform.validator.query_parameter_validation', $config['validator']['query_parameter_validation']);
+
+        if (!$config['validator']['query_parameter_validation']) {
+            $container->removeDefinition('api_platform.listener.view.validate_query_parameters');
+            $container->removeDefinition('api_platform.validator.query_parameter_validator');
+        }
     }
 
     private function registerDataCollectorConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -100,6 +100,7 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->variableNode('serialize_payload_fields')->defaultValue([])->info('Set to null to serialize all payload fields when a validation error is thrown, or set the fields you want to include explicitly.')->end()
+                        ->booleanNode('query_parameter_validation')->defaultValue(true)->end()
                     ->end()
                 ->end()
                 ->arrayNode('eager_loading')

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -60,6 +60,7 @@
         <service id="api_platform.listener.view.validate_query_parameters" class="ApiPlatform\Core\EventListener\QueryParameterValidateListener" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.validator.query_parameter_validator" />
+            <argument>%api_platform.validator.query_parameter_validation%</argument>
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="16" />
         </service>

--- a/tests/Annotation/ApiResourceTest.php
+++ b/tests/Annotation/ApiResourceTest.php
@@ -66,6 +66,7 @@ class ApiResourceTest extends TestCase
             'validationGroups' => ['foo', 'bar'],
             'sunset' => 'Thu, 11 Oct 2018 00:00:00 +0200',
             'urlGenerationStrategy' => UrlGeneratorInterface::ABS_PATH,
+            'queryParameterValidationEnabled' => false,
         ]);
 
         $this->assertSame('shortName', $resource->shortName);
@@ -107,6 +108,7 @@ class ApiResourceTest extends TestCase
             'cache_headers' => ['max_age' => 0, 'shared_max_age' => 0, 'vary' => ['Custom-Vary-1', 'Custom-Vary-2']],
             'sunset' => 'Thu, 11 Oct 2018 00:00:00 +0200',
             'url_generation_strategy' => 1,
+            'query_parameter_validation_enabled' => false,
         ], $resource->attributes);
     }
 
@@ -162,6 +164,7 @@ return new \ApiPlatform\Core\Annotation\ApiResource(
     exceptionToStatus: [
         \DomainException::class => 400,
     ],
+    queryParameterValidationEnabled: false,
 );
 PHP
         );
@@ -214,6 +217,7 @@ PHP
             'exception_to_status' => [
                 \DomainException::class => 400,
             ],
+            'query_parameter_validation_enabled' => false,
         ], $resource->attributes);
     }
 

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1227,6 +1227,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.graphql.graphql_playground.enabled' => true,
             'api_platform.resource_class_directories' => Argument::type('array'),
             'api_platform.validator.serialize_payload_fields' => [],
+            'api_platform.validator.query_parameter_validation' => true,
             'api_platform.elasticsearch.enabled' => false,
             'api_platform.asset_package' => null,
             'api_platform.defaults' => ['attributes' => []],

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -105,6 +105,7 @@ class ConfigurationTest extends TestCase
             'path_segment_name_generator' => 'api_platform.path_segment_name_generator.underscore',
             'validator' => [
                 'serialize_payload_fields' => [],
+                'query_parameter_validation' => true,
             ],
             'name_converter' => null,
             'enable_fos_user' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/1329

Query parameter validation can be costly if you are not using any required filters, so we should have an option to disable it.
If you think that this is a good addition, I'll add some tests.