### PR TITLE
Make sure the order of nested order filters is preserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Swagger UI: Remove Google fonts (#4112)
 * Doctrine: Revert #3774 support for binary UUID in search filter (#4134) 
 * Do not override Vary headers already set in the Response 
+* GraphQL: Make sure the order of order filters is preserved if nested resources are used
 
 ## 2.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Swagger UI: Remove Google fonts (#4112)
 * Doctrine: Revert #3774 support for binary UUID in search filter (#4134) 
 * Do not override Vary headers already set in the Response 
-* GraphQL: Make sure the order of order filters is preserved if nested resources are used
+* GraphQL: Make sure the order of order filters is preserved if nested resources are used (#4171)
 
 ## 2.6.3
 

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -161,7 +161,7 @@ final class ReadStage implements ReadStageInterface
                 $filters =
                     \array_slice($filters, 0, $index + 1) +
                     [str_replace($this->nestingSeparator, '.', $name) => $value] +
-                    \array_slice($filters, $index);
+                    \array_slice($filters, $index + 1);
             }
         }
 

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -157,7 +157,11 @@ final class ReadStage implements ReadStageInterface
 
             if (\is_string($name) && strpos($name, $this->nestingSeparator)) {
                 // Gives a chance to relations/nested fields.
-                $filters[str_replace($this->nestingSeparator, '.', $name)] = $value;
+                $index = array_search($name, array_keys($filters), true);
+                $filters =
+                    \array_slice($filters, 0, $index + 1) +
+                    [str_replace($this->nestingSeparator, '.', $name) => $value] +
+                    \array_slice($filters, $index);
             }
         }
 

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -222,7 +222,7 @@ class ReadStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testPreserveOrderOfOrderFitlersIfNested(): void
+    public function testPreserveOrderOfOrderFiltersIfNested(): void
     {
         $operationName = 'collection_query';
         $resourceClass = 'myResource';

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -222,11 +222,7 @@ class ReadStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    /**
-     * Test a regression where the order in which order fitlers were applied
-     * was wrong when the data had been ordered by a nested field.
-     */
-    public function testPreserveOrderOfOrderFitlersIfNested()
+    public function testPreserveOrderOfOrderFitlersIfNested(): void
     {
         $operationName = 'collection_query';
         $resourceClass = 'myResource';

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -25,6 +25,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use GraphQL\Type\Definition\ResolveInfo;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -219,6 +220,45 @@ class ReadStageTest extends TestCase
         $result = ($this->readStage)($resourceClass, $rootClass, $operationName, $context);
 
         $this->assertSame($expectedResult, $result);
+    }
+
+    /**
+     * Test a regression where the order in which order fitlers were applied
+     * was wrong when the data had been ordered by a nested field.
+     */
+    public function testPreserveOrderOfOrderFitlersIfNested()
+    {
+        $operationName = 'collection_query';
+        $resourceClass = 'myResource';
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $fieldName = 'subresource';
+        $info->fieldName = $fieldName;
+        $context = [
+            'is_collection' => true,
+            'is_mutation' => false,
+            'is_subscription' => false,
+            'args' => [
+                'order' => [
+                    'some_field' => 'ASC',
+                    'localField' => 'ASC',
+                ],
+            ],
+            'info' => $info,
+            'source' => null,
+        ];
+        $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadata());
+
+        $normalizationContext = ['normalization' => true];
+        $this->serializerContextBuilderProphecy->create($resourceClass, $operationName, $context, true)->shouldBeCalled()->willReturn($normalizationContext);
+
+        ($this->readStage)($resourceClass, $resourceClass, $operationName, $context);
+
+        $this->collectionDataProviderProphecy->getCollection($resourceClass, $operationName, Argument::that(function ($args) {
+            // Prophecy does not check the order of items in associative arrays. Checking if some.field comes first manually
+            return
+            array_search('some.field', array_keys($args['filters']['order']), true) <
+            array_search('localField', array_keys($args['filters']['order']), true);
+        }))->shouldHaveBeenCalled();
     }
 
     public function collectionProvider(): array


### PR DESCRIPTION
Order filters are being written with underscores in GraphQL but are sent along with dots to access nested entities.

The previous solution appended the dot version to the order array. This leads to an issue where every order filter that accesses a nested property will always be added to the query after local properties.

Looking at the test case: The first order that WAS applied was `localField`. It should have been `some.field` which is now the case.

| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       |  I did not create any
| License       | MIT
| Doc PR        | - 
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
-->
