### PR TITLE
Do not overwrite variable with unknown value

### DIFF
--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
@@ -32,8 +32,8 @@ final class PropertySchemaChoiceRestriction implements PropertySchemaRestriction
     {
         $choices = [];
 
-        if (\is_callable($choices = $constraint->callback)) {
-            $choices = $choices();
+        if (\is_callable($constraint->callback)) {
+            $choices = ($constraint->callback)();
         } elseif (\is_array($constraint->choices)) {
             $choices = $constraint->choices;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #4162
| License       | MIT
| Doc PR        | 

PhpStorm was complaining on line 33:
> Unused local variable 'choices'. The value of the variable is overwritten immediately.

Also if you think about it, in the case of e.g. `@Assert\Choice(callback={"App\Entity\Foo", "getBats"})`, i.e.
- `$constraint->callback === ['App\Entity\Foo', 'getBats']` (_note: typo_, intended `'getBars'`)
- `$constraint->choices === null`
- `$constraint->multiple === false`

we would end up with an incorrect `"enum": ["App\\Entity\\Foo", "getBats"]`