### PR TITLE
Handle Compound validator constraints when generating property metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* JSON Schema: Manage Compound constraint when generating property metadata (#4180)
 * Validator: Add an option to disable query parameter validation (#4165)
 * JSON Schema: Add support for generating property schema with Choice restriction (#4162)
 * JSON Schema: Add support for generating property schema with Range restriction (#4158)

--- a/src/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
@@ -19,6 +19,7 @@ use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Bic;
 use Symfony\Component\Validator\Constraints\CardScheme;
+use Symfony\Component\Validator\Constraints\Compound;
 use Symfony\Component\Validator\Constraints\Currency;
 use Symfony\Component\Validator\Constraints\Date;
 use Symfony\Component\Validator\Constraints\DateTime;
@@ -171,7 +172,7 @@ final class ValidatorPropertyMetadataFactory implements PropertyMetadataFactoryI
             }
 
             foreach ($validatorPropertyMetadata->findConstraints($validationGroup) as $propertyConstraint) {
-                if ($propertyConstraint instanceof Sequentially) {
+                if ($propertyConstraint instanceof Sequentially || $propertyConstraint instanceof Compound) {
                     $constraints[] = $propertyConstraint->getNestedContraints();
                 } else {
                     $constraints[] = [$propertyConstraint];

--- a/tests/Fixtures/DummyCompoundValidatedEntity.php
+++ b/tests/Fixtures/DummyCompoundValidatedEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Validator\Constraint\DummyCompoundRequirements;
+
+class DummyCompoundValidatedEntity
+{
+    /**
+     * @var string
+     *
+     * @DummyCompoundRequirements
+     */
+    public $dummy;
+}

--- a/tests/Fixtures/TestBundle/Validator/Constraint/DummyCompoundRequirements.php
+++ b/tests/Fixtures/TestBundle/Validator/Constraint/DummyCompoundRequirements.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraints\Compound;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
+
+/**
+ * @Annotation
+ */
+final class DummyCompoundRequirements extends Compound
+{
+    public function getConstraints(array $options): array
+    {
+        return [
+            new Length(['min' => 1, 'max' => 32]),
+            new Regex(['pattern' => '/^[a-z]$/']),
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In #4139 I have missed that there is a new [Compound](https://symfony.com/doc/current/reference/constraints/Compound.html) constraint which helps to create reusable validations.

This adds support for Compound constraint, but only when used at the top level without nesting.

I think this factory should be refactored later to properly handle constraint nesting.