### PR TITLE
Add support for generating property schema with Collection restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* JSON Schema: Add support for generating property schema with Collection restriction (#4182)
 * JSON Schema: Add support for generating property schema format for Url and Hostname (#4185)
 * JSON Schema: Add support for generating property schema with Count restriction (#4186)
 * JSON Schema: Manage Compound constraint when generating property metadata (#4180)

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -21,6 +21,11 @@
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>
 
+        <service id="api_platform.metadata.property_schema.collection_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaCollectionRestriction" public="false">
+            <argument type="tagged" tag="api_platform.metadata.property_schema_restriction" />
+            <tag name="api_platform.metadata.property_schema_restriction"/>
+        </service>
+
         <service id="api_platform.metadata.property_schema.count_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaCountRestriction" public="false">
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>

--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
@@ -18,7 +18,6 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
-use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * @author Tomas Norkūnas <norkunas.tom@gmail.com>
@@ -81,16 +80,10 @@ final class PropertySchemaCollectionRestriction implements PropertySchemaRestric
      */
     private function mergeConstraintRestrictions(Constraint $constraint, PropertyMetadata $propertyMetadata): array
     {
-        $propertyRestrictions = [['type' => 'string']];
+        $propertyRestrictions = [];
         $nestedConstraints = method_exists($constraint, 'getNestedContraints') ? $constraint->getNestedContraints() : $constraint->constraints;
 
         foreach ($nestedConstraints as $nestedConstraint) {
-            if ($nestedConstraint instanceof Type) {
-                /** @var string $nestedType */
-                $nestedType = $nestedConstraint->type;
-                $propertyRestrictions[0]['type'] = $this->getConstraintType($nestedType);
-            }
-
             foreach ($this->restrictionsMetadata as $restrictionMetadata) {
                 if ($restrictionMetadata->supports($nestedConstraint, $propertyMetadata) && !empty($nestedConstraintRestriction = $restrictionMetadata->create($nestedConstraint, $propertyMetadata))) {
                     $propertyRestrictions[] = $nestedConstraintRestriction;
@@ -99,30 +92,5 @@ final class PropertySchemaCollectionRestriction implements PropertySchemaRestric
         }
 
         return array_merge([], ...$propertyRestrictions);
-    }
-
-    private function getConstraintType(string $type): string
-    {
-        if (\in_array($type, ['bool', 'boolean'], true)) {
-            return 'boolean';
-        }
-
-        if (\in_array($type, ['int', 'integer', 'long'], true)) {
-            return 'integer';
-        }
-
-        if (\in_array($type, ['float', 'double', 'real', 'numeric'], true)) {
-            return 'number';
-        }
-
-        if (\in_array($type, ['array', 'iterable'], true)) {
-            return 'array';
-        }
-
-        if ('object' === $type) {
-            return 'object';
-        }
-
-        return 'string';
     }
 }

--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\Optional;
+use Symfony\Component\Validator\Constraints\Required;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+final class PropertySchemaCollectionRestriction implements PropertySchemaRestrictionMetadataInterface
+{
+    /**
+     * @var iterable<PropertySchemaRestrictionMetadataInterface>
+     */
+    private $restrictionsMetadata;
+
+    /**
+     * @param iterable<PropertySchemaRestrictionMetadataInterface> $restrictionsMetadata
+     */
+    public function __construct(iterable $restrictionsMetadata = [])
+    {
+        $this->restrictionsMetadata = $restrictionsMetadata;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Collection $constraint
+     */
+    public function create(Constraint $constraint, PropertyMetadata $propertyMetadata): array
+    {
+        $restriction = [
+            'type' => 'object',
+            'properties' => [],
+            'additionalProperties' => $constraint->allowExtraFields,
+        ];
+        $required = [];
+
+        foreach ($constraint->fields as $field => $baseConstraint) {
+            /** @var Required|Optional $baseConstraint */
+            if ($baseConstraint instanceof Required) {
+                $required[] = $field;
+            }
+
+            $restriction['properties'][$field] = $this->mergeConstraintRestrictions($baseConstraint, $propertyMetadata);
+        }
+
+        if ($required) {
+            $restriction['required'] = $required;
+        }
+
+        return $restriction;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Constraint $constraint, PropertyMetadata $propertyMetadata): bool
+    {
+        return $constraint instanceof Collection;
+    }
+
+    /**
+     * @param Required|Optional $constraint
+     */
+    private function mergeConstraintRestrictions(Constraint $constraint, PropertyMetadata $propertyMetadata): array
+    {
+        $propertyRestrictions = [['type' => 'string']];
+        $nestedConstraints = method_exists($constraint, 'getNestedContraints') ? $constraint->getNestedContraints() : $constraint->constraints;
+
+        foreach ($nestedConstraints as $nestedConstraint) {
+            if ($nestedConstraint instanceof Type) {
+                /** @var string $nestedType */
+                $nestedType = $nestedConstraint->type;
+                $propertyRestrictions[0]['type'] = $this->getConstraintType($nestedType);
+            }
+
+            foreach ($this->restrictionsMetadata as $restrictionMetadata) {
+                if ($restrictionMetadata->supports($nestedConstraint, $propertyMetadata) && !empty($nestedConstraintRestriction = $restrictionMetadata->create($nestedConstraint, $propertyMetadata))) {
+                    $propertyRestrictions[] = $nestedConstraintRestriction;
+                }
+            }
+        }
+
+        return array_merge([], ...$propertyRestrictions);
+    }
+
+    private function getConstraintType(string $type): string
+    {
+        if (\in_array($type, ['bool', 'boolean'], true)) {
+            return 'boolean';
+        }
+
+        if (\in_array($type, ['int', 'integer', 'long'], true)) {
+            return 'integer';
+        }
+
+        if (\in_array($type, ['float', 'double', 'real', 'numeric'], true)) {
+            return 'number';
+        }
+
+        if (\in_array($type, ['array', 'iterable'], true)) {
+            return 'array';
+        }
+
+        if ('object' === $type) {
+            return 'object';
+        }
+
+        return 'string';
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1358,6 +1358,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.property.metadata_factory.annotation',
             'api_platform.metadata.property.metadata_factory.validator',
             'api_platform.metadata.property_schema.choice_restriction',
+            'api_platform.metadata.property_schema.collection_restriction',
             'api_platform.metadata.property_schema.count_restriction',
             'api_platform.metadata.property_schema.length_restriction',
             'api_platform.metadata.property_schema.one_of_restriction',

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
@@ -107,11 +107,11 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
             [
                 'type' => 'object',
                 'properties' => [
-                    'name' => ['type' => 'string'],
-                    'email' => ['type' => 'string', 'format' => 'email'],
-                    'phone' => ['type' => 'string', 'pattern' => '[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*'],
-                    'age' => ['type' => 'integer'],
-                    'social' => ['type' => 'object', 'properties' => ['githubUsername' => ['type' => 'string']], 'additionalProperties' => false, 'required' => ['githubUsername']],
+                    'name' => [],
+                    'email' => ['format' => 'email'],
+                    'phone' => ['pattern' => '^(?:[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
+                    'age' => [],
+                    'social' => ['type' => 'object', 'properties' => ['githubUsername' => []], 'additionalProperties' => false, 'required' => ['githubUsername']],
                 ],
                 'additionalProperties' => true,
                 'required' => ['name', 'email', 'social'],

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaCollectionRestriction;
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaFormat;
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaLengthRestriction;
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRegexRestriction;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Optional;
+use Symfony\Component\Validator\Constraints\Positive;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Required;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+final class PropertySchemaCollectionRestrictionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $propertySchemaCollectionRestriction;
+
+    protected function setUp(): void
+    {
+        $this->propertySchemaCollectionRestriction = new PropertySchemaCollectionRestriction([
+            new PropertySchemaLengthRestriction(),
+            new PropertySchemaRegexRestriction(),
+            new PropertySchemaFormat(),
+            new PropertySchemaCollectionRestriction(),
+        ]);
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(Constraint $constraint, PropertyMetadata $propertyMetadata, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaCollectionRestriction->supports($constraint, $propertyMetadata));
+    }
+
+    public function supportsProvider(): \Generator
+    {
+        yield 'supported' => [new Collection(['fields' => []]), new PropertyMetadata(), true];
+
+        yield 'not supported' => [new Positive(), new PropertyMetadata(), false];
+    }
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(Constraint $constraint, PropertyMetadata $propertyMetadata, array $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaCollectionRestriction->create($constraint, $propertyMetadata));
+    }
+
+    public function createProvider(): \Generator
+    {
+        yield 'empty' => [new Collection(['fields' => []]), new PropertyMetadata(), ['type' => 'object', 'properties' => [], 'additionalProperties' => false]];
+
+        yield 'with fields' => [
+            new Collection([
+                'allowExtraFields' => true,
+                'fields' => [
+                    'name' => new Required([
+                        new NotBlank(),
+                    ]),
+                    'email' => [
+                        new NotNull(),
+                        new Length(['min' => 2, 'max' => 255]),
+                        new Email(['mode' => Email::VALIDATION_MODE_LOOSE]),
+                    ],
+                    'phone' => new Optional([
+                        new \Symfony\Component\Validator\Constraints\Type(['type' => 'string']),
+                        new Regex(['pattern' => '/^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\.\/0-9]*$/']),
+                    ]),
+                    'age' => new Optional([
+                        new \Symfony\Component\Validator\Constraints\Type(['type' => 'int']),
+                    ]),
+                    'social' => new Collection([
+                        'fields' => [
+                            'githubUsername' => new NotNull(),
+                        ],
+                    ]),
+                ],
+            ]),
+            new PropertyMetadata(),
+            [
+                'type' => 'object',
+                'properties' => [
+                    'name' => ['type' => 'string'],
+                    'email' => ['type' => 'string', 'format' => 'email'],
+                    'phone' => ['type' => 'string', 'pattern' => '[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*'],
+                    'age' => ['type' => 'integer'],
+                    'social' => ['type' => 'object', 'properties' => ['githubUsername' => ['type' => 'string']], 'additionalProperties' => false, 'required' => ['githubUsername']],
+                ],
+                'additionalProperties' => true,
+                'required' => ['name', 'email', 'social'],
+            ],
+        ];
+    }
+}

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -629,14 +629,14 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertSame([
             'type' => 'object',
             'properties' => [
-                'name' => ['type' => 'string'],
-                'email' => ['type' => 'string', 'format' => 'email'],
-                'phone' => ['type' => 'string', 'pattern' => '[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*'],
-                'age' => ['type' => 'integer'],
+                'name' => [],
+                'email' => ['format' => 'email'],
+                'phone' => ['pattern' => '^(?:[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
+                'age' => [],
                 'social' => [
                     'type' => 'object',
                     'properties' => [
-                        'githubUsername' => ['type' => 'string'],
+                        'githubUsername' => [],
                     ],
                     'additionalProperties' => false,
                     'required' => ['githubUsername'],

--- a/tests/Fixtures/DummyCollectionValidatedEntity.php
+++ b/tests/Fixtures/DummyCollectionValidatedEntity.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummyCollectionValidatedEntity
+{
+    /**
+     * @var array
+     *
+     * @Assert\Collection(
+     *     allowExtraFields=true,
+     *     fields={
+     *         "name"=@Assert\Required({
+     *             @Assert\NotBlank
+     *         }),
+     *         "email"={
+     *             @Assert\NotNull,
+     *             @Assert\Length(min=2, max=255),
+     *             @Assert\Email(mode=Assert\Email::VALIDATION_MODE_LOOSE)
+     *         },
+     *         "phone"=@Assert\Optional({
+     *             @Assert\Type(type="string"),
+     *             @Assert\Regex(pattern="/^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\.\/0-9]*$/")
+     *         }),
+     *         "age"=@Assert\Optional({
+     *             @Assert\Type(type="int")
+     *         }),
+     *         "social"=@Assert\Collection(
+     *             fields={
+     *                 "githubUsername"=@Assert\NotNull
+     *             }
+     *         )
+     *     }
+     * )
+     */
+    public $dummyData;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Add a `PropertySchemaCollectionRestriction` to transform [Collection](https://symfony.com/doc/current/reference/constraints/Collection.html) validation constraint into json schema.