### PR TITLE
Add support for generating property schema format for Url and Hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* JSON Schema: Add support for generating property schema format for Url and Hostname (#4185)
 * JSON Schema: Add support for generating property schema with Count restriction (#4186)
 * JSON Schema: Manage Compound constraint when generating property metadata (#4180)
 * Validator: Add an option to disable query parameter validation (#4165)

--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormat.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormat.php
@@ -16,8 +16,10 @@ namespace ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restrictio
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Hostname;
 use Symfony\Component\Validator\Constraints\Ip;
 use Symfony\Component\Validator\Constraints\Ulid;
+use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Constraints\Uuid;
 
 /**
@@ -34,6 +36,14 @@ class PropertySchemaFormat implements PropertySchemaRestrictionMetadataInterface
     {
         if ($constraint instanceof Email) {
             return ['format' => 'email'];
+        }
+
+        if ($constraint instanceof Url) {
+            return ['format' => 'uri'];
+        }
+
+        if ($constraint instanceof Hostname) {
+            return ['format' => 'hostname'];
         }
 
         if ($constraint instanceof Uuid) {
@@ -62,6 +72,6 @@ class PropertySchemaFormat implements PropertySchemaRestrictionMetadataInterface
     {
         $schema = $propertyMetadata->getSchema();
 
-        return empty($schema['format']) && ($constraint instanceof Email || $constraint instanceof Uuid || $constraint instanceof Ulid || $constraint instanceof Ip);
+        return empty($schema['format']) && ($constraint instanceof Email || $constraint instanceof Url || $constraint instanceof Hostname || $constraint instanceof Uuid || $constraint instanceof Ulid || $constraint instanceof Ip);
     }
 }

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormatTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormatTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaFormat;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Hostname;
+use Symfony\Component\Validator\Constraints\Ip;
+use Symfony\Component\Validator\Constraints\Positive;
+use Symfony\Component\Validator\Constraints\Ulid;
+use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\Constraints\Uuid;
+
+final class PropertySchemaFormatTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $propertySchemaFormatRestriction;
+
+    protected function setUp(): void
+    {
+        $this->propertySchemaFormatRestriction = new PropertySchemaFormat();
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(Constraint $constraint, PropertyMetadata $propertyMetadata, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaFormatRestriction->supports($constraint, $propertyMetadata));
+    }
+
+    public function supportsProvider(): \Generator
+    {
+        yield 'email' => [new Email(), new PropertyMetadata(), true];
+        yield 'url' => [new Url(), new PropertyMetadata(), true];
+        if (class_exists(Hostname::class)) {
+            yield 'hostname' => [new Hostname(), new PropertyMetadata(), true];
+        }
+        yield 'uuid' => [new Uuid(), new PropertyMetadata(), true];
+        if (class_exists(Ulid::class)) {
+            yield 'ulid' => [new Ulid(), new PropertyMetadata(), true];
+        }
+        yield 'ip' => [new Ip(), new PropertyMetadata(), true];
+        yield 'not supported' => [new Positive(), new PropertyMetadata(), false];
+    }
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(Constraint $constraint, PropertyMetadata $propertyMetadata, array $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaFormatRestriction->create($constraint, $propertyMetadata));
+    }
+
+    public function createProvider(): \Generator
+    {
+        yield 'email' => [new Email(), new PropertyMetadata(), ['format' => 'email']];
+        yield 'url' => [new Url(), new PropertyMetadata(), ['format' => 'uri']];
+        if (class_exists(Hostname::class)) {
+            yield 'hostname' => [new Hostname(), new PropertyMetadata(), ['format' => 'hostname']];
+        }
+        yield 'uuid' => [new Uuid(), new PropertyMetadata(), ['format' => 'uuid']];
+        if (class_exists(Ulid::class)) {
+            yield 'ulid' => [new Ulid(), new PropertyMetadata(), ['format' => 'ulid']];
+        }
+        yield 'ipv4' => [new Ip(['version' => '4']), new PropertyMetadata(), ['format' => 'ipv4']];
+        yield 'ipv6' => [new Ip(['version' => '6']), new PropertyMetadata(), ['format' => 'ipv6']];
+        yield 'not supported' => [new Positive(), new PropertyMetadata(), []];
+    }
+}

--- a/tests/Fixtures/DummyValidatedEntity.php
+++ b/tests/Fixtures/DummyValidatedEntity.php
@@ -77,4 +77,11 @@ class DummyValidatedEntity
      * @Assert\NotNull(groups={"dummy"})
      */
     public $dummyGroup;
+
+    /**
+     * @var string A dummy url
+     *
+     * @Assert\Url
+     */
+    public $dummyUrl;
 }

--- a/tests/Fixtures/DummyValidatedHostnameEntity.php
+++ b/tests/Fixtures/DummyValidatedHostnameEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummyValidatedHostnameEntity
+{
+    /**
+     * @var string
+     *
+     * @Assert\Hostname
+     */
+    public $dummyHostname;
+}

--- a/tests/Fixtures/DummyValidatedUlidEntity.php
+++ b/tests/Fixtures/DummyValidatedUlidEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummyValidatedUlidEntity
+{
+    /**
+     * @var string
+     *
+     * @Assert\Ulid
+     */
+    public $dummyUlid;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Add a `PropertySchemaUrlRestriction` to transform [Url](https://symfony.com/doc/current/reference/constraints/Url.html) validation constraint into json schema.