### PR TITLE
Add support for generating property schema with Count restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* JSON Schema: Add support for generating property schema with Count restriction (#4186)
 * JSON Schema: Manage Compound constraint when generating property metadata (#4180)
 * Validator: Add an option to disable query parameter validation (#4165)
 * JSON Schema: Add support for generating property schema with Choice restriction (#4162)

--- a/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/validator.xml
@@ -21,6 +21,10 @@
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>
 
+        <service id="api_platform.metadata.property_schema.count_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaCountRestriction" public="false">
+            <tag name="api_platform.metadata.property_schema_restriction"/>
+        </service>
+
         <service id="api_platform.metadata.property_schema.length_restriction" class="ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaLengthRestriction" public="false">
             <tag name="api_platform.metadata.property_schema_restriction"/>
         </service>

--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCountRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCountRestriction.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Count;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+class PropertySchemaCountRestriction implements PropertySchemaRestrictionMetadataInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param Count $constraint
+     */
+    public function create(Constraint $constraint, PropertyMetadata $propertyMetadata): array
+    {
+        $restriction = [];
+
+        if (null !== $constraint->min) {
+            $restriction['minItems'] = $constraint->min;
+        }
+
+        if (null !== $constraint->max) {
+            $restriction['maxItems'] = $constraint->max;
+        }
+
+        return $restriction;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Constraint $constraint, PropertyMetadata $propertyMetadata): bool
+    {
+        return $constraint instanceof Count;
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1337,6 +1337,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.property.metadata_factory.annotation',
             'api_platform.metadata.property.metadata_factory.validator',
             'api_platform.metadata.property_schema.choice_restriction',
+            'api_platform.metadata.property_schema.count_restriction',
             'api_platform.metadata.property_schema.length_restriction',
             'api_platform.metadata.property_schema.one_of_restriction',
             'api_platform.metadata.property_schema.range_restriction',

--- a/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCountRestrictionTest.php
+++ b/tests/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCountRestrictionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Symfony\Validator\Metadata\Property\Restriction;
+
+use ApiPlatform\Core\Bridge\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaCountRestriction;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Count;
+use Symfony\Component\Validator\Constraints\Positive;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+final class PropertySchemaCountRestrictionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $propertySchemaCountRestriction;
+
+    protected function setUp(): void
+    {
+        $this->propertySchemaCountRestriction = new PropertySchemaCountRestriction();
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(Constraint $constraint, PropertyMetadata $propertyMetadata, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaCountRestriction->supports($constraint, $propertyMetadata));
+    }
+
+    public function supportsProvider(): \Generator
+    {
+        yield 'supported' => [new Count(['min' => 1]), new PropertyMetadata(), true];
+        yield 'not supported' => [new Positive(), new PropertyMetadata(), false];
+    }
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(Constraint $constraint, PropertyMetadata $propertyMetadata, array $expectedResult): void
+    {
+        self::assertSame($expectedResult, $this->propertySchemaCountRestriction->create($constraint, $propertyMetadata));
+    }
+
+    public function createProvider(): \Generator
+    {
+        yield 'min items' => [new Count(['min' => 1]), new PropertyMetadata(), ['minItems' => 1]];
+        yield 'max items' => [new Count(['max' => 10]), new PropertyMetadata(), ['maxItems' => 10]];
+        yield 'min/max items' => [new Count(['min' => 1, 'max' => 10]), new PropertyMetadata(), ['minItems' => 1, 'maxItems' => 10]];
+    }
+}

--- a/tests/Fixtures/DummyCountValidatedEntity.php
+++ b/tests/Fixtures/DummyCountValidatedEntity.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummyCountValidatedEntity
+{
+    /**
+     * @var array
+     *
+     * @Assert\Count(min=1)
+     */
+    public $dummyMin;
+
+    /**
+     * @var array
+     *
+     * @Assert\Count(max=10)
+     */
+    public $dummyMax;
+
+    /**
+     * @var array
+     *
+     * @Assert\Count(min=1, max=10)
+     */
+    public $dummyMinMax;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Add a `PropertySchemaCountRestriction` to transform [Count](https://symfony.com/doc/current/reference/constraints/Count.html) validation constraint into json schema.
