### PR TITLE
Make twig dependency lazy

### DIFF
--- a/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -67,7 +67,7 @@ final class SwaggerUiAction
      * @param int[]      $swaggerVersions
      * @param mixed|null $assetPackage
      */
-    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, TwigEnvironment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', $formats = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [], bool $showWebby = true, bool $swaggerUiEnabled = false, bool $reDocEnabled = false, bool $graphqlEnabled = false, bool $graphiQlEnabled = false, bool $graphQlPlaygroundEnabled = false, array $swaggerVersions = [2, 3], OpenApiSwaggerUiAction $swaggerUiAction = null, $assetPackage = null)
+    public function __construct(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataFactoryInterface $resourceMetadataFactory, NormalizerInterface $normalizer, ?TwigEnvironment $twig, UrlGeneratorInterface $urlGenerator, string $title = '', string $description = '', string $version = '', $formats = [], $oauthEnabled = false, $oauthClientId = '', $oauthClientSecret = '', $oauthType = '', $oauthFlow = '', $oauthTokenUrl = '', $oauthAuthorizationUrl = '', $oauthScopes = [], bool $showWebby = true, bool $swaggerUiEnabled = false, bool $reDocEnabled = false, bool $graphqlEnabled = false, bool $graphiQlEnabled = false, bool $graphQlPlaygroundEnabled = false, array $swaggerVersions = [2, 3], OpenApiSwaggerUiAction $swaggerUiAction = null, $assetPackage = null)
     {
         $this->resourceNameCollectionFactory = $resourceNameCollectionFactory;
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -94,6 +94,10 @@ final class SwaggerUiAction
         $this->swaggerVersions = $swaggerVersions;
         $this->swaggerUiAction = $swaggerUiAction;
         $this->assetPackage = $assetPackage;
+
+        if (null === $this->twig) {
+            throw new \RuntimeException('The documentation cannot be displayed since the Twig bundle is not installed. Try running "composer require symfony/twig-bundle".');
+        }
 
         if (null === $this->swaggerUiAction) {
             @trigger_error(sprintf('The use of "%s" is deprecated since API Platform 2.6, use "%s" instead.', __CLASS__, OpenApiSwaggerUiAction::class), \E_USER_DEPRECATED);

--- a/src/Bridge/Symfony/Bundle/Resources/config/swagger-ui.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/swagger-ui.xml
@@ -15,7 +15,7 @@
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.serializer" />
-            <argument type="service" id="twig" />
+            <argument type="service" id="twig" on-invalid="null" />
             <argument type="service" id="router" />
             <argument>%api_platform.title%</argument>
             <argument>%api_platform.description%</argument>
@@ -52,7 +52,7 @@
 
         <service id="api_platform.swagger_ui.action" class="ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiAction" public="true">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
-            <argument type="service" id="twig" />
+            <argument type="service" id="twig" on-invalid="null" />
             <argument type="service" id="router" />
             <argument type="service" id="api_platform.serializer" />
             <argument type="service" id="api_platform.openapi.factory" />

--- a/src/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
+++ b/src/Bridge/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
@@ -41,7 +41,7 @@ final class SwaggerUiAction
     private $oauthClientId;
     private $oauthClientSecret;
 
-    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, TwigEnvironment $twig, UrlGeneratorInterface $urlGenerator, NormalizerInterface $normalizer, OpenApiFactoryInterface $openApiFactory, Options $openApiOptions, SwaggerUiContext $swaggerUiContext, array $formats = [], string $oauthClientId = null, string $oauthClientSecret = null)
+    public function __construct(ResourceMetadataFactoryInterface $resourceMetadataFactory, ?TwigEnvironment $twig, UrlGeneratorInterface $urlGenerator, NormalizerInterface $normalizer, OpenApiFactoryInterface $openApiFactory, Options $openApiOptions, SwaggerUiContext $swaggerUiContext, array $formats = [], string $oauthClientId = null, string $oauthClientSecret = null)
     {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->twig = $twig;
@@ -53,6 +53,10 @@ final class SwaggerUiAction
         $this->formats = $formats;
         $this->oauthClientId = $oauthClientId;
         $this->oauthClientSecret = $oauthClientSecret;
+
+        if (null === $this->twig) {
+            throw new \RuntimeException('The documentation cannot be displayed since the Twig bundle is not installed. Try running "composer require symfony/twig-bundle".');
+        }
     }
 
     public function __invoke(Request $request)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #1149 
| License       | MIT

`twig` is only a part of `require-dev`. But `api_platform.swagger.action.ui` and `api_platform.swagger_ui.action` are requiring it when swagger doc is enabled. As a result, theses services are requiring an unexisting service.

Here is a tiny reproducer:
```bash
$ composer create-project symfony/skeleton:^4.4 # Same goes for 5.x versions
$ cd skeleton
$ composer req api-platform/core:2.6 
[...]
Script cache:clear returned with error code 1
!!  
!!  In CheckExceptionOnInvalidReferenceBehaviorPass.php line 86:
!!                                                                                 
!!    The service "api_platform.swagger.action.ui" has a dependency on a non-exis  
!!    tent service "twig". 
```

This fix approach is to make twig dependency lazy and throwing an exception asking the user to require twig bundle when calling swagger controllers.