### PR TITLE
Resource attribute implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,16 +245,26 @@ jobs:
         if: (startsWith(matrix.php, '8.0'))
         run: rm -Rf tests/Fixtures/app/var/cache/*
       - name: Run Behat tests
+        if: (!startsWith(matrix.php, '8.0'))
+        run: |
+          mkdir -p build/logs/behat
+          if [ "$COVERAGE" = '1' ]; then
+            vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default-coverage --no-interaction --tags='~@php8'
+          else
+            if [ "${{ matrix.php }}" = '7.1' ]; then
+              vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default --no-interaction --tags='~@symfony/uid&&~@php8'
+            else
+              vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default --no-interaction --tags='~@php8'
+            fi
+          fi
+      - name: Run Behat tests
+        if: (startsWith(matrix.php, '8.0'))
         run: |
           mkdir -p build/logs/behat
           if [ "$COVERAGE" = '1' ]; then
             vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default-coverage --no-interaction
           else
-            if [ "${{ matrix.php }}" = '7.1' ]; then
-              vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default --no-interaction --tags='~@symfony/uid'
-            else
-              vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default --no-interaction
-            fi
+            vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default --no-interaction
           fi
       - name: Merge code coverage reports
         if: matrix.coverage
@@ -387,7 +397,7 @@ jobs:
         run: tests/Fixtures/app/console cache:clear --ansi
       - name: Run Behat tests
         # @TODO remove the tag "@symfony/uid" in 3.0
-        run: vendor/bin/behat --out=std --format=progress --profile=default --no-interaction --tags='~@symfony/uid'
+        run: vendor/bin/behat --out=std --format=progress --profile=default --no-interaction --tags='~@symfony/uid&&~php8'
 
   postgresql:
     name: Behat (PHP ${{ matrix.php }}) (PostgreSQL)
@@ -438,7 +448,7 @@ jobs:
         run: tests/Fixtures/app/console cache:clear --ansi
       - name: Run Behat tests
         run: | 
-          vendor/bin/behat --out=std --format=progress --profile=postgres --no-interaction -vv
+          vendor/bin/behat --out=std --format=progress --profile=postgres --no-interaction -vv --tags='~php8'
 
   mysql:
     name: Behat (PHP ${{ matrix.php }}) (MySQL)
@@ -498,7 +508,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.4'
+          - '8'
       fail-fast: false
     env:
       APP_ENV: mongodb
@@ -854,5 +864,10 @@ jobs:
       - name: Clear test app cache
         run: tests/Fixtures/app/console cache:clear --ansi
       - name: Run Behat tests
-        run: vendor/bin/behat --out=std --format=progress --profile=default --no-interaction
+        run: |
+            if ( "${{ matrix.php }}" -eq '7.4' ) {
+                vendor/bin/behat --out=std --format=progress --profile=default --no-interaction --tags='~@php8'
+            } else {
+                vendor/bin/behat --out=std --format=progress --profile=default --no-interaction 
+            }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,13 @@ env:
 
 jobs:
   php-cs-fixer:
+    name: PHP-cs-fixer (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
         php:
-          - '7.4'
+          - '8'
       fail-fast: false
     env:
       PHP_CS_FIXER_FUTURE_MODE: '1'
@@ -34,16 +35,17 @@ jobs:
         run: php-cs-fixer fix --dry-run --diff --ansi
 
   phpstan:
-    name: PHPStan
+    name: PHPStan (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
         php:
-          - '7.4'
+          - '8'
       fail-fast: false
     env:
       APP_DEBUG: '1' # https://github.com/phpstan/phpstan-symfony/issues/37
+      SYMFONY_PHPUNIT_VERSION: '9.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -69,8 +71,6 @@ jobs:
       - name: Require Symfony Uid
         run: composer require symfony/uid --dev --no-interaction --no-progress --ansi
       - name: Install PHPUnit
-        env:
-          SYMFONY_PHPUNIT_VERSION: '9.5'
         run: vendor/bin/simple-phpunit --version
       - name: Cache PHPStan results
         uses: actions/cache@v2
@@ -85,8 +85,6 @@ jobs:
         run: |
           tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPStan analysis
-        env:
-          SYMFONY_PHPUNIT_VERSION: '9.5'
         run: ./vendor/bin/phpstan analyse --no-interaction --no-progress --no-interaction --ansi
 
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,8 @@
     },
     "autoload": {
         "psr-4": {
-            "ApiPlatform\\Core\\": "src/"
+            "ApiPlatform\\Core\\": "src/",
+            "ApiPlatform\\": "src/Core"
         }
     },
     "autoload-dev": {

--- a/docs/adr/0002-resource-definition.md
+++ b/docs/adr/0002-resource-definition.md
@@ -24,8 +24,7 @@ In API Platform, this resource identifier is also named [IRI (Internationalized 
 ```php
 <?php
 
-#[Get]
-#[Post]
+#[Resource]
 class Users
 {
     #[ApiProperty(iri="hydra:member")]
@@ -34,9 +33,11 @@ class Users
     public float $averageRate;
 }
 
-#[Get]
-#[Put]
-#[Delete]
+#[Resource("/companies/{companyId}/users/{id}", normalization_context=["groups"= [....]]), operations={}]
+#[Resource(normalization_context=["groups"= [....]], operations=[
+ new Get(),
+ new Post(),
+])]
 class User
 {
     #[ApiProperty(identifier=true)]

--- a/features/jsonld/context.feature
+++ b/features/jsonld/context.feature
@@ -80,7 +80,7 @@ Feature: JSON-LD contexts generation
               "hydra": "http://www.w3.org/ns/hydra/core#",
               "person": {
                   "@id": "http://example.com/id",
-                  "@type": "@id",
+                  "@var": "@id",
                   "foo": "bar"
               }
           }

--- a/features/main/attribute_resource.feature
+++ b/features/main/attribute_resource.feature
@@ -1,0 +1,56 @@
+Feature: Resource attributes
+  In order to use the Resource attribute
+  As a developer
+  I should be able to fetch data from a state provider
+  
+  @php8
+  @!mysql
+  @!mongodb
+  Scenario: Retrieve a Resource collection
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/attribute_resources"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/AttributeResources",
+      "@id": "/attribute_resources",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/attribute_resources/1",
+          "@type": "AttributeResource",
+          "identifier": 1,
+          "name": "Foo"
+        },
+        {
+          "@id": "/attribute_resources/2",
+          "@type": "AttributeResource",
+          "identifier": 2,
+          "name": "Bar"
+        }
+      ]
+    }
+    """
+
+  @php8
+  @!mysql
+  @!mongodb
+  Scenario: Retrieve the first resource 
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/attribute_resources/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/AttributeResource",
+      "@id": "/attribute_resources/1",
+      "@type": "AttributeResource",
+      "identifier": 1,
+      "name": "Foo"
+    } 
+    """

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -94,9 +94,6 @@ parameters:
 		- '#UserPasswordHasherInterface#'
 
 		# Expected, due to PHP 8 attributes
-		- '#ReflectionProperty::getAttributes\(\)#'
-		- '#ReflectionMethod::getAttributes\(\)#'
-		- '#ReflectionClass<object>::getAttributes\(\)#'
 		- '#Constructor of class ApiPlatform\\Core\\Annotation\\ApiResource has an unused parameter#'
 		- '#Constructor of class ApiPlatform\\Core\\Annotation\\ApiProperty has an unused parameter#'
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,12 @@
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>
+            <file phpVersion="8.0" phpVersionOperator=">=">tests/Metadata/Resource/Factory/ResourceCollectionMetadataFactoryTest.php</file>
+            <directory phpVersion="8.0" phpVersionOperator=">=">tests/Core</directory>
+            <directory phpVersion="8.0" phpVersionOperator=">=">tests/Metadata/ResourceCollection</directory>
+            <exclude>tests/Metadata/Resource/Factory/ResourceCollectionMetadataFactoryTest.php</exclude>
+            <exclude>tests/Metadata/ResourceCollection</exclude>
+            <exclude>tests/Core</exclude>
         </testsuite>
     </testsuites>
 

--- a/src/Annotation/ApiProperty.php
+++ b/src/Annotation/ApiProperty.php
@@ -80,6 +80,11 @@ final class ApiProperty
     public $iri;
 
     /**
+     * @var array
+     */
+    public $types;
+
+    /**
      * @var bool
      */
     public $identifier;
@@ -139,7 +144,8 @@ final class ApiProperty
         ?bool $push = null,
         ?string $security = null,
         ?array $swaggerContext = null,
-        ?string $securityPostDenormalize = null
+        ?string $securityPostDenormalize = null,
+        ?array $types = null
     ) {
         if (!\is_array($description)) { // @phpstan-ignore-line Doctrine annotations support
             [$publicProperties, $configurableAttributes] = self::getConfigMetadata();

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -143,6 +143,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $loader->load('api.xml');
         $loader->load('data_persister.xml');
         $loader->load('data_provider.xml');
+        $loader->load('state.xml');
         $loader->load('filter.xml');
 
         $container->getDefinition('api_platform.operation_method_resolver')
@@ -258,6 +259,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     private function registerMetadataConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void
     {
         $loader->load('metadata/metadata.xml');
+        $loader->load('metadata/resource_collection.xml');
         $loader->load('metadata/xml.xml');
 
         [$xmlResources, $yamlResources] = $this->getResourcesToWatch($container, $config);

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -44,6 +44,7 @@
             <argument>%api_platform.graphql.graphiql.enabled%</argument>
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
             <argument type="service" id="api_platform.identifiers_extractor.cached"></argument>
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory"></argument>
 
             <tag name="routing.loader" />
         </service>
@@ -67,6 +68,7 @@
             <argument type="service" id="api_platform.identifier.converter" on-invalid="ignore" />
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory" />
         </service>
         <service id="ApiPlatform\Core\Api\IriConverterInterface" alias="api_platform.iri_converter" />
 
@@ -167,6 +169,7 @@
             <argument type="service" id="api_platform.serializer.context_builder" />
             <argument type="service" id="api_platform.identifier.converter" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.state_provider" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="4" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/data_provider.xml
@@ -48,7 +48,6 @@
             <argument>%api_platform.collection.pagination.partial_parameter_name%</argument>
         </service>
         <service id="ApiPlatform\Core\DataProvider\PaginationOptions" alias="api_platform.pagination_options" />
-
     </services>
 
 </container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -120,6 +120,11 @@
             <argument type="service" id="api_platform.doctrine.orm.metadata.property.metadata_factory.inner" />
         </service>
 
+        <service id="api_platform.doctrine.orm.metadata.property.identifier_metadata_factory" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Metadata\Property\DoctrineOrmPropertyMetadataFactory" decorates="api_platform.metadata.property.identifier_metadata_factory" decoration-priority="40" public="false">
+            <argument type="service" id="doctrine" />
+            <argument type="service" id="api_platform.doctrine.orm.metadata.property.identifier_metadata_factory.inner" />
+        </service>
+
         <!-- Doctrine Query extensions -->
 
         <service id="api_platform.doctrine.orm.query_extension.eager_loading" class="ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\EagerLoadingExtension" public="false">

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/annotation.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/annotation.xml
@@ -35,6 +35,12 @@
             <argument type="service" id="api_platform.metadata.property.metadata_factory.annotation.inner" />
         </service>
 
+        <service id="api_platform.metadata.property.identifier_metadata_factory.annotation" decorates="api_platform.metadata.property.identifier_metadata_factory" decoration-priority="30" class="ApiPlatform\Core\Metadata\Property\Factory\AnnotationPropertyMetadataFactory" public="false">
+            <argument type="service" id="annotation_reader" />
+        </service>
+
+        <service id="api_platform.metadata.property.identifier_metadata_factory" alias="api_platform.metadata.property.identifier_metadata_factory.annotation" />
+
         <service id="api_platform.metadata.subresource.metadata_factory.annotation" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="30" class="ApiPlatform\Core\Metadata\Property\Factory\AnnotationSubresourceMetadataFactory" public="false">
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="api_platform.metadata.subresource.metadata_factory.annotation.inner" />

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
@@ -14,6 +14,11 @@
         <service id="ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface" alias="api_platform.metadata.resource.name_collection_factory" />
 
         <!-- Resource metadata -->
+        <service id="api_platform.metadata.resource.metadata_factory.resource_collection" class="ApiPlatform\Core\Metadata\Resource\Factory\ResourceCollectionMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="40" public="false">
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory.resource_collection.inner" />
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory" />
+        </service>
+
         <service id="api_platform.metadata.resource.metadata_factory.input_output" class="ApiPlatform\Core\Metadata\Resource\Factory\InputOutputResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="30" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory.input_output.inner" />
         </service>

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/resource_collection.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/resource_collection.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api_platform.metadata.resource_collection.metadata_factory.cached" class="ApiPlatform\Core\Metadata\ResourceCollection\Factory\CachedResourceCollectionMetadataFactory" decorates="api_platform.metadata.resource_collection.metadata_factory" decoration-priority="-10" public="false">
+            <argument type="service" id="api_platform.cache.metadata.resource_collection" />
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory.cached.inner" />
+        </service>
+
+        <service id="api_platform.metadata.resource_collection.metadata_factory.input_output" class="ApiPlatform\Core\Metadata\ResourceCollection\Factory\InputOutputResourceCollectionMetadataFactory" decorates="api_platform.metadata.resource_collection.metadata_factory" decoration-priority="30" public="false">
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory.input_output.inner" />
+        </service>
+
+        <service id="api_platform.metadata.resource_collection.metadata_factory.php_doc" class="ApiPlatform\Core\Metadata\ResourceCollection\Factory\PhpDocResourceCollectionMetadataFactory" decorates="api_platform.metadata.resource_collection.metadata_factory" decoration-priority="30" public="false">
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory.php_doc.inner" />
+        </service>
+
+        <service id="api_platform.metadata.resource_collection.metadata_factory.formats" class="ApiPlatform\Core\Metadata\ResourceCollection\Factory\FormatsResourceCollectionMetadataFactory" decorates="api_platform.metadata.resource_collection.metadata_factory" decoration-priority="40" public="false">
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory.formats.inner" />
+            <argument>%api_platform.formats%</argument>
+            <argument>%api_platform.patch_formats%</argument>
+        </service>
+
+        <service id="api_platform.metadata.resource_collection.metadata_factory.attributes" class="ApiPlatform\Core\Metadata\ResourceCollection\Factory\AttributeResourceCollectionMetadataFactory" public="false">
+            <argument>%api_platform.defaults%</argument>
+        </service>
+
+        <service id="api_platform.metadata.resource_collection.metadata_factory.identifier" class="ApiPlatform\Core\Metadata\ResourceCollection\Factory\IdentifierResourceCollectionMetadataFactory" decorates="api_platform.metadata.resource_collection.metadata_factory" decoration-priority="10" public="false">
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory.identifier.inner" />
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.identifier_metadata_factory" />
+        </service>
+
+        <service id="api_platform.metadata.resource_collection.metadata_factory.uri_template" class="ApiPlatform\Core\Metadata\ResourceCollection\Factory\UriTemplateResourceCollectionMetadataFactory" decorates="api_platform.metadata.resource_collection.metadata_factory" decoration-priority="10" public="false">
+            <argument type="service" id="api_platform.path_segment_name_generator" />
+            <argument type="service" id="api_platform.metadata.resource_collection.metadata_factory.uri_template.inner" />
+        </service>
+
+        <service id="ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface" alias="api_platform.metadata.resource_collection.metadata_factory" />
+
+        <service id="api_platform.metadata.resource_collection.metadata_factory" alias="api_platform.metadata.resource_collection.metadata_factory.attributes" />
+
+        <service id="api_platform.cache.metadata.resource_collection" parent="cache.system" public="false">
+            <tag name="cache.pool" />
+        </service>
+
+    </services>
+
+</container>

--- a/src/Bridge/Symfony/Bundle/Resources/config/state.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/state.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api_platform.state_provider" class="ApiPlatform\State\ChainProvider">
+            <argument type="tagged" tag="api_platform.state_provider" />
+        </service>
+        <service id="ApiPlatform\State\ProviderInterface" alias="api_platform.state_provider" />
+    </services>
+</container>

--- a/src/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Bridge/Symfony/Routing/IriConverter.php
@@ -25,14 +25,17 @@ use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Identifier\CompositeIdentifierParser;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
 use ApiPlatform\Core\Util\AttributesExtractor;
 use ApiPlatform\Core\Util\ResourceClassInfoTrait;
+use ApiPlatform\Metadata\Resource;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;
@@ -51,8 +54,9 @@ final class IriConverter implements IriConverterInterface
     private $routeNameResolver;
     private $router;
     private $identifiersExtractor;
+    private $resourceCollectionMetadataFactory;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ItemDataProviderInterface $itemDataProvider, RouteNameResolverInterface $routeNameResolver, RouterInterface $router, PropertyAccessorInterface $propertyAccessor = null, IdentifiersExtractorInterface $identifiersExtractor = null, SubresourceDataProviderInterface $subresourceDataProvider = null, IdentifierConverterInterface $identifierConverter = null, ResourceClassResolverInterface $resourceClassResolver = null, ResourceMetadataFactoryInterface $resourceMetadataFactory = null)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, ItemDataProviderInterface $itemDataProvider, RouteNameResolverInterface $routeNameResolver, RouterInterface $router, PropertyAccessorInterface $propertyAccessor = null, IdentifiersExtractorInterface $identifiersExtractor = null, SubresourceDataProviderInterface $subresourceDataProvider = null, IdentifierConverterInterface $identifierConverter = null, ResourceClassResolverInterface $resourceClassResolver = null, ResourceMetadataFactoryInterface $resourceMetadataFactory = null, ResourceCollectionMetadataFactoryInterface $resourceCollectionMetadataFactory = null)
     {
         $this->itemDataProvider = $itemDataProvider;
         $this->routeNameResolver = $routeNameResolver;
@@ -62,6 +66,7 @@ final class IriConverter implements IriConverterInterface
         $this->resourceClassResolver = $resourceClassResolver;
         $this->identifiersExtractor = $identifiersExtractor ?: new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, $propertyAccessor ?? PropertyAccess::createPropertyAccessor());
         $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->resourceCollectionMetadataFactory = $resourceCollectionMetadataFactory;
     }
 
     /**
@@ -131,8 +136,9 @@ final class IriConverter implements IriConverterInterface
      */
     public function getIriFromResourceClass(string $resourceClass, int $referenceType = null): string
     {
+        // TODO: use ResourceMetadataCollection somehow to fetch the correct route, this makes no sense as relying a lot on OperationType
         try {
-            return $this->router->generate($this->routeNameResolver->getRouteName($resourceClass, OperationType::COLLECTION), [], $this->getReferenceType($resourceClass, $referenceType));
+            return $this->router->generate($this->getRouteName($resourceClass, OperationType::COLLECTION), [], $this->getReferenceType($resourceClass, $referenceType));
         } catch (RoutingExceptionInterface $e) {
             throw new InvalidArgumentException(sprintf('Unable to generate an IRI for "%s".', $resourceClass), $e->getCode(), $e);
         }
@@ -143,7 +149,8 @@ final class IriConverter implements IriConverterInterface
      */
     public function getItemIriFromResourceClass(string $resourceClass, array $identifiers, int $referenceType = null): string
     {
-        $routeName = $this->routeNameResolver->getRouteName($resourceClass, OperationType::ITEM);
+        // TODO: use ResourceMetadataCollection somehow to fetch the correct route, this makes no sense as relying a lot on OperationType
+        $routeName = $this->getRouteName($resourceClass, OperationType::ITEM);
         $metadata = $this->resourceMetadataFactory->create($resourceClass);
 
         if (\count($identifiers) > 1 && true === $metadata->getAttribute('composite_identifier', true)) {
@@ -177,5 +184,31 @@ final class IriConverter implements IriConverterInterface
         }
 
         return $referenceType ?? UrlGeneratorInterface::ABS_PATH;
+    }
+
+    private function getRouteName(string $resourceClass, string $operationType)
+    {
+        if (null !== $this->resourceCollectionMetadataFactory) {
+            try {
+                $collection = $this->resourceCollectionMetadataFactory->create($resourceClass);
+
+                foreach ($collection as $resource) {
+                    foreach ($resource->operations as $key => $operation) {
+                        // TODO: This is wrong as it can happen but as we need to keep a layer with declaring every operation on a single entity we need to keep the behavior
+                        if (OperationType::COLLECTION === $operationType && $operation->identifiers) {
+                            continue;
+                        }
+
+                        if ('GET' === $operation->method) {
+                            return $key;
+                        }
+                    }
+                }
+            } catch (ResourceClassNotFoundException $e) {
+                // This is probably a pre-2.7 resource
+            }
+        }
+
+        return $this->routeNameResolver->getRouteName($resourceClass, $operationType);
     }
 }

--- a/src/Core/Metadata/AttributeTrait.php
+++ b/src/Core/Metadata/AttributeTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+/**
+ * @experimental
+ */
+trait AttributeTrait
+{
+    public array $extraProperties;
+
+    public function __get(string $name): mixed
+    {
+        return $this->extraProperties[$name] ?? null;
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        $this->extraProperties[$name] = $value;
+    }
+}

--- a/src/Core/Metadata/Delete.php
+++ b/src/Core/Metadata/Delete.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Delete extends Operation
+{
+    public function __construct(...$values)
+    {
+        parent::__construct('DELETE', ...$values);
+    }
+}

--- a/src/Core/Metadata/Get.php
+++ b/src/Core/Metadata/Get.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Get extends Operation
+{
+    public function __construct(...$values)
+    {
+        parent::__construct(...$values);
+    }
+}

--- a/src/Core/Metadata/GetCollection.php
+++ b/src/Core/Metadata/GetCollection.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class GetCollection extends Operation
+{
+    public function __construct(...$values)
+    {
+        parent::__construct(...$values);
+    }
+}

--- a/src/Core/Metadata/Operation.php
+++ b/src/Core/Metadata/Operation.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+class Operation
+{
+    use AttributeTrait;
+
+    /**
+     * @param string       $method
+     * @param array        $defaults
+     * @param array        $requirements
+     * @param array        $options
+     * @param string       $host
+     * @param array        $schemes
+     * @param string       $condition
+     * @param string       $controller
+     * @param string       $uriTemplate
+     * @param string       $description
+     * @param array        $types
+     * @param string       $shortName
+     * @param array        $cacheHeaders                   https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers
+     * @param array        $denormalizationContext         https://api-platform.com/docs/core/serialization/#using-serialization-groups
+     * @param string       $deprecationReason              https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
+     * @param bool         $elasticsearch                  https://api-platform.com/docs/core/elasticsearch/
+     * @param bool         $fetchPartial                   https://api-platform.com/docs/core/performance/#fetch-partial
+     * @param bool         $forceEager                     https://api-platform.com/docs/core/performance/#force-eager
+     * @param array|string $formats                        https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
+     * @param array|string $inputFormats                   https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
+     * @param array|string $outputFormats                  https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
+     * @param string[]     $filters                        https://api-platform.com/docs/core/filters/#doctrine-orm-and-mongodb-odm-filters
+     * @param string[]     $hydraContext                   https://api-platform.com/docs/core/extending-jsonld-context/#hydra
+     * @param mixed        $input                          https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
+     * @param bool|array   $mercure                        https://api-platform.com/docs/core/mercure
+     * @param bool         $messenger                      https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
+     * @param array        $normalizationContext           https://api-platform.com/docs/core/serialization/#using-serialization-groups
+     * @param array        $openapiContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param array        $order                          https://api-platform.com/docs/core/default-order/#overriding-default-order
+     * @param mixed        $output                         https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
+     * @param bool         $paginationClientEnabled        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
+     * @param bool         $paginationClientItemsPerPage   https://api-platform.com/docs/core/pagination/#for-a-specific-resource-3
+     * @param bool         $paginationClientPartial        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-6
+     * @param array        $paginationViaCursor            https://api-platform.com/docs/core/pagination/#cursor-based-pagination
+     * @param bool         $paginationEnabled              https://api-platform.com/docs/core/pagination/#for-a-specific-resource
+     * @param bool         $paginationFetchJoinCollection  https://api-platform.com/docs/core/pagination/#controlling-the-behavior-of-the-doctrine-orm-paginator
+     * @param int          $paginationItemsPerPage         https://api-platform.com/docs/core/pagination/#changing-the-number-of-items-per-page
+     * @param int          $paginationMaximumItemsPerPage  https://api-platform.com/docs/core/pagination/#changing-maximum-items-per-page
+     * @param bool         $paginationPartial              https://api-platform.com/docs/core/performance/#partial-pagination
+     * @param string       $routePrefix                    https://api-platform.com/docs/core/operations/#prefixing-all-routes-of-all-operations
+     * @param string       $security                       https://api-platform.com/docs/core/security
+     * @param string       $securityMessage                https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
+     * @param string       $securityPostDenormalize        https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
+     * @param string       $securityPostDenormalizeMessage https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
+     * @param bool         $stateless
+     * @param string       $sunset                         https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
+     * @param array        $swaggerContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param array        $validationGroups               https://api-platform.com/docs/core/validation/#using-validation-groups
+     * @param int          $urlGenerationStrategy
+     * @param bool         $compositeIdentifier
+     * @param array        $identifiers
+     * @param array        $graphql
+     */
+    public function __construct(
+        public string $method = 'GET',
+        public ?array $defaults = [],
+        public ?array $requirements = [],
+        public ?array $options = [],
+        public ?string $host = '',
+        public ?array $schemes = [],
+        public ?string $condition = '',
+        public ?string $controller = 'api_platform.action.placeholder',
+        public ?string $uriTemplate = null,
+        public ?string $shortName = null,
+        public ?string $description = null,
+        public ?string $class = null,
+        public ?array $types = null,
+
+        public ?array $cacheHeaders = null,
+        public ?array $denormalizationContext = null,
+        public ?string $deprecationReason = null,
+        public ?bool $elasticsearch = null,
+        public ?bool $fetchPartial = null,
+        public ?bool $forceEager = null,
+        public mixed $formats = null,
+        public mixed $inputFormats = null,
+        public mixed $outputFormats = null,
+        public ?array $filters = null,
+        public ?array $hydraContext = null,
+        public mixed $input = null,
+        public $mercure = null,
+        public $messenger = null,
+        public ?array $normalizationContext = null,
+        public ?array $openapiContext = null,
+        public ?array $order = null,
+        public mixed $output = null,
+        public ?bool $paginationClientEnabled = null,
+        public ?bool $paginationClientItemsPerPage = null,
+        public ?bool $paginationClientPartial = null,
+        public ?array $paginationViaCursor = null,
+        public ?bool $paginationEnabled = null,
+        public ?bool $paginationFetchJoinCollection = null,
+        public ?int $paginationItemsPerPage = null,
+        public ?int $paginationMaximumItemsPerPage = null,
+        public ?bool $paginationPartial = null,
+        public ?string $routePrefix = null,
+        public ?string $security = null,
+        public ?string $securityMessage = null,
+        public ?string $securityPostDenormalize = null,
+        public ?string $securityPostDenormalizeMessage = null,
+        public ?bool $stateless = null,
+        public ?string $sunset = null,
+        public ?array $swaggerContext = null,
+        public ?array $validationGroups = null,
+        public ?int $urlGenerationStrategy = null,
+        public ?bool $compositeIdentifier = null,
+        public ?array $identifiers = null,
+        public ?array $graphql = null,
+        ...$extraProperties
+    ) {
+        $this->extraProperties = $extraProperties;
+    }
+}

--- a/src/Core/Metadata/Patch.php
+++ b/src/Core/Metadata/Patch.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Patch extends Operation
+{
+    public function __construct(...$values)
+    {
+        parent::__construct('PATCH', ...$values);
+    }
+}

--- a/src/Core/Metadata/Post.php
+++ b/src/Core/Metadata/Post.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Post extends Operation
+{
+    public function __construct(...$values)
+    {
+        parent::__construct('POST', ...$values);
+    }
+}

--- a/src/Core/Metadata/Put.php
+++ b/src/Core/Metadata/Put.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Put extends Operation
+{
+    public function __construct(...$values)
+    {
+        parent::__construct('PUT', ...$values);
+    }
+}

--- a/src/Core/Metadata/Resource.php
+++ b/src/Core/Metadata/Resource.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+/**
+ * Resource metadata attribute.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Resource
+{
+    use AttributeTrait;
+
+    /**
+     * @param string            $uriTemplate
+     * @param string            $description
+     * @param array             $types
+     * @param string            $shortName
+     * @param array             $cacheHeaders                   https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers
+     * @param array             $denormalizationContext         https://api-platform.com/docs/core/serialization/#using-serialization-groups
+     * @param string            $deprecationReason              https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
+     * @param bool              $elasticsearch                  https://api-platform.com/docs/core/elasticsearch/
+     * @param bool              $fetchPartial                   https://api-platform.com/docs/core/performance/#fetch-partial
+     * @param bool              $forceEager                     https://api-platform.com/docs/core/performance/#force-eager
+     * @param array|string|null $formats                        https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
+     * @param array|string|null $inputFormats                   https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
+     * @param array|string|null $outputFormats                  https://api-platform.com/docs/core/content-negotiation/#configuring-formats-for-a-specific-resource-or-operation
+     * @param string[]          $filters                        https://api-platform.com/docs/core/filters/#doctrine-orm-and-mongodb-odm-filters
+     * @param string[]          $hydraContext                   https://api-platform.com/docs/core/extending-jsonld-context/#hydra
+     * @param mixed             $input                          https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
+     * @param bool|array        $mercure                        https://api-platform.com/docs/core/mercure
+     * @param bool              $messenger                      https://api-platform.com/docs/core/messenger/#dispatching-a-resource-through-the-message-bus
+     * @param array             $normalizationContext           https://api-platform.com/docs/core/serialization/#using-serialization-groups
+     * @param array             $openapiContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param array             $order                          https://api-platform.com/docs/core/default-order/#overriding-default-order
+     * @param mixed             $output                         https://api-platform.com/docs/core/dto/#specifying-an-input-or-an-output-data-representation
+     * @param bool              $paginationClientEnabled        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-1
+     * @param bool              $paginationClientItemsPerPage   https://api-platform.com/docs/core/pagination/#for-a-specific-resource-3
+     * @param bool              $paginationClientPartial        https://api-platform.com/docs/core/pagination/#for-a-specific-resource-6
+     * @param array             $paginationViaCursor            https://api-platform.com/docs/core/pagination/#cursor-based-pagination
+     * @param bool              $paginationEnabled              https://api-platform.com/docs/core/pagination/#for-a-specific-resource
+     * @param bool              $paginationFetchJoinCollection  https://api-platform.com/docs/core/pagination/#controlling-the-behavior-of-the-doctrine-orm-paginator
+     * @param int               $paginationItemsPerPage         https://api-platform.com/docs/core/pagination/#changing-the-number-of-items-per-page
+     * @param int               $paginationMaximumItemsPerPage  https://api-platform.com/docs/core/pagination/#changing-maximum-items-per-page
+     * @param bool              $paginationPartial              https://api-platform.com/docs/core/performance/#partial-pagination
+     * @param string            $routePrefix                    https://api-platform.com/docs/core/operations/#prefixing-all-routes-of-all-operations
+     * @param string            $security                       https://api-platform.com/docs/core/security
+     * @param string            $securityMessage                https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
+     * @param string            $securityPostDenormalize        https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
+     * @param string            $securityPostDenormalizeMessage https://api-platform.com/docs/core/security/#configuring-the-access-control-error-message
+     * @param bool              $stateless
+     * @param string            $sunset                         https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
+     * @param array             $swaggerContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param array             $validationGroups               https://api-platform.com/docs/core/validation/#using-validation-groups
+     * @param int               $urlGenerationStrategy
+     * @param bool              $compositeIdentifier
+     * @param array             $identifiers
+     */
+    public function __construct(
+        public ?string $uriTemplate = null,
+        public ?string $shortName = null,
+        public ?string $description = null,
+        public ?string $class = null,
+        public ?array $types = null,
+        public ?array $operations = null,
+
+        public ?array $cacheHeaders = null,
+        public ?array $denormalizationContext = null,
+        public ?string $deprecationReason = null,
+        public ?bool $elasticsearch = null,
+        public ?bool $fetchPartial = null,
+        public ?bool $forceEager = null,
+        public mixed $formats = null,
+        public mixed $inputFormats = null,
+        public mixed $outputFormats = null,
+        public ?array $filters = null,
+        public ?array $hydraContext = null,
+        public mixed $input = null,
+        public $mercure = null,
+        public $messenger = null,
+        public ?array $normalizationContext = null,
+        public ?array $openapiContext = null,
+        public ?array $order = null,
+        public mixed $output = null,
+        public ?bool $paginationClientEnabled = null,
+        public ?bool $paginationClientItemsPerPage = null,
+        public ?bool $paginationClientPartial = null,
+        public ?array $paginationViaCursor = null,
+        public ?bool $paginationEnabled = null,
+        public ?bool $paginationFetchJoinCollection = null,
+        public ?int $paginationItemsPerPage = null,
+        public ?int $paginationMaximumItemsPerPage = null,
+        public ?bool $paginationPartial = null,
+        public ?string $routePrefix = null,
+        public ?string $security = null,
+        public ?string $securityMessage = null,
+        public ?string $securityPostDenormalize = null,
+        public ?string $securityPostDenormalizeMessage = null,
+        public ?bool $stateless = null,
+        public ?string $sunset = null,
+        public ?array $swaggerContext = null,
+        public ?array $validationGroups = null,
+        public ?int $urlGenerationStrategy = null,
+        public ?bool $compositeIdentifier = null,
+        public ?array $identifiers = null,
+        public ?array $graphQl = null,
+        ...$extraProperties
+    ) {
+        $this->extraProperties = $extraProperties;
+    }
+}

--- a/src/Core/State/ChainProvider.php
+++ b/src/Core/State/ChainProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State;
+
+/**
+ * Tries each configured data provider and returns the result of the first able to handle the resource class.
+ *
+ * @experimental
+ */
+final class ChainProvider implements ProviderInterface
+{
+    /**
+     * @var iterable<ProviderInterface>
+     *
+     * @internal
+     */
+    public $providers;
+
+    /**
+     * @param ProviderInterface[] $providers
+     */
+    public function __construct(iterable $providers)
+    {
+        $this->providers = $providers;
+    }
+
+    public function provide(string $resourceClass, array $identifiers = [], array $context = [])
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider->supports($resourceClass, $identifiers, $context)) {
+                return $provider->provide($resourceClass, $identifiers, $context);
+            }
+        }
+
+        return \count($identifiers) ? null : [];
+    }
+
+    public function supports(string $resourceClass, array $identifiers = [], array $context = []): bool
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider->supports($resourceClass, $identifiers, $context)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Core/State/ProcessorInterface.php
+++ b/src/Core/State/ProcessorInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State;
+
+/**
+ * Process data: send an email, persist to storage, add to queue etc.
+ *
+ * @experimental
+ */
+interface ProcessorInterface
+{
+    /**
+     * Should we continue calling the next Processor or stop after this one?
+     * Defaults to stop the ChainProcessor if this interface is not implemented.
+     */
+    public function resumable(array $context = []): bool;
+
+    /**
+     * Whether this state handler supports the class/identifier tuple.
+     */
+    public function supports($data, array $identifiers = [], array $context = []): bool;
+
+    /**
+     * Handle the state.
+     */
+    public function process($data, array $identifiers = [], array $context = []);
+}

--- a/src/Core/State/ProviderInterface.php
+++ b/src/Core/State/ProviderInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State;
+
+/**
+ * Retrieves data from a persistence layer.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+interface ProviderInterface
+{
+    /**
+     * Provides data.
+     *
+     * @return object|array|null
+     */
+    public function provide(string $resourceClass, array $identifiers = [], array $context = []);
+
+    /**
+     * Whether this state provider supports the class/identifier tuple.
+     */
+    public function supports(string $resourceClass, array $identifiers = [], array $context = []): bool;
+}

--- a/src/DataProvider/OperationDataProviderTrait.php
+++ b/src/DataProvider/OperationDataProviderTrait.php
@@ -51,7 +51,7 @@ trait OperationDataProviderTrait
      */
     private function getCollectionData(array $attributes, array $context)
     {
-        return $this->collectionDataProvider->getCollection($attributes['resource_class'], $attributes['collection_operation_name'], $context);
+        return $this->collectionDataProvider->getCollection($attributes['resource_class'], $attributes['operation_name'] ?? $attributes['collection_operation_name'], $context);
     }
 
     /**
@@ -61,7 +61,7 @@ trait OperationDataProviderTrait
      */
     private function getItemData($identifiers, array $attributes, array $context)
     {
-        return $this->itemDataProvider->getItem($attributes['resource_class'], $identifiers, $attributes['item_operation_name'], $context);
+        return $this->itemDataProvider->getItem($attributes['resource_class'], $identifiers, $attributes['operation_name'] ?? $attributes['item_operation_name'], $context);
     }
 
     /**

--- a/src/DataProvider/StateLegacyDataProvider.php
+++ b/src/DataProvider/StateLegacyDataProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\DataProvider;
+
+use ApiPlatform\State\ProviderInterface;
+
+/**
+ * State provider legacy bridge to use new Providers with pre-2.7 resources.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+class StateLegacyDataProvider implements DenormalizedIdentifiersAwareItemDataProviderInterface, ContextAwareCollectionDataProviderInterface
+{
+    public function __construct(private ?ProviderInterface $provider = null)
+    {
+    }
+
+    public function getItem(string $resourceClass, /* array */ $id, string $operationName = null, array $context = [])
+    {
+        return $this->provider->provide($resourceClass, (array) $id, $context);
+    }
+
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
+    {
+        return $this->provider->provide($resourceClass, [], $context);
+    }
+}

--- a/src/EventListener/AddFormatListener.php
+++ b/src/EventListener/AddFormatListener.php
@@ -76,7 +76,7 @@ final class AddFormatListener
         $attributes = RequestAttributesExtractor::extractAttributes($request);
 
         // BC check to be removed in 3.0
-        if ($this->resourceMetadataFactory) {
+        if (!isset($attributes['operation_name']) && $this->resourceMetadataFactory) {
             if ($attributes) {
                 // TODO: Subresource operation metadata aren't available by default, for now we have to fallback on default formats.
                 // TODO: A better approach would be to always populate the subresource operation array.

--- a/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
@@ -22,7 +22,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
+final class CachedResourceNameCollectionFactory implements LegacyResourceNameCollectionFactoryInterface
 {
     use CachedTrait;
 
@@ -39,10 +39,10 @@ final class CachedResourceNameCollectionFactory implements ResourceNameCollectio
     /**
      * {@inheritdoc}
      */
-    public function create(): ResourceNameCollection
+    public function create(bool $legacy = true): ResourceNameCollection
     {
-        return $this->getCached(self::CACHE_KEY, function () {
-            return $this->decorated->create();
+        return $this->getCached($this->decorated instanceof LegacyResourceNameCollectionFactoryInterface ? sprintf('%s-%s', self::CACHE_KEY, $legacy) : self::CACHE_KEY, function () use ($legacy) {
+            return $this->decorated instanceof LegacyResourceNameCollectionFactoryInterface ? $this->decorated->create($legacy) : $this->decorated->create();
         });
     }
 }

--- a/src/Metadata/Resource/Factory/ExtractorResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceNameCollectionFactory.php
@@ -23,7 +23,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-final class ExtractorResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
+final class ExtractorResourceNameCollectionFactory implements LegacyResourceNameCollectionFactoryInterface
 {
     private $extractor;
     private $decorated;
@@ -39,13 +39,23 @@ final class ExtractorResourceNameCollectionFactory implements ResourceNameCollec
      *
      * @throws InvalidArgumentException
      */
-    public function create(): ResourceNameCollection
+    public function create(bool $legacy = true): ResourceNameCollection
     {
+        if (true === $legacy) {
+            @trigger_error(sprintf('Using a legacy %s is deprecated since 2.7 and will not be possible in 3.0.', __CLASS__), \E_USER_DEPRECATED);
+        }
+
         $classes = [];
+
         if ($this->decorated) {
-            foreach ($this->decorated->create() as $resourceClass) {
+            foreach ($this->decorated instanceof LegacyResourceNameCollectionFactoryInterface ? $this->decorated->create($legacy) : $this->decorated->create() as $resourceClass) {
                 $classes[$resourceClass] = true;
             }
+        }
+
+        // TODO: Handle extractors
+        if (!$legacy) {
+            return new ResourceNameCollection(array_keys($classes));
         }
 
         foreach ($this->extractor->getResources() as $resourceClass => $resource) {

--- a/src/Metadata/Resource/Factory/LegacyResourceNameCollectionFactoryInterface.php
+++ b/src/Metadata/Resource/Factory/LegacyResourceNameCollectionFactoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
+
+/**
+ * Creates a resource name collection value object.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface LegacyResourceNameCollectionFactoryInterface extends ResourceNameCollectionFactoryInterface
+{
+    /**
+     * Creates the resource name collection.
+     */
+    public function create(bool $legacy = true): ResourceNameCollection;
+}

--- a/src/Metadata/Resource/Factory/ResourceCollectionMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/ResourceCollectionMetadataFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+/**
+ * BC layer with the < 3.0 ResourceMetadata system.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class ResourceCollectionMetadataFactory implements ResourceMetadataFactoryInterface
+{
+    private $decorated;
+    private $resourceCollectionMetadataFactory;
+    private $nameConverter;
+
+    public function __construct(ResourceMetadataFactoryInterface $decorated, ResourceCollectionMetadataFactoryInterface $resourceCollectionMetadataFactory)
+    {
+        $this->decorated = $decorated;
+        $this->resourceCollectionMetadataFactory = $resourceCollectionMetadataFactory;
+        $this->nameConverter = new CamelCaseToSnakeCaseNameConverter();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceMetadata
+    {
+        try {
+            return $this->decorated->create($resourceClass);
+        } catch (ResourceClassNotFoundException $e) {
+            $resourceMetadataCollection = $this->resourceCollectionMetadataFactory->create($resourceClass);
+            if (!isset($resourceMetadataCollection[0])) {
+                throw new ResourceClassNotFoundException(sprintf('Resource "%s" not found.', $resourceClass));
+            }
+
+            @trigger_error(sprintf('Using a %s for a #[Resource] is deprecated since 2.7 and will not be possible in 3.0. Use %s instead.', ResourceMetadataFactoryInterface::class, ResourceCollectionMetadataFactoryInterface::class), \E_USER_DEPRECATED);
+
+            $collectionOperations = [];
+            $itemOperations = [];
+            foreach ($resourceMetadataCollection[0]->operations as $name => $operation) {
+                if (!$operation->identifiers) {
+                    $collectionOperations[$name] = $this->toArray($operation);
+                    continue;
+                }
+
+                $itemOperations[$name] = $this->toArray($operation);
+            }
+            $attributes = $this->toArray($resourceMetadataCollection[0]);
+            $graphql = $resourceMetadataCollection[0]->graphQl ? $this->toArray($resourceMetadataCollection[0]->graphQl) : null;
+
+            return new ResourceMetadata($resourceMetadataCollection[0]->shortName, $resourceMetadataCollection[0]->description, null, $itemOperations, $collectionOperations, $attributes, null, $graphql);
+        }
+    }
+
+    private function toArray($object): array
+    {
+        $arr = [];
+        foreach ($object as $key => $value) {
+            $arr[$this->nameConverter->normalize($key)] = $value;
+        }
+
+        return $arr;
+    }
+}

--- a/src/Metadata/ResourceCollection/Factory/AttributeResourceCollectionMetadataFactory.php
+++ b/src/Metadata/ResourceCollection/Factory/AttributeResourceCollectionMetadataFactory.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Resource;
+
+/**
+ * Creates a resource metadata from {@see Resource} annotations.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+final class AttributeResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    private $defaults;
+
+    public function __construct(array $defaults = [])
+    {
+        $this->defaults = $defaults;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceCollection
+    {
+        $resourceMetadataCollection = [];
+
+        try {
+            $reflectionClass = new \ReflectionClass($resourceClass);
+        } catch (\ReflectionException $reflectionException) {
+            throw new ResourceClassNotFoundException(sprintf('Resource "%s" not found.', $resourceClass));
+        }
+
+        if (\PHP_VERSION_ID >= 80000 && $reflectionClass->getAttributes(Resource::class)) {
+            foreach ($this->buildResourceOperations($reflectionClass->getAttributes(), $resourceClass) as $i => $resource) {
+                foreach ($this->defaults as $key => $value) {
+                    if (!$resource->{$key}) {
+                        $resource->{$key} = $value;
+                    }
+                }
+
+                $resourceMetadataCollection[$i] = $resource;
+            }
+        }
+
+        if (!$resourceMetadataCollection) {
+            throw new ResourceClassNotFoundException(sprintf('Resource "%s" not found.', $resourceClass));
+        }
+
+        return new ResourceCollection($resourceMetadataCollection);
+    }
+
+    /**
+     * Builds resource operations to support:.
+     *
+     * Resource
+     * Get
+     * Post
+     * Resource
+     * Put
+     * Get
+     *
+     * In the future, we will be able to use nested attributes (https://wiki.php.net/rfc/new_in_initializers)
+     *
+     * @return resource[]
+     */
+    private function buildResourceOperations(array $attributes, string $resourceClass): array
+    {
+        $shortName = (false !== $pos = strrpos($resourceClass, '\\')) ? substr($resourceClass, $pos + 1) : $resourceClass;
+        $resources = [];
+        $index = -1;
+        foreach ($attributes as $attribute) {
+            if (Resource::class === $attribute->getName()) {
+                $resource = $attribute->newInstance();
+                $resource->shortName = $shortName;
+                $resource->class = $resourceClass;
+                $resources[++$index] = $resource;
+                continue;
+            }
+
+            // Create default operations
+            if (!is_subclass_of($attribute->getName(), Operation::class)) {
+                continue;
+            }
+
+            [$key, $operation] = $this->getOperationWithDefaults($resources[$index], $attribute->newInstance());
+            $resources[$index]->operations[$key] = $operation;
+        }
+
+        // Loop again and set default operations if none where found
+        foreach ($resources as $index => $resource) {
+            if ($resource->operations) {
+                continue;
+            }
+
+            foreach ([new Get(), new GetCollection(), new Post(), new Put(), new Patch(), new Delete()] as $operation) {
+                [$key, $operation] = $this->getOperationWithDefaults($resources[$index], $operation);
+                $resources[$index]->operations[$key] = $operation;
+            }
+        }
+
+        return $resources;
+    }
+
+    private function getOperationWithDefaults(Resource $resource, Operation $operation): array
+    {
+        // @phpstan-ignore-next-line
+        foreach ($resource as $property => $value) {
+            if ('operations' === $property) {
+                continue;
+            }
+
+            if ($operation->{$property} || !$value) {
+                continue;
+            }
+
+            $operation->{$property} = $value;
+        }
+
+        $key = sprintf('_api_%s_%s%s', $operation->uriTemplate ?: $operation->shortName, strtolower($operation->method), $operation instanceof GetCollection ? '_collection' : '');
+
+        return [$key, $operation];
+    }
+}

--- a/src/Metadata/ResourceCollection/Factory/CachedResourceCollectionMetadataFactory.php
+++ b/src/Metadata/ResourceCollection/Factory/CachedResourceCollectionMetadataFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Cache\CachedTrait;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Caches resource metadata.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class CachedResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    use CachedTrait;
+
+    public const CACHE_KEY_PREFIX = 'resource_metadata_collection_';
+
+    private $decorated;
+
+    public function __construct(CacheItemPoolInterface $cacheItemPool, ResourceCollectionMetadataFactoryInterface $decorated)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceCollection
+    {
+        $cacheKey = self::CACHE_KEY_PREFIX.md5($resourceClass);
+
+        return $this->getCached($cacheKey, function () use ($resourceClass) {
+            return $this->decorated->create($resourceClass);
+        });
+    }
+}

--- a/src/Metadata/ResourceCollection/Factory/FormatsResourceCollectionMetadataFactory.php
+++ b/src/Metadata/ResourceCollection/Factory/FormatsResourceCollectionMetadataFactory.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+
+/**
+ * Normalizes enabled formats.
+ *
+ * Formats hierarchy:
+ * * resource formats
+ *   * resource input/output formats
+ *     * operation formats
+ *       * operation input/output formats
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ * @experimental
+ */
+final class FormatsResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    private $decorated;
+    private $formats;
+    private $patchFormats;
+
+    public function __construct(ResourceCollectionMetadataFactoryInterface $decorated, array $formats, array $patchFormats)
+    {
+        $this->decorated = $decorated;
+        $this->formats = $formats;
+        $this->patchFormats = $patchFormats;
+    }
+
+    /**
+     * Adds the formats attributes.
+     *
+     * @see OperationResourceMetadataFactory
+     *
+     * @throws ResourceClassNotFoundException
+     */
+    public function create(string $resourceClass): ResourceCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+
+        foreach ($resourceMetadataCollection as $index => $resourceMetadata) {
+            $rawResourceFormats = $resourceMetadata->formats;
+            $resourceFormats = null === $rawResourceFormats ? $this->formats : $this->normalizeFormats($rawResourceFormats);
+            $resourceInputFormats = $resourceMetadata->inputFormats ? $this->normalizeFormats($resourceMetadata->inputFormats) : $resourceFormats;
+            $resourceOutputFormats = $resourceMetadata->outputFormats ? $this->normalizeFormats($resourceMetadata->outputFormats) : $resourceFormats;
+
+            $resourceMetadataCollection[$index]->operations = $this->normalize($resourceInputFormats, $resourceOutputFormats, $resourceMetadata->operations);
+        }
+
+        return $resourceMetadataCollection;
+    }
+
+    private function normalize(array $resourceInputFormats, array $resourceOutputFormats, array $operations): array
+    {
+        $newOperations = [];
+        foreach ($operations as $operationName => $operation) {
+            if ('PATCH' === ($operation->method ?? '') && !$operation->formats && !$operation->inputFormats) {
+                $operation->inputFormats = $this->patchFormats;
+            }
+
+            if ($operation->formats) {
+                $operation->formats = $this->normalizeFormats($operation->formats);
+            }
+
+            $operation->inputFormats = $operation->inputFormats ? $this->normalizeFormats($operation->inputFormats) : $operation->formats ?? $resourceInputFormats;
+            $operation->outputFormats = $operation->outputFormats ? $this->normalizeFormats($operation->outputFormats) : $operation->formats ?? $resourceOutputFormats;
+
+            $newOperations[$operationName] = $operation;
+        }
+
+        return $newOperations;
+    }
+
+    /**
+     * @param array|string $currentFormats
+     *
+     * @throws InvalidArgumentException
+     */
+    private function normalizeFormats($currentFormats): array
+    {
+        $currentFormats = (array) $currentFormats;
+
+        $normalizedFormats = [];
+        foreach ($currentFormats as $format => $value) {
+            if (!is_numeric($format)) {
+                $normalizedFormats[$format] = (array) $value;
+                continue;
+            }
+            if (!\is_string($value)) {
+                throw new InvalidArgumentException(sprintf("The 'formats' attributes value must be a string when trying to include an already configured format, %s given.", \gettype($value)));
+            }
+            if (\array_key_exists($value, $this->formats)) {
+                $normalizedFormats[$value] = $this->formats[$value];
+                continue;
+            }
+
+            throw new InvalidArgumentException(sprintf("You either need to add the format '%s' to your project configuration or declare a mime type for it in your annotation.", $value));
+        }
+
+        return $normalizedFormats;
+    }
+}

--- a/src/Metadata/ResourceCollection/Factory/IdentifierResourceCollectionMetadataFactory.php
+++ b/src/Metadata/ResourceCollection/Factory/IdentifierResourceCollectionMetadataFactory.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Exception\PropertyNotFoundException;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+
+/**
+ * Helps creating metadata on the Resource based on the properties of this same resource. Computes "identifiers".
+ * TODO: compute serialization groups as in SerializerPropertyMetadataFactory using the same injected services trying to avoid recursion.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+final class IdentifierResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    private $decorated;
+    private $propertyNameCollectionFactory;
+    private $propertyMetadataFactory;
+
+    public function __construct(ResourceCollectionMetadataFactoryInterface $decorated, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory)
+    {
+        $this->decorated = $decorated;
+        $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
+        $this->propertyMetadataFactory = $propertyMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+        $identifiers = null;
+
+        foreach ($resourceMetadataCollection as $i => $resource) {
+            if (!$resource->identifiers) {
+                $resource->identifiers = $identifiers ?: ($identifiers = $this->getIdentifiersFromResourceClass($resourceClass));
+
+                foreach ($resource->operations as $key => $operation) {
+                    if (!$operation->identifiers && !$operation instanceof Post && !$operation instanceof GetCollection) {
+                        $resource->operations[$key]->identifiers = $identifiers;
+                    }
+                }
+
+                $resourceMetadataCollection[$i] = $resource;
+                continue;
+            }
+
+            if (!\is_string(current($resource->identifiers))) {
+                continue;
+            }
+
+            $formatted = [];
+            foreach ($resource->identifiers as $identifier) {
+                $formatted[$identifier] = [$identifier => $resourceClass];
+            }
+
+            $resource->identifiers = $formatted;
+
+            foreach ($resource->operations as $key => $operation) {
+                if (!$operation->identifiers) {
+                    $resource->operations[$key]->identifiers = $formatted;
+                }
+            }
+
+            $resourceMetadataCollection[$i] = $resource;
+        }
+
+        return new ResourceCollection($resourceMetadataCollection);
+    }
+
+    private function getIdentifiersFromResourceClass(string $resourceClass): array
+    {
+        $identifiers = [];
+        $hasIdProperty = false;
+        foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
+            $hasIdProperty = 'id' === $property;
+            try {
+                if ($this->propertyMetadataFactory->create($resourceClass, $property)->isIdentifier() ?? false) {
+                    $identifiers[$property] = [$resourceClass, $property];
+                }
+            } catch (PropertyNotFoundException $e) {
+            }
+        }
+
+        if (!$identifiers) {
+            if ($hasIdProperty) {
+                return ['id' => [$resourceClass, 'id']];
+            }
+
+            return $identifiers;
+        }
+
+        return $identifiers;
+    }
+}

--- a/src/Metadata/ResourceCollection/Factory/InputOutputResourceCollectionMetadataFactory.php
+++ b/src/Metadata/ResourceCollection/Factory/InputOutputResourceCollectionMetadataFactory.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Metadata\Resource;
+
+/**
+ * Transforms the given input/output metadata to a normalized one.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+final class InputOutputResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    private $decorated;
+
+    public function __construct(ResourceCollectionMetadataFactoryInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+
+        foreach ($resourceMetadataCollection as $key => $resourceMetadata) {
+            $resourceMetadata->input = $this->transformInputOutput($resourceMetadata->input);
+            $resourceMetadata->output = $this->transformInputOutput($resourceMetadata->output);
+
+            if ($resourceMetadata->operations) {
+                $resourceMetadata->operations = $this->getTransformedOperations($resourceMetadata->operations, $resourceMetadata);
+            }
+
+            // TODO: GraphQL operations as an object?
+            // if ($graphQlAttributes = $resourceMetadata->graphQl) {
+            //     $resourceMetadata->graphQl = $this->getTransformedOperations($resourceMetadata->graphQl, $resourceMetadata);
+            // }
+
+            $resourceMetadataCollection[$key] = $resourceMetadata;
+        }
+
+        return new ResourceCollection($resourceMetadataCollection);
+    }
+
+    private function getTransformedOperations(array $operations, Resource $resourceMetadata): array
+    {
+        foreach ($operations as $key => &$operation) {
+            $operation->input = $operation->input ? $this->transformInputOutput($operation->input) : $resourceMetadata->input;
+            $operation->output = $operation->output ? $this->transformInputOutput($operation->output) : $resourceMetadata->output;
+
+            if (
+                $operation->input
+                && \array_key_exists('class', $operation->input)
+                && null === $operation->input['class']
+            ) {
+                $operation->deserialize = $operation->deserialize ?? false;
+                $operation->validate = $operation->validate ?? false;
+            }
+
+            if (
+                $operation->output
+                && \array_key_exists('class', $operation->output)
+                && null === $operation->output['class']
+            ) {
+                $operation->status = $operation->status ?? 204;
+            }
+        }
+
+        return $operations;
+    }
+
+    private function transformInputOutput($attribute): ?array
+    {
+        if (false === $attribute) {
+            return ['class' => null];
+        }
+
+        if (!$attribute) {
+            return null;
+        }
+
+        if (\is_string($attribute)) {
+            $attribute = ['class' => $attribute];
+        }
+
+        if (!isset($attribute['name']) && isset($attribute['class'])) {
+            $attribute['name'] = (new \ReflectionClass($attribute['class']))->getShortName();
+        }
+
+        return $attribute;
+    }
+}

--- a/src/Metadata/ResourceCollection/Factory/PhpDocResourceCollectionMetadataFactory.php
+++ b/src/Metadata/ResourceCollection/Factory/PhpDocResourceCollectionMetadataFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\DocBlockFactoryInterface;
+use phpDocumentor\Reflection\Types\ContextFactory;
+
+/**
+ * Extracts descriptions from PHPDoc.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ * @experimental
+ */
+final class PhpDocResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    private $decorated;
+    private $docBlockFactory;
+    private $contextFactory;
+
+    public function __construct(ResourceCollectionMetadataFactoryInterface $decorated, DocBlockFactoryInterface $docBlockFactory = null)
+    {
+        $this->decorated = $decorated;
+        $this->docBlockFactory = $docBlockFactory ?: DocBlockFactory::createInstance();
+        $this->contextFactory = new ContextFactory();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+
+        foreach ($resourceMetadataCollection as $key => $resourceMetadata) {
+            if (null !== $resourceMetadata->description) {
+                continue;
+            }
+
+            $reflectionClass = new \ReflectionClass($resourceClass);
+
+            try {
+                $docBlock = $this->docBlockFactory->create($reflectionClass, $this->contextFactory->createFromReflector($reflectionClass));
+                $resourceMetadata->description = $docBlock->getSummary();
+                $resourceMetadataCollection[$key] = $resourceMetadata;
+            } catch (\InvalidArgumentException $e) {
+                // Ignore empty DocBlocks
+            }
+        }
+
+        return new ResourceCollection($resourceMetadataCollection);
+    }
+}

--- a/src/Metadata/ResourceCollection/Factory/ResourceCollectionMetadataFactoryInterface.php
+++ b/src/Metadata/ResourceCollection/Factory/ResourceCollectionMetadataFactoryInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+
+/**
+ * Creates a resource metadata value object.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+interface ResourceCollectionMetadataFactoryInterface
+{
+    /**
+     * Creates a resource metadata.
+     *
+     * @throws ResourceClassNotFoundException
+     */
+    public function create(string $resourceClass): ResourceCollection;
+}

--- a/src/Metadata/ResourceCollection/Factory/UriTemplateResourceCollectionMetadataFactory.php
+++ b/src/Metadata/ResourceCollection/Factory/UriTemplateResourceCollectionMetadataFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Operation\PathSegmentNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @experimental
+ */
+final class UriTemplateResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    private $pathSegmentNameGenerator;
+    private $decorated;
+
+    public function __construct(PathSegmentNameGeneratorInterface $pathSegmentNameGenerator, ResourceCollectionMetadataFactoryInterface $decorated = null)
+    {
+        $this->pathSegmentNameGenerator = $pathSegmentNameGenerator;
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceCollection
+    {
+        $parentResourceMetadata = [];
+        if ($this->decorated) {
+            try {
+                $parentResourceMetadata = $this->decorated->create($resourceClass)->getArrayCopy();
+            } catch (ResourceClassNotFoundException $resourceNotFoundException) {
+                // Ignore not found exception from decorated factories
+            }
+        }
+
+        foreach ($parentResourceMetadata as $i => $resource) {
+            if (!$resource->uriTemplate) {
+                foreach ($resource->operations as $key => $operation) {
+                    $operation->uriTemplate = $this->generateUriTemplate($operation);
+                    // Change the operation key
+                    unset($resource->operations[$key]);
+                    $resource->operations[sprintf('_api_%s_%s', $operation->uriTemplate, strtolower($operation->method))] = $operation;
+                }
+            }
+
+            $parentResourceMetadata[$i] = $resource;
+        }
+
+        return new ResourceCollection($parentResourceMetadata);
+    }
+
+    private function generateUriTemplate(Operation $operation): string
+    {
+        $uriTemplate = $operation->routePrefix ?: '';
+        if (!$operation->identifiers) {
+            return sprintf('%s/%s.{_format}', $uriTemplate, $this->pathSegmentNameGenerator->getSegmentName($operation->shortName));
+        }
+
+        $uriTemplate = sprintf('%s/%s', $uriTemplate, $this->pathSegmentNameGenerator->getSegmentName($operation->shortName));
+        foreach (array_keys($operation->identifiers) as $parameterName) {
+            $uriTemplate .= sprintf('/{%s}', $parameterName);
+        }
+
+        return sprintf('%s.{_format}', $uriTemplate);
+    }
+}

--- a/src/Metadata/ResourceCollection/ResourceCollection.php
+++ b/src/Metadata/ResourceCollection/ResourceCollection.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Metadata\ResourceCollection;
+
+use ApiPlatform\Metadata\Resource;
+
+/**
+ * @experimental
+ * @extends \ArrayObject<int, Resource>
+ */
+final class ResourceCollection extends \ArrayObject
+{
+    private $metadataCache = [];
+    private $operationCache = [];
+
+    public function getOperation(string $method, string $uriTemplate)
+    {
+        if (isset($this->operationCache[$uriTemplate][$method])) {
+            return $this->operationCache[$uriTemplate][$method];
+        }
+
+        if (!($resourceMetadata = $this->getResource($uriTemplate))) {
+            return null;
+        }
+
+        foreach ($resourceMetadata->operations as $operation) {
+            if ($operation->method === $method) {
+                if (!isset($this->operationCache[$uriTemplate])) {
+                    $this->operationCache[$uriTemplate] = [];
+                }
+
+                return $this->operationCache[$uriTemplate][$method] = $operation;
+            }
+        }
+
+        return null;
+    }
+
+    public function getResource(string $uriTemplate): ?Resource
+    {
+        if (isset($this->metadataCache[$uriTemplate])) {
+            return $this->metadataCache[$uriTemplate];
+        }
+
+        $it = $this->getIterator();
+
+        while ($it->valid()) {
+            /** @var resource */
+            $metadata = $it->current();
+
+            if ($metadata->uriTemplate === $uriTemplate) {
+                $this->metadataCache[$uriTemplate] = $metadata;
+
+                return $metadata;
+            }
+
+            $it->next();
+        }
+
+        return null;
+    }
+}

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -104,7 +104,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     public function supportsNormalization($data, $format = null)
     {
-        if (!\is_object($data)) {
+        if (!\is_object($data) || is_iterable($data)) {
             return false;
         }
 

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use ApiPlatform\Metadata\Resource;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 
@@ -46,7 +47,12 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
 
         $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
         $key = $normalization ? 'normalization_context' : 'denormalization_context';
-        if (isset($attributes['collection_operation_name'])) {
+
+        // TODO: remove in 3.0
+        if (isset($attributes['operation_name'])) {
+            $operationKey = 'operation_name';
+            $operationType = ($attributes['identifiers'] ?? []) ? OperationType::ITEM : OperationType::COLLECTION;
+        } elseif (isset($attributes['collection_operation_name'])) {
             $operationKey = 'collection_operation_name';
             $operationType = OperationType::COLLECTION;
         } elseif (isset($attributes['item_operation_name'])) {

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -56,12 +56,17 @@ final class AttributesExtractor
         }
 
         $hasRequestAttributeKey = false;
-        foreach (OperationType::TYPES as $operationType) {
-            $attribute = "_api_{$operationType}_operation_name";
-            if (isset($attributes[$attribute])) {
-                $result["{$operationType}_operation_name"] = $attributes[$attribute];
-                $hasRequestAttributeKey = true;
-                break;
+        if (isset($attributes['_api_operation_name'])) {
+            $hasRequestAttributeKey = true;
+            $result['operation_name'] = $attributes['_api_operation_name'];
+        } else {
+            foreach (OperationType::TYPES as $operationType) {
+                $attribute = "_api_{$operationType}_operation_name";
+                if (isset($attributes[$attribute])) {
+                    $result["{$operationType}_operation_name"] = $attributes[$attribute];
+                    $hasRequestAttributeKey = true;
+                    break;
+                }
             }
         }
 

--- a/tests/Bridge/Symfony/Bundle/Command/OpenApiCommandTest.php
+++ b/tests/Bridge/Symfony/Bundle/Command/OpenApiCommandTest.php
@@ -41,6 +41,11 @@ class OpenApiCommandTest extends KernelTestCase
         $this->tester = new ApplicationTester($application);
     }
 
+    /**
+     * TODO: change this once we support #[Resource].
+     *
+     * @group legacy
+     */
     public function testExecute()
     {
         $this->tester->run(['command' => 'api:openapi:export']);

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -79,6 +79,7 @@ use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
 use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;
 use ApiPlatform\Core\OpenApi\Options;
 use ApiPlatform\Core\OpenApi\Serializer\OpenApiNormalizer;
@@ -89,6 +90,7 @@ use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\TestBundle;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use ApiPlatform\Core\Validator\ValidatorInterface;
+use ApiPlatform\State\ProviderInterface;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\OptimisticLockException;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
@@ -580,6 +582,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.doctrine.orm.search_filter', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.doctrine.orm.subresource_data_provider', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.doctrine.orm.listener.mercure.publish', Argument::type(Definition::class))->shouldNotBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.doctrine.orm.metadata.property.identifier_metadata_factory', Argument::type(Definition::class))->shouldNotBeCalled();
         $containerBuilderProphecy->setAlias(EagerLoadingExtension::class, 'api_platform.doctrine.orm.query_extension.eager_loading')->shouldNotBeCalled();
         $containerBuilderProphecy->setAlias(FilterExtension::class, 'api_platform.doctrine.orm.query_extension.filter')->shouldNotBeCalled();
         $containerBuilderProphecy->setAlias(FilterEagerLoadingExtension::class, 'api_platform.doctrine.orm.query_extension.filter_eager_loading')->shouldNotBeCalled();
@@ -981,6 +984,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.cache.identifiers_extractor',
             'api_platform.cache.metadata.property',
             'api_platform.cache.metadata.resource',
+            'api_platform.cache.metadata.resource_collection',
             'api_platform.cache.route_name_resolver',
             'api_platform.cache.subresource_operation_factory',
             'api_platform.cache_warmer.cache_pool_clearer',
@@ -1018,10 +1022,18 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.resource.metadata_factory.operation',
             'api_platform.metadata.resource.metadata_factory.formats',
             'api_platform.metadata.resource.metadata_factory.input_output',
+            'api_platform.metadata.resource.metadata_factory.resource_collection',
             'api_platform.metadata.resource.metadata_factory.short_name',
             'api_platform.metadata.resource.metadata_factory.xml',
             'api_platform.metadata.resource.name_collection_factory.cached',
             'api_platform.metadata.resource.name_collection_factory.xml',
+            'api_platform.metadata.resource_collection.metadata_factory.attributes',
+            'api_platform.metadata.resource_collection.metadata_factory.cached',
+            'api_platform.metadata.resource_collection.metadata_factory.formats',
+            'api_platform.metadata.resource_collection.metadata_factory.identifier',
+            'api_platform.metadata.resource_collection.metadata_factory.input_output',
+            'api_platform.metadata.resource_collection.metadata_factory.php_doc',
+            'api_platform.metadata.resource_collection.metadata_factory.uri_template',
             'api_platform.metadata.property.metadata_factory.default_property',
             'api_platform.negotiator',
             'api_platform.operation_method_resolver',
@@ -1046,6 +1058,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.serializer.property_filter',
             'api_platform.serializer.uuid_denormalizer',
             'api_platform.serializer_locator',
+            'api_platform.state_provider',
             'api_platform.subresource_data_provider',
             'api_platform.subresource_operation_factory',
             'api_platform.subresource_operation_factory.cached',
@@ -1097,6 +1110,9 @@ class ApiPlatformExtensionTest extends TestCase
             SubresourceDataProviderInterface::class => 'api_platform.subresource_data_provider',
             UrlGeneratorInterface::class => 'api_platform.router',
             PaginationOptions::class => 'api_platform.pagination_options',
+            ProviderInterface::class => 'api_platform.state_provider',
+            ResourceCollectionMetadataFactoryInterface::class => 'api_platform.metadata.resource_collection.metadata_factory',
+            'api_platform.metadata.resource_collection.metadata_factory' => 'api_platform.metadata.resource_collection.metadata_factory.attributes',
         ];
 
         foreach ($aliases as $alias => $service) {
@@ -1300,6 +1316,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.doctrine.orm.range_filter',
             'api_platform.doctrine.orm.search_filter',
             'api_platform.doctrine.orm.subresource_data_provider',
+            'api_platform.doctrine.orm.metadata.property.identifier_metadata_factory',
             'api_platform.graphql.action.entrypoint',
             'api_platform.graphql.action.graphiql',
             'api_platform.graphql.action.graphql_playground',
@@ -1392,6 +1409,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.swagger.listener.ui',
             'api_platform.validator',
             'api_platform.validator.query_parameter_validator',
+            'api_platform.metadata.property.identifier_metadata_factory.annotation',
         ];
 
         if (\in_array('odm', $doctrineIntegrationsToLoad, true)) {
@@ -1476,6 +1494,7 @@ class ApiPlatformExtensionTest extends TestCase
         $aliases = [
             'api_platform.http_cache.purger' => 'api_platform.http_cache.purger.varnish',
             'api_platform.message_bus' => 'messenger.default_bus',
+            'api_platform.metadata.property.identifier_metadata_factory' => 'api_platform.metadata.property.identifier_metadata_factory.annotation',
             EagerLoadingExtension::class => 'api_platform.doctrine.orm.query_extension.eager_loading',
             FilterExtension::class => 'api_platform.doctrine.orm.query_extension.filter',
             FilterEagerLoadingExtension::class => 'api_platform.doctrine.orm.query_extension.filter_eager_loading',

--- a/tests/Bridge/Symfony/Routing/IriConverterTest.php
+++ b/tests/Bridge/Symfony/Routing/IriConverterTest.php
@@ -24,14 +24,19 @@ use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\InvalidIdentifierException;
 use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Resource;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
@@ -381,6 +386,44 @@ class IriConverterTest extends TestCase
         );
     }
 
+    /**
+     * @requires PHP 8.0
+     */
+    public function testGetIriFromResourceClassWithResourceCollection()
+    {
+        $routeNameResolverProphecy = $this->prophesize(RouteNameResolverInterface::class);
+        $routeNameResolverProphecy->getRouteName(Dummy::class, OperationType::COLLECTION)->willReturn('dummies')->shouldNotBeCalled();
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->generate('operationName', [], UrlGeneratorInterface::ABS_PATH)->willReturn('/dummies');
+        $resourceCollectionMetadataFactory = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $resource = new Resource();
+        $itemOperation = new Get();
+        $itemOperation->identifiers = ['id'];
+        $resource->operations = ['itemOperationName' => $itemOperation, 'operationName' => new Get()];
+        $resourceCollectionMetadataFactory->create(Dummy::class)->willReturn(new ResourceCollection([$resource]));
+
+        $converter = $this->getIriConverter($routerProphecy, $routeNameResolverProphecy, null, null, null, null, $resourceCollectionMetadataFactory->reveal());
+        $this->assertEquals($converter->getIriFromResourceClass(Dummy::class), '/dummies');
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testGetIriFromResourceClassWithResourceCollectionNotFound()
+    {
+        $routeNameResolverProphecy = $this->prophesize(RouteNameResolverInterface::class);
+        $routeNameResolverProphecy->getRouteName(Dummy::class, OperationType::COLLECTION)->willReturn('dummies');
+
+        $routerProphecy = $this->prophesize(RouterInterface::class);
+        $routerProphecy->generate('dummies', [], UrlGeneratorInterface::ABS_PATH)->willReturn('/dummies');
+        $resourceCollectionMetadataFactory = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $resourceCollectionMetadataFactory->create(Dummy::class)->willThrow(ResourceClassNotFoundException::class);
+
+        $converter = $this->getIriConverter($routerProphecy, $routeNameResolverProphecy, null, null, null, null, $resourceCollectionMetadataFactory->reveal());
+        $this->assertEquals($converter->getIriFromResourceClass(Dummy::class), '/dummies');
+    }
+
     private function getResourceClassResolver()
     {
         $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
@@ -391,7 +434,7 @@ class IriConverterTest extends TestCase
         return $resourceClassResolver->reveal();
     }
 
-    private function getIriConverter($routerProphecy = null, $routeNameResolverProphecy = null, $itemDataProviderProphecy = null, $subresourceDataProviderProphecy = null, $identifierConverterProphecy = null, ResourceMetadataFactoryInterface $resourceMetadataFactory = null)
+    private function getIriConverter($routerProphecy = null, $routeNameResolverProphecy = null, $itemDataProviderProphecy = null, $subresourceDataProviderProphecy = null, $identifierConverterProphecy = null, ResourceMetadataFactoryInterface $resourceMetadataFactory = null, $resourceCollectionMetadataFactory = null)
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
@@ -427,7 +470,8 @@ class IriConverterTest extends TestCase
             $subresourceDataProviderProphecy ? $subresourceDataProviderProphecy->reveal() : null,
             $identifierConverterProphecy->reveal(),
             null,
-            $resourceMetadataFactory
+            $resourceMetadataFactory,
+            $resourceCollectionMetadataFactory
         );
     }
 }

--- a/tests/Core/Metadata/AttributeTraitTest.php
+++ b/tests/Core/Metadata/AttributeTraitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Core\Metadata;
+
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+class AttributeTraitTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testExtraProperties()
+    {
+        /** @var \stdClass */
+        $resource = new Resource();
+        $resource->foo = 'bar';
+        $this->assertEquals(['foo' => 'bar'], $resource->extraProperties);
+        $this->assertEquals($resource->foo, 'bar');
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testNamedArguments()
+    {
+        /** @var \stdClass */
+        $resource = new Resource(types: ['Resource'], foo: 'bar');
+        $this->assertEquals($resource->types, ['Resource']);
+        $this->assertEquals($resource->foo, 'bar');
+        $this->assertEquals(['foo' => 'bar'], $resource->extraProperties);
+    }
+}

--- a/tests/Core/State/ChainProviderTest.php
+++ b/tests/Core/State/ChainProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Core\Metadata;
+
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\State\ChainProvider;
+use ApiPlatform\State\ProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class ChainProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testChainProvider()
+    {
+        $a = $this->prophesize(ProviderInterface::class);
+        $a->supports('class', [], [])->willReturn(false);
+        $a->provide('class', [], [])->shouldNotBeCalled();
+
+        $b = $this->prophesize(ProviderInterface::class);
+        $b->supports('class', [], [])->willReturn(true);
+        $b->provide('class', [], [])->willReturn('value');
+
+        $chainProvider = new ChainProvider([
+            $a->reveal(),
+            $b->reveal(),
+        ]);
+
+        $this->assertEquals('value', $chainProvider->provide('class', [], []));
+        $this->assertTrue($chainProvider->supports('class', [], []));
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testReturnValueWhenNoProvider()
+    {
+        $a = $this->prophesize(ProviderInterface::class);
+        $a->supports('class', ['id' => 1], [])->willReturn(false);
+        $a->supports('class', [], [])->willReturn(false);
+        $a->provide('class', ['id' => 1], [])->shouldNotBeCalled();
+        $a->provide('class', [], [])->shouldNotBeCalled();
+
+        $chainProvider = new ChainProvider([
+            $a->reveal(),
+        ]);
+
+        $this->assertNull($chainProvider->provide('class', ['id' => 1], []));
+        $this->assertEquals([], $chainProvider->provide('class', [], []));
+        $this->assertFalse($chainProvider->supports('class', [], []));
+    }
+}

--- a/tests/DataProvider/StateLegacyDataProviderTest.php
+++ b/tests/DataProvider/StateLegacyDataProviderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Core\Metadata;
+
+use ApiPlatform\Core\DataProvider\StateLegacyDataProvider;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\State\ProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class StateLegacyDataProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testStateLegacyDataProviderTest()
+    {
+        $provider = $this->prophesize(ProviderInterface::class);
+        $provider->provide('class', ['id' => 1], [])->shouldBeCalled()->willReturn('item');
+        $provider->provide('class', [], [])->shouldBeCalled()->willReturn('collection');
+        $legacyDataProvider = new StateLegacyDataProvider($provider->reveal());
+        $this->assertEquals('item', $legacyDataProvider->getItem('class', ['id' => 1]));
+        $this->assertEquals('collection', $legacyDataProvider->getCollection('class'));
+    }
+}

--- a/tests/EventListener/ReadListenerTest.php
+++ b/tests/EventListener/ReadListenerTest.php
@@ -24,8 +24,10 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\State\ProviderInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -35,6 +37,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ReadListenerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
     use ProphecyTrait;
 
     public function testNotAnApiPlatformRequest()
@@ -164,7 +167,7 @@ class ReadListenerTest extends TestCase
         $identifierConverter = $this->prophesize(IdentifierConverterInterface::class);
 
         $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
-        $collectionDataProvider->getCollection('Foo', 'get', ['filters' => ['foo' => 'bar']])->willReturn([])->shouldBeCalled();
+        $collectionDataProvider->getCollection('Foo', 'get', ['filters' => ['foo' => 'bar'], IdentifierConverterInterface::HAS_IDENTIFIER_CONVERTER => true])->willReturn([])->shouldBeCalled();
 
         $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
         $itemDataProvider->getItem()->shouldNotBeCalled();
@@ -397,6 +400,53 @@ class ReadListenerTest extends TestCase
         $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
 
         $request = new Request([], [], ['id' => 'foo=22;bar=test', '_api_resource_class' => 'DummyWithCompositeIdentifier', '_api_item_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json', '_api_identifiers' => ['foo', 'bar'], '_api_has_composite_identifier' => true]);
+        $request->setMethod('GET');
+
+        $event = $this->prophesize(RequestEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $listener = new ReadListener($collectionDataProvider->reveal(), $itemDataProvider->reveal(), $subresourceDataProvider->reveal(), null, $identifierConverter->reveal());
+        $listener->onKernelRequest($event->reveal());
+    }
+
+    public function testRetrieveOperationWithStateProvider()
+    {
+        $identifierConverter = $this->prophesize(IdentifierConverterInterface::class);
+        $identifierConverter->convert(['id' => '22'], 'Foo')->shouldBeCalled()->willReturn(['id' => 22]);
+        $this->expectException(NotFoundHttpException::class);
+
+        $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
+        $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
+        $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+        $stateProvider = $this->prophesize(ProviderInterface::class);
+        $stateProvider->provide('Foo', ['id' => 22], Argument::cetera())->shouldBeCalled()->willReturn(null);
+
+        $request = new Request([], [], ['id' => '22', '_api_resource_class' => 'Foo', '_api_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json', '_api_identifiers' => ['id' => ['Foo', 'id']]]);
+        $request->setMethod('GET');
+
+        $event = $this->prophesize(RequestEvent::class);
+        $event->getRequest()->willReturn($request)->shouldBeCalled();
+
+        $listener = new ReadListener($collectionDataProvider->reveal(), $itemDataProvider->reveal(), $subresourceDataProvider->reveal(), null, $identifierConverter->reveal(), null, $stateProvider->reveal());
+        $listener->onKernelRequest($event->reveal());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testRetrieveOperationWithoutStateProvider()
+    {
+        $this->expectDeprecation('Using a #[Resource] without a state provider is deprecated since 2.7 and will not be possible anymore in 3.0.');
+        $identifierConverter = $this->prophesize(IdentifierConverterInterface::class);
+        $identifierConverter->convert(['id' => '22'], 'Foo')->shouldBeCalled()->willReturn(['id' => 22]);
+        $this->expectException(NotFoundHttpException::class);
+
+        $collectionDataProvider = $this->prophesize(CollectionDataProviderInterface::class);
+        $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
+        $itemDataProvider->getItem('Foo', ['id' => 22], 'get', Argument::cetera())->willReturn(null)->shouldBeCalled();
+        $subresourceDataProvider = $this->prophesize(SubresourceDataProviderInterface::class);
+
+        $request = new Request([], [], ['id' => '22', '_api_resource_class' => 'Foo', '_api_operation_name' => 'get', '_api_format' => 'json', '_api_mime_type' => 'application/json', '_api_identifiers' => ['id' => ['Foo', 'id']]]);
         $request->setMethod('GET');
 
         $event = $this->prophesize(RequestEvent::class);

--- a/tests/Fixtures/TestBundle/Document/JsonldContextDummy.php
+++ b/tests/Fixtures/TestBundle/Document/JsonldContextDummy.php
@@ -40,7 +40,7 @@ class JsonldContextDummy
      *     attributes={
      *         "jsonld_context"={
      *             "@id"="http://example.com/id",
-     *             "@type"="@id",
+     *             "@var"="@id",
      *             "foo"="bar"
      *         }
      *     },

--- a/tests/Fixtures/TestBundle/Entity/AttributeDefaultOperations.php
+++ b/tests/Fixtures/TestBundle/Entity/AttributeDefaultOperations.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Metadata\Resource;
+
+#[Resource]
+final class AttributeDefaultOperations
+{
+    #[ApiProperty(identifier: true)]
+    private int $identifier;
+
+    public function __construct(int $identifier, public string $name)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/AttributeResource.php
+++ b/tests/Fixtures/TestBundle/Entity/AttributeResource.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Resource;
+
+#[Resource]
+#[Get]
+#[Put]
+#[Delete]
+#[Resource('/dummy/{dummyId}/attribute_resources/{id}', identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']])]
+#[Get]
+final class AttributeResource
+{
+    #[ApiProperty(identifier: true)]
+    private int $identifier;
+
+    public function __construct(int $identifier, public string $name)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/AttributeResources.php
+++ b/tests/Fixtures/TestBundle/Entity/AttributeResources.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Resource;
+use IteratorAggregate;
+
+#[Resource('/attribute_resources.{_format}')]
+#[Get]
+#[Post]
+final class AttributeResources implements IteratorAggregate
+{
+    private $collection;
+
+    public function __construct($collection)
+    {
+        $this->collection = $collection;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->collection);
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/JsonldContextDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/JsonldContextDummy.php
@@ -42,7 +42,7 @@ class JsonldContextDummy
      *     attributes={
      *         "jsonld_context"={
      *             "@id"="http://example.com/id",
-     *             "@type"="@id",
+     *             "@var"="@id",
      *             "foo"="bar"
      *         }
      *     },

--- a/tests/Fixtures/TestBundle/State/AttributeResourceProvider.php
+++ b/tests/Fixtures/TestBundle/State/AttributeResourceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\State;
+
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResources;
+use ApiPlatform\State\ProviderInterface;
+
+class AttributeResourceProvider implements ProviderInterface
+{
+    public function provide(string $resourceClass, array $identifiers = [], array $context = [])
+    {
+        if (isset($identifiers['identifier'])) {
+            return new AttributeResource($identifiers['identifier'], 'Foo');
+        }
+
+        return new AttributeResources([new AttributeResource(1, 'Foo'), new AttributeResource(2, 'Bar')]);
+    }
+
+    public function supports(string $resourceClass, array $identifiers = [], array $context = []): bool
+    {
+        return AttributeResource::class === $resourceClass || AttributeResources::class === $resourceClass;
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -92,6 +92,12 @@ services:
         autowire: true
         autoconfigure: true
 
+    attribute_resources.state_provider:
+        class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\State\AttributeResourceProvider'
+        public: false
+        tags:
+            -  { name: 'api_platform.state_provider' }
+
     contain_non_resource.item_data_provider:
         class: 'ApiPlatform\Core\Tests\Fixtures\TestBundle\DataProvider\ContainNonResourceItemDataProvider'
         public: false

--- a/tests/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AnnotationResourceNameCollectionFactoryTest.php
@@ -19,16 +19,22 @@ use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
 class AnnotationResourceNameCollectionFactoryTest extends TestCase
 {
+    use ExpectDeprecationTrait;
     use ProphecyTrait;
 
+    /**
+     * @group legacy
+     */
     public function testCreate()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\AnnotationResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $decorated = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $decorated->create()->willReturn(new ResourceNameCollection(['foo', 'bar']))->shouldBeCalled();
 
@@ -40,10 +46,11 @@ class AnnotationResourceNameCollectionFactoryTest extends TestCase
     }
 
     /**
-     * @requires PHP 8.0
+     * @group legacy
      */
     public function testCreateAttribute()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\AnnotationResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $decorated = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
         $decorated->create()->willReturn(new ResourceNameCollection(['foo', 'bar']))->shouldBeCalled();
 

--- a/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceMetadataFactoryTest.php
@@ -27,6 +27,7 @@ use ApiPlatform\Core\Tests\Fixtures\DummyResourceInterface;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy;
 use ApiPlatform\Core\Tests\ProphecyTrait;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * Tests extractor resource metadata factory.
@@ -35,6 +36,7 @@ use ApiPlatform\Core\Tests\ProphecyTrait;
  */
 class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFactoryProvider
 {
+    use ExpectDeprecationTrait;
     use ProphecyTrait;
 
     /**
@@ -50,8 +52,12 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
     }
 
+    /**
+     * @group legacy
+     */
     public function testXmlDoesNotExistMetadataFactory()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $this->expectException(ResourceClassNotFoundException::class);
         $this->expectExceptionMessage('Resource "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" not found.');
 
@@ -176,8 +182,12 @@ class ExtractorResourceMetadataFactoryTest extends FileConfigurationMetadataFact
         $this->assertEquals($expectedResourceMetadata, $resourceMetadata);
     }
 
+    /**
+     * @group legacy
+     */
     public function testYamlDoesNotExistMetadataFactory()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $this->expectException(ResourceClassNotFoundException::class);
         $this->expectExceptionMessage('Resource "ApiPlatform\\Core\\Tests\\Fixtures\\TestBundle\\Entity\\ThisDoesNotExist" not found.');
 

--- a/tests/Metadata/Resource/Factory/ExtractorResourceNameCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ExtractorResourceNameCollectionFactoryTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\FileConfigDummy;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * Tests extractor resource name collection factory.
@@ -29,8 +30,14 @@ use PHPUnit\Framework\TestCase;
  */
 class ExtractorResourceNameCollectionFactoryTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testXmlResourceName()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.xml';
         $factory = new ExtractorResourceNameCollectionFactory(new XmlExtractor([$configPath]));
 
@@ -40,8 +47,12 @@ class ExtractorResourceNameCollectionFactoryTest extends TestCase
         ]));
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidExtractorResourceNameCollectionFactory()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $this->expectException(InvalidArgumentException::class);
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resourcesinvalid.xml';
@@ -49,8 +60,12 @@ class ExtractorResourceNameCollectionFactoryTest extends TestCase
         $factory->create();
     }
 
+    /**
+     * @group legacy
+     */
     public function testYamlResourceName()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/resources.yml';
         $factory = new ExtractorResourceNameCollectionFactory(new YamlExtractor([$configPath]));
 
@@ -60,16 +75,24 @@ class ExtractorResourceNameCollectionFactoryTest extends TestCase
         ]));
     }
 
+    /**
+     * @group legacy
+     */
     public function testYamlSingleResourceName()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/single_resource.yml';
         $factory = new ExtractorResourceNameCollectionFactory(new YamlExtractor([$configPath]));
 
         $this->assertEquals($factory->create(), new ResourceNameCollection([FileConfigDummy::class]));
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateWithMalformedYaml()
     {
+        $this->expectDeprecation('Using a legacy ApiPlatform\Core\Metadata\Resource\Factory\ExtractorResourceNameCollectionFactory is deprecated since 2.7 and will not be possible in 3.0.');
         $this->expectException(InvalidArgumentException::class);
 
         $configPath = __DIR__.'/../../../Fixtures/FileConfigurations/parse_exception.yml';

--- a/tests/Metadata/Resource/Factory/ResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/ResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResource;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+class ResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+    use ProphecyTrait;
+
+    /**
+     * @requires PHP 8.0
+     * @group legacy
+     */
+    public function testCreateAttribute()
+    {
+        $this->expectDeprecation('Using a ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface for a #[Resource] is deprecated since 2.7 and will not be possible in 3.0. Use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface instead.');
+        $decorated = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decorated->create(AttributeResource::class)->willThrow(ResourceClassNotFoundException::class);
+        $resourceCollectionMetadataFactory = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $operations = ['get' => new Get('/resources', normalizationContext: ['groups' => ['a']]), 'get_item' => new Get('/resources/{id}', identifiers: ['id' => ['id', AttributeResource::class]])];
+        $resourceCollectionMetadataFactory->create(AttributeResource::class)->willReturn(new ResourceCollection([new Resource(operations: $operations)]));
+        $factory = new ResourceCollectionMetadataFactory($decorated->reveal(), $resourceCollectionMetadataFactory->reveal());
+        $metadata = $factory->create(AttributeResource::class);
+
+        $this->assertCount(1, $metadata->getItemOperations());
+        $this->assertEquals(['id' => ['id', AttributeResource::class]], $metadata->getItemOperationAttribute('get_item', 'identifiers'));
+        $this->assertCount(1, $metadata->getCollectionOperations());
+        $this->assertEquals(['groups' => ['a']], $metadata->getCollectionOperationAttribute('get', 'normalization_context'));
+    }
+}

--- a/tests/Metadata/ResourceCollection/Factory/AttributeResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/ResourceCollection/Factory/AttributeResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\AttributeResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeDefaultOperations;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResources;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class AttributeResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCreate()
+    {
+        $attributeResourceCollectionMetadataFactory = new AttributeResourceCollectionMetadataFactory();
+
+        $this->assertEquals(
+            new ResourceCollection([
+                new Resource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    operations: [
+                        '_api_AttributeResource_get' => new Get(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeResource_put' => new Put(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeResource_delete' => new Delete(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder'),
+                    ]
+                ),
+                new Resource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                    identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                    operations: [
+                        '_api_/dummy/{dummyId}/attribute_resources/{id}_get' => new Get(
+                            class: AttributeResource::class,
+                            uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                            shortName: 'AttributeResource',
+                            identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                        ),
+                    ]
+                ),
+            ]),
+            $attributeResourceCollectionMetadataFactory->create(AttributeResource::class)
+        );
+
+        $this->assertEquals(
+            new ResourceCollection([
+                new Resource(
+                    uriTemplate: '/attribute_resources.{_format}',
+                    shortName: 'AttributeResources',
+                    class: AttributeResources::class,
+                    operations: [
+                        '_api_/attribute_resources.{_format}_get' => new Get(shortName: 'AttributeResources', class: AttributeResources::class, controller: 'api_platform.action.placeholder', uriTemplate: '/attribute_resources.{_format}'),
+                        '_api_/attribute_resources.{_format}_post' => new Post(shortName: 'AttributeResources', class: AttributeResources::class, controller: 'api_platform.action.placeholder', uriTemplate: '/attribute_resources.{_format}'),
+                    ]
+                ),
+            ]),
+            $attributeResourceCollectionMetadataFactory->create(AttributeResources::class)
+        );
+
+        $this->assertEquals(
+            new ResourceCollection([
+                new Resource(
+                    shortName: 'AttributeDefaultOperations',
+                    class: AttributeDefaultOperations::class,
+                    operations: [
+                        '_api_AttributeDefaultOperations_get' => new Get(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_put' => new Put(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_delete' => new Delete(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_get_collection' => new GetCollection(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_patch' => new Patch(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_post' => new Post(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                    ]
+                ),
+            ]),
+            $attributeResourceCollectionMetadataFactory->create(AttributeDefaultOperations::class)
+        );
+    }
+}

--- a/tests/Metadata/ResourceCollection/Factory/CachedResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/ResourceCollection/Factory/CachedResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\CachedResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheException;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * @author Baptiste Meyer <baptiste.meyer@gmail.com>
+ */
+class CachedResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCreateWithItemHit()
+    {
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()->willReturn(true)->shouldBeCalled();
+        $cacheItem->get()->willReturn(new ResourceCollection(new Resource(shortName: 'Dummy', class: Dummy::class)))->shouldBeCalled();
+
+        $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
+        $cacheItemPool->getItem($this->generateCacheKey())->willReturn($cacheItem->reveal())->shouldBeCalled();
+
+        $decoratedResourceMetadataFactory = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+
+        $cachedResourceMetadataFactory = new CachedResourceCollectionMetadataFactory($cacheItemPool->reveal(), $decoratedResourceMetadataFactory->reveal());
+        $resultedResourceMetadata = $cachedResourceMetadataFactory->create(Dummy::class);
+
+        $this->assertEquals(new ResourceCollection(new Resource(shortName: 'Dummy', class: Dummy::class)), $resultedResourceMetadata);
+    }
+
+    public function testCreateWithItemNotHit()
+    {
+        $resources = new ResourceCollection(new Resource(shortName: 'Dummy', class: Dummy::class));
+
+        $decoratedResourceMetadataFactory = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $decoratedResourceMetadataFactory->create(Dummy::class)->willReturn($resources)->shouldBeCalled();
+
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()->willReturn(false)->shouldBeCalled();
+        $cacheItem->set($resources)->willReturn($cacheItem->reveal())->shouldBeCalled();
+
+        $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
+        $cacheItemPool->getItem($this->generateCacheKey())->willReturn($cacheItem->reveal())->shouldBeCalled();
+        $cacheItemPool->save($cacheItem->reveal())->willReturn(true)->shouldBeCalled();
+
+        $cachedResourceMetadataFactory = new CachedResourceCollectionMetadataFactory($cacheItemPool->reveal(), $decoratedResourceMetadataFactory->reveal());
+        $resultedResourceMetadata = $cachedResourceMetadataFactory->create(Dummy::class);
+
+        $this->assertEquals($resources, $resultedResourceMetadata);
+        $this->assertEquals($resources, $cachedResourceMetadataFactory->create(Dummy::class), 'Trigger the local cache');
+    }
+
+    public function testCreateWithGetCacheItemThrowsCacheException()
+    {
+        $decoratedResourceMetadataFactory = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $decoratedResourceMetadataFactory->create(Dummy::class)->willReturn(new ResourceCollection(new Resource(shortName: 'Dummy', class: Dummy::class)))->shouldBeCalled();
+
+        $cacheException = new class() extends \Exception implements CacheException {};
+
+        $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
+        $cacheItemPool->getItem($this->generateCacheKey())->willThrow($cacheException)->shouldBeCalled();
+
+        $cachedResourceMetadataFactory = new CachedResourceCollectionMetadataFactory($cacheItemPool->reveal(), $decoratedResourceMetadataFactory->reveal());
+        $resultedResourceMetadata = $cachedResourceMetadataFactory->create(Dummy::class);
+
+        $expectedResult = new ResourceCollection(new Resource(shortName: 'Dummy', class: Dummy::class));
+        $this->assertEquals($expectedResult, $resultedResourceMetadata);
+        $this->assertEquals($expectedResult, $cachedResourceMetadataFactory->create(Dummy::class), 'Trigger the local cache');
+    }
+
+    private function generateCacheKey(string $resourceClass = Dummy::class)
+    {
+        return CachedResourceCollectionMetadataFactory::CACHE_KEY_PREFIX.md5($resourceClass);
+    }
+}

--- a/tests/Metadata/ResourceCollection/Factory/FormatsResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/ResourceCollection/Factory/FormatsResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\FormatsResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+class FormatsResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(Resource $previous, Resource $expected, array $formats = [], array $patchFormats = []): void
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceCollection([$previous]));
+
+        $actual = (new FormatsResourceCollectionMetadataFactory($resourceMetadataFactoryProphecy->reveal(), $formats, $patchFormats))->create('Foo')[0];
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            new Resource(
+                formats: 'json',
+                operations: [new Get()]
+            ),
+            new Resource(
+                formats: 'json',
+                operations: [new Get(inputFormats: ['json' => ['application/json']], outputFormats: ['json' => ['application/json']])]
+            ),
+            ['json' => ['application/json']],
+        ];
+
+        yield [
+            new Resource(
+                formats: ['json' => ['application/json']],
+                operations: [new Get()]
+            ),
+            new Resource(
+                formats: ['json' => ['application/json']],
+                operations: [new Get(inputFormats: ['json' => ['application/json']], outputFormats: ['json' => ['application/json']])]
+            ),
+        ];
+
+        yield [
+            new Resource(
+                inputFormats: ['json' => ['application/json'], 'xml' => ['text/xml', 'application/xml']],
+                outputFormats: ['csv' => ['text/csv']],
+                operations: [new Get()]
+            ),
+            new Resource(
+                inputFormats: ['json' => ['application/json'], 'xml' => ['text/xml', 'application/xml']],
+                outputFormats: ['csv' => ['text/csv']],
+                operations: [new Get(
+                    inputFormats: ['json' => ['application/json'], 'xml' => ['text/xml', 'application/xml']],
+                    outputFormats: ['csv' => ['text/csv']],
+                )]
+            ),
+        ];
+
+        yield [
+            new Resource(
+                operations: [
+                    new Patch(),
+                ]
+            ),
+            new Resource(
+                operations: [
+                    new Patch(inputFormats: ['json' => ['application/merge-patch+json']], outputFormats: []),
+                ]
+            ),
+            [],
+            ['json' => ['application/merge-patch+json']],
+        ];
+
+        yield [
+            new Resource(
+                operations: [new Get(formats: 'json')]
+            ),
+            new Resource(
+                operations: [new Get(formats: ['json' => ['application/json']], inputFormats: ['json' => ['application/json']], outputFormats: ['json' => ['application/json']])]
+            ),
+            ['json' => ['application/json']],
+        ];
+
+        yield [
+            new Resource(
+                operations: [new Get(inputFormats: 'json', outputFormats: 'json')]
+            ),
+            new Resource(
+                operations: [new Get(inputFormats: ['json' => ['application/json']], outputFormats: ['json' => ['application/json']])]
+            ),
+            ['json' => ['application/json']],
+        ];
+    }
+
+    public function testInvalidFormatType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The \'formats\' attributes value must be a string when trying to include an already configured format, object given.');
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceCollection([new Resource(formats: [new \stdClass()])]));
+
+        (new FormatsResourceCollectionMetadataFactory($resourceMetadataFactoryProphecy->reveal(), [], []))->create('Foo');
+    }
+
+    public function testNotConfiguredFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You either need to add the format \'xml\' to your project configuration or declare a mime type for it in your annotation.');
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceCollection([new Resource(formats: ['xml'])]));
+
+        (new FormatsResourceCollectionMetadataFactory($resourceMetadataFactoryProphecy->reveal(), [], []))->create('Foo');
+    }
+}

--- a/tests/Metadata/ResourceCollection/Factory/IdentifierResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/ResourceCollection/Factory/IdentifierResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\AttributeResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\IdentifierResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeDefaultOperations;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResources;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class IdentifierResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCreate()
+    {
+        $propertyNameCollectionProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionProphecy->create(AttributeResource::class)->willReturn(new PropertyNameCollection(['id']));
+        $propertyNameCollectionProphecy->create(AttributeDefaultOperations::class)->willReturn(new PropertyNameCollection(['id']));
+        $propertyNameCollectionProphecy->create(AttributeResources::class)->willReturn(new PropertyNameCollection([]));
+        $propertyMetadataProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataProphecy->create(AttributeResource::class, 'id')->willReturn(new PropertyMetadata(identifier: true));
+        $propertyMetadataProphecy->create(AttributeDefaultOperations::class, 'id')->willReturn(new PropertyMetadata(identifier: true));
+        $decorated = new AttributeResourceCollectionMetadataFactory();
+        $identifierResourceCollectionMetadataFactory = new IdentifierResourceCollectionMetadataFactory($decorated, $propertyNameCollectionProphecy->reveal(), $propertyMetadataProphecy->reveal());
+
+        $this->assertEquals(
+            new ResourceCollection([
+                new Resource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    identifiers: ['id' => [AttributeResource::class, 'id']],
+                    operations: [
+                        '_api_AttributeResource_get' => new Get(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_AttributeResource_put' => new Put(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_AttributeResource_delete' => new Delete(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                    ]
+                ),
+                new Resource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                    identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                    operations: [
+                        '_api_/dummy/{dummyId}/attribute_resources/{id}_get' => new Get(
+                            class: AttributeResource::class,
+                            uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                            shortName: 'AttributeResource',
+                            identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                        ),
+                    ]
+                ),
+            ]),
+            $identifierResourceCollectionMetadataFactory->create(AttributeResource::class)
+        );
+
+        $this->assertEquals(
+            new ResourceCollection([
+                new Resource(
+                    uriTemplate: '/attribute_resources.{_format}',
+                    identifiers: [],
+                    shortName: 'AttributeResources',
+                    class: AttributeResources::class,
+                    operations: [
+                        '_api_/attribute_resources.{_format}_get' => new Get(shortName: 'AttributeResources', class: AttributeResources::class, controller: 'api_platform.action.placeholder', uriTemplate: '/attribute_resources.{_format}', identifiers: []),
+                        '_api_/attribute_resources.{_format}_post' => new Post(shortName: 'AttributeResources', class: AttributeResources::class, controller: 'api_platform.action.placeholder', uriTemplate: '/attribute_resources.{_format}', identifiers: null),
+                    ]
+                ),
+            ]),
+            $identifierResourceCollectionMetadataFactory->create(AttributeResources::class)
+        );
+
+        $this->assertEquals(
+            new ResourceCollection([
+                new Resource(
+                    shortName: 'AttributeDefaultOperations',
+                    class: AttributeDefaultOperations::class,
+                    identifiers: ['id' => [AttributeDefaultOperations::class, 'id']],
+                    operations: [
+                        '_api_AttributeDefaultOperations_get' => new Get(identifiers: ['id' => [AttributeDefaultOperations::class, 'id']], shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_put' => new Put(identifiers: ['id' => [AttributeDefaultOperations::class, 'id']], shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_delete' => new Delete(identifiers: ['id' => [AttributeDefaultOperations::class, 'id']], shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_get_collection' => new GetCollection(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_patch' => new Patch(identifiers: ['id' => [AttributeDefaultOperations::class, 'id']], shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                        '_api_AttributeDefaultOperations_post' => new Post(shortName: 'AttributeDefaultOperations', class: AttributeDefaultOperations::class, controller: 'api_platform.action.placeholder'),
+                    ]
+                ),
+            ]),
+            $identifierResourceCollectionMetadataFactory->create(AttributeDefaultOperations::class)
+        );
+    }
+}

--- a/tests/Metadata/ResourceCollection/Factory/InputOutputResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/ResourceCollection/Factory/InputOutputResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\ResourceCollection\Factory;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\InputOutputResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+class InputOutputResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @dataProvider getAttributes
+     */
+    public function testInputOutputMetadata($input, $expected)
+    {
+        $resourceCollection = new ResourceCollection([new Resource(input: $input)]);
+        $decoratedProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $decoratedProphecy->create('Foo')->willReturn($resourceCollection)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new InputOutputResourceCollectionMetadataFactory($decorated);
+        $this->assertSame($expected, $factory->create('Foo')[0]->input);
+    }
+
+    /**
+     * @dataProvider getAttributes
+     * TODO: GraphQl operations as object?
+     */
+    // public function testInputOutputViaGraphQlMetadata($attributes, $expected)
+    // {
+    //     $resourceCollection = new ResourceCollection([new Resource(graphQl: ['create' => ['input' => $attributes]])]);
+    //     $decoratedProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+    //     $decoratedProphecy->create('Foo')->willReturn($resourceCollection)->shouldBeCalled();
+    //     $decorated = $decoratedProphecy->reveal();
+    //
+    //     $factory = new InputOutputResourceCollectionMetadataFactory($decorated);
+    //     $this->assertSame($expected, $factory->create('Foo')[0]->graphQl['create']['input']);
+    // }
+
+    public function getAttributes(): array
+    {
+        return [
+            // no input class defined
+            [[], null],
+            // input is a string
+            [DummyEntity::class, ['class' => DummyEntity::class, 'name' => 'DummyEntity']],
+            // input is false
+            [false, ['class' => null]],
+            // input is an array
+            [['class' => DummyEntity::class, 'type' => 'Foo'], ['class' => DummyEntity::class, 'type' => 'Foo', 'name' => 'DummyEntity']],
+        ];
+    }
+}

--- a/tests/Metadata/ResourceCollection/Factory/PhpDocResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/ResourceCollection/Factory/PhpDocResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\PhpDocResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\Fixtures\ClassWithNoDocBlock;
+use ApiPlatform\Core\Tests\Fixtures\DummyEntity;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+class PhpDocResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testExistingDescription()
+    {
+        $resourceCollection = new ResourceCollection([new Resource(description: 'I am foo')]);
+        $decoratedProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $decoratedProphecy->create('Foo')->willReturn($resourceCollection)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new PhpDocResourceCollectionMetadataFactory($decorated);
+        $this->assertSame($resourceCollection[0], $factory->create('Foo')[0]);
+    }
+
+    public function testNoDocBlock()
+    {
+        $resourceCollection = new ResourceCollection([new Resource()]);
+        $decoratedProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $decoratedProphecy->create(ClassWithNoDocBlock::class)->willReturn($resourceCollection)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new PhpDocResourceCollectionMetadataFactory($decorated);
+        $this->assertSame($resourceCollection[0], $factory->create(ClassWithNoDocBlock::class)[0]);
+    }
+
+    public function testExtractDescription()
+    {
+        $resourceCollection = new ResourceCollection([new Resource()]);
+        $decoratedProphecy = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $decoratedProphecy->create(DummyEntity::class)->willReturn($resourceCollection)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new PhpDocResourceCollectionMetadataFactory($decorated);
+        $this->assertSame('My dummy entity.', $factory->create(DummyEntity::class)[0]->description);
+    }
+}

--- a/tests/Metadata/ResourceCollection/Factory/UriTemplateResourceCollectionMetadataFactoryTest.php
+++ b/tests/Metadata/ResourceCollection/Factory/UriTemplateResourceCollectionMetadataFactoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\ResourceCollectionMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\ResourceCollection\Factory\UriTemplateResourceCollectionMetadataFactory;
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Operation\PathSegmentNameGeneratorInterface;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\AttributeResource;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class UriTemplateResourceCollectionMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCreate()
+    {
+        $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
+        $pathSegmentNameGeneratorProphecy->getSegmentName('AttributeResource')->willReturn('attribute_resources');
+        $pathSegmentNameGeneratorProphecy->getSegmentName('AttributeDefaultOperations')->willReturn('attribute_default_operations');
+        $resourceCollectionMetadataFactory = $this->prophesize(ResourceCollectionMetadataFactoryInterface::class);
+        $resourceCollectionMetadataFactory->create(AttributeResource::class)->willReturn(
+            new ResourceCollection([
+                new Resource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    identifiers: ['id' => [AttributeResource::class, 'id']],
+                    operations: [
+                        '_api_AttributeResource_get' => new Get(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_AttributeResource_put' => new Put(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_AttributeResource_delete' => new Delete(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_AttributeResource_get_collection' => new GetCollection(shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: []),
+                    ]
+                ),
+                new Resource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                    identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                    operations: [
+                        '_api_/dummy/{dummyId}/attribute_resources/{id}_get' => new Get(
+                            class: AttributeResource::class,
+                            uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                            shortName: 'AttributeResource',
+                            identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                        ),
+                    ]
+                ),
+            ]),
+        );
+        $uriTemplateResourceCollectionMetadataFactory = new UriTemplateResourceCollectionMetadataFactory($pathSegmentNameGeneratorProphecy->reveal(), $resourceCollectionMetadataFactory->reveal());
+
+        $this->assertEquals(
+            new ResourceCollection([
+                new Resource(
+                    identifiers: ['id' => [AttributeResource::class, 'id']],
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    operations: [
+                        '_api_/attribute_resources/{id}.{_format}_get' => new Get(uriTemplate: '/attribute_resources/{id}.{_format}', shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_/attribute_resources/{id}.{_format}_put' => new Put(uriTemplate: '/attribute_resources/{id}.{_format}', shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_/attribute_resources/{id}.{_format}_delete' => new Delete(uriTemplate: '/attribute_resources/{id}.{_format}', shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: ['id' => [AttributeResource::class, 'id']]),
+                        '_api_/attribute_resources.{_format}_get' => new GetCollection(uriTemplate: '/attribute_resources.{_format}', shortName: 'AttributeResource', class: AttributeResource::class, controller: 'api_platform.action.placeholder', identifiers: []),
+                    ]
+                ),
+                new Resource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                    identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                    operations: [
+                        '_api_/dummy/{dummyId}/attribute_resources/{id}_get' => new Get(
+                            class: AttributeResource::class,
+                            uriTemplate: '/dummy/{dummyId}/attribute_resources/{id}',
+                            shortName: 'AttributeResource',
+                            identifiers: ['dummyId' => [Dummy::class, 'id'], 'id' => [AttributeResource::class, 'id']],
+                        ),
+                    ]
+                ),
+            ]),
+            $uriTemplateResourceCollectionMetadataFactory->create(AttributeResource::class)
+        );
+    }
+}

--- a/tests/Metadata/ResourceCollection/ResourceCollectionTest.php
+++ b/tests/Metadata/ResourceCollection/ResourceCollectionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Metadata\ResourceCollection;
+
+use ApiPlatform\Core\Metadata\ResourceCollection\ResourceCollection;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Resource;
+use PHPUnit\Framework\TestCase;
+
+class ResourceCollectionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testResourceCollection()
+    {
+        $operation = new Get();
+        $resource = new Resource(uriTemplate: '/dummies/{id}', operations: [$operation]);
+        $resourceCollection = new ResourceCollection([$resource]);
+
+        $this->assertEquals($resource, $resourceCollection->getResource('/dummies/{id}'));
+        $this->assertEquals($resource, $resourceCollection->getResource('/dummies/{id}'));
+        $this->assertEquals($operation, $resourceCollection->getOperation('GET', '/dummies/{id}'));
+        $this->assertEquals($operation, $resourceCollection->getOperation('GET', '/dummies/{id}'));
+    }
+}

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -125,6 +125,7 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
         $this->assertTrue($normalizer->hasCacheableSupportsMethod());
+        $this->assertFalse($normalizer->supportsNormalization([]));
     }
 
     public function testNormalize()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       |  na
| License       | MIT
| Doc PR        | 

Implements https://github.com/api-platform/core/blob/main/docs/adr/0002-resource-definition.md 

This first step is needed to validate the implementation.

This is only a starting point, lots to do after this:

- [x] new data provider
- [ ] missing coverage

In another PR:

- [ ] openapi/swagger support
- [ ] use ResourceCollectionMetadataFactory everywhere 
- [ ] allow second resource to work on a class (== write support for previous subresources)