### PR TITLE
FIX: ApiPlatform Extension extra configuration - merging arrays

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -398,7 +398,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.enable_swagger_ui', $config['enable_swagger_ui']);
         $container->setParameter('api_platform.enable_re_doc', $config['enable_re_doc']);
         $container->setParameter('api_platform.swagger.api_keys', $config['swagger']['api_keys']);
-        $container->setParameter('api_platform.swagger_ui.extra_configuration', array_merge($config['openapi']['swagger_ui_extra_configuration'], $config['swagger']['swagger_ui_extra_configuration']));
+        if ($config['openapi']['swagger_ui_extra_configuration'] && $config['swagger']['swagger_ui_extra_configuration']) {
+            throw new RuntimeException('You can not set "swagger_ui_extra_configuration" twice - in "openapi" and "swagger" section.');
+        }
+        $container->setParameter('api_platform.swagger_ui.extra_configuration', $config['openapi']['swagger_ui_extra_configuration'] ?: $config['swagger']['swagger_ui_extra_configuration']);
 
         if (true === $config['openapi']['backward_compatibility_layer']) {
             $container->getDefinition('api_platform.swagger.normalizer.documentation')->addArgument($container->getDefinition('api_platform.openapi.normalizer'));

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -398,7 +398,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.enable_swagger_ui', $config['enable_swagger_ui']);
         $container->setParameter('api_platform.enable_re_doc', $config['enable_re_doc']);
         $container->setParameter('api_platform.swagger.api_keys', $config['swagger']['api_keys']);
-        $container->setParameter('api_platform.swagger_ui.extra_configuration', $config['openapi']['swagger_ui_extra_configuration'] ?? $config['swagger']['swagger_ui_extra_configuration']);
+        $container->setParameter('api_platform.swagger_ui.extra_configuration', array_merge($config['openapi']['swagger_ui_extra_configuration'], $config['swagger']['swagger_ui_extra_configuration']));
 
         if (true === $config['openapi']['backward_compatibility_layer']) {
             $container->getDefinition('api_platform.swagger.normalizer.documentation')->addArgument($container->getDefinition('api_platform.openapi.normalizer'));

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -859,6 +859,19 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load($config, $containerBuilderProphecy->reveal());
     }
 
+    public function testExtraConfigurationMegrging()
+    {
+        $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
+        $containerBuilderProphecy->setParameter('api_platform.swagger_ui.extra_configuration', [])->shouldNotBeCalled();
+        $containerBuilderProphecy->setParameter('api_platform.swagger_ui.extra_configuration', ['someParameter' => 'someValue'])->shouldBeCalled();
+
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['openapi']['swagger_ui_extra_configuration'] = [];
+        $config['api_platform']['swagger']['swagger_ui_extra_configuration'] = ['someParameter' => 'someValue'];
+
+        $this->extension->load($config, $containerBuilderProphecy->reveal());
+    }
+
     private function getPartialContainerBuilderProphecy($configuration = null)
     {
         $parameterBag = new EnvPlaceholderParameterBag();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -864,12 +864,20 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setParameter('api_platform.swagger_ui.extra_configuration', [])->shouldNotBeCalled();
         $containerBuilderProphecy->setParameter('api_platform.swagger_ui.extra_configuration', ['someParameter' => 'someValue'])->shouldBeCalled();
+        $containerBuilder = $containerBuilderProphecy->reveal();
 
         $config = self::DEFAULT_CONFIG;
         $config['api_platform']['openapi']['swagger_ui_extra_configuration'] = [];
         $config['api_platform']['swagger']['swagger_ui_extra_configuration'] = ['someParameter' => 'someValue'];
 
-        $this->extension->load($config, $containerBuilderProphecy->reveal());
+        $this->extension->load($config, $containerBuilder);
+
+        $config['api_platform']['openapi']['swagger_ui_extra_configuration'] = ['someParameter' => 'someValue'];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('You can not set "swagger_ui_extra_configuration" twice - in "openapi" and "swagger" section.');
+
+        $this->extension->load($config, $containerBuilder);
     }
 
     private function getPartialContainerBuilderProphecy($configuration = null)

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -859,7 +859,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load($config, $containerBuilderProphecy->reveal());
     }
 
-    public function testExtraConfigurationMegrging()
+    public function testExtraConfigurationMerging()
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setParameter('api_platform.swagger_ui.extra_configuration', [])->shouldNotBeCalled();

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -859,7 +859,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->extension->load($config, $containerBuilderProphecy->reveal());
     }
 
-    public function testExtraConfigurationMerging()
+    public function testSwaggerUiExtraConfigurationMerging()
     {
         $containerBuilderProphecy = $this->getBaseContainerBuilderProphecy();
         $containerBuilderProphecy->setParameter('api_platform.swagger_ui.extra_configuration', [])->shouldNotBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

In src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php:401 used ?? between `openapi` and `swagger` for `swagger_ui_extra_configuration`, but their value cannot be null - `[]` by default. So, `$config['swagger']['swagger_ui_extra_configuration']` can never be used.

I suggest using `array_merge` to solve this problem.
