### PR TITLE
Simplify refactored OpenApiFactory collectPaths()

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -93,12 +93,10 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $resourceShortName = $resourceMetadata->getShortName();
 
             // Items needs to be parsed first to be able to reference the lines from the collection operation
-            [$itemOperationLinks, $itemOperationSchemas] = $this->collectPaths($resourceMetadata, $resourceClass, OperationType::ITEM, $context, $paths, $links, $schemas);
-            $this->appendSchemaDefinitions($schemas, $itemOperationSchemas);
-            [$collectionOperationLinks, $collectionOperationSchemas] = $this->collectPaths($resourceMetadata, $resourceClass, OperationType::COLLECTION, $context, $paths, $links, $schemas);
+            $this->collectPaths($resourceMetadata, $resourceClass, OperationType::ITEM, $context, $paths, $links, $schemas);
+            $this->collectPaths($resourceMetadata, $resourceClass, OperationType::COLLECTION, $context, $paths, $links, $schemas);
 
-            [$subresourceOperationLinks, $subresourceOperationSchemas] = $this->collectPaths($resourceMetadata, $resourceClass, OperationType::SUBRESOURCE, $context, $paths, $links, $schemas);
-            $this->appendSchemaDefinitions($schemas, $collectionOperationSchemas);
+            $this->collectPaths($resourceMetadata, $resourceClass, OperationType::SUBRESOURCE, $context, $paths, $links, $schemas);
         }
 
         $securitySchemes = $this->getSecuritySchemes();
@@ -125,10 +123,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         );
     }
 
-    /**
-     * @return array | array
-     */
-    private function collectPaths(ResourceMetadata $resourceMetadata, string $resourceClass, string $operationType, array $context, Model\Paths $paths, array &$links, \ArrayObject $schemas): array
+    private function collectPaths(ResourceMetadata $resourceMetadata, string $resourceClass, string $operationType, array $context, Model\Paths $paths, array &$links, \ArrayObject $schemas): void
     {
         $resourceShortName = $resourceMetadata->getShortName();
         $operations = OperationType::COLLECTION === $operationType ? $resourceMetadata->getCollectionOperations() : (OperationType::ITEM === $operationType ? $resourceMetadata->getItemOperations() : $this->subresourceOperationFactory->create($resourceClass));

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -128,7 +128,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         $resourceShortName = $resourceMetadata->getShortName();
         $operations = OperationType::COLLECTION === $operationType ? $resourceMetadata->getCollectionOperations() : (OperationType::ITEM === $operationType ? $resourceMetadata->getItemOperations() : $this->subresourceOperationFactory->create($resourceClass));
         if (!$operations) {
-            return [$links, $schemas];
+            return;
         }
 
         $rootResourceClass = $resourceClass;
@@ -286,8 +286,6 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
             $paths->addPath($path, $pathItem);
         }
-
-        return [$links, $schemas];
     }
 
     private function buildContent(array $responseMimeTypes, array $operationSchemas): \ArrayObject


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Follows https://github.com/api-platform/core/pull/3407#discussion_r609533441 and #4138
| License       | MIT
| Doc PR        | 

The `$links` array is passed by reference and `$schemas` is now an `\ArrayObject` (automatically passed by "handle"), so both get appended to (like `$paths`) at each call to `collectPaths()`