### PR TITLE
Restore `Model\Parameter::canAllowEmptyValue()`

### DIFF
--- a/src/OpenApi/Model/Parameter.php
+++ b/src/OpenApi/Model/Parameter.php
@@ -83,6 +83,11 @@ final class Parameter
         return $this->deprecated;
     }
 
+    public function canAllowEmptyValue(): bool
+    {
+        return $this->allowEmptyValue;
+    }
+
     public function getAllowEmptyValue(): bool
     {
         return $this->allowEmptyValue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/api-platform/core/pull/4138#discussion_r610613037
| License       | MIT
| Doc PR        | 
