### PR TITLE
Add $context to DataPersisterInterface for decorator on DataPersister

### DIFF
--- a/src/DataPersister/DataPersisterInterface.php
+++ b/src/DataPersister/DataPersisterInterface.php
@@ -23,17 +23,17 @@ interface DataPersisterInterface
     /**
      * Is the data supported by the persister?
      */
-    public function supports($data): bool;
+    public function supports($data, $context = []): bool;
 
     /**
      * Persists the data.
      *
      * @return object|void Void will not be supported in API Platform 3, an object should always be returned
      */
-    public function persist($data);
+    public function persist($data, $context = []);
 
     /**
      * Removes the data.
      */
-    public function remove($data);
+    public function remove($data, $context = []);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | next
| Bug fix?      | yes <!-- please update CHANGELOG.md file -->
| New feature?  |no <!-- please update CHANGELOG.md file -->
| Deprecations? |no
| Tickets       | On DataPersister we can't map $context argument to decorator methods because the prototype of interface is not complete.
| License       | MIT
| Doc PR        | 
