### PR TITLE
Fix graphql fetching with Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * GraphQL: **BC** Fix security on association collection properties. The collection resource `item_query` security is no longer used. `ApiProperty` security can now be used to secure collection (or any other) properties. (#4143)
 * Deprecate `allow_plain_identifiers` option (#4167)
 * Exception: Add the ability to customize multiple status codes based on the validation exception (#4017)
+* GraphQL: Fix graphql fetching with Elasticsearch (#4217)
 
 ## 2.6.5
 

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -84,6 +84,7 @@ elasticsearch:
       contexts:
         - 'ApiPlatform\Core\Tests\Behat\CommandContext'
         - 'ApiPlatform\Core\Tests\Behat\ElasticsearchContext'
+        - 'ApiPlatform\Core\Tests\Behat\GraphqlContext'
         - 'ApiPlatform\Core\Tests\Behat\JsonContext'
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'

--- a/features/elasticsearch/graphql.feature
+++ b/features/elasticsearch/graphql.feature
@@ -1,0 +1,99 @@
+Feature: GraphQL query support
+
+  @elasticsearch
+  Scenario: Execute a GraphQL query on an ElasticSearch model with SubResources
+    When I send the following GraphQL request:
+    """
+    query {
+      users {
+        edges {
+          node {
+            id,
+            gender,
+            tweets {
+              edges {
+                node {
+                  id,
+                  message,
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON should be equal to:
+    """
+    {
+      "data": {
+        "users": {
+          "edges": [
+            {
+              "node": {
+                "id": "/users/116b83f8-6c32-48d8-8e28-c5c247532d3f",
+                "gender": "male",
+                "tweets": {
+                  "edges": [
+                    {
+                      "node": {
+                        "id": "/tweets/89601e1c-3ef2-4ef7-bca2-7511d38611c6",
+                        "message": "Great day in any endur... During the Himalayas were very talented skimo racer junior podiums, top 10."
+                      }
+                    },
+                    {
+                      "node": {
+                        "id": "/tweets/9da70727-d656-42d9-876a-1be6321f171b",
+                        "message": "During the path and his Summits Of My Life project. Next Wednesday, Kilian Jornet..."
+                      }
+                    },
+                    {
+                      "node": {
+                        "id": "/tweets/f36a0026-0635-4865-86a6-5adb21d94d64",
+                        "message": "The north summit, Store Vengetind Thanks for t... These Top 10 Women of a fk... Francois is the field which."
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "id": "/users/15fce6f1-18fd-4ef6-acab-7e6a3333ec7f",
+                "gender": "male",
+                "tweets": {
+                  "edges": [
+                    {
+                      "node": {
+                        "id": "/tweets/0cfe3d33-6116-416b-8c50-3b8319331998",
+                        "message": "Thanks! Fun day with Next up one of our 2018 cover: One look into what races we'll be running that they!"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "id": "/users/6a457188-d1ba-45e3-8509-81e5c66a5297",
+                "gender": "female",
+                "tweets": {
+                  "edges": [
+                    {
+                      "node": {
+                        "id": "/tweets/9de3308c-6f82-4a57-a33c-4e3cd5d5a3f6",
+                        "message": "In case you do! A humble beginning to traverse... Im so now until you can't tell how strong she run at!"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+    """

--- a/src/Bridge/Elasticsearch/DataProvider/SubresourceDataProvider.php
+++ b/src/Bridge/Elasticsearch/DataProvider/SubresourceDataProvider.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Bridge\Elasticsearch\DataProvider;
+
+use ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractorInterface;
+use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
+use ApiPlatform\Core\Bridge\Elasticsearch\Exception\NonUniqueIdentifierException;
+use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
+use ApiPlatform\Core\DataProvider\Pagination;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Elasticsearch\Client;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class SubresourceDataProvider implements SubresourceDataProviderInterface, RestrictedDataProviderInterface
+{
+    private $client;
+    private $documentMetadataFactory;
+    private $identifierExtractor;
+    private $denormalizer;
+    private $pagination;
+    private $resourceMetadataFactory;
+    private $propertyNameCollectionFactory;
+    private $propertyMetadataFactory;
+    private $collectionExtensions;
+
+    public function __construct(Client $client, DocumentMetadataFactoryInterface $documentMetadataFactory, IdentifierExtractorInterface $identifierExtractor, DenormalizerInterface $denormalizer, Pagination $pagination, ResourceMetadataFactoryInterface $resourceMetadataFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, iterable $collectionExtensions = [])
+    {
+        $this->client = $client;
+        $this->documentMetadataFactory = $documentMetadataFactory;
+        $this->identifierExtractor = $identifierExtractor;
+        $this->denormalizer = $denormalizer;
+        $this->pagination = $pagination;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
+        $this->propertyMetadataFactory = $propertyMetadataFactory;
+        $this->collectionExtensions = $collectionExtensions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(string $resourceClass, ?string $operationName = null, array $context = []): bool
+    {
+        try {
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+            if (false === $resourceMetadata->getCollectionOperationAttribute($operationName, 'elasticsearch', true, true)) {
+                return false;
+            }
+        } catch (ResourceClassNotFoundException $e) {
+            return false;
+        }
+
+        try {
+            $this->documentMetadataFactory->create($resourceClass);
+        } catch (IndexNotFoundException $e) {
+            return false;
+        }
+
+        // Elasticsearch does not support subresources as items (yet)
+        if (false === ($context['collection'] ?? false)) {
+            return false;
+        }
+
+        try {
+            $this->identifierExtractor->getIdentifierFromResourceClass($resourceClass);
+        } catch (NonUniqueIdentifierException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null)
+    {
+        $documentMetadata = $this->documentMetadataFactory->create($resourceClass);
+        $body = [];
+
+        foreach ($this->collectionExtensions as $collectionExtension) {
+            $body = $collectionExtension->applyToCollection($body, $resourceClass, $operationName, $context);
+        }
+
+        // Elasticsearch subresources only works with single identifiers
+        $idKey = key($context['identifiers']);
+        [$relationClass, $identiferProperty] = $context['identifiers'][$idKey];
+
+        $propertyName = null;
+
+        foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
+            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property);
+            $type = $propertyMetadata->getType();
+
+            if ($type && $type->getClassName() === $relationClass) {
+                $propertyName = $property;
+                break;
+            }
+        }
+
+        if (!$propertyName) {
+            throw new RuntimeException('The property has not been found for this relation.');
+        }
+
+        $relationQuery = ['match' => [$propertyName.'.'.$identiferProperty => $identifiers[$idKey]]];
+
+        if (!isset($body['query']) && !isset($body['aggs'])) {
+            $body['query'] = $relationQuery;
+        } else {
+            $body['query']['constant_score']['filter']['bool']['must'][] = $relationQuery;
+        }
+
+        $limit = $body['size'] = $body['size'] ?? $this->pagination->getLimit($resourceClass, $operationName, $context);
+        $offset = $body['from'] = $body['from'] ?? $this->pagination->getOffset($resourceClass, $operationName, $context);
+
+        $documents = $this->client->search([
+            'index' => $documentMetadata->getIndex(),
+            'type' => $documentMetadata->getType(),
+            'body' => $body,
+        ]);
+
+        return new Paginator(
+            $this->denormalizer,
+            $documents,
+            $resourceClass,
+            $limit,
+            $offset,
+            $context
+        );
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -82,6 +82,20 @@
             <tag name="api_platform.collection_data_provider" priority="5" />
         </service>
 
+        <service id="api_platform.elasticsearch.subresource_data_provider" class="ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\SubresourceDataProvider" public="false">
+            <argument type="service" id="api_platform.elasticsearch.client" />
+            <argument type="service" id="api_platform.elasticsearch.metadata.document.metadata_factory" />
+            <argument type="service" id="api_platform.elasticsearch.identifier_extractor" />
+            <argument type="service" id="serializer" />
+            <argument type="service" id="api_platform.pagination" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="tagged" tag="api_platform.elasticsearch.request_body_search_extension.collection" />
+
+            <tag name="api_platform.subresource_data_provider" priority="5" />
+        </service>
+
         <service id="api_platform.elasticsearch.request_body_search_extension.filter" public="false" abstract="true">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.filter_locator" />

--- a/tests/Bridge/Elasticsearch/DataProvider/SubresourceDataProviderTest.php
+++ b/tests/Bridge/Elasticsearch/DataProvider/SubresourceDataProviderTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Bridge\Elasticsearch\DataProvider;
+
+use ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractorInterface;
+use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Extension\RequestBodySearchCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Paginator;
+use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\SubresourceDataProvider;
+use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
+use ApiPlatform\Core\Bridge\Elasticsearch\Exception\NonUniqueIdentifierException;
+use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata;
+use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
+use ApiPlatform\Core\DataProvider\Pagination;
+use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
+use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\CompositeRelation;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCarColor;
+use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Foo;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use Elasticsearch\Client;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class SubresourceDataProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testConstruct()
+    {
+        self::assertInstanceOf(
+            SubresourceDataProviderInterface::class,
+            new SubresourceDataProvider(
+                $this->prophesize(Client::class)->reveal(),
+                $this->prophesize(DocumentMetadataFactoryInterface::class)->reveal(),
+                $this->prophesize(IdentifierExtractorInterface::class)->reveal(),
+                $this->prophesize(DenormalizerInterface::class)->reveal(),
+                new Pagination($this->prophesize(ResourceMetadataFactoryInterface::class)->reveal()),
+                $this->prophesize(ResourceMetadataFactoryInterface::class)->reveal(),
+                $this->prophesize(PropertyNameCollectionFactoryInterface::class)->reveal(),
+                $this->prophesize(PropertyMetadataFactoryInterface::class)->reveal()
+            )
+        );
+    }
+
+    public function testSupports()
+    {
+        $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);
+        $documentMetadataFactoryProphecy->create(Foo::class)->willReturn(new DocumentMetadata('foo'))->shouldBeCalled();
+        $documentMetadataFactoryProphecy->create(Dummy::class)->willThrow(new IndexNotFoundException())->shouldBeCalled();
+        $documentMetadataFactoryProphecy->create(CompositeRelation::class)->willReturn(new DocumentMetadata('composite_relation'))->shouldBeCalled();
+
+        $identifierExtractorProphecy = $this->prophesize(IdentifierExtractorInterface::class);
+        $identifierExtractorProphecy->getIdentifierFromResourceClass(Foo::class)->willReturn('id')->shouldBeCalled();
+        $identifierExtractorProphecy->getIdentifierFromResourceClass(CompositeRelation::class)->willThrow(new NonUniqueIdentifierException())->shouldBeCalled();
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Foo::class)->shouldBeCalled()->willReturn(new ResourceMetadata());
+        $resourceMetadataFactoryProphecy->create(DummyCar::class)->shouldBeCalled()->willReturn((new ResourceMetadata())->withAttributes(['elasticsearch' => false]));
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn(new ResourceMetadata());
+        $resourceMetadataFactoryProphecy->create(CompositeRelation::class)->shouldBeCalled()->willReturn(new ResourceMetadata());
+        $resourceMetadataFactoryProphecy->create(DummyCarColor::class)->shouldBeCalled()->willThrow(new ResourceClassNotFoundException());
+
+        $subresourceDataProvider = new SubresourceDataProvider(
+            $this->prophesize(Client::class)->reveal(),
+            $documentMetadataFactoryProphecy->reveal(),
+            $identifierExtractorProphecy->reveal(),
+            $this->prophesize(DenormalizerInterface::class)->reveal(),
+            new Pagination($this->prophesize(ResourceMetadataFactoryInterface::class)->reveal()),
+            $resourceMetadataFactoryProphecy->reveal(),
+            $this->prophesize(PropertyNameCollectionFactoryInterface::class)->reveal(),
+            $this->prophesize(PropertyMetadataFactoryInterface::class)->reveal()
+        );
+
+        self::assertTrue($subresourceDataProvider->supports(Foo::class, null, ['collection' => true]));
+        self::assertFalse($subresourceDataProvider->supports(Dummy::class, null, ['collection' => true]));
+        self::assertFalse($subresourceDataProvider->supports(CompositeRelation::class, null, ['collection' => true]));
+        self::assertFalse($subresourceDataProvider->supports(DummyCar::class, null, ['collection' => true]));
+        self::assertFalse($subresourceDataProvider->supports(DummyCarColor::class, null, ['collection' => true]));
+        self::assertFalse($subresourceDataProvider->supports(Foo::class, null, ['collection' => false]));
+    }
+
+    public function testGetSubresource()
+    {
+        $context = [
+            'groups' => ['custom'],
+            'identifiers' => ['id' => ['BarRelationClass', 'barId']],
+        ];
+
+        $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);
+        $documentMetadataFactoryProphecy->create(Foo::class)->willReturn(new DocumentMetadata('foo'))->shouldBeCalled();
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Foo::class)->willReturn(new ResourceMetadata());
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(Foo::class)->willReturn(new PropertyNameCollection(['id', 'bar', 'nanme']));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'id')->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'bar')->willReturn(new PropertyMetadata(new Type('object', true, 'BarRelationClass')));
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'name')->willReturn(new PropertyMetadata());
+
+        $documents = [
+            'took' => 15,
+            'time_out' => false,
+            '_shards' => [
+                'total' => 5,
+                'successful' => 5,
+                'skipped' => 0,
+                'failed' => 0,
+            ],
+            'hits' => [
+                'total' => 4,
+                'max_score' => 1,
+                'hits' => [
+                    [
+                        '_index' => 'foo',
+                        '_type' => '_doc',
+                        '_id' => '1',
+                        '_score' => 1,
+                        '_source' => [
+                            'id' => 1,
+                            'name' => 'Kilian',
+                            'bar' => 'Jornet',
+                        ],
+                    ],
+                    [
+                        '_index' => 'foo',
+                        '_type' => '_doc',
+                        '_id' => '2',
+                        '_score' => 1,
+                        '_source' => [
+                            'id' => 2,
+                            'name' => 'François',
+                            'bar' => 'D\'Haene',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $clientProphecy = $this->prophesize(Client::class);
+        $clientProphecy
+            ->search(
+                Argument::allOf(
+                    Argument::withEntry('index', 'foo'),
+                    Argument::withEntry('type', DocumentMetadata::DEFAULT_TYPE),
+                    Argument::withEntry('body', Argument::allOf(
+                        Argument::withEntry('size', 2),
+                        Argument::withEntry('from', 0),
+                        Argument::withEntry('query', Argument::allOf(
+                            Argument::withEntry('match', Argument::allOf(Argument::withEntry('bar.barId', 1))),
+                            Argument::size(1)
+                        )),
+                        Argument::size(3)
+                    )),
+                    Argument::size(3)
+                )
+            )
+            ->willReturn($documents)
+            ->shouldBeCalled();
+
+        $requestBodySearchCollectionExtensionProphecy = $this->prophesize(RequestBodySearchCollectionExtensionInterface::class);
+        $requestBodySearchCollectionExtensionProphecy->applyToCollection([], Foo::class, 'get', $context)->willReturn([])->shouldBeCalled();
+
+        $subresourceDataProvider = new SubresourceDataProvider(
+            $clientProphecy->reveal(),
+            $documentMetadataFactoryProphecy->reveal(),
+            $this->prophesize(IdentifierExtractorInterface::class)->reveal(),
+            $denormalizer = $this->prophesize(DenormalizerInterface::class)->reveal(),
+            new Pagination($resourceMetadataFactoryProphecy->reveal(), ['items_per_page' => 2]),
+            $resourceMetadataFactoryProphecy->reveal(),
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            [$requestBodySearchCollectionExtensionProphecy->reveal()]
+        );
+
+        self::assertEquals(
+            new Paginator($denormalizer, $documents, Foo::class, 2, 0, $context),
+            $subresourceDataProvider->getSubresource(Foo::class, ['id' => 1], $context, 'get')
+        );
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -675,6 +675,7 @@ class ApiPlatformExtensionTest extends TestCase
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.term_filter', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.order_filter', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.match_filter', Argument::type(Definition::class))->shouldBeCalled();
+        $containerBuilderProphecy->setDefinition('api_platform.elasticsearch.subresource_data_provider', Argument::type(Definition::class))->shouldBeCalled();
         $containerBuilderProphecy->setAlias('api_platform.elasticsearch.metadata.document.metadata_factory', 'api_platform.elasticsearch.metadata.document.metadata_factory.configured')->shouldBeCalled();
         $containerBuilderProphecy->setAlias(DocumentMetadataFactoryInterface::class, 'api_platform.elasticsearch.metadata.document.metadata_factory')->shouldBeCalled();
         $containerBuilderProphecy->setAlias(IdentifierExtractorInterface::class, 'api_platform.elasticsearch.identifier_extractor')->shouldBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fixes https://github.com/api-platform/api-platform/issues/1809  
| License       | MIT
| Doc PR        | na]

Elasticsearch doesn't work for subcollection as there are no SubresourceDataProvider. This patch adds one. 

Runs a GraphQL query like this:

```
query {
  products {
    collection {
      id, attributes { collection { id }}
    }
  }
}
```

Where you have a sub-collection with Elasticsearch. 
