### PR TITLE
OpenAPI: Allow to set extensionProperties with YAML schema definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * OpenAPI: Fix notice/warning for `response` without `content` in the `openapi_context` (#4210)
 * Serializer: Convert internal error to HTTP 400 in Ramsey uuid denormalization from invalid body string (#4200)
 * Symfony: Add tests with Symfony Uuid (#4230)
+* OpenAPI: Allow to set extensionProperties with YAML schema definition (#4228)
 
 ## 2.6.4
 

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -213,6 +213,13 @@ Feature: Documentation support
     And I should see text matching "My Dummy API"
     And I should see text matching "openapi"
 
+  Scenario: OpenAPI extension properties is enabled in JSON docs
+    Given I send a "GET" request to "/docs.json?spec_version=3"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON node "paths./dummy_addresses.get.x-visibility" should be equal to "hide"
+
   Scenario: OpenAPI UI is enabled for an arbitrary endpoint
     Given I add "Accept" header equal to "text/html"
     And I send a "GET" request to "/dummies?spec_version=3"

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -281,7 +281,10 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                 isset($operation['openapi_context']['callbacks']) ? new \ArrayObject($operation['openapi_context']['callbacks']) : null,
                 $operation['openapi_context']['deprecated'] ?? (bool) $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'deprecation_reason', false, true),
                 $operation['openapi_context']['security'] ?? null,
-                $operation['openapi_context']['servers'] ?? null
+                $operation['openapi_context']['servers'] ?? null,
+                array_filter($operation['openapi_context'] ?? [], static function ($item) {
+                    return preg_match('/^x-.*$/i', $item);
+                }, \ARRAY_FILTER_USE_KEY)
             ));
 
             $paths->addPath($path, $pathItem);

--- a/src/OpenApi/Model/Operation.php
+++ b/src/OpenApi/Model/Operation.php
@@ -30,7 +30,7 @@ final class Operation
     private $servers;
     private $externalDocs;
 
-    public function __construct(string $operationId = null, array $tags = [], array $responses = [], string $summary = '', string $description = '', ExternalDocumentation $externalDocs = null, array $parameters = [], RequestBody $requestBody = null, \ArrayObject $callbacks = null, bool $deprecated = false, ?array $security = null, ?array $servers = null, array $extentionProperties = [])
+    public function __construct(string $operationId = null, array $tags = [], array $responses = [], string $summary = '', string $description = '', ExternalDocumentation $externalDocs = null, array $parameters = [], RequestBody $requestBody = null, \ArrayObject $callbacks = null, bool $deprecated = false, ?array $security = null, ?array $servers = null, array $extensionProperties = [])
     {
         $this->tags = $tags;
         $this->summary = $summary;
@@ -44,7 +44,7 @@ final class Operation
         $this->security = $security;
         $this->servers = $servers;
         $this->externalDocs = $externalDocs;
-        $this->extensionProperties = $extentionProperties;
+        $this->extensionProperties = $extensionProperties;
     }
 
     public function addResponse(Response $response, $status = 'default'): self

--- a/src/OpenApi/Model/Operation.php
+++ b/src/OpenApi/Model/Operation.php
@@ -30,7 +30,7 @@ final class Operation
     private $servers;
     private $externalDocs;
 
-    public function __construct(string $operationId = null, array $tags = [], array $responses = [], string $summary = '', string $description = '', ExternalDocumentation $externalDocs = null, array $parameters = [], RequestBody $requestBody = null, \ArrayObject $callbacks = null, bool $deprecated = false, ?array $security = null, ?array $servers = null)
+    public function __construct(string $operationId = null, array $tags = [], array $responses = [], string $summary = '', string $description = '', ExternalDocumentation $externalDocs = null, array $parameters = [], RequestBody $requestBody = null, \ArrayObject $callbacks = null, bool $deprecated = false, ?array $security = null, ?array $servers = null, array $extentionProperties = [])
     {
         $this->tags = $tags;
         $this->summary = $summary;
@@ -44,6 +44,7 @@ final class Operation
         $this->security = $security;
         $this->servers = $servers;
         $this->externalDocs = $externalDocs;
+        $this->extensionProperties = $extentionProperties;
     }
 
     public function addResponse(Response $response, $status = 'default'): self

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -834,6 +834,7 @@ class ApiPlatformExtensionTest extends TestCase
                     "{$testsDirectory}/Bridge/Symfony/Bundle/DependencyInjection/Fixtures/resources/c.yaml",
                     "{$testsDirectory}/Bridge/Symfony/Bundle/DependencyInjection/Fixtures/resources/c/a.yaml",
                     "{$testsDirectory}/Fixtures/TestBundle/Resources/config/api_resources.yml",
+                    "{$testsDirectory}/Fixtures/TestBundle/Resources/config/api_resources/dummy_address.yml",
                     "{$testsDirectory}/Fixtures/TestBundle/Resources/config/api_resources/my_resource.yml",
                 ]),
                 $normalizePaths($paths)

--- a/tests/Fixtures/TestBundle/Model/DummyAddress.php
+++ b/tests/Fixtures/TestBundle/Model/DummyAddress.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Model;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+class DummyAddress
+{
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $address;
+}

--- a/tests/Fixtures/TestBundle/Resources/config/api_resources/dummy_address.yml
+++ b/tests/Fixtures/TestBundle/Resources/config/api_resources/dummy_address.yml
@@ -1,0 +1,6 @@
+resources:
+    ApiPlatform\Core\Tests\Fixtures\TestBundle\Model\DummyAddress:
+        collectionOperations:
+            get:
+                openapi_context:
+                    x-visibility: hide

--- a/tests/OpenApi/Factory/OpenApiFactoryTest.php
+++ b/tests/OpenApi/Factory/OpenApiFactoryTest.php
@@ -75,6 +75,7 @@ class OpenApiFactoryTest extends TestCase
                 'put' => ['method' => 'PUT'] + self::OPERATION_FORMATS,
                 'delete' => ['method' => 'DELETE'] + self::OPERATION_FORMATS,
                 'custom' => ['method' => 'HEAD', 'path' => '/foo/{id}', 'openapi_context' => [
+                    'x-visibility' => 'hide',
                     'description' => 'Custom description',
                     'parameters' => [
                         ['description' => 'Test parameter', 'name' => 'param', 'in' => 'path', 'required' => true],
@@ -454,7 +455,12 @@ class OpenApiFactoryTest extends TestCase
                         ],
                     ],
                 ],
-            ]), true)
+            ]), true),
+            null,
+            false,
+            null,
+            null,
+            ['x-visibility' => 'hide']
         ));
 
         $formattedPath = $paths->getPath('/formatted/{id}');
@@ -569,8 +575,6 @@ class OpenApiFactoryTest extends TestCase
 
     public function testOverrideDocumentation()
     {
-        $defaultContext = ['base_url' => '/app_dev.php/'];
-
         $dummyMetadata = new ResourceMetadata(
             'Dummy',
             'This is a dummy.',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #4002
| License       | MIT
| Doc PR        | N/A