### PR TITLE
Remove wrong return doc

### DIFF
--- a/src/Bridge/Symfony/Bundle/Test/Client.php
+++ b/src/Bridge/Symfony/Bundle/Test/Client.php
@@ -83,8 +83,6 @@ final class Client implements HttpClientInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return Response
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |  

* The doc is superfluous, so rely on the return type instead.
* This fixes Psalm `InternalMethod` error when clients call methods 
  such as such as `toArray()` on `Response`, which is marked internal.