### PR TITLE
Don't force format in multipart tests, see #3374

### DIFF
--- a/tests/GraphQl/Action/EntrypointActionTest.php
+++ b/tests/GraphQl/Action/EntrypointActionTest.php
@@ -73,7 +73,6 @@ class EntrypointActionTest extends TestCase
     public function testPostRawAction(): void
     {
         $request = new Request(['variables' => '["graphqlVariable"]', 'operationName' => 'graphqlOperationName'], [], [], [], [], [], 'graphqlQuery');
-        $request->setFormat('graphql', 'application/graphql');
         $request->setMethod('POST');
         $request->headers->set('Content-Type', 'application/graphql');
         $mockedEntrypoint = $this->getEntrypointAction();
@@ -104,7 +103,6 @@ class EntrypointActionTest extends TestCase
             $requestParams['map'] = $map;
         }
         $request = new Request([], $requestParams, [], [], $files);
-        $request->setFormat('multipart', 'multipart/form-data');
         $request->setMethod('POST');
         $request->headers->set('Content-Type', 'multipart/form-data');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | ?
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #3374
| License       | MIT
| Doc PR        | -

I suspect that forcing the type here hides the issue related in #3374.

These formats were added in the default configuration: https://github.com/api-platform/core/pull/3041/files#diff-3e119d86a53425e719763f6573fc1752746601e1940e09f51084b5d02dae04cb

Isn't the file `config_common.yml` loaded by these PHPUnit tests?