### PR TITLE
Fix configuration description

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -251,7 +251,7 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('clientId')->defaultValue('')->info('The oauth client id.')->end()
                         ->scalarNode('clientSecret')->defaultValue('')->info('The oauth client secret.')->end()
-                        ->scalarNode('type')->defaultValue('oauth2')->info('The oauth client secret.')->end()
+                        ->scalarNode('type')->defaultValue('oauth2')->info('The oauth type.')->end()
                         ->scalarNode('flow')->defaultValue('application')->info('The oauth flow grant type.')->end()
                         ->scalarNode('tokenUrl')->defaultValue('')->info('The oauth token url.')->end()
                         ->scalarNode('authorizationUrl')->defaultValue('')->info('The oauth authentication url.')->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6 <!-- see below -->
| Bug fix?      | yes <!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

When running command `bin/console config:dump-reference api_platform`, I noticed that description of param `oauth.type` was not relevant and the same as `oauth.clientSecret.` I suspect a copy/paste issue.

This PR is just a fix about param description.


<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
-->
