### PR TITLE
fix(MongoDB): Handle deprecated setMetadataCacheImpl

### DIFF
--- a/src/Test/DoctrineMongoDbOdmSetup.php
+++ b/src/Test/DoctrineMongoDbOdmSetup.php
@@ -62,7 +62,11 @@ class DoctrineMongoDbOdmSetup
         $cache = self::createCacheConfiguration($isDevMode, $proxyDir, $hydratorDir, $cache);
 
         $config = new Configuration();
-        $config->setMetadataCacheImpl($cache);
+        if (method_exists($config, 'setMetadataCache')) {
+            $config->setMetadataCache($cache);
+        } else {
+            $config->setMetadataCacheImpl($cache);
+        }
         $config->setProxyDir($proxyDir);
         $config->setHydratorDir($hydratorDir);
         $config->setProxyNamespace('DoctrineProxies');

--- a/src/Test/DoctrineMongoDbOdmTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmTestCase.php
@@ -39,7 +39,11 @@ class DoctrineMongoDbOdmTestCase extends TestCase
         $config->setProxyNamespace('SymfonyTests\Doctrine');
         $config->setHydratorNamespace('SymfonyTests\Doctrine');
         $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), $paths));
-        $config->setMetadataCacheImpl(new ArrayCache());
+        if (method_exists($config, 'setMetadataCache')) {
+            $config->setMetadataCache(new ArrayCache());
+        } else {
+            $config->setMetadataCacheImpl(new ArrayCache());
+        }
 
         return DocumentManager::create(null, $config);
     }


### PR DESCRIPTION
NB: other deprecations need a fix upstream at https://github.com/doctrine/DoctrineMongoDBBundle/blob/4.4.x/DependencyInjection/DoctrineMongoDBExtension.php#L209 