### PR TITLE
fix(openapi): do not use jsonld schema for all media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Filter validation: Fix issue in Required filter validator with dot notation (#4221)
 * OpenAPI: Fix notice/warning for `response` without `content` in the `openapi_context` (#4210)
 * OpenAPI: Do not use output for request body (#4213)
-* OpenAPI: Do not use jsonld schema for all media types (#4247) (BC note: `SchemaFactory::buildSchema()` no longer modifies the passed `$schema`, callers must use the return value)
+* OpenAPI: Do not use jsonld schema for all media types (#4247) (BC note: `SchemaFactory::buildSchema()` is now immutable as it no longer modifies the passed `$schema`)
 * Serializer: Convert internal error to HTTP 400 in Ramsey uuid denormalization from invalid body string (#4200)
 * Symfony: Add tests with Symfony Uuid (#4230)
 * OpenAPI: Allow to set extensionProperties with YAML schema definition (#4228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Filter validation: Fix issue in Required filter validator with dot notation (#4221)
 * OpenAPI: Fix notice/warning for `response` without `content` in the `openapi_context` (#4210)
 * OpenAPI: Do not use output for request body (#4213)
+* OpenAPI: Do not use jsonld schema for all media types (#4247) (BC note: `SchemaFactory::buildSchema()` no longer modifies the passed `$schema`, callers must use the return value)
 * Serializer: Convert internal error to HTTP 400 in Ramsey uuid denormalization from invalid body string (#4200)
 * Symfony: Add tests with Symfony Uuid (#4230)
 * OpenAPI: Allow to set extensionProperties with YAML schema definition (#4228)

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -109,6 +109,103 @@ Feature: Documentation support
     And the JSON node "paths./deprecated_resources/{id}.put.deprecated" should be true
     And the JSON node "paths./deprecated_resources/{id}.patch.deprecated" should be true
 
+    # Formats
+    And the OpenAPI class "Dummy.jsonld" exists
+    And the "@id" property exists for the OpenAPI class "Dummy.jsonld"
+    And the JSON node "paths./dummies.get.responses.200.content.application/ld+json" should be equal to:
+    """
+    {
+        "schema": {
+            "type": "object",
+            "properties": {
+                "hydra:member": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/Dummy.jsonld"
+                    }
+                },
+                "hydra:totalItems": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "hydra:view": {
+                    "type": "object",
+                    "properties": {
+                        "@id": {
+                            "type": "string",
+                            "format": "iri-reference"
+                        },
+                        "@type": {
+                            "type": "string"
+                        },
+                        "hydra:first": {
+                            "type": "string",
+                            "format": "iri-reference"
+                        },
+                        "hydra:last": {
+                            "type": "string",
+                            "format": "iri-reference"
+                        },
+                        "hydra:next": {
+                            "type": "string",
+                            "format": "iri-reference"
+                        }
+                    }
+                },
+                "hydra:search": {
+                    "type": "object",
+                    "properties": {
+                        "@type": {
+                            "type": "string"
+                        },
+                        "hydra:template": {
+                            "type": "string"
+                        },
+                        "hydra:variableRepresentation": {
+                            "type": "string"
+                        },
+                        "hydra:mapping": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "@type": {
+                                        "type": "string"
+                                    },
+                                    "variable": {
+                                        "type": "string"
+                                    },
+                                    "property": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "required": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "hydra:member"
+            ]
+        }
+    }
+    """
+    And the JSON node "paths./dummies.get.responses.200.content.application/json" should be equal to:
+    """
+    {
+        "schema": {
+            "type": "array",
+            "items": {
+                "$ref": "#/components/schemas/Dummy"
+            }
+        }
+    }
+    """
+
   @createSchema
   Scenario: Retrieve the Swagger documentation
     Given I send a "GET" request to "/docs.json?spec_version=2"

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -69,7 +69,7 @@ final class SchemaFactory implements SchemaFactoryInterface
      */
     public function buildSchema(string $className, string $format = 'json', string $type = Schema::TYPE_OUTPUT, ?string $operationType = null, ?string $operationName = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
     {
-        $schema = null !== $schema ? clone $schema : new Schema();
+        $schema = $schema ? clone $schema : new Schema();
         if (null === $metadata = $this->getMetadata($className, $type, $operationType, $operationName, $serializerContext)) {
             return $schema;
         }

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -69,7 +69,7 @@ final class SchemaFactory implements SchemaFactoryInterface
      */
     public function buildSchema(string $className, string $format = 'json', string $type = Schema::TYPE_OUTPUT, ?string $operationType = null, ?string $operationName = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
     {
-        $schema = $schema ?? new Schema();
+        $schema = null !== $schema ? clone $schema : new Schema();
         if (null === $metadata = $this->getMetadata($className, $type, $operationType, $operationName, $serializerContext)) {
             return $schema;
         }

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -254,9 +254,6 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                 }
             }
 
-            $schema = new Schema('openapi');
-            $schema->setDefinitions($schemas);
-
             $requestBody = null;
             if ($contextRequestBody = $operation['openapi_context']['requestBody'] ?? false) {
                 $requestBody = new Model\RequestBody($contextRequestBody['description'] ?? '', new \ArrayObject($contextRequestBody['content']), $contextRequestBody['required'] ?? false);

--- a/src/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Swagger/Serializer/DocumentationNormalizer.php
@@ -637,9 +637,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $schema = new Schema($v3 ? Schema::VERSION_OPENAPI : Schema::VERSION_SWAGGER);
         $schema->setDefinitions($definitions);
 
-        $this->jsonSchemaFactory->buildSchema($resourceClass, $format, $type, $operationType, $operationName, $schema, $serializerContext, $forceCollection);
-
-        return $schema;
+        return $this->jsonSchemaFactory->buildSchema($resourceClass, $format, $type, $operationType, $operationName, $schema, $serializerContext, $forceCollection);
     }
 
     private function computeDoc(bool $v3, Documentation $documentation, \ArrayObject $definitions, \ArrayObject $paths, array $context): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #4215
| License       | MIT
| Doc PR        | 

Follows #4213