### PR TITLE
[GraphQL] Fix `FieldsBuilder` not always fully unwrapping a type before deciding if a resolver is needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Serializer: Convert internal error to HTTP 400 in Ramsey uuid denormalization from invalid body string (#4200)
 * Symfony: Add tests with Symfony Uuid (#4230)
 * OpenAPI: Allow to set extensionProperties with YAML schema definition (#4228)
+* GraphQL: Fix `FieldsBuilder` not fully unwrapping nested types before deciding if a resolver is needed (#4251)
 
 ## 2.6.4
 

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -276,7 +276,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
                 return null;
             }
 
-            $graphqlWrappedType = $graphqlType instanceof WrappingType ? $graphqlType->getWrappedType() : $graphqlType;
+            $graphqlWrappedType = $graphqlType instanceof WrappingType ? $graphqlType->getWrappedType(true) : $graphqlType;
             $isStandardGraphqlType = \in_array($graphqlWrappedType, GraphQLType::getStandardTypes(), true);
             if ($isStandardGraphqlType) {
                 $resourceClass = '';

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -505,6 +505,7 @@ class FieldsBuilderTest extends TestCase
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), null, $mutationName, null, '', $resourceClass, $propertyName, 1)->willReturn(GraphQLType::string());
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), null, null, $subscriptionName, '', $resourceClass, $propertyName, 1)->willReturn(GraphQLType::string());
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, null, $mutationName, null, 'subresourceClass', $propertyName, 1)->willReturn(GraphQLType::string());
+            $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)), Argument::type('bool'), $queryName, null, null, '', $resourceClass, $propertyName, 1)->willReturn(GraphQLType::nonNull(GraphQLType::listOf(GraphQLType::nonNull(GraphQLType::string()))));
         }
         $this->typesContainerProphecy->has('NotRegisteredType')->willReturn(false);
         $this->typesContainerProphecy->all()->willReturn([]);
@@ -585,6 +586,24 @@ class FieldsBuilderTest extends TestCase
                     ],
                     'propertyBool' => [
                         'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => null,
+                    ],
+                ],
+            ],
+            'query with simple non-null string array property' => ['resourceClass', new ResourceMetadata(),
+                [
+                    'property' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)), null, true, false),
+                ],
+                false, 'item_query', null, null, null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'property' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::listOf(GraphQLType::nonNull(GraphQLType::string()))),
                         'description' => null,
                         'args' => [],
                         'resolve' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This fixes `FieldsBuilder` not using the recursive version of `getWrappedType`. Without this, if the type is wrapped in both `NonNull` and then `ListOfType`, then `ListOfType` is returned instead of the actual type of the list items - which I think was the original intention of this code, as it's trying to decide if the base type needs a special resolver. For example, a non-null list of non-null strings (`[String!]!`) will now correctly return `String` as the wrapped type with this fix. This means that simple arrays such as this, which are already deserialized by the Symfony deserializer and therefore do not need to use a special resolver, can now work.