### PR TITLE
fix: avoid default order by duplication

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/OrderExtension.php
@@ -58,6 +58,10 @@ final class OrderExtension implements ContextAwareQueryCollectionExtensionInterf
             }
             if (null !== $defaultOrder) {
                 foreach ($defaultOrder as $field => $order) {
+                    if(isset($context['filters']['order'][$field])){
+                        continue;
+                    }
+                    
                     if (\is_int($field)) {
                         // Default direction
                         $field = $order;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6 <!-- see below -->
| Bug fix?      | yes <!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | Fix #2690 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
-->

Avoid duplicate fields in "order by" when the field already exists in the filter order.