### PR TITLE
fix: handle unofficial http status code with custom exceptions

### DIFF
--- a/src/Problem/Serializer/ErrorNormalizerTrait.php
+++ b/src/Problem/Serializer/ErrorNormalizerTrait.php
@@ -31,7 +31,7 @@ trait ErrorNormalizerTrait
         if ($object instanceof FlattenException || $object instanceof LegacyFlattenException) {
             $statusCode = $context['statusCode'] ?? $object->getStatusCode();
             if ($statusCode >= 500 && $statusCode < 600) {
-                $message = Response::$statusTexts[$statusCode];
+                $message = Response::$statusTexts[$statusCode] ?? Response::$statusTexts[Response::HTTP_INTERNAL_SERVER_ERROR];
             }
         }
 

--- a/tests/Problem/Serializer/ErrorNormalizerTest.php
+++ b/tests/Problem/Serializer/ErrorNormalizerTest.php
@@ -74,7 +74,7 @@ class ErrorNormalizerTest extends TestCase
         $expected = [
             'type' => 'https://tools.ietf.org/html/rfc2616#section-10',
             'title' => 'An error occurred',
-            'detail' => ($debug || $status < 500) ? $originalMessage : Response::$statusTexts[$status],
+            'detail' => ($debug || $status < 500) ? $originalMessage : Response::$statusTexts[$status] ?? Response::$statusTexts[Response::HTTP_INTERNAL_SERVER_ERROR],
         ];
 
         if ($debug) {
@@ -93,6 +93,7 @@ class ErrorNormalizerTest extends TestCase
             [Response::HTTP_INTERNAL_SERVER_ERROR, 'Sensitive SQL error displayed', true],
             [Response::HTTP_GATEWAY_TIMEOUT, 'Sensitive server error displayed', true],
             [Response::HTTP_BAD_REQUEST, 'Bad Request Message', true],
+            [509, Response::$statusTexts[Response::HTTP_INTERNAL_SERVER_ERROR], true],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       |  https://github.com/api-platform/core/issues/4275
| License       | MIT

When using custom Exception class and custom HTTP status code, a check was missing if the http status code really exists or is an unofficial ones.
This worked in devel mode because the verbosity mode does not replace the message but failed in production.
