### PR TITLE
fix(graphql): do not use a resolver for the nested payload of a mutation or subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Symfony: Add tests with Symfony Uuid (#4230)
 * OpenAPI: Allow to set extensionProperties with YAML schema definition (#4228)
 * GraphQL: Fix `FieldsBuilder` not fully unwrapping nested types before deciding if a resolver is needed (#4251)
+* GraphQL: Do not use a resolver for the nested payload of a mutation or subscription (#4289)
 
 ## 2.6.4
 

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -662,6 +662,44 @@ Feature: GraphQL mutation support
     And the JSON node "data.createDummyGroup.dummyGroup.__typename" should be equal to "createDummyGroupPayloadData"
     And the JSON node "data.createDummyGroup.clientMutationId" should be equal to "myId"
 
+  @createSchema
+  Scenario: Use serialization groups with relations
+    Given there is 1 dummy object with relatedDummy and its thirdLevel
+    And there is a RelatedDummy with 2 friends
+    When I send the following GraphQL request:
+    """
+    mutation {
+      updateRelatedDummy(input: {id: "/related_dummies/2", symfony: "laravel", embeddedDummy: "{}", thirdLevel: "/third_levels/1"}) {
+        relatedDummy {
+          id
+          symfony
+          thirdLevel {
+            id
+            __typename
+          }
+          relatedToDummyFriend {
+            edges {
+              node {
+                name
+              }
+            }
+            __typename
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.id" should be equal to "/related_dummies/2"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.symfony" should be equal to "laravel"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.id" should be equal to "/third_levels/1"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.__typename" should be equal to "updateThirdLevelNestedPayload"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.__typename" should be equal to "updateRelatedToDummyFriendNestedPayloadConnection"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[0].node.name" should be equal to "Relation-1"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[1].node.name" should be equal to "Relation-2"
+
   Scenario: Trigger a validation error
     When I send the following GraphQL request:
     """

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -306,10 +306,12 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
             if ($isStandardGraphqlType || $input) {
                 $resolve = null;
-            } elseif ($mutationName) {
-                $resolve = ($this->itemMutationResolverFactory)($resourceClass, $rootResource, $mutationName);
-            } elseif ($subscriptionName) {
-                $resolve = ($this->itemSubscriptionResolverFactory)($resourceClass, $rootResource, $subscriptionName);
+            } elseif (($mutationName || $subscriptionName) && $depth <= 0) {
+                if ($mutationName) {
+                    $resolve = ($this->itemMutationResolverFactory)($resourceClass, $rootResource, $mutationName);
+                } else {
+                    $resolve = ($this->itemSubscriptionResolverFactory)($resourceClass, $rootResource, $subscriptionName);
+                }
             } elseif ($this->typeBuilder->isCollection($type)) {
                 $resolve = ($this->collectionResolverFactory)($resourceClass, $rootResource, $queryName);
             } else {

--- a/tests/Fixtures/TestBundle/Document/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Document/RelatedDummy.php
@@ -27,7 +27,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Alexandre Delplace <alexandre.delplacemille@gmail.com>
  *
- * @ApiResource(iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.mongodb.friends"}})
+ * @ApiResource(graphql={"update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.mongodb.friends"}})
  * @ODM\Document
  */
 class RelatedDummy extends ParentDummy

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
+ * @ApiResource(graphql={"update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
  * @ORM\Entity
  */
 class RelatedDummy extends ParentDummy

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -503,6 +503,12 @@ class FieldsBuilderTest extends TestCase
             $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_CALLABLE), Argument::type('bool'), $queryName, null, null, '', $resourceClass, $propertyName, 1)->willReturn('NotRegisteredType');
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), $queryName, null, null, '', $resourceClass, $propertyName, 1)->willReturn(GraphQLType::string());
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), null, $mutationName, null, '', $resourceClass, $propertyName, 1)->willReturn(GraphQLType::string());
+            if ('propertyObject' === $propertyName) {
+                $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), null, $mutationName, null, 'objectClass', $resourceClass, $propertyName, 1)->willReturn(new ObjectType(['name' => 'objectType']));
+                $this->resourceMetadataFactoryProphecy->create('objectClass')->willReturn(new ResourceMetadata());
+                $this->itemResolverFactoryProphecy->__invoke('objectClass', $resourceClass, $queryName)->willReturn(static function () {
+                });
+            }
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), null, null, $subscriptionName, '', $resourceClass, $propertyName, 1)->willReturn(GraphQLType::string());
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, null, $mutationName, null, 'subresourceClass', $propertyName, 1)->willReturn(GraphQLType::string());
             $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)), Argument::type('bool'), $queryName, null, null, '', $resourceClass, $propertyName, 1)->willReturn(GraphQLType::nonNull(GraphQLType::listOf(GraphQLType::nonNull(GraphQLType::string()))));
@@ -616,6 +622,7 @@ class FieldsBuilderTest extends TestCase
                     'property' => new PropertyMetadata(),
                     'propertyBool' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, false, true),
                     'propertyReadable' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL), null, true, true),
+                    'propertyObject' => new PropertyMetadata(new Type(Type::BUILTIN_TYPE_BOOL, false, 'objectClass'), null, true, true),
                 ],
                 false, null, 'mutation', null, null,
                 [
@@ -627,6 +634,14 @@ class FieldsBuilderTest extends TestCase
                         'description' => null,
                         'args' => [],
                         'resolve' => null,
+                        'deprecationReason' => null,
+                    ],
+                    'propertyObject' => [
+                        'type' => GraphQLType::nonNull(new ObjectType(['name' => 'objectType'])),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => static function () {
+                        },
                         'deprecationReason' => null,
                     ],
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | #3492 #4183
| License       | MIT
| Doc PR        | N/A

Fixes a regression introduced in https://github.com/api-platform/core/commit/d6f2603fe80236b1c7bac2a92b49b337c8cc6973#diff-d7bf2d1671fc1d774236691a30000b7d2c1a9296094faf093c98fd549f727bd5R299-R300.

The resolver for the mutation (and the subscription) was set for nested payload properties and was wrongly called when resolving the root mutation.

This PR fixes the issue by only setting the mutation resolver for the root payload and uses the item / collection resolver for the nested payload properties.

Notice that this issue only appears when a specific normalization context is used for the mutation (different of the query one). Else the item type is used instead of the nested payload type (for client caching).