### PR TITLE
[ApiLoader] Support _format resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Deprecate `allow_plain_identifiers` option (#4167)
 * Exception: Add the ability to customize multiple status codes based on the validation exception (#4017)
 * GraphQL: Fix graphql fetching with Elasticsearch (#4217)
+* ApiLoader: Support `_format` resolving (#4292)
 
 ## 2.6.5
 
@@ -41,7 +42,6 @@
 * Symfony: Add tests with Symfony Uuid (#4230)
 * OpenAPI: Allow to set extensionProperties with YAML schema definition (#4228)
 * GraphQL: Fix `FieldsBuilder` not fully unwrapping nested types before deciding if a resolver is needed (#4251)
-* ApiLoader: Support `_format` resolving (#4292)
 
 ## 2.6.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Symfony: Add tests with Symfony Uuid (#4230)
 * OpenAPI: Allow to set extensionProperties with YAML schema definition (#4228)
 * GraphQL: Fix `FieldsBuilder` not fully unwrapping nested types before deciding if a resolver is needed (#4251)
+* ApiLoader: Support `_format` resolving (#4292)
 
 ## 2.6.4
 

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -128,7 +128,7 @@ final class ApiLoader extends Loader
                     $operation['path'],
                     [
                         '_controller' => $controller,
-                        '_format' => null,
+                        '_format' => !empty($operation['defaults']['_format']) ? $operation['defaults']['_format'] : null,
                         '_stateless' => $operation['stateless'] ?? $resourceMetadata->getAttribute('stateless'),
                         '_api_resource_class' => $operation['resource_class'],
                         '_api_identifiers' => $operation['identifiers'],
@@ -241,7 +241,7 @@ final class ApiLoader extends Loader
             $path,
             [
                 '_controller' => $controller,
-                '_format' => null,
+                '_format' => !empty($operation['defaults']['_format']) ? $operation['defaults']['_format'] : null,
                 '_stateless' => $operation['stateless'],
                 '_api_resource_class' => $resourceClass,
                 '_api_identifiers' => $operation['identifiers'],

--- a/src/Bridge/Symfony/Routing/ApiLoader.php
+++ b/src/Bridge/Symfony/Routing/ApiLoader.php
@@ -128,7 +128,7 @@ final class ApiLoader extends Loader
                     $operation['path'],
                     [
                         '_controller' => $controller,
-                        '_format' => !empty($operation['defaults']['_format']) ? $operation['defaults']['_format'] : null,
+                        '_format' => $operation['defaults']['_format'] ?? null,
                         '_stateless' => $operation['stateless'] ?? $resourceMetadata->getAttribute('stateless'),
                         '_api_resource_class' => $operation['resource_class'],
                         '_api_identifiers' => $operation['identifiers'],
@@ -241,7 +241,7 @@ final class ApiLoader extends Loader
             $path,
             [
                 '_controller' => $controller,
-                '_format' => !empty($operation['defaults']['_format']) ? $operation['defaults']['_format'] : null,
+                '_format' => $operation['defaults']['_format'] ?? null,
                 '_stateless' => $operation['stateless'],
                 '_api_resource_class' => $resourceClass,
                 '_api_identifiers' => $operation['identifiers'],

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -60,7 +60,7 @@ class ApiLoaderTest extends TestCase
         ]);
         //custom operations
         $resourceMetadata = $resourceMetadata->withCollectionOperations([
-            'my_op' => ['method' => 'GET', 'controller' => 'some.service.name', 'requirements' => ['_format' => 'a valid format'], 'defaults' => ['my_default' => 'default_value'], 'condition' => "request.headers.get('User-Agent') matches '/firefox/i'", 'stateless' => null], //with controller
+            'my_op' => ['method' => 'GET', 'controller' => 'some.service.name', 'requirements' => ['_format' => 'a valid format'], 'defaults' => ['my_default' => 'default_value', '_format' => 'a valid format'], 'condition' => "request.headers.get('User-Agent') matches '/firefox/i'", 'stateless' => null], //with controller
             'my_second_op' => ['method' => 'POST', 'options' => ['option' => 'option_value'], 'host' => '{subdomain}.api-platform.com', 'schemes' => ['https'], 'stateless' => null], //without controller, takes the default one
             'my_path_op' => ['method' => 'GET', 'path' => 'some/custom/path', 'stateless' => null], //custom path
             'my_stateless_op' => ['method' => 'GET', 'stateless' => true],
@@ -87,7 +87,7 @@ class ApiLoaderTest extends TestCase
         );
 
         $this->assertEquals(
-            $this->getRoute('/dummies.{_format}', 'some.service.name', DummyEntity::class, 'my_op', ['GET'], true, ['_format' => 'a valid format'], ['my_default' => 'default_value', '_stateless' => null], [], '', [], "request.headers.get('User-Agent') matches '/firefox/i'"),
+            $this->getRoute('/dummies.{_format}', 'some.service.name', DummyEntity::class, 'my_op', ['GET'], true, ['_format' => 'a valid format'], ['my_default' => 'default_value', '_format' => 'a valid format', '_stateless' => null], [], '', [], "request.headers.get('User-Agent') matches '/firefox/i'"),
             $routeCollection->get('api_dummies_my_op_collection')
         );
 
@@ -318,7 +318,7 @@ class ApiLoaderTest extends TestCase
             $path,
             [
                 '_controller' => $controller,
-                '_format' => null,
+                '_format' => !empty($extraDefaults['_format']) ? $extraDefaults['_format'] : null,
                 '_api_resource_class' => $resourceClass,
                 '_api_identifiers' => ['id'],
                 '_api_has_composite_identifier' => false,
@@ -339,7 +339,7 @@ class ApiLoaderTest extends TestCase
             $path,
             [
                 '_controller' => $controller,
-                '_format' => null,
+                '_format' => !empty($extraDefaults['_format']) ? $extraDefaults['_format'] : null,
                 '_api_resource_class' => $resourceClass,
                 '_api_subresource_operation_name' => $operationName,
                 '_api_subresource_context' => $context,

--- a/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -318,7 +318,7 @@ class ApiLoaderTest extends TestCase
             $path,
             [
                 '_controller' => $controller,
-                '_format' => !empty($extraDefaults['_format']) ? $extraDefaults['_format'] : null,
+                '_format' => $extraDefaults['_format'] ?? null,
                 '_api_resource_class' => $resourceClass,
                 '_api_identifiers' => ['id'],
                 '_api_has_composite_identifier' => false,
@@ -339,7 +339,7 @@ class ApiLoaderTest extends TestCase
             $path,
             [
                 '_controller' => $controller,
-                '_format' => !empty($extraDefaults['_format']) ? $extraDefaults['_format'] : null,
+                '_format' => $extraDefaults['_format'] ?? null,
                 '_api_resource_class' => $resourceClass,
                 '_api_subresource_operation_name' => $operationName,
                 '_api_subresource_context' => $context,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no, yes
| New feature?  |no, yes 
| BC breaks?    | no
| Deprecations? | no
| Tickets       | #There's no ticket
| License       | MIT

Hello there,

Currently, it is not possible to resolve the  default value for the `_format` parameter under a custom operation definition.
This is due to the `ApiLoader` which forces this value to `nul` no matter what value we set in the configuration.
This fix makes it possible to take into account the definition of the `defaults._format` value and have the right value under the request route params.

**Use case:**
Imagine that we have a resource that which is used to export both the data in csv and in xlsx.

resources.yaml:

```
resources:
    App\Entity\Activity\Contract:
        collectionOperations:
            export:
                method: 'GET'
                path: /contracts/export.{_format}
                defaults:
                    _format: "xlsx"
               requirements:
                   _format: "xlsx|csv"
                controller: App\Controller\Api\ExportContractController

```
ExportContractController:

```
final class ExportContractController extends AbstractController
{
    public function __invoke($_format, $data)
    {
    // before the fix, $_format return null
    dd($_format);
    // after the fix, $_format return 'xlsx'
    
    }
}
```