### PR TITLE
fix(serializer): collection denormalization from object linked to doctrine entities

### DIFF
--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -51,6 +51,12 @@ class ItemNormalizer extends AbstractItemNormalizer
      */
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (null === $objectToPopulate = $this->extractObjectToPopulate($class, $context, static::OBJECT_TO_POPULATE)) {
+            $normalizedData = $this->prepareForDenormalization($data);
+            $class = $this->getClassDiscriminatorResolvedClass($normalizedData, $class);
+        }
+        $resourceClass = $this->resourceClassResolver->getResourceClass($objectToPopulate, $class);
+        $context['resource_class'] = $resourceClass;
         // Avoid issues with proxies if we populated the object
         if (isset($data['id']) && !isset($context[self::OBJECT_TO_POPULATE])) {
             if (isset($context['api_allow_update']) && true !== $context['api_allow_update']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | current
| Type       | Bug fix
| Tickets       |  no
| License       | MIT

As it, denormalization doesn't find the children class in this case : 

```php
// Class to denormalize, not an entity, just an input class from a operation with messenger=input
class X {
  // id, other props not mentionned here ...
  /** @var Entity[] */
  public $collection;
}

// Object receive in json-ld
['collection'=>[{"@id"=>"/entities/5"}]]
// Object receive in json
['collection'=>[{"id"=>5}]]

```

If $entity has an id like in the example, object is denormalized normally with json ld (```"@id": "iri"```). With json format, the resource_class is absent from context and the object is denormalized without database populate and losing the id value. This fix come from parent class https://github.com/api-platform/core/blob/2.6/src/Serializer/AbstractItemNormalizer.php#L187 which will be call after the populate.

