### PR TITLE
Fix api-platform#4037 allow POST operations without identifiers on raw json

### DIFF
--- a/src/EventListener/WriteListener.php
+++ b/src/EventListener/WriteListener.php
@@ -20,6 +20,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ToggleableOperationAttributeTrait;
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use ApiPlatform\Core\Util\ResourceClassInfoTrait;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 
@@ -100,8 +101,12 @@ final class WriteListener
                     break;
                 }
 
-                if ($this->iriConverter instanceof IriConverterInterface && $this->isResourceClass($this->getObjectClass($controllerResult))) {
-                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
+                try {
+                    if ($this->iriConverter instanceof IriConverterInterface && $this->isResourceClass($this->getObjectClass($controllerResult))) {
+                        $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
+                    }
+                } catch (InvalidArgumentException $e) {
+                    // The original resource has no identifiers
                 }
 
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | --- 
| Bug fix?    | yes
| New feature | no
| BC Breaks? | no
| Deprecations? | no (fixes bc)
| Tickets | fixes #4037 #3975 
| License | MIT
| Doc PR | TODO

This allows POST operations without itemOperations and without identifiers on raw json :)