### PR TITLE
fix(openapi): do not throw error with non standard HTTP verb

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -27,6 +27,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInte
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\OpenApi\Model;
 use ApiPlatform\Core\OpenApi\Model\ExternalDocumentation;
+use ApiPlatform\Core\OpenApi\Model\PathItem;
 use ApiPlatform\Core\OpenApi\OpenApi;
 use ApiPlatform\Core\OpenApi\Options;
 use ApiPlatform\Core\Operation\Factory\SubresourceOperationFactoryInterface;
@@ -144,6 +145,11 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $resourceClass = $operation['resource_class'] ?? $rootResourceClass;
             $path = $this->getPath($resourceShortName, $operationName, $operation, $operationType);
             $method = $resourceMetadata->getTypedOperationAttribute($operationType, $operationName, 'method', 'GET');
+
+            if (!\in_array($method, PathItem::$methods, true)) {
+                continue;
+            }
+
             [$requestMimeTypes, $responseMimeTypes] = $this->getMimeTypes($resourceClass, $operationName, $operationType, $resourceMetadata);
             $operationId = $operation['openapi_context']['operationId'] ?? lcfirst($operationName).ucfirst($resourceShortName).ucfirst($operationType);
             $linkedOperationId = 'get'.ucfirst($resourceShortName).ucfirst(OperationType::ITEM);

--- a/src/OpenApi/Model/PathItem.php
+++ b/src/OpenApi/Model/PathItem.php
@@ -17,7 +17,7 @@ final class PathItem
 {
     use ExtensionTrait;
 
-    private static $methods = ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE'];
+    public static $methods = ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE'];
     private $ref;
     private $summary;
     private $description;

--- a/tests/OpenApi/Factory/OpenApiFactoryTest.php
+++ b/tests/OpenApi/Factory/OpenApiFactoryTest.php
@@ -118,6 +118,7 @@ class OpenApiFactoryTest extends TestCase
                         ],
                     ],
                 ]] + self::OPERATION_FORMATS,
+                'custom-http-verb' => ['method' => 'TEST'] + self::OPERATION_FORMATS,
                 'formats' => ['method' => 'PUT', 'path' => '/formatted/{id}', 'output_formats' => ['json' => ['application/json'], 'csv' => ['text/csv']], 'input_formats' => ['json' => ['application/json'], 'csv' => ['text/csv']]],
             ],
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | current stable (2.6)
| License       | MIT

Hello!

I'm trying to use a non standard HTTP verb in my ApiResource operations:
```
collectionOperations={
 *          "test":{
 *              "method": "TEST",
 *              "path": "/something",
 *              "controller": TesterController::class,
 *          },
 *      },
``` 

Everything works great, but when I want to access the Swagger UI (`/docs`), I got an error: 
```
Attempted to call an undefined method named "withTEST" of class "ApiPlatform\Core\OpenApi\Model\PathItem".
```

It seems that we don't check the HTTP verb before creating the related `PathItem` method here: 
```php
$pathItem = $pathItem->{'with' . ucfirst($method)}(new Model\Operation(
```
https://github.com/api-platform/core/blob/2.6/src/OpenApi/Factory/OpenApiFactory.php#L271

OpenApi only supports: `['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE']`.
So I propose this fix: continue if the HTTP verb is unknown, which fix the above error.

Thanks