### PR TITLE
Fix: Improved Doctrine SearchFilter for entities that have an (ORM) identifier that is not just 'id'

### DIFF
--- a/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilter.php
@@ -100,9 +100,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         $metadata = $this->getNestedMetadata($resourceClass, $associations);
 
         if ($metadata->hasField($field) && !$metadata->hasAssociation($field)) {
-            if ('id' === $field) {
-                $values = array_map([$this, 'getIdFromValue'], $values);
-            }
+            $values = array_map([$this, 'getIdFromValue'], $values);
 
             if (!$this->hasValidValues($values, $this->getDoctrineFieldType($property, $resourceClass))) {
                 $this->logger->notice('Invalid filter ignored', [

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -101,9 +101,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         $metadata = $this->getNestedMetadata($resourceClass, $associations);
 
         if ($metadata->hasField($field)) {
-            if ('id' === $field) {
-                $values = array_map([$this, 'getIdFromValue'], $values);
-            }
+            $values = array_map([$this, 'getIdFromValue'], $values);
 
             if (!$this->hasValidValues($values, $this->getDoctrineFieldType($property, $resourceClass))) {
                 $this->logger->notice('Invalid filter ignored', [


### PR DESCRIPTION
Still won't work with multiple identifiers but it's probably too complicated to support in a generic filter.

| Q             | A
| ------------- | ---
| Branch?       | 2.6
| License       | MIT

SearchFilter does not work when searching a related entity that is not identified by a field name 'id'.
