### PR TITLE
Add hydra:previous to the hydra view schema properties

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -146,6 +146,10 @@ Feature: Documentation support
                             "type": "string",
                             "format": "iri-reference"
                         },
+                        "hydra:previous": {
+                            "type": "string",
+                            "format": "iri-reference"
+                        },
                         "hydra:next": {
                             "type": "string",
                             "format": "iri-reference"

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -133,6 +133,10 @@ final class SchemaFactory implements SchemaFactoryInterface
                             'type' => 'string',
                             'format' => 'iri-reference',
                         ],
+                        'hydra:previous' => [
+                            'type' => 'string',
+                            'format' => 'iri-reference',
+                        ],
                         'hydra:next' => [
                             'type' => 'string',
                             'format' => 'iri-reference',

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -136,4 +136,18 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('@type', $properties);
         $this->assertArrayHasKey('@id', $properties);
     }
+
+    public function testHasHydraViewNavigationBuildSchema(): void
+    {
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, OperationType::COLLECTION);
+
+        $this->assertNull($resultSchema->getRootDefinitionKey());
+        $this->assertArrayHasKey('properties', $resultSchema);
+        $this->assertArrayHasKey('hydra:view', $resultSchema['properties']);
+        $this->assertArrayHasKey('properties', $resultSchema['properties']['hydra:view']);
+        $this->assertArrayHasKey('hydra:first', $resultSchema['properties']['hydra:view']['properties']);
+        $this->assertArrayHasKey('hydra:last', $resultSchema['properties']['hydra:view']['properties']);
+        $this->assertArrayHasKey('hydra:previous', $resultSchema['properties']['hydra:view']['properties']);
+        $this->assertArrayHasKey('hydra:next', $resultSchema['properties']['hydra:view']['properties']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

I don't know if this is intentional, but the `hydra:previous` property is not in the SchemaFactory (rendering the openapi specs incomplete).