### PR TITLE
fix(ulid): convert Ulid object to binary for ORM search filter

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -28,6 +28,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
 
 /**
  * Filter the collection by given properties.
@@ -160,6 +162,14 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
     {
         if (!\is_array($values)) {
             $values = [$values];
+        }
+
+        if (class_exists(AbstractUid::class)) {
+            foreach ($values as $key => $value) {
+                if ($value instanceof Ulid) {
+                    $values[$key] = $value->toBinary();
+                }
+            }
         }
 
         $wrapCase = $this->createWrapCase($caseSensitive);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When I want filter a resource by a relation property defined by an Ulid identifier, it doesn't work. This PR adds the conversion to binary before calling the query builder of Doctrine (as explained on the Symfony documentation: https://symfony.com/doc/current/components/uid.html#storing-ulids-in-databases).

Example:
```
Given the entity `Fruit` has a relation `ManyToOne` with the entity `Producer`
And the ID for each entity is Ulid type
And I have one producer with Ulid `01F7RK5K7FE9V0WPT8AGXS2C2J` who has a fruit
When I call the API `GET /api/fruits?producer=/api/producers/01F7RK5K7FE9V0WPT8AGXS2C2J`
Then I want to have one fruit as result
```
Currently, the result is 0 because the query builder uses the string representation that does not correspond to the binary stored in the database.

It is my first contribution. I don't know if I have to add a test for it and how, and I don't know if I have to change the Changelog file right now.

Don't hesitate to help me to improve this PR :slightly_smiling_face:  
