### PR TITLE
fix(openapi): failing recursion on api resources with "paths" key

### DIFF
--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -59,7 +59,7 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
             }
 
             // Side effect of using getPaths(): Paths which itself contains the array
-            if ('paths' === $key) {
+            if ('paths' === $key && \is_array($value) && isset($data['paths']['paths'])) {
                 $value = $data['paths'] = $data['paths']['paths'];
                 if ($value) {
                     ksort($value);

--- a/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
+++ b/tests/OpenApi/Serializer/OpenApiNormalizerTest.php
@@ -60,7 +60,7 @@ class OpenApiNormalizerTest extends TestCase
         $resourceNameCollectionFactoryProphecy->create()->shouldBeCalled()->willReturn(new ResourceNameCollection([Dummy::class, 'Zorro']));
         $defaultContext = ['base_url' => '/app_dev.php/'];
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactoryProphecy->create(Dummy::class, Argument::any())->shouldBeCalled()->willReturn(new PropertyNameCollection(['id', 'name', 'description', 'dummyDate']));
+        $propertyNameCollectionFactoryProphecy->create(Dummy::class, Argument::any())->shouldBeCalled()->willReturn(new PropertyNameCollection(['id', 'name', 'description', 'dummyDate', 'paths']));
         $propertyNameCollectionFactoryProphecy->create('Zorro', Argument::any())->shouldBeCalled()->willReturn(new PropertyNameCollection(['id']));
 
         $dummyMetadata = new ResourceMetadata(
@@ -104,6 +104,8 @@ class OpenApiNormalizerTest extends TestCase
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', Argument::any())->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'This is a name.', true, true, true, true, false, false, null, null, [], null, null, null, null, ['minLength' => 3, 'maxLength' => 20, 'pattern' => '^dummyPattern$']));
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'description', Argument::any())->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_STRING), 'This is an initializable but not writable property.', true, false, true, true, false, false, null, null, [], null, true));
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'dummyDate', Argument::any())->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_OBJECT, true, \DateTime::class), 'This is a \DateTimeInterface object.', true, true, true, true, false, false, null, null, []));
+        // Check reserved word "paths": when normalize->recursiveClean in OpenApi Component Schema.
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'paths', Argument::any())->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_ARRAY), 'This is a array.', true, true, true, true, false, false, null, null, []));
 
         $propertyMetadataFactoryProphecy->create('Zorro', 'id', Argument::any())->shouldBeCalled()->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_INT), 'This is an id.', true, false, null, null, null, true));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | #4318
| License       | MIT

As described in issue #4318 the function recursiveClean does nest one more time and fails, if an ApiResource has a property named `paths`. Found no tests to reproduce or fail due to this fact.
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
