### PR TITLE
fix(metadata): allow to use constants in XML configuration (resource attribute)

### DIFF
--- a/src/Metadata/Extractor/YamlExtractor.php
+++ b/src/Metadata/Extractor/YamlExtractor.php
@@ -114,7 +114,11 @@ final class YamlExtractor extends AbstractExtractor
                 'identifier' => $this->phpize($propertyValues, 'identifier', 'bool'),
                 'iri' => $this->phpize($propertyValues, 'iri', 'string'),
                 'attributes' => $propertyValues['attributes'] ?? [],
-                'subresource' => $propertyValues['subresource'] ?? null,
+                'subresource' => isset($propertyValues['subresource']) ? [
+                    'collection' => $this->phpize($propertyValues['subresource'], 'collection', 'bool'),
+                    'resourceClass' => $this->phpize($propertyValues['subresource'], 'resourceClass', 'string'),
+                    'maxDepth' => $this->phpize($propertyValues['subresource'], 'maxDepth', 'integer'),
+                ] : null,
             ];
         }
     }
@@ -124,7 +128,7 @@ final class YamlExtractor extends AbstractExtractor
      *
      * @throws InvalidArgumentException
      *
-     * @return bool|string|null
+     * @return bool|int|string|null
      */
     private function phpize(array $array, string $key, string $type)
     {
@@ -135,6 +139,11 @@ final class YamlExtractor extends AbstractExtractor
         switch ($type) {
             case 'bool':
                 if (\is_bool($array[$key])) {
+                    return $array[$key];
+                }
+                break;
+            case 'integer':
+                if (\is_int($array[$key])) {
                     return $array[$key];
                 }
                 break;

--- a/src/Metadata/schema/metadata.xsd
+++ b/src/Metadata/schema/metadata.xsd
@@ -89,6 +89,14 @@
             <xsd:element name="attribute" type="attribute" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
         <xsd:attribute type="xsd:string" name="name"/>
+        <xsd:attribute name="type">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="string" />
+                    <xsd:enumeration value="constant" />
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
     </xsd:complexType>
 
     <xsd:complexType name="subresource" mixed="true">

--- a/tests/Fixtures/FileConfigurations/resources_with_parameters.xml
+++ b/tests/Fixtures/FileConfigurations/resources_with_parameters.xml
@@ -79,6 +79,7 @@
                 <attribute name="baz">Baz</attribute>
             </attribute>
             <attribute name="baz">Baz</attribute>
+            <attribute name="const" type="constant">ApiPlatform\Core\Api\UrlGeneratorInterface::ABS_URL</attribute>
         </property>
 
         <property name="name" description="The dummy name"/>

--- a/tests/Fixtures/FileConfigurations/resources_with_parameters.yml
+++ b/tests/Fixtures/FileConfigurations/resources_with_parameters.yml
@@ -49,5 +49,6 @@ resources:
                         '0': ['Bar']
                         'baz': 'Baz'
                     'baz': 'Baz'
+                    const: !php/const ApiPlatform\Core\Api\UrlGeneratorInterface::ABS_URL
             'name':
                 description: 'The dummy name'

--- a/tests/Metadata/Extractor/XmlExtractorTest.php
+++ b/tests/Metadata/Extractor/XmlExtractorTest.php
@@ -19,7 +19,7 @@ use ApiPlatform\Core\Metadata\Extractor\XmlExtractor;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo Fidry <theo.fidry@gmail.com>
  */
-class XmlExtractorTestCase extends ExtractorTestCase
+class XmlExtractorTest extends ExtractorTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/Metadata/Extractor/YamlExtractorTest.php
+++ b/tests/Metadata/Extractor/YamlExtractorTest.php
@@ -21,7 +21,7 @@ use Generator;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo Fidry <theo.fidry@gmail.com>
  */
-class YamlExtractorTestCase extends ExtractorTestCase
+class YamlExtractorTest extends ExtractorTestCase
 {
     public function testInvalidProperty()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Allow to use constants in XML configuration, like this:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<!-- api/config/api_platform/resources.xml -->

<resources
        xmlns="https://api-platform.com/schema/metadata"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://api-platform.com/schema/metadata
        https://api-platform.com/schema/metadata/metadata-2.0.xsd">
    <resource class="App\Entity\Book">
        <attribute name="url_generation_strategy" type="constant">ApiPlatform\Core\Api\UrlGeneratorInterface::ABS_URL</attribute>
    </resource>
</resources>
```

Enable again the tests for the XML / YAML configuration, disabled since a long time.