### PR TITLE
fix: resolve proxy class in class metadata factory

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -121,6 +121,10 @@
             <tag name="serializer.normalizer" priority="-895" />
         </service>
 
+        <service id="api_platform.serializer.mapping.class_metadata_factory" class="ApiPlatform\Core\Serializer\Mapping\Factory\ClassMetadataFactory" decorates="serializer.mapping.class_metadata_factory" decoration-priority="-1" public="false">
+            <argument type="service" id="api_platform.serializer.mapping.class_metadata_factory.inner" />
+        </service>
+
         <!-- Resources Operations path resolver -->
 
         <service id="api_platform.operation_path_resolver" alias="api_platform.operation_path_resolver.router" public="false" />

--- a/src/Serializer/Mapping/Factory/ClassMetadataFactory.php
+++ b/src/Serializer/Mapping/Factory/ClassMetadataFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Serializer\Mapping\Factory;
+
+use ApiPlatform\Core\Util\ClassInfoTrait;
+use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+
+final class ClassMetadataFactory implements ClassMetadataFactoryInterface
+{
+    use ClassInfoTrait;
+
+    private $decorated;
+
+    public function __construct(ClassMetadataFactoryInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataFor($value): ClassMetadataInterface
+    {
+        return $this->decorated->getMetadataFor(\is_object($value) ? $this->getObjectClass($value) : $this->getRealClassName($value));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMetadataFor($value): bool
+    {
+        return $this->decorated->hasMetadataFor(\is_object($value) ? $this->getObjectClass($value) : $this->getRealClassName($value));
+    }
+}

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -1019,6 +1019,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.serializer.normalizer.item',
             'api_platform.serializer.property_filter',
             'api_platform.serializer.uuid_denormalizer',
+            'api_platform.serializer.mapping.class_metadata_factory',
             'api_platform.serializer_locator',
             'api_platform.subresource_data_provider',
             'api_platform.subresource_operation_factory',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Fix MongoDB tests by resolving the proxy class in the `ClassMetadataFactory`.
Since https://github.com/doctrine/annotations/pull/412, the annotation reader needs the real class to calculate the last modification time.
When normalizing a lazy-loaded relation, metadata are loaded using the proxy object.
In order to solve the issue, the `ClassMetadataFactory` is decorated and our `ClassInfoTrait` is used to determine the real class.