### PR TITLE
chore: bump Symfony next to 5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,7 +651,9 @@ jobs:
           - '5.4'
       fail-fast: false
     env:
-      SYMFONY_DEPRECATIONS_HELPER: max[direct]=0
+      # See https://github.com/doctrine/DoctrineMongoDBBundle/pull/673
+      #SYMFONY_DEPRECATIONS_HELPER: max[direct]=0
+      SYMFONY_DEPRECATIONS_HELPER: max[self]=0
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,7 +648,7 @@ jobs:
         php:
           - '8.0'
         symfony:
-          - '5.3'
+          - '5.4'
       fail-fast: false
     env:
       SYMFONY_DEPRECATIONS_HELPER: max[direct]=0
@@ -710,7 +710,7 @@ jobs:
         php:
           - '8.0'
         symfony:
-          - '5.3'
+          - '5.4'
       fail-fast: false
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "authors": [
         {
             "name": "Kévin Dunglas",
-            "email": "dunglas@gmail.com",
+            "email": "kevin@dunglas.fr",
             "homepage": "https://dunglas.fr"
         }
     ],
@@ -30,6 +30,7 @@
         "behat/behat": "^3.1",
         "behat/mink": "^1.7",
         "doctrine/annotations": "^1.7",
+        "doctrine/cache": "^1.11",
         "doctrine/common": "^2.11 || ^3.0",
         "doctrine/data-fixtures": "^1.2.2",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",

--- a/src/Test/DoctrineMongoDbOdmSetup.php
+++ b/src/Test/DoctrineMongoDbOdmSetup.php
@@ -18,6 +18,7 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Convenience class for setting up Doctrine from different installations and configurations.
@@ -63,7 +64,7 @@ class DoctrineMongoDbOdmSetup
 
         $config = new Configuration();
         if (method_exists($config, 'setMetadataCache')) {
-            $config->setMetadataCache($cache);
+            $config->setMetadataCache(new ArrayAdapter());
         } else {
             $config->setMetadataCacheImpl($cache);
         }

--- a/src/Test/DoctrineMongoDbOdmTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmTestCase.php
@@ -19,7 +19,7 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use PHPUnit\Framework\TestCase;
-use function sys_get_temp_dir;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Source: https://github.com/doctrine/DoctrineMongoDBBundle/blob/0174003844bc566bb4cb3b7d10c5528d1924d719/Tests/TestCase.php
@@ -40,7 +40,7 @@ class DoctrineMongoDbOdmTestCase extends TestCase
         $config->setHydratorNamespace('SymfonyTests\Doctrine');
         $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), $paths));
         if (method_exists($config, 'setMetadataCache')) {
-            $config->setMetadataCache(new ArrayCache());
+            $config->setMetadataCache(new ArrayAdapter());
         } else {
             $config->setMetadataCacheImpl(new ArrayCache());
         }

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
@@ -725,7 +725,7 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
         });
 
         $iriConverter = $iriConverterProphecy->reveal();
-        $propertyAccessor = self::$kernel->getContainer()->get('test.property_accessor');
+        $propertyAccessor = static::$kernel->getContainer()->get('test.property_accessor');
 
         $identifierExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
         $identifierExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -343,7 +343,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         $requestStack->push(Request::create('/api/dummies', 'GET', []));
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverter = $iriConverterProphecy->reveal();
-        $propertyAccessor = self::$kernel->getContainer()->get('test.property_accessor');
+        $propertyAccessor = static::$kernel->getContainer()->get('test.property_accessor');
 
         return new SearchFilter($this->managerRegistry, $requestStack, $iriConverter, $propertyAccessor, null, null, null);
     }
@@ -593,7 +593,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         });
 
         $iriConverter = $iriConverterProphecy->reveal();
-        $propertyAccessor = self::$kernel->getContainer()->get('test.property_accessor');
+        $propertyAccessor = static::$kernel->getContainer()->get('test.property_accessor');
 
         $identifierExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
         $identifierExtractorProphecy->getIdentifiersFromResourceClass(Argument::type('string'))->willReturn(['id']);

--- a/tests/Bridge/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -143,7 +143,7 @@ JSON;
         $this->recreateSchema();
 
         /** @var EntityManagerInterface $manager */
-        $manager = self::$container->get('doctrine')->getManager();
+        $manager = (method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container)->get('doctrine')->getManager();
         $dummyDtoInputOutput = new DummyDtoInputOutput();
         $dummyDtoInputOutput->str = 'lorem';
         $dummyDtoInputOutput->num = 54;
@@ -187,7 +187,8 @@ JSON;
         ]);
         $this->assertResponseIsSuccessful();
 
-        $resource = 'mongodb' === self::$container->getParameter('kernel.environment') ? DummyDocument::class : Dummy::class;
+        $container = method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container;
+        $resource = 'mongodb' === $container->getParameter('kernel.environment') ? DummyDocument::class : Dummy::class;
         $this->assertMatchesRegularExpression('~^/dummies/\d+~', self::findIriBy($resource, ['name' => 'Kevin']));
         $this->assertNull(self::findIriBy($resource, ['name' => 'not-exist']));
     }
@@ -197,7 +198,7 @@ JSON;
         self::bootKernel();
 
         /** @var EntityManagerInterface $manager */
-        $manager = self::$container->get('doctrine')->getManager();
+        $manager = (method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container)->get('doctrine')->getManager();
         /** @var \Doctrine\ORM\Mapping\ClassMetadata[] $classes */
         $classes = $manager->getMetadataFactory()->getAllMetadata();
         $schemaTool = new SchemaTool($manager);

--- a/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
@@ -28,7 +28,7 @@ class ClientTest extends ApiTestCase
         /**
          * @var EntityManagerInterface
          */
-        $manager = self::$container->get('doctrine')->getManager();
+        $manager = (method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container)->get('doctrine')->getManager();
         /** @var \Doctrine\ORM\Mapping\ClassMetadata[] $classes */
         $classes = $manager->getMetadataFactory()->getAllMetadata();
         $schemaTool = new SchemaTool($manager);
@@ -41,8 +41,7 @@ class ClientTest extends ApiTestCase
     {
         $client = self::createClient();
         $client->getKernelBrowser();
-        $this->assertSame(self::$kernel->getContainer(), $client->getContainer());
-        $this->assertSame(self::$kernel, $client->getKernel());
+        $this->assertSame(static::$kernel, $client->getKernel());
 
         $client->enableProfiler();
         $response = $client->request('GET', '/');

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -31,7 +31,7 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
     protected function setUp(): void
     {
         self::bootKernel();
-        $this->extractor = new AnnotationFilterExtractor(self::$kernel->getContainer()->get('test.annotation_reader'));
+        $this->extractor = new AnnotationFilterExtractor(static::$kernel->getContainer()->get('test.annotation_reader'));
     }
 
     public function testReadAnnotations()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Also adds `doctrine/cache` as a dev dependency because of https://github.com/doctrine/DoctrineMongoDBBundle/issues/677.