### PR TITLE
Add a flag to allow an opt-out from AddTagsListener

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -585,6 +585,8 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $loader->load('doctrine_orm_http_cache_purger.xml');
         }
 
+        $loader->load('http_cache_tags.xml');
+
         if ($config['http_cache']['cloudflare'] === true) {
             $iriConverter = new Reference('api_platform.iri_converter');
             $container->register(
@@ -596,8 +598,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
                     ["event" => "kernel.response", "method" => "onKernelResponse", "priority" => 2]
                 );
         }
-
-        $loader->load('http_cache_tags.xml');
 
         $definitions = [];
         foreach ($config['http_cache']['invalidation']['varnish_urls'] as $key => $url) {

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -388,6 +388,7 @@ final class Configuration implements ConfigurationInterface
                             ->info('Default values of the "Vary" HTTP header.')
                         ->end()
                         ->booleanNode('public')->defaultNull()->info('To make all responses public by default.')->end()
+                        ->booleanNode('cloudflare')->defaultTrue()->info('Include Cache-Tags in request headers for CloudFlare')->end()
                         ->arrayNode('invalidation')
                             ->info('Enable the tags-based cache invalidation system.')
                             ->canBeEnabled()

--- a/src/Bridge/Symfony/Bundle/Resources/config/http_cache_tags.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/http_cache_tags.xml
@@ -8,10 +8,5 @@
         <service id="api_platform.http_cache.purger.varnish_client" class="GuzzleHttp\Client" abstract="true" public="false" />
         <service id="api_platform.http_cache.purger.varnish" class="ApiPlatform\Core\HttpCache\VarnishPurger" public="false" />
 
-        <service id="api_platform.http_cache.listener.response.add_tags" class="ApiPlatform\Core\HttpCache\EventListener\AddTagsListener">
-            <argument type="service" id="api_platform.iri_converter" />
-
-            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-2" />
-        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features
| Tickets       | https://github.com/api-platform/core/issues/3168
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

I noticed that at each request this `ApiPlatform\Core\HttpCache\EventListener\AddTagsListener` adds `Cache-Tags` just before returning the response. For large interconnected entities this can have unexpected consequences and it should really be an opt-in listener in my mind. In my case for example I have https://linkerd.io/ limiting infra service communication headers to 12k. On each get because of this listener I have bigger than 12k headers for specific "big" linked resources ... this happens on GET(s) too! For backward compatibility though I added a flag so that by default is turned on but can be turned off easily under `http_cache` config.