### PR TITLE
Fix : the path of the nested property

### DIFF
--- a/src/Bridge/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Bridge/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -76,7 +76,7 @@ trait FieldDatatypeTrait
         ) {
             $nestedPath = $this->getNestedFieldPath($nextResourceClass, implode('.', $properties));
 
-            return null === $nestedPath ? $nestedPath : "$currentProperty.$nestedPath";
+            return null === $nestedPath ? $currentProperty : "$currentProperty.$nestedPath";
         }
 
         if (


### PR DESCRIPTION
Allows you to filter on nested properties going up the path

| Q             | A
| ------------- | ---
| Branch?       | main for features
| Tickets       | 
| License       | MIT
| Doc PR        | 

I noticed that filtering on a nested property didn't work: the path of the nested property was null, so we were looking for that nested property in the parent object.

Example : 

{ "vehicle": { "brand": "xxx", "model": "yyy"}}

filter like "vehicle.brand" don't work because path is null instead of "vehicle"
