### PR TITLE
fix(openapi): Collection fields VS property metadata

### DIFF
--- a/src/Core/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
+++ b/src/Core/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
@@ -57,7 +57,7 @@ final class PropertySchemaCollectionRestriction implements PropertySchemaRestric
                 $required[] = $field;
             }
 
-            $restriction['properties'][$field] = $this->mergeConstraintRestrictions($baseConstraint, $propertyMetadata);
+            $restriction['properties'][$field] = $this->mergeConstraintRestrictions($baseConstraint, new ApiProperty());
         }
 
         if ($required) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | related to https://github.com/api-platform/core/pull/4182#discussion_r612125005
| License       | MIT
| Doc PR        | 

The initial implementation was wrong to pass the *collection* `$propertyMetadata` for each *nested field*, so I fixed it to use a new PropertyMetadata (empty, for lack of anything better)