### PR TITLE
feat: OpenApi: Remove a path from Paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Exception: Add the ability to customize multiple status codes based on the validation exception (#4017)
 * GraphQL: Fix graphql fetching with Elasticsearch (#4217)
 * ApiLoader: Support `_format` resolving (#4292)
+* OpenAPI: Allow removing paths
 
 ## 2.6.5
 

--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -22,6 +22,11 @@ final class Paths
         $this->paths[$path] = $pathItem;
     }
 
+    public function removePath(string $path): void
+    {
+        unset($this->paths[$path]);
+    }
+
     public function getPath(string $path): ?PathItem
     {
         return $this->paths[$path] ?? null;

--- a/tests/OpenApi/Factory/OpenApiFactoryTest.php
+++ b/tests/OpenApi/Factory/OpenApiFactoryTest.php
@@ -675,6 +675,10 @@ class OpenApiFactoryTest extends TestCase
 
         $this->assertEquals($openApi->getInfo()->getExtensionProperties(), ['x-info-key' => 'Info value']);
         $this->assertEquals($openApi->getExtensionProperties(), ['x-key' => 'Custom x-key value', 'x-value' => 'Custom x-value value']);
+
+        $this->assertNotNull($openApi->getPaths()->getPath('/dummies/{id}'));
+        $openApi->getPaths()->removePath('/dummies/{id}');
+        $this->assertNull($openApi->getPaths()->getPath('/dummies/{id}'));
     }
 
     public function testSubresourceDocumentation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#... 

There is currently no way to remove a path from the generated OpenAPI docs. This PR adds a method to more easily remove a path, for example in a decorator:

Before:
```
    public function __invoke(array $context = []): OpenApi
    {
        $openApi = $this->decorated->__invoke($context);

        $paths = $openApi->getPaths()->getPaths();

        unset(
            $paths['/users'],
            $paths['/users/{id}'],
        );

        $newPaths = new Paths();

        foreach ($paths as $path => $pathItem) {
            $newPaths->addPath($path, $pathItem);
        }

        return $openApi->withPaths($newPaths);
    }
```

After:
```
    public function __invoke(array $context = []): OpenApi
    {
        $openApi = $this->decorated->__invoke($context);

        $openApi->getPaths()->removePath('/users');
        $openApi->getPaths()->removePath('/users/{id}');

        return $openApi;
    }
```