### PR TITLE
feat: OpenAPI: Allow null as parameter for Operation->withRequestBody

### DIFF
--- a/src/OpenApi/Model/Operation.php
+++ b/src/OpenApi/Model/Operation.php
@@ -170,7 +170,7 @@ final class Operation
         return $clone;
     }
 
-    public function withRequestBody(RequestBody $requestBody): self
+    public function withRequestBody(?RequestBody $requestBody): self
     {
         $clone = clone $this;
         $clone->requestBody = $requestBody;

--- a/src/OpenApi/Model/Operation.php
+++ b/src/OpenApi/Model/Operation.php
@@ -170,7 +170,7 @@ final class Operation
         return $clone;
     }
 
-    public function withRequestBody(?RequestBody $requestBody): self
+    public function withRequestBody(?RequestBody $requestBody = null): self
     {
         $clone = clone $this;
         $clone->requestBody = $requestBody;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#...

This RP allows overriding request body of the documentation of an operation with null (to remove the request body), for example in a decorator:

Before:
```
    public function __invoke(array $context = []): OpenApi
    {
        $openApi = $this->decorated->__invoke($context);

        $path = '/users/register';

        $pathItem = $openApi->getPaths()->getPath($path);

        if (!$pathItem) {
            return $openApi;
        }

        $operation = $pathItem->getPost();

        if (!$operation) {
            return $openApi;
        }

        $newOperation = new Operation(
            $operation->getOperationId(),
            $operation->getTags(),
            $operation->getResponses(),
            $operation->getSummary(),
            $operation->getDescription(),
            $operation->getExternalDocs(),
            $operation->getParameters(),
            null,
            $operation->getCallbacks(),
            $operation->getDeprecated(),
            $operation->getSecurity(),
            $operation->getServers()
        );

        $openApi->getPaths()->addPath($path, $pathItem->withPost($newOperation));

        return $openApi;
    }
```

After:
```
    public function __invoke(array $context = []): OpenApi
    {
        $openApi = $this->decorated->__invoke($context);

        $path = '/users/register';

        $pathItem = $openApi->getPaths()->getPath($path);

        if (!$pathItem) {
            return $openApi;
        }

        $operation = $pathItem->getPost();

        if (!$operation) {
            return $openApi;
        }

        $openApi->getPaths()->addPath($path, $pathItem->withPost($operation->withRequestBody(null)));

        return $openApi;
    }
```