### PR TITLE
Fix: Problem to use partial searchFilter with an integer as input.

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -219,7 +219,9 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         }
 
         $queryBuilder->andWhere($queryBuilder->expr()->orX(...$ors));
-        array_walk($parameters, [$queryBuilder, 'setParameter']);
+        foreach ($parameters as $value => $name) {
+            $queryBuilder->setParameter($name, (string) $value);
+        }
     }
 
     /**


### PR DESCRIPTION
SQL Server does not automatically cast an integer to a string in
the concatenation with + method (...WHERE field1 LIKE :param1 + :param2)

So there is an SQL Server error when we try to enter "1" in a partial filter : 
An exception occurred while executing 'SELECT […] WHERE b0_.label LIKE ('%' + ? + '%') ORDER BY […]' with params [1]:\n\nSQLSTATE [22018, 245]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Conversion failed when converting the varchar value '%' to data type int.


The CONCAT function is not available before the 2012 version.


I so simply force the casting when the searchFilter is not of type exact.

| Q             | A
| ------------- | ---
| Branch?       | current
| Tickets       | not declared
| License       | MIT


About tests, I did not find your test suite. So don’t hesitate to give me the right procedure.

EDIT : After Alan Poulain message, I run tests without any problem.