### PR TITLE
Add preserve_empty_objects support

### DIFF
--- a/src/Core/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Core/Hydra/Serializer/CollectionNormalizer.php
@@ -23,6 +23,7 @@ use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
 use ApiPlatform\Core\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait;
 use ApiPlatform\Core\Serializer\ContextTrait;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -78,6 +79,9 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
     public function normalize($object, $format = null, array $context = [])
     {
         if (!isset($context['resource_class']) || isset($context['api_sub_level'])) {
+            if (($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && $object instanceof \Countable && 0 === $object->count()) {
+                return $object;
+            }
             return $this->normalizeRawCollection($object, $format, $context);
         }
 

--- a/src/Core/Serializer/AbstractCollectionNormalizer.php
+++ b/src/Core/Serializer/AbstractCollectionNormalizer.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\DataProvider\PaginatorInterface;
 use ApiPlatform\Core\DataProvider\PartialPaginatorInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -79,6 +80,9 @@ abstract class AbstractCollectionNormalizer implements NormalizerInterface, Norm
     public function normalize($object, $format = null, array $context = [])
     {
         if (!isset($context['resource_class']) || isset($context['api_sub_level'])) {
+            if (($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && $object instanceof \Countable && 0 === $object->count()) {
+                return $object;
+            }
             return $this->normalizeRawCollection($object, $format, $context);
         }
 

--- a/tests/Core/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Core/Hydra/Serializer/CollectionNormalizerTest.php
@@ -27,6 +27,7 @@ use ApiPlatform\Tests\Fixtures\Foo;
 use ApiPlatform\Tests\Fixtures\NotAResource;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -254,6 +255,27 @@ class CollectionNormalizerTest extends TestCase
             $normalizedNotAResourceA,
             $normalizedNotAResourceB,
         ], $actual);
+    }
+
+    public function testPreserveEmptyObject()
+    {
+        $data = new \ArrayObject();
+
+        $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+
+        $normalizer = new CollectionNormalizer($contextBuilderProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $iriConverterProphecy->reveal());
+
+        $actual = $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
+            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true
+        ]);
+
+        $this->assertSame($data, $actual);
+
+        $actual = $normalizer->normalize($data, CollectionNormalizer::FORMAT, []);
+
+        $this->assertSame([], $actual);
     }
 
     public function testNormalizePaginator()

--- a/tests/Core/JsonApi/Serializer/CollectionNormalizerTest.php
+++ b/tests/Core/JsonApi/Serializer/CollectionNormalizerTest.php
@@ -22,6 +22,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -337,5 +338,25 @@ class CollectionNormalizerTest extends TestCase
             'uri' => 'http://example.com/foos',
             'resource_class' => 'Foo',
         ]);
+    }
+
+    public function testPreserveEmptyObject()
+    {
+        $data = new \ArrayObject();
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+
+        $normalizer = new CollectionNormalizer($resourceClassResolverProphecy->reveal(), 'page', $resourceMetadataFactoryProphecy->reveal());
+
+        $actual = $normalizer->normalize($data, CollectionNormalizer::FORMAT, [
+            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true
+        ]);
+
+        $this->assertSame($data, $actual);
+
+        $actual = $normalizer->normalize($data, CollectionNormalizer::FORMAT, []);
+
+        $this->assertSame([], $actual);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | #38192 ?
| License       | MIT
| Doc PR        | 

CollectionNormalizer currently replacing ArrayObject with an empty array

More about main idea discussed here https://github.com/symfony/symfony/pull/28363

Feel free to help me with test case and test location. Thank you :smile: 