### PR TITLE
Type factory with nested objects for json schema

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -94,7 +94,8 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
                 if (\array_key_exists($pos, $args)) {
                     @trigger_error(sprintf('Passing "$%s" arguments is deprecated since API Platform 2.4 and will not be possible anymore in API Platform 3. Pass an instance of "%s" as third argument instead.', implode('", "$', array_column($legacyPaginationArgs, 'arg_name')), Paginator::class), \E_USER_DEPRECATED);
 
-                    if (!((null === $arg['default'] && null === $args[$pos]) || \call_user_func("is_{$arg['type']}", $args[$pos]))) {
+                    $callable = "is_{$arg['type']}";
+                    if (!((null === $arg['default'] && null === $args[$pos]) || (\is_callable($callable) && \call_user_func($callable, $args[$pos])))) {
                         throw new InvalidArgumentException(sprintf('The "$%s" argument is expected to be a %s%s.', $arg['arg_name'], $arg['type'], null === $arg['default'] ? ' or null' : ''));
                     }
 

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -171,7 +171,6 @@ final class TypeFactory implements TypeFactoryInterface
                     ],
                 ];
             }
-            
             return [
                 'nullable' => true,
                 'anyOf' => [$jsonSchema],

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -171,6 +171,7 @@ final class TypeFactory implements TypeFactoryInterface
                     ],
                 ];
             }
+
             return [
                 'nullable' => true,
                 'anyOf' => [$jsonSchema],

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -163,6 +163,15 @@ final class TypeFactory implements TypeFactoryInterface
         }
 
         if (\array_key_exists('$ref', $jsonSchema)) {
+            if ($schema && Schema::VERSION_JSON_SCHEMA === $schema->getVersion()) {
+                return [
+                    'anyOf' => [
+                        $jsonSchema,
+                        ['type' => 'null'],
+                    ],
+                ];
+            }
+            
             return [
                 'nullable' => true,
                 'anyOf' => [$jsonSchema],

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -413,10 +413,12 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     protected function validateType(string $attribute, Type $type, $value, string $format = null)
     {
         $builtinType = $type->getBuiltinType();
+        $callback = 'is_'.$builtinType;
+        $isValid = false;
         if (Type::BUILTIN_TYPE_FLOAT === $builtinType && null !== $format && false !== strpos($format, 'json')) {
             $isValid = \is_float($value) || \is_int($value);
-        } else {
-            $isValid = \call_user_func('is_'.$builtinType, $value);
+        } elseif (\is_callable($callback)) {
+            $isValid = \call_user_func($callback, $value);
         }
 
         if (!$isValid) {
@@ -440,7 +442,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         $values = [];
         foreach ($value as $index => $obj) {
-            if (null !== $collectionKeyBuiltinType && !\call_user_func('is_'.$collectionKeyBuiltinType, $index)) {
+            $callable = 'is_'.$collectionKeyBuiltinType;
+            if (null !== $collectionKeyBuiltinType && \is_callable($callable) && !\call_user_func($callable, $index)) {
                 throw new InvalidArgumentException(sprintf('The type of the key "%s" must be "%s", "%s" given.', $index, $collectionKeyBuiltinType, \gettype($index)));
             }
 

--- a/tests/Api/FilterCollectionFactoryTest.php
+++ b/tests/Api/FilterCollectionFactoryTest.php
@@ -42,8 +42,8 @@ class FilterCollectionFactoryTest extends TestCase
 
         $filterCollection = (new FilterCollectionFactory(['foo', 'bar']))->createFilterCollectionFromLocator($filterLocatorProphecy->reveal());
 
-        $this->assertArrayNotHasKey('bar', $filterCollection);
-        $this->assertArrayHasKey('foo', $filterCollection);
+        $this->assertArrayNotHasKey('bar', $filterCollection->getArrayCopy());
+        $this->assertArrayHasKey('foo', $filterCollection->getArrayCopy());
         $this->assertInstanceOf(FilterInterface::class, $filterCollection['foo']);
         $this->assertEquals(new FilterCollection(['foo' => $filter]), $filterCollection);
     }

--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -71,7 +71,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(NotAResource::class))->getShortName(), $rootDefinitionKey);
-        $this->assertArrayHasKey($rootDefinitionKey, $definitions);
+        $this->assertArrayHasKey($rootDefinitionKey, $definitions->getArrayCopy());
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
         $this->assertArrayNotHasKey('additionalProperties', $definitions[$rootDefinitionKey]);
@@ -144,7 +144,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(OverriddenOperationDummy::class))->getShortName().'-'.$serializerGroup, $rootDefinitionKey);
-        $this->assertArrayHasKey($rootDefinitionKey, $definitions);
+        $this->assertArrayHasKey($rootDefinitionKey, $definitions->getArrayCopy());
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
         $this->assertFalse($definitions[$rootDefinitionKey]['additionalProperties']);

--- a/tests/JsonSchema/SchemaTest.php
+++ b/tests/JsonSchema/SchemaTest.php
@@ -73,11 +73,11 @@ class SchemaTest extends TestCase
         if (Schema::VERSION_OPENAPI === $version) {
             $this->assertArrayHasKey('schemas', $schema['components']);
         } else {
-            $this->assertArrayHasKey('definitions', $schema);
+            $this->assertArrayHasKey('definitions', $schema->getArrayCopy());
         }
 
         $definitions = $schema->getDefinitions();
-        $this->assertArrayHasKey('foo', $definitions);
+        $this->assertArrayHasKey('foo', $definitions->getArrayCopy());
 
         $this->assertArrayNotHasKey('definitions', $schema->getArrayCopy(false));
         $this->assertArrayNotHasKey('components', $schema->getArrayCopy(false));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6.5
| License       | MIT

When I did run tests, and I used the `assertMatchesResourceCollectionJsonSchema`, it failed on resources with nested objects where these objects are allowed to be null.

This is generated well for an open api schema, but not for json schema:

See: https://github.com/api-platform/core/blob/main/src/JsonSchema/TypeFactory.php#L165-L181

This should be fixed by this MR.
