### PR TITLE
Fix: Type factory with nested objects for json schema (anyOf)

### DIFF
--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -169,6 +169,15 @@ final class TypeFactory implements TypeFactoryInterface
         }
 
         if (\array_key_exists('$ref', $jsonSchema)) {
+            if ($schema && Schema::VERSION_JSON_SCHEMA === $schema->getVersion()) {
+                return [
+                    'anyOf' => [
+                        $jsonSchema,
+                        ['type' => 'null'],
+                    ],
+                ];
+            }
+
             return [
                 'nullable' => true,
                 'anyOf' => [$jsonSchema],

--- a/tests/JsonSchema/TypeFactoryTest.php
+++ b/tests/JsonSchema/TypeFactoryTest.php
@@ -387,7 +387,33 @@ class TypeFactoryTest extends TestCase
         $this->assertSame(['$ref' => 'ref'], $typeFactory->getType(new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class), 'jsonld', true, ['foo' => 'bar'], new Schema()));
     }
 
-    public function testGetClassTypeWithNullability(): void
+    public function testGetClassTypeWithNullabilityForJsonSchema(): void
+    {
+        $schemaFactory = $this->createMock(SchemaFactoryInterface::class);
+
+        $schemaFactory
+            ->method('buildSchema')
+            ->willReturnCallback(static function (): Schema {
+                $schema = new Schema();
+
+                $schema['$ref'] = 'the-ref-name';
+                $schema['description'] = 'more stuff here';
+
+                return $schema;
+            });
+
+        $typeFactory = new TypeFactory();
+        $typeFactory->setSchemaFactory($schemaFactory);
+
+        self::assertSame([
+            'anyOf' => [
+                ['$ref' => 'the-ref-name'],
+                ['type' => 'null'],
+            ],
+        ], $typeFactory->getType(new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class), 'jsonld', true, ['foo' => 'bar'], new Schema()));
+    }
+
+    public function testGetClassTypeWithNullabilityForOpenApi(): void
     {
         $schemaFactory = $this->createMock(SchemaFactoryInterface::class);
 
@@ -410,6 +436,6 @@ class TypeFactoryTest extends TestCase
             'anyOf' => [
                 ['$ref' => 'the-ref-name'],
             ],
-        ], $typeFactory->getType(new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class), 'jsonld', true, ['foo' => 'bar'], new Schema()));
+        ], $typeFactory->getType(new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class), 'jsonld', true, ['foo' => 'bar'], new Schema(Schema::VERSION_OPENAPI)));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6.5
| License       | MIT

When I did run tests, and I used the `assertMatchesResourceCollectionJsonSchema`, it failed on resources with nested objects where these objects are allowed to be null.

This is generated well for an open api schema, but not for json schema:

See: https://github.com/api-platform/core/blob/main/src/JsonSchema/TypeFactory.php#L165-L181

This should be fixed by this MR.
