### PR TITLE
fix(doctrine): handle inverse side of OneToOne association in Doctrine search filter

### DIFF
--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -143,7 +143,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
 
         $associationAlias = $alias;
         $associationField = $field;
-        if ($metadata->isCollectionValuedAssociation($associationField)) {
+        if ($metadata->isCollectionValuedAssociation($associationField) || $metadata->isAssociationInverseSide($field)) {
             $associationAlias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $alias, $associationField);
             $associationField = $associationFieldIdentifier;
         }

--- a/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Bridge/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -482,6 +482,24 @@ trait SearchFilterTestTrait
                     'age' => 46,
                 ],
             ],
+            'related owned one-to-one association' => [
+                [
+                    'id' => null,
+                    'relatedOwnedDummy' => null,
+                ],
+                [
+                    'relatedOwnedDummy' => 1,
+                ],
+            ],
+            'related owning one-to-one association' => [
+                [
+                    'id' => null,
+                    'relatedOwningDummy' => null,
+                ],
+                [
+                    'relatedOwningDummy' => 1,
+                ],
+            ],
         ];
     }
 }

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/SearchFilterTest.php
@@ -705,6 +705,34 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     $filterFactory,
                     RelatedDummy::class,
                 ],
+                'related owned one-to-one association' => [
+                    [
+                        [
+                            '$match' => [
+                                'relatedOwnedDummy' => [
+                                    '$in' => [
+                                        1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    $filterFactory,
+                ],
+                'related owning one-to-one association' => [
+                    [
+                        [
+                            '$match' => [
+                                'relatedOwningDummy' => [
+                                    '$in' => [
+                                        1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    $filterFactory,
+                ],
             ]
         );
     }

--- a/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Bridge/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -573,6 +573,18 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                     RelatedDummy::class,
                 ],
+                'related owned one-to-one association' => [
+                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedOwnedDummy relatedOwnedDummy_a1 WHERE relatedOwnedDummy_a1.id = :id_p1', $this->alias, Dummy::class),
+                    ['id_p1' => 1],
+                    $filterFactory,
+                    Dummy::class,
+                ],
+                'related owning one-to-one association' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.relatedOwningDummy = :relatedOwningDummy_p1', $this->alias, Dummy::class),
+                    ['relatedOwningDummy_p1' => 1],
+                    $filterFactory,
+                    Dummy::class,
+                ],
             ]
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main because @soyuka told me so, but ideally it should be for the current stable branch
| Tickets       | Same as api-platform/core#2049, but for SearchFilter instead of ExistsFilter
| License       | MIT

The same problem explained in api-platform/core#2049 also happens for the Doctrine SearchFilter. This PR fixes the SearchFilter, similarly to how api-platform/core#2051 fixed the ExistsFilter.

The issue can be reproduced by adding an Entity `Dummy` that has an owning one-to-one relation to another Entity `RelatedOwnedDummy`, and then adding a `SearchFilter` for that relation:

```php
/**
 * @ORM\Entity
 */
#[ApiResource]
#[ApiFilter(SearchFilter::class, properties: ['relatedOwnedDummy'])]
class Dummy {

    /**
     * @ORM\OneToOne(targetEntity="RelatedOwnedDummy", mappedBy="owner", cascade={"persist"})
     */
    public ?RelatedOwnedDummy $relatedOwnedDummy = null;

}
```

Without this fix, Doctrine complains:
"A single-valued association path expression to an inverse side is not supported in DQL queries. Instead of \"o.relatedOwnedDummy\" use an explicit join."

 - [x] Always add tests and ensure they pass.
 - [x] Never break backward compatibility (see https://symfony.com/bc).
 - [x] Bug fixes must be submitted against the current stable version branch.
 - ~Features and deprecations must be submitted against main branch.~
 - ~Legacy code removals go to the main branch.~
 - [ ] Update CHANGELOG.md file.
 - [x] Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
