### PR TITLE
fix: Respect skip_null_values in the HAL normalizer

### DIFF
--- a/features/hal/collection.feature
+++ b/features/hal/collection.feature
@@ -68,7 +68,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/1"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Smart dummy.",
             "dummy": "SomeDummyTest1",
@@ -88,7 +91,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/2"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest2",
@@ -108,7 +114,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/3"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Smart dummy.",
             "dummy": "SomeDummyTest3",
@@ -175,7 +184,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/7"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Smart dummy.",
             "dummy": "SomeDummyTest7",
@@ -195,7 +207,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/8"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest8",
@@ -215,7 +230,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/9"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Smart dummy.",
             "dummy": "SomeDummyTest9",
@@ -273,7 +291,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/10"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest10",
@@ -334,7 +355,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/4"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest4",
@@ -354,7 +378,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/5"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Smart dummy.",
             "dummy": "SomeDummyTest5",
@@ -374,7 +401,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/6"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest6",
@@ -496,7 +526,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/2"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest2",
@@ -545,7 +578,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/8"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest8",
@@ -594,7 +630,10 @@ Feature: HAL Collections support
             "_links": {
               "self": {
                 "href": "/dummies/8"
-              }
+              },
+              "relatedDummy": null,
+              "relatedOwnedDummy": null,
+              "relatedOwningDummy": null
             },
             "description": "Not so smart dummy.",
             "dummy": "SomeDummyTest8",

--- a/features/hal/hal.feature
+++ b/features/hal/hal.feature
@@ -66,7 +66,9 @@ Feature: HAL support
           {
             "href": "/related_dummies/1"
           }
-        ]
+        ],
+        "relatedOwnedDummy": null,
+        "relatedOwningDummy": null
       },
       "description": null,
       "dummy": null,
@@ -109,7 +111,9 @@ Feature: HAL support
           {
             "href": "/related_dummies/1"
           }
-        ]
+        ],
+        "relatedOwnedDummy": null,
+        "relatedOwningDummy": null
       },
       "description": null,
       "dummy": null,
@@ -151,11 +155,13 @@ Feature: HAL support
         "self": {
           "href": "/relation_embedders/1"
         },
+        "anotherRelated": null,
         "related": {
           "href": "/related_dummies/1"
         }
       },
       "_embedded": {
+        "anotherRelated": null,
         "related": {
           "_links": {
             "self": {
@@ -170,7 +176,11 @@ Feature: HAL support
               "_links": {
                 "self": {
                   "href": "/third_levels/1"
-                }
+                },
+                "fourthLevel": null
+              },
+              "_embedded": {
+                "fourthLevel": null
               },
               "level": 3
             }

--- a/features/hal/non_resource.feature
+++ b/features/hal/non_resource.feature
@@ -27,7 +27,11 @@ Feature: HAL non-resource handling
           "_links": {
             "self": {
               "href": "/contain_non_resources/1-nested"
-            }
+            },
+            "nested": null
+          },
+          "_embedded": {
+            "nested": null
           },
           "id": "1-nested",
           "notAResource": {

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -190,7 +190,10 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
             $attributeValue = $this->getAttributeValue($object, $relation['name'], $format, $context);
             if (empty($attributeValue)) {
-                continue;
+                $skipNullValues = $context[self::SKIP_NULL_VALUES] ?? $this->defaultContext[self::SKIP_NULL_VALUES] ?? false;
+                if (null !== $attributeValue || $skipNullValues) {
+                    continue;
+                }
             }
 
             $relationName = $relation['name'];
@@ -199,7 +202,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             }
 
             if ('one' === $relation['cardinality']) {
-                if ('links' === $type) {
+                if ('links' === $type && null !== $attributeValue) {
                     $data[$key][$relationName]['href'] = $this->getRelationIri($attributeValue);
                     continue;
                 }

--- a/tests/Fixtures/JsonHal/jsonhal.json
+++ b/tests/Fixtures/JsonHal/jsonhal.json
@@ -16,6 +16,9 @@
       "additionalProperties": {
         "oneOf": [
           {
+            "type": "null"
+          },
+          {
             "$ref": "#/definitions/linkObject"
           },
           {
@@ -70,6 +73,9 @@
       "type": "object",
       "additionalProperties": {
         "oneOf": [
+          {
+            "type": "null"
+          },
           {
             "$ref": "#"
           },

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -60,7 +60,7 @@ class Dummy
     private $name;
 
     /**
-     * @var string The dummy name alias
+     * @var string|null The dummy name alias
      *
      * @ORM\Column(nullable=true)
      * @ApiProperty(iri="https://schema.org/alternateName")
@@ -117,7 +117,7 @@ class Dummy
     public $dummyPrice;
 
     /**
-     * @var RelatedDummy A related dummy
+     * @var RelatedDummy|null A related dummy
      *
      * @ORM\ManyToOne(targetEntity="RelatedDummy")
      * @ApiProperty(push=true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | fix --> 2.6
| Tickets       | #4372
| License       | MIT

RFC: This PR adds support for `skip_null_values: false` with relations to the HAL normalizer. This however deviates from the hyperschema, because now the entries in `_links` and `_embedded` may be null, which isn't really allowed in HAL.

Side note: I have tried to fix all tests that failed due to my changes, but PHP CS Fixer and PHPStan are complaining about some unrelated problems.
