### PR TITLE
Throw UnexpectedValueException when value is not valid

### DIFF
--- a/src/Core/Serializer/AbstractItemNormalizer.php
+++ b/src/Core/Serializer/AbstractItemNormalizer.php
@@ -489,7 +489,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         if (!$isValid) {
-            throw new InvalidArgumentException(sprintf('The type of the "%s" attribute must be "%s", "%s" given.', $attribute, $builtinType, \gettype($value)));
+            throw new UnexpectedValueException(sprintf('The type of the "%s" attribute must be "%s", "%s" given.', $attribute, $builtinType, \gettype($value)));
         }
     }
 

--- a/tests/Core/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Core/Serializer/AbstractItemNormalizerTest.php
@@ -937,7 +937,7 @@ class AbstractItemNormalizerTest extends TestCase
 
     public function testBadType()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('The type of the "foo" attribute must be "float", "integer" given.');
 
         $data = [


### PR DESCRIPTION
The current behavior is not logic

With the following JSON:
```
{
	"triggers": [
		{
			"type": "url",
			"options": {
				"url": "http://google.fr"
			}
		},
	"priority": 0,
	"description": "description"
}
```

If I put `true` in front of `triggers[0].url`, a `UnexpectedValueException` is raised. 
If I put `true` in front of `priority`, a `InvalidArgumentException` is raised. 

IMHO, the same exception should be thrown in similar situation.