### PR TITLE
Adding collectionKeyType JSON Schema

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -215,8 +215,10 @@ final class SchemaFactory implements SchemaFactoryInterface
         $valueSchema = [];
         if (null !== $type = $propertyMetadata->getType()) {
             if ($isCollection = $type->isCollection()) {
+                $keyType = method_exists(Type::class, 'getCollectionKeyTypes') ? ($type->getCollectionKeyTypes()[0] ?? null) : $type->getCollectionKeyType();
                 $valueType = method_exists(Type::class, 'getCollectionValueTypes') ? ($type->getCollectionValueTypes()[0] ?? null) : $type->getCollectionValueType();
             } else {
+                $keyType = null;
                 $valueType = $type;
             }
 
@@ -228,7 +230,7 @@ final class SchemaFactory implements SchemaFactoryInterface
                 $className = $valueType->getClassName();
             }
 
-            $valueSchema = $this->typeFactory->getType(new Type($builtinType, $type->isNullable(), $className, $isCollection), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
+            $valueSchema = $this->typeFactory->getType(new Type($builtinType, $type->isNullable(), $className, $isCollection, $keyType, $valueType), $format, $propertyMetadata->isReadableLink(), $serializerContext, $schema);
         }
 
         if (\array_key_exists('type', $propertySchema) && \array_key_exists('$ref', $valueSchema)) {

--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -156,4 +156,69 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['description']);
         $this->assertSame('string', $definitions[$rootDefinitionKey]['properties']['description']['type']);
     }
+
+    public function testBuildSchemaForAssociativeArray(): void
+    {
+        if (!method_exists(Type::class, 'getCollectionKeyTypes')) {
+            $this->markTestSkipped();
+        }
+
+        $typeFactoryProphecy = $this->prophesize(TypeFactoryInterface::class);
+        $typeFactoryProphecy->getType(Argument::allOf(
+            Argument::type(Type::class),
+            Argument::which('getBuiltinType', Type::BUILTIN_TYPE_STRING),
+            Argument::which('isCollection', true),
+            Argument::that(function (Type $type) {
+                $keyTypes = $type->getCollectionKeyTypes();
+
+                return 1 === \count($keyTypes) && $keyTypes[0] instanceof Type && Type::BUILTIN_TYPE_INT === $keyTypes[0]->getBuiltinType();
+            })
+        ), Argument::cetera())->willReturn([
+            'type' => 'array',
+        ]);
+        $typeFactoryProphecy->getType(Argument::allOf(
+            Argument::type(Type::class),
+            Argument::which('getBuiltinType', Type::BUILTIN_TYPE_STRING),
+            Argument::which('isCollection', true),
+            Argument::that(function (Type $type) {
+                $keyTypes = $type->getCollectionKeyTypes();
+
+                return 1 === \count($keyTypes) && $keyTypes[0] instanceof Type && Type::BUILTIN_TYPE_STRING === $keyTypes[0]->getBuiltinType();
+            })
+        ), Argument::cetera())->willReturn([
+            'type' => 'object',
+            'additionalProperties' => Type::BUILTIN_TYPE_STRING,
+        ]);
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create(NotAResource::class, Argument::cetera())->willReturn(new PropertyNameCollection(['foo', 'bar']));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(NotAResource::class, 'foo', Argument::cetera())->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)), null, true, null, null, null, null, null, null, null, null, null, null, '', ''));
+        $propertyMetadataFactoryProphecy->create(NotAResource::class, 'bar', Argument::cetera())->willReturn(new PropertyMetadata(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_STRING)), null, true, null, null, null, null, null, null, null, null, null, null, '', ''));
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
+
+        $schemaFactory = new SchemaFactory($typeFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
+        $resultSchema = $schemaFactory->buildSchema(NotAResource::class);
+
+        $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
+        $definitions = $resultSchema->getDefinitions();
+
+        $this->assertSame((new \ReflectionClass(NotAResource::class))->getShortName(), $rootDefinitionKey);
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]));
+        $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
+        $this->assertArrayHasKey('foo', $definitions[$rootDefinitionKey]['properties']);
+        $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['foo']);
+        $this->assertArrayNotHasKey('additionalProperties', $definitions[$rootDefinitionKey]['properties']['foo']);
+        $this->assertSame('array', $definitions[$rootDefinitionKey]['properties']['foo']['type']);
+        $this->assertArrayHasKey('bar', $definitions[$rootDefinitionKey]['properties']);
+        $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['bar']);
+        $this->assertArrayHasKey('additionalProperties', $definitions[$rootDefinitionKey]['properties']['bar']);
+        $this->assertSame('object', $definitions[$rootDefinitionKey]['properties']['bar']['type']);
+        $this->assertSame('string', $definitions[$rootDefinitionKey]['properties']['bar']['additionalProperties']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | #4384
| License       | MIT
| Doc PR        | -

This fix makes sure collection key type is saved for collection properties.
Eg. this makes sure an associative array property has type 'object' instead of 'array'.