### PR TITLE
fix(elasticsearch): type error with $propertyName

### DIFF
--- a/src/Bridge/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
+++ b/src/Bridge/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
@@ -49,11 +49,11 @@ final class InnerFieldsNameConverter implements AdvancedNameConverterInterface
         return $this->convertInnerFields($propertyName, false, $class, $format, $context);
     }
 
-    private function convertInnerFields(string $propertyName, bool $normalization, string $class = null, string $format = null, $context = []): string
+    private function convertInnerFields($propertyName, bool $normalization, string $class = null, string $format = null, $context = []): string
     {
         $convertedProperties = [];
 
-        foreach (explode('.', $propertyName) as $decomposedProperty) {
+        foreach (explode('.', (string) $propertyName) as $decomposedProperty) {
             $convertedProperties[] = $this->decorated->{$normalization ? 'normalize' : 'denormalize'}($decomposedProperty, $class, $format, $context);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | 
| License       | MIT
| Doc PR        | N/A

Hi ! I have a `date` field in ElasticSearch, and I currently get the following error:

```json
{
  "@context": "/api/contexts/Error",
  "@type": "hydra:Error",
  "hydra:title": "An error occurred",
  "hydra:description": "ApiPlatform\\Core\\Bridge\\Elasticsearch\\Serializer\\NameConverter\\InnerFieldsNameConverter::convertInnerFields(): Argument #1 ($propertyName) must be of type string, int given, called in vendor/api-platform/core/src/Bridge/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php on line 49",
  "trace": [...]
}
```

With an attribute typed as follow:

```php
class MyModel
{
    public ?DateTimeImmutable $updatedAt = null;
}
```
And the updatedAt is an ISO string.

Because there is no "propertyName" when using contructor.
