### PR TITLE
fix: usage of deprecated DBAL type constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
     },
     "conflict": {
         "doctrine/common": "<2.7",
+        "doctrine/dbal": "<2.10",
         "doctrine/mongodb-odm": "<2.2",
         "doctrine/persistence": "<1.3"
     },

--- a/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/BooleanFilter.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\BooleanFilterTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\QueryBuilder;
 
 /**
@@ -35,7 +35,7 @@ class BooleanFilter extends AbstractContextAwareFilter
     use BooleanFilterTrait;
 
     public const DOCTRINE_BOOLEAN_TYPES = [
-        DBALType::BOOLEAN => true,
+        Types::BOOLEAN => true,
     ];
 
     /**

--- a/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/DateFilter.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\DateFilterTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\QueryBuilder;
 
 /**
@@ -31,14 +32,14 @@ class DateFilter extends AbstractContextAwareFilter implements DateFilterInterfa
     use DateFilterTrait;
 
     public const DOCTRINE_DATE_TYPES = [
-        DBALType::DATE => true,
-        DBALType::DATETIME => true,
-        DBALType::DATETIMETZ => true,
-        DBALType::TIME => true,
-        DBALType::DATE_IMMUTABLE => true,
-        DBALType::DATETIME_IMMUTABLE => true,
-        DBALType::DATETIMETZ_IMMUTABLE => true,
-        DBALType::TIME_IMMUTABLE => true,
+        Types::DATE_MUTABLE => true,
+        Types::DATETIME_MUTABLE => true,
+        Types::DATETIMETZ_MUTABLE => true,
+        Types::TIME_MUTABLE => true,
+        Types::DATE_IMMUTABLE => true,
+        Types::DATETIME_IMMUTABLE => true,
+        Types::DATETIMETZ_IMMUTABLE => true,
+        Types::TIME_IMMUTABLE => true,
     ];
 
     /**

--- a/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/NumericFilter.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Orm\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\NumericFilterTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\QueryBuilder;
 
 /**
@@ -39,11 +39,11 @@ class NumericFilter extends AbstractContextAwareFilter
      * @see http://doctrine-orm.readthedocs.org/projects/doctrine-dbal/en/latest/reference/types.html
      */
     public const DOCTRINE_NUMERIC_TYPES = [
-        DBALType::BIGINT => true,
-        DBALType::DECIMAL => true,
-        DBALType::FLOAT => true,
-        DBALType::INTEGER => true,
-        DBALType::SMALLINT => true,
+        Types::BIGINT => true,
+        Types::DECIMAL => true,
+        Types::FLOAT => true,
+        Types::INTEGER => true,
+        Types::SMALLINT => true,
     ];
 
     /**
@@ -89,11 +89,11 @@ class NumericFilter extends AbstractContextAwareFilter
      */
     protected function getType(string $doctrineType = null): string
     {
-        if (null === $doctrineType || DBALType::DECIMAL === $doctrineType) {
+        if (null === $doctrineType || Types::DECIMAL === $doctrineType) {
             return 'string';
         }
 
-        if (DBALType::FLOAT === $doctrineType) {
+        if (Types::FLOAT === $doctrineType) {
             return 'float';
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -20,7 +20,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\SearchFilterTrait;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryBuilderHelper;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
-use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
@@ -38,7 +38,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
 {
     use SearchFilterTrait;
 
-    public const DOCTRINE_INTEGER_TYPE = DBALType::INTEGER;
+    public const DOCTRINE_INTEGER_TYPE = Types::INTEGER;
 
     public function __construct(ManagerRegistry $managerRegistry, ?RequestStack $requestStack, IriConverterInterface $iriConverter, PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null, array $properties = null, IdentifiersExtractorInterface $identifiersExtractor = null, NameConverterInterface $nameConverter = null)
     {
@@ -246,31 +246,25 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
     protected function getType(string $doctrineType): string
     {
         switch ($doctrineType) {
-            case DBALType::TARRAY:
+            case Types::ARRAY:
                 return 'array';
-            case DBALType::BIGINT:
-            case DBALType::INTEGER:
-            case DBALType::SMALLINT:
+            case Types::BIGINT:
+            case Types::INTEGER:
+            case Types::SMALLINT:
                 return 'int';
-            case DBALType::BOOLEAN:
+            case Types::BOOLEAN:
                 return 'bool';
-            case DBALType::DATE:
-            case DBALType::TIME:
-            case DBALType::DATETIME:
-            case DBALType::DATETIMETZ:
+            case Types::DATE_MUTABLE:
+            case Types::TIME_MUTABLE:
+            case Types::DATETIME_MUTABLE:
+            case Types::DATETIMETZ_MUTABLE:
+            case Types::DATE_IMMUTABLE:
+            case Types::TIME_IMMUTABLE:
+            case Types::DATETIME_IMMUTABLE:
+            case Types::DATETIMETZ_IMMUTABLE:
                 return \DateTimeInterface::class;
-            case DBALType::FLOAT:
+            case Types::FLOAT:
                 return 'float';
-        }
-
-        if (\defined(DBALType::class.'::DATE_IMMUTABLE')) {
-            switch ($doctrineType) {
-                case DBALType::DATE_IMMUTABLE:
-                case DBALType::TIME_IMMUTABLE:
-                case DBALType::DATETIME_IMMUTABLE:
-                case DBALType::DATETIMETZ_IMMUTABLE:
-                    return \DateTimeInterface::class;
-            }
         }
 
         return 'string';

--- a/tests/Bridge/Doctrine/Common/Util/IdentifierManagerTraitTest.php
+++ b/tests/Bridge/Doctrine/Common/Util/IdentifierManagerTraitTest.php
@@ -26,6 +26,7 @@ use ApiPlatform\Core\Tests\ProphecyTrait;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MongoDbOdmClassMetadata;
 use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
@@ -64,7 +65,7 @@ class IdentifierManagerTraitTest extends TestCase
         ]);
         $objectManager = $this->getEntityManager(Dummy::class, [
             'id' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
         ]);
 
@@ -104,10 +105,10 @@ class IdentifierManagerTraitTest extends TestCase
         ]);
         $objectManager = $this->getEntityManager(Dummy::class, [
             'ida' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
             'idb' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
         ]);
 
@@ -130,10 +131,10 @@ class IdentifierManagerTraitTest extends TestCase
         ]);
         $objectManager = $this->getEntityManager(Dummy::class, [
             'ida' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
             'idb' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
         ]);
 

--- a/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/ItemDataProviderTest.php
@@ -28,7 +28,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
@@ -65,7 +65,7 @@ class ItemDataProviderTest extends TestCase
         $queryBuilderProphecy->expr()->willReturn($exprProphecy->reveal())->shouldBeCalled();
         $queryBuilderProphecy->andWhere($comparison)->shouldBeCalled();
         $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
-        $queryBuilderProphecy->setParameter(':id_id', 1, DBALType::INTEGER)->shouldBeCalled();
+        $queryBuilderProphecy->setParameter(':id_id', 1, Types::INTEGER)->shouldBeCalled();
 
         $queryBuilder = $queryBuilderProphecy->reveal();
 
@@ -74,7 +74,7 @@ class ItemDataProviderTest extends TestCase
         ]);
         $managerRegistry = $this->getManagerRegistry(Dummy::class, [
             'id' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
         ], $queryBuilder);
 
@@ -104,8 +104,8 @@ class ItemDataProviderTest extends TestCase
         $queryBuilderProphecy->andWhere($comparison)->shouldBeCalled();
         $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
 
-        $queryBuilderProphecy->setParameter(':id_ida', 1, DBALType::INTEGER)->shouldBeCalled();
-        $queryBuilderProphecy->setParameter(':id_idb', 2, DBALType::INTEGER)->shouldBeCalled();
+        $queryBuilderProphecy->setParameter(':id_ida', 1, Types::INTEGER)->shouldBeCalled();
+        $queryBuilderProphecy->setParameter(':id_idb', 2, Types::INTEGER)->shouldBeCalled();
 
         $queryBuilder = $queryBuilderProphecy->reveal();
 
@@ -115,10 +115,10 @@ class ItemDataProviderTest extends TestCase
         ]);
         $managerRegistry = $this->getManagerRegistry(Dummy::class, [
             'ida' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
             'idb' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
         ], $queryBuilder);
 
@@ -144,10 +144,10 @@ class ItemDataProviderTest extends TestCase
         ]);
         $managerRegistry = $this->getManagerRegistry(Dummy::class, [
             'ida' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
             'idb' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
         ], $this->prophesize(QueryBuilder::class)->reveal());
 
@@ -167,7 +167,7 @@ class ItemDataProviderTest extends TestCase
         $queryBuilderProphecy->expr()->willReturn($exprProphecy->reveal())->shouldBeCalled();
         $queryBuilderProphecy->andWhere($comparison)->shouldBeCalled();
         $queryBuilderProphecy->getRootAliases()->shouldBeCalled()->willReturn(['o']);
-        $queryBuilderProphecy->setParameter(':id_id', 1, DBALType::INTEGER)->shouldBeCalled();
+        $queryBuilderProphecy->setParameter(':id_id', 1, Types::INTEGER)->shouldBeCalled();
 
         $queryBuilder = $queryBuilderProphecy->reveal();
 
@@ -176,7 +176,7 @@ class ItemDataProviderTest extends TestCase
         ]);
         $managerRegistry = $this->getManagerRegistry(Dummy::class, [
             'id' => [
-                'type' => DBALType::INTEGER,
+                'type' => Types::INTEGER,
             ],
         ], $queryBuilder);
 
@@ -216,7 +216,7 @@ class ItemDataProviderTest extends TestCase
         $classMetadataProphecy->getIdentifier()->willReturn([
             'id',
         ]);
-        $classMetadataProphecy->getTypeOfField('id')->willReturn(DBALType::INTEGER);
+        $classMetadataProphecy->getTypeOfField('id')->willReturn(Types::INTEGER);
 
         $platformProphecy = $this->prophesize(AbstractPlatform::class);
 

--- a/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
+++ b/tests/Bridge/Doctrine/Orm/SubresourceDataProviderTest.php
@@ -30,7 +30,7 @@ use ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\ThirdLevel;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
@@ -130,7 +130,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $identifiers = ['id'];
         $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->setParameter('id_p1', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p1', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
         $funcProphecy = $this->prophesize(Func::class);
         $func = $funcProphecy->reveal();
 
@@ -148,7 +148,7 @@ class SubresourceDataProviderTest extends TestCase
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $classMetadataProphecy->hasAssociation('relatedDummies')->willReturn(true)->shouldBeCalled();
         $classMetadataProphecy->getAssociationMapping('relatedDummies')->shouldBeCalled()->willReturn(['type' => ClassMetadata::MANY_TO_MANY]);
-        $classMetadataProphecy->getTypeOfField('id')->willReturn(DBALType::INTEGER)->shouldBeCalled();
+        $classMetadataProphecy->getTypeOfField('id')->willReturn(Types::INTEGER)->shouldBeCalled();
 
         $managerProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
 
@@ -207,7 +207,7 @@ class SubresourceDataProviderTest extends TestCase
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $classMetadataProphecy->hasAssociation('relatedDummies')->willReturn(true)->shouldBeCalled();
         $classMetadataProphecy->getAssociationMapping('relatedDummies')->shouldBeCalled()->willReturn(['type' => ClassMetadata::MANY_TO_MANY]);
-        $classMetadataProphecy->getTypeOfField('id')->willReturn(DBALType::INTEGER)->shouldBeCalled();
+        $classMetadataProphecy->getTypeOfField('id')->willReturn(Types::INTEGER)->shouldBeCalled();
 
         $dummyManagerProphecy = $this->prophesize(EntityManager::class);
         $dummyManagerProphecy->createQueryBuilder()->shouldBeCalled()->willReturn($qb->reveal());
@@ -234,7 +234,7 @@ class SubresourceDataProviderTest extends TestCase
         $rClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $rClassMetadataProphecy->hasAssociation('thirdLevel')->shouldBeCalled()->willReturn(true);
         $rClassMetadataProphecy->getAssociationMapping('thirdLevel')->shouldBeCalled()->willReturn(['type' => ClassMetadata::MANY_TO_ONE]);
-        $rClassMetadataProphecy->getTypeOfField('id')->willReturn(DBALType::INTEGER)->shouldBeCalled();
+        $rClassMetadataProphecy->getTypeOfField('id')->willReturn(Types::INTEGER)->shouldBeCalled();
 
         $rDummyManagerProphecy = $this->prophesize(EntityManager::class);
         $rDummyManagerProphecy->createQueryBuilder()->shouldBeCalled()->willReturn($rqb->reveal());
@@ -253,8 +253,8 @@ class SubresourceDataProviderTest extends TestCase
         $queryBuilder->andWhere($func)->shouldBeCalled()->willReturn($queryBuilder);
 
         $queryBuilder->getQuery()->shouldBeCalled()->willReturn($queryProphecy->reveal());
-        $queryBuilder->setParameter('id_p1', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->setParameter('id_p2', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p1', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p2', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
 
         $repositoryProphecy = $this->prophesize(EntityRepository::class);
         $repositoryProphecy->createQueryBuilder('o')->shouldBeCalled()->willReturn($queryBuilder->reveal());
@@ -283,7 +283,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $identifiers = ['id'];
         $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->setParameter('id_p1', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p1', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
         $funcProphecy = $this->prophesize(Func::class);
         $func = $funcProphecy->reveal();
         $queryBuilder->andWhere($func)->shouldBeCalled()->willReturn($queryBuilder);
@@ -299,7 +299,7 @@ class SubresourceDataProviderTest extends TestCase
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $classMetadataProphecy->hasAssociation('ownedDummy')->willReturn(true)->shouldBeCalled();
         $classMetadataProphecy->getAssociationMapping('ownedDummy')->shouldBeCalled()->willReturn(['type' => ClassMetadata::ONE_TO_ONE]);
-        $classMetadataProphecy->getTypeOfField('id')->willReturn(DBALType::INTEGER)->shouldBeCalled();
+        $classMetadataProphecy->getTypeOfField('id')->willReturn(Types::INTEGER)->shouldBeCalled();
 
         $managerProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
 
@@ -335,7 +335,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $identifiers = ['id'];
         $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->setParameter('id_p1', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p1', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
         $funcProphecy = $this->prophesize(Func::class);
         $func = $funcProphecy->reveal();
 
@@ -351,7 +351,7 @@ class SubresourceDataProviderTest extends TestCase
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $classMetadataProphecy->hasAssociation('relatedDummies')->willReturn(true)->shouldBeCalled();
         $classMetadataProphecy->getAssociationMapping('relatedDummies')->shouldBeCalled()->willReturn(['type' => ClassMetadata::MANY_TO_MANY]);
-        $classMetadataProphecy->getTypeOfField('id')->willReturn(DBALType::INTEGER)->shouldBeCalled();
+        $classMetadataProphecy->getTypeOfField('id')->willReturn(Types::INTEGER)->shouldBeCalled();
 
         $managerProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
         $this->assertIdentifierManagerMethodCalls($managerProphecy);
@@ -456,7 +456,7 @@ class SubresourceDataProviderTest extends TestCase
         $classMetadataProphecy->getIdentifier()->shouldBeCalled()->willReturn($identifiers);
         $classMetadataProphecy->hasAssociation('relatedDummies')->willReturn(true)->shouldBeCalled();
         $classMetadataProphecy->getAssociationMapping('relatedDummies')->shouldBeCalled()->willReturn(['type' => ClassMetadata::MANY_TO_MANY]);
-        $classMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(DBALType::INTEGER);
+        $classMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(Types::INTEGER);
 
         $dummyManagerProphecy = $this->prophesize(EntityManager::class);
         $dummyManagerProphecy->createQueryBuilder()->shouldBeCalled()->willReturn($qb->reveal());
@@ -482,7 +482,7 @@ class SubresourceDataProviderTest extends TestCase
 
         $rClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $rClassMetadataProphecy->getIdentifier()->shouldBeCalled()->willReturn($identifiers);
-        $rClassMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(DBALType::INTEGER);
+        $rClassMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(Types::INTEGER);
         $rClassMetadataProphecy->hasAssociation('thirdLevel')->shouldBeCalled()->willReturn(true);
         $rClassMetadataProphecy->getAssociationMapping('thirdLevel')->shouldBeCalled()->willReturn(['type' => ClassMetadata::MANY_TO_ONE]);
 
@@ -503,8 +503,8 @@ class SubresourceDataProviderTest extends TestCase
         $queryBuilder->andWhere($func)->shouldBeCalled()->willReturn($queryBuilder);
 
         $queryBuilder->getQuery()->shouldBeCalled()->willReturn($queryProphecy->reveal());
-        $queryBuilder->setParameter('id_p1', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->setParameter('id_p2', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p1', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p2', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
 
         $repositoryProphecy = $this->prophesize(EntityRepository::class);
         $repositoryProphecy->createQueryBuilder('o')->shouldBeCalled()->willReturn($queryBuilder->reveal());
@@ -551,7 +551,7 @@ class SubresourceDataProviderTest extends TestCase
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $classMetadataProphecy->hasAssociation('relatedDummies')->willReturn(true)->shouldBeCalled();
         $classMetadataProphecy->getAssociationMapping('relatedDummies')->shouldBeCalled()->willReturn(['type' => ClassMetadata::MANY_TO_MANY]);
-        $classMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(DBALType::INTEGER);
+        $classMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(Types::INTEGER);
 
         $dummyManagerProphecy = $this->prophesize(EntityManager::class);
         $dummyManagerProphecy->createQueryBuilder()->shouldBeCalled()->willReturn($qb->reveal());
@@ -578,7 +578,7 @@ class SubresourceDataProviderTest extends TestCase
         $rClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $rClassMetadataProphecy->hasAssociation('id')->shouldBeCalled()->willReturn(false);
         $rClassMetadataProphecy->isIdentifier('id')->shouldBeCalled()->willReturn(true);
-        $rClassMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(DBALType::INTEGER);
+        $rClassMetadataProphecy->getTypeOfField('id')->shouldBeCalled()->willReturn(Types::INTEGER);
 
         $rDummyManagerProphecy = $this->prophesize(EntityManager::class);
         $rDummyManagerProphecy->createQueryBuilder()->shouldBeCalled()->willReturn($rqb->reveal());
@@ -596,8 +596,8 @@ class SubresourceDataProviderTest extends TestCase
         $queryBuilder->andWhere($func)->shouldBeCalled()->willReturn($queryBuilder);
 
         $queryBuilder->getQuery()->shouldBeCalled()->willReturn($queryProphecy->reveal());
-        $queryBuilder->setParameter('id_p1', 2, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->setParameter('id_p2', 1, DBALType::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p1', 2, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('id_p2', 1, Types::INTEGER)->shouldBeCalled()->willReturn($queryBuilder);
 
         $repositoryProphecy = $this->prophesize(EntityRepository::class);
         $repositoryProphecy->createQueryBuilder('o')->shouldBeCalled()->willReturn($queryBuilder->reveal());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

API platform references constants from Doctrine DBAL that have been deprecated two years ago (see doctrine/dbal#3356). Those constants have been removed in DBAL 3.0. At the moment, Doctrine ORM blocks the installation of DBAL 3, but this might change soon. This PR fixes all references and should prevent API platform applications from exploding once they bump DBAL beyond 3.0.