### PR TITLE
chore: fix CS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.log
-/.php_cs
-/.php_cs.cache
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
 /.phpunit.result.cache
 /build/
 /composer.lock

--- a/src/Bridge/Symfony/Identifier/Normalizer/UuidNormalizer.php
+++ b/src/Bridge/Symfony/Identifier/Normalizer/UuidNormalizer.php
@@ -29,7 +29,7 @@ final class UuidNormalizer implements DenormalizerInterface
     {
         try {
             return Uuid::fromString($data);
-        } catch (\InvalidArgumentException | \ValueError $e) { // catching ValueError will not be necessary anymore when https://github.com/symfony/symfony/pull/39636 will be released
+        } catch (\InvalidArgumentException|\ValueError $e) { // catching ValueError will not be necessary anymore when https://github.com/symfony/symfony/pull/39636 will be released
             throw new InvalidIdentifierException($e->getMessage(), $e->getCode(), $e);
         }
     }

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -2244,7 +2244,7 @@ final class DoctrineContext implements Context
     }
 
     /**
-     * @return BookDocument | Book
+     * @return BookDocument|Book
      */
     private function buildBook()
     {
@@ -2252,7 +2252,7 @@ final class DoctrineContext implements Context
     }
 
     /**
-     * @return CustomMultipleIdentifierDummy | CustomMultipleIdentifierDummyDocument
+     * @return CustomMultipleIdentifierDummy|CustomMultipleIdentifierDummyDocument
      */
     private function buildCustomMultipleIdentifierDummy()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The GitHub Actions workflow run PHP-CS-Fixer 3.1.0 now which causes a red build on new PRs. This PR normalizes the codebase and adjusts the `.gitignore` file for the new filenames used by PHP-CS-Fixer 3.