### PR TITLE
fix: indexing relations resources IRIs in normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* Fix indexing relations resources IRIs in serializer
 * Security: **BC** Fix `ApiProperty` `security` attribute expression being passed a class string for the `object` variable on updates/creates - null is now passed instead if the object is not available (#4184)
 * Security: `ApiProperty` now supports a `security_post_denormalize` attribute, which provides access to the `object` variable for the object being updated/created and `previous_object` for the object before it was updated (#4184)
 * Maker: Add `make:data-provider` and `make :data-persister` commands to generate a data provider / persister (#3850)
@@ -231,7 +232,7 @@ For compatibility reasons with Symfony 5.2 and PHP 8, we do not test anymore the
 * Doctrine: Order filter doesn't throw anymore with numeric key (#3673 and #3687)
 * Doctrine: Fix ODM check change tracking deferred (#3629)
 * Doctrine: Allow 2inflector version 2.0 (#3607)
-* OpenAPI: Allow subresources context to be added (#3685) 
+* OpenAPI: Allow subresources context to be added (#3685)
 * OpenAPI: Fix pagination documentation on subresources (#3678)
 * Subresource: Fix query when using a custom identifier (#3529 and #3671)
 * GraphQL: Fix relation types without Doctrine (#3591)

--- a/src/Core/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/Core/JsonApi/Serializer/ItemNormalizer.php
@@ -212,10 +212,6 @@ final class ItemNormalizer extends AbstractItemNormalizer
         if (null !== $relatedObject) {
             $iri = $this->iriConverter->getIriFromItem($relatedObject);
             $context['iri'] = $iri;
-
-            if (isset($context['resources'])) {
-                $context['resources'][$iri] = $iri;
-            }
         }
 
         if (null === $relatedObject || isset($context['api_included'])) {
@@ -227,6 +223,16 @@ final class ItemNormalizer extends AbstractItemNormalizer
             // @phpstan-ignore-next-line throwing an explicit exception helps debugging
             if (!\is_string($normalizedRelatedObject) && !\is_array($normalizedRelatedObject) && !$normalizedRelatedObject instanceof \ArrayObject && null !== $normalizedRelatedObject) {
                 throw new UnexpectedValueException('Expected normalized relation to be an IRI, array, \ArrayObject or null');
+            }
+
+            if (is_object($relatedObject) === true
+                && isset($context['resources']) === true
+            ) {
+                $iri = $this->iriConverter->getIriFromItem($relatedObject);
+
+                if ($normalizedRelatedObject !== $iri) {
+                    $context['resources'][$iri] = $iri;
+                }
             }
 
             return $normalizedRelatedObject;

--- a/src/Core/Serializer/AbstractItemNormalizer.php
+++ b/src/Core/Serializer/AbstractItemNormalizer.php
@@ -771,14 +771,20 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 throw new UnexpectedValueException('Expected normalized relation to be an IRI, array, \ArrayObject or null');
             }
 
+            if (is_object($relatedObject) === true
+                && isset($context['resources']) === true
+            ) {
+                $iri = $this->iriConverter->getIriFromItem($relatedObject);
+
+                if ($normalizedRelatedObject !== $iri) {
+                    $context['resources'][$iri] = $iri;
+                }
+            }
+
             return $normalizedRelatedObject;
         }
 
         $iri = $this->iriConverter->getIriFromItem($relatedObject);
-
-        if (isset($context['resources'])) {
-            $context['resources'][$iri] = $iri;
-        }
 
         $push = $propertyMetadata instanceof PropertyMetadata ? $propertyMetadata->getAttribute('push', false) : ($propertyMetadata->getPush() ?? false);
         if (isset($context['resources_to_push']) && $push) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | https://github.com/api-platform/core/issues/3168
| License       | MIT

Hi,

Currently all the IRIs of the resource relations being normalized are indexed in the cache.

However only relationship IRIs that are normalized and nested should be indexed.

This correction allows to considerably lighten the `Cache-Tags` header in the case of a fullREST hypermedia API and thus repair the maximum header size problem, especially with Varnish

Maybe must apply this fix to current 2.6 ?