### PR TITLE
feat: add Maker command for state processor and provider

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,6 +16,7 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude([
         'src/Core/Bridge/Symfony/Maker/Resources/skeleton',
         'tests/Fixtures/app/var',
+        'tests/Fixtures/Symfony/Maker',
     ])
     ->notPath('src/Symfony/Bundle/DependencyInjection/Configuration.php')
     ->notPath('src/Annotation/ApiFilter.php') // temporary

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -234,7 +234,8 @@ parameters:
 		- src/Core/Util/RequestParser.php
 		- src/Core/Validator/EventListener/ValidateListener.php
 		# Symfony cache
-		- tests/Fixtures/app/var/cache
+		- tests/Fixtures/app/var/
+		- tests/Fixtures/Symfony/Maker
 		# Deprecated integrations (will be removed in API Platform 3)
 		- src/Core/Bridge/NelmioApiDoc/*
 		- tests/Core/Bridge/NelmioApiDoc/*
@@ -259,7 +260,7 @@ parameters:
 		- tests/Fixtures/TestBundle/Security/AbstractSecurityUser.php
 		# Templates for Maker
 		- src/Core/Bridge/Symfony/Maker/Resources/skeleton
-		- src/Bridge/Symfony/Maker/Resources/skeleton
+		- src/Symfony/Maker/Resources/skeleton
 		# Rector because new API Platform 3.0 classes don't exist yet
 		- src/Core/Bridge/Rector
 		- src/Core/Bridge/Symfony/Bundle/Command/RectorCommand.php
@@ -324,7 +325,7 @@ parameters:
 
 		# Expected, due to deprecations
 		- '#Method ApiPlatform\\PathResolver\\OperationPathResolverInterface::resolveOperationPath\(\) invoked with 4 parameters, 3 required\.#'
-		- 
+		-
 			message: '#If condition is always false.#'
 			path: src/Core
 
@@ -350,10 +351,10 @@ parameters:
 			message: '#Call to an undefined method Symfony\\Component\\PropertyInfo\\Type::getCollectionKeyType\(\)#'
 			path: src
 		# Skipped tests, we do this on purpose
-		- 
+		-
 			message: "#^Unreachable statement - code above always terminates.$#"
 			path: tests
-		- 
+		-
 			message: "#^Unreachable statement - code above always terminates.$#"
 			path: src/Core/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
 		-

--- a/src/Symfony/Bundle/Resources/config/maker.xml
+++ b/src/Symfony/Bundle/Resources/config/maker.xml
@@ -14,6 +14,16 @@
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
             <tag name="maker.command" />
         </service>
+
+        <service id="api_platform.maker.command.state_processor" class="ApiPlatform\Symfony\Maker\MakeStateProcessor">
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
+            <tag name="maker.command" />
+        </service>
+
+        <service id="api_platform.maker.command.state_provider" class="ApiPlatform\Symfony\Maker\MakeStateProvider">
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
+            <tag name="maker.command" />
+        </service>
     </services>
 
 </container>

--- a/src/Symfony/Maker/MakeStateProcessor.php
+++ b/src/Symfony/Maker/MakeStateProcessor.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+
+final class MakeStateProcessor extends AbstractMaker
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCommandName(): string
+    {
+        return 'make:state-processor';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCommandDescription(): string
+    {
+        return 'Creates an API Platform state processor';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->addArgument('name', InputArgument::REQUIRED, 'Choose a class name for your state processor (e.g. <fg=yellow>AwesomeStateProcessor</>)')
+            ->setHelp(file_get_contents(__DIR__.'/Resources/help/MakeStateProcessor.txt'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $stateProcessorClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'State\\'
+        );
+
+        $generator->generateClass(
+            $stateProcessorClassNameDetails->getFullName(),
+            __DIR__.'/Resources/skeleton/StateProcessor.tpl.php'
+        );
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+        $io->text([
+            'Next: Open your new state processor class and start customizing it.',
+        ]);
+    }
+}

--- a/src/Symfony/Maker/MakeStateProvider.php
+++ b/src/Symfony/Maker/MakeStateProvider.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+
+final class MakeStateProvider extends AbstractMaker
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCommandName(): string
+    {
+        return 'make:state-provider';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCommandDescription(): string
+    {
+        return 'Creates an API Platform state provider';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->addArgument('name', InputArgument::REQUIRED, 'Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)')
+            ->setHelp(file_get_contents(__DIR__.'/Resources/help/MakeStateProvider.txt'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $stateProviderClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'State\\'
+        );
+
+        $generator->generateClass(
+            $stateProviderClassNameDetails->getFullName(),
+            __DIR__.'/Resources/skeleton/StateProvider.tpl.php'
+        );
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+        $io->text([
+            'Next: Open your new state provider class and start customizing it.',
+        ]);
+    }
+}

--- a/src/Symfony/Maker/Resources/help/MakeStateProcessor.txt
+++ b/src/Symfony/Maker/Resources/help/MakeStateProcessor.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new API Platform state processor class.
+
+<info>php %command.full_name% AwesomeStateProcessor</info>
+
+If the argument is missing, the command will ask for the class name interactively.

--- a/src/Symfony/Maker/Resources/help/MakeStateProvider.txt
+++ b/src/Symfony/Maker/Resources/help/MakeStateProvider.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new API Platform state provider class.
+
+<info>php %command.full_name% AwesomeStateProvider</info>
+
+If the argument is missing, the command will ask for the class name interactively.

--- a/src/Symfony/Maker/Resources/skeleton/StateProcessor.tpl.php
+++ b/src/Symfony/Maker/Resources/skeleton/StateProcessor.tpl.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+echo "<?php\n"; ?>
+
+namespace <?php echo $namespace; ?>;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+
+class <?php echo $class_name; ?> implements ProcessorInterface
+{
+    public function process($data, Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        // Handle the state
+    }
+}

--- a/src/Symfony/Maker/Resources/skeleton/StateProvider.tpl.php
+++ b/src/Symfony/Maker/Resources/skeleton/StateProvider.tpl.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+echo "<?php\n"; ?>
+
+namespace <?php echo $namespace; ?>;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+class <?php echo $class_name; ?> implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = [])<?php if (\PHP_VERSION_ID >= 80000) { ?>: object|array|null<?php } ?>
+
+    {
+        // Retrieve the state from somewhere
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/CustomStateProcessor.php
+++ b/tests/Fixtures/Symfony/Maker/CustomStateProcessor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+
+class CustomStateProcessor implements ProcessorInterface
+{
+    public function process($data, Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        // Handle the state
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/CustomStateProviderPhp7.php
+++ b/tests/Fixtures/Symfony/Maker/CustomStateProviderPhp7.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+class CustomStateProvider implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        // Retrieve the state from somewhere
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/CustomStateProviderPhp8.php
+++ b/tests/Fixtures/Symfony/Maker/CustomStateProviderPhp8.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+class CustomStateProvider implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        // Retrieve the state from somewhere
+    }
+}

--- a/tests/Symfony/Maker/MakeStateProcessorTest.php
+++ b/tests/Symfony/Maker/MakeStateProcessorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Symfony\Maker;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class MakeStateProcessorTest extends KernelTestCase
+{
+    protected function setup(): void
+    {
+        (new Filesystem())->remove(self::tempDir());
+    }
+
+    /** @dataProvider stateProcessorProvider */
+    public function testMakeStateProcessor(bool $isInteractive): void
+    {
+        $inputs = ['name' => 'CustomStateProcessor'];
+        $newProcessorFile = self::tempFile('src/State/CustomStateProcessor.php');
+
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:state-processor'));
+        $tester->setInputs($isInteractive ? $inputs : []);
+        $tester->execute($isInteractive ? [] : $inputs);
+
+        $this->assertFileExists($newProcessorFile);
+
+        // Unify line endings
+        $expected = preg_replace('~\R~u', "\r\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/CustomStateProcessor.php'));
+        $result = preg_replace('~\R~u', "\r\n", file_get_contents($newProcessorFile));
+        $this->assertSame($expected, $result);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+
+        $notInteractiveOutput = 'Choose a class name for your state processor (e.g. AwesomeStateProcessor):';
+
+        if ($isInteractive) {
+            $this->assertStringContainsString($notInteractiveOutput, $display);
+        } else {
+            $this->assertStringNotContainsString($notInteractiveOutput, $display);
+        }
+
+        $this->assertStringContainsString('Next: Open your new state processor class and start customizing it.', $display);
+    }
+
+    public function stateProcessorProvider(): \Generator
+    {
+        yield 'Generate state processor' => [
+            'isInteractive' => true,
+        ];
+
+        yield 'Generate state processor not interactively' => [
+            'isInteractive' => false,
+        ];
+    }
+
+    private static function tempDir(): string
+    {
+        return __DIR__.'/../../Fixtures/app/var/tmp';
+    }
+
+    private static function tempFile(string $path): string
+    {
+        return sprintf('%s/%s', self::tempDir(), $path);
+    }
+}

--- a/tests/Symfony/Maker/MakeStateProviderTest.php
+++ b/tests/Symfony/Maker/MakeStateProviderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Symfony\Maker;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class MakeStateProviderTest extends KernelTestCase
+{
+    protected function setup(): void
+    {
+        (new Filesystem())->remove(self::tempDir());
+    }
+
+    /** @dataProvider stateProviderDataProvider */
+    public function testMakeStateProvider(bool $isInteractive): void
+    {
+        $inputs = ['name' => 'CustomStateProvider'];
+        $newProviderFile = self::tempFile('src/State/CustomStateProvider.php');
+
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:state-provider'));
+        $tester->setInputs($isInteractive ? $inputs : []);
+        $tester->execute($isInteractive ? [] : $inputs);
+
+        $this->assertFileExists($newProviderFile);
+        $fixtureFile = \PHP_VERSION_ID < 80000 ? 'CustomStateProviderPhp7.php' : 'CustomStateProviderPhp8.php';
+
+        // Unify line endings
+        $expected = preg_replace('~\R~u', "\r\n", file_get_contents(__DIR__."/../../Fixtures/Symfony/Maker/$fixtureFile"));
+        $result = preg_replace('~\R~u', "\r\n", file_get_contents($newProviderFile));
+        $this->assertSame($expected, $result);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+
+        $notInteractiveOutput = 'Choose a class name for your state provider (e.g. AwesomeStateProvider):';
+
+        if ($isInteractive) {
+            $this->assertStringContainsString($notInteractiveOutput, $display);
+        } else {
+            $this->assertStringNotContainsString($notInteractiveOutput, $display);
+        }
+
+        $this->assertStringContainsString('Next: Open your new state provider class and start customizing it.', $display);
+    }
+
+    public function stateProviderDataProvider(): \Generator
+    {
+        yield 'Generate state provider' => [
+            'isInteractive' => true,
+        ];
+
+        yield 'Generate state provider not interactively' => [
+            'isInteractive' => false,
+        ];
+    }
+
+    private static function tempDir(): string
+    {
+        return __DIR__.'/../../Fixtures/app/var/tmp';
+    }
+
+    private static function tempFile(string $path): string
+    {
+        return sprintf('%s/%s', self::tempDir(), $path);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #4414
| License       | MIT

Here is a maker command to generate a `State\Processor` and a `State\Provider`

It was heavily inspired by existing makers

