### PR TITLE
feat(graphql): use denormalization groups to allow creation of relation in mutation

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -425,7 +425,7 @@ Feature: GraphQL mutation support
     And the JSON node "data.createFoo.foo.name" should be equal to "Created without mutation id"
     And the JSON node "data.createFoo.foo.bar" should be equal to "works"
 
-  Scenario: Create an item with a subresource
+  Scenario: Create an item with a relation to an existing resource
     Given there are 1 dummy objects with relatedDummy
     When I send the following GraphQL request:
     """
@@ -666,15 +666,26 @@ Feature: GraphQL mutation support
   Scenario: Use serialization groups with relations
     Given there is 1 dummy object with relatedDummy and its thirdLevel
     And there is a RelatedDummy with 2 friends
+    And there is a dummy object with a fourth level relation
     When I send the following GraphQL request:
     """
     mutation {
-      updateRelatedDummy(input: {id: "/related_dummies/2", symfony: "laravel", embeddedDummy: "{}", thirdLevel: "/third_levels/1"}) {
+      updateRelatedDummy(input: {
+        id: "/related_dummies/2",
+        symfony: "laravel",
+        thirdLevel: {
+          fourthLevel: "/fourth_levels/1"
+        }
+      }) {
         relatedDummy {
           id
           symfony
           thirdLevel {
             id
+            fourthLevel {
+              id
+              __typename
+            }
             __typename
           }
           relatedToDummyFriend {
@@ -694,8 +705,10 @@ Feature: GraphQL mutation support
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "data.updateRelatedDummy.relatedDummy.id" should be equal to "/related_dummies/2"
     And the JSON node "data.updateRelatedDummy.relatedDummy.symfony" should be equal to "laravel"
-    And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.id" should be equal to "/third_levels/1"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.id" should be equal to "/third_levels/3"
     And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.__typename" should be equal to "updateThirdLevelNestedPayload"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.fourthLevel.id" should be equal to "/fourth_levels/1"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.fourthLevel.__typename" should be equal to "updateFourthLevelNestedPayload"
     And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.__typename" should be equal to "updateRelatedToDummyFriendNestedPayloadConnection"
     And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[0].node.name" should be equal to "Relation-1"
     And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[1].node.name" should be equal to "Relation-2"

--- a/src/Core/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Core/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -130,6 +130,7 @@
             <argument type="service" id="api_platform.graphql.type_builder" />
             <argument type="service" id="api_platform.graphql.types_container" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
         </service>
 
         <service id="api_platform.graphql.type_builder" class="ApiPlatform\GraphQl\Type\TypeBuilder" public="false">

--- a/src/Core/Serializer/AbstractItemNormalizer.php
+++ b/src/Core/Serializer/AbstractItemNormalizer.php
@@ -864,6 +864,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $resourceClass = $this->resourceClassResolver->getResourceClass(null, $className);
             $childContext = $this->createChildContext($context, $attribute, $format);
             $childContext['resource_class'] = $resourceClass;
+            if ($this->resourceMetadataFactory instanceof ResourceMetadataCollectionFactoryInterface) {
+                $childContext['operation'] = $this->resourceMetadataFactory->create($resourceClass)->getOperation();
+            }
 
             return $this->denormalizeRelation($attribute, $propertyMetadata, $resourceClass, $value, $format, $childContext);
         }

--- a/src/GraphQl/Type/FieldsBuilderInterface.php
+++ b/src/GraphQl/Type/FieldsBuilderInterface.php
@@ -32,30 +32,30 @@ interface FieldsBuilderInterface
     /**
      * Gets the item query fields of the schema.
      */
-    public function getItemQueryFields(string $resourceClass, Operation $operation, string $queryName, array $configuration): array;
+    public function getItemQueryFields(string $resourceClass, Operation $operation, array $configuration): array;
 
     /**
      * Gets the collection query fields of the schema.
      */
-    public function getCollectionQueryFields(string $resourceClass, Operation $operation, string $queryName, array $configuration): array;
+    public function getCollectionQueryFields(string $resourceClass, Operation $operation, array $configuration): array;
 
     /**
      * Gets the mutation fields of the schema.
      */
-    public function getMutationFields(string $resourceClass, Operation $operation, string $mutationName): array;
+    public function getMutationFields(string $resourceClass, Operation $operation): array;
 
     /**
      * Gets the subscription fields of the schema.
      */
-    public function getSubscriptionFields(string $resourceClass, Operation $operation, string $subscriptionName): array;
+    public function getSubscriptionFields(string $resourceClass, Operation $operation): array;
 
     /**
      * Gets the fields of the type of the given resource.
      */
-    public function getResourceObjectTypeFields(?string $resourceClass, Operation $operation, bool $input, string $operationName, int $depth = 0, ?array $ioMetadata = null): array;
+    public function getResourceObjectTypeFields(?string $resourceClass, Operation $operation, bool $input, int $depth = 0, ?array $ioMetadata = null): array;
 
     /**
      * Resolve the args of a resource by resolving its types.
      */
-    public function resolveResourceArgs(array $args, string $operationName, string $shortName): array;
+    public function resolveResourceArgs(array $args, Operation $operation): array;
 }

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -66,35 +66,35 @@ final class SchemaBuilder implements SchemaBuilderInterface
 
                     //TODO: 3.0 remove these
                     if ('item_query' === $operationName) {
-                        $queryFields += $this->fieldsBuilder->getItemQueryFields($resourceClass, $operation, $operationName, $configuration);
+                        $queryFields += $this->fieldsBuilder->getItemQueryFields($resourceClass, $operation, $configuration);
                         continue;
                     }
 
                     if ('collection_query' === $operationName) {
-                        $queryFields += $this->fieldsBuilder->getCollectionQueryFields($resourceClass, $operation, $operationName, $configuration);
+                        $queryFields += $this->fieldsBuilder->getCollectionQueryFields($resourceClass, $operation, $configuration);
 
                         continue;
                     }
 
                     if ($operation instanceof Query && !$operation->isCollection()) {
-                        $queryFields += $this->fieldsBuilder->getItemQueryFields($resourceClass, $operation, $operationName, $configuration);
+                        $queryFields += $this->fieldsBuilder->getItemQueryFields($resourceClass, $operation, $configuration);
 
                         continue;
                     }
 
                     if ($operation instanceof Query && $operation->isCollection()) {
-                        $queryFields += $this->fieldsBuilder->getCollectionQueryFields($resourceClass, $operation, $operationName, $configuration);
+                        $queryFields += $this->fieldsBuilder->getCollectionQueryFields($resourceClass, $operation, $configuration);
 
                         continue;
                     }
 
                     if ($operation instanceof Subscription && $operation->getMercure()) {
-                        $subscriptionFields += $this->fieldsBuilder->getSubscriptionFields($resourceClass, $operation, $operationName);
+                        $subscriptionFields += $this->fieldsBuilder->getSubscriptionFields($resourceClass, $operation);
 
                         continue;
                     }
 
-                    $mutationFields += $this->fieldsBuilder->getMutationFields($resourceClass, $operation, $operationName);
+                    $mutationFields += $this->fieldsBuilder->getMutationFields($resourceClass, $operation);
                 }
             }
         }

--- a/src/GraphQl/Type/TypeBuilderInterface.php
+++ b/src/GraphQl/Type/TypeBuilderInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\Type;
 
+use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NonNull;
@@ -34,7 +35,7 @@ interface TypeBuilderInterface
      *
      * @return ObjectType|NonNull the object type, possibly wrapped by NonNull
      */
-    public function getResourceObjectType(?string $resourceClass, ResourceMetadataCollection $resourceMetadataCollection, string $operationName, bool $input, bool $wrapped = false, int $depth = 0): GraphQLType;
+    public function getResourceObjectType(?string $resourceClass, ResourceMetadataCollection $resourceMetadataCollection, Operation $operation, bool $input, bool $wrapped = false, int $depth = 0): GraphQLType;
 
     /**
      * Get the interface type of a node.

--- a/src/GraphQl/Type/TypeConverterInterface.php
+++ b/src/GraphQl/Type/TypeConverterInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\Type;
 
+use ApiPlatform\Metadata\GraphQl\Operation;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -31,7 +32,7 @@ interface TypeConverterInterface
      *
      * @return string|GraphQLType|null
      */
-    public function convertType(Type $type, bool $input, string $operationName, string $resourceClass, string $rootResource, ?string $property, int $depth);
+    public function convertType(Type $type, bool $input, Operation $rootOperation, string $resourceClass, string $rootResource, ?string $property, int $depth);
 
     /**
      * Resolves a type written with the GraphQL type system to its object representation.

--- a/tests/Fixtures/TestBundle/Document/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Document/RelatedDummy.php
@@ -27,7 +27,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Alexandre Delplace <alexandre.delplacemille@gmail.com>
  *
- * @ApiResource(graphql={"update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.mongodb.friends"}})
+ * @ApiResource(graphql={"update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.mongodb.friends"}})
  * @ODM\Document
  */
 class RelatedDummy extends ParentDummy

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(graphql={"update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
+ * @ApiResource(graphql={"update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
  * @ORM\Entity
  */
 class RelatedDummy extends ParentDummy

--- a/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Type;
 
 use ApiPlatform\GraphQl\Type\TypeConverterInterface;
+use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Dummy as DummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use GraphQL\Type\Definition\Type as GraphQLType;
@@ -36,7 +37,7 @@ final class TypeConverter implements TypeConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function convertType(Type $type, bool $input, string $operationName, string $resourceClass, string $rootResource, ?string $property, int $depth)
+    public function convertType(Type $type, bool $input, Operation $rootOperation, string $resourceClass, string $rootResource, ?string $property, int $depth)
     {
         if ('dummyDate' === $property
             && \in_array($rootResource, [Dummy::class, DummyDocument::class], true)
@@ -46,7 +47,7 @@ final class TypeConverter implements TypeConverterInterface
             return 'DateTime';
         }
 
-        return $this->defaultTypeConverter->convertType($type, $input, $operationName, $resourceClass, $rootResource, $property, $depth);
+        return $this->defaultTypeConverter->convertType($type, $input, $rootOperation, $resourceClass, $rootResource, $property, $depth);
     }
 
     /**

--- a/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -20,7 +20,7 @@ use ApiPlatform\GraphQl\Resolver\Stage\SecurityPostDenormalizeStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SecurityStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SerializeStageInterface;
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -92,7 +92,7 @@ class CollectionResolverFactoryTest extends TestCase
         $readStageCollection = [new \stdClass()];
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageCollection);
 
-        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => (new Query())->withCollection(true)])]));
+        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => new QueryCollection()])]));
 
         $this->securityStageProphecy->__invoke($resourceClass, $operationName, $resolverContext + [
             'extra_variables' => [
@@ -162,7 +162,7 @@ class CollectionResolverFactoryTest extends TestCase
         $readStageCollection = [new \stdClass()];
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageCollection);
 
-        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => (new Query())->withCollection(true)])]));
+        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => new QueryCollection()])]));
 
         $this->securityStageProphecy->__invoke($resourceClass, $operationName, $resolverContext + [
             'extra_variables' => [
@@ -238,7 +238,7 @@ class CollectionResolverFactoryTest extends TestCase
         $readStageCollection = [new \stdClass()];
         $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operationName, $resolverContext)->shouldBeCalled()->willReturn($readStageCollection);
 
-        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => (new Query())->withCollection(true)->withResolver('query_resolver_id')])]));
+        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => (new QueryCollection())->withResolver('query_resolver_id')])]));
 
         $customCollection = [new \stdClass()];
         $customCollection[0]->field = 'foo';

--- a/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
@@ -23,6 +23,7 @@ use ApiPlatform\GraphQl\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Subscription;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
@@ -134,7 +135,7 @@ class SerializeStageTest extends TestCase
             'args' => $args,
             'info' => $this->prophesize(ResolveInfo::class)->reveal(),
         ];
-        $resourceMetadata = new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => (new Query())->withShortName('shortName')->withCollection(true)])]);
+        $resourceMetadata = new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operationName => (new QueryCollection())->withShortName('shortName')])]);
         $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn($resourceMetadata);
 
         $normalizationContext = ['normalization' => true];

--- a/tests/GraphQl/Type/TypeConverterTest.php
+++ b/tests/GraphQl/Type/TypeConverterTest.php
@@ -13,19 +13,23 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Tests\GraphQl\Type;
 
+use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use ApiPlatform\Exception\ResourceClassNotFoundException;
 use ApiPlatform\GraphQl\Type\TypeBuilderInterface;
 use ApiPlatform\GraphQl\Type\TypeConverter;
 use ApiPlatform\GraphQl\Type\TypesContainerInterface;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Type\Definition\DateTimeType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -45,6 +49,9 @@ class TypeConverterTest extends TestCase
     /** @var ObjectProphecy */
     private $resourceMetadataCollectionFactoryProphecy;
 
+    /** @var ObjectProphecy */
+    private $propertyMetadataFactoryProphecy;
+
     /** @var TypeConverter */
     private $typeConverter;
 
@@ -56,7 +63,8 @@ class TypeConverterTest extends TestCase
         $this->typeBuilderProphecy = $this->prophesize(TypeBuilderInterface::class);
         $this->typesContainerProphecy = $this->prophesize(TypesContainerInterface::class);
         $this->resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
-        $this->typeConverter = new TypeConverter($this->typeBuilderProphecy->reveal(), $this->typesContainerProphecy->reveal(), $this->resourceMetadataCollectionFactoryProphecy->reveal());
+        $this->propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $this->typeConverter = new TypeConverter($this->typeBuilderProphecy->reveal(), $this->typesContainerProphecy->reveal(), $this->resourceMetadataCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal());
     }
 
     /**
@@ -68,7 +76,7 @@ class TypeConverterTest extends TestCase
     {
         $this->typeBuilderProphecy->isCollection($type)->willReturn(false);
 
-        $graphqlType = $this->typeConverter->convertType($type, $input, 'test', 'resourceClass', 'rootClass', null, $depth);
+        $graphqlType = $this->typeConverter->convertType($type, $input, (new Operation())->withName('test'), 'resourceClass', 'rootClass', null, $depth);
         $this->assertEquals($expectedGraphqlType, $graphqlType);
     }
 
@@ -81,7 +89,6 @@ class TypeConverterTest extends TestCase
             [new Type(Type::BUILTIN_TYPE_STRING), false, 0, GraphQLType::string()],
             [new Type(Type::BUILTIN_TYPE_ARRAY), false, 0, 'Iterable'],
             [new Type(Type::BUILTIN_TYPE_ITERABLE), false, 0, 'Iterable'],
-            [new Type(Type::BUILTIN_TYPE_OBJECT), true, 1, GraphQLType::string()],
             [new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateTimeInterface::class), false, 0, GraphQLType::string()],
             [new Type(Type::BUILTIN_TYPE_OBJECT), false, 0, null],
             [new Type(Type::BUILTIN_TYPE_CALLABLE), false, 0, null],
@@ -97,7 +104,7 @@ class TypeConverterTest extends TestCase
         $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(false);
         $this->resourceMetadataCollectionFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn(new ResourceMetadataCollection('dummy', [new ApiResource()]));
 
-        $graphqlType = $this->typeConverter->convertType($type, false, 'test', 'resourceClass', 'rootClass', null, 0);
+        $graphqlType = $this->typeConverter->convertType($type, false, (new Operation())->withName('test'), 'resourceClass', 'rootClass', null, 0);
         $this->assertNull($graphqlType);
     }
 
@@ -111,7 +118,7 @@ class TypeConverterTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('A "Node" resource cannot be used with GraphQL because the type is already used by the Relay specification.');
 
-        $this->typeConverter->convertType($type, false, 'test', 'resourceClass', 'rootClass', null, 0);
+        $this->typeConverter->convertType($type, false, (new Operation())->withName('test'), 'resourceClass', 'rootClass', null, 0);
     }
 
     public function testConvertTypeResourceClassNotFound(): void
@@ -121,22 +128,52 @@ class TypeConverterTest extends TestCase
         $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(false);
         $this->resourceMetadataCollectionFactoryProphecy->create('dummy')->shouldBeCalled()->willThrow(new ResourceClassNotFoundException());
 
-        $graphqlType = $this->typeConverter->convertType($type, false, 'test', 'resourceClass', 'rootClass', null, 0);
+        $graphqlType = $this->typeConverter->convertType($type, false, (new Operation())->withName('test'), 'resourceClass', 'rootClass', null, 0);
         $this->assertNull($graphqlType);
+    }
+
+    public function testConvertTypeResourceIri(): void
+    {
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummy');
+
+        $graphqlResourceMetadata = new ResourceMetadataCollection('dummy', [(new ApiResource())->withGraphQlOperations(['test' => new Query()])]);
+        $this->resourceMetadataCollectionFactoryProphecy->create('dummy')->willReturn($graphqlResourceMetadata);
+        $this->typeBuilderProphecy->isCollection($type)->willReturn(false);
+        $this->propertyMetadataFactoryProphecy->create('rootClass', 'dummyProperty', Argument::type('array'))->shouldBeCalled()->willReturn((new PropertyMetadata())->withWritableLink(false));
+
+        $graphqlType = $this->typeConverter->convertType($type, true, (new Operation())->withName('test'), 'dummy', 'rootClass', 'dummyProperty', 1);
+        $this->assertEquals(GraphQLType::string(), $graphqlType);
+    }
+
+    public function testConvertTypeInputResource(): void
+    {
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummy');
+        $operation = new Query();
+        $graphqlResourceMetadata = new ResourceMetadataCollection('dummy', [(new ApiResource())->withGraphQlOperations(['test' => $operation])]);
+        $expectedGraphqlType = new ObjectType(['name' => 'resourceObjectType']);
+
+        $this->resourceMetadataCollectionFactoryProphecy->create('dummy')->willReturn($graphqlResourceMetadata);
+        $this->typeBuilderProphecy->isCollection($type)->willReturn(false);
+        $this->propertyMetadataFactoryProphecy->create('rootClass', 'dummyProperty', Argument::type('array'))->shouldBeCalled()->willReturn((new PropertyMetadata())->withWritableLink(true));
+        $this->typeBuilderProphecy->getResourceObjectType('dummy', $graphqlResourceMetadata, $operation, true, false, 1)->shouldBeCalled()->willReturn($expectedGraphqlType);
+
+        $graphqlType = $this->typeConverter->convertType($type, true, (new Operation())->withName('test'), 'dummy', 'rootClass', 'dummyProperty', 1);
+        $this->assertEquals($expectedGraphqlType, $graphqlType);
     }
 
     /**
      * @dataProvider convertTypeResourceProvider
      */
-    public function testConvertTypeResource(Type $type, ObjectType $expectedGraphqlType): void
+    public function testConvertTypeCollectionResource(Type $type, ObjectType $expectedGraphqlType): void
     {
-        $graphqlResourceMetadata = new ResourceMetadataCollection('dummyValue', [(new ApiResource())->withShortName('DummyValue')->withGraphQlOperations(['test' => new Query()])]);
+        $operation = (new Query())->withName('test');
+        $graphqlResourceMetadata = new ResourceMetadataCollection('dummyValue', [(new ApiResource())->withShortName('DummyValue')->withGraphQlOperations(['test' => $operation])]);
 
         $this->typeBuilderProphecy->isCollection($type)->shouldBeCalled()->willReturn(true);
         $this->resourceMetadataCollectionFactoryProphecy->create('dummyValue')->shouldBeCalled()->willReturn($graphqlResourceMetadata);
-        $this->typeBuilderProphecy->getResourceObjectType('dummyValue', $graphqlResourceMetadata, 'test', false, false, 0)->shouldBeCalled()->willReturn($expectedGraphqlType);
+        $this->typeBuilderProphecy->getResourceObjectType('dummyValue', $graphqlResourceMetadata, $operation, false, false, 0)->shouldBeCalled()->willReturn($expectedGraphqlType);
 
-        $graphqlType = $this->typeConverter->convertType($type, false, 'test', 'resourceClass', 'rootClass', null, 0);
+        $graphqlType = $this->typeConverter->convertType($type, false, (new Operation())->withName('test'), 'resourceClass', 'rootClass', null, 0);
         $this->assertEquals($expectedGraphqlType, $graphqlType);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #1964 #3258
| License       | MIT
| Doc PR        | TODO

This PR does two things:
- use only the new `Operation` instead of having both `operation` and `operationName`,
- use denormalization context and groups to transform the required string (IRI) for a relation in a mutation input into an object with an optional ID, in the GraphQL schema.