### PR TITLE
fix(testClient): Support REMOTE_ADDR header

### DIFF
--- a/src/Bridge/Symfony/Bundle/Test/Client.php
+++ b/src/Bridge/Symfony/Bundle/Test/Client.php
@@ -93,14 +93,10 @@ final class Client implements HttpClientInterface
 
         // Convert headers to a $_SERVER-like array
         foreach (self::extractHeaders($options) as $key => $value) {
-            if ('content-type' === $key) {
-                $server['CONTENT_TYPE'] = $value[0] ?? '';
-
-                continue;
-            }
-
+            $normalizedHeaderName = strtoupper(str_replace('-', '_', $key));
+            $header = \in_array($normalizedHeaderName, ['CONTENT_TYPE', 'REMOTE_ADDR'], true) ? $normalizedHeaderName : sprintf('HTTP_%s', $normalizedHeaderName);
             // BrowserKit doesn't support setting several headers with the same name
-            $server['HTTP_'.strtoupper(str_replace('-', '_', $key))] = $value[0] ?? '';
+            $server[$header] = $value[0] ?? '';
         }
 
         if ($basic) {

--- a/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Bridge/Symfony/Bundle/Test/ClientTest.php
@@ -58,10 +58,15 @@ class ClientTest extends ApiTestCase
         $response = $client->request('POST', '/dummies', [
             'headers' => [
                 'content-type' => 'application/json',
+                'remote-addr' => '10.10.10.10',
                 'accept' => 'text/xml',
             ],
             'body' => '{"name": "Kevin"}',
         ]);
+        $server = $client->getKernelBrowser()->getInternalRequest()->getServer();
+        $this->assertSame('application/json', $server['CONTENT_TYPE']);
+        $this->assertSame('10.10.10.10', $server['REMOTE_ADDR']);
+        $this->assertSame('text/xml', $server['HTTP_ACCEPT']);
         $this->assertSame('application/xml; charset=utf-8', $response->getHeaders()['content-type'][0]);
         $this->assertResponseHeaderSame('content-type', 'application/xml; charset=utf-8');
         $this->assertStringContainsString('<name>Kevin</name>', $response->getContent());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | https://github.com/api-platform/core/issues/4352
| License       | MIT

Header `REMOTE_ADDR` is prefixed with `HTTP_` although [Symfony](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpFoundation/Request.php#L805) use header without prefix