### PR TITLE
fix: TraceableChainItemDataProvider bug

### DIFF
--- a/src/Core/Bridge/Symfony/Bundle/DataProvider/TraceableChainItemDataProvider.php
+++ b/src/Core/Bridge/Symfony/Bundle/DataProvider/TraceableChainItemDataProvider.php
@@ -75,7 +75,9 @@ final class TraceableChainItemDataProvider implements ItemDataProviderInterface,
                 }
 
                 $result = $dataProvider->getItem($resourceClass, $identifier, $operationName, $context);
-                $this->providersResponse[\get_class($dataProvider)] = $match = true;
+                if(null !== $result){
+                    $this->providersResponse[\get_class($dataProvider)] = $match = true;
+                }
             } catch (ResourceClassNotSupportedException $e) {
                 @trigger_error(sprintf('Throwing a "%s" is deprecated in favor of implementing "%s"', \get_class($e), RestrictedDataProviderInterface::class), \E_USER_DEPRECATED);
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

This will fix ```TraceableChainItemDataProvider::getItem``` logic, because when the first ```dataProvider``` executed and the result is null, the ```$match``` condition will always be true and the loop will be stopped. This will cause  the other ```dataProvider::getItem()``` will never be executed.
