### PR TITLE
fix: use different pagination types for the queries of a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.7.0
 
-* GraphQL: Add ability to use different pagination type from queries of a same resource (#4453)
+* GraphQL: Add ability to use different pagination types for the queries of a resource (#4453)
 * Security: **BC** Fix `ApiProperty` `security` attribute expression being passed a class string for the `object` variable on updates/creates - null is now passed instead if the object is not available (#4184)
 * Security: `ApiProperty` now supports a `security_post_denormalize` attribute, which provides access to the `object` variable for the object being updated/created and `previous_object` for the object before it was updated (#4184)
 * Maker: Add `make:data-provider` and `make :data-persister` commands to generate a data provider / persister (#3850)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* GraphQL: Add ability to use different pagination type from queries of a same resource (#4453)
 * Security: **BC** Fix `ApiProperty` `security` attribute expression being passed a class string for the `object` variable on updates/creates - null is now passed instead if the object is not available (#4184)
 * Security: `ApiProperty` now supports a `security_post_denormalize` attribute, which provides access to the `object` variable for the object being updated/created and `previous_object` for the object before it was updated (#4184)
 * Maker: Add `make:data-provider` and `make :data-persister` commands to generate a data provider / persister (#3850)
@@ -231,7 +232,7 @@ For compatibility reasons with Symfony 5.2 and PHP 8, we do not test anymore the
 * Doctrine: Order filter doesn't throw anymore with numeric key (#3673 and #3687)
 * Doctrine: Fix ODM check change tracking deferred (#3629)
 * Doctrine: Allow 2inflector version 2.0 (#3607)
-* OpenAPI: Allow subresources context to be added (#3685) 
+* OpenAPI: Allow subresources context to be added (#3685)
 * OpenAPI: Fix pagination documentation on subresources (#3678)
 * Subresource: Fix query when using a custom identifier (#3529 and #3671)
 * GraphQL: Fix relation types without Doctrine (#3591)
@@ -337,7 +338,7 @@ For compatibility reasons with Symfony 5.2 and PHP 8, we do not test anymore the
 ## 2.5.0 beta 1
 
 * Add an HTTP client dedicated to functional API testing (#2608)
-* Add PATCH support (#2895)  
+* Add PATCH support (#2895)
   Note: with JSON Merge Patch, responses will skip null values. As this may break on some endpoints, you need to manually [add the `merge-patch+json` format](https://api-platform.com/docs/core/content-negotiation/#configuring-patch-formats) to enable PATCH support. This will be the default behavior in API Platform 3.
 * Add a command to generate json schemas `api:json-schema:generate` (#2996)
 * Add infrastructure to generate a JSON Schema from a Resource `ApiPlatform\Core\JsonSchema\SchemaFactoryInterface` (#2983)

--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -9,7 +9,7 @@ Feature: GraphQL collection support
         ...dummyFields
       }
     }
-    fragment dummyFields on DummyConnection {
+    fragment dummyFields on DummyConnection_cursor {
       edges {
         node {
           id

--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -9,7 +9,7 @@ Feature: GraphQL collection support
         ...dummyFields
       }
     }
-    fragment dummyFields on DummyConnection_cursor {
+    fragment dummyFields on DummyCursorConnection {
       edges {
         node {
           id

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -37,7 +37,7 @@ Feature: GraphQL introspection support
           }
         }
       }
-      type2: __type(name: "DummyAggregateOfferConnection") {
+      type2: __type(name: "DummyAggregateOfferConnection_cursor") {
         description,
         fields {
           name
@@ -76,7 +76,7 @@ Feature: GraphQL introspection support
     {
       "name":"offers",
       "type":{
-        "name":"DummyAggregateOfferConnection",
+        "name":"DummyAggregateOfferConnection_cursor",
         "kind":"OBJECT",
         "ofType":null
       }
@@ -546,7 +546,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      typeNotAvailable: __type(name: "VoDummyInspectionConnection") {
+      typeNotAvailable: __type(name: "VoDummyInspectionConnection_cursor") {
         description
       }
       typeOwner: __type(name: "VoDummyCar") {
@@ -563,6 +563,6 @@ Feature: GraphQL introspection support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "errors[0].debugMessage" should be equal to 'Type with id "VoDummyInspectionConnection" is not present in the types container'
+    And the JSON node "errors[0].debugMessage" should be equal to 'Type with id "VoDummyInspectionConnection_cursor" is not present in the types container'
     And the JSON node "data.typeNotAvailable" should be null
-    And the JSON node "data.typeOwner.fields[3].type.name" should be equal to "VoDummyInspectionConnection"
+    And the JSON node "data.typeOwner.fields[3].type.name" should be equal to "VoDummyInspectionConnection_cursor"

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -37,7 +37,7 @@ Feature: GraphQL introspection support
           }
         }
       }
-      type2: __type(name: "DummyAggregateOfferConnection_cursor") {
+      type2: __type(name: "DummyAggregateOfferCursorConnection") {
         description,
         fields {
           name
@@ -76,7 +76,7 @@ Feature: GraphQL introspection support
     {
       "name":"offers",
       "type":{
-        "name":"DummyAggregateOfferConnection_cursor",
+        "name":"DummyAggregateOfferCursorConnection",
         "kind":"OBJECT",
         "ofType":null
       }
@@ -546,7 +546,7 @@ Feature: GraphQL introspection support
     When I send the following GraphQL request:
     """
     {
-      typeNotAvailable: __type(name: "VoDummyInspectionConnection_cursor") {
+      typeNotAvailable: __type(name: "VoDummyInspectionCursorConnection") {
         description
       }
       typeOwner: __type(name: "VoDummyCar") {
@@ -563,6 +563,6 @@ Feature: GraphQL introspection support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "errors[0].debugMessage" should be equal to 'Type with id "VoDummyInspectionConnection_cursor" is not present in the types container'
+    And the JSON node "errors[0].debugMessage" should be equal to 'Type with id "VoDummyInspectionCursorConnection" is not present in the types container'
     And the JSON node "data.typeNotAvailable" should be null
-    And the JSON node "data.typeOwner.fields[3].type.name" should be equal to "VoDummyInspectionConnection_cursor"
+    And the JSON node "data.typeOwner.fields[3].type.name" should be equal to "VoDummyInspectionCursorConnection"

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -709,7 +709,7 @@ Feature: GraphQL mutation support
     And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.__typename" should be equal to "updateThirdLevelNestedPayload"
     And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.fourthLevel.id" should be equal to "/fourth_levels/1"
     And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.fourthLevel.__typename" should be equal to "updateFourthLevelNestedPayload"
-    And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.__typename" should be equal to "updateRelatedToDummyFriendNestedPayloadConnection"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.__typename" should be equal to "updateRelatedToDummyFriendNestedPayloadConnection_cursor"
     And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[0].node.name" should be equal to "Relation-1"
     And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[1].node.name" should be equal to "Relation-2"
 

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -709,7 +709,7 @@ Feature: GraphQL mutation support
     And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.__typename" should be equal to "updateThirdLevelNestedPayload"
     And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.fourthLevel.id" should be equal to "/fourth_levels/1"
     And the JSON node "data.updateRelatedDummy.relatedDummy.thirdLevel.fourthLevel.__typename" should be equal to "updateFourthLevelNestedPayload"
-    And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.__typename" should be equal to "updateRelatedToDummyFriendNestedPayloadConnection_cursor"
+    And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.__typename" should be equal to "updateRelatedToDummyFriendNestedPayloadCursorConnection"
     And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[0].node.name" should be equal to "Relation-1"
     And the JSON node "data.updateRelatedDummy.relatedDummy.relatedToDummyFriend.edges[1].node.name" should be equal to "Relation-2"
 

--- a/features/graphql/schema.feature
+++ b/features/graphql/schema.feature
@@ -16,7 +16,7 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    ###Connection for DummyFriend. (cursor)###
+    ###Cursor connection for DummyFriend.###
     type DummyFriendCursorConnection {
       edges: [DummyFriendEdge]
       pageInfo: DummyFriendPageInfo!
@@ -54,7 +54,7 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    # Connection for DummyFriend. (cursor)
+    # Cursor connection for DummyFriend.
     type DummyFriendCursorConnection {
       edges: [DummyFriendEdge]
       pageInfo: DummyFriendPageInfo!

--- a/features/graphql/schema.feature
+++ b/features/graphql/schema.feature
@@ -16,8 +16,8 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    ###Connection for DummyFriend.###
-    type DummyFriendConnection {
+    ###Connection for DummyFriend. (cursor)###
+    type DummyFriendConnection_cursor {
       edges: [DummyFriendEdge]
       pageInfo: DummyFriendPageInfo!
       totalCount: Int!
@@ -54,8 +54,8 @@ Feature: GraphQL schema-related features
       name: String!
     }
 
-    # Connection for DummyFriend.
-    type DummyFriendConnection {
+    # Connection for DummyFriend. (cursor)
+    type DummyFriendConnection_cursor {
       edges: [DummyFriendEdge]
       pageInfo: DummyFriendPageInfo!
       totalCount: Int!

--- a/features/graphql/schema.feature
+++ b/features/graphql/schema.feature
@@ -17,7 +17,7 @@ Feature: GraphQL schema-related features
     }
 
     ###Connection for DummyFriend. (cursor)###
-    type DummyFriendConnection_cursor {
+    type DummyFriendCursorConnection {
       edges: [DummyFriendEdge]
       pageInfo: DummyFriendPageInfo!
       totalCount: Int!
@@ -55,7 +55,7 @@ Feature: GraphQL schema-related features
     }
 
     # Connection for DummyFriend. (cursor)
-    type DummyFriendConnection_cursor {
+    type DummyFriendCursorConnection {
       edges: [DummyFriendEdge]
       pageInfo: DummyFriendPageInfo!
       totalCount: Int!

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -226,8 +226,9 @@ final class TypeBuilder implements TypeBuilderInterface
         $shortName = $resourceType->name;
         $paginationType = $this->pagination->getGraphQlPaginationType($resourceClass, $operationName);
 
-        if ($this->typesContainer->has("{$shortName}Connection_{$paginationType}")) {
-            return $this->typesContainer->get("{$shortName}Connection_{$paginationType}");
+        $connectionTypeKey = sprintf('%s%sConnection', $shortName, ucfirst($paginationType));
+        if ($this->typesContainer->has($connectionTypeKey)) {
+            return $this->typesContainer->get($connectionTypeKey);
         }
 
         $fields = 'cursor' === $paginationType ?
@@ -235,13 +236,13 @@ final class TypeBuilder implements TypeBuilderInterface
             $this->getPageBasedPaginationFields($resourceType);
 
         $configuration = [
-            'name' => "{$shortName}Connection_{$paginationType}",
-            'description' => "Connection for $shortName. ({$paginationType})",
+            'name' => $connectionTypeKey,
+            'description' => sprintf("%s connection for $shortName.", ucfirst($paginationType)),
             'fields' => $fields,
         ];
 
         $resourcePaginatedCollectionType = new ObjectType($configuration);
-        $this->typesContainer->set("{$shortName}Connection_{$paginationType}", $resourcePaginatedCollectionType);
+        $this->typesContainer->set($connectionTypeKey, $resourcePaginatedCollectionType);
 
         return $resourcePaginatedCollectionType;
     }

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -224,25 +224,24 @@ final class TypeBuilder implements TypeBuilderInterface
     public function getResourcePaginatedCollectionType(GraphQLType $resourceType, string $resourceClass, string $operationName): GraphQLType
     {
         $shortName = $resourceType->name;
-
-        if ($this->typesContainer->has("{$shortName}Connection")) {
-            return $this->typesContainer->get("{$shortName}Connection");
-        }
-
         $paginationType = $this->pagination->getGraphQlPaginationType($resourceClass, $operationName);
+
+        if ($this->typesContainer->has("{$shortName}Connection_{$paginationType}")) {
+            return $this->typesContainer->get("{$shortName}Connection_{$paginationType}");
+        }
 
         $fields = 'cursor' === $paginationType ?
             $this->getCursorBasedPaginationFields($resourceType) :
             $this->getPageBasedPaginationFields($resourceType);
 
         $configuration = [
-            'name' => "{$shortName}Connection",
-            'description' => "Connection for $shortName.",
+            'name' => "{$shortName}Connection_{$paginationType}",
+            'description' => "Connection for $shortName. ({$paginationType})",
             'fields' => $fields,
         ];
 
         $resourcePaginatedCollectionType = new ObjectType($configuration);
-        $this->typesContainer->set("{$shortName}Connection", $resourcePaginatedCollectionType);
+        $this->typesContainer->set("{$shortName}Connection_{$paginationType}", $resourcePaginatedCollectionType);
 
         return $resourcePaginatedCollectionType;
     }

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -485,7 +485,7 @@ class TypeBuilderTest extends TestCase
         /** @var ObjectType $resourcePaginatedCollectionType */
         $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', 'operationName');
         $this->assertSame('StringCursorConnection', $resourcePaginatedCollectionType->name);
-        $this->assertSame('Connection for String. (cursor)', $resourcePaginatedCollectionType->description);
+        $this->assertSame('Cursor connection for String.', $resourcePaginatedCollectionType->description);
 
         $resourcePaginatedCollectionTypeFields = $resourcePaginatedCollectionType->getFields();
         $this->assertArrayHasKey('edges', $resourcePaginatedCollectionTypeFields);
@@ -544,7 +544,7 @@ class TypeBuilderTest extends TestCase
         /** @var ObjectType $resourcePaginatedCollectionType */
         $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', 'operationName');
         $this->assertSame('StringPageConnection', $resourcePaginatedCollectionType->name);
-        $this->assertSame('Connection for String. (page)', $resourcePaginatedCollectionType->description);
+        $this->assertSame('Page connection for String.', $resourcePaginatedCollectionType->description);
 
         $resourcePaginatedCollectionTypeFields = $resourcePaginatedCollectionType->getFields();
         $this->assertArrayHasKey('collection', $resourcePaginatedCollectionTypeFields);

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -472,8 +472,8 @@ class TypeBuilderTest extends TestCase
 
     public function testCursorBasedGetResourcePaginatedCollectionType(): void
     {
-        $this->typesContainerProphecy->has('StringConnection')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('StringConnection', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('StringConnection_cursor')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('StringConnection_cursor', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->set('StringEdge', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->set('StringPageInfo', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->resourceMetadataCollectionFactoryProphecy->create('StringResourceClass')->shouldBeCalled()->willReturn(new ResourceMetadataCollection('StringResourceClass', [
@@ -484,8 +484,8 @@ class TypeBuilderTest extends TestCase
 
         /** @var ObjectType $resourcePaginatedCollectionType */
         $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', 'operationName');
-        $this->assertSame('StringConnection', $resourcePaginatedCollectionType->name);
-        $this->assertSame('Connection for String.', $resourcePaginatedCollectionType->description);
+        $this->assertSame('StringConnection_cursor', $resourcePaginatedCollectionType->name);
+        $this->assertSame('Connection for String. (cursor)', $resourcePaginatedCollectionType->description);
 
         $resourcePaginatedCollectionTypeFields = $resourcePaginatedCollectionType->getFields();
         $this->assertArrayHasKey('edges', $resourcePaginatedCollectionTypeFields);
@@ -531,8 +531,8 @@ class TypeBuilderTest extends TestCase
 
     public function testPageBasedGetResourcePaginatedCollectionType(): void
     {
-        $this->typesContainerProphecy->has('StringConnection')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('StringConnection', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('StringConnection_page')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('StringConnection_page', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->set('StringPaginationInfo', Argument::type(ObjectType::class))->shouldBeCalled();
 
         $this->resourceMetadataCollectionFactoryProphecy->create('StringResourceClass')->shouldBeCalled()->willReturn(new ResourceMetadataCollection('StringResourceClass', [
@@ -543,8 +543,8 @@ class TypeBuilderTest extends TestCase
 
         /** @var ObjectType $resourcePaginatedCollectionType */
         $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', 'operationName');
-        $this->assertSame('StringConnection', $resourcePaginatedCollectionType->name);
-        $this->assertSame('Connection for String.', $resourcePaginatedCollectionType->description);
+        $this->assertSame('StringConnection_page', $resourcePaginatedCollectionType->name);
+        $this->assertSame('Connection for String. (page)', $resourcePaginatedCollectionType->description);
 
         $resourcePaginatedCollectionTypeFields = $resourcePaginatedCollectionType->getFields();
         $this->assertArrayHasKey('collection', $resourcePaginatedCollectionTypeFields);

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -472,8 +472,8 @@ class TypeBuilderTest extends TestCase
 
     public function testCursorBasedGetResourcePaginatedCollectionType(): void
     {
-        $this->typesContainerProphecy->has('StringConnection_cursor')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('StringConnection_cursor', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('StringCursorConnection')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('StringCursorConnection', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->set('StringEdge', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->set('StringPageInfo', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->resourceMetadataCollectionFactoryProphecy->create('StringResourceClass')->shouldBeCalled()->willReturn(new ResourceMetadataCollection('StringResourceClass', [
@@ -484,7 +484,7 @@ class TypeBuilderTest extends TestCase
 
         /** @var ObjectType $resourcePaginatedCollectionType */
         $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', 'operationName');
-        $this->assertSame('StringConnection_cursor', $resourcePaginatedCollectionType->name);
+        $this->assertSame('StringCursorConnection', $resourcePaginatedCollectionType->name);
         $this->assertSame('Connection for String. (cursor)', $resourcePaginatedCollectionType->description);
 
         $resourcePaginatedCollectionTypeFields = $resourcePaginatedCollectionType->getFields();
@@ -531,8 +531,8 @@ class TypeBuilderTest extends TestCase
 
     public function testPageBasedGetResourcePaginatedCollectionType(): void
     {
-        $this->typesContainerProphecy->has('StringConnection_page')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('StringConnection_page', Argument::type(ObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('StringPageConnection')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('StringPageConnection', Argument::type(ObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->set('StringPaginationInfo', Argument::type(ObjectType::class))->shouldBeCalled();
 
         $this->resourceMetadataCollectionFactoryProphecy->create('StringResourceClass')->shouldBeCalled()->willReturn(new ResourceMetadataCollection('StringResourceClass', [
@@ -543,7 +543,7 @@ class TypeBuilderTest extends TestCase
 
         /** @var ObjectType $resourcePaginatedCollectionType */
         $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', 'operationName');
-        $this->assertSame('StringConnection_page', $resourcePaginatedCollectionType->name);
+        $this->assertSame('StringPageConnection', $resourcePaginatedCollectionType->name);
         $this->assertSame('Connection for String. (page)', $resourcePaginatedCollectionType->description);
 
         $resourcePaginatedCollectionTypeFields = $resourcePaginatedCollectionType->getFields();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main?
| Tickets       | #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

See if considered as fix or not?

Use case:

```
...
#[QueryCollection(name: 'collectionQueryCursor', resolver: MiscCollectionResolver::class)]
#[QueryCollection(name: 'collectionQueryPage', resolver: MiscCollectionResolver::class, paginationType: 'page', paginationItemsPerPage:12, paginationClientEnabled: true)]
...
```

By the way, there is still an issue about `paginationClientEnabled` that is available in the QueryCollection attribute (or even ApiResource attribute), but inactive per query (or even resource) if not enabled at default configuration level by `api_platform.defaults.pagination_client_items_per_page: true`
But to resolve this another issue, it require more deeper changes.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
