### PR TITLE
fix(graphql): make sure form content type is recognized as a multipart request

### DIFF
--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -121,7 +121,7 @@ final class EntrypointAction
             $query = $request->getContent();
         }
 
-        if ('multipart' === $request->getContentType()) {
+        if (\in_array($request->getContentType(), ['multipart', 'form'], true)) {
             return $this->parseMultipartRequest($query, $operationName, $variables, $request->request->all(), $request->files->all());
         }
 


### PR DESCRIPTION
Fix due to a change in Symfony: https://github.com/symfony/symfony/pull/43017.
Multipart content type is now recognized as `form` and takes over the format defined by API Platform.