### PR TITLE
fix(graphql): make sure form content type is recognized as a multipart request

### DIFF
--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -119,7 +119,7 @@ final class EntrypointAction
             $query = $request->getContent();
         }
 
-        if ('multipart' === $request->getContentType()) {
+        if (\in_array($request->getContentType(), ['multipart', 'form'], true)) {
             return $this->parseMultipartRequest($query, $operationName, $variables, $request->request->all(), $request->files->all());
         }
 

--- a/tests/Api/FilterCollectionFactoryTest.php
+++ b/tests/Api/FilterCollectionFactoryTest.php
@@ -43,7 +43,7 @@ class FilterCollectionFactoryTest extends TestCase
         $filterCollection = (new FilterCollectionFactory(['foo', 'bar']))->createFilterCollectionFromLocator($filterLocatorProphecy->reveal());
 
         $this->assertArrayNotHasKey('bar', $filterCollection);
-        $this->assertArrayHasKey('foo', $filterCollection);
+        $this->assertTrue(isset($filterCollection['foo']));
         $this->assertInstanceOf(FilterInterface::class, $filterCollection['foo']);
         $this->assertEquals(new FilterCollection(['foo' => $filter]), $filterCollection);
     }

--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -71,7 +71,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(NotAResource::class))->getShortName(), $rootDefinitionKey);
-        $this->assertArrayHasKey($rootDefinitionKey, $definitions);
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]));
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
         $this->assertArrayNotHasKey('additionalProperties', $definitions[$rootDefinitionKey]);
@@ -144,7 +144,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(OverriddenOperationDummy::class))->getShortName().'-'.$serializerGroup, $rootDefinitionKey);
-        $this->assertArrayHasKey($rootDefinitionKey, $definitions);
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]));
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
         $this->assertFalse($definitions[$rootDefinitionKey]['additionalProperties']);

--- a/tests/JsonSchema/SchemaTest.php
+++ b/tests/JsonSchema/SchemaTest.php
@@ -73,11 +73,11 @@ class SchemaTest extends TestCase
         if (Schema::VERSION_OPENAPI === $version) {
             $this->assertArrayHasKey('schemas', $schema['components']);
         } else {
-            $this->assertArrayHasKey('definitions', $schema);
+            $this->assertTrue(isset($schema['definitions']));
         }
 
         $definitions = $schema->getDefinitions();
-        $this->assertArrayHasKey('foo', $definitions);
+        $this->assertTrue(isset($definitions['foo']));
 
         $this->assertArrayNotHasKey('definitions', $schema->getArrayCopy(false));
         $this->assertArrayNotHasKey('components', $schema->getArrayCopy(false));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Fix due to a change in Symfony: https://github.com/symfony/symfony/pull/43017.
Multipart content type is now recognized as `form` and takes over the format defined by API Platform.