### PR TITLE
fix: use asset_package for all assets

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -191,6 +191,7 @@
             <argument type="service" id="api_platform.router" />
             <argument>%api_platform.graphql.graphiql.enabled%</argument>
             <argument>%api_platform.title%</argument>
+            <argument>%api_platform.asset_package%</argument>
         </service>
 
         <service id="api_platform.graphql.action.graphql_playground" class="ApiPlatform\Core\GraphQl\Action\GraphQlPlaygroundAction" public="true">
@@ -198,6 +199,7 @@
             <argument type="service" id="api_platform.router" />
             <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
             <argument>%api_platform.title%</argument>
+            <argument>%api_platform.asset_package%</argument>
         </service>
 
         <!-- Error -->

--- a/src/Bridge/Symfony/Bundle/Resources/views/GraphQlPlayground/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/GraphQlPlayground/index.html.twig
@@ -5,9 +5,9 @@
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
     <title>{% if title %}{{ title }} - {% endif %}API Platform</title>
 
-    <link rel="stylesheet" href="{{ asset('bundles/apiplatform/graphql-playground/index.css') }}">
+    <link rel="stylesheet" href="{{ asset('bundles/apiplatform/graphql-playground/index.css', assetPackage) }}">
 
-    <script src="{{ asset('bundles/apiplatform/graphql-playground/middleware.js') }}"></script>
+    <script src="{{ asset('bundles/apiplatform/graphql-playground/middleware.js', assetPackage) }}"></script>
     {# json_encode(65) is for JSON_UNESCAPED_SLASHES|JSON_HEX_TAG to avoid JS XSS #}
     <script id="graphql-playground-data" type="application/json">{{ graphql_playground_data|json_encode(65)|raw }}</script>
 </head>
@@ -522,7 +522,7 @@
 
 <div id="graphql-playground" />
 
-<script src="{{ asset('bundles/apiplatform/init-graphql-playground.js') }}"></script>
+<script src="{{ asset('bundles/apiplatform/init-graphql-playground.js', assetPackage) }}"></script>
 
 </body>
 </html>

--- a/src/Bridge/Symfony/Bundle/Resources/views/Graphiql/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/Graphiql/index.html.twig
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <title>{% if title %}{{ title }} - {% endif %}API Platform</title>
 
-    <link rel="stylesheet" href="{{ asset('bundles/apiplatform/graphiql/graphiql.css') }}">
-    <link rel="stylesheet" href="{{ asset('bundles/apiplatform/graphiql-style.css') }}">
+    <link rel="stylesheet" href="{{ asset('bundles/apiplatform/graphiql/graphiql.css', assetPackage) }}">
+    <link rel="stylesheet" href="{{ asset('bundles/apiplatform/graphiql-style.css', assetPackage) }}">
 
     {# json_encode(65) is for JSON_UNESCAPED_SLASHES|JSON_HEX_TAG to avoid JS XSS #}
     <script id="graphiql-data" type="application/json">{{ graphiql_data|json_encode(65)|raw }}</script>
@@ -14,10 +14,10 @@
 <body>
 <div id="graphiql">Loading...</div>
 
-<script src="{{ asset('bundles/apiplatform/react/react.production.min.js') }}"></script>
-<script src="{{ asset('bundles/apiplatform/react/react-dom.production.min.js') }}"></script>
-<script src="{{ asset('bundles/apiplatform/graphiql/graphiql.min.js') }}"></script>
-<script src="{{ asset('bundles/apiplatform/init-graphiql.js') }}"></script>
+<script src="{{ asset('bundles/apiplatform/react/react.production.min.js', assetPackage) }}"></script>
+<script src="{{ asset('bundles/apiplatform/react/react-dom.production.min.js', assetPackage) }}"></script>
+<script src="{{ asset('bundles/apiplatform/graphiql/graphiql.min.js', assetPackage) }}"></script>
+<script src="{{ asset('bundles/apiplatform/init-graphiql.js', assetPackage) }}"></script>
 
 </body>
 </html>

--- a/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Bridge/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -5,8 +5,8 @@
     <title>{% if title %}{{ title }} - {% endif %}API Platform</title>
 
     {% block stylesheet %}
-        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/fonts/open-sans/400.css') }}">
-        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/fonts/open-sans/700.css') }}">
+        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/fonts/open-sans/400.css', assetPackage) }}">
+        <link rel="stylesheet" href="{{ asset('bundles/apiplatform/fonts/open-sans/700.css', assetPackage) }}">
         <link rel="stylesheet" href="{{ asset('bundles/apiplatform/swagger-ui/swagger-ui.css', assetPackage) }}">
         <link rel="stylesheet" href="{{ asset('bundles/apiplatform/style.css', assetPackage) }}">
     {% endblock %}

--- a/src/GraphQl/Action/GraphQlPlaygroundAction.php
+++ b/src/GraphQl/Action/GraphQlPlaygroundAction.php
@@ -32,13 +32,15 @@ final class GraphQlPlaygroundAction
     private $router;
     private $graphQlPlaygroundEnabled;
     private $title;
+    private $assetPackage;
 
-    public function __construct(TwigEnvironment $twig, RouterInterface $router, bool $graphQlPlaygroundEnabled = false, string $title = '')
+    public function __construct(TwigEnvironment $twig, RouterInterface $router, bool $graphQlPlaygroundEnabled = false, string $title = '', $assetPackage = null)
     {
         $this->twig = $twig;
         $this->router = $router;
         $this->graphQlPlaygroundEnabled = $graphQlPlaygroundEnabled;
         $this->title = $title;
+        $this->assetPackage = $assetPackage;
     }
 
     public function __invoke(Request $request): Response
@@ -47,6 +49,7 @@ final class GraphQlPlaygroundAction
             return new Response($this->twig->render('@ApiPlatform/GraphQlPlayground/index.html.twig', [
                 'title' => $this->title,
                 'graphql_playground_data' => ['entrypoint' => $this->router->generate('api_graphql_entrypoint')],
+                'assetPackage' => $this->assetPackage,
             ]));
         }
 

--- a/src/GraphQl/Action/GraphiQlAction.php
+++ b/src/GraphQl/Action/GraphiQlAction.php
@@ -32,13 +32,15 @@ final class GraphiQlAction
     private $router;
     private $graphiqlEnabled;
     private $title;
+    private $assetPackage;
 
-    public function __construct(TwigEnvironment $twig, RouterInterface $router, bool $graphiqlEnabled = false, string $title = '')
+    public function __construct(TwigEnvironment $twig, RouterInterface $router, bool $graphiqlEnabled = false, string $title = '', $assetPackage = null)
     {
         $this->twig = $twig;
         $this->router = $router;
         $this->graphiqlEnabled = $graphiqlEnabled;
         $this->title = $title;
+        $this->assetPackage = $assetPackage;
     }
 
     public function __invoke(Request $request): Response
@@ -47,6 +49,7 @@ final class GraphiQlAction
             return new Response($this->twig->render('@ApiPlatform/Graphiql/index.html.twig', [
                 'title' => $this->title,
                 'graphiql_data' => ['entrypoint' => $this->router->generate('api_graphql_entrypoint')],
+                'assetPackage' => $this->assetPackage,
             ]));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | fixed #4469
| License       | MIT

Use the configurable asset_path for every asset, not just in SwaggerUi, also in Graphiql and GraphQlPlayground
