### PR TITLE
Fix: Make sure the route prefix is only applied once

### DIFF
--- a/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
@@ -90,8 +90,7 @@ final class UriTemplateResourceMetadataCollectionFactory implements ResourceMeta
 
     private function generateUriTemplate(Operation $operation): string
     {
-        $uriTemplate = $operation->getRoutePrefix() ?: '';
-        $uriTemplate = sprintf('%s/%s', $uriTemplate, $this->pathSegmentNameGenerator->getSegmentName($operation->getShortName()));
+        $uriTemplate = sprintf('/%s', $this->pathSegmentNameGenerator->getSegmentName($operation->getShortName()));
         $uriVariables = $operation->getUriVariables() ?? [];
 
         if ($parameters = array_keys($uriVariables)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | #4488 
| License       | MIT
| Doc PR        |

Fix doubled route prefix by only applying the prefix in the ApiLoader.