### PR TITLE
feat: add composer scripts for testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,8 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "process-timeout": 600
     },
     "extra": {
         "branch-alias": {
@@ -138,5 +139,15 @@
         "symfony": {
             "require": "^3.4 || ^4.4 || ^5.1"
         }
+    },
+    "scripts": {
+        "docker-mongo": [
+            "Composer\\Config::disableProcessTimeout",
+            "docker run -p 27017:27017 mongo:latest"
+        ],
+        "phpunit": "vendor/bin/simple-phpunit --stop-on-failure -vvv",
+        "phpunit-coverage": "vendor/bin/simple-phpunit --coverage-html coverage -vvv --stop-on-failure",
+        "behat": "php -d memory_limit=-1 ./vendor/bin/behat --profile=default --stop-on-failure --format=progress",
+        "behat-mongo": "MONGODB_URL=mongodb://localhost:27017 APP_ENV=mongodb php -d memory_limit=-1 ./vendor/bin/behat --profile=mongodb --stop-on-failure --format=progress"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Add [composer scripts](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands) according to the [contributing guide](https://github.com/api-platform/core/blob/main/CONTRIBUTING.md).

This helps to run the tests with the IDE or cli with composer.

I am not sure what is the best way.
Docker for Mongo disables the default timeout.

Maybe the Default [300](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands) (5 Minutes) 
are not enough for tests on slow computers?
"process-timeout": 600