### PR TITLE
perf(metadata): get graphql operation when available

### DIFF
--- a/src/Bridge/Doctrine/Odm/State/CollectionProvider.php
+++ b/src/Bridge/Doctrine/Odm/State/CollectionProvider.php
@@ -63,7 +63,7 @@ final class CollectionProvider implements ProviderInterface
 
         $resourceMetadata = $this->resourceMetadataCollectionFactory->create($resourceClass);
         try {
-            $operation = $context['operation'] ?? (isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName));
+            $operation = $context['operation'] ?? $resourceMetadata->getOperation($operationName);
             $attribute = $operation->getExtraProperties()['doctrine_mongodb'] ?? [];
         } catch (OperationNotFoundException $e) {
             $attribute = $resourceMetadata->getOperation(null, true)->getExtraProperties()['doctrine_mongodb'] ?? [];

--- a/src/Core/Bridge/Doctrine/MongoDbOdm/CollectionDataProvider.php
+++ b/src/Core/Bridge/Doctrine/MongoDbOdm/CollectionDataProvider.php
@@ -77,7 +77,7 @@ final class CollectionDataProvider implements CollectionDataProviderInterface, R
 
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         try {
-            $operation = $context['operation'] ?? (isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName));
+            $operation = $context['operation'] ?? $resourceMetadata->getOperation($operationName);
             $attribute = $operation->getExtraProperties()['doctrine_mongodb'] ?? [];
         } catch (OperationNotFoundException $e) {
             $attribute = $resourceMetadata->getOperation(null, true)->getExtraProperties()['doctrine_mongodb'] ?? [];

--- a/src/Core/Bridge/Doctrine/MongoDbOdm/Extension/FilterExtension.php
+++ b/src/Core/Bridge/Doctrine/MongoDbOdm/Extension/FilterExtension.php
@@ -57,7 +57,7 @@ final class FilterExtension implements AggregationCollectionExtensionInterface
     {
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         try {
-            $operation = isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName);
+            $operation = $resourceMetadata->getOperation($operationName);
             $resourceFilters = $operation->getFilters();
         } catch (OperationNotFoundException $e) {
             $resourceFilters = $resourceMetadata->getOperation(null, true)->getFilters();

--- a/src/Core/Bridge/Doctrine/MongoDbOdm/Extension/OrderExtension.php
+++ b/src/Core/Bridge/Doctrine/MongoDbOdm/Extension/OrderExtension.php
@@ -65,7 +65,7 @@ final class OrderExtension implements AggregationCollectionExtensionInterface
                 } else {
                     $metadata = $this->resourceMetadataFactory->create($resourceClass);
                     try {
-                        $defaultOrder = isset($context['graphql_operation_name']) ? $metadata->getGraphQlOperation($operationName)->getOrder() : $metadata->getOperation($operationName)->getOrder();
+                        $defaultOrder = $metadata->getOperation($operationName)->getOrder();
                     } catch (OperationNotFoundException $e) {
                         $defaultOrder = $metadata->getOperation(null, true)->getOrder();
                     }

--- a/src/Core/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtension.php
+++ b/src/Core/Bridge/Doctrine/MongoDbOdm/Extension/PaginationExtension.php
@@ -125,7 +125,7 @@ final class PaginationExtension implements AggregationResultCollectionExtensionI
 
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         try {
-            $operation = $context['operation'] ?? (isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName));
+            $operation = $context['operation'] ?? $resourceMetadata->getOperation($operationName);
             $attribute = $operation->getExtraProperties()['doctrine_mongodb'] ?? [];
         } catch (OperationNotFoundException $e) {
             $attribute = $resourceMetadata->getOperation(null, true)->getExtraProperties()['doctrine_mongodb'] ?? [];

--- a/src/Core/Bridge/Doctrine/MongoDbOdm/SubresourceDataProvider.php
+++ b/src/Core/Bridge/Doctrine/MongoDbOdm/SubresourceDataProvider.php
@@ -97,7 +97,7 @@ final class SubresourceDataProvider implements SubresourceDataProviderInterface
 
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
         try {
-            $operation = $context['operation'] ?? (isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName));
+            $operation = $context['operation'] ?? $resourceMetadata->getOperation($operationName);
             $attribute = $operation->getExtraProperties()['doctrine_mongodb'] ?? [];
         } catch (OperationNotFoundException $e) {
             $attribute = $resourceMetadata->getOperation()->getExtraProperties()['doctrine_mongodb'] ?? [];

--- a/src/Core/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Core/Bridge/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -119,7 +119,7 @@ final class EagerLoadingExtension implements ContextAwareQueryCollectionExtensio
         if ($this->resourceMetadataFactory instanceof ResourceMetadataCollectionFactoryInterface) {
             $resourceMetadataCollection = $this->resourceMetadataFactory->create($resourceClass);
             try {
-                $operation = isset($context['graphql_operation_name']) ? $resourceMetadataCollection->getGraphQlOperation($operationName) : $resourceMetadataCollection->getOperation($operationName);
+                $operation = $resourceMetadataCollection->getOperation($operationName);
                 $forceEager = $operation->getForceEager() ?? $this->forceEager;
                 $fetchPartial = $operation->getFetchPartial() ?? $this->fetchPartial;
             } catch (OperationNotFoundException $e) {

--- a/src/Core/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Core/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -65,7 +65,7 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
         if ($this->resourceMetadataFactory instanceof ResourceMetadataCollectionFactoryInterface) {
             $resourceMetadataCollection = $this->resourceMetadataFactory->create($resourceClass);
             try {
-                $operation = isset($context['graphql_operation_name']) ? $resourceMetadataCollection->getGraphQlOperation($operationName) : $resourceMetadataCollection->getOperation($operationName);
+                $operation = $resourceMetadataCollection->getOperation($operationName);
                 $forceEager = $operation->getForceEager() ?? $this->forceEager;
             } catch (OperationNotFoundException $e) {
                 // In some cases the operation may not exist

--- a/src/Core/Bridge/Doctrine/Orm/Extension/FilterExtension.php
+++ b/src/Core/Bridge/Doctrine/Orm/Extension/FilterExtension.php
@@ -69,7 +69,7 @@ final class FilterExtension implements ContextAwareQueryCollectionExtensionInter
             $resourceFilters = $resourceMetadata->getCollectionOperationAttribute($operationName, 'filters', [], true);
         } else {
             try {
-                $operation = $context['operation'] ?? (isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName));
+                $operation = $context['operation'] ?? $resourceMetadata->getOperation($operationName);
                 $resourceFilters = $operation->getFilters();
             } catch (OperationNotFoundException $e) {
                 // In some cases the operation may not exist

--- a/src/Core/Bridge/Doctrine/Orm/Extension/OrderExtension.php
+++ b/src/Core/Bridge/Doctrine/Orm/Extension/OrderExtension.php
@@ -64,7 +64,7 @@ final class OrderExtension implements ContextAwareQueryCollectionExtensionInterf
             if ($this->resourceMetadataFactory instanceof ResourceMetadataCollectionFactoryInterface) {
                 $resourceMetadataCollection = $this->resourceMetadataFactory->create($resourceClass);
                 try {
-                    $defaultOrder = isset($context['graphql_operation_name']) ? ($resourceMetadataCollection->getGraphQlOperation($operationName)->getOrder() ?? []) : ($resourceMetadataCollection->getOperation($operationName)->getOrder() ?? []);
+                    $defaultOrder = $resourceMetadataCollection->getOperation($operationName)->getOrder() ?? [];
                 } catch (OperationNotFoundException $e) {
                     // In some cases the operation may not exist
                     $defaultOrder = [];

--- a/src/Core/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Core/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
@@ -242,7 +242,7 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
             }
         } elseif ($resourceMetadata instanceof ResourceMetadataCollection) {
             try {
-                $operation = isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName);
+                $operation = $resourceMetadata->getOperation($operationName);
                 $itemsPerPage = $operation->getPaginationItemsPerPage();
                 if ($operation->getPaginationClientItemsPerPage()) {
                     $maxItemsPerPage = $operation->getPaginationMaximumItemsPerPage() ?? $this->maximumItemPerPage;
@@ -373,7 +373,7 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
                 $fetchJoinCollection = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_fetch_join_collection', null, true);
             } elseif ($resourceMetadata instanceof ResourceMetadataCollection) {
                 try {
-                    $operation = isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName);
+                    $operation = $resourceMetadata->getOperation($operationName);
                     $fetchJoinCollection = $operation->getPaginationFetchJoinCollection();
                 } catch (OperationNotFoundException $e) {
                     // In some cases the operation may not exist
@@ -427,7 +427,7 @@ final class PaginationExtension implements ContextAwareQueryResultCollectionExte
                 $useOutputWalkers = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_use_output_walkers', null, true);
             } elseif ($resourceMetadata instanceof ResourceMetadataCollection) {
                 try {
-                    $operation = isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName);
+                    $operation = $resourceMetadata->getOperation($operationName);
                     $useOutputWalkers = $operation->getPaginationUseOutputWalkers();
                 } catch (OperationNotFoundException $e) {
                     // In some cases the operation may not exist

--- a/src/Core/DataProvider/Pagination.php
+++ b/src/Core/DataProvider/Pagination.php
@@ -136,7 +136,7 @@ final class Pagination
                 $clientLimit = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_client_items_per_page', $clientLimit, true);
             } else {
                 try {
-                    $operation = $graphql ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName);
+                    $operation = $resourceMetadata->getOperation($operationName);
                     $limit = $operation->getPaginationItemsPerPage() ?? $limit;
                     $clientLimit = $operation->getPaginationClientItemsPerPage() ?? $clientLimit;
                 } catch (OperationNotFoundException $e) {
@@ -170,7 +170,7 @@ final class Pagination
                 $maxItemsPerPage = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_maximum_items_per_page', $maxItemsPerPage ?? $this->options['maximum_items_per_page'], true);
             } elseif ($resourceMetadata instanceof ResourceMetadataCollection) {
                 try {
-                    $operation = $graphql ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName);
+                    $operation = $resourceMetadata->getOperation($operationName);
                     $maxItemsPerPage = $operation->getPaginationMaximumItemsPerPage() ?? $this->options['maximum_items_per_page'];
                 } catch (OperationNotFoundException $e) {
                     $maxItemsPerPage = $this->options['maximum_items_per_page'];
@@ -246,7 +246,7 @@ final class Pagination
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
 
             if ($resourceMetadata instanceof ResourceMetadataCollection) {
-                $operation = $resourceMetadata->getGraphQlOperation($operationName);
+                $operation = $resourceMetadata->getOperation($operationName);
 
                 return $operation->getPaginationType() ?? 'cursor';
             }
@@ -272,7 +272,7 @@ final class Pagination
 
             if ($resourceMetadata instanceof ResourceMetadataCollection) {
                 try {
-                    $operation = isset($context['graphql_operation_name']) ? $resourceMetadata->getGraphQlOperation($operationName) : $resourceMetadata->getOperation($operationName);
+                    $operation = $resourceMetadata->getOperation($operationName);
                     $enabled = ($partial ? $operation->getPaginationPartial() : $operation->getPaginationEnabled()) ?? $enabled;
                     $clientEnabled = ($partial ? $operation->getPaginationClientPartial() : $operation->getPaginationClientEnabled()) ?? $clientEnabled;
                 } catch (OperationNotFoundException $e) {
@@ -300,7 +300,7 @@ final class Pagination
                 $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
 
                 if ($resourceMetadata instanceof ResourceMetadataCollection) {
-                    $operation = $resourceMetadata->getGraphQlOperation($operationName);
+                    $operation = $resourceMetadata->getOperation($operationName);
 
                     return $operation->getPaginationEnabled() ?? $enabled;
                 }

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -80,7 +80,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
 
             $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
             try {
-                $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+                $operation = $resourceMetadataCollection->getOperation($operationName);
                 $queryResolverId = $operation->getResolver();
             } catch (OperationNotFoundException $e) {
                 $queryResolverId = null;

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -99,7 +99,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
             $item = ($this->deserializeStage)($item, $resourceClass, $operationName, $resolverContext);
 
             $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-            $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+            $operation = $resourceMetadataCollection->getOperation($operationName);
 
             $mutationResolverId = $operation->getResolver();
             if (null !== $mutationResolverId) {

--- a/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
@@ -71,7 +71,7 @@ final class ItemResolverFactory implements ResolverFactoryInterface
 
             $resourceClass = $this->getResourceClass($item, $resourceClass);
             $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-            $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+            $operation = $resourceMetadataCollection->getOperation($operationName);
 
             $queryResolverId = $operation->getResolver();
             if (null !== $queryResolverId) {

--- a/src/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactory.php
@@ -74,7 +74,7 @@ final class ItemSubscriptionResolverFactory implements ResolverFactoryInterface
             $subscriptionId = $this->subscriptionManager->retrieveSubscriptionId($resolverContext, $result);
 
             $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-            $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+            $operation = $resourceMetadataCollection->getOperation($operationName);
 
             if ($subscriptionId && ($mercure = $operation->getMercure())) {
                 if (!$this->mercureSubscriptionIriGenerator) {

--- a/src/GraphQl/Resolver/Stage/DeserializeStage.php
+++ b/src/GraphQl/Resolver/Stage/DeserializeStage.php
@@ -43,7 +43,7 @@ final class DeserializeStage implements DeserializeStageInterface
     public function __invoke($objectToPopulate, string $resourceClass, string $operationName, array $context)
     {
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-        $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+        $operation = $resourceMetadataCollection->getOperation($operationName);
         if (!($operation->canDeserialize() ?? true)) {
             return $objectToPopulate;
         }

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -62,7 +62,7 @@ final class ReadStage implements ReadStageInterface
     {
         $operation = null;
         try {
-            $operation = $resourceClass ? $this->resourceMetadataCollectionFactory->create($resourceClass)->getGraphQlOperation($operationName) : null;
+            $operation = $resourceClass ? $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation($operationName) : null;
         } catch (OperationNotFoundException $e) {
             // ReadStage may be invoked without an existing operation
         }

--- a/src/GraphQl/Resolver/Stage/SecurityPostDenormalizeStage.php
+++ b/src/GraphQl/Resolver/Stage/SecurityPostDenormalizeStage.php
@@ -39,7 +39,7 @@ final class SecurityPostDenormalizeStage implements SecurityPostDenormalizeStage
     public function __invoke(string $resourceClass, string $operationName, array $context): void
     {
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-        $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+        $operation = $resourceMetadataCollection->getOperation($operationName);
         $isGranted = $operation->getSecurityPostDenormalize();
 
         if (null !== $isGranted && null === $this->resourceAccessChecker) {

--- a/src/GraphQl/Resolver/Stage/SecurityPostValidationStage.php
+++ b/src/GraphQl/Resolver/Stage/SecurityPostValidationStage.php
@@ -40,7 +40,7 @@ final class SecurityPostValidationStage implements SecurityPostValidationStageIn
     public function __invoke(string $resourceClass, string $operationName, array $context): void
     {
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-        $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+        $operation = $resourceMetadataCollection->getOperation($operationName);
         $isGranted = $operation->getSecurityPostValidation();
 
         if (null !== $isGranted && null === $this->resourceAccessChecker) {

--- a/src/GraphQl/Resolver/Stage/SecurityStage.php
+++ b/src/GraphQl/Resolver/Stage/SecurityStage.php
@@ -39,7 +39,7 @@ final class SecurityStage implements SecurityStageInterface
     public function __invoke(string $resourceClass, string $operationName, array $context): void
     {
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-        $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+        $operation = $resourceMetadataCollection->getOperation($operationName);
         $isGranted = $operation->getSecurity();
 
         if (null !== $isGranted && null === $this->resourceAccessChecker) {

--- a/src/GraphQl/Resolver/Stage/SerializeStage.php
+++ b/src/GraphQl/Resolver/Stage/SerializeStage.php
@@ -56,18 +56,12 @@ final class SerializeStage implements SerializeStageInterface
         $isSubscription = $context['is_subscription'];
 
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
+        $operation = null;
         try {
-            $shortName = $resourceMetadataCollection->getGraphQlOperation($operationName)->getShortName();
+            $operation = $resourceMetadataCollection->getOperation($operationName);
+            $shortName = $operation->getShortName();
         } catch (OperationNotFoundException $e) {
             $shortName = $resourceMetadataCollection->getOperation()->getShortName();
-        }
-
-        $operation = null;
-
-        try {
-            $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
-        } catch (OperationNotFoundException $e) {
-            // In some cases the operation may not exist
         }
 
         if ($operation && !($operation->canSerialize() ?? true)) {

--- a/src/GraphQl/Resolver/Stage/ValidateStage.php
+++ b/src/GraphQl/Resolver/Stage/ValidateStage.php
@@ -38,7 +38,7 @@ final class ValidateStage implements ValidateStageInterface
     public function __invoke($object, string $resourceClass, string $operationName, array $context): void
     {
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-        $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+        $operation = $resourceMetadataCollection->getOperation($operationName);
 
         if (!($operation->canValidate() ?? true)) {
             return;

--- a/src/GraphQl/Resolver/Stage/WriteStage.php
+++ b/src/GraphQl/Resolver/Stage/WriteStage.php
@@ -42,7 +42,7 @@ final class WriteStage implements WriteStageInterface
     public function __invoke($data, string $resourceClass, string $operationName, array $context)
     {
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-        $operation = $resourceMetadataCollection->getGraphQlOperation($operationName);
+        $operation = $resourceMetadataCollection->getOperation($operationName);
         if (null === $data || !($operation->canWrite() ?? true)) {
             return $data;
         }

--- a/src/GraphQl/Serializer/SerializerContextBuilder.php
+++ b/src/GraphQl/Serializer/SerializerContextBuilder.php
@@ -38,20 +38,19 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
 
     public function create(?string $resourceClass, string $operationName, array $resolverContext, bool $normalization): array
     {
-        $context = ['resource_class' => $resourceClass, 'graphql_operation_name' => $operationName];
+        $context = ['resource_class' => $resourceClass, 'operation_name' => $operationName, 'graphql_operation_name' => $operationName];
         $operation = null;
 
         if ($resourceClass) {
             $resourceMetadata = $this->resourceMetadataCollectionFactory->create($resourceClass);
             try {
-                $operation = $resourceMetadata->getGraphQlOperation($operationName);
+                $operation = $resourceMetadata->getOperation($operationName);
             } catch (OperationNotFoundException $e) {
                 // It's possible that the serialization context may not be tight to an existing operation
-            }
-
-            try {
-                $context['operation_name'] = $resourceMetadata->getOperation()->getName();
-            } catch (OperationNotFoundException $e) {
+                try {
+                    $context['operation_name'] = $resourceMetadata->getOperation()->getName();
+                } catch (OperationNotFoundException $e) {
+                }
             }
         }
 

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -297,7 +297,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
             if (!empty($resourceClass)) {
                 $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
                 try {
-                    $operation = $resourceMetadataCollection->getGraphQlOperation($rootOperation->getName());
+                    $operation = $resourceMetadataCollection->getOperation($rootOperation->getName());
                 } catch (OperationNotFoundException $e) {
                 }
             }

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -80,7 +80,7 @@ final class TypeBuilder implements TypeBuilderInterface
         if ('item_query' === $operationName || 'collection_query' === $operationName) {
             // Test if the collection/item operation exists and it has different groups
             try {
-                if ($resourceMetadataCollection->getGraphQlOperation($operation->isCollection() ? 'item_query' : 'collection_query')->getNormalizationContext() !== $operation->getNormalizationContext()) {
+                if ($resourceMetadataCollection->getOperation($operation->isCollection() ? 'item_query' : 'collection_query')->getNormalizationContext() !== $operation->getNormalizationContext()) {
                     $shortName .= $operation->isCollection() ? 'Collection' : 'Item';
                 }
             } catch (OperationNotFoundException $e) {
@@ -114,13 +114,13 @@ final class TypeBuilder implements TypeBuilderInterface
             'fields' => function () use ($resourceClass, $operation, $operationName, $resourceMetadataCollection, $input, $wrapData, $depth, $ioMetadata) {
                 if ($wrapData) {
                     try {
-                        $queryNormalizationContext = $operation instanceof Query ? ($resourceMetadataCollection->getGraphQlOperation($operationName)->getNormalizationContext() ?? []) : [];
+                        $queryNormalizationContext = $operation instanceof Query ? ($resourceMetadataCollection->getOperation($operationName)->getNormalizationContext() ?? []) : [];
                     } catch (OperationNotFoundException $e) {
                         $queryNormalizationContext = [];
                     }
 
                     try {
-                        $mutationNormalizationContext = $operation instanceof Mutation || $operation instanceof Subscription ? ($resourceMetadataCollection->getGraphQlOperation($operationName)->getNormalizationContext() ?? []) : [];
+                        $mutationNormalizationContext = $operation instanceof Mutation || $operation instanceof Subscription ? ($resourceMetadataCollection->getOperation($operationName)->getNormalizationContext() ?? []) : [];
                     } catch (OperationNotFoundException $e) {
                         $mutationNormalizationContext = [];
                     }
@@ -135,7 +135,7 @@ final class TypeBuilder implements TypeBuilderInterface
                     }
 
                     try {
-                        $wrappedOperation = $resourceMetadataCollection->getGraphQlOperation($wrappedOperationName);
+                        $wrappedOperation = $resourceMetadataCollection->getOperation($wrappedOperationName);
                     } catch (OperationNotFoundException $e) {
                         $wrappedOperation = (new Query())
                             ->withResource($resourceMetadataCollection[0])

--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -155,7 +155,7 @@ final class TypeConverter implements TypeConverterInterface
         }
 
         try {
-            $operation = $resourceMetadataCollection->getGraphQlOperation($rootOperation->getName());
+            $operation = $resourceMetadataCollection->getOperation($rootOperation->getName());
         } catch (OperationNotFoundException $e) {
             $operation = (new Query())
                 ->withResource($resourceMetadataCollection[0])

--- a/src/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Metadata/Resource/ResourceMetadataCollection.php
@@ -33,10 +33,17 @@ final class ResourceMetadataCollection extends \ArrayObject
         parent::__construct($input);
     }
 
-    public function getOperation(?string $operationName = null, bool $forceCollection = false): Operation
+    /**
+     * @return Operation|GraphQlOperation
+     */
+    public function getOperation(?string $operationName = null, bool $forceCollection = false)
     {
         if (isset($this->operationCache[$operationName ?? ''])) {
             return $this->operationCache[$operationName ?? ''];
+        }
+
+        if (isset($this->operationCache['graphql_'.($operationName ?? '')])) {
+            return $this->operationCache['graphql_'.($operationName ?? '')];
         }
 
         $it = $this->getIterator();
@@ -56,25 +63,6 @@ final class ResourceMetadataCollection extends \ArrayObject
                     return $this->operationCache[$operationName] = $operation;
                 }
             }
-
-            $it->next();
-        }
-
-        $this->handleNotFound($operationName, $metadata);
-    }
-
-    public function getGraphQlOperation(string $operationName): GraphQlOperation
-    {
-        if (isset($this->operationCache['graphql_'.$operationName])) {
-            return $this->operationCache['graphql_'.$operationName];
-        }
-
-        $it = $this->getIterator();
-        $metadata = null;
-
-        while ($it->valid()) {
-            /** @var ApiResource */
-            $metadata = $it->current();
 
             foreach ($metadata->getGraphQlOperations() ?? [] as $name => $operation) {
                 if ($name === $operationName) {

--- a/src/Symfony/Messenger/Processor.php
+++ b/src/Symfony/Messenger/Processor.php
@@ -89,7 +89,7 @@ final class Processor implements ProcessorInterface
     {
         try {
             $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($context['resource_class'] ?? $this->getObjectClass($data));
-            $operation = isset($context['graphql_operation_name']) ? $resourceMetadataCollection->getGraphQlOperation($context['graphql_operation_name']) : $resourceMetadataCollection->getOperation($operationName ?? null);
+            $operation = $resourceMetadataCollection->getOperation($operationName ?? null);
 
             return false !== ($operation->getMessenger() ?? false);
         } catch (OperationNotFoundException $e) {

--- a/tests/GraphQl/Serializer/SerializerContextBuilderTest.php
+++ b/tests/GraphQl/Serializer/SerializerContextBuilderTest.php
@@ -111,6 +111,7 @@ class SerializerContextBuilderTest extends TestCase
                 [
                     'groups' => ['normalization_group'],
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                     'input' => ['class' => 'inputClass'],
                     'output' => ['class' => 'outputClass'],
@@ -130,6 +131,7 @@ class SerializerContextBuilderTest extends TestCase
                 [
                     'groups' => ['normalization_group'],
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                     'input' => ['class' => 'inputClass'],
                     'output' => ['class' => 'outputClass'],
@@ -150,6 +152,7 @@ class SerializerContextBuilderTest extends TestCase
                 [
                     'groups' => ['normalization_group'],
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                     'input' => ['class' => 'inputClass'],
                     'output' => ['class' => 'outputClass'],
@@ -167,6 +170,7 @@ class SerializerContextBuilderTest extends TestCase
                 false,
                 [
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                     'attributes' => [
                         'related' => ['id' => 9],
@@ -183,6 +187,7 @@ class SerializerContextBuilderTest extends TestCase
                 [
                     'groups' => ['normalization_group'],
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                     'input' => ['class' => 'inputClass'],
                     'output' => ['class' => 'outputClass'],
@@ -214,6 +219,7 @@ class SerializerContextBuilderTest extends TestCase
                 [
                     'groups' => ['normalization_group'],
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                     'no_resolver_data' => true,
                     'input' => ['class' => 'inputClass'],
@@ -250,6 +256,7 @@ class SerializerContextBuilderTest extends TestCase
                 [
                     'groups' => ['denormalization_group'],
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                     'input' => ['class' => 'inputClass'],
                     'output' => ['class' => 'outputClass'],
@@ -260,6 +267,7 @@ class SerializerContextBuilderTest extends TestCase
                 $operationName = 'item_query',
                 [
                     'resource_class' => $resourceClass,
+                    'operation_name' => $operationName,
                     'graphql_operation_name' => $operationName,
                 ],
             ],

--- a/tests/Metadata/Resource/ResourceMetadataCollectionTest.php
+++ b/tests/Metadata/Resource/ResourceMetadataCollectionTest.php
@@ -34,7 +34,7 @@ final class ResourceMetadataCollectionTest extends TestCase
         $resourceMetadataCollection = new ResourceMetadataCollection('class', [$resource]);
 
         $this->assertEquals($operation, $resourceMetadataCollection->getOperation('name'));
-        $this->assertEquals($query, $resourceMetadataCollection->getGraphQlOperation('query'));
+        $this->assertEquals($query, $resourceMetadataCollection->getOperation('query'));
     }
 
     public function testOperationNotFound()


### PR DESCRIPTION
Removes the `graphql_operation_name` context. Simplifies the `ResourceCollectionMetadata->getOperation()` method which can return either an Operation either a Graphql\Operation metadata class. 