### PR TITLE
feat: Add `not equal` range filter

### DIFF
--- a/src/Core/Bridge/Doctrine/Common/Filter/RangeFilterInterface.php
+++ b/src/Core/Bridge/Doctrine/Common/Filter/RangeFilterInterface.php
@@ -18,6 +18,7 @@ namespace ApiPlatform\Core\Bridge\Doctrine\Common\Filter;
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ * @author Samuel Chiriluta <samuel4x4@gmail.com>
  */
 interface RangeFilterInterface
 {
@@ -26,4 +27,5 @@ interface RangeFilterInterface
     public const PARAMETER_GREATER_THAN_OR_EQUAL = 'gte';
     public const PARAMETER_LESS_THAN = 'lt';
     public const PARAMETER_LESS_THAN_OR_EQUAL = 'lte';
+    public const PARAMETER_NOT_EQUAL = 'ne';
 }

--- a/src/Core/Bridge/Doctrine/Common/Filter/RangeFilterTrait.php
+++ b/src/Core/Bridge/Doctrine/Common/Filter/RangeFilterTrait.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ * @author Samuel Chiriluta <samuel4x4@gmail.com>
  */
 trait RangeFilterTrait
 {
@@ -49,6 +50,7 @@ trait RangeFilterTrait
             $description += $this->getFilterDescription($property, self::PARAMETER_GREATER_THAN_OR_EQUAL);
             $description += $this->getFilterDescription($property, self::PARAMETER_LESS_THAN);
             $description += $this->getFilterDescription($property, self::PARAMETER_LESS_THAN_OR_EQUAL);
+            $description += $this->getFilterDescription($property, self::PARAMETER_NOT_EQUAL);
         }
 
         return $description;
@@ -78,7 +80,7 @@ trait RangeFilterTrait
 
     private function normalizeValues(array $values, string $property): ?array
     {
-        $operators = [self::PARAMETER_BETWEEN, self::PARAMETER_GREATER_THAN, self::PARAMETER_GREATER_THAN_OR_EQUAL, self::PARAMETER_LESS_THAN, self::PARAMETER_LESS_THAN_OR_EQUAL];
+        $operators = [self::PARAMETER_BETWEEN, self::PARAMETER_GREATER_THAN, self::PARAMETER_GREATER_THAN_OR_EQUAL, self::PARAMETER_LESS_THAN, self::PARAMETER_LESS_THAN_OR_EQUAL, self::PARAMETER_NOT_EQUAL];
 
         foreach ($values as $operator => $value) {
             if (!\in_array($operator, $operators, true)) {

--- a/src/Core/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilter.php
+++ b/src/Core/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilter.php
@@ -24,6 +24,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ * @author Samuel Chiriluta <samuel4x4@gmail.com>
  */
 final class RangeFilter extends AbstractFilter implements RangeFilterInterface
 {
@@ -121,6 +122,15 @@ final class RangeFilter extends AbstractFilter implements RangeFilterInterface
                 }
 
                 $aggregationBuilder->match()->field($matchField)->lte($value);
+
+                break;
+            case self::PARAMETER_NOT_EQUAL:
+                $value = $this->normalizeValue($value, $operator);
+                if (null === $value) {
+                    return;
+                }
+
+                $aggregationBuilder->match()->field($matchField)->notEqual($value);
 
                 break;
         }

--- a/src/Core/Bridge/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Core/Bridge/Doctrine/Orm/Filter/RangeFilter.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\QueryBuilder;
  * Filters the collection by range.
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
+ * @author Samuel Chiriluta <samuel4x4@gmail.com>
  *
  * @final
  */
@@ -142,6 +143,17 @@ class RangeFilter extends AbstractContextAwareFilter implements RangeFilterInter
 
                 $queryBuilder
                     ->andWhere(sprintf('%s.%s <= :%s', $alias, $field, $valueParameter))
+                    ->setParameter($valueParameter, $value);
+
+                break;
+            case self::PARAMETER_NOT_EQUAL:
+                $value = $this->normalizeValue($value, $operator);
+                if (null === $value) {
+                    return;
+                }
+
+                $queryBuilder
+                    ->andWhere(sprintf('%s.%s <> :%s', $alias, $field, $valueParameter))
                     ->setParameter($valueParameter, $value);
 
                 break;

--- a/tests/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilterTest.php
+++ b/tests/Bridge/Doctrine/MongoDbOdm/Filter/RangeFilterTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Core\Tests\Bridge\Doctrine\Common\Filter\RangeFilterTestTrait;
  * @group mongodb
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
+ * @author Samuel Chiriluta <samuel4x4@gmail.com>
  */
 class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
 {
@@ -58,6 +59,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'id[ne]' => [
+                'property' => 'id',
+                'type' => 'string',
+                'required' => false,
+            ],
             'name[between]' => [
                 'property' => 'name',
                 'type' => 'string',
@@ -79,6 +85,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'name[lte]' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'name[ne]' => [
                 'property' => 'name',
                 'type' => 'string',
                 'required' => false,
@@ -108,6 +119,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'alias[ne]' => [
+                'property' => 'alias',
+                'type' => 'string',
+                'required' => false,
+            ],
             'description[between]' => [
                 'property' => 'description',
                 'type' => 'string',
@@ -129,6 +145,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'description[lte]' => [
+                'property' => 'description',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'description[ne]' => [
                 'property' => 'description',
                 'type' => 'string',
                 'required' => false,
@@ -158,6 +179,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'dummy[ne]' => [
+                'property' => 'dummy',
+                'type' => 'string',
+                'required' => false,
+            ],
             'dummyDate[between]' => [
                 'property' => 'dummyDate',
                 'type' => 'string',
@@ -179,6 +205,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'dummyDate[lte]' => [
+                'property' => 'dummyDate',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'dummyDate[ne]' => [
                 'property' => 'dummyDate',
                 'type' => 'string',
                 'required' => false,
@@ -208,6 +239,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'dummyFloat[ne]' => [
+                'property' => 'dummyFloat',
+                'type' => 'string',
+                'required' => false,
+            ],
             'dummyPrice[between]' => [
                 'property' => 'dummyPrice',
                 'type' => 'string',
@@ -229,6 +265,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'dummyPrice[lte]' => [
+                'property' => 'dummyPrice',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'dummyPrice[ne]' => [
                 'property' => 'dummyPrice',
                 'type' => 'string',
                 'required' => false,
@@ -258,6 +299,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'jsonData[ne]' => [
+                'property' => 'jsonData',
+                'type' => 'string',
+                'required' => false,
+            ],
             'arrayData[between]' => [
                 'property' => 'arrayData',
                 'type' => 'string',
@@ -279,6 +325,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'arrayData[lte]' => [
+                'property' => 'arrayData',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'arrayData[ne]' => [
                 'property' => 'arrayData',
                 'type' => 'string',
                 'required' => false,
@@ -308,6 +359,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'nameConverted[ne]' => [
+                'property' => 'nameConverted',
+                'type' => 'string',
+                'required' => false,
+            ],
             'dummyBoolean[between]' => [
                 'property' => 'dummyBoolean',
                 'type' => 'string',
@@ -329,6 +385,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'dummyBoolean[lte]' => [
+                'property' => 'dummyBoolean',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'dummyBoolean[ne]' => [
                 'property' => 'dummyBoolean',
                 'type' => 'string',
                 'required' => false,
@@ -358,6 +419,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'relatedDummy[ne]' => [
+                'property' => 'relatedDummy',
+                'type' => 'string',
+                'required' => false,
+            ],
             'relatedDummies[between]' => [
                 'property' => 'relatedDummies',
                 'type' => 'string',
@@ -379,6 +445,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'relatedDummies[lte]' => [
+                'property' => 'relatedDummies',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'relatedDummies[ne]' => [
                 'property' => 'relatedDummies',
                 'type' => 'string',
                 'required' => false,
@@ -408,6 +479,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'relatedOwnedDummy[ne]' => [
+                'property' => 'relatedOwnedDummy',
+                'type' => 'string',
+                'required' => false,
+            ],
             'relatedOwningDummy[between]' => [
                 'property' => 'relatedOwningDummy',
                 'type' => 'string',
@@ -429,6 +505,11 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
             ],
             'relatedOwningDummy[lte]' => [
+                'property' => 'relatedOwningDummy',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'relatedOwningDummy[ne]' => [
                 'property' => 'relatedOwningDummy',
                 'type' => 'string',
                 'required' => false,
@@ -544,6 +625,20 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                     ],
+                ],
+                'ne' => [
+                    [
+                        [
+                            '$match' => [
+                                'dummyPrice' => [
+                                    '$notEqual' => 9.99,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'ne (non-numeric)' => [
+                    [],
                 ],
             ]
         );

--- a/tests/Core/Bridge/Doctrine/Common/Filter/RangeFilterTestTrait.php
+++ b/tests/Core/Bridge/Doctrine/Common/Filter/RangeFilterTestTrait.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Tests\Bridge\Doctrine\Common\Filter;
 
 /**
  * @author Lee Siong Chan <ahlee2326@me.com>
+ * @author Samuel Chiriluta <samuel4x4@gmail.com>
  */
 trait RangeFilterTestTrait
 {
@@ -131,6 +132,22 @@ trait RangeFilterTestTrait
                     'dummyPrice' => [
                         'gte' => '9.99',
                         'lte' => '19.99',
+                    ],
+                ],
+            ],
+            'ne' => [
+                null,
+                [
+                    'dummyPrice' => [
+                        'ne' => '9.99',
+                    ],
+                ],
+            ],
+            'ne (non-numeric)' => [
+                null,
+                [
+                    'dummyPrice' => [
+                        'ne' => '127.0.0.1',
                     ],
                 ],
             ],

--- a/tests/Core/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
+++ b/tests/Core/Bridge/Doctrine/Orm/Filter/RangeFilterTest.php
@@ -20,6 +20,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 
 /**
  * @author Lee Siong Chan <ahlee2326@me.com>
+ * @author Samuel Chiriluta <samuel4x4@gmail.com>
  */
 class RangeFilterTest extends DoctrineOrmFilterTestCase
 {
@@ -57,6 +58,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'id[ne]' => [
+                'property' => 'id',
+                'type' => 'string',
+                'required' => false,
+            ],
             'name[between]' => [
                 'property' => 'name',
                 'type' => 'string',
@@ -78,6 +84,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'required' => false,
             ],
             'name[lte]' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'name[ne]' => [
                 'property' => 'name',
                 'type' => 'string',
                 'required' => false,
@@ -107,6 +118,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'alias[ne]' => [
+                'property' => 'alias',
+                'type' => 'string',
+                'required' => false,
+            ],
             'description[between]' => [
                 'property' => 'description',
                 'type' => 'string',
@@ -128,6 +144,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'required' => false,
             ],
             'description[lte]' => [
+                'property' => 'description',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'description[ne]' => [
                 'property' => 'description',
                 'type' => 'string',
                 'required' => false,
@@ -157,6 +178,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'dummy[ne]' => [
+                'property' => 'dummy',
+                'type' => 'string',
+                'required' => false,
+            ],
             'dummyDate[between]' => [
                 'property' => 'dummyDate',
                 'type' => 'string',
@@ -178,6 +204,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'required' => false,
             ],
             'dummyDate[lte]' => [
+                'property' => 'dummyDate',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'dummyDate[ne]' => [
                 'property' => 'dummyDate',
                 'type' => 'string',
                 'required' => false,
@@ -207,6 +238,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'dummyFloat[ne]' => [
+                'property' => 'dummyFloat',
+                'type' => 'string',
+                'required' => false,
+            ],
             'dummyPrice[between]' => [
                 'property' => 'dummyPrice',
                 'type' => 'string',
@@ -228,6 +264,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'required' => false,
             ],
             'dummyPrice[lte]' => [
+                'property' => 'dummyPrice',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'dummyPrice[ne]' => [
                 'property' => 'dummyPrice',
                 'type' => 'string',
                 'required' => false,
@@ -257,6 +298,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'jsonData[ne]' => [
+                'property' => 'jsonData',
+                'type' => 'string',
+                'required' => false,
+            ],
             'arrayData[between]' => [
                 'property' => 'arrayData',
                 'type' => 'string',
@@ -278,6 +324,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'required' => false,
             ],
             'arrayData[lte]' => [
+                'property' => 'arrayData',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'arrayData[ne]' => [
                 'property' => 'arrayData',
                 'type' => 'string',
                 'required' => false,
@@ -307,6 +358,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
             ],
+            'nameConverted[ne]' => [
+                'property' => 'nameConverted',
+                'type' => 'string',
+                'required' => false,
+            ],
             'dummyBoolean[between]' => [
                 'property' => 'dummyBoolean',
                 'type' => 'string',
@@ -328,6 +384,11 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 'required' => false,
             ],
             'dummyBoolean[lte]' => [
+                'property' => 'dummyBoolean',
+                'type' => 'string',
+                'required' => false,
+            ],
+            'dummyBoolean[ne]' => [
                 'property' => 'dummyBoolean',
                 'type' => 'string',
                 'required' => false,
@@ -381,6 +442,12 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
                 ],
                 'lte + gte' => [
                     sprintf('SELECT o FROM %s o WHERE o.dummyPrice >= :dummyPrice_p1 AND o.dummyPrice <= :dummyPrice_p2', Dummy::class),
+                ],
+                'ne' => [
+                    sprintf('SELECT o FROM %s o WHERE o.dummyPrice <> :dummyPrice_p1', Dummy::class),
+                ],
+                'ne (non-numeric)' => [
+                    sprintf('SELECT o FROM %s o', Dummy::class),
                 ],
             ]
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

This feature will let you having `not equal` range filter, used like this: `/api/uri?property[ne]=9.99`.
