### PR TITLE
fix: use `getNestedConstraints()` instead of `getNestedContraints` when available

### DIFF
--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestriction.php
@@ -42,7 +42,7 @@ final class PropertySchemaOneOfRestriction implements PropertySchemaRestrictionM
      */
     public function create(Constraint $constraint, ApiProperty $propertyMetadata): array
     {
-        $oneOfConstraints = $constraint->getNestedContraints();
+        $oneOfConstraints = method_exists($constraint, 'getNestedContraints') ? $constraint->getNestedContraints() : $constraint->constraints;
         $oneOfRestrictions = [];
 
         foreach ($oneOfConstraints as $oneOfConstraint) {

--- a/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
+++ b/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
@@ -183,7 +183,7 @@ final class ValidatorPropertyMetadataFactory implements PropertyMetadataFactoryI
 
             foreach ($validatorPropertyMetadata->findConstraints($validationGroup) as $propertyConstraint) {
                 if ($propertyConstraint instanceof Sequentially || $propertyConstraint instanceof Compound) {
-                    $constraints[] = $propertyConstraint->getNestedContraints();
+                    $constraints[] = method_exists($propertyConstraint, 'getNestedContraints') ? $propertyConstraint->getNestedContraints() : $propertyConstraint->getNestedConstraints();
                 } else {
                     $constraints[] = [$propertyConstraint];
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A
