### PR TITLE
feat(mercure): Pass 'resource_class' into serialization context

### DIFF
--- a/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -227,6 +227,9 @@ final class PublishMercureUpdatesListener
         } else {
             $resourceClass = $this->getObjectClass($object);
             $context = $options['normalization_context'] ?? $this->resourceMetadataFactory->create($resourceClass)->getAttribute('normalization_context', []);
+            if (!isset($context['resource_class'])) {
+                $context['resource_class'] = $resourceClass;
+            }
 
             $iri = $options['topics'] ?? $this->iriConverter->getIriFromItem($object, UrlGeneratorInterface::ABS_URL);
             $data = $options['data'] ?? $this->serializer->serialize($object, key($this->formats), $context);

--- a/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Bridge/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -93,8 +93,14 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceMetadataFactoryProphecy->create(DummyFriend::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => "['foo', 'bar']"]));
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize($toInsert, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('1');
-        $serializerProphecy->serialize($toUpdate, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('2');
+        $serializerProphecy->serialize($toInsert, 'jsonld', [
+            'resource_class' => Dummy::class,
+            'groups' => ['foo', 'bar'],
+        ])->willReturn('1');
+        $serializerProphecy->serialize($toUpdate, 'jsonld', [
+            'resource_class' => Dummy::class,
+            'groups' => ['foo', 'bar'],
+        ])->willReturn('2');
 
         $formats = ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']];
 
@@ -189,10 +195,22 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceMetadataFactoryProphecy->create(DummyMercure::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => ['topics' => ['/dummies/1', '/users/3'], 'normalization_context' => ['groups' => ['baz']]]]));
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize($toInsert, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('1');
-        $serializerProphecy->serialize($toUpdate, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('2');
-        $serializerProphecy->serialize($toUpdateMercureOptions, 'jsonld', ['groups' => ['baz']])->willReturn('mercure_options');
-        $serializerProphecy->serialize($toUpdateMercureTopicOptions, 'jsonld', ['groups' => ['baz']])->willReturn('mercure_options');
+        $serializerProphecy->serialize($toInsert, 'jsonld', [
+            'resource_class' => Dummy::class,
+            'groups' => ['foo', 'bar'],
+        ])->willReturn('1');
+        $serializerProphecy->serialize($toUpdate, 'jsonld', [
+            'resource_class' => Dummy::class,
+            'groups' => ['foo', 'bar'],
+        ])->willReturn('2');
+        $serializerProphecy->serialize($toUpdateMercureOptions, 'jsonld', [
+            'resource_class' => DummyOffer::class,
+            'groups' => ['baz'],
+        ])->willReturn('mercure_options');
+        $serializerProphecy->serialize($toUpdateMercureTopicOptions, 'jsonld', [
+            'resource_class' => DummyMercure::class,
+            'groups' => ['baz'],
+        ])->willReturn('mercure_options');
 
         $formats = ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']];
 
@@ -290,10 +308,22 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceMetadataFactoryProphecy->create(DummyMercure::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => ['topics' => ['/dummies/1', '/users/3'], 'normalization_context' => ['groups' => ['baz']], 'hub' => 'managed', 'enable_async_update' => false]]));
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize($toInsert, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('1');
-        $serializerProphecy->serialize($toUpdate, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('2');
-        $serializerProphecy->serialize($toUpdateMercureOptions, 'jsonld', ['groups' => ['baz']])->willReturn('mercure_options');
-        $serializerProphecy->serialize($toUpdateMercureTopicOptions, 'jsonld', ['groups' => ['baz']])->willReturn('mercure_options');
+        $serializerProphecy->serialize($toInsert, 'jsonld', [
+            'resource_class' => Dummy::class,
+            'groups' => ['foo', 'bar'],
+        ])->willReturn('1');
+        $serializerProphecy->serialize($toUpdate, 'jsonld', [
+            'resource_class' => Dummy::class,
+            'groups' => ['foo', 'bar'],
+        ])->willReturn('2');
+        $serializerProphecy->serialize($toUpdateMercureOptions, 'jsonld', [
+            'resource_class' => DummyOffer::class,
+            'groups' => ['baz'],
+        ])->willReturn('mercure_options');
+        $serializerProphecy->serialize($toUpdateMercureTopicOptions, 'jsonld', [
+            'resource_class' => DummyMercure::class,
+            'groups' => ['baz'],
+        ])->willReturn('mercure_options');
 
         $formats = ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']];
 
@@ -361,7 +391,10 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['mercure' => ['enable_async_update' => false], 'normalization_context' => ['groups' => ['foo', 'bar']]]));
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->serialize($toUpdate, 'jsonld', ['groups' => ['foo', 'bar']])->willReturn('2');
+        $serializerProphecy->serialize($toUpdate, 'jsonld', [
+            'resource_class' => Dummy::class,
+            'groups' => ['foo', 'bar'],
+        ])->willReturn('2');
 
         $formats = ['jsonld' => ['application/ld+json'], 'jsonhal' => ['application/hal+json']];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The `$context` array passed to custom normalizers is different whether a resource is being serialized as part of a request-response lifecycle or whether it's being serialized to publish to the Mercure hub. This makes it difficult to ensure that the same resource gets serialized consistently.

The `resource_class` key defines the root resource getting serialized and it's missing when serializing for the Mercure hub. To not rock the boat too much, I decided just to add this to the serialization context.

### Questions to reviewers

1. Is this perhaps small enough of a feature that it could be merged into current stable (2.6) branch?
2. If documentation update is necessary, which article should I update?

### Future work

In the longer run it might be beneficial to ensure the following.

1. All keys of the context variable declared by API Platform are documented (including their types).
2. All keys of the context variable are the same regardless of whether serializing during a request-response lifecycle or whether serializing to publish a Mercure update. If a context variable makes sense only in one of the two cases, then its type can simply by `T|null`.

*But*, I acknowledge this might be a lot of work and I don't want to burden the maintainers by opening yet another issue.

### Background

Making this PR to make my workaround for #4338 work.

> I myself came up with [a workaround](https://gist.github.com/kgilden/5a0bb420e7b4c8e20e6744e90e79a1f4), which uses the `resource_class` context property to determine what the root is and just use an IRI converter for all other cases. But this falls short, when trying to publish to a Mercure hub, because the context is created differently ([here](https://github.com/api-platform/core/blob/6336f6446722cd6728683c36fb70e0074553296d/src/EventListener/SerializeListener.php) vs [here](https://github.com/api-platform/core/blob/6336f6446722cd6728683c36fb70e0074553296d/src/Bridge/Doctrine/EventListener/PublishMercureUpdatesListener.php#L264)).