### PR TITLE
Conflict with symfony/routing 6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,8 @@
         "doctrine/common": "<2.7",
         "doctrine/dbal": "<2.10",
         "doctrine/mongodb-odm": "<2.2",
-        "doctrine/persistence": "<1.3"
+        "doctrine/persistence": "<1.3",
+        "symfony/routing": ">6.0"
     },
     "suggest": {
         "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | N/A
| License       | MIT

When requiring `api-platform/core` on a Symfony 6 project it's breaking because there is no dependencies about `symfony/routing` in the required packages. So we need to conflict with it until compatibility is there.