### PR TITLE
fix(doctrine): FilterEagerLoadingExtension breaks DQL if property name endings matches with query builder aliases

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -141,14 +141,14 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
         // Change join aliases
         foreach ($joinParts[$originAlias] as $joinPart) {
             /** @var Join $joinPart */
-            $joinString = str_replace($aliases, $replacements, $joinPart->getJoin());
+            $joinString = preg_replace($this->buildReplacePatterns($aliases), $replacements, $joinPart->getJoin());
             $pos = strpos($joinString, '.');
             if (false === $pos) {
                 if (null !== $joinPart->getCondition() && null !== $this->resourceClassResolver && $this->resourceClassResolver->isResourceClass($joinString)) {
                     $newAlias = $queryNameGenerator->generateJoinAlias($joinPart->getAlias());
                     $aliases[] = "{$joinPart->getAlias()}.";
                     $replacements[] = "$newAlias.";
-                    $condition = str_replace($aliases, $replacements, $joinPart->getCondition());
+                    $condition = preg_replace($this->buildReplacePatterns($aliases), $replacements, $joinPart->getCondition());
                     $join = new Join($joinPart->getJoinType(), $joinPart->getJoin(), $newAlias, $joinPart->getConditionType(), $condition);
                     /* @phpstan-ignore-next-line */
                     $queryBuilderClone->add('join', [$replacement => $join], true);
@@ -161,12 +161,19 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
             $newAlias = $queryNameGenerator->generateJoinAlias($association);
             $aliases[] = "{$joinPart->getAlias()}.";
             $replacements[] = "$newAlias.";
-            $condition = str_replace($aliases, $replacements, $joinPart->getCondition() ?? '');
+            $condition = preg_replace($this->buildReplacePatterns($aliases), $replacements, $joinPart->getCondition() ?? '');
             QueryBuilderHelper::addJoinOnce($queryBuilderClone, $queryNameGenerator, $alias, $association, $joinPart->getJoinType(), $joinPart->getConditionType(), $condition, $originAlias, $newAlias);
         }
 
-        $queryBuilderClone->add('where', str_replace($aliases, $replacements, (string) $wherePart));
+        $queryBuilderClone->add('where', preg_replace($this->buildReplacePatterns($aliases), $replacements, (string) $wherePart));
 
         return $queryBuilderClone;
+    }
+
+    private function buildReplacePatterns(array $aliases): array
+    {
+        return array_map(static function (string $alias): string {
+            return '/\b'.preg_quote($alias, '/').'/';
+        }, $aliases);
     }
 }

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
@@ -232,7 +232,9 @@ SQL;
             ->from(DummyCar::class, 'o')
             ->leftJoin('o.colors', 'colors', 'ON', 'o.id = colors.car AND colors.id IN (1,2,3)')
             ->where('o.colors = :foo')
-            ->setParameter('foo', 1);
+            ->andWhere('o.embeddableInfo.dummyName = :bar')
+            ->setParameter('foo', 1)
+            ->setParameter('bar', 'a');
 
         $queryNameGenerator = $this->prophesize(QueryNameGeneratorInterface::class);
         $queryNameGenerator->generateJoinAlias('colors')->shouldBeCalled()->willReturn('colors_2');
@@ -248,7 +250,7 @@ LEFT JOIN o.colors colors ON o.id = colors.car AND colors.id IN (1,2,3)
 WHERE o IN(
   SELECT o_2 FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar o_2
   LEFT JOIN o_2.colors colors_2 ON o_2.id = colors_2.car AND colors_2.id IN (1,2,3)
-  WHERE o_2.colors = :foo
+  WHERE o_2.colors = :foo AND o_2.embeddableInfo.dummyName = :bar
 )
 SQL;
 

--- a/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
+++ b/tests/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtensionTest.php
@@ -232,7 +232,7 @@ SQL;
             ->from(DummyCar::class, 'o')
             ->leftJoin('o.colors', 'colors', 'ON', 'o.id = colors.car AND colors.id IN (1,2,3)')
             ->where('o.colors = :foo')
-            ->andWhere('o.embeddableInfo.dummyName = :bar')
+            ->andWhere('o.info.name = :bar')
             ->setParameter('foo', 1)
             ->setParameter('bar', 'a');
 
@@ -250,7 +250,7 @@ LEFT JOIN o.colors colors ON o.id = colors.car AND colors.id IN (1,2,3)
 WHERE o IN(
   SELECT o_2 FROM ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\DummyCar o_2
   LEFT JOIN o_2.colors colors_2 ON o_2.id = colors_2.car AND colors_2.id IN (1,2,3)
-  WHERE o_2.colors = :foo AND o_2.embeddableInfo.dummyName = :bar
+  WHERE o_2.colors = :foo AND o_2.info.name = :bar
 )
 SQL;
 

--- a/tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -125,16 +125,17 @@ class DummyCar
     private $brand = 'DummyBrand';
 
     /**
-     * @var EmbeddableDummy
+     * @var DummyCarInfo
      *
-     * @ORM\Embedded(class="EmbeddableDummy")
+     * @ORM\Embedded(class="DummyCarInfo")
      */
-    private $embeddableInfo;
+    private $info;
 
     public function __construct()
     {
         $this->id = new DummyCarIdentifier();
         $this->colors = new ArrayCollection();
+        $this->info = new DummyCarInfo();
     }
 
     public function getId()
@@ -225,5 +226,15 @@ class DummyCar
     public function setBrand(string $brand): void
     {
         $this->brand = $brand;
+    }
+
+    public function getInfo(): DummyCarInfo
+    {
+        return $this->info;
+    }
+
+    public function setInfo(DummyCarInfo $info): void
+    {
+        $this->info = $info;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -124,6 +124,13 @@ class DummyCar
      */
     private $brand = 'DummyBrand';
 
+    /**
+     * @var EmbeddableDummy
+     *
+     * @ORM\Embedded(class="EmbeddableDummy")
+     */
+    private $embeddableInfo;
+
     public function __construct()
     {
         $this->id = new DummyCarIdentifier();

--- a/tests/Fixtures/TestBundle/Entity/DummyCarInfo.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCarInfo.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Sergey Balasov <sbalasov@gmail.com>
+ *
+ * @ORM\Embeddable
+ */
+class DummyCarInfo
+{
+    /**
+     * @var string
+     *
+     * @ORM\Column(nullable=true)
+     */
+    public $name;
+}

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -41,7 +41,7 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
 
         $this->assertEquals($this->extractor->getFilters($reflectionClass), [
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_bridge_doctrine_orm_filter_date_filter' => [
-                ['properties' => ['id' => 'exclude_null', 'colors' => 'exclude_null', 'name' => 'exclude_null', 'canSell' => 'exclude_null', 'availableAt' => 'exclude_null', 'brand' => 'exclude_null', 'secondColors' => 'exclude_null', 'thirdColors' => 'exclude_null', 'uuid' => 'exclude_null', 'embeddableInfo' => 'exclude_null']],
+                ['properties' => ['id' => 'exclude_null', 'colors' => 'exclude_null', 'name' => 'exclude_null', 'canSell' => 'exclude_null', 'availableAt' => 'exclude_null', 'brand' => 'exclude_null', 'secondColors' => 'exclude_null', 'thirdColors' => 'exclude_null', 'uuid' => 'exclude_null', 'info' => 'exclude_null']],
                 DateFilter::class,
             ],
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_bridge_doctrine_orm_filter_boolean_filter' => [

--- a/tests/Util/AnnotationFilterExtractorTraitTest.php
+++ b/tests/Util/AnnotationFilterExtractorTraitTest.php
@@ -41,7 +41,7 @@ class AnnotationFilterExtractorTraitTest extends KernelTestCase
 
         $this->assertEquals($this->extractor->getFilters($reflectionClass), [
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_bridge_doctrine_orm_filter_date_filter' => [
-                ['properties' => ['id' => 'exclude_null', 'colors' => 'exclude_null', 'name' => 'exclude_null', 'canSell' => 'exclude_null', 'availableAt' => 'exclude_null', 'brand' => 'exclude_null', 'secondColors' => 'exclude_null', 'thirdColors' => 'exclude_null', 'uuid' => 'exclude_null']],
+                ['properties' => ['id' => 'exclude_null', 'colors' => 'exclude_null', 'name' => 'exclude_null', 'canSell' => 'exclude_null', 'availableAt' => 'exclude_null', 'brand' => 'exclude_null', 'secondColors' => 'exclude_null', 'thirdColors' => 'exclude_null', 'uuid' => 'exclude_null', 'embeddableInfo' => 'exclude_null']],
                 DateFilter::class,
             ],
             'annotated_api_platform_core_tests_fixtures_test_bundle_entity_dummy_car_api_platform_core_bridge_doctrine_orm_filter_boolean_filter' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | #4591 
| License       | MIT
| Doc PR        | no