### PR TITLE
[Typo] Rename getNestedContraints to getNestedConstraints

### DIFF
--- a/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestriction.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestriction.php
@@ -42,7 +42,7 @@ final class PropertySchemaOneOfRestriction implements PropertySchemaRestrictionM
      */
     public function create(Constraint $constraint, PropertyMetadata $propertyMetadata): array
     {
-        $oneOfConstraints = $constraint->getNestedContraints();
+        $oneOfConstraints = $constraint->getNestedConstraints();
         $oneOfRestrictions = [];
 
         foreach ($oneOfConstraints as $oneOfConstraint) {

--- a/src/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
+++ b/src/Bridge/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
@@ -172,7 +172,7 @@ final class ValidatorPropertyMetadataFactory implements PropertyMetadataFactoryI
 
             foreach ($validatorPropertyMetadata->findConstraints($validationGroup) as $propertyConstraint) {
                 if ($propertyConstraint instanceof Sequentially) {
-                    $constraints[] = $propertyConstraint->getNestedContraints();
+                    $constraints[] = $propertyConstraint->getNestedConstraints();
                 } else {
                     $constraints[] = [$propertyConstraint];
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | no ticket
| License       | MIT

As you see the <a href="https://github.com/symfony/validator/blob/5.4/Constraints/Composite.php#L142">Constaints/Composite</a> class does not contain `getNestedContraints` method, instead it contains a  `getNestedConstraints` method.
This lead to an UndefinedMethodError  exception :

```
Attempted to call an undefined method named "getNestedContraints" of class "Symfony\Component\Validator\Constraints\Sequentially".
Did you mean to call "getNestedConstraints"?
```

Cheers!