### PR TITLE
fix: leave function to let symfony assert work properly

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -430,6 +430,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     protected function validateType(string $attribute, Type $type, $value, string $format = null)
     {
+        if (is_null($value)) {
+            return; // Leave the function to let symfony assert work properly
+        }
+
         $builtinType = $type->getBuiltinType();
         if (Type::BUILTIN_TYPE_FLOAT === $builtinType && null !== $format && false !== strpos($format, 'json')) {
             $isValid = \is_float($value) || \is_int($value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| License       | MIT

## Current problem this is fixing:

I have an api platform Entity:

```
class Example
{
    #[ORM\Column(type: 'string', length: 255, nullable: false)]
    #[Groups(["write"])]
    #[Assert\NotNull()]
    #[Assert\NotBlank()]
    private $property;
}
```

When I use the POST endpoint /api/examples with a null value on my property
```
{
 "property": null
}
```

The Symfony Asserts are not called/used and instead I have the InvalidArgumentException thrown by the Abstract item normalizer:
```
(400 BAD REQUEST)
{
	"type": "https:\/\/tools.ietf.org\/html\/rfc2616#section-10",
	"title": "An error occurred",
	"detail": "The type of the \"property\" attribute must be \"string\", \"NULL\" given.",
	"trace": [...]
}
```

## Now with this fix

With this fix, the InvalidArgumentException Is not thrown and The Symfony Asserts are called and I have the errors violations message I expected with propertyPath etc:

```
(422 Unprocessables Entity)
{
	"type": "https:\/\/tools.ietf.org\/html\/rfc2616#section-10",
	"title": "An error occurred",
	"detail": "property: Cette valeur ne doit pas être nulle.\nproperty: Cette valeur ne doit pas être vide.",
	"violations": [
		{
			"propertyPath": "property",
			"message": "Cette valeur ne doit pas être nulle.",
			"code": "ad32d13f-c3d4-423b-909a-857b961eb720"
		},
		{
			"propertyPath": "property",
			"message": "Cette valeur ne doit pas être vide.",
			"code": "c1051bb4-d103-4f74-8988-acbcafc7fdc3"
		}
	]
}
```




