### PR TITLE
Avoid php8 only syntax when possible

### DIFF
--- a/src/Util/ClientTrait80.php
+++ b/src/Util/ClientTrait80.php
@@ -15,7 +15,10 @@ namespace ApiPlatform\Core\Util;
 
 trait ClientTrait80
 {
-    public function withOptions(array $options): static
+    /**
+     * @return static
+     */
+    public function withOptions(array $options)
     {
         $clone = clone $this;
         $clone->defaultOptions = self::mergeDefaultOptions($options, $this->defaultOptions);

--- a/src/Util/ResponseTrait80.php
+++ b/src/Util/ResponseTrait80.php
@@ -15,7 +15,10 @@ namespace ApiPlatform\Core\Util;
 
 trait ResponseTrait80
 {
-    public function getInfo(?string $type = null): mixed
+    /**
+     * @return mixed
+     */
+    public function getInfo(?string $type = null)
     {
         if ($type) {
             return $this->info[$type] ?? null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6 <!-- see below -->
| Tickets       | #4614 <!-- please link related issues if existing -->
| License       | MIT

This resulted in phpstan to fail if the active PHP version is <8.0:
Internal error: syntax error, unexpected 'static' (T_STATIC)

In case a project depending on api-platform/core would use ClientTrait directly,
or indirectly, phpstan would try to parse it and fail with the above syntax error.

Move the type declarations into a comment instead.
