### PR TITLE
fix: Allow string in ApiResource attribute "validationGroups"

### DIFF
--- a/src/Annotation/ApiResource.php
+++ b/src/Annotation/ApiResource.php
@@ -168,7 +168,7 @@ final class ApiResource
      * @param bool         $stateless
      * @param string       $sunset                         https://api-platform.com/docs/core/deprecations/#setting-the-sunset-http-header-to-indicate-when-a-resource-or-an-operation-will-be-removed
      * @param array        $swaggerContext                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
-     * @param array        $validationGroups               https://api-platform.com/docs/core/validation/#using-validation-groups
+     * @param string|array $validationGroups               https://api-platform.com/docs/core/validation/#using-validation-groups
      * @param int          $urlGenerationStrategy
      *
      * @throws InvalidArgumentException
@@ -217,7 +217,7 @@ final class ApiResource
         ?bool $stateless = null,
         ?string $sunset = null,
         ?array $swaggerContext = null,
-        ?array $validationGroups = null,
+        $validationGroups = null,
         ?int $urlGenerationStrategy = null,
         ?bool $compositeIdentifier = null
     ) {


### PR DESCRIPTION
Technically a union type would be appropriate here but this needs PHP 8

| Q             | A
| ------------- | ---
| Branch?       | 2.6 <!-- see below -->
| Tickets       | #4632 <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/1497 <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
