### PR TITLE
GraphQL Fix: Apply filters to collection queries

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/graphql.xml
@@ -257,6 +257,7 @@
         <service id="api_platform.graphql.serializer.context_builder" class="ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilder" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="api_platform.filter_locator" />
         </service>
         <service id="ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilderInterface" alias="api_platform.graphql.serializer.context_builder" />
 

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -345,7 +345,7 @@ class ReadStageTest extends TestCase
             Argument::type(Request::class),
             true,
             [],
-            Argument::type('array'),
+            Argument::type('array')
         )->shouldBeCalledOnce();
 
         $filterLocatorProphecy = $this->prophesize();
@@ -359,7 +359,7 @@ class ReadStageTest extends TestCase
         $serializerContextBuilder = new SerializerContextBuilder(
             $resourceMetadataFactoryProphecy->reveal(),
             null,
-            $filterLocatorProphecy->reveal(),
+            $filterLocatorProphecy->reveal()
         );
 
         $this->resourceMetadataFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadata());

--- a/tests/GraphQl/Serializer/SerializerContextBuilderTest.php
+++ b/tests/GraphQl/Serializer/SerializerContextBuilderTest.php
@@ -33,6 +33,7 @@ class SerializerContextBuilderTest extends TestCase
     /** @var SerializerContextBuilder */
     private $serializerContextBuilder;
     private $resourceMetadataFactoryProphecy;
+    private $filterLocatorProphecy;
 
     /**
      * {@inheritdoc}
@@ -40,13 +41,18 @@ class SerializerContextBuilderTest extends TestCase
     protected function setUp(): void
     {
         $this->resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $this->filterLocatorProphecy = $this->prophesize()->willImplement('Psr\Container\ContainerInterface');
 
         $this->serializerContextBuilder = $this->buildSerializerContextBuilder();
     }
 
     private function buildSerializerContextBuilder(?AdvancedNameConverterInterface $advancedNameConverter = null): SerializerContextBuilder
     {
-        return new SerializerContextBuilder($this->resourceMetadataFactoryProphecy->reveal(), $advancedNameConverter ?? new CustomConverter());
+        return new SerializerContextBuilder(
+            $this->resourceMetadataFactoryProphecy->reveal(),
+            $advancedNameConverter ?? new CustomConverter(),
+            $this->filterLocatorProphecy->reveal()
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6 <!-- see below -->
| Tickets       | https://github.com/api-platform/core/issues/4615 <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | none, bug fix <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

## Problem
Custom filters extending `ApiPlatform\Core\Serializer\Filter\FilterInterface` are applied in REST but not GraphQL when using a custom data provider (i.e. not Doctrine). Specifically, the `FilterInterface::apply()` method does not seem to be called.

## Fix
Adds code to collect the filters in GraphQL similar to how they are collected in REST and call the `apply()` method of each filter.

Closes https://github.com/api-platform/core/issues/4615
