### PR TITLE
#4363 - [UI] export the SwaggerUIBundle object to allow extensions

### DIFF
--- a/src/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -148,4 +148,8 @@ window.onload = function() {
             }, 10000);
         });
     }
+
+    // Make SwaggerUIBundle and data available for some other scripts
+    window.swaggerUI = ui;
+    window.swaggerData = data;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #4643 
| License       | MIT
| Doc PR        | n/a 

----
Considering that:
1. It is allowed to [override the UI template](https://api-platform.com/docs/core/openapi/#overriding-the-ui-template)
2. In the `init-swagger-ui.js` released script, the SwaggerUIBundle that configures the UI should be exported to be used in another script file. 

This PR appends a simple 
```
window.swaggerUI = ui;
``` 
at the end of the `window.onload` function to make this object available for another script.

With the same goal, it also exports the `data` object to avoid any other script to parse the JSON one more time -)
```
window.swaggerData = data;
``` 
