### PR TITLE
fix(hydra): use iri-template instead of iri-reference

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -133,26 +133,26 @@ Feature: Documentation support
                     "properties": {
                         "@id": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "@type": {
                             "type": "string"
                         },
                         "hydra:first": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "hydra:last": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "hydra:previous": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "hydra:next": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         }
                     }
                 },

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -120,26 +120,26 @@ final class SchemaFactory implements SchemaFactoryInterface
                     'properties' => [
                         '@id' => [
                             'type' => 'string',
-                            'format' => 'iri-reference',
+                            'format' => 'iri-template',
                         ],
                         '@type' => [
                             'type' => 'string',
                         ],
                         'hydra:first' => [
                             'type' => 'string',
-                            'format' => 'iri-reference',
+                            'format' => 'iri-template',
                         ],
                         'hydra:last' => [
                             'type' => 'string',
-                            'format' => 'iri-reference',
+                            'format' => 'iri-template',
                         ],
                         'hydra:previous' => [
                             'type' => 'string',
-                            'format' => 'iri-reference',
+                            'format' => 'iri-template',
                         ],
                         'hydra:next' => [
                             'type' => 'string',
-                            'format' => 'iri-reference',
+                            'format' => 'iri-template',
                         ],
                     ],
                 ],

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -135,7 +135,7 @@ final class TypeFactory implements TypeFactoryInterface
         if (true !== $readableLink && $this->isResourceClass($className)) {
             return [
                 'type' => 'string',
-                'format' => 'iri-reference',
+                'format' => 'iri-template',
             ];
         }
 

--- a/tests/JsonSchema/TypeFactoryTest.php
+++ b/tests/JsonSchema/TypeFactoryTest.php
@@ -51,8 +51,8 @@ class TypeFactoryTest extends TestCase
         yield [['nullable' => true, 'type' => 'string', 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, true, \DateTimeImmutable::class)];
         yield [['type' => 'string', 'format' => 'duration'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateInterval::class)];
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
-        yield [['nullable' => true, 'type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
+        yield [['nullable' => true, 'type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable' => [
             ['nullable' => true, 'type' => 'array', 'items' => ['type' => 'string']],
@@ -172,8 +172,8 @@ class TypeFactoryTest extends TestCase
         yield [['type' => ['string', 'null'], 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, true, \DateTimeImmutable::class)];
         yield [['type' => 'string', 'format' => 'duration'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateInterval::class)];
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
-        yield [['type' => ['string', 'null'], 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
+        yield [['type' => ['string', 'null'], 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable' => [
             ['type' => ['array', 'null'], 'items' => ['type' => 'string']],
@@ -286,8 +286,8 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, true, \DateTimeImmutable::class)];
         yield [['type' => 'string', 'format' => 'duration'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateInterval::class)];
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable, but ignored in OpenAPI V2' => [
             ['type' => 'array', 'items' => ['type' => 'string']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | fix #4667 
| License       | MIT
| Doc PR        | /

I think it's better to use [iri-template](https://www.hydra-cg.com/spec/latest/core/#iri-template-operations) instead of iri-reference for some hydra properties. And it's fix #4667 

![image](https://user-images.githubusercontent.com/4849233/157192911-2c7e930a-4c23-4e47-8af8-b94751e20232.png)

https://github.com/Redocly/openapi-sampler/blob/3c10a2311f30b440359c8a3273a499e13e3bcbf1/src/samplers/string.js#L103-L124