### PR TITLE
perf(extension): Generate a subquery only if a where clause contains a one-to-many eager fetching

### DIFF
--- a/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
+++ b/src/Bridge/Doctrine/Orm/Extension/FilterEagerLoadingExtension.php
@@ -51,11 +51,7 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
         $em = $queryBuilder->getEntityManager();
         $classMetadata = $em->getClassMetadata($resourceClass);
 
-        if (!$this->shouldOperationForceEager($resourceClass, ['collection_operation_name' => $operationName]) && !$this->hasFetchEagerAssociation($em, $classMetadata)) {
-            return;
-        }
-
-        //If no where part, nothing to do
+        // If no where part, nothing to do
         $wherePart = $queryBuilder->getDQLPart('where');
 
         if (!$wherePart) {
@@ -64,8 +60,11 @@ final class FilterEagerLoadingExtension implements ContextAwareQueryCollectionEx
 
         $joinParts = $queryBuilder->getDQLPart('join');
         $originAlias = $queryBuilder->getRootAliases()[0];
-
         if (!$joinParts || !isset($joinParts[$originAlias])) {
+            return;
+        }
+
+        if (!$this->shouldOperationForceEager($resourceClass, ['collection_operation_name' => $operationName]) && !$this->hasFetchEagerOneToManyInWhere($queryBuilder, $classMetadata)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | #3267
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Accoding to this issue #944, we need to generate a subquery to fetch all wanted entries, when the "where" clause contains a one-to-many relations. But the fix to this issue is too large for me : it checks all the relations (one-to-many, many-to-one, and many-to-many) of the target entity if there are some "eager fetching". This behaviour can cause performance issues due to the subquery.

My fix is to limits the subquery generation to the cases that the joined table 
- is also used in the where clause
- and it has a one-to-many eager feching.
