### PR TITLE
fix: hydra:view example values

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -155,6 +155,14 @@ Feature: Documentation support
                             "type": "string",
                             "format": "iri-reference"
                         }
+                    },
+                    "example": {
+                        "@id": "string",
+                        "type": "string",
+                        "hydra:first": "string",
+                        "hydra:last": "string",
+                        "hydra:previous": "string",
+                        "hydra:next": "string"
                     }
                 },
                 "hydra:search": {

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -140,6 +140,14 @@ final class SchemaFactory implements SchemaFactoryInterface
                             'format' => 'iri-reference',
                         ],
                     ],
+                    'example' => [
+                        '@id' => 'string',
+                        'type' => 'string',
+                        'hydra:first' => 'string',
+                        'hydra:last' => 'string',
+                        'hydra:previous' => 'string',
+                        'hydra:next' => 'string',
+                    ],
                 ],
                 'hydra:search' => [
                     'type' => 'object',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #4354 #4394 #4667
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Hi,

I went ahead and checked what's the reason for this issue.


I can confirm that this is a Redoc issue that when property contains format `"iri-reference"`
<details>
  <summary>hydra:view propery</summary>
  
  ```javascript
  {
	"hydra:view": {
		"type": "object",
		"properties": {
			"@id": {
				"type": "string",
				"format": "iri-reference"
			},
			"@type": {
				"type": "string"
			},
			"hydra:first": {
				"type": "string",
				"format": "iri-reference"
			},
			"hydra:last": {
				"type": "string",
				"format": "iri-reference"
			},
			"hydra:previous": {
				"type": "string",
				"format": "iri-reference"
			},
			"hydra:next": {
				"type": "string",
				"format": "iri-reference"
			}
		}
	}
}
  ```
  
</details>

```json
{"type": "string", "format": "iri-reference"}
```

it's basically [returns sample values](https://github.com/Redocly/openapi-sampler/blob/3c10a2311f30b440359c8a3273a499e13e3bcbf1/src/samplers/string.js#L83-L85):

```javascript
function iriReferenceSample() {
  return '../словник';
}
```

If you remove `"iri-reference"` from the property, everything shows correctly.

The solution would be:

1. Remove `iri-reference` from `hydra:view` property (which isn't nice).
2. Add `example` values to `hydra:view`


This PR contains the 2. changes but it's kinda a BC probably.

Let me know if everything looks good.

Thanks!
