### PR TITLE
fix(symfony): fix swagger config to support Symfony ConfigBuilders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Symfony: Fix swagger config to support Symfony ConfigBuilders  (#4691)
+* [4691](https://github.com/api-platform/core/pull/4691) Symfony: Fix swagger config to support Symfony ConfigBuilders  (#4691)
 
 ## v3.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## v3.0.8
-
-### Bug fixes
-
-* [4691](https://github.com/api-platform/core/pull/4691) Symfony: Fix swagger config to support Symfony ConfigBuilders  (#4691)
-
 ## v3.0.7
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.0.8
+
+### Bug fixes
+
+* Symfony: Fix swagger config to support Symfony ConfigBuilders  (#4691)
+
 ## v3.0.7
 
 ### Bug fixes

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -16,6 +16,28 @@ Feature: Documentation support
     And the JSON node "info.title" should be equal to "My Dummy API"
     And the JSON node "info.description" should contain "This is a test API."
     And the JSON node "info.description" should contain "Made with love"
+    # Security Schemes
+    And the JSON node "components.securitySchemes" should be equal to:
+    """
+    {
+        "oauth": {
+            "type": "oauth2",
+            "description": "OAuth 2.0 implicit Grant",
+            "flows": {
+                "implicit": {
+                    "authorizationUrl": "http://my-custom-server/openid-connect/auth",
+                    "scopes": {}
+                }
+            }
+        },
+        "Some Authorization Name": {
+            "type": "apiKey",
+            "description": "Value for the Authorization header parameter.",
+            "name": "Authorization",
+            "in": "header"
+        }
+    }
+    """
     # Supported classes
     And the OpenAPI class "AbstractDummy" exists
     And the OpenAPI class "CircularReference" exists

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,8 @@ parameters:
 		- src/Symfony/Bundle/Test/Constraint/ArraySubset.php
 		- tests/Fixtures/app/AppKernel.php
 	excludePaths:
+		# Symfony config
+		- tests/Fixtures/app/config/config_swagger.php
 		# Symfony cache
 		- tests/Fixtures/app/var/
 		- tests/Fixtures/Symfony/Maker

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -278,6 +278,7 @@ final class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->arrayNode('api_keys')
+                            ->useAttributeAsKey('key')
                             ->prototype('array')
                                 ->children()
                                     ->scalarNode('name')

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -238,6 +238,8 @@ class AppKernel extends Kernel
             ],
         ]);
 
+        $loader->load(__DIR__.'/config/config_swagger.php');
+
         if ('mongodb' === $this->environment) {
             $c->prependExtensionConfig('api_platform', [
                 'mapping' => [
@@ -253,7 +255,5 @@ class AppKernel extends Kernel
                 'paths' => ['%kernel.project_dir%/../TestBundle/Resources/config/api_resources_orm'],
             ],
         ]);
-
-        $loader->load(__DIR__.'/config/config_swagger.php');
     }
 }

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -253,5 +253,7 @@ class AppKernel extends Kernel
                 'paths' => ['%kernel.project_dir%/../TestBundle/Resources/config/api_resources_orm'],
             ],
         ]);
+
+        $loader->load(__DIR__.'/config/config_swagger.php');
     }
 }

--- a/tests/Fixtures/app/config/config_swagger.php
+++ b/tests/Fixtures/app/config/config_swagger.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Config\ApiPlatformConfig;
+
+return static function (ApiPlatformConfig $apiPlatformConfig): void {
+    $apiPlatformConfig->swagger()->apiKeys('Some Authorization Name')
+        ->name('Authorization')
+        ->type('header');
+};

--- a/tests/Fixtures/app/config/config_swagger.php
+++ b/tests/Fixtures/app/config/config_swagger.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -288,13 +288,13 @@ class ConfigurationTest extends TestCase
         $config = $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [
                 'swagger' => [
-                    'api_keys' => [$exampleConfig],
+                    'api_keys' => ['key' => $exampleConfig],
                 ],
             ],
         ]);
 
         $this->assertArrayHasKey('api_keys', $config['swagger']);
-        $this->assertSame($exampleConfig, $config['swagger']['api_keys'][0]);
+        $this->assertSame($exampleConfig, $config['swagger']['api_keys']['key']);
     }
 
     /**

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -288,13 +288,13 @@ class ConfigurationTest extends TestCase
         $config = $this->processor->processConfiguration($this->configuration, [
             'api_platform' => [
                 'swagger' => [
-                    'api_keys' => ['key' => $exampleConfig],
+                    'api_keys' => ['Some Authorization name, like JWT' => $exampleConfig],
                 ],
             ],
         ]);
 
         $this->assertArrayHasKey('api_keys', $config['swagger']);
-        $this->assertSame($exampleConfig, $config['swagger']['api_keys']['key']);
+        $this->assertSame($exampleConfig, $config['swagger']['api_keys']['Some Authorization name, like JWT']);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | n/a
| License       | MIT
| Doc PR       | n/a

Please see https://symfony.com/doc/current/configuration.html#using-php-configbuilders and https://symfony.com/doc/current/components/config/definition.html#array-node-options