### PR TITLE
Remove @internal annotation from Client::getKernelBrowser()

### DIFF
--- a/src/Symfony/Bundle/Test/Client.php
+++ b/src/Symfony/Bundle/Test/Client.php
@@ -146,8 +146,6 @@ final class Client implements HttpClientInterface
 
     /**
      * Gets the underlying test client.
-     *
-     * @internal
      */
     public function getKernelBrowser(): KernelBrowser
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | none
| License       | MIT
| Doc PR        | none

Remove the @internal annotation from the test Client::getKernelBrowser so that other features of the KernelBrowser, such as user login, can be used without PHPStorm complaining about the usage of an internal method.