### PR TITLE
test date filter with invalid query

### DIFF
--- a/features/doctrine/date_filter.feature
+++ b/features/doctrine/date_filter.feature
@@ -507,6 +507,14 @@ Feature: Date filter on collections
     And the JSON node "hydra:member[1].dateIncludeNullBeforeAndAfter" should be null
 
   @createSchema
+  Scenario: Get collection filtered by wrong filter
+    Given there are 3 dummydate objects with nullable dateIncludeNullBeforeAndAfter
+    When I send a "GET" request to "/dummy_dates?dateIncludeNullBeforeAndAfter[before][]=2015-04-01"
+    Then the response status code should be 200
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON node "hydra:totalItems" should be equal to 0
+
+  @createSchema
   Scenario: Get collection filtered by date that is an immutable date variant
     Given there are 30 dummyimmutabledate objects with dummyDate
     When I send a "GET" request to "/dummy_immutable_dates?dummyDate[after]=2015-04-28"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | I don't know yet
| Tickets       | I don't know yet
| License       | MIT
| Doc PR        | api-platform/docs#... 

I wanted to filter data by several ranges of date.

I tried to use `?dateIncludeNullBeforeAndAfter[before][]=2015-04-01`, it doesn't work. This is the expected result since this feature doesn't exist.

The problem is that it threw an exception:

> Type error: Argument 6 passed to ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter::addWhere() must be of the type string, array given, called in vendor/api-platform/core/src/Bridge/Doctrine/Orm/Filter/DateFilter.php on line 88 (Behat\Testwork\Call\Exception\FatalThrowableError)

So I added a test to try to replicate this.

Maybe a type check should be added to avoid this exception.