### PR TITLE
fix(elasticsearch): remove deprecated type

### DIFF
--- a/src/Elasticsearch/State/CollectionProvider.php
+++ b/src/Elasticsearch/State/CollectionProvider.php
@@ -75,7 +75,6 @@ final class CollectionProvider implements ProviderInterface
 
         $documents = $this->client->search([
             'index' => $documentMetadata->getIndex(),
-            'type' => $documentMetadata->getType(),
             'body' => $body,
         ]);
 

--- a/src/Elasticsearch/State/ItemProvider.php
+++ b/src/Elasticsearch/State/ItemProvider.php
@@ -54,7 +54,6 @@ final class ItemProvider implements ProviderInterface
         try {
             $document = $this->client->get([
                 'index' => $documentMetadata->getIndex(),
-                'type' => $documentMetadata->getType(),
                 'id' => (string) reset($uriVariables),
             ]);
         } catch (Missing404Exception $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | [#... <!-- please link related issues if existing -->](https://github.com/api-platform/core/issues/4628)
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

This is just a small change to remove the `type` from the request, as it is deprecated (see issue). This is needed if you want to support Elasticsearch 8.0.

Let me know how you want to continue, and ill do the work and fix any failed tests. 
- Can i put a composer conflict on Elasticsearch < 6.0 (ES 5 is [EOL](https://www.elastic.co/support/eol) since 2019-03-11)
- Can i remove all references to `type` in the [DocumentMetaData](https://github.com/api-platform/core/blob/main/src/Elasticsearch/Metadata/Document/DocumentMetadata.php) and all classes which decorate this class?
