### PR TITLE
fix: ensure OpenAPI-specific implementation for nullable types does not influence the other ones

### DIFF
--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -169,10 +169,16 @@ final class TypeFactory implements TypeFactoryInterface
         }
 
         if (\array_key_exists('$ref', $jsonSchema)) {
-            return [
-                'nullable' => true,
-                'anyOf' => [$jsonSchema],
-            ];
+            $typeDefinition = ['anyOf' => [$jsonSchema]];
+
+            if ($schema && Schema::VERSION_JSON_SCHEMA === $schema->getVersion()) {
+                $typeDefinition['anyOf'][] = ['type' => 'null'];
+            } else {
+                // OpenAPI < 3.1
+                $typeDefinition['nullable'] = true;
+            }
+
+            return $typeDefinition;
         }
 
         if ($schema && Schema::VERSION_JSON_SCHEMA === $schema->getVersion()) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | main <!-- see below -->
| Tickets       | fix #4621 <!-- please link related issues if existing -->
| License       | MIT

Fixing a bug that prevents the `ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestAssertionsTrait::assertMatchesResourceItemJsonSchema()` method from validating against JSON-Schema correctly for some nullable properties.