### PR TITLE
fix(elasticsearch): verify whether mapping type is supported

### DIFF
--- a/src/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
+++ b/src/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
@@ -132,7 +132,7 @@ final class CollectionDataProvider implements ContextAwareCollectionDataProvider
             'body' => $body,
         ];
 
-        if (ElasticsearchVersion::supportsDocumentType()) {
+        if (ElasticsearchVersion::supportsMappingType()) {
             $params['type'] = $documentMetadata->getType();
         }
 

--- a/src/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
+++ b/src/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Elasticsearch\Exception\NonUniqueIdentifierException;
 use ApiPlatform\Elasticsearch\Extension\RequestBodySearchCollectionExtensionInterface;
 use ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
+use ApiPlatform\Elasticsearch\Util\ElasticsearchVersion;
 use ApiPlatform\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\State\Pagination\Pagination;
@@ -126,11 +127,16 @@ final class CollectionDataProvider implements ContextAwareCollectionDataProvider
         $limit = $body['size'] = $body['size'] ?? $this->pagination->getLimit($resourceClass, $operationName, $context);
         $offset = $body['from'] = $body['from'] ?? $this->pagination->getOffset($resourceClass, $operationName, $context);
 
-        $documents = $this->client->search([
+        $params = [
             'index' => $documentMetadata->getIndex(),
-            'type' => $documentMetadata->getType(),
             'body' => $body,
-        ]);
+        ];
+
+        if (ElasticsearchVersion::supportsDocumentType()) {
+            $params['type'] = $documentMetadata->getType();
+        }
+
+        $documents = $this->client->search($params);
 
         return new Paginator(
             $this->denormalizer,

--- a/src/Core/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Core/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -98,7 +98,7 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
                 'id' => (string) $id,
             ];
 
-            if (ElasticsearchVersion::supportsDocumentType()) {
+            if (ElasticsearchVersion::supportsMappingType()) {
                 $params['type'] = $documentMetadata->getType();
             }
 

--- a/src/Core/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Core/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -21,6 +21,7 @@ use ApiPlatform\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Elasticsearch\Exception\NonUniqueIdentifierException;
 use ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
 use ApiPlatform\Elasticsearch\Serializer\DocumentNormalizer;
+use ApiPlatform\Elasticsearch\Util\ElasticsearchVersion;
 use ApiPlatform\Exception\ResourceClassNotFoundException;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
@@ -92,11 +93,16 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
         $documentMetadata = $this->documentMetadataFactory->create($resourceClass);
 
         try {
-            $document = $this->client->get([
+            $params = [
                 'index' => $documentMetadata->getIndex(),
-                'type' => $documentMetadata->getType(),
                 'id' => (string) $id,
-            ]);
+            ];
+
+            if (ElasticsearchVersion::supportsDocumentType()) {
+                $params['type'] = $documentMetadata->getType();
+            }
+
+            $document = $this->client->get($params);
         } catch (Missing404Exception $e) {
             return null;
         }

--- a/src/Elasticsearch/State/CollectionProvider.php
+++ b/src/Elasticsearch/State/CollectionProvider.php
@@ -79,7 +79,7 @@ final class CollectionProvider implements ProviderInterface
             'body' => $body,
         ];
 
-        if (ElasticsearchVersion::supportsDocumentType()) {
+        if (ElasticsearchVersion::supportsMappingType()) {
             $params['type'] = $documentMetadata->getType();
         }
 

--- a/src/Elasticsearch/State/CollectionProvider.php
+++ b/src/Elasticsearch/State/CollectionProvider.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Elasticsearch\State;
 use ApiPlatform\Elasticsearch\Extension\RequestBodySearchCollectionExtensionInterface;
 use ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
 use ApiPlatform\Elasticsearch\Paginator;
+use ApiPlatform\Elasticsearch\Util\ElasticsearchVersion;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\ProviderInterface;
@@ -73,11 +74,16 @@ final class CollectionProvider implements ProviderInterface
         $limit = $body['size'] = $body['size'] ?? $this->pagination->getLimit($resourceClass, $operationName, $context);
         $offset = $body['from'] = $body['from'] ?? $this->pagination->getOffset($resourceClass, $operationName, $context);
 
-        $documents = $this->client->search([
+        $params = [
             'index' => $documentMetadata->getIndex(),
-            'type' => $documentMetadata->getType(),
             'body' => $body,
-        ]);
+        ];
+
+        if (ElasticsearchVersion::supportsDocumentType()) {
+            $params['type'] = $documentMetadata->getType();
+        }
+
+        $documents = $this->client->search($params);
 
         return new Paginator(
             $this->denormalizer,

--- a/src/Elasticsearch/State/ItemProvider.php
+++ b/src/Elasticsearch/State/ItemProvider.php
@@ -58,7 +58,7 @@ final class ItemProvider implements ProviderInterface
                 'id' => (string) reset($uriVariables),
             ];
 
-            if (ElasticsearchVersion::supportsDocumentType()) {
+            if (ElasticsearchVersion::supportsMappingType()) {
                 $params['type'] = $documentMetadata->getType();
             }
 

--- a/src/Elasticsearch/State/ItemProvider.php
+++ b/src/Elasticsearch/State/ItemProvider.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Elasticsearch\State;
 
 use ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
 use ApiPlatform\Elasticsearch\Serializer\DocumentNormalizer;
+use ApiPlatform\Elasticsearch\Util\ElasticsearchVersion;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Elasticsearch\Client;
@@ -52,11 +53,16 @@ final class ItemProvider implements ProviderInterface
         $documentMetadata = $this->documentMetadataFactory->create($resourceClass);
 
         try {
-            $document = $this->client->get([
+            $params = [
                 'index' => $documentMetadata->getIndex(),
-                'type' => $documentMetadata->getType(),
                 'id' => (string) reset($uriVariables),
-            ]);
+            ];
+
+            if (ElasticsearchVersion::supportsDocumentType()) {
+                $params['type'] = $documentMetadata->getType();
+            }
+
+            $document = $this->client->get($params);
         } catch (Missing404Exception $e) {
             return null;
         }

--- a/src/Elasticsearch/Util/ElasticsearchVersion.php
+++ b/src/Elasticsearch/Util/ElasticsearchVersion.php
@@ -17,9 +17,6 @@ use Elasticsearch\Client;
 
 class ElasticsearchVersion
 {
-    /**
-     * @see https://regex101.com/r/EWxpuO/2
-     */
     public const REGEX_PATTERN = '/\d(.*)/';
 
     /**

--- a/src/Elasticsearch/Util/ElasticsearchVersion.php
+++ b/src/Elasticsearch/Util/ElasticsearchVersion.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Elasticsearch\Util;
+
+use Elasticsearch\Client;
+
+class ElasticsearchVersion
+{
+    /**
+     * @see https://regex101.com/r/EWxpuO/2
+     */
+    public const REGEX_PATTERN = '/\d(.*)/';
+
+    public static function supportsDocumentType(string $version = Client::VERSION): bool
+    {
+        $matchResult = preg_match(self::REGEX_PATTERN, $version, $matches);
+
+        return is_int($matchResult) && $matchResult > 0 && (int) $matches[0] < 7;
+    }
+}

--- a/src/Elasticsearch/Util/ElasticsearchVersion.php
+++ b/src/Elasticsearch/Util/ElasticsearchVersion.php
@@ -22,10 +22,15 @@ class ElasticsearchVersion
      */
     public const REGEX_PATTERN = '/\d(.*)/';
 
-    public static function supportsDocumentType(string $version = Client::VERSION): bool
+    /**
+     * Detect whether the current ES version supports passing mapping type as a search parameter.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html#_schedule_for_removal_of_mapping_types
+     */
+    public static function supportsMappingType(string $version = Client::VERSION): bool
     {
         $matchResult = preg_match(self::REGEX_PATTERN, $version, $matches);
 
-        return is_int($matchResult) && $matchResult > 0 && (int) $matches[0] < 7;
+        return \is_int($matchResult) && $matchResult > 0 && (int) $matches[0] < 7;
     }
 }

--- a/tests/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProviderTest.php
+++ b/tests/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProviderTest.php
@@ -150,7 +150,6 @@ class CollectionDataProviderTest extends TestCase
             ->search(
                 Argument::allOf(
                     Argument::withEntry('index', 'foo'),
-                    Argument::withEntry('type', DocumentMetadata::DEFAULT_TYPE),
                     Argument::withEntry('body', Argument::allOf(
                         Argument::withEntry('size', 2),
                         Argument::withEntry('from', 0),
@@ -160,7 +159,7 @@ class CollectionDataProviderTest extends TestCase
                         )),
                         Argument::size(3)
                     )),
-                    Argument::size(3)
+                    Argument::size(2)
                 )
             )
             ->willReturn($documents)

--- a/tests/Core/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
+++ b/tests/Core/Bridge/Elasticsearch/DataProvider/ItemDataProviderTest.php
@@ -117,7 +117,7 @@ class ItemDataProviderTest extends TestCase
         $foo->setBar('erèinissor');
 
         $clientProphecy = $this->prophesize(Client::class);
-        $clientProphecy->get(['index' => 'foo', 'type' => DocumentMetadata::DEFAULT_TYPE, 'id' => '1'])->willReturn($document)->shouldBeCalled();
+        $clientProphecy->get(['index' => 'foo', 'id' => '1'])->willReturn($document)->shouldBeCalled();
 
         $denormalizerProphecy = $this->prophesize(DenormalizerInterface::class);
         $denormalizerProphecy->denormalize($document, Foo::class, DocumentNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])->willReturn($foo)->shouldBeCalled();
@@ -138,7 +138,7 @@ class ItemDataProviderTest extends TestCase
         $identifierExtractorProphecy->getIdentifierFromResourceClass(Foo::class)->willReturn('id')->shouldBeCalled();
 
         $clientProphecy = $this->prophesize(Client::class);
-        $clientProphecy->get(['index' => 'foo', 'type' => DocumentMetadata::DEFAULT_TYPE, 'id' => '404'])->willThrow(new Missing404Exception())->shouldBeCalled();
+        $clientProphecy->get(['index' => 'foo', 'id' => '404'])->willThrow(new Missing404Exception())->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
 

--- a/tests/Elasticsearch/State/CollectionProviderTest.php
+++ b/tests/Elasticsearch/State/CollectionProviderTest.php
@@ -108,7 +108,6 @@ final class CollectionProviderTest extends TestCase
             ->search(
                 Argument::allOf(
                     Argument::withEntry('index', 'foo'),
-                    Argument::withEntry('type', DocumentMetadata::DEFAULT_TYPE),
                     Argument::withEntry('body', Argument::allOf(
                         Argument::withEntry('size', 2),
                         Argument::withEntry('from', 0),
@@ -118,7 +117,7 @@ final class CollectionProviderTest extends TestCase
                         )),
                         Argument::size(3)
                     )),
-                    Argument::size(3)
+                    Argument::size(2)
                 )
             )
             ->willReturn($documents)

--- a/tests/Elasticsearch/State/ItemProviderTest.php
+++ b/tests/Elasticsearch/State/ItemProviderTest.php
@@ -73,7 +73,7 @@ final class ItemProviderTest extends TestCase
         $foo->setBar('erèinissor');
 
         $clientProphecy = $this->prophesize(Client::class);
-        $clientProphecy->get(['index' => 'foo', 'type' => DocumentMetadata::DEFAULT_TYPE, 'id' => '1'])->willReturn($document)->shouldBeCalled();
+        $clientProphecy->get(['index' => 'foo', 'id' => '1'])->willReturn($document)->shouldBeCalled();
 
         $denormalizerProphecy = $this->prophesize(DenormalizerInterface::class);
         $denormalizerProphecy->denormalize($document, Foo::class, DocumentNormalizer::FORMAT, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])->willReturn($foo)->shouldBeCalled();
@@ -89,7 +89,7 @@ final class ItemProviderTest extends TestCase
         $documentMetadataFactoryProphecy->create(Foo::class)->willReturn(new DocumentMetadata('foo'))->shouldBeCalled();
 
         $clientProphecy = $this->prophesize(Client::class);
-        $clientProphecy->get(['index' => 'foo', 'type' => DocumentMetadata::DEFAULT_TYPE, 'id' => '404'])->willThrow(new Missing404Exception())->shouldBeCalled();
+        $clientProphecy->get(['index' => 'foo', 'id' => '404'])->willThrow(new Missing404Exception())->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 

--- a/tests/Elasticsearch/Util/ElasticsearchVersionTest.php
+++ b/tests/Elasticsearch/Util/ElasticsearchVersionTest.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Tests\Elasticsearch\Util;
 
 use ApiPlatform\Elasticsearch\Util\ElasticsearchVersion;
@@ -12,7 +23,7 @@ class ElasticsearchVersionTest extends TestCase
      */
     public function testSupportsDocumentType(string $version, bool $expected): void
     {
-        self::assertSame($expected, ElasticsearchVersion::supportsDocumentType($version));
+        self::assertSame($expected, ElasticsearchVersion::supportsMappingType($version));
     }
 
     public function supportsDocumentTypeProvider(): \Generator

--- a/tests/Elasticsearch/Util/ElasticsearchVersionTest.php
+++ b/tests/Elasticsearch/Util/ElasticsearchVersionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ApiPlatform\Tests\Elasticsearch\Util;
+
+use ApiPlatform\Elasticsearch\Util\ElasticsearchVersion;
+use PHPUnit\Framework\TestCase;
+
+class ElasticsearchVersionTest extends TestCase
+{
+    /**
+     * @dataProvider supportsDocumentTypeProvider
+     */
+    public function testSupportsDocumentType(string $version, bool $expected): void
+    {
+        self::assertSame($expected, ElasticsearchVersion::supportsDocumentType($version));
+    }
+
+    public function supportsDocumentTypeProvider(): \Generator
+    {
+        yield 'ES 5' => ['5.5.0', true];
+        yield 'ES 5 dev' => ['5.x', true];
+        yield 'ES 6' => ['6.8.2', true];
+        yield 'ES 7' => ['7.17.0', false];
+        yield 'ES 8' => ['8.1.0', false];
+        yield 'ES 8 dev' => ['8.x', false];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | https://github.com/api-platform/core/issues/4628
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

supersedes https://github.com/api-platform/core/pull/4720

I propose to remove the mapping `type` from the search for certain ES versions, as is deprecated in ES 7 and removed in ES 8 (see [issue](https://github.com/api-platform/core/issues/4628)).

The `type` can still be passed in ES 7 but serves [no purpose](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html#_schedule_for_removal_of_mapping_types) anymore. Thats why the `type` will only be passed on ES 6 and lower so deprecations are not triggered.
