### PR TITLE
chore(deprecation): missing bc flag parameter

### DIFF
--- a/src/Core/EventListener/WriteListener.php
+++ b/src/Core/EventListener/WriteListener.php
@@ -47,7 +47,7 @@ final class WriteListener
     private $iriConverter;
     private $metadataBackwardCompatibilityLayer;
 
-    public function __construct(DataPersisterInterface $dataPersister, $iriConverter = null, ResourceMetadataFactoryInterface $resourceMetadataFactory = null, ResourceClassResolverInterface $resourceClassResolver = null, ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null, bool $metadataBackwardCompatibilityLayer = null)
+    public function __construct(DataPersisterInterface $dataPersister, $iriConverter = null, ResourceMetadataFactoryInterface $resourceMetadataFactory = null, ResourceClassResolverInterface $resourceClassResolver = null, ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null, ?bool $metadataBackwardCompatibilityLayer = null)
     {
         $this->dataPersister = $dataPersister;
         $this->iriConverter = $iriConverter;

--- a/src/Core/Metadata/Property/Factory/AnnotationPropertyMetadataFactory.php
+++ b/src/Core/Metadata/Property/Factory/AnnotationPropertyMetadataFactory.php
@@ -40,7 +40,7 @@ final class AnnotationPropertyMetadataFactory implements PropertyMetadataFactory
      */
     public function create(string $resourceClass, string $property, array $options = []): PropertyMetadata
     {
-        if (false === ($options['deprecate'] ?? null)) {
+        if (null === ($options['deprecate'] ?? null)) {
             trigger_deprecation('api-platform/core', '2.7', sprintf('Decorating the legacy %s is deprecated, use %s instead.', PropertyMetadataFactoryInterface::class, \ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface::class));
         }
 

--- a/src/Core/Operation/Factory/SubresourceOperationFactory.php
+++ b/src/Core/Operation/Factory/SubresourceOperationFactory.php
@@ -50,8 +50,6 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
      */
     public function create(string $resourceClass): array
     {
-        trigger_deprecation('api-platform/core', '2.7', 'Subresources are deprecated, use alternate URLs instead.');
-
         $tree = [];
 
         try {
@@ -78,12 +76,13 @@ final class SubresourceOperationFactory implements SubresourceOperationFactoryIn
         }
 
         foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
-            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property);
+            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, ['deprecate' => false]);
 
             if (!$subresource = $propertyMetadata->getSubresource()) {
                 continue;
             }
 
+            trigger_deprecation('api-platform/core', '2.7', sprintf('A subresource is declared on "%s::%s". Subresources are deprecated, use another #[ApiResource] instead.', $resourceClass, $property));
             $subresourceClass = $subresource->getResourceClass();
             $subresourceMetadata = $this->resourceMetadataFactory->create($subresourceClass);
             $subresourceMetadata = $subresourceMetadata->withAttributes(($subresourceMetadata->getAttributes() ?: []) + ['identifiers' => !$this->identifiersExtractor ? [$property] : $this->identifiersExtractor->getIdentifiersFromResourceClass($subresourceClass)]);

--- a/src/Symfony/Bundle/Resources/config/v3/backward_compatibility.xml
+++ b/src/Symfony/Bundle/Resources/config/v3/backward_compatibility.xml
@@ -27,6 +27,8 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
+            <argument>%api_platform.metadata_backward_compatibility_layer%</argument>
 
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="32" />
         </service>

--- a/tests/Core/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Core/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -275,8 +275,8 @@ class ApiLoaderTest extends TestCase
         $propertyNameCollectionFactoryProphecy->create(RelatedDummyEntity::class)->willReturn(new PropertyNameCollection(['id', 'recursivesubresource', 'secondrecursivesubresource']));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'id')->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'id')->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'id', Argument::type('array'))->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'id', Argument::type('array'))->willReturn(new PropertyMetadata());
 
         $relatedType = new Type(Type::BUILTIN_TYPE_OBJECT, false, RelatedDummyEntity::class);
 
@@ -285,21 +285,21 @@ class ApiLoaderTest extends TestCase
                                         ->withType(new Type(Type::BUILTIN_TYPE_ARRAY, false, \ArrayObject::class, true, null, $relatedType));
 
         if (false === $recursiveSubresource) {
-            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource')->willReturn(new PropertyMetadata());
-            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource')->willReturn(new PropertyMetadata());
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource', Argument::type('array'))->willReturn(new PropertyMetadata());
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource', Argument::type('array'))->willReturn(new PropertyMetadata());
         } else {
             $dummyType = new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyEntity::class);
-            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource')
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'recursivesubresource', Argument::type('array'))
                 ->willReturn((new PropertyMetadata())
                 ->withSubresource(new SubresourceMetadata(DummyEntity::class, false))
                 ->withType($dummyType));
-            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource')
+            $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'secondrecursivesubresource', Argument::type('array'))
                 ->willReturn((new PropertyMetadata())
                 ->withSubresource(new SubresourceMetadata(DummyEntity::class, false))
                 ->withType($dummyType));
         }
 
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->willReturn($subResourcePropertyMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->willReturn($subResourcePropertyMetadata);
 
         $operationPathResolver = new CustomOperationPathResolver(new OperationPathResolver(new UnderscorePathSegmentNameGenerator()));
 

--- a/tests/Core/Operation/Factory/SubresourceOperationFactoryTest.php
+++ b/tests/Core/Operation/Factory/SubresourceOperationFactoryTest.php
@@ -29,6 +29,7 @@ use ApiPlatform\Tests\Fixtures\DummyValidatedEntity;
 use ApiPlatform\Tests\Fixtures\RelatedDummyEntity;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
@@ -36,10 +37,12 @@ use Prophecy\Argument;
  */
 class SubresourceOperationFactoryTest extends TestCase
 {
+    use ExpectDeprecationTrait;
     use ProphecyTrait;
 
     public function testCreate()
     {
+        $this->expectDeprecation('Since api-platform/core 2.7: A subresource is declared on "ApiPlatform\Tests\Fixtures\DummyEntity::subresource". Subresources are deprecated, use another #[ApiResource] instead.');
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(RelatedDummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('relatedDummyEntity'));
         $resourceMetadataFactoryProphecy->create(DummyEntity::class)->shouldBeCalled()->willReturn(new ResourceMetadata('dummyEntity'));
@@ -53,11 +56,11 @@ class SubresourceOperationFactoryTest extends TestCase
         $anotherSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'foo')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadata);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subcollection')->shouldBeCalled()->willReturn($subresourceMetadataCollection);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource')->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'foo', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subcollection', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollection);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresource');
@@ -192,11 +195,11 @@ class SubresourceOperationFactoryTest extends TestCase
         $anotherSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'foo')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadata);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subcollection')->shouldBeCalled()->willReturn($subresourceMetadataCollection);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource')->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'foo', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subcollection', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollection);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('subresource', false)->shouldBeCalled()->willReturn('subresource');
@@ -323,9 +326,9 @@ class SubresourceOperationFactoryTest extends TestCase
         $anotherSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource')->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -386,11 +389,11 @@ class SubresourceOperationFactoryTest extends TestCase
         $moreSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'secondSubresource')->shouldBeCalled()->willReturn($secondSubresourceMetadata);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource')->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
-        $propertyMetadataFactoryProphecy->create(DummyValidatedEntity::class, 'moreSubresource')->shouldBeCalled()->willReturn($moreSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'secondSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($secondSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyValidatedEntity::class, 'moreSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($moreSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -484,11 +487,11 @@ class SubresourceOperationFactoryTest extends TestCase
         $moreSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'secondSubresource')->shouldBeCalled()->willReturn($secondSubresourceMetadata);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource')->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
-        $propertyMetadataFactoryProphecy->create(DummyValidatedEntity::class, 'moreSubresource')->shouldBeCalled()->willReturn($moreSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'secondSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($secondSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyValidatedEntity::class, 'moreSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($moreSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -554,7 +557,7 @@ class SubresourceOperationFactoryTest extends TestCase
         $subresource = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresource);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresource);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -611,8 +614,8 @@ class SubresourceOperationFactoryTest extends TestCase
         $secondSubresourceWithMaxDepthMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false, 1));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceWithMaxDepthMetadata);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'secondSubresource')->shouldBeCalled()->willReturn($secondSubresourceWithMaxDepthMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceWithMaxDepthMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'secondSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($secondSubresourceWithMaxDepthMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -694,8 +697,8 @@ class SubresourceOperationFactoryTest extends TestCase
         $identifierSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false))->withIdentifier(true);
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadataCollection);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'id')->shouldBeCalled()->willReturn($identifierSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollection);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'id', Argument::type('array'))->shouldBeCalled()->willReturn($identifierSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -762,8 +765,8 @@ class SubresourceOperationFactoryTest extends TestCase
         $identifierSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false))->withIdentifier(true);
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadataCollection);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'id')->shouldBeCalled()->willReturn($identifierSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollection);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'id', Argument::type('array'))->shouldBeCalled()->willReturn($identifierSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -814,9 +817,9 @@ class SubresourceOperationFactoryTest extends TestCase
         $anotherSubresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(DummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar')->shouldBeCalled()->willReturn(new PropertyMetadata());
-        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource')->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadataCollectionWithMaxDepth);
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'bar', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyMetadata());
+        $propertyMetadataFactoryProphecy->create(RelatedDummyEntity::class, 'anotherSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($anotherSubresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -870,8 +873,8 @@ class SubresourceOperationFactoryTest extends TestCase
         $otherSubresourceSubresource = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresource);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'otherSubresource')->shouldBeCalled()->willReturn($otherSubresourceSubresource);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresource);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'otherSubresource', Argument::type('array'))->shouldBeCalled()->willReturn($otherSubresourceSubresource);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');
@@ -943,7 +946,7 @@ class SubresourceOperationFactoryTest extends TestCase
         $subresourceMetadata = (new PropertyMetadata())->withSubresource(new SubresourceMetadata(RelatedDummyEntity::class, false));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource')->shouldBeCalled()->willReturn($subresourceMetadata);
+        $propertyMetadataFactoryProphecy->create(DummyEntity::class, 'subresource', Argument::type('array'))->shouldBeCalled()->willReturn($subresourceMetadata);
 
         $pathSegmentNameGeneratorProphecy = $this->prophesize(PathSegmentNameGeneratorInterface::class);
         $pathSegmentNameGeneratorProphecy->getSegmentName('dummyEntity')->shouldBeCalled()->willReturn('dummy_entities');


### PR DESCRIPTION
Also triggers a deprecation only when the legacy resource is found. 

TODO: 
- [x] add a test for these deprecations