### PR TITLE
feat: improve iri converter interface

### DIFF
--- a/.github/patch/v3_features.patch
+++ b/.github/patch/v3_features.patch
@@ -1,0 +1,141 @@
+diff --git a/features/jsonld/input_output.feature b/features/jsonld/input_output.feature
+index ad7ee0344..f05fef8bf 100644
+--- a/features/jsonld/input_output.feature
++++ b/features/jsonld/input_output.feature
+@@ -65,7 +65,7 @@ Feature: JSON-LD DTO input and output
+     """
+     {
+       "@context": "/contexts/DummyDtoCustom",
+-      "@id": "/dummy_dto_customs",
++      "@id": "/dummy_dto_custom_output",
+       "@type": "hydra:Collection",
+       "hydra:member": [
+         {
+diff --git a/features/main/custom_identifier_with_subresource.feature b/features/main/custom_identifier_with_subresource.feature
+index cf18a15a3..773dd8728 100644
+--- a/features/main/custom_identifier_with_subresource.feature
++++ b/features/main/custom_identifier_with_subresource.feature
+@@ -84,7 +84,7 @@ Feature: Using custom parent identifier for subresources
+     """
+     {
+       "@context": "/contexts/SlugParentDummy",
+-      "@id": "/slug_parent_dummies/parent-dummy",
++      "@id": "/slug_child_dummies/child-dummy/parent_dummy",
+       "@type": "SlugParentDummy",
+       "id": 1,
+       "slug": "parent-dummy",
+diff --git a/features/main/custom_operation.feature b/features/main/custom_operation.feature
+index 6b8e4a7bc..9fa829ec5 100644
+--- a/features/main/custom_operation.feature
++++ b/features/main/custom_operation.feature
+@@ -64,7 +64,7 @@ Feature: Custom operation
+     """
+     {
+         "@context": "/contexts/CustomActionDummy",
+-        "@id": "/custom_action_dummies/1",
++        "@id": "/custom_action_collection_dummies/1",
+         "@type": "CustomActionDummy",
+         "id": 1,
+         "foo": "custom!"
+diff --git a/features/main/default_order.feature b/features/main/default_order.feature
+index 1bc97ab37..912110143 100644
+--- a/features/main/default_order.feature
++++ b/features/main/default_order.feature
+@@ -127,7 +127,7 @@ Feature: Default order
+     """
+     {
+       "@context": "/contexts/Foo",
+-      "@id": "/foos",
++      "@id": "/custom_collection_asc_foos",
+       "@type": "hydra:Collection",
+       "hydra:member": [
+         {
+@@ -183,7 +183,7 @@ Feature: Default order
+     """
+     {
+       "@context": "/contexts/Foo",
+-      "@id": "/foos",
++      "@id": "/custom_collection_desc_foos",
+       "@type": "hydra:Collection",
+       "hydra:member": [
+         {
+diff --git a/features/main/operation.feature b/features/main/operation.feature
+index 24dda9b87..8786f6b04 100644
+--- a/features/main/operation.feature
++++ b/features/main/operation.feature
+@@ -47,7 +47,7 @@ Feature: Operation support
+     """
+     {
+       "@context": "/contexts/EmbeddedDummy",
+-      "@id": "/embedded_dummies/1",
++      "@id": "/embedded_dummies_groups/1",
+       "@type": "EmbeddedDummy",
+       "name": "Dummy #1",
+       "embeddedDummy": {
+@@ -76,7 +76,7 @@ Feature: Operation support
+     """
+     {
+         "@context": "/contexts/Book",
+-        "@id": "/books/1",
++        "@id": "/books/by_isbn/9780451524935",
+         "@type": "Book",
+         "name": "1984",
+         "isbn": "9780451524935",
+diff --git a/features/main/subresource.feature b/features/main/subresource.feature
+index ae4969a5a..2fd278ea0 100644
+--- a/features/main/subresource.feature
++++ b/features/main/subresource.feature
+@@ -13,7 +13,7 @@ Feature: Subresource support
+     """
+     {
+       "@context": "/contexts/Answer",
+-      "@id": "/answers/1",
++      "@id": "/questions/1/answer",
+       "@type": "Answer",
+       "id": 1,
+       "content": "42",
+@@ -234,7 +234,7 @@ Feature: Subresource support
+     """
+     {
+       "@context": "/contexts/RelatedDummy",
+-      "@id": "/related_dummies/2",
++      "@id": "/dummies/1/related_dummies/2",
+       "@type": "https://schema.org/Product",
+       "id": 2,
+       "name": null,
+@@ -274,7 +274,7 @@ Feature: Subresource support
+     """
+     {
+       "@context": "/contexts/ThirdLevel",
+-      "@id": "/third_levels/1",
++      "@id": "/dummies/1/related_dummies/1/third_level",
+       "@type": "ThirdLevel",
+       "fourthLevel": "/fourth_levels/1",
+       "badFourthLevel": null,
+@@ -293,7 +293,7 @@ Feature: Subresource support
+     """
+     {
+       "@context": "/contexts/FourthLevel",
+-      "@id": "/fourth_levels/1",
++      "@id": "/dummies/1/related_dummies/1/third_level/fourth_level",
+       "@type": "FourthLevel",
+       "badThirdLevel": [],
+       "id": 1,
+@@ -411,7 +411,7 @@ Feature: Subresource support
+     """
+     {
+       "@context": "/contexts/Dummy",
+-      "@id": "/dummies/1",
++      "@id": "/related_owned_dummies/1/owning_dummy",
+       "@type": "Dummy",
+       "description": null,
+       "dummy": null,
+@@ -444,7 +444,7 @@ Feature: Subresource support
+     """
+     {
+       "@context": "/contexts/Dummy",
+-      "@id": "/dummies/1",
++      "@id": "/related_owning_dummies/1/owned_dummy",
+       "@type": "Dummy",
+       "description": null,
+       "dummy": null,

--- a/.github/patch/v3_features.patch
+++ b/.github/patch/v3_features.patch
@@ -24,19 +24,6 @@ index cf18a15a3..773dd8728 100644
        "@type": "SlugParentDummy",
        "id": 1,
        "slug": "parent-dummy",
-diff --git a/features/main/custom_operation.feature b/features/main/custom_operation.feature
-index 6b8e4a7bc..9fa829ec5 100644
---- a/features/main/custom_operation.feature
-+++ b/features/main/custom_operation.feature
-@@ -64,7 +64,7 @@ Feature: Custom operation
-     """
-     {
-         "@context": "/contexts/CustomActionDummy",
--        "@id": "/custom_action_dummies/1",
-+        "@id": "/custom_action_collection_dummies/1",
-         "@type": "CustomActionDummy",
-         "id": 1,
-         "foo": "custom!"
 diff --git a/features/main/default_order.feature b/features/main/default_order.feature
 index 1bc97ab37..912110143 100644
 --- a/features/main/default_order.feature

--- a/.github/patch/v3_features.patch
+++ b/.github/patch/v3_features.patch
@@ -24,6 +24,19 @@ index cf18a15a3..773dd8728 100644
        "@type": "SlugParentDummy",
        "id": 1,
        "slug": "parent-dummy",
+diff --git a/features/main/custom_operation.feature b/features/main/custom_operation.feature
+index 6b8e4a7bc..9fa829ec5 100644
+--- a/features/main/custom_operation.feature
++++ b/features/main/custom_operation.feature
+@@ -64,7 +64,7 @@ Feature: Custom operation
+     """
+     {
+         "@context": "/contexts/CustomActionDummy",
+-        "@id": "/custom_action_dummies/1",
++        "@id": "/custom_action_collection_dummies/1",
+         "@type": "CustomActionDummy",
+         "id": 1,
+         "foo": "custom!"
 diff --git a/features/main/default_order.feature b/features/main/default_order.feature
 index 1bc97ab37..912110143 100644
 --- a/features/main/default_order.feature

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,8 +818,11 @@ jobs:
       - name: Convert metadata to API Platform 3
         run: |
             tests/Fixtures/app/console api:upgrade-resource -f
-      - name: Clear test app cache
-        run: rm -Rf tests/Fixtures/app/var/cache/*
+      - name: Apply behat features patch (IRIs update)
+        run: |
+            git apply .github/patch/v3_features.patch
+      - name: clear test app cache
+        run: rm -rf tests/Fixtures/app/var/cache/*
       - name: Run Behat tests
         run: |
           mkdir -p build/logs/behat
@@ -901,6 +904,9 @@ jobs:
       - name: Convert metadata to API Platform 3
         run: |
             tests/Fixtures/app/console api:upgrade-resource -f
+      - name: Apply behat features patch (IRIs update)
+        run: |
+            git apply .github/patch/v3_features.patch
       - name: Clear test app cache
         run: rm -Rf tests/Fixtures/app/var/cache/*
       - name: Run Behat tests

--- a/features/main/crud_uri_variables.feature
+++ b/features/main/crud_uri_variables.feature
@@ -169,7 +169,7 @@ Feature: Uri Variables
     """
     {
         "@context": "/contexts/Company",
-        "@id": "/companies/1",
+        "@id": "/employees/1/company",
         "@type": "Company",
         "id": 1,
         "name": "Foo Company 1",

--- a/src/Api/IdentifiersExtractorInterface.php
+++ b/src/Api/IdentifiersExtractorInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Api;
 
 use ApiPlatform\Exception\RuntimeException;
+use ApiPlatform\Metadata\Operation;
 
 /**
  * Extracts identifiers for a given Resource according to the retrieved Metadata.
@@ -29,5 +30,5 @@ interface IdentifiersExtractorInterface
      *
      * @throws RuntimeException
      */
-    public function getIdentifiersFromItem($item, ?string $operationName = null, array $context = []): array;
+    public function getIdentifiersFromItem($item, ?Operation $operation = null, array $context = []): array;
 }

--- a/src/Api/IriConverterInterface.php
+++ b/src/Api/IriConverterInterface.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Api;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Exception\ItemNotFoundException;
 use ApiPlatform\Exception\RuntimeException;
+use ApiPlatform\Metadata\Operation;
 
 /**
  * Converts item and resources to IRI and vice versa.
@@ -32,7 +33,7 @@ interface IriConverterInterface
      *
      * @return object
      */
-    public function getItemFromIri(string $iri, array $context = []);
+    public function getItemFromIri(string $iri, array $context = [], ?Operation $operation = null);
 
     /**
      * Gets the IRI associated with the given item.
@@ -42,12 +43,5 @@ interface IriConverterInterface
      * @throws InvalidArgumentException
      * @throws RuntimeException
      */
-    public function getIriFromItem($item, string $operationName = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): string;
-
-    /**
-     * Gets the IRI associated with the given resource collection.
-     *
-     * @throws InvalidArgumentException
-     */
-    public function getIriFromResourceClass(string $resourceClass, string $operationName = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): string;
+    public function getIriFromItem($item = null, ?Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string;
 }

--- a/src/Api/IriConverterInterface.php
+++ b/src/Api/IriConverterInterface.php
@@ -33,15 +33,15 @@ interface IriConverterInterface
      *
      * @return object
      */
-    public function getItemFromIri(string $iri, array $context = [], ?Operation $operation = null);
+    public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null);
 
     /**
      * Gets the IRI associated with the given item.
      *
-     * @param object|iterable $item
+     * @param object|class-string $resource
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException
      */
-    public function getIriFromItem($item, ?Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string;
+    public function getIriFromResource($resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): ?string;
 }

--- a/src/Api/IriConverterInterface.php
+++ b/src/Api/IriConverterInterface.php
@@ -38,10 +38,10 @@ interface IriConverterInterface
     /**
      * Gets the IRI associated with the given item.
      *
-     * @param object $item
+     * @param object|array $item
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException
      */
-    public function getIriFromItem($item = null, ?Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string;
+    public function getIriFromItem($item, ?Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string;
 }

--- a/src/Api/IriConverterInterface.php
+++ b/src/Api/IriConverterInterface.php
@@ -38,7 +38,7 @@ interface IriConverterInterface
     /**
      * Gets the IRI associated with the given item.
      *
-     * @param object|array $item
+     * @param object|iterable $item
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException

--- a/src/Core/EventListener/WriteListener.php
+++ b/src/Core/EventListener/WriteListener.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
-use ApiPlatform\Core\Api\IriConverterInterface as IriConverterLegacyInterface;
+use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Core\Api\ResourceClassResolverInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
@@ -43,7 +43,7 @@ final class WriteListener
     public const OPERATION_ATTRIBUTE_KEY = 'write';
 
     private $dataPersister;
-    /** @var IriConverterLegacyInterface|IriConverterInterface|null */
+    /** @var LegacyIriConverterInterface|IriConverterInterface|null */
     private $iriConverter;
     private $metadataBackwardCompatibilityLayer;
 
@@ -121,7 +121,7 @@ final class WriteListener
                 }
 
                 if ($this->isResourceClass($this->getObjectClass($controllerResult))) {
-                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
+                    $request->attributes->set('_api_write_item_iri', $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($controllerResult) : $this->iriConverter->getIriFromResource($controllerResult));
                 }
 
                 break;

--- a/src/Core/Swagger/Serializer/DocumentationNormalizer.php
+++ b/src/Core/Swagger/Serializer/DocumentationNormalizer.php
@@ -395,7 +395,6 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
 
             if (
                 ($resourceMetadata->getAttributes()['extra_properties']['is_legacy_subresource'] ?? false) ||
-                ($resourceMetadata->getAttributes()['extra_properties']['legacy_subresource_behavior'] ?? false) ||
                 ($resourceMetadata->getAttributes()['extra_properties']['is_alternate_resource_metadata'] ?? false)) {
                 // Avoid duplicates parameters when there is a filter on a subresource identifier
                 $parametersMemory = [];

--- a/src/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -30,6 +30,9 @@ trait SearchFilterTrait
 {
     use PropertyHelperTrait;
 
+    /**
+     * @var LegacyIriConverterInterface|IriConverterInterface
+     */
     protected $iriConverter;
     protected $propertyAccessor;
     protected $identifiersExtractor;
@@ -124,7 +127,8 @@ trait SearchFilterTrait
     protected function getIdFromValue(string $value)
     {
         try {
-            $item = $this->getIriConverter()->getItemFromIri($value, ['fetch_data' => false]);
+            $iriConverter = $this->getIriConverter();
+            $item = $iriConverter instanceof LegacyIriConverterInterface ? $iriConverter->getItemFromIri($value, ['fetch_data' => false]) : $this->iriConverter->getResourceFromIri($value, ['fetch_data' => false]);
 
             return $this->getPropertyAccessor()->getValue($item, 'id');
         } catch (InvalidArgumentException $e) {

--- a/src/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -128,7 +128,7 @@ trait SearchFilterTrait
     {
         try {
             $iriConverter = $this->getIriConverter();
-            $item = $iriConverter instanceof LegacyIriConverterInterface ? $iriConverter->getItemFromIri($value, ['fetch_data' => false]) : $this->iriConverter->getResourceFromIri($value, ['fetch_data' => false]);
+            $item = $iriConverter instanceof LegacyIriConverterInterface ? $iriConverter->getItemFromIri($value, ['fetch_data' => false]) : $iriConverter->getResourceFromIri($value, ['fetch_data' => false]); // @phpstan-ignore-line bc-compatibility inside a trait
 
             return $this->getPropertyAccessor()->getValue($item, 'id');
         } catch (InvalidArgumentException $e) {

--- a/src/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -100,7 +100,7 @@ final class PublishMercureUpdatesListener
                 new ExpressionFunction('iri', static function (string $apiResource, int $referenceType = UrlGeneratorInterface::ABS_URL): string {
                     return sprintf('iri(%s, %d)', $apiResource, $referenceType);
                 }, static function (array $arguments, $apiResource, int $referenceType = UrlGeneratorInterface::ABS_URL) use ($iriConverter): string {
-                    return $iriConverter->getIriFromItem($apiResource, null, $referenceType);
+                    return $iriConverter->getIriFromResource($apiResource, $referenceType);
                 })
             );
         }
@@ -245,8 +245,8 @@ final class PublishMercureUpdatesListener
 
         if ('deletedObjects' === $property) {
             $this->deletedObjects[(object) [
-                'id' => $this->iriConverter->getIriFromItem($object),
-                'iri' => $this->iriConverter->getIriFromItem($object, null, UrlGeneratorInterface::ABS_URL),
+                'id' => $this->iriConverter->getIriFromResource($object),
+                'iri' => $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_URL),
             ]] = $options;
 
             return;
@@ -271,7 +271,7 @@ final class PublishMercureUpdatesListener
             $resourceClass = $this->getObjectClass($object);
             $context = $options['normalization_context'] ?? $this->resourceMetadataFactory->create($resourceClass)->getOperation()->getNormalizationContext() ?? [];
 
-            $iri = $options['topics'] ?? $this->iriConverter->getIriFromItem($object, null, UrlGeneratorInterface::ABS_URL);
+            $iri = $options['topics'] ?? $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_URL);
             $data = $options['data'] ?? $this->serializer->serialize($object, key($this->formats), $context);
         }
 

--- a/src/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -119,7 +119,7 @@ final class PurgeHttpCacheListener
     {
         try {
             $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
-            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem(null, (new GetCollection())->withClass($resourceClass));
+            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem([], (new GetCollection())->withClass($resourceClass));
             $this->tags[$iri] = $iri;
 
             if ($purgeItem) {

--- a/src/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Doctrine\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface;
+use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Exception\OperationNotFoundException;
@@ -119,7 +120,7 @@ final class PurgeHttpCacheListener
     {
         try {
             $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
-            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem([], (new GetCollection())->withClass($resourceClass));
+            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_PATH, new GetCollection());
             $this->tags[$iri] = $iri;
 
             if ($purgeItem) {
@@ -164,7 +165,7 @@ final class PurgeHttpCacheListener
     {
         try {
             // TODO: test if this is a resource class
-            $iri = $this->iriConverter->getIriFromItem($value);
+            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($value) : $this->iriConverter->getIriFromResource($value);
             $this->tags[$iri] = $iri;
         } catch (RuntimeException|InvalidArgumentException $e) {
         }

--- a/src/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -20,6 +20,7 @@ use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Exception\OperationNotFoundException;
 use ApiPlatform\Exception\RuntimeException;
 use ApiPlatform\HttpCache\PurgerInterface;
+use ApiPlatform\Metadata\GetCollection;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
@@ -118,7 +119,7 @@ final class PurgeHttpCacheListener
     {
         try {
             $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
-            $iri = $this->iriConverter->getIriFromResourceClass($resourceClass);
+            $iri = $this->iriConverter->getIriFromItem(null, (new GetCollection())->withClass($resourceClass));
             $this->tags[$iri] = $iri;
 
             if ($purgeItem) {

--- a/src/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -119,7 +119,7 @@ final class PurgeHttpCacheListener
     {
         try {
             $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
-            $iri = $this->iriConverter->getIriFromItem(null, (new GetCollection())->withClass($resourceClass));
+            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem(null, (new GetCollection())->withClass($resourceClass));
             $this->tags[$iri] = $iri;
 
             if ($purgeItem) {

--- a/src/Elasticsearch/Filter/AbstractSearchFilter.php
+++ b/src/Elasticsearch/Filter/AbstractSearchFilter.php
@@ -158,7 +158,7 @@ abstract class AbstractSearchFilter extends AbstractFilter implements ConstantSc
     protected function getIdentifierValue(string $iri, string $property)
     {
         try {
-            if ($item = $this->iriConverter->getItemFromIri($iri, ['fetch_data' => false])) {
+            if ($item = $this->iriConverter->getResourceFromIri($iri, ['fetch_data' => false])) {
                 return $this->propertyAccessor->getValue($item, $property);
             }
         } catch (InvalidArgumentException $e) {

--- a/src/GraphQl/Resolver/ResourceFieldResolver.php
+++ b/src/GraphQl/Resolver/ResourceFieldResolver.php
@@ -41,7 +41,7 @@ final class ResourceFieldResolver
         $property = null;
         if ('id' === $info->fieldName && !isset($source['_id']) && isset($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY])) {
             // In graphql we use Http operations to retrieve an IRI
-            return $this->iriConverter->getIriFromItem(null, (new Get())->withClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]]);
+            return $this->iriConverter->getIriFromItem([], (new Get())->withClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]]);
         }
 
         if ('_id' === $info->fieldName && !isset($source['_id']) && isset($source['id'])) {

--- a/src/GraphQl/Resolver/ResourceFieldResolver.php
+++ b/src/GraphQl/Resolver/ResourceFieldResolver.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\GraphQl\Resolver;
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
+use ApiPlatform\Metadata\Get;
 use ApiPlatform\Util\ClassInfoTrait;
 use GraphQL\Type\Definition\ResolveInfo;
 
@@ -39,7 +40,8 @@ final class ResourceFieldResolver
     {
         $property = null;
         if ('id' === $info->fieldName && !isset($source['_id']) && isset($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY])) {
-            return $this->iriConverter->getIriFromResourceClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], null, UrlGeneratorInterface::ABS_PATH, ['identifiers_values' => $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY], 'force_collection' => false]);
+            // In graphql we use Http operations to retrieve an IRI
+            return $this->iriConverter->getIriFromItem(null, (new Get())->withClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]]);
         }
 
         if ('_id' === $info->fieldName && !isset($source['_id']) && isset($source['id'])) {

--- a/src/GraphQl/Resolver/ResourceFieldResolver.php
+++ b/src/GraphQl/Resolver/ResourceFieldResolver.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\GraphQl\Resolver;
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
-use ApiPlatform\Metadata\Get;
 use ApiPlatform\Util\ClassInfoTrait;
 use GraphQL\Type\Definition\ResolveInfo;
 
@@ -40,8 +39,7 @@ final class ResourceFieldResolver
     {
         $property = null;
         if ('id' === $info->fieldName && !isset($source['_id']) && isset($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY])) {
-            // In graphql we use Http operations to retrieve an IRI
-            return $this->iriConverter->getIriFromItem([], (new Get())->withClass($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY]), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]]);
+            return $this->iriConverter->getIriFromResource($source[ItemNormalizer::ITEM_RESOURCE_CLASS_KEY], UrlGeneratorInterface::ABS_PATH, null, ['uri_variables' => $source[ItemNormalizer::ITEM_IDENTIFIERS_KEY]]);
         }
 
         if ('_id' === $info->fieldName && !isset($source['_id']) && isset($source['id'])) {

--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -107,7 +107,7 @@ final class ReadStage implements ReadStageInterface
         }
 
         try {
-            $item = $this->iriConverter->getItemFromIri($identifier, $normalizationContext);
+            $item = $this->iriConverter->getResourceFromIri($identifier, $normalizationContext);
         } catch (ItemNotFoundException $e) {
             return null;
         }

--- a/src/GraphQl/Serializer/ObjectNormalizer.php
+++ b/src/GraphQl/Serializer/ObjectNormalizer.php
@@ -88,7 +88,7 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
 
         if (isset($data['id'])) {
             $data['_id'] = $data['id'];
-            $data['id'] = $this->iriConverter->getIriFromItem($originalResource);
+            $data['id'] = $this->iriConverter->getIriFromResource($originalResource);
         }
 
         if (!($context['no_resolver_data'] ?? false)) {

--- a/src/GraphQl/Subscription/SubscriptionManager.php
+++ b/src/GraphQl/Subscription/SubscriptionManager.php
@@ -86,7 +86,7 @@ final class SubscriptionManager implements SubscriptionManagerInterface
      */
     public function getPushPayloads($object): array
     {
-        $iri = $this->iriConverter->getIriFromItem($object);
+        $iri = $this->iriConverter->getIriFromResource($object);
         $subscriptions = $this->getSubscriptionsFromIri($iri);
 
         $resourceClass = $this->getObjectClass($object);

--- a/src/Hal/Serializer/EntrypointNormalizer.php
+++ b/src/Hal/Serializer/EntrypointNormalizer.php
@@ -90,7 +90,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                     }
 
                     try {
-                        $href = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem(null, $operation);
+                        $href = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem([], $operation);
                         $entrypoint['_links'][lcfirst($operation->getShortName())]['href'] = $href;
                     } catch (InvalidArgumentException $ex) {
                         // Ignore resources without GET operations

--- a/src/Hal/Serializer/EntrypointNormalizer.php
+++ b/src/Hal/Serializer/EntrypointNormalizer.php
@@ -90,7 +90,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                     }
 
                     try {
-                        $href = $this->iriConverter instanceof IriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass, $operationName) : $this->iriConverter->getIriFromResourceClass($resourceClass);
+                        $href = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem(null, $operation);
                         $entrypoint['_links'][lcfirst($operation->getShortName())]['href'] = $href;
                     } catch (InvalidArgumentException $ex) {
                         // Ignore resources without GET operations

--- a/src/Hal/Serializer/EntrypointNormalizer.php
+++ b/src/Hal/Serializer/EntrypointNormalizer.php
@@ -90,7 +90,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                     }
 
                     try {
-                        $href = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem([], $operation);
+                        $href = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromResource($operation->getClass(), UrlGeneratorInterface::ABS_PATH, $operation);
                         $entrypoint['_links'][lcfirst($operation->getShortName())]['href'] = $href;
                     } catch (InvalidArgumentException $ex) {
                         // Ignore resources without GET operations

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Hal\Serializer;
 
+use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Serializer\AbstractItemNormalizer;
@@ -65,7 +66,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null);
         $context = $this->initContext($resourceClass, $context);
-        $iri = $this->iriConverter->getIriFromItem($object);
+        $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($object) : $this->iriConverter->getIriFromResource($object);
         $context['iri'] = $iri;
         $context['api_normalize'] = true;
 

--- a/src/Hal/Serializer/ObjectNormalizer.php
+++ b/src/Hal/Serializer/ObjectNormalizer.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Hal\Serializer;
 
 use ApiPlatform\Api\IriConverterInterface;
-use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
@@ -82,7 +81,7 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
         $metadata = [
             '_links' => [
                 'self' => [
-                    'href' => $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($originalResource) : $this->iriConverter->getIriFromItem($originalResource, $context['operation_name'] ?? null, UrlGeneratorInterface::ABS_PATH, $context),
+                    'href' => $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($originalResource) : $this->iriConverter->getIriFromItem($originalResource),
                 ],
             ],
         ];

--- a/src/Hal/Serializer/ObjectNormalizer.php
+++ b/src/Hal/Serializer/ObjectNormalizer.php
@@ -81,7 +81,7 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
         $metadata = [
             '_links' => [
                 'self' => [
-                    'href' => $this->iriConverter->getIriFromItem($originalResource),
+                    'href' => $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($originalResource) : $this->iriConverter->getIriFromResource($originalResource),
                 ],
             ],
         ];

--- a/src/Hal/Serializer/ObjectNormalizer.php
+++ b/src/Hal/Serializer/ObjectNormalizer.php
@@ -81,7 +81,7 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
         $metadata = [
             '_links' => [
                 'self' => [
-                    'href' => $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($originalResource) : $this->iriConverter->getIriFromItem($originalResource),
+                    'href' => $this->iriConverter->getIriFromItem($originalResource),
                 ],
             ],
         ];

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -48,9 +48,9 @@ final class AddTagsListener
     private $purger;
 
     /**
-     * @param LegacyPurgerInterface|PurgerInterface|null $purger
+     * @param LegacyPurgerInterface|PurgerInterface|null        $purger
      * @param LegacyIriConverterInterface|IriConverterInterface $iriConverter
-     * @param mixed|null                            $purger
+     * @param mixed|null                                        $purger
      */
     public function __construct($iriConverter, ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null, $purger = null)
     {

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\HttpCache\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Core\HttpCache\PurgerInterface as LegacyPurgerInterface;
 use ApiPlatform\HttpCache\PurgerInterface;
 use ApiPlatform\Metadata\CollectionOperationInterface;
@@ -47,8 +48,8 @@ final class AddTagsListener
     private $purger;
 
     /**
-     * @param LegacyPurgerInterface|PurgerInterface $purger
-     * @param mixed                                 $iriConverter
+     * @param LegacyPurgerInterface|PurgerInterface|null $purger
+     * @param LegacyIriConverterInterface|IriConverterInterface $iriConverter
      * @param mixed|null                            $purger
      */
     public function __construct($iriConverter, ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null, $purger = null)
@@ -79,7 +80,13 @@ final class AddTagsListener
         if (isset($attributes['collection_operation_name']) || ($attributes['subresource_context']['collection'] ?? false) || ($operation && $operation instanceof CollectionOperationInterface)) {
             // Allows to purge collections
             $uriVariables = $this->getOperationUriVariables($operation, $request->attributes->all(), $attributes['resource_class']);
-            $iri = $this->iriConverter instanceof IriConverterInterface ? $this->iriConverter->getIriFromResourceClass($attributes['resource_class'], $attributes['operation_name'] ?? null, UrlGeneratorInterface::ABS_PATH, ['identifiers_values' => $uriVariables]) : $this->iriConverter->getIriFromResourceClass($attributes['resource_class'], UrlGeneratorInterface::ABS_PATH);
+
+            if ($this->iriConverter instanceof LegacyIriConverterInterface) {
+                $iri = $this->iriConverter->getIriFromResourceClass($attributes['resource_class'], UrlGeneratorInterface::ABS_PATH);
+            } else {
+                $iri = $this->iriConverter->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $uriVariables]);
+            }
+
             $resources[$iri] = $iri;
         }
 

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -84,7 +84,7 @@ final class AddTagsListener
             if ($this->iriConverter instanceof LegacyIriConverterInterface) {
                 $iri = $this->iriConverter->getIriFromResourceClass($attributes['resource_class'], UrlGeneratorInterface::ABS_PATH);
             } else {
-                $iri = $this->iriConverter->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $uriVariables]);
+                $iri = $this->iriConverter->getIriFromResource($attributes['resource_class'], UrlGeneratorInterface::ABS_PATH, $operation, ['uri_variables' => $uriVariables]);
             }
 
             $resources[$iri] = $iri;

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -84,7 +84,7 @@ final class AddTagsListener
             if ($this->iriConverter instanceof LegacyIriConverterInterface) {
                 $iri = $this->iriConverter->getIriFromResourceClass($attributes['resource_class'], UrlGeneratorInterface::ABS_PATH);
             } else {
-                $iri = $this->iriConverter->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $uriVariables]);
+                $iri = $this->iriConverter->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, ['uri_variables' => $uriVariables]);
             }
 
             $resources[$iri] = $iri;

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -89,7 +89,7 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
             // TODO: remove in 3.0
             $data['@id'] = isset($context['operation_type']) && OperationType::SUBRESOURCE === $context['operation_type'] ? $this->iriConverter->getSubresourceIriFromResourceClass($resourceClass, $context) : $this->iriConverter->getIriFromResourceClass($resourceClass);
         } else {
-            $data['@id'] = $this->iriConverter->getIriFromItem(null, $context['operation'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
+            $data['@id'] = $this->iriConverter->getIriFromItem([], $context['operation'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
         }
 
         $data['@type'] = 'hydra:Collection';

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -85,17 +85,17 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
         $context = $this->initContext($resourceClass, $context);
         $data = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
 
-        if ($this->iriConverter instanceof IriConverterInterface) {
-            $data['@id'] = $this->iriConverter->getIriFromResourceClass($resourceClass, $context['operation_name'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
-        } else {
+        if ($this->iriConverter instanceof LegacyIriConverterInterface) {
             // TODO: remove in 3.0
             $data['@id'] = isset($context['operation_type']) && OperationType::SUBRESOURCE === $context['operation_type'] ? $this->iriConverter->getSubresourceIriFromResourceClass($resourceClass, $context) : $this->iriConverter->getIriFromResourceClass($resourceClass);
+        } else {
+            $data['@id'] = $this->iriConverter->getIriFromItem(null, $context['operation'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
         }
 
         $data['@type'] = 'hydra:Collection';
         $data['hydra:member'] = [];
         $iriOnly = $context[self::IRI_ONLY] ?? $this->defaultContext[self::IRI_ONLY];
-        unset($context['operation'], $context['operation_name']);
+        unset($context['operation'], $context['operation_name'], $context['uri_variables']);
 
         foreach ($object as $obj) {
             if ($iriOnly) {

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -89,7 +89,7 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
             // TODO: remove in 3.0
             $data['@id'] = isset($context['operation_type']) && OperationType::SUBRESOURCE === $context['operation_type'] ? $this->iriConverter->getSubresourceIriFromResourceClass($resourceClass, $context) : $this->iriConverter->getIriFromResourceClass($resourceClass);
         } else {
-            $data['@id'] = $this->iriConverter->getIriFromItem([], $context['operation'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
+            $data['@id'] = $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_PATH, $context['operation'] ?? null, $context);
         }
 
         $data['@type'] = 'hydra:Collection';
@@ -99,7 +99,7 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
 
         foreach ($object as $obj) {
             if ($iriOnly) {
-                $data['hydra:member'][] = $this->iriConverter->getIriFromItem($obj);
+                $data['hydra:member'][] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($obj) : $this->iriConverter->getIriFromResource($obj);
             } else {
                 $data['hydra:member'][] = $this->normalizer->normalize($obj, $format, $context);
             }

--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -94,7 +94,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                     }
 
                     try {
-                        $entrypoint[$key] = $this->iriConverter instanceof IriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass, $operationName) : $this->iriConverter->getIriFromResourceClass($resourceClass);
+                        $entrypoint[$key] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem(null, $operation);
                     } catch (InvalidArgumentException|OperationNotFoundException $ex) {
                         // Ignore resources without GET operations
                     }

--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -94,7 +94,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                     }
 
                     try {
-                        $entrypoint[$key] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem(null, $operation);
+                        $entrypoint[$key] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem([], $operation);
                     } catch (InvalidArgumentException|OperationNotFoundException $ex) {
                         // Ignore resources without GET operations
                     }

--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -94,7 +94,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                     }
 
                     try {
-                        $entrypoint[$key] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromItem([], $operation);
+                        $entrypoint[$key] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass) : $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_PATH, $operation);
                     } catch (InvalidArgumentException|OperationNotFoundException $ex) {
                         // Ignore resources without GET operations
                     }

--- a/src/JsonApi/Serializer/EntrypointNormalizer.php
+++ b/src/JsonApi/Serializer/EntrypointNormalizer.php
@@ -88,7 +88,13 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                     }
 
                     try {
-                        $entrypoint['links'][lcfirst($resource->getShortName())] = $this->iriConverter instanceof IriConverterInterface ? $this->iriConverter->getIriFromResourceClass($resourceClass, $operationName, UrlGeneratorInterface::ABS_URL) : $this->iriConverter->getIriFromResourceClass($resourceClass, UrlGeneratorInterface::ABS_URL);
+                        if ($this->iriConverter instanceof LegacyIriConverterInterface) {
+                            $iri = $this->iriConverter->getIriFromResourceClass($resourceClass, UrlGeneratorInterface::ABS_URL);
+                        } else {
+                            $iri = $this->iriConverter->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_URL);
+                        }
+
+                        $entrypoint['links'][lcfirst($resource->getShortName())] = $iri;
                     } catch (InvalidArgumentException $ex) {
                         // Ignore resources without GET operations
                     }

--- a/src/JsonApi/Serializer/EntrypointNormalizer.php
+++ b/src/JsonApi/Serializer/EntrypointNormalizer.php
@@ -91,7 +91,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                         if ($this->iriConverter instanceof LegacyIriConverterInterface) {
                             $iri = $this->iriConverter->getIriFromResourceClass($resourceClass, UrlGeneratorInterface::ABS_URL);
                         } else {
-                            $iri = $this->iriConverter->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_URL);
+                            $iri = $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_URL, $operation);
                         }
 
                         $entrypoint['links'][lcfirst($resource->getShortName())] = $iri;

--- a/src/JsonApi/Serializer/EntrypointNormalizer.php
+++ b/src/JsonApi/Serializer/EntrypointNormalizer.php
@@ -91,7 +91,7 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
                         if ($this->iriConverter instanceof LegacyIriConverterInterface) {
                             $iri = $this->iriConverter->getIriFromResourceClass($resourceClass, UrlGeneratorInterface::ABS_URL);
                         } else {
-                            $iri = $this->iriConverter->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_URL);
+                            $iri = $this->iriConverter->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_URL);
                         }
 
                         $entrypoint['links'][lcfirst($resource->getShortName())] = $iri;

--- a/src/JsonApi/Serializer/ObjectNormalizer.php
+++ b/src/JsonApi/Serializer/ObjectNormalizer.php
@@ -97,7 +97,7 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
         if (isset($originalResource)) {
             $resourceClass = $this->resourceClassResolver->getResourceClass($originalResource);
             $resourceData = [
-                'id' => $this->iriConverter->getIriFromItem($originalResource),
+                'id' => $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($originalResource) : $this->iriConverter->getIriFromResource($originalResource),
                 'type' => $this->getResourceShortName($resourceClass),
             ];
         } else {

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -90,10 +90,10 @@ final class ItemNormalizer extends AbstractItemNormalizer
             unset($context['operation'], $context['operation_name']);
         }
 
-        if ($this->iriConverter instanceof IriConverterInterface) {
-            $iri = $this->iriConverter->getIriFromItem($object, $context['operation_name'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
-        } else {
+        if ($this->iriConverter instanceof LegacyIriConverterInterface) {
             $iri = $this->iriConverter->getIriFromItem($object);
+        } else {
+            $iri = $this->iriConverter->getIriFromItem($object, $context['operation'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
         }
 
         $context['iri'] = $iri;

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -93,7 +93,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
         if ($this->iriConverter instanceof LegacyIriConverterInterface) {
             $iri = $this->iriConverter->getIriFromItem($object);
         } else {
-            $iri = $this->iriConverter->getIriFromItem($object, $context['operation'] ?? null, UrlGeneratorInterface::ABS_PATH, $context);
+            $iri = $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_PATH, $context['operation'] ?? null, $context);
         }
 
         $context['iri'] = $iri;
@@ -144,7 +144,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 throw new NotNormalizableValueException('Update is not allowed for this operation.');
             }
 
-            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getItemFromIri($data['@id'], $context + ['fetch_data' => true]);
+            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getItemFromIri($data['@id'], $context + ['fetch_data' => true]) : $this->iriConverter->getResourceFromIri($data['@id'], $context + ['fetch_data' => true]);
         }
 
         return parent::denormalize($data, $class, $format, $context);

--- a/src/JsonLd/Serializer/ObjectNormalizer.php
+++ b/src/JsonLd/Serializer/ObjectNormalizer.php
@@ -92,7 +92,7 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
 
         if (isset($originalResource)) {
             try {
-                $context['output']['iri'] = $this->iriConverter->getIriFromItem($originalResource);
+                $context['output']['iri'] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($originalResource) : $this->iriConverter->getIriFromResource($originalResource);
             } catch (InvalidArgumentException $e) {
                 // The original resource has no identifiers
             }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -71,6 +71,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      * @var LegacyPropertyMetadataFactoryInterface|PropertyMetadataFactoryInterface
      */
     protected $propertyMetadataFactory;
+    /**
+     * @var LegacyIriConverterInterface|IriConverterInterface
+     */
     protected $iriConverter;
     protected $resourceClassResolver;
     protected $resourceAccessChecker;
@@ -84,7 +87,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     {
         if (!isset($defaultContext['circular_reference_handler'])) {
             $defaultContext['circular_reference_handler'] = function ($object) {
-                return $this->iriConverter->getIriFromItem($object);
+                return $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($object) : $this->iriConverter->getIriFromResource($object);
             };
         }
         if (!interface_exists(AdvancedNameConverterInterface::class) && method_exists($this, 'setCircularReferenceHandler')) {
@@ -185,7 +188,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         if (isset($context['iri'])) {
             $iri = $context['iri'];
         } else {
-            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($object) : $this->iriConverter->getIriFromItem($object, $context['operation'] ?? null, UrlGeneratorInterface::ABS_URL, $context);
+            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($object) : $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_URL, $context['operation'] ?? null, $context);
         }
 
         $context['iri'] = $iri;
@@ -282,7 +285,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if (\is_string($data)) {
             try {
-                return $this->iriConverter->getItemFromIri($data, $context + ['fetch_data' => true]);
+                return $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getItemFromIri($data, $context + ['fetch_data' => true]) : $this->iriConverter->getResourceFromIri($data, $context + ['fetch_data' => true]);
             } catch (ItemNotFoundException $e) {
                 if (!$supportsPlainIdentifiers) {
                     throw new UnexpectedValueException($e->getMessage(), $e->getCode(), $e);
@@ -599,7 +602,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if (\is_string($value)) {
             try {
-                return $this->iriConverter->getItemFromIri($value, $context + ['fetch_data' => true]);
+                return $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getItemFromIri($value, $context + ['fetch_data' => true]) : $this->iriConverter->getResourceFromIri($value, $context + ['fetch_data' => true]);
             } catch (ItemNotFoundException $e) {
                 if (!$supportsPlainIdentifiers) {
                     throw new UnexpectedValueException($e->getMessage(), $e->getCode(), $e);
@@ -838,7 +841,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $normalizedRelatedObject;
         }
 
-        $iri = $this->iriConverter->getIriFromItem($relatedObject);
+        $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($relatedObject) : $this->iriConverter->getIriFromResource($relatedObject);
 
         if (isset($context['resources'])) {
             $context['resources'][$iri] = $iri;

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -185,7 +185,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         if (isset($context['iri'])) {
             $iri = $context['iri'];
         } else {
-            $iri = $this->iriConverter instanceof IriConverterInterface ? $this->iriConverter->getIriFromItem($object, $context['operation_name'] ?? null, UrlGeneratorInterface::ABS_URL, $context) : $this->iriConverter->getIriFromItem($object);
+            $iri = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getIriFromItem($object) : $this->iriConverter->getIriFromItem($object, $context['operation'] ?? null, UrlGeneratorInterface::ABS_URL, $context);
         }
 
         $context['iri'] = $iri;
@@ -744,7 +744,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             if ($this->resourceMetadataFactory instanceof ResourceMetadataCollectionFactoryInterface) {
                 $childContext['operation'] = $this->resourceMetadataFactory->create($resourceClass)->getOperation();
             }
-            unset($childContext['iri']);
+            unset($childContext['iri'], $childContext['uri_variables']);
 
             return $this->normalizeCollectionOfRelations($propertyMetadata, $attributeValue, $resourceClass, $format, $childContext);
         }
@@ -764,7 +764,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             if ($this->resourceMetadataFactory instanceof ResourceMetadataCollectionFactoryInterface) {
                 $childContext['operation'] = $this->resourceMetadataFactory->create($resourceClass)->getOperation();
             }
-            unset($childContext['iri']);
+            unset($childContext['iri'], $childContext['uri_variables']);
 
             return $this->normalizeRelation($propertyMetadata, $attributeValue, $resourceClass, $format, $childContext);
         }
@@ -777,7 +777,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if ($type && $type->getClassName()) {
             $childContext = $this->createChildContext($context, $attribute, $format);
-            unset($childContext['iri']);
+            unset($childContext['iri'], $childContext['uri_variables']);
 
             if (null !== ($propertyIri = $propertyMetadata->getIri())) {
                 $childContext['output']['iri'] = $propertyIri;

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -80,7 +80,7 @@ class ItemNormalizer extends AbstractItemNormalizer
     private function updateObjectToPopulate(array $data, array &$context): void
     {
         try {
-            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getItemFromIri((string) $data['id'], $context + ['fetch_data' => true]);
+            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getItemFromIri((string) $data['id'], $context + ['fetch_data' => true]) : $this->iriConverter->getResourceFromIri((string) $data['id'], $context + ['fetch_data' => true]);
         } catch (InvalidArgumentException $e) {
             if ($this->iriConverter instanceof LegacyIriConverterInterface) {
                 // remove in 3.0
@@ -101,10 +101,10 @@ class ItemNormalizer extends AbstractItemNormalizer
             } else {
                 $operation = $this->resourceMetadataFactory->create($context['resource_class'])->getOperation();
                 // todo: we could guess uri variables with the operation and the data instead of hardcoding id
-                $iri = $this->iriConverter->getIriFromItem($data, $operation, UrlGeneratorInterface::ABS_PATH, ['uri_variables' => ['id' => $data['id']]]);
+                $iri = $this->iriConverter->getIriFromResource($context['resource_class'], UrlGeneratorInterface::ABS_PATH, $operation, ['uri_variables' => ['id' => $data['id']]]);
             }
 
-            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getItemFromIri($iri, ['fetch_data' => true]);
+            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getItemFromIri($iri, ['fetch_data' => true]) : $this->iriConverter->getResourceFromIri($iri, ['fetch_data' => true]);
         }
     }
 }

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Serializer;
 
+use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Exception\InvalidArgumentException;
@@ -34,6 +36,14 @@ class ItemNormalizer extends AbstractItemNormalizer
 {
     private $logger;
 
+    /**
+     * @var LegacyIriConverterInterface|IriConverterInterface
+     *
+     * @param mixed      $propertyMetadataFactory
+     * @param mixed      $iriConverter
+     * @param mixed      $resourceClassResolver
+     * @param mixed|null $resourceMetadataFactory
+     */
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, LoggerInterface $logger = null, iterable $dataTransformers = [], $resourceMetadataFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null)
     {
         parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $itemDataProvider, $allowPlainIdentifiers, [], $dataTransformers, $resourceMetadataFactory, $resourceAccessChecker);
@@ -92,7 +102,8 @@ class ItemNormalizer extends AbstractItemNormalizer
                 $iri = sprintf('%s/%s', $this->iriConverter->getIriFromResourceClass($context['resource_class']), $data[$identifier]);
             } else {
                 $operation = $this->resourceMetadataFactory->create($context['resource_class'])->getOperation();
-                $iri = $this->iriConverter->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, ['uri_variables' => ['id' => $data['id']]]);
+                // todo: we could guess uri variables with the operation and the data instead of hardcoding id
+                $iri = $this->iriConverter->getIriFromItem($data, $operation, UrlGeneratorInterface::ABS_PATH, ['uri_variables' => ['id' => $data['id']]]);
             }
 
             $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getItemFromIri($iri, ['fetch_data' => true]);

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -37,12 +37,10 @@ class ItemNormalizer extends AbstractItemNormalizer
     private $logger;
 
     /**
-     * @var LegacyIriConverterInterface|IriConverterInterface
-     *
-     * @param mixed      $propertyMetadataFactory
-     * @param mixed      $iriConverter
-     * @param mixed      $resourceClassResolver
-     * @param mixed|null $resourceMetadataFactory
+     * @param mixed                                             $propertyMetadataFactory
+     * @param LegacyIriConverterInterface|IriConverterInterface $iriConverter
+     * @param mixed                                             $resourceClassResolver
+     * @param mixed|null                                        $resourceMetadataFactory
      */
     public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, ItemDataProviderInterface $itemDataProvider = null, bool $allowPlainIdentifiers = false, LoggerInterface $logger = null, iterable $dataTransformers = [], $resourceMetadataFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null)
     {

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -71,10 +71,10 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
             $context['input'] = $operation->getInput();
             $context['output'] = $operation->getOutput();
             $context['types'] = $operation->getTypes();
-            $context['identifiers_values'] = [];
+            $context['uri_variables'] = [];
 
             foreach (array_keys($operation->getUriVariables() ?? []) as $parameterName) {
-                $context['identifiers_values'][$parameterName] = $request->attributes->get($parameterName);
+                $context['uri_variables'][$parameterName] = $request->attributes->get($parameterName);
             }
 
             if (!$normalization) {

--- a/src/State/UriVariablesResolverTrait.php
+++ b/src/State/UriVariablesResolverTrait.php
@@ -30,8 +30,6 @@ trait UriVariablesResolverTrait
 
     /**
      * Resolves an operation's UriVariables to their identifiers values.
-     *
-     * @param Operation|null $operation
      */
     private function getOperationUriVariables(?HttpOperation $operation = null, array $parameters = [], ?string $resourceClass = null): array
     {

--- a/src/State/UriVariablesResolverTrait.php
+++ b/src/State/UriVariablesResolverTrait.php
@@ -31,9 +31,9 @@ trait UriVariablesResolverTrait
     /**
      * Resolves an operation's UriVariables to their identifiers values.
      *
-     * @param HttpOperation|null $operation
+     * @param Operation|null $operation
      */
-    private function getOperationUriVariables($operation, array $parameters, string $resourceClass): array
+    private function getOperationUriVariables(?HttpOperation $operation = null, array $parameters = [], ?string $resourceClass = null): array
     {
         $identifiers = [];
 

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Symfony\Bundle\Test;
 
+use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
@@ -99,7 +100,9 @@ abstract class ApiTestCase extends KernelTestCase
             return null;
         }
 
-        return $container->get('api_platform.iri_converter')->getIriFromItem($item);
+        $iriConverter = $container->get('api_platform.iri_converter');
+
+        return $iriConverter instanceof LegacyIriConverterInterface ? $iriConverter->getIriFromItem($item) : $iriConverter->getIriFromResource($item);
     }
 }
 

--- a/src/Symfony/EventListener/RespondListener.php
+++ b/src/Symfony/EventListener/RespondListener.php
@@ -14,10 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
-use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
-use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Util\OperationRequestInitiatorTrait;
 use ApiPlatform\Util\RequestAttributesExtractor;
@@ -111,12 +109,7 @@ final class RespondListener
                 && 301 === $operation->getStatus()
             ) {
                 $status = 301;
-
-                if ($operation instanceof CollectionOperationInterface) {
-                    $headers['Location'] = $this->iriConverter->getIriFromResourceClass($operation->getClass(), $operation->getName(), UrlGeneratorInterface::ABS_PATH, ['operation' => $operation]);
-                } else {
-                    $headers['Location'] = $this->iriConverter->getIriFromItem($request->attributes->get('data'), $operation->getName(), UrlGeneratorInterface::ABS_PATH, ['operation' => $operation]);
-                }
+                $headers['Location'] = $this->iriConverter->getIriFromItem($request->attributes->get('data'), $operation);
             }
         }
 

--- a/src/Symfony/EventListener/RespondListener.php
+++ b/src/Symfony/EventListener/RespondListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -109,7 +110,7 @@ final class RespondListener
                 && 301 === $operation->getStatus()
             ) {
                 $status = 301;
-                $headers['Location'] = $this->iriConverter->getIriFromItem($request->attributes->get('data'), $operation);
+                $headers['Location'] = $this->iriConverter->getIriFromResource($request->attributes->get('data'), UrlGeneratorInterface::ABS_PATH, $operation);
             }
         }
 

--- a/src/Symfony/EventListener/WriteListener.php
+++ b/src/Symfony/EventListener/WriteListener.php
@@ -108,7 +108,7 @@ final class WriteListener
                 }
 
                 if ($this->isResourceClass($this->getObjectClass($controllerResult))) {
-                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromItem($controllerResult));
+                    $request->attributes->set('_api_write_item_iri', $this->iriConverter->getIriFromResource($controllerResult));
                 }
 
                 break;

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -113,7 +113,7 @@ final class IriConverter implements IriConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function getIriFromItem($item = null, Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string
+    public function getIriFromItem($item, Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string
     {
         if (!$item && !$operation) {
             throw new RuntimeException('Provide an item or an operation');
@@ -155,7 +155,7 @@ final class IriConverter implements IriConverterInterface
             $identifiers = [];
         }
 
-        if ($item) {
+        if (\is_object($item)) {
             try {
                 $identifiers = $this->identifiersExtractor->getIdentifiersFromItem($item, $operation);
             } catch (RuntimeException $e) {

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -24,9 +24,9 @@ use ApiPlatform\Exception\ItemNotFoundException;
 use ApiPlatform\Exception\OperationNotFoundException;
 use ApiPlatform\Exception\RuntimeException;
 use ApiPlatform\Metadata\CollectionOperationInterface;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -103,7 +103,7 @@ final class IriConverter implements IriConverterInterface
             }
         }
 
-        if ($item = $this->provider->provide($operation, $uriVariables ?? [], $context)) {
+        if ($item = $this->provider->provide($operation, $uriVariables, $context)) {
             return $item;
         }
 

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -25,6 +25,9 @@ use ApiPlatform\Exception\OperationNotFoundException;
 use ApiPlatform\Exception\RuntimeException;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\State\ProviderInterface;
@@ -66,7 +69,7 @@ final class IriConverter implements IriConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function getItemFromIri(string $iri, array $context = [])
+    public function getItemFromIri(string $iri, array $context = [], ?Operation $operation = null)
     {
         try {
             $parameters = $this->router->match($iri);
@@ -81,12 +84,15 @@ final class IriConverter implements IriConverterInterface
             throw new InvalidArgumentException(sprintf('No resource associated to "%s".', $iri));
         }
 
-        $context['operation'] = $operation = $parameters['_api_operation'] = $this->resourceMetadataCollectionFactory->create($parameters['_api_resource_class'])->getOperation($parameters['_api_operation_name']);
+        $operation = $parameters['_api_operation'] = $this->resourceMetadataCollectionFactory->create($parameters['_api_resource_class'])->getOperation($parameters['_api_operation_name']);
 
         if ($operation instanceof CollectionOperationInterface) {
             throw new InvalidArgumentException(sprintf('The iri "%s" references a collection not an item.', $iri));
         }
 
+        if (!$operation instanceof HttpOperation) {
+            throw new RuntimeException(sprintf('The iri "%s" does not reference an HTTP operation.', $iri));
+        }
         $attributes = AttributesExtractor::extractAttributes($parameters);
 
         if ($operation instanceof HttpOperation) {
@@ -107,89 +113,68 @@ final class IriConverter implements IriConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function getIriFromItem($item, string $operationName = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): string
+    public function getIriFromItem($item = null, Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string
     {
-        $resourceClass = $this->getResourceClass($item, true);
-        $operationName = $context['operation_name'] ?? $operationName;
+        if (!$item && !$operation) {
+            throw new RuntimeException('Provide an item or an operation');
+        }
 
-        // These are special cases were we want to find the related operation
-        // `ResourceMetadataCollection::getOperation` retrieves the first safe operation if no $operationName is given
-        if (isset($context['operation'])) {
-            $operation = $context['operation'];
-            if (
-                ($operation->getExtraProperties()['is_legacy_subresource'] ?? false) ||
-                ($operation->getExtraProperties()['user_defined_uri_template'] ?? false) ||
-                ($operation->getExtraProperties()['is_alternate_resource_metadata'] ?? false) ||
-                ($operation->getExtraProperties()['legacy_subresource_behavior'] ?? false) ||
-                // When we want the Iri from an object, we don't want the collection uriTemplate, for this we use getIriFromResourceClass
-                $operation instanceof CollectionOperationInterface || $operation instanceof Post
-            ) {
-                unset($context['operation']);
-                $operationName = null;
+        $resourceClass = $operation ? $operation->getClass() : $this->getResourceClass($item, true);
+
+        if (!$operation) {
+            $operation = (new Get())->withClass($resourceClass);
+        }
+
+        if ($operation instanceof HttpOperation && 301 === $operation->getStatus()) {
+            $operation = ($operation instanceof CollectionOperationInterface ? new GetCollection() : new Get())->withClass($operation->getClass());
+            unset($context['uri_variables']);
+        }
+
+        // Legacy subresources had bad IRIs but we don't want to break these, remove this in 3.0
+        $isLegacySubresource = ($operation->getExtraProperties()['is_legacy_subresource'] ?? false) && !$operation instanceof CollectionOperationInterface;
+        // Custom resources should have the same IRI as requested, it was not the case pre 2.7
+        $isLegacyCustomResource = ($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false) && ($operation->getExtraProperties()['user_defined_uri_template'] ?? false);
+
+        // In symfony the operation name is the route name, try to find one if none provided
+        if (
+            !$operation->getName()
+            || $operation instanceof Post
+            || $isLegacySubresource
+            || $isLegacyCustomResource
+        ) {
+            $forceCollection = $operation instanceof CollectionOperationInterface;
+            try {
+                $operation = $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation(null, $forceCollection, true);
+            } catch (OperationNotFoundException $e) {
             }
         }
 
-        try {
-            $operation = $context['operation'] ?? $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation($operationName, false, true);
-        } catch (OperationNotFoundException $e) {
-            $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-            foreach ($resourceMetadataCollection as $resource) {
-                foreach ($resource->getOperations() as $name => $operation) {
-                    if ($operationName === $name && !$operation instanceof CollectionOperationInterface) {
-                        break 2;
-                    }
+        $identifiers = $context['uri_variables'] ?? [];
+
+        if ($isLegacySubresource || $isLegacyCustomResource) {
+            $identifiers = [];
+        }
+
+        if ($item) {
+            try {
+                $identifiers = $this->identifiersExtractor->getIdentifiersFromItem($item, $operation);
+            } catch (RuntimeException $e) {
+                // We can try using context uri variables if any
+                if (!$identifiers) {
+                    throw new InvalidArgumentException(sprintf('Unable to generate an IRI for the item of type "%s"', $resourceClass), $e->getCode(), $e);
                 }
             }
+        }
 
-            if (!isset($operation)) {
-                throw new InvalidArgumentException(sprintf('Unable to generate an IRI for the item of type "%s"', $resourceClass), $e->getCode(), $e);
-            }
+        // TODO: call the Skolem IRI generator
+        if (!$operation->getName()) {
+            return null;
         }
 
         try {
-            $identifiers = $this->identifiersExtractor->getIdentifiersFromItem($item, $operation->getName(), ['operation' => $operation]);
-
             return $this->router->generate($operation->getName(), $identifiers, $operation->getUrlGenerationStrategy() ?? $referenceType);
-        } catch (RuntimeException|RoutingExceptionInterface $e) {
+        } catch (RoutingExceptionInterface $e) {
             throw new InvalidArgumentException(sprintf('Unable to generate an IRI for the item of type "%s"', $resourceClass), $e->getCode(), $e);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getIriFromResourceClass(string $resourceClass, string $operationName = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): string
-    {
-        // TODO: 3.0 remove the condition
-        if ($context['extra_properties']['is_legacy_subresource'] ?? false) {
-            trigger_deprecation('api-platform/core', '2.7', 'The IRI will change and match the first operation of the resource. Switch to an alternate resource when possible instead of using subresources.');
-            $operation = $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation($context['extra_properties']['legacy_subresource_operation_name']);
-        }
-
-        $operation = $context['operation'] ?? $operation ?? null;
-
-        if ($operation) {
-            // TODO: 2.7 should we deprecate this behavior ? example : Entity\Foo.php should take it's own operation? As it's a custom operation can we now?
-            if ($operation->getExtraProperties()['is_legacy_subresource'] ?? false) {
-                trigger_deprecation('api-platform/core', '2.7', 'The IRI will change and match the first operation of the resource. Switch to an alternate resource when possible instead of using subresources.');
-                $operationName = $operation->getExtraProperties()['legacy_subresource_operation_name'];
-                $operation = null;
-            } elseif (!($operation->getExtraProperties()['is_alternate_resource_metadata'] ?? false) && ($operation->getExtraProperties()['user_defined_uri_template'] ?? false)) {
-                $operation = null;
-                $operationName = null;
-            }
-        }
-
-        try {
-            if (!$operation) {
-                $operation = $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation($operationName, $context['force_collection'] ?? true);
-            }
-
-            $identifiers = $context['identifiers_values'] ?? [];
-
-            return $this->router->generate($operation->getName(), $identifiers, $operation->getUrlGenerationStrategy() ?? $referenceType);
-        } catch (RoutingExceptionInterface|OperationNotFoundException $e) {
-            throw new InvalidArgumentException(sprintf('Unable to generate an IRI for "%s".', $resourceClass), $e->getCode(), $e);
         }
     }
 }

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -69,7 +69,7 @@ final class IriConverter implements IriConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function getItemFromIri(string $iri, array $context = [], ?Operation $operation = null)
+    public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null)
     {
         try {
             $parameters = $this->router->match($iri);
@@ -113,13 +113,13 @@ final class IriConverter implements IriConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function getIriFromItem($item, Operation $operation = null, int $referenceType = UrlGeneratorInterface::ABS_PATH, array $context = []): ?string
+    public function getIriFromResource($item, int $referenceType = UrlGeneratorInterface::ABS_PATH, Operation $operation = null, array $context = []): ?string
     {
-        if (!$item && !$operation) {
-            throw new RuntimeException('Provide an item or an operation');
+        try {
+            $resourceClass = \is_string($item) ? $item : $this->getResourceClass($item, true);
+        } catch (InvalidArgumentException $e) {
+            return null;
         }
-
-        $resourceClass = $operation ? $operation->getClass() : $this->getResourceClass($item, true);
 
         if (!$operation) {
             $operation = (new Get())->withClass($resourceClass);

--- a/tests/Api/IdentifiersExtractorTest.php
+++ b/tests/Api/IdentifiersExtractorTest.php
@@ -51,14 +51,11 @@ class IdentifiersExtractorTest extends TestCase
         $operation = $this->prophesize(HttpOperation::class);
         $item = new Dummy();
         $resourceClass = Dummy::class;
-        $context = [
-            'operation' => $operation->reveal(),
-        ];
 
         $resourceClassResolverProphecy->getResourceClass($item)->willReturn($resourceClass);
         $operation->getUriVariables()->willReturn([]);
 
-        $this->assertEquals([], $identifiersExtractor->getIdentifiersFromItem($item, 'operation', $context));
+        $this->assertEquals([], $identifiersExtractor->getIdentifiersFromItem($item, $operation->reveal()));
     }
 
     public function testGetIdentifiersFromItemWithId()
@@ -81,12 +78,9 @@ class IdentifiersExtractorTest extends TestCase
         $item = new Dummy();
         $item->setId(1);
         $resourceClass = Dummy::class;
-        $context = [
-            'operation' => $operation,
-        ];
 
         $resourceClassResolverProphecy->getResourceClass($item)->willReturn($resourceClass);
 
-        $this->assertEquals(['id' => '1'], $identifiersExtractor->getIdentifiersFromItem($item, 'operation', $context));
+        $this->assertEquals(['id' => '1'], $identifiersExtractor->getIdentifiersFromItem($item, $operation));
     }
 }

--- a/tests/Core/EventListener/WriteListenerTest.php
+++ b/tests/Core/EventListener/WriteListenerTest.php
@@ -49,7 +49,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->persist($dummy, Argument::type('array'))->willReturn($dummy)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->willReturn('/dummy/1')->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => Dummy::class]);
 
@@ -85,7 +85,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->persist($dummy, Argument::type('array'))->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1');
+        $iriConverterProphecy->getIriFromResource($dummy)->willReturn('/dummy/1');
 
         $request = new Request([], [], ['_api_resource_class' => Dummy::class]);
 
@@ -124,7 +124,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->persist($dummy, Argument::type('array'))->willReturn($dummy2);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy2)->willReturn('/dummy/2');
+        $iriConverterProphecy->getIriFromResource($dummy2)->willReturn('/dummy/2');
 
         $writeListener = new WriteListener($dataPersisterProphecy->reveal(), $iriConverterProphecy->reveal());
 
@@ -158,7 +158,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->supports($dummy, Argument::type('array'))->willReturn(true)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->shouldNotBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadata(null, null, null, null, null, ['output' => ['class' => null]]));
@@ -189,7 +189,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->shouldNotBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'delete']);
         $request->setMethod('DELETE');
@@ -216,7 +216,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->shouldNotBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_item_operation_name' => 'head']);
         $request->setMethod('HEAD');
@@ -331,7 +331,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->shouldNotBeCalled();
 
         $request = new Request();
         $request->setMethod('POST');
@@ -356,7 +356,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->persist($dummy, Argument::type('array'))->willReturn($dummy)->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummy/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->willReturn('/dummy/1')->shouldBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => ConcreteDummy::class, '_api_item_operation_name' => 'put', '_api_persist' => true]);
         $request->setMethod('PUT');
@@ -383,7 +383,7 @@ class WriteListenerTest extends TestCase
         $dataPersisterProphecy->remove($dummy, Argument::type('array'))->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->shouldNotBeCalled();
 
         $request = new Request([], [], ['_api_resource_class' => 'Dummy', '_api_collection_operation_name' => 'post']);
         $request->setMethod('POST');

--- a/tests/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/tests/Doctrine/EventListener/PublishMercureUpdatesListenerTest.php
@@ -85,12 +85,12 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(DummyFriend::class)->willReturn(true);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($toInsert, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toUpdate, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toInsert, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toUpdate, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteExpressionLanguage, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 
@@ -184,17 +184,17 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(DummyMercure::class)->willReturn(true);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($toInsert, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toUpdate, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions)->willReturn('/dummy_offers/5')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_offers/5')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions, null, UrlGeneratorInterface::ABS_PATH)->willReturn('/dummy_offers/5')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions, null, UrlGeneratorInterface::REL_PATH)->willReturn('./dummy_offers/5')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions, null, UrlGeneratorInterface::NET_PATH)->willReturn('//example.com/dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toInsert, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toUpdate, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteExpressionLanguage, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteMercureOptions)->willReturn('/dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteMercureOptions, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteMercureOptions, UrlGeneratorInterface::ABS_PATH)->willReturn('/dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteMercureOptions, UrlGeneratorInterface::REL_PATH)->willReturn('./dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteMercureOptions, UrlGeneratorInterface::NET_PATH)->willReturn('//example.com/dummy_offers/5')->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations([
@@ -298,14 +298,14 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(DummyMercure::class)->willReturn(true);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($toInsert, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toUpdate, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteExpressionLanguage, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions)->willReturn('/dummy_offers/5')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteMercureOptions, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toInsert, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toUpdate, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete)->willReturn('/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteExpressionLanguage)->willReturn('/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteExpressionLanguage, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_friends/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteMercureOptions)->willReturn('/dummy_offers/5')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteMercureOptions, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummy_offers/5')->shouldBeCalled();
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 
@@ -393,7 +393,7 @@ class PublishMercureUpdatesListenerTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(Dummy::class)->willReturn(true);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($toUpdate, null, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2');
+        $iriConverterProphecy->getIriFromResource($toUpdate, UrlGeneratorInterface::ABS_URL)->willReturn('http://example.com/dummies/2');
 
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations([

--- a/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -63,8 +63,8 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge(['/dummies', '/dummies/1', '/dummies/2', '/dummies/3', '/dummies/4'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toUpdate1)->willReturn('/dummies/1')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toUpdate2)->willReturn('/dummies/2')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toDelete1)->willReturn('/dummies/3')->shouldBeCalled();
@@ -118,7 +118,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge(['/dummies', '/dummies/1', '/related_dummies/old', '/related_dummies/new'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($oldRelatedDummy)->willReturn('/related_dummies/old')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($newRelatedDummy)->willReturn('/related_dummies/new')->shouldBeCalled();
@@ -149,7 +149,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge([])->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($dummyNoGetOperation)->shouldNotBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);

--- a/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -20,6 +20,7 @@ use ApiPlatform\Doctrine\EventListener\PurgeHttpCacheListener;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Exception\ItemNotFoundException;
 use ApiPlatform\HttpCache\PurgerInterface;
+use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyNoGetOperation;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
@@ -62,8 +63,8 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge(['/dummies', '/dummies/1', '/dummies/2', '/dummies/3', '/dummies/4'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromResourceClass(DummyNoGetOperation::class)->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toUpdate1)->willReturn('/dummies/1')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toUpdate2)->willReturn('/dummies/2')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($toDelete1)->willReturn('/dummies/3')->shouldBeCalled();
@@ -117,7 +118,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge(['/dummies', '/dummies/1', '/related_dummies/old', '/related_dummies/new'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class)->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($oldRelatedDummy)->willReturn('/related_dummies/old')->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($newRelatedDummy)->willReturn('/related_dummies/new')->shouldBeCalled();
@@ -148,7 +149,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge([])->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(DummyNoGetOperation::class)->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
         $iriConverterProphecy->getIriFromItem($dummyNoGetOperation)->shouldNotBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);

--- a/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Tests\Doctrine\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface;
+use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use ApiPlatform\Doctrine\EventListener\PurgeHttpCacheListener;
 use ApiPlatform\Exception\InvalidArgumentException;
@@ -63,14 +64,14 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge(['/dummies', '/dummies/1', '/dummies/2', '/dummies/3', '/dummies/4'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toUpdate1)->willReturn('/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toUpdate2)->willReturn('/dummies/2')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete1)->willReturn('/dummies/3')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDelete2)->willReturn('/dummies/4')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($toDeleteNoPurge)->shouldNotBeCalled();
-        $iriConverterProphecy->getIriFromItem(Argument::any())->willThrow(new ItemNotFoundException());
+        $iriConverterProphecy->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, new GetCollection())->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource(DummyNoGetOperation::class, UrlGeneratorInterface::ABS_PATH, new GetCollection())->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toUpdate1)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toUpdate2)->willReturn('/dummies/2')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete1)->willReturn('/dummies/3')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDelete2)->willReturn('/dummies/4')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($toDeleteNoPurge)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource(Argument::any())->willThrow(new ItemNotFoundException());
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class)->shouldBeCalled();
@@ -118,10 +119,10 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge(['/dummies', '/dummies/1', '/related_dummies/old', '/related_dummies/new'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(Dummy::class))->willReturn('/dummies')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($oldRelatedDummy)->willReturn('/related_dummies/old')->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($newRelatedDummy)->willReturn('/related_dummies/new')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, new GetCollection())->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($oldRelatedDummy)->willReturn('/related_dummies/old')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($newRelatedDummy)->willReturn('/related_dummies/new')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass(Argument::type(Dummy::class))->willReturn(Dummy::class)->shouldBeCalled();
@@ -149,8 +150,8 @@ class PurgeHttpCacheListenerTest extends TestCase
         $purgerProphecy->purge([])->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], (new GetCollection())->withClass(DummyNoGetOperation::class))->willThrow(new InvalidArgumentException())->shouldBeCalled();
-        $iriConverterProphecy->getIriFromItem($dummyNoGetOperation)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource(DummyNoGetOperation::class, UrlGeneratorInterface::ABS_PATH, new GetCollection())->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummyNoGetOperation)->shouldNotBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass(Argument::type(DummyNoGetOperation::class))->willReturn(DummyNoGetOperation::class)->shouldBeCalled();

--- a/tests/Doctrine/Odm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/SearchFilterTest.php
@@ -745,7 +745,7 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
         $relatedDummyProphecy = $this->prophesize(RelatedDummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
-        $iriConverterProphecy->getItemFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
+        $iriConverterProphecy->getResourceFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
             if (false !== strpos($args[0], '/related_dummies')) {
                 $relatedDummyProphecy->getId()->shouldBeCalled()->willReturn(1);
 

--- a/tests/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -595,7 +595,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         $relatedDummyProphecy = $this->prophesize(RelatedDummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
 
-        $iriConverterProphecy->getItemFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
+        $iriConverterProphecy->getResourceFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
             if (false !== strpos($args[0], '/related_dummies')) {
                 $relatedDummyProphecy->getId()->shouldBeCalled()->willReturn(1);
 

--- a/tests/Elasticsearch/Filter/MatchFilterTest.php
+++ b/tests/Elasticsearch/Filter/MatchFilterTest.php
@@ -71,7 +71,7 @@ class MatchFilterTest extends TestCase
         $foo->setBar('Thévenard');
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getItemFromIri('/foos/1', ['fetch_data' => false])->willReturn($foo)->shouldBeCalled();
+        $iriConverterProphecy->getResourceFromIri('/foos/1', ['fetch_data' => false])->willReturn($foo)->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->getValue($foo, 'id')->willReturn(1)->shouldBeCalled();
@@ -145,7 +145,7 @@ class MatchFilterTest extends TestCase
         $identifierExtractorProphecy->getIdentifierFromResourceClass(Foo::class)->willReturn('id')->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getItemFromIri('/invalid_iri_foos/1', ['fetch_data' => false])->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getResourceFromIri('/invalid_iri_foos/1', ['fetch_data' => false])->willThrow(new InvalidArgumentException())->shouldBeCalled();
 
         $matchFilter = new MatchFilter(
             $propertyNameCollectionFactoryProphecy->reveal(),

--- a/tests/Elasticsearch/Filter/TermFilterTest.php
+++ b/tests/Elasticsearch/Filter/TermFilterTest.php
@@ -71,7 +71,7 @@ class TermFilterTest extends TestCase
         $foo->setBar('Thévenard');
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getItemFromIri('/foos/1', ['fetch_data' => false])->willReturn($foo)->shouldBeCalled();
+        $iriConverterProphecy->getResourceFromIri('/foos/1', ['fetch_data' => false])->willReturn($foo)->shouldBeCalled();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->getValue($foo, 'id')->willReturn(1)->shouldBeCalled();
@@ -145,7 +145,7 @@ class TermFilterTest extends TestCase
         $identifierExtractorProphecy->getIdentifierFromResourceClass(Foo::class)->willReturn('id')->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getItemFromIri('/invalid_iri_foos/1', ['fetch_data' => false])->willThrow(new InvalidArgumentException())->shouldBeCalled();
+        $iriConverterProphecy->getResourceFromIri('/invalid_iri_foos/1', ['fetch_data' => false])->willThrow(new InvalidArgumentException())->shouldBeCalled();
 
         $termFilter = new TermFilter(
             $propertyNameCollectionFactoryProphecy->reveal(),

--- a/tests/Fixtures/TestBundle/Document/CustomActionDummy.php
+++ b/tests/Fixtures/TestBundle/Document/CustomActionDummy.php
@@ -27,7 +27,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  * collectionOperations={
  *     "get",
  *     "get_custom"={"method"="GET", "path"="custom_action_collection_dummies"},
- *     "custom_denormalization"={"method"="GET", "route_name"="custom_denormalization"},
+ *     "custom_denormalization"={"method"="POST", "route_name"="custom_denormalization"},
  *     "short_custom_denormalization"={"method"="GET", "route_name"="short_custom_denormalization"},
  * })
  *

--- a/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/CustomActionDummy.php
@@ -27,7 +27,7 @@ use Doctrine\ORM\Mapping as ORM;
  * collectionOperations={
  *     "get",
  *     "get_custom"={"method"="GET", "path"="custom_action_collection_dummies"},
- *     "custom_denormalization"={"route_name"="custom_denormalization", "method"="GET"},
+ *     "custom_denormalization"={"route_name"="custom_denormalization", "method"="POST"},
  *     "short_custom_denormalization"={"route_name"="short_custom_denormalization", "method"="GET"},
  * })
  *

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/DummyPlainIdentifierDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/DummyPlainIdentifierDenormalizer.php
@@ -68,14 +68,14 @@ class DummyPlainIdentifierDenormalizer implements ContextAwareDenormalizerInterf
 
         $relatedDummyClass = DummyEntity::class === $class ? RelatedDummyEntity::class : RelatedDummyDocument::class;
         if (!empty($data['relatedDummy'])) {
-            $data['relatedDummy'] = $this->iriConverter->getIriFromItem($data['relatedDummy'], (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
+            $data['relatedDummy'] = $this->iriConverter->getIriFromResource($relatedDummyClass, UrlGeneratorInterface::ABS_PATH, new Get(), ['uri_variables' => [
                 'id' => $data['relatedDummy'],
             ]] + $context);
         }
 
         if (!empty($data['relatedDummies'])) {
             foreach ($data['relatedDummies'] as $k => $v) {
-                $data['relatedDummies'][$k] = $this->iriConverter->getIriFromItem($data['relatedDummies'], (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
+                $data['relatedDummies'][$k] = $this->iriConverter->getIriFromResource($relatedDummyClass, UrlGeneratorInterface::ABS_PATH, new Get(), ['uri_variables' => [
                     'id' => $v,
                 ]] + $context);
             }

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/DummyPlainIdentifierDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/DummyPlainIdentifierDenormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\Serializer\Denormalizer;
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
+use ApiPlatform\Metadata\Get;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Dummy as DummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelatedDummy as RelatedDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy as DummyEntity;
@@ -65,20 +66,18 @@ class DummyPlainIdentifierDenormalizer implements ContextAwareDenormalizerInterf
             return $this->denormalizer->denormalize($data, $class, $format, $context + [__CLASS__ => true]);
         }
 
-        $iriConverterContext = ['force_collection' => false, 'operation' => null] + $context;
-
         $relatedDummyClass = DummyEntity::class === $class ? RelatedDummyEntity::class : RelatedDummyDocument::class;
         if (!empty($data['relatedDummy'])) {
-            $data['relatedDummy'] = $this->iriConverter->getIriFromResourceClass($relatedDummyClass, null, UrlGeneratorInterface::ABS_PATH, ['identifiers_values' => [
+            $data['relatedDummy'] = $this->iriConverter->getIriFromItem(null, (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
                 'id' => $data['relatedDummy'],
-            ]] + $iriConverterContext);
+            ]] + $context);
         }
 
         if (!empty($data['relatedDummies'])) {
             foreach ($data['relatedDummies'] as $k => $v) {
-                $data['relatedDummies'][$k] = $this->iriConverter->getIriFromResourceClass($relatedDummyClass, null, UrlGeneratorInterface::ABS_PATH, ['identifiers_values' => [
+                $data['relatedDummies'][$k] = $this->iriConverter->getIriFromItem(null, (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
                     'id' => $v,
-                ]] + $iriConverterContext);
+                ]] + $context);
             }
         }
 

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/DummyPlainIdentifierDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/DummyPlainIdentifierDenormalizer.php
@@ -68,14 +68,14 @@ class DummyPlainIdentifierDenormalizer implements ContextAwareDenormalizerInterf
 
         $relatedDummyClass = DummyEntity::class === $class ? RelatedDummyEntity::class : RelatedDummyDocument::class;
         if (!empty($data['relatedDummy'])) {
-            $data['relatedDummy'] = $this->iriConverter->getIriFromItem(null, (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
+            $data['relatedDummy'] = $this->iriConverter->getIriFromItem($data['relatedDummy'], (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
                 'id' => $data['relatedDummy'],
             ]] + $context);
         }
 
         if (!empty($data['relatedDummies'])) {
             foreach ($data['relatedDummies'] as $k => $v) {
-                $data['relatedDummies'][$k] = $this->iriConverter->getIriFromItem(null, (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
+                $data['relatedDummies'][$k] = $this->iriConverter->getIriFromItem($data['relatedDummies'], (new Get())->withClass($relatedDummyClass), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => [
                     'id' => $v,
                 ]] + $context);
             }

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/RelatedDummyPlainIdentifierDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/RelatedDummyPlainIdentifierDenormalizer.php
@@ -60,10 +60,10 @@ class RelatedDummyPlainIdentifierDenormalizer implements ContextAwareDenormalize
 
         $iriConverterContext = ['uri_variables' => ['id' => $data['thirdLevel']]] + $context;
 
-        $data['thirdLevel'] = $this->iriConverter->getIriFromItem(
-            $data['thirdLevel'],
-            (new Get())->withClass(RelatedDummyEntity::class === $class ? ThirdLevelEntity::class : ThirdLevelDocument::class),
+        $data['thirdLevel'] = $this->iriConverter->getIriFromResource(
+            RelatedDummyEntity::class === $class ? ThirdLevelEntity::class : ThirdLevelDocument::class,
             UrlGeneratorInterface::ABS_PATH,
+            new Get(),
             $iriConverterContext
         );
 

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/RelatedDummyPlainIdentifierDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/RelatedDummyPlainIdentifierDenormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\Serializer\Denormalizer;
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
+use ApiPlatform\Metadata\Get;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelatedDummy as RelatedDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\ThirdLevel as ThirdLevelDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy as RelatedDummyEntity;
@@ -57,11 +58,11 @@ class RelatedDummyPlainIdentifierDenormalizer implements ContextAwareDenormalize
             return $this->denormalizer->denormalize($data, $class, $format, $context + [__CLASS__ => true]);
         }
 
-        $iriConverterContext = ['identifiers_values' => ['id' => $data['thirdLevel']], 'force_collection' => false, 'operation' => null] + $context;
+        $iriConverterContext = ['uri_variables' => ['id' => $data['thirdLevel']]] + $context;
 
-        $data['thirdLevel'] = $this->iriConverter->getIriFromResourceClass(
-            RelatedDummyEntity::class === $class ? ThirdLevelEntity::class : ThirdLevelDocument::class,
+        $data['thirdLevel'] = $this->iriConverter->getIriFromItem(
             null,
+            (new Get())->withClass(RelatedDummyEntity::class === $class ? ThirdLevelEntity::class : ThirdLevelDocument::class),
             UrlGeneratorInterface::ABS_PATH,
             $iriConverterContext
         );

--- a/tests/Fixtures/TestBundle/Serializer/Denormalizer/RelatedDummyPlainIdentifierDenormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/Denormalizer/RelatedDummyPlainIdentifierDenormalizer.php
@@ -61,7 +61,7 @@ class RelatedDummyPlainIdentifierDenormalizer implements ContextAwareDenormalize
         $iriConverterContext = ['uri_variables' => ['id' => $data['thirdLevel']]] + $context;
 
         $data['thirdLevel'] = $this->iriConverter->getIriFromItem(
-            null,
+            $data['thirdLevel'],
             (new Get())->withClass(RelatedDummyEntity::class === $class ? ThirdLevelEntity::class : ThirdLevelDocument::class),
             UrlGeneratorInterface::ABS_PATH,
             $iriConverterContext

--- a/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
+++ b/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
@@ -18,7 +18,6 @@ use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use ApiPlatform\GraphQl\Resolver\ResourceFieldResolver;
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
-use ApiPlatform\Metadata\Get;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
@@ -33,7 +32,7 @@ class ResourceFieldResolverTest extends TestCase
     public function testId()
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], (new Get())->withClass(Dummy::class), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => ['id' => 1]])->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, null, ['uri_variables' => ['id' => 1]])->willReturn('/dummies/1')->shouldBeCalled();
 
         $resolveInfo = new ResolveInfo(FieldDefinition::create(['name' => 'id', 'type' => new ObjectType(['name' => ''])]), [], new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 
@@ -65,7 +64,7 @@ class ResourceFieldResolverTest extends TestCase
     {
         $dummy = new Dummy();
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy)->willReturn('/dummies/1')->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource($dummy)->willReturn('/dummies/1')->shouldNotBeCalled();
 
         $resolveInfo = new ResolveInfo(FieldDefinition::create(['name' => 'id', 'type' => new ObjectType(['name' => ''])]), [], new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 

--- a/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
+++ b/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use ApiPlatform\GraphQl\Resolver\ResourceFieldResolver;
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
+use ApiPlatform\Metadata\Get;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
@@ -32,7 +33,7 @@ class ResourceFieldResolverTest extends TestCase
     public function testId()
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, null, UrlGeneratorInterface::ABS_PATH, ['identifiers_values' => ['id' => 1], 'force_collection' => false])->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, (new Get())->withClass(Dummy::class), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => ['id' => 1]])->willReturn('/dummies/1')->shouldBeCalled();
 
         $resolveInfo = new ResolveInfo(FieldDefinition::create(['name' => 'id', 'type' => new ObjectType(['name' => ''])]), [], new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 

--- a/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
+++ b/tests/GraphQl/Resolver/ResourceFieldResolverTest.php
@@ -33,7 +33,7 @@ class ResourceFieldResolverTest extends TestCase
     public function testId()
     {
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, (new Get())->withClass(Dummy::class), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => ['id' => 1]])->willReturn('/dummies/1')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], (new Get())->withClass(Dummy::class), UrlGeneratorInterface::ABS_PATH, ['uri_variables' => ['id' => 1]])->willReturn('/dummies/1')->shouldBeCalled();
 
         $resolveInfo = new ResolveInfo(FieldDefinition::create(['name' => 'id', 'type' => new ObjectType(['name' => ''])]), [], new ObjectType(['name' => '']), [], new Schema([]), [], null, null, []);
 

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -109,9 +109,9 @@ class ReadStageTest extends TestCase
         $this->serializerContextBuilderProphecy->create($resourceClass, $operationName, $context, true)->shouldBeCalled()->willReturn($normalizationContext);
 
         if ($throwNotFound) {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
+            $this->iriConverterProphecy->getResourceFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
         } else {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willReturn($item);
+            $this->iriConverterProphecy->getResourceFromIri($identifier, $normalizationContext)->willReturn($item);
         }
 
         /** @var Operation $operation */
@@ -154,9 +154,9 @@ class ReadStageTest extends TestCase
         $this->serializerContextBuilderProphecy->create($resourceClass, $operationName, $context, true)->shouldBeCalled()->willReturn($normalizationContext);
 
         if ($throwNotFound) {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
+            $this->iriConverterProphecy->getResourceFromIri($identifier, $normalizationContext)->willThrow(new ItemNotFoundException());
         } else {
-            $this->iriConverterProphecy->getItemFromIri($identifier, $normalizationContext)->willReturn($item);
+            $this->iriConverterProphecy->getResourceFromIri($identifier, $normalizationContext)->willReturn($item);
         }
 
         if ($expectedExceptionClass) {

--- a/tests/GraphQl/Serializer/ItemNormalizerTest.php
+++ b/tests/GraphQl/Serializer/ItemNormalizerTest.php
@@ -86,7 +86,7 @@ class ItemNormalizerTest extends TestCase
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy, Argument::any(), UrlGeneratorInterface::ABS_URL, Argument::type('array'))->willReturn('/dummies/1');
+        $iriConverterProphecy->getIriFromResource($dummy, UrlGeneratorInterface::ABS_URL, Argument::any(), Argument::type('array'))->willReturn('/dummies/1');
 
         $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
         $identifiersExtractorProphecy->getIdentifiersFromItem($dummy)->willReturn(['id' => 1])->shouldBeCalled();
@@ -142,7 +142,7 @@ class ItemNormalizerTest extends TestCase
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'name', [])->willReturn($propertyMetadata);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($dummy, Argument::any(), UrlGeneratorInterface::ABS_URL, Argument::type('array'))->willReturn('/dummies/1');
+        $iriConverterProphecy->getIriFromResource($dummy, UrlGeneratorInterface::ABS_URL, Argument::any(), Argument::type('array'))->willReturn('/dummies/1');
 
         $identifiersExtractorProphecy = $this->prophesize(IdentifiersExtractorInterface::class);
 

--- a/tests/GraphQl/Subscription/SubscriptionManagerTest.php
+++ b/tests/GraphQl/Subscription/SubscriptionManagerTest.php
@@ -178,7 +178,7 @@ class SubscriptionManagerTest extends TestCase
             (new ApiResource())->withOperations(new Operations([(new Get())->withShortName('Dummy')])),
         ]));
 
-        $this->iriConverterProphecy->getIriFromItem($object)->willReturn('/dummies/2');
+        $this->iriConverterProphecy->getIriFromResource($object)->willReturn('/dummies/2');
 
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
         $cacheItemProphecy->isHit()->willReturn(false);
@@ -195,7 +195,7 @@ class SubscriptionManagerTest extends TestCase
             (new ApiResource())->withOperations(new Operations([(new Get())->withShortName('Dummy')])),
         ]));
 
-        $this->iriConverterProphecy->getIriFromItem($object)->willReturn('/dummies/2');
+        $this->iriConverterProphecy->getIriFromResource($object)->willReturn('/dummies/2');
 
         $cacheItemProphecy = $this->prophesize(CacheItemInterface::class);
         $cacheItemProphecy->isHit()->willReturn(true);

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\HttpCache\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use ApiPlatform\HttpCache\EventListener\AddTagsListener;
 use ApiPlatform\HttpCache\PurgerInterface;
@@ -146,8 +148,9 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddCollectionIri()
     {
+        $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, null, 1, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $response = new Response();
         $response->setPublic();
@@ -155,7 +158,7 @@ class AddTagsListenerTest extends TestCase
 
         $event = new ResponseEvent(
             $this->prophesize(HttpKernelInterface::class)->reveal(),
-            new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get']),
+            new Request([], [], ['_resources' => ['/foo', '/bar'], '_api_resource_class' => Dummy::class, '_api_operation_name' => 'get', '_api_operation' => $operation]),
             \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST,
             $response
         );
@@ -168,8 +171,9 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddCollectionIriWhenCollectionIsEmpty()
     {
+        $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, null, 1, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $response = new Response();
         $response->setPublic();
@@ -177,7 +181,7 @@ class AddTagsListenerTest extends TestCase
 
         $event = new ResponseEvent(
             $this->prophesize(HttpKernelInterface::class)->reveal(),
-            new Request([], [], ['_resources' => [], '_api_resource_class' => Dummy::class, '_api_collection_operation_name' => 'get']),
+            new Request([], [], ['_resources' => [], '_api_resource_class' => Dummy::class, '_api_operation_name' => 'get', '_api_operation' => $operation]),
             \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST,
             $response
         );
@@ -190,8 +194,8 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddSubResourceCollectionIri()
     {
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, null, 1, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy = $this->prophesize(LegacyIriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, UrlGeneratorInterface::ABS_PATH)->willReturn('/dummies')->shouldBeCalled();
 
         $response = new Response();
         $response->setPublic();
@@ -212,11 +216,12 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddTagsWithXKey()
     {
+        $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, 'get', 1, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
-        $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => new GetCollection()]))]);
+        $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => $operation]))]);
         $resourceMetadataCollectionFactoryProphecy->create(Dummy::class)->willReturn($dummyMetadata);
 
         $response = new Response();
@@ -241,11 +246,12 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddTagsWithoutHeader()
     {
+        $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResourceClass(Dummy::class, 'get', 1, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
-        $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => new GetCollection()]))]);
+        $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => $operation]))]);
         $resourceMetadataCollectionFactoryProphecy->create(Dummy::class)->willReturn($dummyMetadata);
 
         $response = new Response();

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -150,7 +150,7 @@ class AddTagsListenerTest extends TestCase
     {
         $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $response = new Response();
         $response->setPublic();
@@ -173,7 +173,7 @@ class AddTagsListenerTest extends TestCase
     {
         $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $response = new Response();
         $response->setPublic();
@@ -218,7 +218,7 @@ class AddTagsListenerTest extends TestCase
     {
         $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => $operation]))]);
@@ -248,7 +248,7 @@ class AddTagsListenerTest extends TestCase
     {
         $operation = (new GetCollection())->withClass(Dummy::class);
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => $operation]))]);

--- a/tests/HttpCache/EventListener/AddTagsListenerTest.php
+++ b/tests/HttpCache/EventListener/AddTagsListenerTest.php
@@ -148,9 +148,9 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddCollectionIri()
     {
-        $operation = (new GetCollection())->withClass(Dummy::class);
+        $operation = (new GetCollection());
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, $operation, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $response = new Response();
         $response->setPublic();
@@ -171,9 +171,9 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddCollectionIriWhenCollectionIsEmpty()
     {
-        $operation = (new GetCollection())->withClass(Dummy::class);
+        $operation = (new GetCollection());
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, $operation, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $response = new Response();
         $response->setPublic();
@@ -216,9 +216,9 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddTagsWithXKey()
     {
-        $operation = (new GetCollection())->withClass(Dummy::class);
+        $operation = (new GetCollection());
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, $operation, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => $operation]))]);
@@ -246,9 +246,9 @@ class AddTagsListenerTest extends TestCase
 
     public function testAddTagsWithoutHeader()
     {
-        $operation = (new GetCollection())->withClass(Dummy::class);
+        $operation = (new GetCollection());
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem([], $operation, UrlGeneratorInterface::ABS_PATH, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
+        $iriConverterProphecy->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, $operation, Argument::type('array'))->willReturn('/dummies')->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $dummyMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource())->withOperations(new Operations(['get' => $operation]))]);

--- a/tests/Symfony/EventListener/WriteListenerTest.php
+++ b/tests/Symfony/EventListener/WriteListenerTest.php
@@ -70,7 +70,7 @@ class WriteListenerTest extends TestCase
     {
         $operationResource = new OperationResource(1, 'foo');
 
-        $this->iriConverterProphecy->getIriFromItem($operationResource)->willReturn('/operation_resources/1')->shouldBeCalled();
+        $this->iriConverterProphecy->getIriFromResource($operationResource)->willReturn('/operation_resources/1')->shouldBeCalled();
         $this->resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
         $this->processorProphecy->process($operationResource, Argument::type(Operation::class), [], Argument::type('array'))->willReturn($operationResource)->shouldBeCalled();
 
@@ -110,7 +110,7 @@ class WriteListenerTest extends TestCase
 
         $this->processorProphecy->process($operationResource, Argument::type(Operation::class), [], Argument::type('array'))->willReturn($operationResource)->shouldBeCalled();
 
-        $this->iriConverterProphecy->getIriFromItem($operationResource)->shouldNotBeCalled();
+        $this->iriConverterProphecy->getIriFromResource($operationResource)->shouldNotBeCalled();
         $this->resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
 
         $operationResourceMetadata = new ResourceMetadataCollection(OperationResource::class, [(new ApiResource())->withOperations(new Operations([
@@ -141,7 +141,7 @@ class WriteListenerTest extends TestCase
 
         $this->processorProphecy->process($operationResource, Argument::type(Operation::class), ['identifier' => 1], Argument::type('array'))->willReturn($operationResource)->shouldBeCalled();
 
-        $this->iriConverterProphecy->getIriFromItem($operationResource)->shouldNotBeCalled();
+        $this->iriConverterProphecy->getIriFromResource($operationResource)->shouldNotBeCalled();
         $operationResourceMetadata = new ResourceMetadataCollection(OperationResource::class, [(new ApiResource())->withOperations(new Operations([
             '_api_OperationResource_delete' => (new Delete())->withUriVariables(['identifier' => (new Link())->withFromClass(OperationResource::class)->withIdentifiers(['identifier'])])->withProcessor('processor')->withName('_api_OperationResource_delete'),
         ]))]);
@@ -170,7 +170,7 @@ class WriteListenerTest extends TestCase
 
         $this->processorProphecy->process($operationResource, Argument::type(Operation::class), [], Argument::type('array'))->willReturn($operationResource)->shouldNotBeCalled();
 
-        $this->iriConverterProphecy->getIriFromItem($operationResource)->shouldNotBeCalled();
+        $this->iriConverterProphecy->getIriFromResource($operationResource)->shouldNotBeCalled();
 
         $operationResourceMetadata = new ResourceMetadataCollection(OperationResource::class, [(new ApiResource())->withOperations(new Operations([
             '_api_OperationResource_get' => (new Get())->withName('_api_OperationResource_get'),
@@ -250,7 +250,7 @@ class WriteListenerTest extends TestCase
         $this->processorProphecy->process(Argument::cetera())->shouldNotBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromItem($operationResource)->shouldNotBeCalled();
+        $iriConverterProphecy->getIriFromResource($operationResource)->shouldNotBeCalled();
 
         $request = new Request();
         $request->setMethod('POST');
@@ -277,7 +277,7 @@ class WriteListenerTest extends TestCase
 
         $this->processorProphecy->process($attributeResource, Argument::type(Operation::class), ['slug' => 'test'], Argument::type('array'))->shouldNotBeCalled();
 
-        $this->iriConverterProphecy->getIriFromItem($attributeResource)->shouldNotBeCalled();
+        $this->iriConverterProphecy->getIriFromResource($attributeResource)->shouldNotBeCalled();
         $this->resourceClassResolver->isResourceClass(Argument::type('string'))->shouldNotBeCalled();
 
         $operationResourceMetadata = new ResourceMetadataCollection(OperationResource::class, [(new ApiResource())->withOperations(new Operations([

--- a/tests/Symfony/Routing/IriConverterTest.php
+++ b/tests/Symfony/Routing/IriConverterTest.php
@@ -58,7 +58,7 @@ class IriConverterTest extends TestCase
         ]));
 
         $iriConverter = $this->getIriConverter(null, $routerProphecy, $identifiersExtractyorProphecy, $resourceMetadataCollectionFactoryProphecy);
-        $this->assertEquals('/dummies/1', $iriConverter->getIriFromItem($item, $operation));
+        $this->assertEquals('/dummies/1', $iriConverter->getIriFromResource($item, UrlGeneratorInterface::ABS_PATH, $operation));
     }
 
     public function testGetIriFromItemWithoutOperation()
@@ -81,7 +81,7 @@ class IriConverterTest extends TestCase
         ]));
 
         $iriConverter = $this->getIriConverter(null, $routerProphecy, $identifiersExtractyorProphecy, $resourceMetadataCollectionFactoryProphecy);
-        $this->assertEquals('/dummies/1', $iriConverter->getIriFromItem($item));
+        $this->assertEquals('/dummies/1', $iriConverter->getIriFromResource($item));
     }
 
     public function testGetIriFromItemWithContextOperation()
@@ -102,7 +102,7 @@ class IriConverterTest extends TestCase
         $resourceMetadataCollectionFactoryProphecy->create(Dummy::class)->shouldNotBeCalled();
 
         $iriConverter = $this->getIriConverter(null, $routerProphecy, $identifiersExtractyorProphecy, $resourceMetadataCollectionFactoryProphecy);
-        $this->assertEquals('/dummies/1', $iriConverter->getIriFromItem($item, $operation, UrlGeneratorInterface::ABS_URL));
+        $this->assertEquals('/dummies/1', $iriConverter->getIriFromResource($item, UrlGeneratorInterface::ABS_URL, $operation));
     }
 
     public function testGetIriFromItemWithNoOperations()
@@ -121,7 +121,7 @@ class IriConverterTest extends TestCase
         $identifiersExtractorProphecy->getIdentifiersFromItem($item, Argument::type(HttpOperation::class))->willThrow(RuntimeException::class);
 
         $iriConverter = $this->getIriConverter(null, null, $identifiersExtractorProphecy, $resourceMetadataCollectionFactoryProphecy);
-        $iriConverter->getIriFromItem($item);
+        $iriConverter->getIriFromResource($item);
     }
 
     public function testGetCollectionIri()
@@ -135,7 +135,7 @@ class IriConverterTest extends TestCase
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 
         $iriConverter = $this->getIriConverter(null, $routerProphecy, null, $resourceMetadataCollectionFactoryProphecy);
-        $this->assertEquals('/dummies', $iriConverter->getIriFromItem(null, $operation));
+        $this->assertEquals('/dummies', $iriConverter->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_PATH, $operation));
     }
 
     public function testGetIriFromResourceClassWithIdentifiers()
@@ -152,7 +152,7 @@ class IriConverterTest extends TestCase
         ]));
 
         $iriConverter = $this->getIriConverter(null, $routerProphecy, null, $resourceMetadataCollectionFactoryProphecy);
-        $this->assertEquals('/dummies/1/foo', $iriConverter->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_URL, ['uri_variables' => ['id' => 1]]));
+        $this->assertEquals('/dummies/1/foo', $iriConverter->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_URL, $operation, ['uri_variables' => ['id' => 1]]));
     }
 
     public function testGetIriFromResourceClassWithoutOperation()
@@ -166,7 +166,7 @@ class IriConverterTest extends TestCase
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 
         $iriConverter = $this->getIriConverter(null, $routerProphecy, null, $resourceMetadataCollectionFactoryProphecy);
-        $this->assertEquals('/dummies/1/foo', $iriConverter->getIriFromItem(null, $operation, UrlGeneratorInterface::ABS_URL, ['uri_variables' => ['id' => 1]]));
+        $this->assertEquals('/dummies/1/foo', $iriConverter->getIriFromResource(Dummy::class, UrlGeneratorInterface::ABS_URL, $operation, ['uri_variables' => ['id' => 1]]));
     }
 
     public function testGetItemFromCollectionIri()
@@ -185,7 +185,7 @@ class IriConverterTest extends TestCase
         ]));
 
         $iriConverter = $this->getIriConverter(null, $routerProphecy, null, $resourceMetadataCollectionFactoryProphecy);
-        $iriConverter->getItemFromIri('/dummies');
+        $iriConverter->getResourceFromIri('/dummies');
     }
 
     public function testGetItemFromIri()
@@ -207,7 +207,7 @@ class IriConverterTest extends TestCase
         $stateProviderProphecy = $this->prophesize(ProviderInterface::class);
         $stateProviderProphecy->provide($operation, ['id' => 1], Argument::type('array'))->willReturn($item);
         $iriConverter = $this->getIriConverter($stateProviderProphecy, $routerProphecy, null, $resourceMetadataCollectionFactoryProphecy);
-        $this->assertEquals($item, $iriConverter->getItemFromIri('/dummies/1'));
+        $this->assertEquals($item, $iriConverter->getResourceFromIri('/dummies/1'));
     }
 
     public function testGetNoItemFromIri()
@@ -229,7 +229,7 @@ class IriConverterTest extends TestCase
         $stateProviderProphecy = $this->prophesize(ProviderInterface::class);
         $stateProviderProphecy->provide($operation, ['id' => 1], Argument::type('array'))->willReturn(null);
         $iriConverter = $this->getIriConverter($stateProviderProphecy, $routerProphecy, null, $resourceMetadataCollectionFactoryProphecy);
-        $iriConverter->getItemFromIri('/dummies/1');
+        $iriConverter->getResourceFromIri('/dummies/1');
     }
 
     private function getResourceClassResolver()


### PR DESCRIPTION
Removes a method we introduced for "collection" iris, we're back to the original interface:

```php
<?php

/*
 * This file is part of the API Platform project.
 *
 * (c) Kévin Dunglas <dunglas@gmail.com>
 *
 * For the full copyright and license information, please view the LICENSE
 * file that was distributed with this source code.
 */

declare(strict_types=1);

namespace ApiPlatform\Api;

use ApiPlatform\Exception\InvalidArgumentException;
use ApiPlatform\Exception\ItemNotFoundException;
use ApiPlatform\Exception\RuntimeException;
use ApiPlatform\Metadata\Operation;

/**
 * Converts item and resources to IRI and vice versa.
 *
 * @author Kévin Dunglas <dunglas@gmail.com>
 */
interface IriConverterInterface
{
    /**
     * Retrieves an item from its IRI.
     *
     * @throws InvalidArgumentException
     * @throws ItemNotFoundException
     *
     * @return object
     */
    public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null);

    /**
     * Gets the IRI associated with the given item.
     *
     * @param object|class-string $resource
     *
     * @throws InvalidArgumentException
     * @throws RuntimeException
     */
    public function getIriFromResource($resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): ?string;
}
```

The interesting diff is available at: https://github.com/api-platform/core/compare/main...soyuka:feat/iri-converter?diff=split#diff-ac4847d931ec39d251d7b28fc138a9c65b7fb2f981fe313d9e373a2c2d6b8860

Basically this means:
- easier to implement
- easier to decorate (in the future we will provide an IriConverter that doesn't use symfony's routing system and one for Skolem IRIs #4731)
- Operation is already used in our Providers and Processors this is in the continuity of the work initialized there
- better vocabulary 