### PR TITLE
fix: json encoder invalid utf8 characters

### DIFF
--- a/src/Serializer/JsonEncoder.php
+++ b/src/Serializer/JsonEncoder.php
@@ -40,7 +40,7 @@ final class JsonEncoder implements EncoderInterface, DecoderInterface
         }
 
         // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML.
-        $jsonEncodeOptions = \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_IGNORE;
+        $jsonEncodeOptions = \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_UNESCAPED_UNICODE | (\PHP_VERSION_ID >= 70200 ? \JSON_INVALID_UTF8_IGNORE : 0);
         if (interface_exists(AdvancedNameConverterInterface::class)) {
             $jsonEncode = new JsonEncode(['json_encode_options' => $jsonEncodeOptions]);
             $jsonDecode = new JsonDecode(['json_decode_associative' => true]);

--- a/src/Serializer/JsonEncoder.php
+++ b/src/Serializer/JsonEncoder.php
@@ -40,7 +40,7 @@ final class JsonEncoder implements EncoderInterface, DecoderInterface
         }
 
         // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML.
-        $jsonEncodeOptions = \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_UNESCAPED_UNICODE;
+        $jsonEncodeOptions = \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_IGNORE;
         if (interface_exists(AdvancedNameConverterInterface::class)) {
             $jsonEncode = new JsonEncode(['json_encode_options' => $jsonEncodeOptions]);
             $jsonDecode = new JsonDecode(['json_decode_associative' => true]);

--- a/tests/Serializer/JsonEncoderTest.php
+++ b/tests/Serializer/JsonEncoderTest.php
@@ -64,8 +64,10 @@ class JsonEncoderTest extends TestCase
 
     public function testUTF8MalformedHandlingEncoding()
     {
-        $data = ['foo' => pack('H*', 'B11111')];
+        if (\PHP_VERSION_ID >= 70200) {
+            $data = ['foo' => pack('H*', 'B11111')];
 
-        $this->assertEquals('{"foo":"\u0011\u0011"}', $this->encoder->encode($data, 'json'));
+            $this->assertEquals('{"foo":"\u0011\u0011"}', $this->encoder->encode($data, 'json'));
+        }
     }
 }

--- a/tests/Serializer/JsonEncoderTest.php
+++ b/tests/Serializer/JsonEncoderTest.php
@@ -54,4 +54,18 @@ class JsonEncoderTest extends TestCase
     {
         $this->assertEquals(['foo' => 'bar'], $this->encoder->decode('{"foo":"bar"}', 'json'));
     }
+
+    public function testUTF8EncodedString()
+    {
+        $data = ['foo' => 'Über'];
+
+        $this->assertEquals('{"foo":"Über"}', $this->encoder->encode($data, 'json'));
+    }
+
+    public function testUTF8MalformedHandlingEncoding()
+    {
+        $data = ['foo' => pack('H*', 'B11111')];
+
+        $this->assertEquals('{"foo":"\u0011\u0011"}', $this->encoder->encode($data, 'json'));
+    }
 }


### PR DESCRIPTION
Co-Authored-By: AntonioCS <1086401+antoniocs@users.noreply.github.com>

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #4416 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

This is a follow-up for #4416 with the added test.

Test for PHP 7.1 failing because of:

```
JSON_INVALID_UTF8_IGNORE (int)
Ignore invalid UTF-8 characters. Available as of PHP 7.2.0.
```
