### PR TITLE
FIX: Read provider property from XML definition into metadata

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -302,6 +302,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
                 'queryParameterValidate' => $this->phpize($operation, 'queryParameterValidate', 'bool'),
                 'priority' => $this->phpize($operation, 'priority', 'integer'),
                 'name' => $this->phpize($operation, 'name', 'string'),
+                'provider' => $this->phpize($operation, 'provider', 'string'),
             ]);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The provider attribute on an operation defined in XML metadata is not processed or read into the operation object. This fixes that. E.g. my XML deifnition:
```xml
<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
           https://api-platform.com/schema/metadata/resources-3.0.xsd">
    <resource class="Silverback\ApiComponentsBundle\Metadata\PageDataMetadata">
        <normalizationContext>
            <values>
                <value name="jsonld_embed_context">true</value>
            </values>
        </normalizationContext>
        <defaults>
            <values>
                <value name="route_prefix">/_</value>
            </values>
        </defaults>
        <operations>
            <operation
                class="ApiPlatform\Metadata\Get"
                provider="Silverback\ApiComponentsBundle\DataProvider\StateProvider\PageDataMetadataStateProvider"
            />
            <operation
                class="ApiPlatform\Metadata\GetCollection"
                provider="Silverback\ApiComponentsBundle\DataProvider\StateProvider\PageDataMetadataStateProvider"
            />
        </operations>
    </resource>
</resources>
```
