### PR TITLE
fix(messenger): unwrap DelayedMessageHandlingException when dispatching a delayed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * chore(openapi): upgrade Swagger UI to version 4.1.3
 * chore(openapi): upgrade ReDoc to version 2.0.0-rc.59
 * chore(graphql): upgrade GraphiQL to version 1.5.16
+* fix(messenger): unwrap exception thrown in the handler for delayed messages
+
 
 ## 2.6.7
 

--- a/src/Bridge/Symfony/Messenger/DispatchTrait.php
+++ b/src/Bridge/Symfony/Messenger/DispatchTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Symfony\Messenger;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -42,7 +43,11 @@ trait DispatchTrait
 
         try {
             return $this->messageBus->dispatch($message);
-        } catch (HandlerFailedException $e) {
+        } catch (DelayedMessageHandlingException|HandlerFailedException $e) {
+            while ($e instanceof DelayedMessageHandlingException) {
+                /** @var \Throwable $e */
+                $e = $e->getPrevious();
+            }
             // unwrap the exception thrown in handler for Symfony Messenger >= 4.3
             while ($e instanceof HandlerFailedException) {
                 /** @var \Throwable $e */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6 <!-- see below -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Unwrapping exceptions thrown when handling a new message after this one has been done. Messenger wraps all exceptions thrown in delayed commands into one `DelayedMessageHandlingException`. Docs for that are here: https://symfony.com/doc/current/messenger/dispatch_after_current_bus.html#dispatchaftercurrentbusmiddleware-middleware

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
