### PR TITLE
fix: parameters added on violations list

### DIFF
--- a/features/hal/problem.feature
+++ b/features/hal/problem.feature
@@ -23,7 +23,10 @@ Feature: Error handling valid according to RFC 7807 (application/problem+json)
         {
           "propertyPath": "name",
           "message": "This value should not be blank.",
-          "code": "c1051bb4-d103-4f74-8988-acbcafc7fdc3"
+          "code": "c1051bb4-d103-4f74-8988-acbcafc7fdc3",
+          "parameters": {
+            "{{ value }}": "null"
+          }
         }
       ]
     }

--- a/features/hydra/error.feature
+++ b/features/hydra/error.feature
@@ -23,7 +23,10 @@ Feature: Error handling
         {
           "propertyPath": "name",
           "message": "This value should not be blank.",
-          "code": "c1051bb4-d103-4f74-8988-acbcafc7fdc3"
+          "code": "c1051bb4-d103-4f74-8988-acbcafc7fdc3",
+          "parameters": {
+            "{{ value }}": "null"
+          }
         }
       ]
     }

--- a/features/main/validation.feature
+++ b/features/main/validation.feature
@@ -37,7 +37,10 @@ Feature: Using validations groups
          {
              "propertyPath": "name",
              "message": "This value should not be null.",
-             "code": "ad32d13f-c3d4-423b-909a-857b961eb720"
+             "code": "ad32d13f-c3d4-423b-909a-857b961eb720",
+             "parameters": {
+                "{{ value }}": "null"
+             }
          }
       ]
     }
@@ -66,7 +69,10 @@ Feature: Using validations groups
          {
              "propertyPath": "title",
              "message": "This value should not be null.",
-             "code": "ad32d13f-c3d4-423b-909a-857b961eb720"
+             "code": "ad32d13f-c3d4-423b-909a-857b961eb720",
+             "parameters": {
+                "{{ value }}": "null"
+             }
          }
       ]
     }

--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -65,6 +65,7 @@ abstract class AbstractConstraintViolationListNormalizer implements NormalizerIn
                 'propertyPath' => $this->nameConverter ? $this->nameConverter->normalize($violation->getPropertyPath(), $class, static::FORMAT) : $violation->getPropertyPath(),
                 'message' => $violation->getMessage(),
                 'code' => $violation->getCode(),
+                'parameters' => $violation->getParameters(),
             ];
 
             $constraint = $violation instanceof ConstraintViolation ? $violation->getConstraint() : null;

--- a/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Hydra/Serializer/ConstraintViolationNormalizerTest.php
@@ -64,23 +64,32 @@ class ConstraintViolationNormalizerTest extends TestCase
         $list = new ConstraintViolationList([
             new ConstraintViolation('a', 'b', [], 'c', 'd', 'e', null, 'f24bdbad0becef97a6887238aa58221c', $constraint),
             new ConstraintViolation('1', '2', [], '3', '4', '5'),
+            new ConstraintViolation('1', '2', ['p1', 'p2'], '3', '4', '5'),
         ]);
 
         $expected = [
             '@context' => '/context/foo',
             '@type' => 'ConstraintViolationList',
             'hydra:title' => 'An error occurred',
-            'hydra:description' => "_d: a\n_4: 1",
+            'hydra:description' => "_d: a\n_4: 1\n_4: 1",
             'violations' => [
                 [
                     'propertyPath' => '_d',
                     'message' => 'a',
                     'code' => 'f24bdbad0becef97a6887238aa58221c',
+                    'parameters' => [],
                 ],
                 [
                     'propertyPath' => '_4',
                     'message' => '1',
                     'code' => null,
+                    'parameters' => [],
+                ],
+                [
+                    'propertyPath' => '_4',
+                    'message' => '1',
+                    'code' => null,
+                    'parameters' => ['p1', 'p2'],
                 ],
             ],
         ];

--- a/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
@@ -55,12 +55,13 @@ class ConstraintViolationNormalizerTest extends TestCase
         $list = new ConstraintViolationList([
             new ConstraintViolation('a', 'b', [], 'c', 'd', 'e', null, 'f24bdbad0becef97a6887238aa58221c', $constraint),
             new ConstraintViolation('1', '2', [], '3', '4', '5'),
+            new ConstraintViolation('1', '2', ['p1', 'p2'], '3', '4', '5'),
         ]);
 
         $expected = [
             'type' => 'https://tools.ietf.org/html/rfc2616#section-10',
             'title' => 'An error occurred',
-            'detail' => "_d: a\n_4: 1",
+            'detail' => "_d: a\n_4: 1\n_4: 1",
             'violations' => [
                 [
                     'propertyPath' => '_d',
@@ -69,11 +70,19 @@ class ConstraintViolationNormalizerTest extends TestCase
                     'payload' => [
                         'severity' => 'warning',
                     ],
+                    'parameters' => [],
                 ],
                 [
                     'propertyPath' => '_4',
                     'message' => '1',
                     'code' => null,
+                    'parameters' => [],
+                ],
+                [
+                    'propertyPath' => '_4',
+                    'message' => '1',
+                    'code' => null,
+                    'parameters' => ['p1', 'p2'],
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       |
| License       | MIT
| Doc PR        |

During validation process the parameters of the constraint violations are skipped while normalizing and thus missing in the response.
This makes impossible to pass parameters in the result in cases where the translations are not done in php. 
This PR fixes that issue.
