### PR TITLE
[BUG] Do not rely on api-platform/core attributes classes but on interfaces instead

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -31,7 +31,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
-use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\PostOperationInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
@@ -353,7 +353,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             $hydraOperations = [];
             foreach ($resourceMetadataCollection as $resourceMetadata) {
                 foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
-                    if (($operation instanceof Post || $operation instanceof CollectionOperationInterface) !== $collection) {
+                    if (($operation instanceof PostOperationInterface || $operation instanceof CollectionOperationInterface) !== $collection) {
                         continue;
                     }
 

--- a/src/Metadata/Post.php
+++ b/src/Metadata/Post.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-final class Post extends HttpOperation
+final class Post extends HttpOperation implements PostOperationInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Metadata/PostOperationInterface.php
+++ b/src/Metadata/PostOperationInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+/**
+ * The Operation creates content.
+ */
+interface PostOperationInterface
+{
+}

--- a/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -224,7 +224,7 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
         }
 
         return [
-            sprintf('_api_%s_%s%s', $operation->getUriTemplate() ?: $operation->getShortName(), strtolower($operation->getMethod() ?? HttpOperation::METHOD_GET), $operation instanceof GetCollection ? '_collection' : ''),
+            sprintf('_api_%s_%s%s', $operation->getUriTemplate() ?: $operation->getShortName(), strtolower($operation->getMethod() ?? HttpOperation::METHOD_GET), $operation instanceof CollectionOperationInterface ? '_collection' : ''),
             $operation,
         ];
     }

--- a/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
@@ -18,7 +18,7 @@ use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Operations;
-use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\PostOperationInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Operation\PathSegmentNameGeneratorInterface;
 use Symfony\Component\Routing\Route;
@@ -137,7 +137,7 @@ final class UriTemplateResourceMetadataCollectionFactory implements ResourceMeta
         $operation = $this->normalizeUriVariables($operation);
 
         if (!($uriTemplate = $operation->getUriTemplate())) {
-            if ($operation instanceof Post) {
+            if ($operation instanceof PostOperationInterface) {
                 return $operation->withUriVariables([]);
             }
 

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -21,7 +21,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
-use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\PostOperationInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -228,7 +228,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     break;
             }
 
-            if (!$operation instanceof CollectionOperationInterface && !$operation instanceof Post) {
+            if (!$operation instanceof CollectionOperationInterface && !$operation instanceof PostOperationInterface) {
                 $responses['404'] = new Model\Response('Resource not found');
             }
 

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -28,7 +28,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
-use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\PostOperationInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\UriVariablesResolverTrait;
@@ -138,7 +138,7 @@ final class IriConverter implements IriConverterInterface
         // In symfony the operation name is the route name, try to find one if none provided
         if (
             !$operation->getName()
-            || $operation instanceof Post
+            || $operation instanceof PostOperationInterface
             || $isLegacySubresource
             || $isLegacyCustomResource
         ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | N/A
| License       | MIT
| Doc PR        | **TODO**

In case of a custom GetCollection operation attribute class, the AttributesResourceMetadataCollectionFactory generates the same name as Get operation attribute, which erases the previous operation. api-platform/core should not rely on its own attributes but on interfaces (like CollectionOperationInterface). Same for Post operation, that's why I created a PostOperationInterface.