### PR TITLE
feat: add context parameter to document metadata

### DIFF
--- a/src/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
+++ b/src/Core/Bridge/Elasticsearch/DataProvider/CollectionDataProvider.php
@@ -86,7 +86,7 @@ final class CollectionDataProvider implements ContextAwareCollectionDataProvider
         }
 
         try {
-            $this->documentMetadataFactory->create($resourceClass);
+            $this->documentMetadataFactory->create($resourceClass, $context);
         } catch (IndexNotFoundException $e) {
             return false;
         }
@@ -113,7 +113,7 @@ final class CollectionDataProvider implements ContextAwareCollectionDataProvider
      */
     public function getCollection(string $resourceClass, ?string $operationName = null, array $context = []): iterable
     {
-        $documentMetadata = $this->documentMetadataFactory->create($resourceClass);
+        $documentMetadata = $this->documentMetadataFactory->create($resourceClass, $context);
         $body = [];
 
         foreach ($this->collectionExtensions as $collectionExtension) {

--- a/src/Core/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
+++ b/src/Core/Bridge/Elasticsearch/DataProvider/ItemDataProvider.php
@@ -67,7 +67,7 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
         }
 
         try {
-            $this->documentMetadataFactory->create($resourceClass);
+            $this->documentMetadataFactory->create($resourceClass, $context);
         } catch (IndexNotFoundException $e) {
             return false;
         }
@@ -90,7 +90,7 @@ final class ItemDataProvider implements ItemDataProviderInterface, RestrictedDat
             $id = $id[$this->identifierExtractor->getIdentifierFromResourceClass($resourceClass)];
         }
 
-        $documentMetadata = $this->documentMetadataFactory->create($resourceClass);
+        $documentMetadata = $this->documentMetadataFactory->create($resourceClass, $context);
 
         try {
             $params = [

--- a/src/Elasticsearch/Metadata/Document/Factory/AttributeDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/AttributeDocumentMetadataFactory.php
@@ -47,7 +47,7 @@ final class AttributeDocumentMetadataFactory implements DocumentMetadataFactoryI
     /**
      * {@inheritdoc}
      */
-    public function create(string $resourceClass): DocumentMetadata
+    public function create(string $resourceClass, array $context = []): DocumentMetadata
     {
         $documentMetadata = null;
 

--- a/src/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
@@ -42,7 +42,7 @@ final class CachedDocumentMetadataFactory implements DocumentMetadataFactoryInte
     /**
      * {@inheritdoc}
      */
-    public function create(string $resourceClass): DocumentMetadata
+    public function create(string $resourceClass, array $context = []): DocumentMetadata
     {
         if (isset($this->localCache[$resourceClass])) {
             return $this->handleNotFound($this->localCache[$resourceClass], $resourceClass);

--- a/src/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
@@ -54,7 +54,7 @@ final class CatDocumentMetadataFactory implements DocumentMetadataFactoryInterfa
     /**
      * {@inheritdoc}
      */
-    public function create(string $resourceClass): DocumentMetadata
+    public function create(string $resourceClass, array $context = []): DocumentMetadata
     {
         $documentMetadata = null;
 

--- a/src/Elasticsearch/Metadata/Document/Factory/ConfiguredDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/ConfiguredDocumentMetadataFactory.php
@@ -37,7 +37,7 @@ final class ConfiguredDocumentMetadataFactory implements DocumentMetadataFactory
     /**
      * {@inheritdoc}
      */
-    public function create(string $resourceClass): DocumentMetadata
+    public function create(string $resourceClass, array $context = []): DocumentMetadata
     {
         $documentMetadata = null;
 

--- a/src/Elasticsearch/Metadata/Document/Factory/DocumentMetadataFactoryInterface.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/DocumentMetadataFactoryInterface.php
@@ -30,5 +30,5 @@ interface DocumentMetadataFactoryInterface
      *
      * @throws IndexNotFoundException
      */
-    public function create(string $resourceClass): DocumentMetadata;
+    public function create(string $resourceClass, array $context = []): DocumentMetadata;
 }

--- a/src/Elasticsearch/State/CollectionProvider.php
+++ b/src/Elasticsearch/State/CollectionProvider.php
@@ -60,7 +60,7 @@ final class CollectionProvider implements ProviderInterface
     {
         $resourceClass = $operation->getClass();
         $operationName = $operation->getName();
-        $documentMetadata = $this->documentMetadataFactory->create($resourceClass);
+        $documentMetadata = $this->documentMetadataFactory->create($resourceClass, $context);
         $body = [];
 
         foreach ($this->collectionExtensions as $collectionExtension) {

--- a/src/Elasticsearch/State/ItemProvider.php
+++ b/src/Elasticsearch/State/ItemProvider.php
@@ -50,7 +50,7 @@ final class ItemProvider implements ProviderInterface
     public function provide(Operation $operation, array $uriVariables = [], array $context = [])
     {
         $resourceClass = $operation->getClass();
-        $documentMetadata = $this->documentMetadataFactory->create($resourceClass);
+        $documentMetadata = $this->documentMetadataFactory->create($resourceClass, $context);
 
         try {
             $params = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | https://github.com/api-platform/core/pull/4720#issuecomment-1157502265
| License       | MIT
| Doc PR        | Pending

See comment. This PR is to get the ball rolling, I guess a BC layer must be provided. 

I need additional business logic to return the correct DocumentMetadata (the index name is dynamic based on business logic). Besides the `context` the `Operation $operation` could be passed as well.

But I'm not sure whether you want to continue this way or remove the DocumentMetadata in favor of extending the ApiPlatform\Metadata\Operation in ApiPlatform\Elasticsearch\Metadata\Operation (as mentioned [here](https://github.com/api-platform/core/pull/4720#issuecomment-1103908461) by @soyuka)


