### PR TITLE
Cast int to float when unserialize json typed as elasticsearch

### DIFF
--- a/src/Elasticsearch/Serializer/DocumentNormalizer.php
+++ b/src/Elasticsearch/Serializer/DocumentNormalizer.php
@@ -34,6 +34,8 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 final class DocumentNormalizer extends ObjectNormalizer
 {
     public const FORMAT = 'elasticsearch';
+    
+    public const JSON_ENCODER_FORMAT = self::FORMAT;
 
     private $resourceMetadataFactory;
 


### PR DESCRIPTION
fixes api-platform/api-platform#1344

original fix by @dunglas https://github.com/symfony/symfony/pull/21165/files

need to apply this pull in Symfony/Serializer https://github.com/symfony/symfony/pull/46878

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #1344
| License       | MIT

