### PR TITLE
Return the data type "string" for the enum PHP class in the JSON Schema document.

### DIFF
--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -127,6 +127,13 @@ final class TypeFactory implements TypeFactoryInterface
             ];
         }
 
+        if (is_a($className, \BackedEnum::class, true)) {
+            return [
+                'type' => 'string',
+                'format' => 'enum',
+            ];
+        }        
+        
         // Skip if $schema is null (filters only support basic types)
         if (null === $schema) {
             return ['type' => 'string'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| License       | MIT

Actually, the JSON Schema document specifies the data type "object" for an enum property. According to my interpretation of the specification, it should be a string ( https://swagger.io/docs/specification/data-models/enums/ )

This PR add a test if the class is a BackedEnum class and in this case, return an array ['type'=>'string, 'format'=>'enum']
