### PR TITLE
feat (ApiTestCase): Assert Item|collection JsonSchema with SerializerContext

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -105,7 +105,7 @@ trait ApiTestAssertionsTrait
         static::assertThat(self::getHttpResponse()->toArray(false), $constraint, $message);
     }
 
-    public static function assertMatchesResourceCollectionJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld'): void
+    public static function assertMatchesResourceCollectionJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld', ?array $serializationContext = null): void
     {
         $schemaFactory = self::getSchemaFactory();
 
@@ -115,12 +115,12 @@ trait ApiTestAssertionsTrait
             $operation = $operationName ? (new GetCollection())->withName($operationName) : new GetCollection();
         }
 
-        $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null);
+        $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null, $serializationContext);
 
         static::assertMatchesJsonSchema($schema->getArrayCopy());
     }
 
-    public static function assertMatchesResourceItemJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld'): void
+    public static function assertMatchesResourceItemJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld', ?array $serializationContext = null): void
     {
         $schemaFactory = self::getSchemaFactory();
 
@@ -130,7 +130,7 @@ trait ApiTestAssertionsTrait
             $operation = $operationName ? (new Get())->withName($operationName) : new Get();
         }
 
-        $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null);
+        $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null, $serializationContext);
 
         static::assertMatchesJsonSchema($schema->getArrayCopy());
     }

--- a/tests/Fixtures/TestBundle/Entity/User.php
+++ b/tests/Fixtures/TestBundle/Entity/User.php
@@ -50,6 +50,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
         normalizationContext: ['groups' => ['user_password_reset_request']],
         denormalizationContext: ['groups' => ['user_password_reset_request']]
     ),
+    new Get('users-with-groups/{id}', normalizationContext: ['groups' => ['api-test-case-group']]),
+    new GetCollection('users-with-groups', normalizationContext: ['groups' => ['api-test-case-group']]),
 ], normalizationContext: ['groups' => ['user', 'user-read']], denormalizationContext: ['groups' => ['user', 'user-write']])]
 #[ORM\Entity]
 #[ORM\Table(name: 'user_test')]
@@ -62,7 +64,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[Groups(['user'])]
     private ?string $email = null;
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    #[Groups(['user'])]
+    #[Groups(['user', 'api-test-case-group'])]
     private ?string $fullname = null;
     #[Groups(['user-write'])]
     private ?string $plainPassword = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | ~
| License       | MIT
| Doc PR        | #todo

When a JsonSchema needs to be tested over specific serialization context, one has to rewrite it's own methods.
This allows to pass the serializationContext to create the right JsonSchema during testing.