### PR TITLE
 Fix exceptionToStatus in ApiResource and Operation

### DIFF
--- a/features/main/exception_to_status.feature
+++ b/features/main/exception_to_status.feature
@@ -3,6 +3,7 @@ Feature: Using exception_to_status config
   I can customize the status code returned if the application throws an exception
 
   @createSchema
+  @!mongodb
   Scenario: Configure status code via the operation exceptionToStatus to map custom NotFound error to 404
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/dummy_exception_to_statuses/123"
@@ -10,6 +11,7 @@ Feature: Using exception_to_status config
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
+  @!mongodb
   Scenario: Configure status code via the resource exceptionToStatus to map custom NotFound error to 400
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/dummy_exception_to_statuses/123" with body:
@@ -22,6 +24,7 @@ Feature: Using exception_to_status config
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
+  @!mongodb
   Scenario: Configure status code via the config file to map FilterValidationException to 400
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/dummy_exception_to_statuses"

--- a/features/main/exception_to_status.feature
+++ b/features/main/exception_to_status.feature
@@ -1,0 +1,27 @@
+Feature: Using exception_to_status config
+  As an API developer
+  I can customize the status code returned if the application throw an exception
+
+  @createSchema
+  Scenario: Configure status code via the operation exceptionToStatus to map custom NotFound error to 404
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/dummy_exception_to_statuses/123"
+    Then the response status code should be 404
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @createSchema
+  Scenario: Configure status code via the resource exceptionToStatus to map custom NotFound error to 400
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/dummy_exceptions/123"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @createSchema
+  Scenario: Configure status code via the config file to map FilterValidationException to 400
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "GET" request to "/dummy_exception_to_statuses"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"

--- a/features/main/exception_to_status.feature
+++ b/features/main/exception_to_status.feature
@@ -12,7 +12,7 @@ Feature: Using exception_to_status config
 
   Scenario: Configure status code via the resource exceptionToStatus to map custom NotFound error to 400
     When I add "Content-Type" header equal to "application/ld+json"
-    And I send a "PUT" request to "/dummy_exceptions/123" with body:
+    And I send a "PUT" request to "/dummy_exception_to_statuses/123" with body:
     """
     {
         "name": "black"

--- a/features/main/exception_to_status.feature
+++ b/features/main/exception_to_status.feature
@@ -1,6 +1,6 @@
 Feature: Using exception_to_status config
   As an API developer
-  I can customize the status code returned if the application throw an exception
+  I can customize the status code returned if the application throws an exception
 
   @createSchema
   Scenario: Configure status code via the operation exceptionToStatus to map custom NotFound error to 404
@@ -10,15 +10,18 @@ Feature: Using exception_to_status config
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
-  @createSchema
   Scenario: Configure status code via the resource exceptionToStatus to map custom NotFound error to 400
     When I add "Content-Type" header equal to "application/ld+json"
-    And I send a "GET" request to "/dummy_exceptions/123"
+    And I send a "PUT" request to "/dummy_exceptions/123" with body:
+    """
+    {
+        "name": "black"
+    }
+    """
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
 
-  @createSchema
   Scenario: Configure status code via the config file to map FilterValidationException to 400
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/dummy_exception_to_statuses"

--- a/src/Action/ExceptionAction.php
+++ b/src/Action/ExceptionAction.php
@@ -96,6 +96,11 @@ final class ExceptionAction
 
     private function getOperationExceptionToStatus(Request $request): array
     {
+        // TODO: remove legacy layer in 3.0
+        if ($request->attributes->has('_api_exception_to_status')) {
+            return $request->attributes->get('_api_exception_to_status');
+        }
+
         $attributes = RequestAttributesExtractor::extractAttributes($request);
 
         if ([] === $attributes || null === $this->resourceMetadataFactory) {

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -63,6 +63,7 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * The extension of this bundle.
@@ -655,6 +656,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     {
         if (!$this->isConfigEnabled($container, $config['doctrine'])) {
             return;
+        }
+
+        // For older versions of doctrine bridge this allows autoconfiguration for filters
+        if (!$container->has(ManagerRegistry::class)) {
+            $container->setAlias(ManagerRegistry::class, 'doctrine');
         }
 
         $container->registerForAutoconfiguration(QueryItemExtensionInterface::class)

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -43,6 +43,7 @@ use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRestrictionMetadataInterface;
 use ApiPlatform\Symfony\Validator\ValidationGroupsGeneratorInterface;
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Persistence\ManagerRegistry;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -63,7 +64,6 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
-use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * The extension of this bundle.

--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -175,5 +175,8 @@
             <tag name="api_platform.uri_variables.transformer" priority="-100" />
         </service>
 
+        <service id="api_platform.error_listener" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener">
+            <argument key="$controller">api_platform.action.exception</argument>
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/Resources/config/legacy/api.xml
+++ b/src/Symfony/Bundle/Resources/config/legacy/api.xml
@@ -99,12 +99,11 @@
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
 
-        <service id="api_platform.listener.error" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener" />
-
         <service id="api_platform.listener.exception" class="ApiPlatform\Symfony\EventListener\ExceptionListener">
             <argument>api_platform.action.exception</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <argument>false</argument>
+            <argument type="service" id="api_platform.error_listener" on-invalid="null" />
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-96" />
             <tag name="monolog.logger" channel="request" />

--- a/src/Symfony/Bundle/Resources/config/legacy/api.xml
+++ b/src/Symfony/Bundle/Resources/config/legacy/api.xml
@@ -99,11 +99,12 @@
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
 
+        <service id="api_platform.listener.error" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener" />
+
         <service id="api_platform.listener.exception" class="ApiPlatform\Symfony\EventListener\ExceptionListener">
             <argument>api_platform.action.exception</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <argument>false</argument>
-            <argument type="service" id="exception_listener" on-invalid="null" />
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-96" />
             <tag name="monolog.logger" channel="request" />

--- a/src/Symfony/Bundle/Resources/config/symfony.xml
+++ b/src/Symfony/Bundle/Resources/config/symfony.xml
@@ -66,13 +66,12 @@
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
 
-        <service id="api_platform.listener.error" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener">
-        </service>
+        <service id="api_platform.listener.error" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener" />
+
         <service id="api_platform.listener.exception" class="ApiPlatform\Symfony\EventListener\ExceptionListener">
             <argument>api_platform.action.exception</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <argument>false</argument>
-            <argument type="service" id="api_platform.listener.error" on-invalid="null" />
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-96" />
             <tag name="monolog.logger" channel="request" />

--- a/src/Symfony/Bundle/Resources/config/symfony.xml
+++ b/src/Symfony/Bundle/Resources/config/symfony.xml
@@ -66,11 +66,13 @@
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
 
+        <service id="api_platform.listener.error" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener">
+        </service>
         <service id="api_platform.listener.exception" class="ApiPlatform\Symfony\EventListener\ExceptionListener">
             <argument>api_platform.action.exception</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <argument>false</argument>
-            <argument type="service" id="exception_listener" on-invalid="null" />
+            <argument type="service" id="api_platform.listener.error" on-invalid="null" />
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-96" />
             <tag name="monolog.logger" channel="request" />

--- a/src/Symfony/Bundle/Resources/config/symfony.xml
+++ b/src/Symfony/Bundle/Resources/config/symfony.xml
@@ -66,12 +66,11 @@
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
 
-        <service id="api_platform.listener.error" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener" />
-
         <service id="api_platform.listener.exception" class="ApiPlatform\Symfony\EventListener\ExceptionListener">
             <argument>api_platform.action.exception</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <argument>false</argument>
+            <argument type="service" id="api_platform.error_listener" on-invalid="null" />
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-96" />
             <tag name="monolog.logger" channel="request" />

--- a/src/Symfony/EventListener/ErrorListener.php
+++ b/src/Symfony/EventListener/ErrorListener.php
@@ -27,8 +27,14 @@ final class ErrorListener extends SymfonyErrorListener
     protected function duplicateRequest(\Throwable $exception, Request $request): Request
     {
         $dup = parent::duplicateRequest($exception, $request);
+
         if ($request->attributes->has('_api_operation')) {
             $dup->attributes->set('_api_operation', $request->attributes->get('_api_operation'));
+        }
+
+        // TODO: remove legacy layer in 3.0
+        if ($request->attributes->has('_api_exception_to_status')) {
+            $dup->attributes->set('_api_exception_to_status', $request->attributes->get('_api_exception_to_status'));
         }
 
         return $dup;

--- a/src/Symfony/EventListener/ErrorListener.php
+++ b/src/Symfony/EventListener/ErrorListener.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the API Platform project.
  *
@@ -12,13 +13,20 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Symfony\EventListener;
 
+use ApiPlatform\Action\ExceptionAction;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener as SymfonyErrorListener;
 
-final class ErrorListener extends \Symfony\Component\HttpKernel\EventListener\ErrorListener
+/**
+ * This error listener extends the Symfony one in order to add
+ * the `_api_operation` attribute when the request is duplicated.
+ * It will later be used to retrieve the exceptionToStatus from the operation ({@see ExceptionAction}).
+ */
+final class ErrorListener extends SymfonyErrorListener
 {
     protected function duplicateRequest(\Throwable $exception, Request $request): Request
     {
-        $dup =  parent::duplicateRequest($exception, $request);
+        $dup = parent::duplicateRequest($exception, $request);
         $dup->attributes->set('_api_operation', $request->attributes->get('_api_operation'));
 
         return $dup;

--- a/src/Symfony/EventListener/ErrorListener.php
+++ b/src/Symfony/EventListener/ErrorListener.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\EventListener;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class ErrorListener extends \Symfony\Component\HttpKernel\EventListener\ErrorListener
+{
+    protected function duplicateRequest(\Throwable $exception, Request $request): Request
+    {
+        $dup =  parent::duplicateRequest($exception, $request);
+        $dup->attributes->set('_api_operation', $request->attributes->get('_api_operation'));
+
+        return $dup;
+    }
+}

--- a/src/Symfony/EventListener/ErrorListener.php
+++ b/src/Symfony/EventListener/ErrorListener.php
@@ -27,7 +27,9 @@ final class ErrorListener extends SymfonyErrorListener
     protected function duplicateRequest(\Throwable $exception, Request $request): Request
     {
         $dup = parent::duplicateRequest($exception, $request);
-        $dup->attributes->set('_api_operation', $request->attributes->get('_api_operation'));
+        if ($request->attributes->has('_api_operation')) {
+            $dup->attributes->set('_api_operation', $request->attributes->get('_api_operation'));
+        }
 
         return $dup;
     }

--- a/src/Symfony/EventListener/ExceptionListener.php
+++ b/src/Symfony/EventListener/ExceptionListener.php
@@ -29,7 +29,8 @@ final class ExceptionListener
 {
     /**
      * @phpstan-ignore-next-line legacy may not exist
-     * @var ErrorListener|LegacyExceptionListener 
+     *
+     * @var ErrorListener|LegacyExceptionListener
      */
     private $exceptionListener;
 

--- a/src/Symfony/EventListener/ExceptionListener.php
+++ b/src/Symfony/EventListener/ExceptionListener.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Symfony\EventListener;
 use ApiPlatform\Util\RequestAttributesExtractor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\EventListener\ExceptionListener as LegacyExceptionListener;
 
 /**
  * Handles requests errors.
@@ -29,11 +28,11 @@ final class ExceptionListener
     /**
      * @var ErrorListener
      */
-    private $exceptionListener;
+    private $errorListener;
 
-    public function __construct($controller, LoggerInterface $logger = null, $debug = false, ErrorListener $errorListener = null)
+    public function __construct($controller, LoggerInterface $logger = null, $debug = false)
     {
-        $this->exceptionListener = $errorListener ? new ErrorListener($controller, $logger, $debug) : new LegacyExceptionListener($controller, $logger, $debug); // @phpstan-ignore-line
+        $this->errorListener = new ErrorListener($controller, $logger, $debug);
     }
 
     public function onKernelException(ExceptionEvent $event): void
@@ -47,7 +46,7 @@ final class ExceptionListener
             return;
         }
 
-        $this->exceptionListener->onKernelException($event);
+        $this->errorListener->onKernelException($event);
     }
 }
 

--- a/src/Symfony/EventListener/ExceptionListener.php
+++ b/src/Symfony/EventListener/ExceptionListener.php
@@ -16,6 +16,8 @@ namespace ApiPlatform\Symfony\EventListener;
 use ApiPlatform\Util\RequestAttributesExtractor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListener as LegacyExceptionListener;
 
 /**
  * Handles requests errors.
@@ -26,13 +28,13 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 final class ExceptionListener
 {
     /**
-     * @var ErrorListener
+     * @var ErrorListener|LegacyExceptionListener
      */
-    private $errorListener;
+    private $exceptionListener;
 
-    public function __construct($controller, LoggerInterface $logger = null, $debug = false)
+    public function __construct($controller, LoggerInterface $logger = null, $debug = false, ErrorListener $errorListener = null)
     {
-        $this->errorListener = new ErrorListener($controller, $logger, $debug);
+        $this->exceptionListener = $errorListener ?: new LegacyExceptionListener($controller, $logger, $debug);
     }
 
     public function onKernelException(ExceptionEvent $event): void
@@ -46,7 +48,7 @@ final class ExceptionListener
             return;
         }
 
-        $this->errorListener->onKernelException($event);
+        $this->exceptionListener->onKernelException($event);
     }
 }
 

--- a/src/Symfony/EventListener/ExceptionListener.php
+++ b/src/Symfony/EventListener/ExceptionListener.php
@@ -28,12 +28,14 @@ use Symfony\Component\HttpKernel\EventListener\ExceptionListener as LegacyExcept
 final class ExceptionListener
 {
     /**
-     * @var ErrorListener|LegacyExceptionListener
+     * @phpstan-ignore-next-line legacy may not exist
+     * @var ErrorListener|LegacyExceptionListener 
      */
     private $exceptionListener;
 
     public function __construct($controller, LoggerInterface $logger = null, $debug = false, ErrorListener $errorListener = null)
     {
+        // @phpstan-ignore-next-line legacy may not exist
         $this->exceptionListener = $errorListener ?: new LegacyExceptionListener($controller, $logger, $debug);
     }
 
@@ -48,7 +50,7 @@ final class ExceptionListener
             return;
         }
 
-        $this->exceptionListener->onKernelException($event);
+        $this->exceptionListener->onKernelException($event); // @phpstan-ignore-line
     }
 }
 

--- a/src/Symfony/EventListener/ExceptionListener.php
+++ b/src/Symfony/EventListener/ExceptionListener.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Symfony\EventListener;
 use ApiPlatform\Util\RequestAttributesExtractor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener as LegacyExceptionListener;
 
 /**

--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -336,6 +336,7 @@ final class ApiLoader extends Loader
                 '_api_resource_class' => $resourceClass,
                 '_api_identifiers' => $operation['identifiers'] ?? [],
                 '_api_has_composite_identifier' => $operation['has_composite_identifier'] ?? true,
+                '_api_exception_to_status' => $operation['exception_to_status'] ?? $resourceMetadata->getAttribute('exception_to_status') ?? [],
                 '_api_operation_name' => RouteNameGenerator::generate($operationName, $resourceShortName, $operationType),
                 sprintf('_api_%s_operation_name', $operationType) => $operationName,
             ] + ($operation['defaults'] ?? []),

--- a/src/Test/DoctrineMongoDbOdmTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmTestCase.php
@@ -20,6 +20,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
 use function sys_get_temp_dir;
 
 /**

--- a/tests/Core/Bridge/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Core/Bridge/Symfony/Routing/ApiLoaderTest.php
@@ -328,6 +328,7 @@ class ApiLoaderTest extends TestCase
                 '_api_has_composite_identifier' => false,
                 sprintf('_api_%s_operation_name', $collection ? 'collection' : 'item') => $legacyOperationName,
                 '_api_operation_name' => $operationName,
+                '_api_exception_to_status' => [],
             ] + $extraDefaults,
             $requirements,
             $options,

--- a/tests/Fixtures/TestBundle/Entity/DummyExceptionToStatus.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyExceptionToStatus.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
+use ApiPlatform\Tests\Fixtures\TestBundle\State\DummyExceptionToStatusProvider;
+use ApiPlatform\Tests\Fixtures\TestBundle\State\NotFound;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            exceptionToStatus: [
+                NotFound::class => 404
+            ],
+        ),
+        new Get(uriTemplate: '/dummy_exceptions/{id}'),
+        new GetCollection()
+    ],
+    exceptionToStatus: [
+        NotFound::class => 400
+    ],
+    provider: DummyExceptionToStatusProvider::class
+)]
+#[ApiFilter(RequiredFilter::class)]
+#[ORM\Entity]
+class DummyExceptionToStatus
+{
+    /**
+     * @var int|null The id
+     */
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+    /**
+     * @var string|null The dummy name
+     */
+    #[ORM\Column(nullable: true)]
+    private ?string $name = null;
+    /**
+     * @var string|null The dummy title
+     */
+    #[ORM\Column(nullable: true)]
+    private ?string $title = null;
+    /**
+     * @var string The dummy code
+     */
+    #[ORM\Column]
+    private string $code;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(string $code): self
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyExceptionToStatus.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyExceptionToStatus.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\Exception\NotFoundException;
 use ApiPlatform\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @ApiResource(
@@ -27,7 +28,7 @@ use Doctrine\ORM\Mapping as ORM;
  *     },
  *     collectionOperations={"get"},
  *     exceptionToStatus={
- *         NotFoundException::class=400
+ *         NotFoundHttpException::class=400
  *     }
  * )
  * @ApiFilter(RequiredFilter::class)

--- a/tests/Fixtures/TestBundle/Entity/DummyExceptionToStatus.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyExceptionToStatus.php
@@ -13,56 +13,57 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Get;
-use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Core\Annotation\ApiFilter;
+use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Exception\NotFoundException;
 use ApiPlatform\Tests\Fixtures\TestBundle\Filter\RequiredFilter;
-use ApiPlatform\Tests\Fixtures\TestBundle\State\DummyExceptionToStatusProvider;
-use ApiPlatform\Tests\Fixtures\TestBundle\State\NotFound;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ApiResource(
-    operations: [
-        new Get(
-            exceptionToStatus: [
-                NotFound::class => 404
-            ],
-        ),
-        new Get(uriTemplate: '/dummy_exceptions/{id}'),
-        new GetCollection()
-    ],
-    exceptionToStatus: [
-        NotFound::class => 400
-    ],
-    provider: DummyExceptionToStatusProvider::class
-)]
-#[ApiFilter(RequiredFilter::class)]
-#[ORM\Entity]
+/**
+ * @ApiResource(
+ *     itemOperations={
+ *         "get"={"exception_to_status"={NotFoundException::class=404}},
+ *         "put"
+ *     },
+ *     collectionOperations={"get"},
+ *     exceptionToStatus={
+ *         NotFoundException::class=400
+ *     }
+ * )
+ * @ApiFilter(RequiredFilter::class)
+ * @ORM\Entity
+ */
 class DummyExceptionToStatus
 {
     /**
      * @var int|null The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
-    #[ORM\Column(type: 'integer')]
-    #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
-    private ?int $id = null;
+    private $id = null;
+
     /**
      * @var string|null The dummy name
+     *
+     * @ORM\Column(nullable=true)
      */
-    #[ORM\Column(nullable: true)]
-    private ?string $name = null;
+    private $name = null;
+
     /**
      * @var string|null The dummy title
+     *
+     * @ORM\Column(nullable=true)
      */
-    #[ORM\Column(nullable: true)]
-    private ?string $title = null;
+    private $title = null;
+
     /**
      * @var string The dummy code
+     *
+     * @ORM\Column
      */
-    #[ORM\Column]
-    private string $code;
+    private $code;
 
     public function getId(): ?int
     {

--- a/tests/Fixtures/TestBundle/Exception/NotFoundException.php
+++ b/tests/Fixtures/TestBundle/Exception/NotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Exception;
+
+final class NotFoundException extends \Exception
+{
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/tests/Fixtures/TestBundle/State/DummyExceptionToStatusProvider.php
+++ b/tests/Fixtures/TestBundle/State/DummyExceptionToStatusProvider.php
@@ -1,24 +1,26 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use ApiPlatform\Tests\Fixtures\TestBundle\Exception\NotFoundException;
 
 class DummyExceptionToStatusProvider implements ProviderInterface
 {
     public function provide(Operation $operation, array $uriVariables = [], array $context = [])
     {
-        throw new NotFound();
-    }
-}
-
-class NotFound extends \Exception
-{
-    public function __construct(string $message = "", int $code = 0, ?\Throwable $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
+        throw new NotFoundException();
     }
 }

--- a/tests/Fixtures/TestBundle/State/DummyExceptionToStatusProvider.php
+++ b/tests/Fixtures/TestBundle/State/DummyExceptionToStatusProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+class DummyExceptionToStatusProvider implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        throw new NotFound();
+    }
+}
+
+class NotFound extends \Exception
+{
+    public function __construct(string $message = "", int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -105,7 +105,7 @@ services:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\AttributeResourceProvider'
         public: false
         tags:
-            -  { name: 'api_platform.state_provider' }
+            - { name: 'api_platform.state_provider' }
 
     ApiPlatform\Tests\Fixtures\TestBundle\State\DummyCollectionDtoProvider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\DummyCollectionDtoProvider'
@@ -115,7 +115,7 @@ services:
 
     ApiPlatform\Tests\Fixtures\TestBundle\State\DummyExceptionToStatusProvider:
         tags:
-            -  { name: 'api_platform.state_provider' }
+            - { name: 'api_platform.state_provider' }
 
     # related_questions.state_provider:
     #     class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\RelatedQuestionsProvider'
@@ -131,84 +131,85 @@ services:
         tags:
             - { name: 'api_platform.state_processor' }
 
-
     ApiPlatform\Tests\Fixtures\TestBundle\State\ContainNonResourceProvider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\ContainNonResourceProvider'
         public: false
         tags:
-            -  { name: 'api_platform.state_provider' }
+            - { name: 'api_platform.state_provider' }
 
     ApiPlatform\Tests\Fixtures\TestBundle\State\SerializableProvider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\SerializableProvider'
         public: false
         tags:
-            -  { name: 'api_platform.state_provider' }
+            - { name: 'api_platform.state_provider' }
 
     ApiPlatform\Tests\Fixtures\TestBundle\State\FakeProvider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\FakeProvider'
         tags:
-            -  { name: 'api_platform.state_provider' }
+            - { name: 'api_platform.state_provider' }
 
     ApiPlatform\Tests\Fixtures\TestBundle\State\CarProcessor:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\CarProcessor'
         tags:
-            -  { name: 'api_platform.state_processor' }
+            - { name: 'api_platform.state_processor' }
 
     ApiPlatform\Tests\Fixtures\TestBundle\State\ResourceInterfaceImplementationProvider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\ResourceInterfaceImplementationProvider'
         public: false
         tags:
-            -  { name: 'api_platform.state_provider' }
+            - { name: 'api_platform.state_provider' }
 
     contain_non_resource.item_data_provider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataProvider\ContainNonResourceItemDataProvider'
         public: false
         tags:
-            -  { name: 'api_platform.item_data_provider' }
+            - { name: 'api_platform.item_data_provider' }
 
     serializable.item_data_provider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataProvider\SerializableItemDataProvider'
         public: false
         tags:
-            -  { name: 'api_platform.item_data_provider' }
+            - { name: 'api_platform.item_data_provider' }
 
     resource_interface.data_provider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataProvider\ResourceInterfaceImplementationDataProvider'
         public: false
         tags:
-            -  { name: 'api_platform.item_data_provider' }
-            -  { name: 'api_platform.collection_data_provider' }
+            - { name: 'api_platform.item_data_provider' }
+            - { name: 'api_platform.collection_data_provider' }
 
     app.serializer.denormalizer.serializable_resource:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\Serializer\Denormalizer\SerializableResourceDenormalizer'
         public: false
         tags:
-            -  { name: 'serializer.normalizer' }
+            - { name: 'serializer.normalizer' }
 
     app.serializer.denormalizer.related_dummy_plain_identifier:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\Serializer\Denormalizer\RelatedDummyPlainIdentifierDenormalizer'
         public: false
         arguments: ['@api_platform.iri_converter']
         tags:
-            -  { name: 'serializer.normalizer' }
+            - { name: 'serializer.normalizer' }
 
     app.serializer.denormalizer.dummy_plain_identifier:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\Serializer\Denormalizer\DummyPlainIdentifierDenormalizer'
         public: false
         arguments: ['@api_platform.iri_converter']
         tags:
-            -  { name: 'serializer.normalizer' }
+            - { name: 'serializer.normalizer' }
 
     app.name_converter:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\Serializer\NameConverter\CustomConverter'
 
     app.my_dummy_resource.property_filter:
-        parent:    'api_platform.serializer.property_filter'
-        tags:      [ { name: 'api_platform.filter', id: 'my_dummy.property' } ]
+        parent: 'api_platform.serializer.property_filter'
+        tags:
+            - { name: 'api_platform.filter', id: 'my_dummy.property' }
 
     app.dummy_travel_resource.property_filter:
         parent: 'api_platform.serializer.property_filter'
-        tags: [ { name: 'api_platform.filter', id: 'dummy_travel.property' } ]
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_travel.property' }
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\RequiredFilter:
         arguments: ['@doctrine']
@@ -220,19 +221,19 @@ services:
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\RequiredAllowEmptyFilter:
         arguments: [ '@doctrine' ]
-        tags: [ 'api_platform.filter' ]
+        tags: ['api_platform.filter']
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\BoundsFilter:
         arguments: [ '@doctrine' ]
-        tags: [ 'api_platform.filter' ]
+        tags: ['api_platform.filter']
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\LengthFilter:
         arguments: [ '@doctrine' ]
-        tags: [ 'api_platform.filter' ]
+        tags: ['api_platform.filter']
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\PatternFilter:
         arguments: [ '@doctrine' ]
-        tags: [ 'api_platform.filter' ]
+        tags: ['api_platform.filter']
 
     ApiPlatform\Tests\Fixtures\TestBundle\Controller\:
         resource: '../../TestBundle/Controller'
@@ -242,15 +243,15 @@ services:
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\EnumFilter:
         arguments: [ '@doctrine' ]
-        tags: [ 'api_platform.filter' ]
+        tags: ['api_platform.filter']
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\MultipleOfFilter:
         arguments: [ '@doctrine' ]
-        tags: [ 'api_platform.filter' ]
+        tags: ['api_platform.filter']
 
     ApiPlatform\Tests\Fixtures\TestBundle\Filter\ArrayItemsFilter:
         arguments: [ '@doctrine' ]
-        tags: [ 'api_platform.filter' ]
+        tags: ['api_platform.filter']
 
     app.config_dummy_resource.action:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\Action\ConfigCustom'
@@ -258,37 +259,44 @@ services:
         public: true
 
     app.entity.filter.dummy_property.property:
-        parent:    'api_platform.serializer.property_filter'
-        tags:      [ { name: 'api_platform.filter', id: 'dummy_property.property' } ]
+        parent: 'api_platform.serializer.property_filter'
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_property.property' }
 
     app.entity.filter.dummy_property.whitelist_property:
-        parent:    'api_platform.serializer.property_filter'
+        parent: 'api_platform.serializer.property_filter'
         arguments: [ 'whitelisted_properties', false, [foo, nameConverted] ]
-        tags:      [ { name: 'api_platform.filter', id: 'dummy_property.whitelist_property' } ]
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_property.whitelist_property' }
 
     app.entity.filter.dummy_property.whitelist_nested_property:
-        parent:    'api_platform.serializer.property_filter'
+        parent: 'api_platform.serializer.property_filter'
         arguments: [ 'whitelisted_nested_properties', false, {foo: ~, group: [baz, qux]} ]
-        tags:      [ { name: 'api_platform.filter', id: 'dummy_property.whitelisted_properties' } ]
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_property.whitelisted_properties' }
 
     app.entity.filter.dummy_group.group:
-        parent:    'api_platform.serializer.group_filter'
-        tags:      [ { name: 'api_platform.filter', id: 'dummy_group.group' } ]
+        parent: 'api_platform.serializer.group_filter'
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_group.group' }
 
     app.entity.filter.dummy_group.override_group:
-        parent:    'api_platform.serializer.group_filter'
+        parent: 'api_platform.serializer.group_filter'
         arguments: [ 'override_groups', true ]
-        tags:      [ { name: 'api_platform.filter', id: 'dummy_group.override_group' } ]
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_group.override_group' }
 
     app.entity.filter.dummy_group.whitelist_group:
-        parent:    'api_platform.serializer.group_filter'
+        parent: 'api_platform.serializer.group_filter'
         arguments: [ 'whitelisted_groups', false, ['dummy_foo', 'dummy_baz'] ]
-        tags:      [ { name: 'api_platform.filter', id: 'dummy_group.whitelist_group' } ]
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_group.whitelist_group' }
 
     app.entity.filter.dummy_group.override_whitelist_group:
-        parent:    'api_platform.serializer.group_filter'
+        parent: 'api_platform.serializer.group_filter'
         arguments: [ 'override_whitelisted_groups', true, ['dummy_foo', 'dummy_baz'] ]
-        tags:      [ { name: 'api_platform.filter', id: 'dummy_group.override_whitelist_group' } ]
+        tags:
+            - { name: 'api_platform.filter', id: 'dummy_group.override_whitelist_group' }
 
     logger:
         class: Psr\Log\NullLogger
@@ -322,13 +330,13 @@ services:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\CustomInputDtoDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.data_transformer.custom_output_dto:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\CustomOutputDtoDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.data_transformer.custom_output_dto_fallback_same_class:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\OutputDtoSameClassTransformer'
@@ -340,43 +348,43 @@ services:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\InputDtoDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.data_transformer.output_dto:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\OutputDtoDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.data_transformer.dummy_dto_no_input_to_output_dto:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\DummyDtoNoInputToOutputDtoDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.data_transformer.recover_password_input:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\RecoverPasswordInputDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.data_transformer.recover_password_output:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\RecoverPasswordOutputDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.data_transformer.initialize_input:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\InitializeInputDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.messenger_handler.messenger_with_response:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\MessengerHandler\MessengerWithResponseHandler'
         public: false
         tags:
-            -  { name: 'messenger.message_handler' }
+            - { name: 'messenger.message_handler' }
 
     app.graphql.query_resolver.dummy_custom_item:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryItemResolver'
@@ -442,7 +450,7 @@ services:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataTransformer\RPCOutputDataTransformer'
         public: false
         tags:
-            -  { name: 'api_platform.data_transformer' }
+            - { name: 'api_platform.data_transformer' }
 
     app.security.authentication_entrypoint:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\Security\AuthenticationEntryPoint'

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -113,6 +113,10 @@ services:
         tags:
             -  { name: 'api_platform.state_provider' }
 
+    ApiPlatform\Tests\Fixtures\TestBundle\State\DummyExceptionToStatusProvider:
+        tags:
+            -  { name: 'api_platform.state_provider' }
+
     # related_questions.state_provider:
     #     class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\RelatedQuestionsProvider'
     #     public: false

--- a/tests/Symfony/EventListener/ExceptionListenerTest.php
+++ b/tests/Symfony/EventListener/ExceptionListenerTest.php
@@ -20,7 +20,6 @@ use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
@@ -38,7 +37,7 @@ class ExceptionListenerTest extends TestCase
         $kernel = $this->prophesize(HttpKernelInterface::class);
         $kernel->handle(Argument::type(Request::class), HttpKernelInterface::SUB_REQUEST, false)->willReturn(new Response())->shouldBeCalled();
 
-        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
+        $listener = new ExceptionListener('foo:bar', null, false);
         $event = new ExceptionEvent($kernel->reveal(), $request, \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST, new \Exception());
         $listener->onKernelException($event);
 
@@ -55,7 +54,7 @@ class ExceptionListenerTest extends TestCase
 
     public function testDoNothingWhenNotAnApiCall()
     {
-        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
+        $listener = new ExceptionListener('foo:bar', null, false);
         $event = new ExceptionEvent($this->prophesize(HttpKernelInterface::class)->reveal(), new Request(), \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST, new \Exception());
         $listener->onKernelException($event);
 
@@ -67,7 +66,7 @@ class ExceptionListenerTest extends TestCase
         $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('html');
 
-        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
+        $listener = new ExceptionListener('foo:bar', null, false);
         $event = new ExceptionEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST, new \Exception());
         $listener->onKernelException($event);
 

--- a/tests/Symfony/EventListener/ExceptionListenerTest.php
+++ b/tests/Symfony/EventListener/ExceptionListenerTest.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Symfony\EventListener;
 
 use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Metadata\Get;
 use ApiPlatform\Symfony\EventListener\ExceptionListener;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
@@ -35,26 +35,29 @@ class ExceptionListenerTest extends TestCase
     public function testOnKernelException(Request $request)
     {
         $kernel = $this->prophesize(HttpKernelInterface::class);
-        $kernel->handle(Argument::type(Request::class), HttpKernelInterface::SUB_REQUEST, false)->willReturn(new Response())->shouldBeCalled();
 
-        $listener = new ExceptionListener('foo:bar', null, false);
+        $errorListener = class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class) : null;
+
         $event = new ExceptionEvent($kernel->reveal(), $request, \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST, new \Exception());
-        $listener->onKernelException($event);
 
-        $this->assertInstanceOf(Response::class, $event->getResponse());
+        if ($errorListener) {
+            $errorListener->onKernelException($event)->shouldBeCalled();
+        }
+
+        $listener = new ExceptionListener('foo:bar', null, false, $errorListener ? $errorListener->reveal() : null);
+        $listener->onKernelException($event);
     }
 
     public function getRequest()
     {
         return [
-            [new Request([], [], ['_api_resource_class' => 'Foo', '_api_collection_operation_name' => 'get'])],
-            [new Request([], [], ['_api_respond' => true])],
+            [new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation' => new Get(), '_api_respond' => true])],
         ];
     }
 
     public function testDoNothingWhenNotAnApiCall()
     {
-        $listener = new ExceptionListener('foo:bar', null, false);
+        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
         $event = new ExceptionEvent($this->prophesize(HttpKernelInterface::class)->reveal(), new Request(), \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST, new \Exception());
         $listener->onKernelException($event);
 
@@ -66,7 +69,7 @@ class ExceptionListenerTest extends TestCase
         $request = new Request([], [], ['_api_respond' => true]);
         $request->setRequestFormat('html');
 
-        $listener = new ExceptionListener('foo:bar', null, false);
+        $listener = new ExceptionListener('foo:bar', null, false, class_exists(ErrorListener::class) ? $this->prophesize(ErrorListener::class)->reveal() : null);
         $event = new ExceptionEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST, new \Exception());
         $listener->onKernelException($event);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Tickets       | #4848 
| License       | MIT

I open this PR to discuss about the possible solution to fix the `exceptionToStatus` feature inside ApiResource attribute and operation

Because of [Symfony ErrorListener](https://github.com/symfony/symfony/blob/f42339552cdeee8aa1e6286c2c97dff1cca3032e/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php#L166) the request is duplicated without all the attributes needed to fetch the exception to status mapping.

A possible solution (the one I choose) could be to extend this listener to override the `duplicateRequest` method to also duplicate the attributes needed to get the exception to status mapping but I'm not realy satisfied with this solution so I'm really open to suggestions