### PR TITLE
fix: deprecated `UpgradeApiResourceCommand::$defaultName`

### DIFF
--- a/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
+++ b/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
@@ -31,13 +31,18 @@ use PhpParser\NodeTraverser;
 use PhpParser\Parser\Php7;
 use PhpParser\PrettyPrinter\Standard;
 use SebastianBergmann\Diff\Differ;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'api:upgrade-resource')]
 final class UpgradeApiResourceCommand extends Command
 {
+    /**
+     * @deprecated To be removed along with Symfony < 6.1 compatibility
+     */
     protected static $defaultName = 'api:upgrade-resource';
 
     private $resourceNameCollectionFactory;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes: 

>  * 1x: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "ApiPlatform\Core\Bridge\Symfony\Bundle\Command\UpgradeApiResourceCommand" class instead.