### PR TITLE
chore: better BC/FC layer for deprecated `Command::$defaultName`

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/GraphQlExportCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/GraphQlExportCommand.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Command;
 
 use ApiPlatform\Core\GraphQl\Type\SchemaBuilderInterface;
 use GraphQL\Utils\SchemaPrinter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -28,8 +29,14 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
+#[AsCommand(name: 'api:graphql:export', description: 'Export the GraphQL schema in Schema Definition Language (SDL)')]
 class GraphQlExportCommand extends Command
 {
+    /**
+     * @deprecated To be removed along with Symfony <6.1 compatibility
+     */
+    protected static $defaultName = 'api:graphql:export';
+
     private $schemaBuilder;
 
     public function __construct(SchemaBuilderInterface $schemaBuilder)
@@ -76,10 +83,5 @@ class GraphQlExportCommand extends Command
         }
 
         return 0;
-    }
-
-    public static function getDefaultName(): string
-    {
-        return 'api:graphql:export';
     }
 }

--- a/src/Bridge/Symfony/Bundle/Command/OpenApiCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/OpenApiCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Command;
 
 use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,8 +28,14 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Dumps Open API documentation.
  */
+#[AsCommand(name: 'api:openapi:export', description: 'Dump the Open API documentation')]
 final class OpenApiCommand extends Command
 {
+    /**
+     * @deprecated To be removed along with Symfony <6.1 compatibility
+     */
+    protected static $defaultName = 'api:openapi:export';
+
     private $openApiFactory;
     private $normalizer;
 
@@ -88,10 +95,5 @@ final class OpenApiCommand extends Command
         $output->writeln($content);
 
         return 0;
-    }
-
-    public static function getDefaultName(): string
-    {
-        return 'api:openapi:export';
     }
 }

--- a/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/SwaggerCommand.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Documentation\Documentation;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Core\Swagger\Serializer\ApiGatewayNormalizer;
 use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,8 +32,14 @@ use Symfony\Component\Yaml\Yaml;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
+#[AsCommand(name: 'swagger:export', description: 'Dump the Swagger v2 documentation')]
 final class SwaggerCommand extends Command
 {
+    /**
+     * @deprecated To be removed along with Symfony <6.1 compatibility
+     */
+    protected static $defaultName = 'api:swagger:export';
+
     private $normalizer;
     private $resourceNameCollectionFactory;
     private $apiTitle;
@@ -106,10 +113,5 @@ final class SwaggerCommand extends Command
         }
 
         return 0;
-    }
-
-    public static function getDefaultName(): string
-    {
-        return 'api:swagger:export';
     }
 }

--- a/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
+++ b/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\JsonSchema\Command;
 use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\JsonSchema\Schema;
 use ApiPlatform\Core\JsonSchema\SchemaFactoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -29,8 +30,14 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @author Jacques Lefebvre <jacques@les-tilleuls.coop>
  */
+#[AsCommand(name: 'api:json-schema:generate', description: 'Generates the JSON Schema for a resource operation.')]
 final class JsonSchemaGenerateCommand extends Command
 {
+    /**
+     * @deprecated To be removed along with Symfony <6.1 compatibility
+     */
+    protected static $defaultName = 'api:json-schema:generate';
+
     private $schemaFactory;
     private $formats;
 
@@ -111,10 +118,5 @@ final class JsonSchemaGenerateCommand extends Command
         $io->text((string) json_encode($schema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         return 0;
-    }
-
-    public static function getDefaultName(): string
-    {
-        return 'api:json-schema:generate';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6
| Tickets       | -
| License       | MIT
| Doc PR        | -

`Command::setDescription()` method calls can also be removed once Symfony 6.1+ is required