### PR TITLE
If property metadata fetches GroupSequence, skip

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -26,6 +26,7 @@ use ApiPlatform\Util\ResourceClassInfoTrait;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
  * {@inheritdoc}
@@ -199,6 +200,9 @@ final class SchemaFactory implements SchemaFactoryInterface
         // TODO: 3.0 support multiple types
         $type = $propertyMetadata->getBuiltinTypes()[0] ?? null;
         if (null !== $type) {
+            if (is_a($type->getClassName(), GroupSequence::class, true)) {
+                return;
+            }
             if ($isCollection = $type->isCollection()) {
                 $keyType = method_exists(Type::class, 'getCollectionKeyTypes') ? ($type->getCollectionKeyTypes()[0] ?? null) : $type->getCollectionKeyType();
                 $valueType = method_exists(Type::class, 'getCollectionValueTypes') ? ($type->getCollectionValueTypes()[0] ?? null) : $type->getCollectionValueType();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #4613
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Allow the Schema Factory to generate schemas if one of the Classes is a GroupSequence Provider.
It seems the Factory is picking up on the Getter defined by the interface and is trying to add it as property.

Now the question is if we should fix it like this OR add a section to the docs that explains that people have to tell the serializer to ignore the getter as that also seems to fix it.

Let me know what you want to do with this :)

