### PR TITLE
feat(symfony): Deprecate the `$exceptionOnNoToken` parameter in  `ResourceAccessChecker::__construct()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.0-rc.3
+
+* Symfony: deprecate the `$exceptionOnNoToken` parameter in `ResourceAccessChecker::__construct()` (#4900)
+
 ## 2.7.0-beta.5
 
 * Serializer: ignore no-operation on SerializeListener (#4828)

--- a/src/Symfony/Security/ResourceAccessChecker.php
+++ b/src/Symfony/Security/ResourceAccessChecker.php
@@ -43,7 +43,11 @@ final class ResourceAccessChecker implements ResourceAccessCheckerInterface
         $this->roleHierarchy = $roleHierarchy;
         $this->tokenStorage = $tokenStorage;
         $this->authorizationChecker = $authorizationChecker;
-        $this->exceptionOnNoToken = $exceptionOnNoToken;
+
+        if (5 < func_num_args()) {
+            $this->exceptionOnNoToken = $exceptionOnNoToken;
+            trigger_deprecation('api-platform/core', '2.7', 'The $exceptionOnNoToken parameter in "%s()" is deprecated and will always be false in 3.0, you should stop using it.', __METHOD__);
+        }
     }
 
     public function isGranted(string $resourceClass, string $expression, array $extraVariables = []): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | -
| License       | MIT
| Doc PR        | -

Just syncing with symfony/security: https://github.com/symfony/symfony/pull/41965.
This argument is useless with the not-so-new authenticator system, and it must be `false` everywhere in Symfony 6.
The plan is to do the same in 3.0: deprecate the parameter entirely and throw if it's passed as `true`, then remove it in 4.0.
The impact of this deprecation is likely to be small since very few or nobody should be extending this class anyway.
