### PR TITLE
fix: AbstractItemNormalizer 

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -546,7 +546,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $type->isCollection() &&
             ($collectionValueType = $type->getCollectionValueTypes()[0] ?? null) &&
             ($className = $collectionValueType->getClassName()) &&
-            $this->resourceClassResolver->isResourceClass($className)
+            $this->resourceClassResolver->isResourceClass($className) &&
+            null !== $attributeValue
         ) {
             if (!is_iterable($attributeValue)) {
                 throw new UnexpectedValueException('Unexpected non-iterable value for to-many relation.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

```php
/** 
 * @var Car[]|null
*/
public ?array $cars;
```

Having `?array` type of member fields in entities breaks serialization when held value is `null` with docblock similar to the above where `Car` is API Resource.

