### PR TITLE
ignore api_platform.state.item_provider when Doctrine is not enabled

### DIFF
--- a/src/Symfony/Bundle/Resources/config/state.xml
+++ b/src/Symfony/Bundle/Resources/config/state.xml
@@ -42,7 +42,7 @@
         <service id="ApiPlatform\State\Pagination\PaginationOptions" alias="api_platform.pagination_options" />
 
         <service id="ApiPlatform\State\CreateProvider" class="ApiPlatform\State\CreateProvider">
-            <argument type="service" id="api_platform.state.item_provider" />
+            <argument type="service" id="api_platform.state.item_provider" on-invalid="ignore" />
 
             <tag name="api_platform.state_provider" />
         </service>


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | none
| License       | MIT
| Doc PR        | 


hi,

Similar to <https://github.com/api-platform/api-platform/issues/1265>  

Getting:

``` 
bin/console cache:clear
# ...
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In CheckExceptionOnInvalidReferenceBehaviorPass.php line 86:
!!                                                                                 
!!    The service "ApiPlatform\State\CreateProvider" has a dependency on a non-ex  
!!    istent service "api_platform.state.item_provider".                           
!!                                                                                 
!!  
!!  
Script @auto-scripts was called via post-update-cmd
``` 

after upgrade to `3.0` 
manually removing the cache did not help

`state.xml` defines a non existing dependency when neither Doctrine, Doctrine-MongoDb or Elastic are enabled

Adding the `on-invalid="ignore"` solves the unmatched dependency
