### PR TITLE
fix(symfony): upgrade command removes filters

### DIFF
--- a/src/Core/Upgrade/UpgradeApiFilterVisitor.php
+++ b/src/Core/Upgrade/UpgradeApiFilterVisitor.php
@@ -147,6 +147,7 @@ final class UpgradeApiFilterVisitor extends NodeVisitorAbstract
                 $reflection = $this->reflectionClass->getProperty($node->props[0]->name->__toString());
             }
 
+            $filterAttributes = [];
             foreach ($this->readApiFilters($reflection) as $annotation) {
                 [$filterAnnotation, $isAnnotation] = $annotation;
                 if ($isAnnotation) {
@@ -172,12 +173,14 @@ final class UpgradeApiFilterVisitor extends NodeVisitorAbstract
                     $arguments[$key] = $this->valueToNode($value);
                 }
 
-                $node->attrGroups[] = new Node\AttributeGroup([
-                    new Node\Attribute(
-                        new Node\Name('ApiFilter'),
-                        $this->arrayToArguments($arguments),
-                    ),
-                ]);
+                $filterAttributes[] = new Node\Attribute(
+                    new Node\Name('ApiFilter'),
+                    $this->arrayToArguments($arguments),
+                );
+            }
+
+            foreach ($filterAttributes as $filterAttribute) {
+                $node->attrGroups[] = new Node\AttributeGroup([$filterAttribute]);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #4966
| License       | MIT
| Doc PR        | -

The `api:upgrade-resource` command is only leaving the last `ApiFilter` attribute of each resource. I did not dig into `nikic/php-parser`but adding an `ApiFilter` removes the previous one.