### PR TITLE
Use output walkers when ordering by non-fetched relation

### DIFF
--- a/src/Core/Bridge/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Core/Bridge/Doctrine/Orm/Util/QueryChecker.php
@@ -93,7 +93,6 @@ final class QueryChecker
     public static function hasOrderByOnFetchJoinedToManyAssociation(QueryBuilder $queryBuilder, ManagerRegistry $managerRegistry): bool
     {
         if (
-            0 === \count($selectParts = $queryBuilder->getDQLPart('select')) ||
             0 === \count($queryBuilder->getDQLPart('join')) ||
             0 === \count($orderByParts = $queryBuilder->getDQLPart('orderBy'))
         ) {
@@ -101,21 +100,6 @@ final class QueryChecker
         }
 
         $rootAliases = $queryBuilder->getRootAliases();
-
-        $selectAliases = [];
-
-        foreach ($selectParts as $select) {
-            foreach ($select->getParts() as $part) {
-                [$alias] = explode('.', $part);
-
-                $selectAliases[] = $alias;
-            }
-        }
-
-        $selectAliases = array_diff($selectAliases, $rootAliases);
-        if (0 === \count($selectAliases)) {
-            return false;
-        }
 
         $orderByAliases = [];
 
@@ -134,11 +118,13 @@ final class QueryChecker
             return false;
         }
 
+        $allAliases = $queryBuilder->getAllAliases();
+
         foreach ($orderByAliases as $orderByAlias) {
             $inToManyContext = false;
 
             foreach (QueryBuilderHelper::traverseJoins($orderByAlias, $queryBuilder, $managerRegistry) as $alias => [$metadata, $association]) {
-                if ($inToManyContext && \in_array($alias, $selectAliases, true)) {
+                if ($inToManyContext && \in_array($alias, $allAliases, true)) {
                     return true;
                 }
 

--- a/src/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Doctrine/Orm/Util/QueryChecker.php
@@ -92,7 +92,6 @@ final class QueryChecker
     public static function hasOrderByOnFetchJoinedToManyAssociation(QueryBuilder $queryBuilder, ManagerRegistry $managerRegistry): bool
     {
         if (
-            0 === \count($selectParts = $queryBuilder->getDQLPart('select')) ||
             0 === \count($queryBuilder->getDQLPart('join')) ||
             0 === \count($orderByParts = $queryBuilder->getDQLPart('orderBy'))
         ) {
@@ -100,21 +99,6 @@ final class QueryChecker
         }
 
         $rootAliases = $queryBuilder->getRootAliases();
-
-        $selectAliases = [];
-
-        foreach ($selectParts as $select) {
-            foreach ($select->getParts() as $part) {
-                [$alias] = explode('.', $part);
-
-                $selectAliases[] = $alias;
-            }
-        }
-
-        $selectAliases = array_diff($selectAliases, $rootAliases);
-        if (0 === \count($selectAliases)) {
-            return false;
-        }
 
         $orderByAliases = [];
 
@@ -133,11 +117,13 @@ final class QueryChecker
             return false;
         }
 
+        $allAliases = $queryBuilder->getAllAliases();
+
         foreach ($orderByAliases as $orderByAlias) {
             $inToManyContext = false;
 
             foreach (QueryBuilderHelper::traverseJoins($orderByAlias, $queryBuilder, $managerRegistry) as $alias => [$metadata, $association]) {
-                if ($inToManyContext && \in_array($alias, $selectAliases, true)) {
+                if ($inToManyContext && \in_array($alias, $allAliases, true)) {
                     return true;
                 }
 

--- a/tests/Doctrine/Orm/Util/QueryCheckerTest.php
+++ b/tests/Doctrine/Orm/Util/QueryCheckerTest.php
@@ -175,7 +175,7 @@ class QueryCheckerTest extends TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($entityManagerProphecy);
         $managerRegistryProphecy->getManagerForClass(RelatedDummy::class)->willReturn($entityManagerProphecy);
 
-        $this->assertFalse(QueryChecker::hasOrderByOnFetchJoinedToManyAssociation($queryBuilder, $managerRegistryProphecy->reveal()));
+        $this->assertTrue(QueryChecker::hasOrderByOnFetchJoinedToManyAssociation($queryBuilder, $managerRegistryProphecy->reveal()));
     }
 
     public function testHasOrderByOnFetchJoinedToManyAssociationWithJoinByAssociation()
@@ -277,7 +277,7 @@ class QueryCheckerTest extends TestCase
         $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($entityManagerProphecy);
         $managerRegistryProphecy->getManagerForClass(RelatedDummy::class)->willReturn($entityManagerProphecy);
 
-        $this->assertFalse(LegacyQueryChecker::hasOrderByOnToManyJoin($queryBuilder, $managerRegistryProphecy->reveal()));
+        $this->assertTrue(LegacyQueryChecker::hasOrderByOnToManyJoin($queryBuilder, $managerRegistryProphecy->reveal()));
     }
 
     /**


### PR DESCRIPTION
fixes #4936

| Q             | A
| ------------- | ---
| Branch?       | 2.7 - current stable version branch for bug fixes
| Tickets       | #4936
| License       | MIT
| Doc PR        | -

Here is a PR with the changes proposed in the corresponding issue.
From my understanding there is already a way to define this option on per operation basis, but setting that option would result in always using the output walkers, even if they are not needed.
I've described the changes in the issue already, if needed we may discuss here.

I'm submitting this as a bugfix, even though the behavior seems intended, because this change should fix potentially unexpected errors and should not break anything existing.