### PR TITLE
[Metadata] Do not auto-generate NotExposed operation when using custom operation classes

### DIFF
--- a/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
@@ -59,7 +59,7 @@ final class NotExposedOperationResourceMetadataCollectionFactory implements Reso
 
             foreach ($operations as $operation) {
                 // An item operation has been found, nothing to do anymore in this factory
-                if (('GET' === strtoupper($operation->getMethod()) && !$operation instanceof CollectionOperationInterface) || ($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false)) {
+                if ((HttpOperation::METHOD_GET === $operation->getMethod() && !$operation instanceof CollectionOperationInterface) || ($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false)) {
                     return $resourceMetadataCollection;
                 }
             }

--- a/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Resource\Factory;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\NotExposed;
@@ -58,7 +59,7 @@ final class NotExposedOperationResourceMetadataCollectionFactory implements Reso
 
             foreach ($operations as $operation) {
                 // An item operation has been found, nothing to do anymore in this factory
-                if ($operation instanceof Get || ($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false)) {
+                if (('GET' === strtoupper($operation->getMethod()) && !$operation instanceof CollectionOperationInterface) || ($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false)) {
                     return $resourceMetadataCollection;
                 }
             }

--- a/tests/Fixtures/TestBundle/Metadata/Get.php
+++ b/tests/Fixtures/TestBundle/Metadata/Get.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Metadata;
+
+use ApiPlatform\Metadata\HttpOperation;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class Get extends HttpOperation
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(...$args)
+    {
+        parent::__construct(self::METHOD_GET, ...$args);
+    }
+}

--- a/tests/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactoryTest.php
@@ -24,6 +24,7 @@ use ApiPlatform\Metadata\Resource\Factory\NotExposedOperationResourceMetadataCol
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AttributeResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Metadata\Get as CustomGet;
 use ApiPlatform\Tests\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -68,8 +69,8 @@ class NotExposedOperationResourceMetadataCollectionFactoryTest extends TestCase
                 new ApiResource(
                     shortName: 'AttributeResource',
                     operations: [
-                        '_api_AttributeResource_get' => new Get(uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])], controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
                         '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
+                        '_api_AttributeResource_get' => new Get(uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])], controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
                     ],
                     uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])],
                     class: AttributeResource::class
@@ -88,8 +89,55 @@ class NotExposedOperationResourceMetadataCollectionFactoryTest extends TestCase
                 new ApiResource(
                     shortName: 'AttributeResource',
                     operations: [
-                        '_api_AttributeResource_get' => new Get(uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])], controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
                         '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
+                        '_api_AttributeResource_get' => new Get(uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])], controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
+                    ],
+                    uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])],
+                    class: AttributeResource::class
+                ),
+            ]),
+            $factory->create(AttributeResource::class)
+        );
+    }
+
+    public function testItIgnoresResourcesWithAnItemOperationUsingCustomClass()
+    {
+        $linkFactoryProphecy = $this->prophesize(LinkFactoryInterface::class);
+        $linkFactoryProphecy->createLinksFromIdentifiers(Argument::type(HttpOperation::class))->shouldNotBeCalled();
+
+        $resourceCollectionMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceCollectionMetadataFactoryProphecy->create(AttributeResource::class)->willReturn(
+            new ResourceMetadataCollection(AttributeResource::class, [
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    operations: [],
+                    class: AttributeResource::class
+                ),
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    operations: [
+                        '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
+                        '_api_AttributeResource_get' => new CustomGet(uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])], controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
+                    ],
+                    uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])],
+                    class: AttributeResource::class
+                ),
+            ]),
+        );
+
+        $factory = new NotExposedOperationResourceMetadataCollectionFactory($linkFactoryProphecy->reveal(), $resourceCollectionMetadataFactoryProphecy->reveal());
+        $this->assertEquals(
+            new ResourceMetadataCollection(AttributeResource::class, [
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    operations: [],
+                    class: AttributeResource::class
+                ),
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    operations: [
+                        '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
+                        '_api_AttributeResource_get' => new CustomGet(uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])], controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
                     ],
                     uriVariables: ['id' => new Link(fromClass: AttributeResource::class, identifiers: ['id'])],
                     class: AttributeResource::class


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #4977
| License       | MIT