### PR TITLE
fix(symfony): metadata cache is broken in dev/prod

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -486,16 +486,16 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
     private function registerCacheConfiguration(ContainerBuilder $container): void
     {
-        if (!$container->hasParameter('kernel.debug') || !$container->getParameter('kernel.debug')) {
+        if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
+            $container->register('api_platform.cache.metadata.property', ArrayAdapter::class)->addTag('cache.pool');
+            $container->register('api_platform.cache.metadata.resource', ArrayAdapter::class)->addTag('cache.pool');
+            $container->register('api_platform.cache.metadata.resource_collection', ArrayAdapter::class)->addTag('cache.pool');
+            $container->register('api_platform.cache.route_name_resolver', ArrayAdapter::class)->addTag('cache.pool');
+            $container->register('api_platform.cache.identifiers_extractor', ArrayAdapter::class);
+            $container->register('api_platform.elasticsearch.cache.metadata.document', ArrayAdapter::class);
+        } else {
             $container->removeDefinition('api_platform.cache_warmer.cache_pool_clearer');
         }
-
-        $container->register('api_platform.cache.metadata.property', ArrayAdapter::class)->addTag('cache.pool');
-        $container->register('api_platform.cache.metadata.resource', ArrayAdapter::class)->addTag('cache.pool');
-        $container->register('api_platform.cache.metadata.resource_collection', ArrayAdapter::class)->addTag('cache.pool');
-        $container->register('api_platform.cache.route_name_resolver', ArrayAdapter::class)->addTag('cache.pool');
-        $container->register('api_platform.cache.identifiers_extractor', ArrayAdapter::class);
-        $container->register('api_platform.elasticsearch.cache.metadata.document', ArrayAdapter::class);
     }
 
     private function registerDoctrineOrmConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader): void

--- a/src/Symfony/Bundle/Resources/config/state.xml
+++ b/src/Symfony/Bundle/Resources/config/state.xml
@@ -42,7 +42,7 @@
         <service id="ApiPlatform\State\Pagination\PaginationOptions" alias="api_platform.pagination_options" />
 
         <service id="ApiPlatform\State\CreateProvider" class="ApiPlatform\State\CreateProvider">
-            <argument type="service" id="api_platform.state.item_provider" />
+            <argument type="service" id="api_platform.state.item_provider" on-invalid="ignore" />
 
             <tag name="api_platform.state_provider" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #4975
| License       | MIT

Hi!

Cache seems broken in 3.0.0. Metadatas are not stored in the filesystem nor in APCu, resulting in poor performances (see https://github.com/api-platform/core/issues/4975#issuecomment-1251668523).

Cache services are provided by each metadata XML file located in `src/Symfony/Bundle/Resources/config/`.

- `api_platform.cache.metadata.property` => `metadata/property.xml`
- `api_platform.cache.metadata.resource` => `metadata/resource_name.xml`
- `api_platform.cache.metadata.resource_collection` => `metadata/resource.xml`
- `api_platform.cache.route_name_resolver` => `metadata/api.xml`
- `api_platform.cache.identifiers_extractor` => seems unused
- `api_platform.elasticsearch.cache.metadata.document` => `elasticsearch.xml`

In `ApiPlatformExtension`, these files are loaded in `registerMetadataConfiguration` but then each cache is overrided in `registerCacheConfiguration` for an `ArrayAdapter` instead of the usual `cache.system`.