### PR TITLE
Missing dependency on symfony/deprecation-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "doctrine/inflector": "^1.0 || ^2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1.0 || ^2.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/http-foundation": "^4.4 || ^5.1 || ^6.0",
         "symfony/http-kernel": "^4.4 || ^5.1 || ^6.0",
         "symfony/property-access": "^3.4.19 || ^4.4 || ^5.1 || ^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- 2.7 for bugs related to the **backward compatibility layer**, if the bug was in 2.6 let's fix it on the 3.0 branch instead
- 3.0 for bug fixes
- main for new features

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

I noticed some errors in the tests of NelmioApiDocBundle after upgrading to 2.7: https://github.com/nelmio/NelmioApiDocBundle/actions/runs/3123031427/jobs/5065374592.

It seems the dependency on symfony/deprecation-contracts is missing.
