### PR TITLE
fix: compatibility with PHP 8.2

### DIFF
--- a/src/GraphQl/Resolver/Stage/ReadStage.php
+++ b/src/GraphQl/Resolver/Stage/ReadStage.php
@@ -43,7 +43,7 @@ final class ReadStage implements ReadStageInterface
     /**
      * {@inheritdoc}
      */
-    public function __invoke(?string $resourceClass, ?string $rootClass, Operation $operation, array $context): iterable|object|null
+    public function __invoke(?string $resourceClass, ?string $rootClass, Operation $operation, array $context): object|array|null
     {
         if (!($operation->canRead() ?? true)) {
             return $context['is_collection'] ? [] : null;

--- a/src/GraphQl/Resolver/Stage/ReadStageInterface.php
+++ b/src/GraphQl/Resolver/Stage/ReadStageInterface.php
@@ -22,5 +22,5 @@ use ApiPlatform\Metadata\GraphQl\Operation;
  */
 interface ReadStageInterface
 {
-    public function __invoke(?string $resourceClass, ?string $rootClass, Operation $operation, array $context): iterable|object|null;
+    public function __invoke(?string $resourceClass, ?string $rootClass, Operation $operation, array $context): object|array|null;
 }

--- a/src/GraphQl/Resolver/Stage/SerializeStage.php
+++ b/src/GraphQl/Resolver/Stage/SerializeStage.php
@@ -38,7 +38,7 @@ final class SerializeStage implements SerializeStageInterface
     {
     }
 
-    public function __invoke(iterable|object|null $itemOrCollection, string $resourceClass, Operation $operation, array $context): ?array
+    public function __invoke(object|array|null $itemOrCollection, string $resourceClass, Operation $operation, array $context): ?array
     {
         $isCollection = $operation instanceof CollectionOperationInterface;
         $isMutation = $operation instanceof Mutation;

--- a/src/GraphQl/Resolver/Stage/SerializeStageInterface.php
+++ b/src/GraphQl/Resolver/Stage/SerializeStageInterface.php
@@ -22,5 +22,5 @@ use ApiPlatform\Metadata\GraphQl\Operation;
  */
 interface SerializeStageInterface
 {
-    public function __invoke(iterable|object|null $itemOrCollection, string $resourceClass, Operation $operation, array $context): ?array;
+    public function __invoke(object|array|null $itemOrCollection, string $resourceClass, Operation $operation, array $context): ?array;
 }

--- a/src/State/CallableProvider.php
+++ b/src/State/CallableProvider.php
@@ -26,7 +26,7 @@ final class CallableProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|iterable|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         if (\is_callable($provider = $operation->getProvider())) {
             return $provider($operation, $uriVariables, $context);

--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -27,5 +27,5 @@ interface ProviderInterface
     /**
      * Provides data.
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|iterable|null;
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null;
 }

--- a/src/Symfony/Maker/Resources/skeleton/StateProvider.tpl.php
+++ b/src/Symfony/Maker/Resources/skeleton/StateProvider.tpl.php
@@ -8,7 +8,7 @@ use ApiPlatform\State\ProviderInterface;
 
 class <?php echo $class_name; ?> implements ProviderInterface
 {
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|iterable|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         // Retrieve the state from somewhere
     }

--- a/tests/Fixtures/Symfony/Maker/CustomStateProvider.php
+++ b/tests/Fixtures/Symfony/Maker/CustomStateProvider.php
@@ -7,7 +7,7 @@ use ApiPlatform\State\ProviderInterface;
 
 class CustomStateProvider implements ProviderInterface
 {
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|iterable|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         // Retrieve the state from somewhere
     }

--- a/tests/Fixtures/TestBundle/State/CustomOutputDtoProvider.php
+++ b/tests/Fixtures/TestBundle/State/CustomOutputDtoProvider.php
@@ -27,7 +27,7 @@ final class CustomOutputDtoProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|iterable|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         if ($operation instanceof CollectionOperationInterface) {
             $object = $this->collectionProvider->provide($operation, $uriVariables, $context);

--- a/tests/Fixtures/TestBundle/State/DummyExceptionToStatusProvider.php
+++ b/tests/Fixtures/TestBundle/State/DummyExceptionToStatusProvider.php
@@ -19,7 +19,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Exception\NotFoundException;
 
 class DummyExceptionToStatusProvider implements ProviderInterface
 {
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable|object|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         throw new NotFoundException();
     }

--- a/tests/Fixtures/TestBundle/State/FakeProvider.php
+++ b/tests/Fixtures/TestBundle/State/FakeProvider.php
@@ -23,7 +23,7 @@ final class FakeProvider implements ProviderInterface
      *
      * @return array|object|null
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable|object|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         $className = $operation->getClass();
         $data = [

--- a/tests/Fixtures/TestBundle/State/FakeProvider.php
+++ b/tests/Fixtures/TestBundle/State/FakeProvider.php
@@ -18,11 +18,6 @@ use ApiPlatform\State\ProviderInterface;
 
 final class FakeProvider implements ProviderInterface
 {
-    /**
-     * {@inheritDoc}
-     *
-     * @return array|object|null
-     */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         $className = $operation->getClass();

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -62,7 +62,7 @@ class ReadStageTest extends TestCase
     /**
      * @dataProvider contextProvider
      */
-    public function testApplyDisabled(array $context, iterable|object|null $expectedResult): void
+    public function testApplyDisabled(array $context, object|array|null $expectedResult): void
     {
         $resourceClass = 'myResource';
         /** @var Operation $operation */

--- a/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
@@ -80,7 +80,7 @@ class SerializeStageTest extends TestCase
     /**
      * @dataProvider applyProvider
      */
-    public function testApply(iterable|object $itemOrCollection, string $operationName, array $context, bool $paginationEnabled, ?array $expectedResult): void
+    public function testApply(object|array $itemOrCollection, string $operationName, array $context, bool $paginationEnabled, ?array $expectedResult): void
     {
         $resourceClass = 'myResource';
         $operation = $context['is_mutation'] ? new Mutation() : new Query();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Prevents this error:

> Compile Error: Type Traversable|object|array|null contains both object and a class type, which is redundant

Related to https://github.com/php/php-src/issues/9556.
Please note that as described in this issue, this change isn't a BC break and doesn't break existing code even on PHP 8.1.