### PR TITLE
fix(symfony): Command constants not available for symfony <5.1

### DIFF
--- a/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
+++ b/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
@@ -86,13 +86,13 @@ This will remove "ApiPlatform\Core\Annotation\ApiResource" annotation/attribute 
         if (!$input->getOption('force') && \PHP_VERSION_ID < 80100) {
             $output->write('<error>The new metadata system only works with PHP 8.1 and above.');
 
-            return Command::INVALID;
+            return \defined(Command::class.'::INVALID') ? Command::INVALID : 2;
         }
 
         if (!class_exists(NodeTraverser::class)) {
             $output->writeln('Run `composer require --dev `nikic/php-parser` or install phpunit to use this command.');
 
-            return Command::FAILURE;
+            return \defined(Command::class.'::FAILURE') ? Command::FAILURE : 1;
         }
 
         $subresources = $this->getSubresources();
@@ -151,7 +151,7 @@ This will remove "ApiPlatform\Core\Annotation\ApiResource" annotation/attribute 
                 if (!class_exists(Differ::class)) {
                     $output->writeln('Run `composer require --dev sebastian/diff` or install phpunit to print a diff.');
 
-                    return Command::FAILURE;
+                    return \defined(Command::class.'::FAILURE') ? Command::FAILURE : 1;
                 }
 
                 $this->printDiff($oldCode, $newCode, $output);
@@ -161,7 +161,7 @@ This will remove "ApiPlatform\Core\Annotation\ApiResource" annotation/attribute 
             file_put_contents($fileName, $newCode);
         }
 
-        return Command::SUCCESS;
+        return \defined(Command::class.'::SUCCESS') ? Command::SUCCESS : 0;
     }
 
     /**

--- a/src/Symfony/Bundle/Command/DebugResourceCommand.php
+++ b/src/Symfony/Bundle/Command/DebugResourceCommand.php
@@ -58,7 +58,7 @@ final class DebugResourceCommand extends Command
         if (0 === \count($resourceCollection)) {
             $output->writeln(sprintf('<error>No resources found for class %s</error>', $resourceClass));
 
-            return Command::INVALID;
+            return \defined(Command::class.'::INVALID') ? Command::INVALID : 2;
         }
 
         $shortName = (false !== $pos = strrpos($resourceClass, '\\')) ? substr($resourceClass, $pos + 1) : $resourceClass;
@@ -110,13 +110,13 @@ final class DebugResourceCommand extends Command
             $this->dumper->dump($this->cloner->cloneVar($selectedResource));
             $output->writeln('Successfully dumped the selected resource');
 
-            return Command::SUCCESS;
+            return \defined(Command::class.'::SUCCESS') ? Command::SUCCESS : 0;
         }
 
         $this->dumper->dump($this->cloner->cloneVar($resourceCollection->getOperation($answerOperation)));
         $output->writeln('Successfully dumped the selected operation');
 
-        return Command::SUCCESS;
+        return \defined(Command::class.'::SUCCESS') ? Command::SUCCESS : 0;
     }
 
     public static function getDefaultName(): string

--- a/src/Symfony/Bundle/Command/GraphQlExportCommand.php
+++ b/src/Symfony/Bundle/Command/GraphQlExportCommand.php
@@ -75,7 +75,7 @@ class GraphQlExportCommand extends Command
             $output->writeln($schemaExport);
         }
 
-        return 0;
+        return \defined(Command::class.'::SUCCESS') ? Command::SUCCESS : 0;
     }
 
     public static function getDefaultName(): string

--- a/src/Symfony/Bundle/Command/OpenApiCommand.php
+++ b/src/Symfony/Bundle/Command/OpenApiCommand.php
@@ -86,12 +86,12 @@ final class OpenApiCommand extends Command
             $filesystem->dumpFile($filename, $content);
             $io->success(sprintf('Data written to %s.', $filename));
 
-            return 0;
+            return \defined(Command::class.'::SUCCESS') ? Command::SUCCESS : 0;
         }
 
         $output->writeln($content);
 
-        return 0;
+        return \defined(Command::class.'::SUCCESS') ? Command::SUCCESS : 0;
     }
 
     public static function getDefaultName(): string


### PR DESCRIPTION
…ALID)

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Command constant are only available since Symfony 5.1 (for SUCCESS and FAILURE) and 5.3 (for INVALID).
