### PR TITLE
fix(metadata): no skolem iri by default

### DIFF
--- a/features/jsonld/non_resource.feature
+++ b/features/jsonld/non_resource.feature
@@ -38,6 +38,7 @@ Feature: JSON-LD non-resource handling
       }
     }
     """
+    And the JSON node "notAResource.@id" should not exist
 
   Scenario: Get a resource containing a raw object with selected properties
     Given there are 1 dummy objects with relatedDummy and its thirdLevel
@@ -123,3 +124,11 @@ Feature: JSON-LD non-resource handling
       "id": 1
     }
     """
+
+  @php8
+  Scenario: Get a generated id
+    When I send a "GET" request to "/genids/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON node "totalPrice.@id" should exist

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -87,6 +87,7 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
 
         $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class']);
         $context = $this->initContext($resourceClass, $context);
+        $context['api_collection_sub_level'] = true;
         $data = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
 
         if ($this->iriConverter instanceof LegacyIriConverterInterface) {

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -200,6 +200,10 @@ final class ContextBuilder implements AnonymousContextBuilderInterface
             }
         }
 
+        if (false === ($context['iri'] ?? null)) {
+            trigger_deprecation('api-platform/core', '2.7', 'An anonymous resource will use a Skolem IRI in API Platform 3.0. Use #[ApiProperty(skolemIri: false)] to keep this behavior in 3.0.');
+        }
+
         if ($context['has_context'] ?? false) {
             unset($jsonLdContext['@context']);
         }

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -200,8 +200,12 @@ final class ContextBuilder implements AnonymousContextBuilderInterface
             }
         }
 
+        if ($this->iriConverter && isset($context['gen_id']) && true === $context['gen_id']) {
+            $jsonLdContext['@id'] = $this->iriConverter->getIriFromResource($object);
+        }
+
         if (false === ($context['iri'] ?? null)) {
-            trigger_deprecation('api-platform/core', '2.7', 'An anonymous resource will use a Skolem IRI in API Platform 3.0. Use #[ApiProperty(skolemIri: false)] to keep this behavior in 3.0.');
+            trigger_deprecation('api-platform/core', '2.7', 'An anonymous resource will use a Skolem IRI in API Platform 3.0. Use #[ApiProperty(genId: false)] to keep this behavior in 3.0.');
         }
 
         if ($context['has_context'] ?? false) {

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -89,6 +89,12 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $context = $this->initContext($resourceClass, $context);
             $metadata = $this->addJsonLdContext($this->contextBuilder, $resourceClass, $context);
         } elseif ($this->contextBuilder instanceof AnonymousContextBuilderInterface) {
+            if ($context['api_collection_sub_level'] ?? false) {
+                unset($context['api_collection_sub_level']);
+                $context['output']['genid'] = true;
+                $context['output']['iri'] = null;
+            }
+
             // We should improve what's behind the context creation, its probably more complicated then it should
             $metadata = $this->createJsonLdContext($this->contextBuilder, $object, $context);
         }

--- a/src/JsonLd/Serializer/JsonLdContextTrait.php
+++ b/src/JsonLd/Serializer/JsonLdContextTrait.php
@@ -51,7 +51,7 @@ trait JsonLdContextTrait
     {
         // We're in a collection, don't add the @context part
         if (isset($context['jsonld_has_context'])) {
-            return $contextBuilder->getAnonymousResourceContext($object, ($context['output'] ?? []) + ['api_resource' => $context['api_resource'] ?? null, 'has_context' => true]);
+            return $contextBuilder->getAnonymousResourceContext($object, ($context['output'] ?? []) + ['api_resource' => $context['api_resource'] ?? null, 'has_context' => true, 'iri' => false]);
         }
 
         $context['jsonld_has_context'] = true;

--- a/src/Metadata/ApiProperty.php
+++ b/src/Metadata/ApiProperty.php
@@ -92,6 +92,7 @@ final class ApiProperty
 
     private $schema;
     private $initializable;
+    private $skolemIri;
 
     /**
      * @var string[]
@@ -146,6 +147,7 @@ final class ApiProperty
         ?array $builtinTypes = null,
         ?array $schema = null,
         ?bool $initializable = null,
+        ?bool $skolemIri = null,
 
         $iris = null,
 
@@ -175,6 +177,7 @@ final class ApiProperty
         $this->builtinTypes = $builtinTypes;
         $this->schema = $schema;
         $this->initializable = $initializable;
+        $this->skolemIri = $skolemIri;
         $this->iris = $iris;
         $this->extraProperties = $extraProperties;
     }
@@ -504,6 +507,22 @@ final class ApiProperty
     {
         $metadata = clone $this;
         $metadata->iris = (array) $iris;
+
+        return $metadata;
+    }
+
+    /**
+     * Whether to generate a skolem iri on anonymous resources.
+     */
+    public function getSkolemIri()
+    {
+        return $this->skolemIri;
+    }
+
+    public function withSkolemIri($skolemIri): self
+    {
+        $metadata = clone $this;
+        $metadata->skolemIri = $skolemIri;
 
         return $metadata;
     }

--- a/src/Metadata/ApiProperty.php
+++ b/src/Metadata/ApiProperty.php
@@ -92,7 +92,7 @@ final class ApiProperty
 
     private $schema;
     private $initializable;
-    private $skolemIri;
+    private $genId;
 
     /**
      * @var string[]
@@ -147,7 +147,7 @@ final class ApiProperty
         ?array $builtinTypes = null,
         ?array $schema = null,
         ?bool $initializable = null,
-        ?bool $skolemIri = null,
+        ?bool $genId = null,
 
         $iris = null,
 
@@ -177,7 +177,7 @@ final class ApiProperty
         $this->builtinTypes = $builtinTypes;
         $this->schema = $schema;
         $this->initializable = $initializable;
-        $this->skolemIri = $skolemIri;
+        $this->genId = $genId;
         $this->iris = $iris;
         $this->extraProperties = $extraProperties;
     }
@@ -514,15 +514,15 @@ final class ApiProperty
     /**
      * Whether to generate a skolem iri on anonymous resources.
      */
-    public function getSkolemIri()
+    public function getGenId()
     {
-        return $this->skolemIri;
+        return $this->genId;
     }
 
-    public function withSkolemIri($skolemIri): self
+    public function withGenId(bool $genId): self
     {
         $metadata = clone $this;
-        $metadata->skolemIri = $skolemIri;
+        $metadata->genId = $genId;
 
         return $metadata;
     }

--- a/src/Metadata/Extractor/XmlPropertyExtractor.php
+++ b/src/Metadata/Extractor/XmlPropertyExtractor.php
@@ -71,6 +71,7 @@ final class XmlPropertyExtractor extends AbstractPropertyExtractor
                 'initializable' => $this->phpize($property, 'initializable', 'bool'),
                 'extraProperties' => $this->buildExtraProperties($property, 'extraProperties'),
                 'iris' => $this->buildArrayValue($property, 'iri'),
+                'genId' => $this->phpize($property, 'genId', 'bool'),
             ];
         }
     }

--- a/src/Metadata/Extractor/YamlPropertyExtractor.php
+++ b/src/Metadata/Extractor/YamlPropertyExtractor.php
@@ -92,6 +92,7 @@ final class YamlPropertyExtractor extends AbstractPropertyExtractor
                     'example' => $propertyValues['example'] ?? null,
                     'builtinTypes' => $this->buildAttribute($propertyValues, 'builtinTypes'),
                     'schema' => $this->buildAttribute($propertyValues, 'schema'),
+                    'genId' => $this->phpize($propertyValues, 'genId', 'bool'),
                 ];
             }
         }

--- a/src/Metadata/Extractor/schema/properties.xsd
+++ b/src/Metadata/Extractor/schema/properties.xsd
@@ -43,6 +43,7 @@
         <xsd:attribute name="security" type="xsd:string"/>
         <xsd:attribute name="securityPostDenormalize" type="xsd:string"/>
         <xsd:attribute name="initializable" type="xsd:boolean"/>
+        <xsd:attribute name="skolemIri" type="xsd:boolean"/>
     </xsd:complexType>
 
     <xsd:complexType name="types">

--- a/src/Metadata/Extractor/schema/properties.xsd
+++ b/src/Metadata/Extractor/schema/properties.xsd
@@ -43,7 +43,7 @@
         <xsd:attribute name="security" type="xsd:string"/>
         <xsd:attribute name="securityPostDenormalize" type="xsd:string"/>
         <xsd:attribute name="initializable" type="xsd:boolean"/>
-        <xsd:attribute name="skolemIri" type="xsd:boolean"/>
+        <xsd:attribute name="genId" type="xsd:boolean"/>
     </xsd:complexType>
 
     <xsd:complexType name="types">

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -833,9 +833,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             if ($propertyMetadata instanceof PropertyMetadata) {
                 $childContext['output']['iri'] = $propertyMetadata->getIri() ?? false;
             } else {
-                if (null !== ($propertyIris = $propertyMetadata->getIris())) {
-                    $childContext['output']['iri'] = 1 === \count($propertyIris) ? ($propertyIris[0] ?? false) : $propertyIris;
-                }
+                $childContext['output']['gen_id'] = $propertyMetadata->getGenId() ?? false;
             }
 
             return $this->serializer->normalize($attributeValue, $format, $childContext);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -831,10 +831,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             unset($childContext['iri'], $childContext['uri_variables']);
 
             if ($propertyMetadata instanceof PropertyMetadata) {
-                $childContext['output']['iri'] = $propertyMetadata->getIri();
+                $childContext['output']['iri'] = $propertyMetadata->getIri() ?? false;
             } else {
                 if (null !== ($propertyIris = $propertyMetadata->getIris())) {
-                    $childContext['output']['iri'] = 1 === \count($propertyIris) ? $propertyIris[0] : $propertyIris;
+                    $childContext['output']['iri'] = 1 === \count($propertyIris) ? ($propertyIris[0] ?? false) : $propertyIris;
                 }
             }
 

--- a/tests/Fixtures/TestBundle/Model/GenId.php
+++ b/tests/Fixtures/TestBundle/Model/GenId.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Model;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+
+#[Get('/genids/{id}', provider: [GenId::class, 'getData'])]
+class GenId
+{
+    #[ApiProperty(genId: true)]
+    public MonetaryAmount $totalPrice;
+
+    public function __construct(public int $id)
+    {
+        $this->totalPrice = new MonetaryAmount(1000.01);
+    }
+
+    public static function getData(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        return new self($uriVariables['id']);
+    }
+}

--- a/tests/Fixtures/TestBundle/Model/MonetaryAmount.php
+++ b/tests/Fixtures/TestBundle/Model/MonetaryAmount.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Model;
+
+class MonetaryAmount
+{
+    public function __construct(public float $value = 0.0, public string $currency = 'EUR', public float $minValue = 0.0)
+    {
+    }
+}

--- a/tests/Hydra/Serializer/CollectionNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionNormalizerTest.php
@@ -327,6 +327,7 @@ class CollectionNormalizerTest extends TestCase
             'jsonld_has_context' => true,
             'api_sub_level' => true,
             'resource_class' => 'Foo',
+            'api_collection_sub_level' => true,
         ])->willReturn(['name' => 'Kévin', 'friend' => 'Smail']);
 
         $normalizer = new CollectionNormalizer($contextBuilder->reveal(), $resourceClassResolverProphecy->reveal(), $iriConvert->reveal());

--- a/tests/Metadata/Extractor/Adapter/XmlPropertyAdapter.php
+++ b/tests/Metadata/Extractor/Adapter/XmlPropertyAdapter.php
@@ -42,7 +42,7 @@ final class XmlPropertyAdapter implements PropertyAdapterInterface
         'securityPostDenormalize',
         'initializable',
         'iris',
-        'skolemIri'
+        'genId',
     ];
 
     /**

--- a/tests/Metadata/Extractor/Adapter/XmlPropertyAdapter.php
+++ b/tests/Metadata/Extractor/Adapter/XmlPropertyAdapter.php
@@ -42,6 +42,7 @@ final class XmlPropertyAdapter implements PropertyAdapterInterface
         'securityPostDenormalize',
         'initializable',
         'iris',
+        'skolemIri'
     ];
 
     /**

--- a/tests/Metadata/Extractor/PropertyMetadataCompatibilityTest.php
+++ b/tests/Metadata/Extractor/PropertyMetadataCompatibilityTest.php
@@ -75,7 +75,7 @@ final class PropertyMetadataCompatibilityTest extends TestCase
             'custom_property' => 'Lorem ipsum dolor sit amet',
         ],
         'iris' => ['https://schema.org/totalPrice'],
-        'skolemIri' => true
+        'genId' => true,
     ];
 
     /**

--- a/tests/Metadata/Extractor/PropertyMetadataCompatibilityTest.php
+++ b/tests/Metadata/Extractor/PropertyMetadataCompatibilityTest.php
@@ -75,6 +75,7 @@ final class PropertyMetadataCompatibilityTest extends TestCase
             'custom_property' => 'Lorem ipsum dolor sit amet',
         ],
         'iris' => ['https://schema.org/totalPrice'],
+        'skolemIri' => true
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | bug fix (bc break)
| Tickets       | #5035
| License       | MIT

On 3.0 this behavior will be the default one, I'll add it only in 3.0 so that one can disable the skolemIri generation. We break the compatibility here, so let's revert for 2.7. 