### PR TITLE
fix: Set twig.exception_listener as service parent

### DIFF
--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -191,8 +191,8 @@
 
         <service id="api_platform.error_listener" class="ApiPlatform\Symfony\EventListener\ErrorListener">
             <argument key="$controller">api_platform.action.exception</argument>
-            <argument type="service" id="logger" on-invalid="null">@logger</argument>
-            <argument>%kernel.debug%</argument>
+            <argument key="$logger" type="service" id="logger" on-invalid="null" />
+            <argument key="$debug">%kernel.debug%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -189,8 +189,10 @@
             <tag name="api_platform.uri_variables.transformer" priority="-100" />
         </service>
 
-        <service id="api_platform.error_listener" class="ApiPlatform\Symfony\EventListener\ErrorListener" parent="exception_listener">
+        <service id="api_platform.error_listener" class="ApiPlatform\Symfony\EventListener\ErrorListener">
             <argument key="$controller">api_platform.action.exception</argument>
+            <argument type="service" id="logger" on-invalid="null">@logger</argument>
+            <argument>%kernel.debug%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| License       | MIT

On branch 2.7, the service `api_platform.error_listener` defines `exception_listener` as parent. https://github.com/api-platform/core/blob/main/src/Symfony/Bundle/Resources/config/api.xml#L170

Twig v4.4 deletes the definition of `exception_listener` and replaces it by `twig.exception_listener` https://github.com/symfony/twig-bundle/blob/4.4/DependencyInjection/Compiler/ExceptionListenerPass.php#L43

So, when using api_platform 2.7 and twig 4.4, the following error occurs at cache clear : 
```
In ResolveChildDefinitionsPass.php line 76:
                                                                                                 
  Service "api_platform.error_listener": Parent definition "exception_listener" does not exist.
```

This PR checks if twig is enabled, and changes the parent of `api_platform.error_listener` from `exception_listener` to `twig.exception_listener`.

I'm not convinced that this is the best condition, nor this is the right place to do this check, any advice ?
