### PR TITLE
[GraphQL] Add a clearer error message when TwigBundle is disable but graphql clients aren't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.3
+
+* Graphql: add a clearer error message when TwigBundle is disabled but graphQL clients are enabled (#5064)
+
 ## 3.0.2
 
 * Metadata: generate skolem IRI by default, use `genId: false` to disable **BC**

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -34,7 +34,7 @@ final class EntrypointAction
 {
     private int $debug;
 
-    public function __construct(private readonly SchemaBuilderInterface $schemaBuilder, private readonly ExecutorInterface $executor, private readonly GraphiQlAction $graphiQlAction, private readonly GraphQlPlaygroundAction $graphQlPlaygroundAction, private readonly NormalizerInterface $normalizer, private readonly ErrorHandlerInterface $errorHandler, bool $debug = false, private readonly bool $graphiqlEnabled = false, private readonly bool $graphQlPlaygroundEnabled = false, private readonly ?string $defaultIde = null)
+    public function __construct(private readonly SchemaBuilderInterface $schemaBuilder, private readonly ExecutorInterface $executor, private readonly ?GraphiQlAction $graphiQlAction, private readonly ?GraphQlPlaygroundAction $graphQlPlaygroundAction, private readonly NormalizerInterface $normalizer, private readonly ErrorHandlerInterface $errorHandler, bool $debug = false, private readonly bool $graphiqlEnabled = false, private readonly bool $graphQlPlaygroundEnabled = false, private readonly ?string $defaultIde = null)
     {
         $this->debug = $debug ? DebugFlag::INCLUDE_DEBUG_MESSAGE | DebugFlag::INCLUDE_TRACE : DebugFlag::NONE;
     }
@@ -43,11 +43,11 @@ final class EntrypointAction
     {
         try {
             if ($request->isMethod('GET') && 'html' === $request->getRequestFormat()) {
-                if ('graphiql' === $this->defaultIde && $this->graphiqlEnabled) {
+                if ('graphiql' === $this->defaultIde && $this->graphiqlEnabled && $this->graphiQlAction) {
                     return ($this->graphiQlAction)($request);
                 }
 
-                if ('graphql-playground' === $this->defaultIde && $this->graphQlPlaygroundEnabled) {
+                if ('graphql-playground' === $this->defaultIde && $this->graphQlPlaygroundEnabled && $this->graphQlPlaygroundAction) {
                     return ($this->graphQlPlaygroundAction)($request);
                 }
             }

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -53,6 +53,7 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
+use Twig\Environment;
 
 /**
  * The extension of this bundle.
@@ -462,9 +463,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     {
         $enabled = $this->isConfigEnabled($container, $config['graphql']);
 
+        $graphiqlEnabled = $enabled && $this->isConfigEnabled($container, $config['graphql']['graphiql']);
+        $graphqlPlayGroundEnabled = $enabled && $this->isConfigEnabled($container, $config['graphql']['graphql_playground']);
+
         $container->setParameter('api_platform.graphql.enabled', $enabled);
-        $container->setParameter('api_platform.graphql.graphiql.enabled', $enabled && $this->isConfigEnabled($container, $config['graphql']['graphiql']));
-        $container->setParameter('api_platform.graphql.graphql_playground.enabled', $enabled && $this->isConfigEnabled($container, $config['graphql']['graphql_playground']));
+        $container->setParameter('api_platform.graphql.graphiql.enabled', $graphiqlEnabled);
+        $container->setParameter('api_platform.graphql.graphql_playground.enabled', $graphqlPlayGroundEnabled);
         $container->setParameter('api_platform.graphql.collection.pagination', $config['graphql']['collection']['pagination']);
 
         if (!$enabled) {
@@ -475,6 +479,15 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.graphql.nesting_separator', $config['graphql']['nesting_separator']);
 
         $loader->load('graphql.xml');
+
+        // @phpstan-ignore-next-line because PHPStan uses the container of the test env cache and in test the parameter kernel.bundles always contains the key TwigBundle
+        if (!class_exists(Environment::class) || !isset($container->getParameter('kernel.bundles')['TwigBundle'])) {
+            if ($graphiqlEnabled || $graphqlPlayGroundEnabled) {
+                throw new RuntimeException(sprintf('GraphiQL and GraphQL Playground interfaces depend on Twig. Please activate TwigBundle for the %s environnement or disable GraphiQL and GraphQL Playground.', $container->getParameter('kernel.environment')));
+            }
+            $container->removeDefinition('api_platform.graphql.action.graphiql');
+            $container->removeDefinition('api_platform.graphql.action.graphql_playground');
+        }
 
         $container->registerForAutoconfiguration(QueryItemResolverInterface::class)
             ->addTag('api_platform.graphql.query_resolver');

--- a/src/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Symfony/Bundle/Resources/config/graphql.xml
@@ -49,8 +49,8 @@
         <service id="api_platform.graphql.action.entrypoint" class="ApiPlatform\GraphQl\Action\EntrypointAction" public="true">
             <argument type="service" id="api_platform.graphql.schema_builder" />
             <argument type="service" id="api_platform.graphql.executor" />
-            <argument type="service" id="api_platform.graphql.action.graphiql" />
-            <argument type="service" id="api_platform.graphql.action.graphql_playground" />
+            <argument type="service" id="api_platform.graphql.action.graphiql" on-invalid="null"/>
+            <argument type="service" id="api_platform.graphql.action.graphql_playground" on-invalid="null"/>
             <argument type="service" id="serializer" />
             <argument type="service" id="api_platform.graphql.error_handler" />
             <argument>%kernel.debug%</argument>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0 <!-- see below -->
| Tickets       | https://github.com/api-platform/core/issues/4897 <!-- please link related issues if existing -->
| License       | MIT

Instead of having an error thrown by the CheckExceptionOnInvalidReferenceBehaviorPass when Twig is not installed or enabled we send a clearer exception and force the user to either disable the GraphQL clients or enable Twig.

If the clients are not enabled we remove the definition as they can't be instantiate and we pass null to the GraphQl action.

Maybe we should not trowing an exception and instead disable silently the the clients if Twig is not enabled but I find better to add an explicit error message.



