### PR TITLE
feat(filters): Allow to configure multiple strategies for SearchFilter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.log
+/.idea
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.3
+
+* Filters: Allow to configure multiple strategies for SearchFilter
+
 ## 2.7.2
 
 * Metadata: no skolem IRI by default

--- a/src/Core/Bridge/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Core/Bridge/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -46,6 +46,13 @@ trait SearchFilterTrait
         }
 
         foreach ($properties as $property => $strategy) {
+            $filterParameter = $property;
+
+            if (\is_array($strategy)) {
+                $property = array_keys($strategy)[0];
+                $strategy = $strategy[$property];
+            }
+
             if (!$this->isPropertyMapped($property, $resourceClass, true)) {
                 continue;
             }
@@ -60,13 +67,14 @@ trait SearchFilterTrait
             }
 
             $propertyName = $this->normalizePropertyName($property);
+            $filterParameterName = $this->normalizePropertyName($filterParameter);
             if ($metadata->hasField($field)) {
                 $typeOfField = $this->getType($metadata->getTypeOfField($field));
-                $strategy = $this->getProperties()[$property] ?? self::STRATEGY_EXACT;
-                $filterParameterNames = [$propertyName];
+                $strategy = $strategy ?? self::STRATEGY_EXACT;
+                $filterParameterNames = [$filterParameterName];
 
                 if (self::STRATEGY_EXACT === $strategy) {
-                    $filterParameterNames[] = $propertyName.'[]';
+                    $filterParameterNames[] = $filterParameterName.'[]';
                 }
 
                 foreach ($filterParameterNames as $filterParameterName) {
@@ -80,8 +88,8 @@ trait SearchFilterTrait
                 }
             } elseif ($metadata->hasAssociation($field)) {
                 $filterParameterNames = [
-                    $propertyName,
-                    $propertyName.'[]',
+                    $filterParameterName,
+                    $filterParameterName.'[]',
                 ];
 
                 foreach ($filterParameterNames as $filterParameterName) {

--- a/src/Core/Bridge/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Core/Bridge/Doctrine/Orm/Filter/SearchFilter.php
@@ -68,9 +68,29 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
      */
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
     {
+        $filterParameter = $property;
+        if (isset($this->properties[$filterParameter]) && \is_array($this->properties[$filterParameter])) {
+            $property = (string) array_keys($this->properties[$filterParameter])[0];
+            $strategy = array_values($this->properties[$filterParameter])[0];
+        }
+
+        if (\is_array($value) && \count($value) > 0) {
+            $valueKey = array_keys($value)[0];
+            $possibleFilterParameter = $filterParameter.'['.$valueKey.']';
+
+            if (isset($this->properties[$possibleFilterParameter]) && \is_array($this->properties[$possibleFilterParameter])) {
+                $filterParameter = $possibleFilterParameter;
+
+                $property = (string) array_keys($this->properties[$filterParameter])[0];
+                $strategy = array_values($this->properties[$filterParameter])[0];
+
+                $value = $value[$valueKey];
+            }
+        }
+
         if (
             null === $value ||
-            !$this->isPropertyEnabled($property, $resourceClass) ||
+            !$this->isPropertyEnabled($filterParameter, $resourceClass) ||
             !$this->isPropertyMapped($property, $resourceClass, true)
         ) {
             return;
@@ -90,7 +110,7 @@ class SearchFilter extends AbstractContextAwareFilter implements SearchFilterInt
         }
 
         $caseSensitive = true;
-        $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
+        $strategy = $strategy ?? ($this->properties[$filterParameter] ?? self::STRATEGY_EXACT);
 
         // prefixing the strategy with i makes it case insensitive
         if (0 === strpos($strategy, 'i')) {

--- a/src/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -45,6 +45,13 @@ trait SearchFilterTrait
         }
 
         foreach ($properties as $property => $strategy) {
+            $filterParameter = $property;
+
+            if (\is_array($strategy)) {
+                $property = array_keys($strategy)[0];
+                $strategy = $strategy[$property];
+            }
+
             if (!$this->isPropertyMapped($property, $resourceClass, true)) {
                 continue;
             }
@@ -59,13 +66,14 @@ trait SearchFilterTrait
             }
 
             $propertyName = $this->normalizePropertyName($property);
+            $filterParameterName = $this->normalizePropertyName($filterParameter);
             if ($metadata->hasField($field)) {
                 $typeOfField = $this->getType($metadata->getTypeOfField($field));
-                $strategy = $this->getProperties()[$property] ?? self::STRATEGY_EXACT;
-                $filterParameterNames = [$propertyName];
+                $strategy = $strategy ?? self::STRATEGY_EXACT;
+                $filterParameterNames = [$filterParameterName];
 
                 if (self::STRATEGY_EXACT === $strategy) {
-                    $filterParameterNames[] = $propertyName.'[]';
+                    $filterParameterNames[] = $filterParameterName.'[]';
                 }
 
                 foreach ($filterParameterNames as $filterParameterName) {
@@ -79,8 +87,8 @@ trait SearchFilterTrait
                 }
             } elseif ($metadata->hasAssociation($field)) {
                 $filterParameterNames = [
-                    $propertyName,
-                    $propertyName.'[]',
+                    $filterParameterName,
+                    $filterParameterName.'[]',
                 ];
 
                 foreach ($filterParameterNames as $filterParameterName) {

--- a/src/Doctrine/Odm/Filter/SearchFilter.php
+++ b/src/Doctrine/Odm/Filter/SearchFilter.php
@@ -64,9 +64,29 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
      */
     protected function filterProperty(string $property, $value, Builder $aggregationBuilder, string $resourceClass, Operation $operation = null, array &$context = []): void
     {
+        $filterParameter = $property;
+        if (isset($this->properties[$filterParameter]) && \is_array($this->properties[$filterParameter])) {
+            $property = (string) array_keys($this->properties[$filterParameter])[0];
+            $strategy = array_values($this->properties[$filterParameter])[0];
+        }
+
+        if (\is_array($value) && \count($value) > 0) {
+            $valueKey = array_keys($value)[0];
+            $possibleFilterParameter = $filterParameter.'['.$valueKey.']';
+
+            if (isset($this->properties[$possibleFilterParameter]) && \is_array($this->properties[$possibleFilterParameter])) {
+                $filterParameter = $possibleFilterParameter;
+
+                $property = (string) array_keys($this->properties[$filterParameter])[0];
+                $strategy = array_values($this->properties[$filterParameter])[0];
+
+                $value = $value[$valueKey];
+            }
+        }
+
         if (
             null === $value ||
-            !$this->isPropertyEnabled($property, $resourceClass) ||
+            !$this->isPropertyEnabled($filterParameter, $resourceClass) ||
             !$this->isPropertyMapped($property, $resourceClass, true)
         ) {
             return;
@@ -85,7 +105,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         }
 
         $caseSensitive = true;
-        $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
+        $strategy = $strategy ?? ($this->properties[$filterParameter] ?? self::STRATEGY_EXACT);
 
         // prefixing the strategy with i makes it case insensitive
         if (str_starts_with($strategy, 'i')) {

--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -63,9 +63,29 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
      */
     protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, Operation $operation = null, array $context = []): void
     {
+        $filterParameter = $property;
+        if (isset($this->properties[$filterParameter]) && \is_array($this->properties[$filterParameter])) {
+            $property = (string) array_keys($this->properties[$filterParameter])[0];
+            $strategy = array_values($this->properties[$filterParameter])[0];
+        }
+
+        if (\is_array($value) && \count($value) > 0) {
+            $valueKey = array_keys($value)[0];
+            $possibleFilterParameter = $filterParameter.'['.$valueKey.']';
+
+            if (isset($this->properties[$possibleFilterParameter]) && \is_array($this->properties[$possibleFilterParameter])) {
+                $filterParameter = $possibleFilterParameter;
+
+                $property = (string) array_keys($this->properties[$filterParameter])[0];
+                $strategy = array_values($this->properties[$filterParameter])[0];
+
+                $value = $value[$valueKey];
+            }
+        }
+
         if (
             null === $value ||
-            !$this->isPropertyEnabled($property, $resourceClass) ||
+            !$this->isPropertyEnabled($filterParameter, $resourceClass) ||
             !$this->isPropertyMapped($property, $resourceClass, true)
         ) {
             return;
@@ -85,7 +105,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         }
 
         $caseSensitive = true;
-        $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
+        $strategy = $strategy ?? ($this->properties[$filterParameter] ?? self::STRATEGY_EXACT);
 
         // prefixing the strategy with i makes it case insensitive
         if (str_starts_with($strategy, 'i')) {

--- a/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -24,6 +24,18 @@ trait SearchFilterTestTrait
         $filter = $this->buildSearchFilter($this->managerRegistry, [
             'id' => null,
             'name' => null,
+            'name_exact' => [
+                'name' => 'exact',
+            ],
+            'name_partial' => [
+                'name' => 'partial',
+            ],
+            'name[istart]' => [
+                'name' => 'istart',
+            ],
+            'name[exact]' => [
+                'name' => 'exact',
+            ],
             'alias' => null,
             'dummy' => null,
             'dummyDate' => null,
@@ -32,6 +44,9 @@ trait SearchFilterTestTrait
             'nameConverted' => null,
             'foo' => null,
             'relatedDummies.dummyDate' => null,
+            'relatedDummies.name[start]' => [
+                'relatedDummies.name' => 'start'
+            ],
             'relatedDummy' => null,
         ]);
 
@@ -58,6 +73,48 @@ trait SearchFilterTestTrait
                 'is_collection' => false,
             ],
             'name[]' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => true,
+            ],
+            'name_exact' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => false,
+            ],
+            'name_exact[]' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => true,
+            ],
+            'name_partial' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'partial',
+                'is_collection' => false,
+            ],
+            'name[istart]' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'istart',
+                'is_collection' => false,
+            ],
+            'name[exact]' => [
+                'property' => 'name',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'exact',
+                'is_collection' => false,
+            ],
+            'name[exact][]' => [
                 'property' => 'name',
                 'type' => 'string',
                 'required' => false,
@@ -162,6 +219,13 @@ trait SearchFilterTestTrait
                 'strategy' => 'exact',
                 'is_collection' => true,
             ],
+            'relatedDummies.name[start]' => [
+                'property' => 'relatedDummies.name',
+                'type' => 'string',
+                'required' => false,
+                'strategy' => 'start',
+                'is_collection' => false,
+            ],
             'relatedDummy' => [
                 'property' => 'relatedDummy',
                 'type' => 'string',
@@ -191,6 +255,30 @@ trait SearchFilterTestTrait
                     'name' => 'exact',
                 ],
             ],
+            'multiple strategies (one strategy)' => [
+                [
+                    'id' => null,
+                    'name[exact]' => [
+                        'name' => 'exact'
+                    ],
+                ],
+                ['name[exact]' => 'exact'],
+            ],
+            'multiple strategies (two strategy)' => [
+                [
+                    'id' => null,
+                    'name[start]' => [
+                        'name' => 'start'
+                    ],
+                    'name[end]' => [
+                        'name' => 'end'
+                    ],
+                ],
+                [
+                    'name[start]' => 'start with',
+                    'name[end]' => 'end with',
+                ],
+            ],
             'exact (case insensitive)' => [
                 [
                     'id' => null,
@@ -218,6 +306,22 @@ trait SearchFilterTestTrait
                     'name' => [
                         'CaSE',
                         'SENSitive',
+                    ],
+                ],
+            ],
+            'multiple strategies (one strategy; multiple values)' => [
+                [
+                    'id' => null,
+                    'name[exact]' => [
+                        'name' => 'exact'
+                    ],
+                ],
+                [
+                    'name' => [
+                        'exact' => [
+                            'CaSE',
+                            'SENSitive',
+                        ]
                     ],
                 ],
             ],

--- a/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -45,7 +45,7 @@ trait SearchFilterTestTrait
             'foo' => null,
             'relatedDummies.dummyDate' => null,
             'relatedDummies.name[start]' => [
-                'relatedDummies.name' => 'start'
+                'relatedDummies.name' => 'start',
             ],
             'relatedDummy' => null,
         ]);
@@ -259,7 +259,7 @@ trait SearchFilterTestTrait
                 [
                     'id' => null,
                     'name[exact]' => [
-                        'name' => 'exact'
+                        'name' => 'exact',
                     ],
                 ],
                 ['name[exact]' => 'exact'],
@@ -268,10 +268,10 @@ trait SearchFilterTestTrait
                 [
                     'id' => null,
                     'name[start]' => [
-                        'name' => 'start'
+                        'name' => 'start',
                     ],
                     'name[end]' => [
-                        'name' => 'end'
+                        'name' => 'end',
                     ],
                 ],
                 [
@@ -313,7 +313,7 @@ trait SearchFilterTestTrait
                 [
                     'id' => null,
                     'name[exact]' => [
-                        'name' => 'exact'
+                        'name' => 'exact',
                     ],
                 ],
                 [
@@ -321,7 +321,7 @@ trait SearchFilterTestTrait
                         'exact' => [
                             'CaSE',
                             'SENSitive',
-                        ]
+                        ],
                     ],
                 ],
             ],

--- a/tests/Doctrine/Odm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/SearchFilterTest.php
@@ -292,6 +292,43 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     ],
                     $filterFactory,
                 ],
+                'multiple strategies (one strategy)' => [
+                    [
+                        [
+                            '$match' => [
+                                'name' => [
+                                    '$in' => [
+                                        'exact',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    $filterFactory,
+                ],
+                'multiple strategies (two strategy)' => [
+                    [
+                        [
+                            '$match' => [
+                                'name' => [
+                                    '$in' => [
+                                        new Regex('^start with'),
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            '$match' => [
+                                'name' => [
+                                    '$in' => [
+                                        new Regex('end with$'),
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    $filterFactory,
+                ],
                 'exact (case insensitive)' => [
                     [
                         [
@@ -321,6 +358,21 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     $filterFactory,
                 ],
                 'exact (multiple values)' => [
+                    [
+                        [
+                            '$match' => [
+                                'name' => [
+                                    '$in' => [
+                                        'CaSE',
+                                        'SENSitive',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    $filterFactory,
+                ],
+                'multiple strategies (one strategy; multiple values)' => [
                     [
                         [
                             '$match' => [

--- a/tests/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -286,6 +286,19 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     ['name_p1' => 'exact'],
                     $filterFactory,
                 ],
+                'multiple strategies (one strategy)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', $this->alias, Dummy::class),
+                    ['name_p1' => 'exact'],
+                    $filterFactory,
+                ],
+                'multiple strategies (two strategy)' => [
+                    sprintf("SELECT %s FROM %s %1\$s WHERE %1\$s.name LIKE CONCAT(:name_p1_0, '%%') AND %1\$s.name LIKE CONCAT('%%', :name_p2_0)", $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'start with',
+                        'name_p2_0' => 'end with',
+                    ],
+                    $filterFactory,
+                ],
                 'exact (case insensitive)' => [
                     sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) = LOWER(:name_p1)', $this->alias, Dummy::class),
                     ['name_p1' => 'exact'],
@@ -297,6 +310,16 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'exact (multiple values)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN(:name_p1)', $this->alias, Dummy::class),
+                    [
+                        'name_p1' => [
+                            'CaSE',
+                            'SENSitive',
+                        ],
+                    ],
+                    $filterFactory,
+                ],
+                'multiple strategies (one strategy; multiple values)' => [
                     sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN(:name_p1)', $this->alias, Dummy::class),
                     [
                         'name_p1' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#1627

This feature allows to do the:
```php
#[ApiFilter(
     SearchFilter::class,
     properties: [
         'id' => 'exact',
         'price' => 'exact',
         'description[exact]' => ['description' => 'exact'], // Filter for description field with exact strategy
         'description[partial]' => ['description' => 'partial'], // Filter for description field with partial strategy
     ]
 )]
```

We need this feature in the `2.7` branch for migration to `3.0`.


