### PR TITLE
[Doctrine] SearchFilter - Use abitrary index instead of value

### DIFF
--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -179,7 +179,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         $parameters = [];
         foreach ($values as $key => $value) {
             $keyValueParameter = sprintf('%s_%s', $valueParameter, $key);
-            $parameters[$caseSensitive ? $value : strtolower($value)] = $keyValueParameter;
+            $parameters[] = [$caseSensitive ? $value : strtolower($value), $keyValueParameter];
 
             $ors[] = match ($strategy) {
                 self::STRATEGY_PARTIAL => $queryBuilder->expr()->like(
@@ -209,7 +209,9 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         }
 
         $queryBuilder->andWhere($queryBuilder->expr()->orX(...$ors));
-        array_walk($parameters, $queryBuilder->setParameter(...));
+        foreach ($parameters as $parameter) {
+            $queryBuilder->setParameter($parameter[1], $parameter[0]);
+        }
     }
 
     /**

--- a/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -297,6 +297,18 @@ trait SearchFilterTestTrait
                     ],
                 ],
             ],
+            'partial (multiple almost same values; case insensitive)' => [
+                [
+                    'id' => null,
+                    'name' => 'ipartial',
+                ],
+                [
+                    'name' => [
+                        'blue car',
+                        'Blue Car',
+                    ],
+                ],
+            ],
             'start' => [
                 [
                     'id' => null,

--- a/tests/Doctrine/Odm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/SearchFilterTest.php
@@ -426,6 +426,21 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     ],
                     $filterFactory,
                 ],
+                'partial (multiple almost same values; case insensitive)' => [
+                    [
+                        [
+                            '$match' => [
+                                'name' => [
+                                    '$in' => [
+                                        new Regex('blue car', 'i'),
+                                        new Regex('Blue Car', 'i'),
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    $filterFactory,
+                ],
                 'start' => [
                     [
                         [

--- a/tests/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -352,6 +352,14 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     ],
                     $filterFactory,
                 ],
+                'partial (multiple almost same values; case insensitive)' => [
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    [
+                        'name_p1_0' => 'blue car',
+                        'name_p1_1' => 'blue car',
+                    ],
+                    $filterFactory,
+                ],
                 'start' => [
                     sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\')', $this->alias, Dummy::class),
                     ['name_p1_0' => 'partial'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When using a search filter with multiple values that have the same lowercase identity, for example:
```
array:2 [▼
  0 => "rayon bleu"
  1 => "Rayon Bleu"
]
```

SearchFilter will lowercase the value and use it as index key, which makes it send only one parameter to Doctrine when it needs two of them.

I choosed to leave the arbitrary array index so we don't have this kind of issues anymore.