### PR TITLE
Serializer: don't use abstract class as resource_class on denormalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.3
+
+* Serializer: don't use abstract class as resource_class on denormalization
+
 ## 2.7.2
 
 * Metadata: no skolem IRI by default

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -322,8 +322,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $context['api_denormalize'] = true;
 
         if ($this->resourceClassResolver->isResourceClass($class)) {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($objectToPopulate, $class);
-            $context['resource_class'] = $resourceClass;
+            $context['resource_class'] = $resourceClass = $this->getResourceClass($objectToPopulate, $class);
         }
 
         $supportsPlainIdentifiers = $this->supportsPlainIdentifiers();
@@ -490,7 +489,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
         }
 
-        $resourceClass = $this->resourceClassResolver->getResourceClass(null, $context['resource_class']); // fix for abstract classes and interfaces
+        $context['resource_class'] = $resourceClass = $this->getResourceClass(null, $context['resource_class']);
+
         $options = $this->getFactoryOptions($context);
         $propertyNames = $this->propertyNameCollectionFactory->create($resourceClass, $options);
 
@@ -1086,6 +1086,15 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     private function supportsPlainIdentifiers(): bool
     {
         return $this->allowPlainIdentifiers && null !== $this->itemDataProvider;
+    }
+
+    private function getResourceClass($objectToPopulate, $class): string
+    {
+        $newResourceClass = $this->resourceClassResolver->getResourceClass($objectToPopulate, $class);
+        if (!(new \ReflectionClass($newResourceClass))->isAbstract()) {
+            return $newResourceClass;
+        }
+        return $class;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #2933
| License       | MIT
| Doc PR        | 

as we can see in the issue #2933 during the deserialization process the abstract class is taken and used as `resource_class` for the rest of the process. It will crash when it will try to instantiate the object.

I'm doing a quick fix to unlock this point.
