### PR TITLE
fix: remove @internal annotation for Operations

### DIFF
--- a/src/Metadata/Operations.php
+++ b/src/Metadata/Operations.php
@@ -15,9 +15,6 @@ namespace ApiPlatform\Metadata;
 
 use RuntimeException;
 
-/**
- * @internal
- */
 final class Operations implements \IteratorAggregate, \Countable
 {
     private $operations;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #5084 
| License       | MIT
| Doc PR        | NA

Remove inconsistent `@internal` docstring.