### PR TITLE
fix(metadata): define a name on a single operation

### DIFF
--- a/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -215,8 +215,8 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
         }
 
         // Check for name conflict
-        if ($operation->getName()) {
-            if (null !== $resource->getOperations() && !$resource->getOperations()->has($operation->getName())) {
+        if ($operation->getName() && null !== ($operations = $resource->getOperations())) {
+            if (!$operations->has($operation->getName())) {
                 return [$operation->getName(), $operation];
             }
 

--- a/tests/Fixtures/TestBundle/Entity/AttributeOnlyOperation.php
+++ b/tests/Fixtures/TestBundle/Entity/AttributeOnlyOperation.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\Get;
+
+#[Get(name: 'my own name')]
+final class AttributeOnlyOperation
+{
+}

--- a/tests/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -29,6 +29,7 @@ use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFactory;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AttributeDefaultOperations;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AttributeOnlyOperation;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AttributeResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AttributeResources;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ExtraPropertiesResource;
@@ -205,5 +206,21 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
 
         $this->assertEquals($extraPropertiesResource[0]->getExtraProperties(), ['foo' => 'bar']);
         $this->assertEquals($extraPropertiesResource->getOperation('_api_ExtraPropertiesResource_get')->getExtraProperties(), ['foo' => 'bar']);
+    }
+
+    public function testOverrideNameWithoutOperations(): void
+    {
+        $attributeResourceMetadataCollectionFactory = new AttributesResourceMetadataCollectionFactory();
+
+        $operation = new HttpOperation(shortName: 'AttributeOnlyOperation', class: AttributeOnlyOperation::class);
+        $this->assertEquals(new ResourceMetadataCollection(AttributeOnlyOperation::class, [
+            new ApiResource(
+                shortName: 'AttributeOnlyOperation',
+                class: AttributeOnlyOperation::class,
+                operations: [
+                    'my own name' => (new Get(name: 'my own name', priority: 1))->withOperation($operation),
+                ]
+            ),
+        ]), $attributeResourceMetadataCollectionFactory->create(AttributeOnlyOperation::class));
     }
 }


### PR DESCRIPTION
fixes #5082
