### PR TITLE
Bugfix: Respect input DTO without adding additional id field

### DIFF
--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -195,7 +195,7 @@ final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumIn
             return $fields;
         }
 
-        if (!$input || 'create' !== $operation->getName()) {
+        if (!$input || ('create' !== $operation->getName() && !$operation->getInput())) {
             $fields['id'] = $idField;
         }
         if ($input && $depth >= 1) {

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -697,6 +697,31 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
+            'mutation using input DTO' => ['resourceClass', (new Mutation())->withName('mutation')->withInput(GraphQLType::string()),
+                [
+                    'property' => new ApiProperty(),
+                    'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withDescription('propertyBool description')->withReadable(false)->withWritable(true)->withDeprecationReason('not useful'),
+                    'propertySubresource' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
+                ],
+                true, 0, null,
+                [
+                    'propertyBool' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => 'propertyBool description',
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => 'not useful',
+                    ],
+                    'propertySubresource' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::string()),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => null,
+                        'deprecationReason' => null,
+                    ],
+                    'clientMutationId' => GraphQLType::string(),
+                ],
+            ],
             'mutation nested input' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('mutation'),
                 [
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #5097 #2736
| License       | MIT
| Doc PR        | -

For all GraphQL mutations except  `create` the `id` field is added automatically. Also for scenarios where an input DTO is used the `id` got added. This PR respects the given input DTO and will not add an additional `id` field. If you need the id your DTO may contain it.

The related Ticker #2736 is not completely solved with this PR but it enables the workaround to have multipe create mutations by using a specifiy input DTO.

Branch: 
- `main`, because not sure if it is a real bugfix or more a tiny new feature.


Note: Failing PHP-cs-fixer is not related to the changes in this PR