### PR TITLE
fix(symfony): call item data provider for legacy api resource

### DIFF
--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -141,6 +141,7 @@
             <argument type="service" id="api_platform.api.identifiers_extractor" />
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
+            <argument type="service" id="api_platform.item_data_provider" />
             <argument type="service" id="api_platform.uri_variables.converter" />
             <argument type="service" id="api_platform.symfony.iri_converter.skolem" on-invalid="null" />
         </service>

--- a/tests/Symfony/Routing/IriConverterTest.php
+++ b/tests/Symfony/Routing/IriConverterTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Symfony\Routing;
 use ApiPlatform\Api\IdentifiersExtractorInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\Tests\ProphecyTrait;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Exception\RuntimeException;
@@ -283,7 +284,7 @@ class IriConverterTest extends TestCase
         return $resourceClassResolver->reveal();
     }
 
-    private function getIriConverter($stateProviderProphecy = null, $routerProphecy = null, $identifiersExtractorProphecy = null, $resourceMetadataCollectionFactoryProphecy = null, $uriVariablesConverter = null, $decorated = null)
+    private function getIriConverter($stateProviderProphecy = null, $routerProphecy = null, $identifiersExtractorProphecy = null, $resourceMetadataCollectionFactoryProphecy = null, $uriVariablesConverter = null, $decorated = null, $itemDataProvider = null)
     {
         if (!$stateProviderProphecy) {
             $stateProviderProphecy = $this->prophesize(ProviderInterface::class);
@@ -301,6 +302,10 @@ class IriConverterTest extends TestCase
             $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         }
 
-        return new IriConverter($stateProviderProphecy->reveal(), $routerProphecy->reveal(), $identifiersExtractorProphecy->reveal(), $this->getResourceClassResolver(), $resourceMetadataCollectionFactoryProphecy->reveal(), $uriVariablesConverter, $decorated);
+        if (!$itemDataProvider) {
+            $itemDataProvider = $this->prophesize(ItemDataProviderInterface::class);
+        }
+
+        return new IriConverter($stateProviderProphecy->reveal(), $routerProphecy->reveal(), $identifiersExtractorProphecy->reveal(), $this->getResourceClassResolver(), $resourceMetadataCollectionFactoryProphecy->reveal(), $itemDataProvider->reveal(), $uriVariablesConverter, $decorated);
     }
 }


### PR DESCRIPTION
fix #5094 