### PR TITLE
fix(graphql): use right nested operation

### DIFF
--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -910,3 +910,49 @@ Feature: GraphQL collection support
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "data.fooDummies.collection" should have 1 element
+
+  @createSchema
+  Scenario: Retrieve paginated collections using mixed pagination
+    Given there are 5 fooDummy objects with fake names
+    When I send the following GraphQL request:
+    """
+    {
+      fooDummies(page: 1) {
+        collection {
+          id
+          name
+          soManies(first: 2) {
+            edges {
+              node {
+                content
+              }
+              cursor
+            }
+            pageInfo {
+              startCursor
+              endCursor
+              hasNextPage
+              hasPreviousPage
+            }
+          }
+        }
+        paginationInfo {
+          itemsPerPage
+          lastPage
+          totalCount
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data.fooDummies.collection" should have 3 elements
+    And the JSON node "data.fooDummies.collection[2].id" should exist
+    And the JSON node "data.fooDummies.collection[2].name" should exist
+    And the JSON node "data.fooDummies.collection[2].soManies" should exist
+    And the JSON node "data.fooDummies.collection[2].soManies.edges" should have 2 elements
+    And the JSON node "data.fooDummies.collection[2].soManies.edges[1].node.content" should be equal to "So many 1"
+    And the JSON node "data.fooDummies.collection[2].soManies.pageInfo.startCursor" should be equal to "MA=="
+    And the JSON node "data.fooDummies.paginationInfo.itemsPerPage" should be equal to the number 3
+    And the JSON node "data.fooDummies.paginationInfo.lastPage" should be equal to the number 2
+    And the JSON node "data.fooDummies.paginationInfo.totalCount" should be equal to the number 5

--- a/features/main/default_order.feature
+++ b/features/main/default_order.feature
@@ -79,35 +79,61 @@ Feature: Default order
           "@type": "FooDummy",
           "id": 5,
           "name": "Balbo",
-          "dummy": "/dummies/5"
+          "dummy": "/dummies/5",
+          "soManies": [
+            "/so_manies/13",
+            "/so_manies/14",
+            "/so_manies/15"
+          ]
+
         },
         {
           "@id": "/foo_dummies/3",
           "@type": "FooDummy",
           "id": 3,
           "name": "Sthenelus",
-          "dummy": "/dummies/3"
+          "dummy": "/dummies/3",
+          "soManies": [
+            "/so_manies/7",
+            "/so_manies/8",
+            "/so_manies/9"
+          ]
         },
         {
           "@id": "/foo_dummies/2",
           "@type": "FooDummy",
           "id": 2,
           "name": "Ephesian",
-          "dummy": "/dummies/2"
+          "dummy": "/dummies/2",
+          "soManies": [
+            "/so_manies/4",
+            "/so_manies/5",
+            "/so_manies/6"
+          ]
         },
         {
           "@id": "/foo_dummies/1",
           "@type": "FooDummy",
           "id": 1,
           "name": "Hawsepipe",
-          "dummy": "/dummies/1"
+          "dummy": "/dummies/1",
+          "soManies": [
+            "/so_manies/1",
+            "/so_manies/2",
+            "/so_manies/3"
+          ]
         },
         {
           "@id": "/foo_dummies/4",
           "@type": "FooDummy",
           "id": 4,
           "name": "Separativeness",
-          "dummy": "/dummies/4"
+          "dummy": "/dummies/4",
+          "soManies": [
+            "/so_manies/10",
+            "/so_manies/11",
+            "/so_manies/12"
+          ]
         }
       ],
       "hydra:totalItems": 5,

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -17,12 +17,10 @@ use ApiPlatform\Api\ResourceClassResolverInterface;
 use ApiPlatform\Exception\OperationNotFoundException;
 use ApiPlatform\GraphQl\Resolver\Factory\ResolverFactoryInterface;
 use ApiPlatform\GraphQl\Type\Definition\TypeInterface;
+use ApiPlatform\Metadata\Extractor\DynamicResourceExtractorInterface;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation;
-use ApiPlatform\Metadata\GraphQl\Query;
-use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Subscription;
-use ApiPlatform\Metadata\Operation as AbstractOperation;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -47,7 +45,7 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  */
 final class FieldsBuilder implements FieldsBuilderInterface
 {
-    public function __construct(private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ResourceClassResolverInterface $resourceClassResolver, private readonly TypesContainerInterface $typesContainer, private readonly TypeBuilderInterface $typeBuilder, private readonly TypeConverterInterface $typeConverter, private readonly ResolverFactoryInterface $itemResolverFactory, private readonly ResolverFactoryInterface $collectionResolverFactory, private readonly ResolverFactoryInterface $itemMutationResolverFactory, private readonly ResolverFactoryInterface $itemSubscriptionResolverFactory, private readonly ContainerInterface $filterLocator, private readonly Pagination $pagination, private readonly ?NameConverterInterface $nameConverter, private readonly string $nestingSeparator)
+    public function __construct(private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly DynamicResourceExtractorInterface $dynamicResourceExtractor, private readonly ResourceClassResolverInterface $resourceClassResolver, private readonly TypesContainerInterface $typesContainer, private readonly TypeBuilderInterface $typeBuilder, private readonly TypeConverterInterface $typeConverter, private readonly ResolverFactoryInterface $itemResolverFactory, private readonly ResolverFactoryInterface $collectionResolverFactory, private readonly ResolverFactoryInterface $itemMutationResolverFactory, private readonly ResolverFactoryInterface $itemSubscriptionResolverFactory, private readonly ContainerInterface $filterLocator, private readonly Pagination $pagination, private readonly ?NameConverterInterface $nameConverter, private readonly string $nestingSeparator)
     {
     }
 
@@ -256,7 +254,25 @@ final class FieldsBuilder implements FieldsBuilderInterface
                 $resourceClass = $type->getClassName();
             }
 
-            $graphqlType = $this->convertType($type, $input, $rootOperation, $resourceClass ?? '', $rootResource, $property, $depth, $forceNullable);
+            $resourceOperation = $rootOperation;
+            if ($resourceClass && $rootOperation->getClass() && $this->resourceClassResolver->isResourceClass($resourceClass) && $rootOperation->getClass() !== $resourceClass) {
+                $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
+                try {
+                    $resourceOperation = $resourceMetadataCollection->getOperation($isCollectionType ? 'collection_query' : 'item_query');
+                } catch (OperationNotFoundException) {
+                    // If there is no query operation for a nested resource, use a dynamic resource to get one.
+                    $dynamicResourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($this->dynamicResourceExtractor->addResource($resourceClass));
+
+                    $resourceOperation = $dynamicResourceMetadataCollection->getOperation($isCollectionType ? 'collection_query' : 'item_query')
+                        ->withResource($resourceMetadataCollection[0]);
+                }
+            }
+
+            if (!$resourceOperation instanceof Operation) {
+                throw new \LogicException('The resource operation should be a GraphQL operation.');
+            }
+
+            $graphqlType = $this->convertType($type, $input, $resourceOperation, $rootOperation, $resourceClass ?? '', $rootResource, $property, $depth, $forceNullable);
 
             $graphqlWrappedType = $graphqlType instanceof WrappingType ? $graphqlType->getWrappedType(true) : $graphqlType;
             $isStandardGraphqlType = \in_array($graphqlWrappedType, GraphQLType::getStandardTypes(), true);
@@ -271,43 +287,22 @@ final class FieldsBuilder implements FieldsBuilderInterface
 
             $args = [];
 
-            $resolverOperation = $rootOperation;
-
-            if ($resourceClass && $this->resourceClassResolver->isResourceClass($resourceClass) && $rootOperation->getClass() !== $resourceClass) {
-                $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-                $resolverOperation = $resourceMetadataCollection->getOperation(null, $isCollectionType);
-
-                if (!$resolverOperation instanceof Operation) {
-                    $resolverOperation = ($isCollectionType ? new QueryCollection() : new Query())->withOperation($resolverOperation);
-                }
-            }
-
             if (!$input && !$rootOperation instanceof Mutation && !$rootOperation instanceof Subscription && !$isStandardGraphqlType && $isCollectionType) {
-                if ($this->pagination->isGraphQlEnabled($rootOperation)) {
-                    $args = $this->getGraphQlPaginationArgs($rootOperation);
+                if ($this->pagination->isGraphQlEnabled($resourceOperation)) {
+                    $args = $this->getGraphQlPaginationArgs($resourceOperation);
                 }
 
-                // Find the collection operation to get filters, there might be a smarter way to do this
-                $operation = null;
-                if (!empty($resourceClass)) {
-                    $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-                    try {
-                        $operation = $resourceMetadataCollection->getOperation(null, true);
-                    } catch (OperationNotFoundException) {
-                    }
-                }
-
-                $args = $this->getFilterArgs($args, $resourceClass, $rootResource, $rootOperation, $property, $depth, $operation);
+                $args = $this->getFilterArgs($args, $resourceClass, $rootResource, $resourceOperation, $rootOperation, $property, $depth);
             }
 
             if ($isStandardGraphqlType || $input) {
                 $resolve = null;
             } elseif (($rootOperation instanceof Mutation || $rootOperation instanceof Subscription) && $depth <= 0) {
-                $resolve = $rootOperation instanceof Mutation ? ($this->itemMutationResolverFactory)($resourceClass, $rootResource, $resolverOperation) : ($this->itemSubscriptionResolverFactory)($resourceClass, $rootResource, $resolverOperation);
+                $resolve = $rootOperation instanceof Mutation ? ($this->itemMutationResolverFactory)($resourceClass, $rootResource, $resourceOperation) : ($this->itemSubscriptionResolverFactory)($resourceClass, $rootResource, $resourceOperation);
             } elseif ($this->typeBuilder->isCollection($type)) {
-                $resolve = ($this->collectionResolverFactory)($resourceClass, $rootResource, $resolverOperation);
+                $resolve = ($this->collectionResolverFactory)($resourceClass, $rootResource, $resourceOperation);
             } else {
-                $resolve = ($this->itemResolverFactory)($resourceClass, $rootResource, $resolverOperation);
+                $resolve = ($this->itemResolverFactory)($resourceClass, $rootResource, $resourceOperation);
             }
 
             return [
@@ -368,13 +363,13 @@ final class FieldsBuilder implements FieldsBuilderInterface
         return $args;
     }
 
-    private function getFilterArgs(array $args, ?string $resourceClass, string $rootResource, Operation $rootOperation, ?string $property, int $depth, ?AbstractOperation $operation = null): array
+    private function getFilterArgs(array $args, ?string $resourceClass, string $rootResource, Operation $resourceOperation, Operation $rootOperation, ?string $property, int $depth): array
     {
-        if (null === $operation || null === $resourceClass) {
+        if (null === $resourceClass) {
             return $args;
         }
 
-        foreach ($operation->getFilters() ?? [] as $filterId) {
+        foreach ($resourceOperation->getFilters() ?? [] as $filterId) {
             if (!$this->filterLocator->has($filterId)) {
                 continue;
             }
@@ -382,7 +377,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
             foreach ($this->filterLocator->get($filterId)->getDescription($resourceClass) as $key => $value) {
                 $nullable = isset($value['required']) ? !$value['required'] : true;
                 $filterType = \in_array($value['type'], Type::$builtinTypes, true) ? new Type($value['type'], $nullable) : new Type('object', $nullable, $value['type']);
-                $graphqlFilterType = $this->convertType($filterType, false, $rootOperation, $resourceClass, $rootResource, $property, $depth);
+                $graphqlFilterType = $this->convertType($filterType, false, $resourceOperation, $rootOperation, $resourceClass, $rootResource, $property, $depth);
 
                 if (str_ends_with($key, '[]')) {
                     $graphqlFilterType = GraphQLType::listOf($graphqlFilterType);
@@ -399,14 +394,14 @@ final class FieldsBuilder implements FieldsBuilderInterface
                 array_walk_recursive($parsed, static function (&$value) use ($graphqlFilterType): void {
                     $value = $graphqlFilterType;
                 });
-                $args = $this->mergeFilterArgs($args, $parsed, $operation, $key);
+                $args = $this->mergeFilterArgs($args, $parsed, $resourceOperation, $key);
             }
         }
 
         return $this->convertFilterArgsToTypes($args);
     }
 
-    private function mergeFilterArgs(array $args, array $parsed, ?AbstractOperation $operation = null, string $original = ''): array
+    private function mergeFilterArgs(array $args, array $parsed, ?Operation $operation = null, string $original = ''): array
     {
         foreach ($parsed as $key => $value) {
             // Never override keys that cannot be merged
@@ -470,7 +465,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
      *
      * @throws InvalidTypeException
      */
-    private function convertType(Type $type, bool $input, Operation $rootOperation, string $resourceClass, string $rootResource, ?string $property, int $depth, bool $forceNullable = false): GraphQLType|ListOfType|NonNull
+    private function convertType(Type $type, bool $input, Operation $resourceOperation, Operation $rootOperation, string $resourceClass, string $rootResource, ?string $property, int $depth, bool $forceNullable = false): GraphQLType|ListOfType|NonNull
     {
         $graphqlType = $this->typeConverter->convertType($type, $input, $rootOperation, $resourceClass, $rootResource, $property, $depth);
 
@@ -487,7 +482,7 @@ final class FieldsBuilder implements FieldsBuilderInterface
         }
 
         if ($this->typeBuilder->isCollection($type)) {
-            return $this->pagination->isGraphQlEnabled($rootOperation) && !$input ? $this->typeBuilder->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $rootOperation) : GraphQLType::listOf($graphqlType);
+            return $this->pagination->isGraphQlEnabled($resourceOperation) && !$input ? $this->typeBuilder->getResourcePaginatedCollectionType($graphqlType, $resourceOperation) : GraphQLType::listOf($graphqlType);
         }
 
         return $forceNullable || !$graphqlType instanceof NullableType || $type->isNullable() || ($rootOperation instanceof Mutation && 'update' === $rootOperation->getName())

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -210,7 +210,7 @@ final class TypeBuilder implements TypeBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function getResourcePaginatedCollectionType(GraphQLType $resourceType, string $resourceClass, Operation $operation): GraphQLType
+    public function getResourcePaginatedCollectionType(GraphQLType $resourceType, Operation $operation): GraphQLType
     {
         $shortName = $resourceType->name;
         $paginationType = $this->pagination->getGraphQlPaginationType($operation);

--- a/src/GraphQl/Type/TypeBuilderInterface.php
+++ b/src/GraphQl/Type/TypeBuilderInterface.php
@@ -43,7 +43,7 @@ interface TypeBuilderInterface
     /**
      * Gets the type of a paginated collection of the given resource type.
      */
-    public function getResourcePaginatedCollectionType(GraphQLType $resourceType, string $resourceClass, Operation $operation): GraphQLType;
+    public function getResourcePaginatedCollectionType(GraphQLType $resourceType, Operation $operation): GraphQLType;
 
     /**
      * Returns true if a type is a collection.

--- a/src/Metadata/Extractor/DynamicResourceExtractor.php
+++ b/src/Metadata/Extractor/DynamicResourceExtractor.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Extractor;
+
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+
+/**
+ * Extracts a dynamic resource (used by GraphQL for nested resources).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class DynamicResourceExtractor implements DynamicResourceExtractorInterface
+{
+    private array $dynamicResources = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResources(): array
+    {
+        return $this->dynamicResources;
+    }
+
+    public function addResource(string $resourceClass, array $config = []): string
+    {
+        $dynamicResourceName = $this->getDynamicResourceName($resourceClass);
+
+        $this->dynamicResources[$dynamicResourceName] = [
+            array_merge(['class' => $resourceClass], $config),
+        ];
+
+        return $dynamicResourceName;
+    }
+
+    private function getDynamicResourceName(string $resourceClass): string
+    {
+        return ResourceMetadataCollection::DYNAMIC_RESOURCE_CLASS_PREFIX.$resourceClass;
+    }
+}

--- a/src/Metadata/Extractor/DynamicResourceExtractorInterface.php
+++ b/src/Metadata/Extractor/DynamicResourceExtractorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Extractor;
+
+/**
+ * Extracts a dynamic resource (used by GraphQL for nested resources).
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+interface DynamicResourceExtractorInterface extends ResourceExtractorInterface
+{
+    public function addResource(string $resourceClass, array $config = []): string;
+}

--- a/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -64,6 +64,10 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
             $resourceMetadataCollection = $this->decorated->create($resourceClass);
         }
 
+        if ($resourceMetadataCollection->isDynamic()) {
+            return $resourceMetadataCollection;
+        }
+
         try {
             $reflectionClass = new \ReflectionClass($resourceClass);
         } catch (\ReflectionException) {

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
@@ -19,7 +19,12 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Extractor\ResourceExtractorInterface;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\DeleteMutation;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
@@ -51,7 +56,7 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
             $resourceMetadataCollection = $this->decorated->create($resourceClass);
         }
 
-        if (!(class_exists($resourceClass) || interface_exists($resourceClass)) || !$resources = $this->extractor->getResources()[$resourceClass] ?? false) {
+        if (!($resourceMetadataCollection->isDynamic() || class_exists($resourceClass) || interface_exists($resourceClass)) || !$resources = $this->extractor->getResources()[$resourceClass] ?? false) {
             return $resourceMetadataCollection;
         }
 
@@ -88,9 +93,7 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
                 }
             }
 
-            if (isset($node['graphQlOperations'])) {
-                $resource = $resource->withGraphQlOperations($this->buildGraphQlOperations($node['graphQlOperations'], $resource));
-            }
+            $resource = $resource->withGraphQlOperations($this->buildGraphQlOperations($node['graphQlOperations'] ?? null, $resource));
 
             $resources[] = $resource->withOperations(new Operations($this->buildOperations($node['operations'] ?? null, $resource)));
         }
@@ -148,6 +151,20 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
     {
         $operations = [];
 
+        if (null === $data) {
+            foreach ([new QueryCollection(), new Query(), (new Mutation())->withName('update'), (new DeleteMutation())->withName('delete'), (new Mutation())->withName('create')] as $operation) {
+                $operation = $this->getOperationWithDefaults($resource, $operation);
+
+                if ($operation instanceof Mutation) {
+                    $operation = $operation->withDescription(ucfirst("{$operation->getName()}s a {$resource->getShortName()}."));
+                }
+
+                $operations[$operation->getName()] = $operation;
+            }
+
+            return $operations;
+        }
+
         foreach ($data as $attributes) {
             /** @var HttpOperation $operation */
             $operation = (new $attributes['graphql_operation_class']())->withShortName($resource->getShortName());
@@ -175,7 +192,7 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
         return $operations;
     }
 
-    private function getOperationWithDefaults(ApiResource $resource, HttpOperation $operation): HttpOperation
+    private function getOperationWithDefaults(ApiResource $resource, Operation $operation): Operation
     {
         foreach (($this->defaults['attributes'] ?? []) as $key => $value) {
             $key = $this->camelCaseToSnakeCaseNameConverter->denormalize($key);

--- a/src/Metadata/Resource/Factory/FiltersResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/FiltersResourceMetadataCollectionFactory.php
@@ -41,6 +41,10 @@ final class FiltersResourceMetadataCollectionFactory implements ResourceMetadata
             $resourceMetadataCollection = $this->decorated->create($resourceClass);
         }
 
+        if ($resourceMetadataCollection->isDynamic()) {
+            return $resourceMetadataCollection;
+        }
+
         try {
             $reflectionClass = new \ReflectionClass($resourceClass);
         } catch (\ReflectionException) {

--- a/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
@@ -42,6 +42,10 @@ final class PhpDocResourceMetadataCollectionFactory implements ResourceMetadataC
     {
         $resourceMetadataCollection = $this->decorated->create($resourceClass);
 
+        if ($resourceMetadataCollection->isDynamic()) {
+            return $resourceMetadataCollection;
+        }
+
         foreach ($resourceMetadataCollection as $key => $resourceMetadata) {
             if (null !== $resourceMetadata->getDescription()) {
                 continue;

--- a/src/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Metadata/Resource/ResourceMetadataCollection.php
@@ -24,6 +24,8 @@ use ApiPlatform\Metadata\Operation;
  */
 final class ResourceMetadataCollection extends \ArrayObject
 {
+    public const DYNAMIC_RESOURCE_CLASS_PREFIX = 'Dynamic#';
+
     private array $operationCache = [];
 
     public function __construct(private readonly string $resourceClass, array $input = [])
@@ -84,6 +86,11 @@ final class ResourceMetadataCollection extends \ArrayObject
         // }
 
         $this->handleNotFound($operationName, $metadata);
+    }
+
+    public function isDynamic(): bool
+    {
+        return str_starts_with($this->resourceClass, self::DYNAMIC_RESOURCE_CLASS_PREFIX);
     }
 
     /**

--- a/src/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Symfony/Bundle/Resources/config/graphql.xml
@@ -121,6 +121,7 @@
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
+            <argument type="service" id="api_platform.metadata.resource_extractor.dynamic" />
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.graphql.types_container" />
             <argument type="service" id="api_platform.graphql.type_builder" />

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -23,6 +23,14 @@
             <argument>%api_platform.defaults%</argument>
         </service>
 
+        <service id="api_platform.metadata.resource_extractor.dynamic" class="ApiPlatform\Metadata\Extractor\DynamicResourceExtractor" public="false" />
+
+        <service id="api_platform.metadata.resource.metadata_collection_factory.dynamic" class="ApiPlatform\Metadata\Resource\Factory\ExtractorResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="800" public="false">
+            <argument type="service" id="api_platform.metadata.resource_extractor.dynamic" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.dynamic.inner" />
+            <argument>%api_platform.defaults%</argument>
+        </service>
+
         <service id="api_platform.metadata.resource.metadata_collection_factory.not_exposed_operation" class="ApiPlatform\Metadata\Resource\Factory\NotExposedOperationResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="700" public="false">
             <argument type="service" id="api_platform.metadata.resource.link_factory" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.not_exposed_operation.inner" />

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -286,10 +286,10 @@ final class DoctrineContext implements Context
     public function thereAreOfTheseSoManyObjects(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
-            $dummy = $this->isOrm() ? new SoMany() : new SoManyDocument();
-            $dummy->content = 'Many #'.$i;
+            $soMany = $this->buildSoMany();
+            $soMany->content = 'Many #'.$i;
 
-            $this->manager->persist($dummy);
+            $this->manager->persist($soMany);
         }
 
         $this->manager->flush();
@@ -340,6 +340,12 @@ final class DoctrineContext implements Context
             $foo = $this->buildFooDummy();
             $foo->setName($names[$i]);
             $foo->setDummy($dummy);
+            for ($j = 0; $j < 3; ++$j) {
+                $soMany = $this->buildSoMany();
+                $soMany->content = "So many $j";
+                $soMany->fooDummy = $foo;
+                $foo->soManies->add($soMany);
+            }
 
             $this->manager->persist($foo);
         }
@@ -2198,6 +2204,11 @@ final class DoctrineContext implements Context
     private function buildRelatedSecureDummy(): RelatedSecuredDummy|RelatedSecuredDummyDocument
     {
         return $this->isOrm() ? new RelatedSecuredDummy() : new RelatedSecuredDummyDocument();
+    }
+
+    private function buildSoMany(): SoMany|SoManyDocument
+    {
+        return $this->isOrm() ? new SoMany() : new SoManyDocument();
     }
 
     private function buildThirdLevel(): ThirdLevel|ThirdLevelDocument

--- a/tests/Fixtures/TestBundle/Document/FooDummy.php
+++ b/tests/Fixtures/TestBundle/Document/FooDummy.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
@@ -41,6 +43,17 @@ class FooDummy
      */
     #[ODM\ReferenceOne(targetDocument: Dummy::class, cascade: ['persist'], storeAs: 'id')]
     private ?Dummy $dummy = null;
+
+    /**
+     * @var Collection<SoMany>
+     */
+    #[ODM\ReferenceMany(targetDocument: SoMany::class, cascade: ['persist'], storeAs: 'id')]
+    public Collection $soManies;
+
+    public function __construct()
+    {
+        $this->soManies = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {

--- a/tests/Fixtures/TestBundle/Entity/FooDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/FooDummy.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -43,6 +45,17 @@ class FooDummy
      */
     #[ORM\ManyToOne(targetEntity: Dummy::class, cascade: ['persist'])]
     private ?Dummy $dummy = null;
+
+    /**
+     * @var Collection<SoMany>
+     */
+    #[ORM\OneToMany(targetEntity: SoMany::class, mappedBy: 'fooDummy', cascade: ['persist'])]
+    public Collection $soManies;
+
+    public function __construct()
+    {
+        $this->soManies = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {

--- a/tests/Fixtures/TestBundle/Entity/SoMany.php
+++ b/tests/Fixtures/TestBundle/Entity/SoMany.php
@@ -31,4 +31,7 @@ class SoMany
     public $id;
     #[ORM\Column(nullable: true)]
     public $content;
+
+    #[ORM\ManyToOne]
+    public ?FooDummy $fooDummy;
 }

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -22,6 +22,7 @@ use ApiPlatform\GraphQl\Type\TypeConverterInterface;
 use ApiPlatform\GraphQl\Type\TypesContainerInterface;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Extractor\DynamicResourceExtractorInterface;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
@@ -56,29 +57,18 @@ class FieldsBuilderTest extends TestCase
     use ProphecyTrait;
 
     private ObjectProphecy $propertyNameCollectionFactoryProphecy;
-
     private ObjectProphecy $propertyMetadataFactoryProphecy;
-
     private ObjectProphecy $resourceMetadataCollectionFactoryProphecy;
-
+    private ObjectProphecy $dynamicResourceExtractorProphecy;
     private ObjectProphecy $typesContainerProphecy;
-
     private ObjectProphecy $typeBuilderProphecy;
-
     private ObjectProphecy $typeConverterProphecy;
-
     private ObjectProphecy $itemResolverFactoryProphecy;
-
     private ObjectProphecy $collectionResolverFactoryProphecy;
-
     private ObjectProphecy $itemMutationResolverFactoryProphecy;
-
     private ObjectProphecy $itemSubscriptionResolverFactoryProphecy;
-
     private ObjectProphecy $filterLocatorProphecy;
-
     private ObjectProphecy $resourceClassResolverProphecy;
-
     private FieldsBuilder $fieldsBuilder;
 
     /**
@@ -89,6 +79,7 @@ class FieldsBuilderTest extends TestCase
         $this->propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $this->propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $this->resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $this->dynamicResourceExtractorProphecy = $this->prophesize(DynamicResourceExtractorInterface::class);
         $this->typesContainerProphecy = $this->prophesize(TypesContainerInterface::class);
         $this->typeBuilderProphecy = $this->prophesize(TypeBuilderInterface::class);
         $this->typeConverterProphecy = $this->prophesize(TypeConverterInterface::class);
@@ -103,7 +94,7 @@ class FieldsBuilderTest extends TestCase
 
     private function buildFieldsBuilder(?AdvancedNameConverterInterface $advancedNameConverter = null): FieldsBuilder
     {
-        return new FieldsBuilder($this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->resourceMetadataCollectionFactoryProphecy->reveal(), $this->resourceClassResolverProphecy->reveal(), $this->typesContainerProphecy->reveal(), $this->typeBuilderProphecy->reveal(), $this->typeConverterProphecy->reveal(), $this->itemResolverFactoryProphecy->reveal(), $this->collectionResolverFactoryProphecy->reveal(), $this->itemMutationResolverFactoryProphecy->reveal(), $this->itemSubscriptionResolverFactoryProphecy->reveal(), $this->filterLocatorProphecy->reveal(), new Pagination(), $advancedNameConverter ?? new CustomConverter(), '__');
+        return new FieldsBuilder($this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->resourceMetadataCollectionFactoryProphecy->reveal(), $this->dynamicResourceExtractorProphecy->reveal(), $this->resourceClassResolverProphecy->reveal(), $this->typesContainerProphecy->reveal(), $this->typeBuilderProphecy->reveal(), $this->typeConverterProphecy->reveal(), $this->itemResolverFactoryProphecy->reveal(), $this->collectionResolverFactoryProphecy->reveal(), $this->itemMutationResolverFactoryProphecy->reveal(), $this->itemSubscriptionResolverFactoryProphecy->reveal(), $this->filterLocatorProphecy->reveal(), new Pagination(), $advancedNameConverter ?? new CustomConverter(), '__');
     }
 
     public function testGetNodeQueryFields(): void
@@ -139,7 +130,6 @@ class FieldsBuilderTest extends TestCase
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), $resourceClass, $resourceClass, null, 0)->willReturn($graphqlType);
         $this->typeConverterProphecy->resolveType(Argument::type('string'))->willReturn(GraphQLType::string());
         $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn(false);
-        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operation->getName() => $operation])]));
         $this->itemResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, $operation)->willReturn($resolver);
 
         $queryFields = $this->fieldsBuilder->getItemQueryFields($resourceClass, $operation, $configuration);
@@ -150,8 +140,8 @@ class FieldsBuilderTest extends TestCase
     public function itemQueryFieldsProvider(): array
     {
         return [
-            'no resource field configuration' => ['resourceClass', (new Query())->withName('action'), [], null, null, []],
-            'nominal standard type case with deprecation reason and description' => ['resourceClass', (new Query())->withName('action')->withShortName('ShortName')->withDeprecationReason('not useful')->withDescription('Custom description.'), [], GraphQLType::string(), null,
+            'no resource field configuration' => ['resourceClass', (new Query())->withClass('resourceClass')->withName('action'), [], null, null, []],
+            'nominal standard type case with deprecation reason and description' => ['resourceClass', (new Query())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withDeprecationReason('not useful')->withDescription('Custom description.'), [], GraphQLType::string(), null,
                 [
                     'actionShortName' => [
                         'type' => GraphQLType::string(),
@@ -164,7 +154,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'nominal item case' => ['resourceClass', (new Query())->withName('action')->withShortName('ShortName'), [], $graphqlType = new ObjectType(['name' => 'item']), $resolver = function (): void {
+            'nominal item case' => ['resourceClass', (new Query())->withClass('resourceClass')->withName('action')->withShortName('ShortName'), [], $graphqlType = new ObjectType(['name' => 'item']), $resolver = function (): void {
             },
                 [
                     'actionShortName' => [
@@ -179,7 +169,7 @@ class FieldsBuilderTest extends TestCase
                 ],
             ],
             'empty overridden args and add fields' => [
-                'resourceClass', (new Query())->withShortName('ShortName'), ['args' => [], 'name' => 'customActionName'], GraphQLType::string(), null,
+                'resourceClass', (new Query())->withClass('resourceClass')->withShortName('ShortName'), ['args' => [], 'name' => 'customActionName'], GraphQLType::string(), null,
                 [
                     'shortName' => [
                         'type' => GraphQLType::string(),
@@ -192,7 +182,7 @@ class FieldsBuilderTest extends TestCase
                 ],
             ],
             'override args with custom ones' => [
-                'resourceClass', (new Query())->withShortName('ShortName'), ['args' => ['customArg' => ['type' => 'a type']]], GraphQLType::string(), null,
+                'resourceClass', (new Query())->withClass('resourceClass')->withShortName('ShortName'), ['args' => ['customArg' => ['type' => 'a type']]], GraphQLType::string(), null,
                 [
                     'shortName' => [
                         'type' => GraphQLType::string(),
@@ -219,8 +209,7 @@ class FieldsBuilderTest extends TestCase
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), $resourceClass, $resourceClass, null, 0)->willReturn($graphqlType);
         $this->typeConverterProphecy->resolveType(Argument::type('string'))->willReturn(GraphQLType::string());
         $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn(true);
-        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $operation)->willReturn($graphqlType);
-        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operation->getName() => $operation])]));
+        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType, $operation)->willReturn($graphqlType);
         $this->collectionResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, $operation)->willReturn($resolver);
         $this->filterLocatorProphecy->has('my_filter')->willReturn(true);
         $filterProphecy = $this->prophesize(FilterInterface::class);
@@ -244,8 +233,8 @@ class FieldsBuilderTest extends TestCase
     public function collectionQueryFieldsProvider(): array
     {
         return [
-            'no resource field configuration' => ['resourceClass', (new QueryCollection())->withName('action'), [], null, null, []],
-            'nominal collection case with deprecation reason and description' => ['resourceClass', (new QueryCollection())->withName('action')->withShortName('ShortName')->withDeprecationReason('not useful')->withDescription('Custom description.'), [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
+            'no resource field configuration' => ['resourceClass', (new QueryCollection())->withClass('resourceClass')->withName('action'), [], null, null, []],
+            'nominal collection case with deprecation reason and description' => ['resourceClass', (new QueryCollection())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withDeprecationReason('not useful')->withDescription('Custom description.'), [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
             },
                 [
                     'actionShortNames' => [
@@ -274,7 +263,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'collection with filters' => ['resourceClass', (new QueryCollection())->withName('action')->withShortName('ShortName')->withFilters(['my_filter']), [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
+            'collection with filters' => ['resourceClass', (new QueryCollection())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withFilters(['my_filter']), [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
             },
                 [
                     'actionShortNames' => [
@@ -308,7 +297,7 @@ class FieldsBuilderTest extends TestCase
                 ],
             ],
             'collection empty overridden args and add fields' => [
-                'resourceClass', (new QueryCollection())->withArgs([])->withName('action')->withShortName('ShortName'), ['args' => [], 'name' => 'customActionName'], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
+                'resourceClass', (new QueryCollection())->withArgs([])->withClass('resourceClass')->withName('action')->withShortName('ShortName'), ['args' => [], 'name' => 'customActionName'], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
                 },
                 [
                     'actionShortNames' => [
@@ -322,7 +311,7 @@ class FieldsBuilderTest extends TestCase
                 ],
             ],
             'collection override args with custom ones' => [
-                'resourceClass', (new QueryCollection())->withName('action')->withShortName('ShortName'), ['args' => ['customArg' => ['type' => 'a type']]], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
+                'resourceClass', (new QueryCollection())->withClass('resourceClass')->withName('action')->withShortName('ShortName'), ['args' => ['customArg' => ['type' => 'a type']]], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
                 },
                 [
                     'actionShortNames' => [
@@ -338,7 +327,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'collection with page-based pagination enabled' => ['resourceClass', (new QueryCollection())->withName('action')->withShortName('ShortName')->withPaginationType('page')->withFilters(['my_filter']), [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
+            'collection with page-based pagination enabled' => ['resourceClass', (new QueryCollection())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withPaginationType('page')->withFilters(['my_filter']), [], $graphqlType = GraphQLType::listOf(new ObjectType(['name' => 'collection'])), $resolver = function (): void {
             },
                 [
                     'actionShortNames' => [
@@ -371,8 +360,6 @@ class FieldsBuilderTest extends TestCase
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), $resourceClass, $resourceClass, null, 0)->willReturn($graphqlType);
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), $resourceClass, $resourceClass, null, 0)->willReturn($inputGraphqlType);
         $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn(false);
-        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $operation->getName())->willReturn($graphqlType);
-        $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operation->getName() => $operation])]));
         $this->itemMutationResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, $operation)->willReturn($mutationResolver);
 
         $mutationFields = $this->fieldsBuilder->getMutationFields($resourceClass, $operation);
@@ -383,7 +370,7 @@ class FieldsBuilderTest extends TestCase
     public function mutationFieldsProvider(): array
     {
         return [
-            'nominal case with deprecation reason' => ['resourceClass', (new Mutation())->withName('action')->withShortName('ShortName')->withDeprecationReason('not useful'), $graphqlType = new ObjectType(['name' => 'mutation']), $inputGraphqlType = new ObjectType(['name' => 'input']), $mutationResolver = function (): void {
+            'nominal case with deprecation reason' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withDeprecationReason('not useful'), $graphqlType = new ObjectType(['name' => 'mutation']), $inputGraphqlType = new ObjectType(['name' => 'input']), $mutationResolver = function (): void {
             },
                 [
                     'actionShortName' => [
@@ -403,7 +390,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'custom description' => ['resourceClass', (new Mutation())->withName('action')->withShortName('ShortName')->withDescription('Custom description.'), $graphqlType = new ObjectType(['name' => 'mutation']), $inputGraphqlType = new ObjectType(['name' => 'input']), $mutationResolver = function (): void {
+            'custom description' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withDescription('Custom description.'), $graphqlType = new ObjectType(['name' => 'mutation']), $inputGraphqlType = new ObjectType(['name' => 'input']), $mutationResolver = function (): void {
             },
                 [
                     'actionShortName' => [
@@ -435,7 +422,6 @@ class FieldsBuilderTest extends TestCase
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), false, Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), $resourceClass, $resourceClass, null, 0)->willReturn($graphqlType);
         $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), $resourceClass, $resourceClass, null, 0)->willReturn($inputGraphqlType);
         $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn(false);
-        $this->typeBuilderProphecy->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $operation->getName())->willReturn($graphqlType);
         $this->resourceMetadataCollectionFactoryProphecy->create($resourceClass)->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operation->getName() => $operation])]));
         $this->itemSubscriptionResolverFactoryProphecy->__invoke($resourceClass, $resourceClass, $operation)->willReturn($subscriptionResolver);
 
@@ -447,9 +433,9 @@ class FieldsBuilderTest extends TestCase
     public function subscriptionFieldsProvider(): array
     {
         return [
-            'mercure not enabled' => ['resourceClass', (new Subscription())->withName('action')->withShortName('ShortName'), new ObjectType(['name' => 'subscription']), new ObjectType(['name' => 'input']), null, [],
+            'mercure not enabled' => ['resourceClass', (new Subscription())->withClass('resourceClass')->withName('action')->withShortName('ShortName'), new ObjectType(['name' => 'subscription']), new ObjectType(['name' => 'input']), null, [],
             ],
-            'nominal case with deprecation reason' => ['resourceClass', (new Subscription())->withName('action')->withShortName('ShortName')->withMercure(true)->withDeprecationReason('not useful'), $graphqlType = new ObjectType(['name' => 'subscription']), $inputGraphqlType = new ObjectType(['name' => 'input']), $subscriptionResolver = function (): void {
+            'nominal case with deprecation reason' => ['resourceClass', (new Subscription())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withMercure(true)->withDeprecationReason('not useful'), $graphqlType = new ObjectType(['name' => 'subscription']), $inputGraphqlType = new ObjectType(['name' => 'input']), $subscriptionResolver = function (): void {
             },
                 [
                     'actionShortNameSubscribe' => [
@@ -469,7 +455,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'custom description' => ['resourceClass', (new Subscription())->withName('action')->withShortName('ShortName')->withMercure(true)->withDescription('Custom description.'), $graphqlType = new ObjectType(['name' => 'subscription']), $inputGraphqlType = new ObjectType(['name' => 'input']), $subscriptionResolver = function (): void {
+            'custom description' => ['resourceClass', (new Subscription())->withClass('resourceClass')->withName('action')->withShortName('ShortName')->withMercure(true)->withDescription('Custom description.'), $graphqlType = new ObjectType(['name' => 'subscription']), $inputGraphqlType = new ObjectType(['name' => 'input']), $subscriptionResolver = function (): void {
             },
                 [
                     'actionShortNameSubscribe' => [
@@ -498,6 +484,8 @@ class FieldsBuilderTest extends TestCase
     public function testGetResourceObjectTypeFields(string $resourceClass, Operation $operation, array $properties, bool $input, int $depth, ?array $ioMetadata, array $expectedResourceObjectTypeFields, ?AdvancedNameConverterInterface $advancedNameConverter = null): void
     {
         $this->resourceClassResolverProphecy->isResourceClass($resourceClass)->willReturn(true);
+        $this->resourceClassResolverProphecy->isResourceClass('nestedResourceClass')->willReturn(true);
+        $this->resourceClassResolverProphecy->isResourceClass('nestedResourceNoQueryClass')->willReturn(true);
         $this->resourceClassResolverProphecy->isResourceClass(Argument::type('string'))->willReturn(false);
         $this->propertyNameCollectionFactoryProphecy->create($resourceClass)->willReturn(new PropertyNameCollection(array_keys($properties)));
         foreach ($properties as $propertyName => $propertyMetadata) {
@@ -505,20 +493,33 @@ class FieldsBuilderTest extends TestCase
             $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_NULL), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), '', $resourceClass, $propertyName, $depth + 1)->willReturn(null);
             $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_CALLABLE), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), '', $resourceClass, $propertyName, $depth + 1)->willReturn('NotRegisteredType');
             $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), '', $resourceClass, $propertyName, $depth + 1)->willReturn(GraphQLType::string());
+            $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), '', $resourceClass, $propertyName, $depth + 1)->willReturn(GraphQLType::nonNull(GraphQLType::listOf(GraphQLType::nonNull(GraphQLType::string()))));
+
             if ('propertyObject' === $propertyName) {
                 $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), 'objectClass', $resourceClass, $propertyName, $depth + 1)->willReturn(new ObjectType(['name' => 'objectType']));
-                $this->resourceMetadataCollectionFactoryProphecy->create('objectClass')->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations(['item_query' => new Query()])]));
                 $this->itemResolverFactoryProphecy->__invoke('objectClass', $resourceClass, $operation)->willReturn(static function (): void {
                 });
             }
-            $this->typeConverterProphecy->convertType(Argument::type(Type::class), true, Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), 'anotherResourceClass', $propertyName, $depth + 1)->willReturn(GraphQLType::string());
-            $this->typeConverterProphecy->convertType(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), '', $resourceClass, $propertyName, $depth + 1)->willReturn(GraphQLType::nonNull(GraphQLType::listOf(GraphQLType::nonNull(GraphQLType::string()))));
+            if ('propertyNestedResource' === $propertyName) {
+                $nestedResourceQueryOperation = new Query();
+                $this->resourceMetadataCollectionFactoryProphecy->create('nestedResourceClass')->willReturn(new ResourceMetadataCollection('nestedResourceClass', [(new ApiResource())->withGraphQlOperations(['item_query' => $nestedResourceQueryOperation])]));
+                $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), 'nestedResourceClass', $resourceClass, $propertyName, $depth + 1)->willReturn(new ObjectType(['name' => 'objectType']));
+                $this->itemResolverFactoryProphecy->__invoke('nestedResourceClass', $resourceClass, $nestedResourceQueryOperation)->willReturn(static function (): void {
+                });
+            }
+            if ('propertyNestedResourceNoQuery' === $propertyName) {
+                $this->resourceMetadataCollectionFactoryProphecy->create('nestedResourceNoQueryClass')->willReturn(new ResourceMetadataCollection('nestedResourceNoQueryClass', [(new ApiResource())->withDescription('A description.')->withGraphQlOperations([])]));
+                $this->dynamicResourceExtractorProphecy->addResource('nestedResourceNoQueryClass')->shouldBeCalled()->willReturn('Dynamic#nestedResourceNoQueryClass');
+                $dynamicResourceQueryOperation = new Query();
+                $this->resourceMetadataCollectionFactoryProphecy->create('Dynamic#nestedResourceNoQueryClass')->willReturn(new ResourceMetadataCollection('nestedResourceNoQueryClass', [(new ApiResource())->withGraphQlOperations(['item_query' => $dynamicResourceQueryOperation])]));
+                $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), 'nestedResourceNoQueryClass', $resourceClass, $propertyName, $depth + 1)->willReturn(new ObjectType(['name' => 'objectType']));
+                $this->itemResolverFactoryProphecy->__invoke('nestedResourceNoQueryClass', $resourceClass, $dynamicResourceQueryOperation->withDescription('A description.'))->willReturn(static function (): void {
+                });
+            }
         }
         $this->typesContainerProphecy->has('NotRegisteredType')->willReturn(false);
         $this->typesContainerProphecy->all()->willReturn([]);
         $this->typeBuilderProphecy->isCollection(Argument::type(Type::class))->willReturn(false);
-        $this->resourceMetadataCollectionFactoryProphecy->create('resourceClass')->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations([$operation->getName() => $operation])]));
-        $this->resourceMetadataCollectionFactoryProphecy->create('anotherResourceClass')->willReturn(new ResourceMetadataCollection($resourceClass, [(new ApiResource())->withGraphQlOperations(['item_query' => new Query()])]));
 
         $fieldsBuilder = $this->fieldsBuilder;
         if ($advancedNameConverter) {
@@ -535,7 +536,7 @@ class FieldsBuilderTest extends TestCase
         $advancedNameConverter->normalize('field', 'resourceClass')->willReturn('normalizedField');
 
         return [
-            'query' => ['resourceClass', new Query(),
+            'query' => ['resourceClass', (new Query())->withClass('resourceClass'),
                 [
                     'property' => new ApiProperty(),
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(true)->withWritable(false),
@@ -563,7 +564,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'query with advanced name converter' => ['resourceClass', new Query(),
+            'query with advanced name converter' => ['resourceClass', (new Query())->withClass('resourceClass'),
                 [
                     'field' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)])->withReadable(true)->withWritable(false),
                 ],
@@ -582,7 +583,7 @@ class FieldsBuilderTest extends TestCase
                 ],
                 $advancedNameConverter->reveal(),
             ],
-            'query input' => ['resourceClass', new Query(),
+            'query input' => ['resourceClass', (new Query())->withClass('resourceClass'),
                 [
                     'property' => new ApiProperty(),
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(false),
@@ -601,7 +602,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'query with simple non-null string array property' => ['resourceClass', new Query(),
+            'query with simple non-null string array property' => ['resourceClass', (new Query())->withClass('resourceClass'),
                 [
                     'property' => (new ApiProperty())->withBuiltinTypes([
                         new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)),
@@ -621,12 +622,40 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'mutation non input' => ['resourceClass', (new Mutation())->withName('mutation'),
+            'query with nested resources' => ['resourceClass', (new Query())->withClass('resourceClass'),
+                [
+                    'propertyNestedResource' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_OBJECT, false, 'nestedResourceClass')])->withReadable(true)->withWritable(true),
+                    'propertyNestedResourceNoQuery' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_OBJECT, false, 'nestedResourceNoQueryClass')])->withReadable(true)->withWritable(true),
+                ],
+                false, 0, null,
+                [
+                    'id' => [
+                        'type' => GraphQLType::nonNull(GraphQLType::id()),
+                    ],
+                    'propertyNestedResource' => [
+                        'type' => GraphQLType::nonNull(new ObjectType(['name' => 'objectType'])),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => static function (): void {
+                        },
+                        'deprecationReason' => null,
+                    ],
+                    'propertyNestedResourceNoQuery' => [
+                        'type' => GraphQLType::nonNull(new ObjectType(['name' => 'objectType'])),
+                        'description' => null,
+                        'args' => [],
+                        'resolve' => static function (): void {
+                        },
+                        'deprecationReason' => null,
+                    ],
+                ],
+            ],
+            'mutation non input' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('mutation'),
                 [
                     'property' => new ApiProperty(),
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
                     'propertyReadable' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(true)->withWritable(true),
-                    'propertyObject' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL, false, 'objectClass')])->withReadable(true)->withWritable(true),
+                    'propertyObject' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_OBJECT, false, 'objectClass')])->withReadable(true)->withWritable(true),
                 ],
                 false, 0, null,
                 [
@@ -650,7 +679,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'mutation input' => ['resourceClass', (new Mutation())->withName('mutation'),
+            'mutation input' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('mutation'),
                 [
                     'property' => new ApiProperty(),
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withDescription('propertyBool description')->withReadable(false)->withWritable(true)->withDeprecationReason('not useful'),
@@ -686,7 +715,7 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
-            'mutation nested input' => ['resourceClass', (new Mutation())->withName('mutation'),
+            'mutation nested input' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('mutation'),
                 [
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
                 ],
@@ -705,7 +734,7 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
-            'delete mutation input' => ['resourceClass', (new Mutation())->withName('delete'),
+            'delete mutation input' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('delete'),
                 [
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
                 ],
@@ -717,7 +746,7 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
-            'create mutation input' => ['resourceClass', (new Mutation())->withName('create'),
+            'create mutation input' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('create'),
                 [
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
                 ],
@@ -733,7 +762,7 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
-            'update mutation input' => ['resourceClass', (new Mutation())->withName('update'),
+            'update mutation input' => ['resourceClass', (new Mutation())->withClass('resourceClass')->withName('update'),
                 [
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
                 ],
@@ -752,7 +781,7 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
-            'subscription non input' => ['resourceClass', new Subscription(),
+            'subscription non input' => ['resourceClass', (new Subscription())->withClass('resourceClass'),
                 [
                     'property' => new ApiProperty(),
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
@@ -772,7 +801,7 @@ class FieldsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'subscription input' => ['resourceClass', new Subscription(),
+            'subscription input' => ['resourceClass', (new Subscription())->withClass('resourceClass'),
                 [
                     'property' => new ApiProperty(),
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withDescription('propertyBool description')->withReadable(false)->withWritable(true)->withDeprecationReason('not useful'),
@@ -787,13 +816,13 @@ class FieldsBuilderTest extends TestCase
                     'clientSubscriptionId' => GraphQLType::string(),
                 ],
             ],
-            'null io metadata non input' => ['resourceClass', new Query(),
+            'null io metadata non input' => ['resourceClass', (new Query())->withClass('resourceClass'),
                 [
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
                 ],
                 false, 0, ['class' => null], [],
             ],
-            'null io metadata input' => ['resourceClass', new Query(),
+            'null io metadata input' => ['resourceClass', (new Query())->withClass('resourceClass'),
                 [
                     'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
                 ],
@@ -802,7 +831,7 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
-            'invalid types' => ['resourceClass', new Query(),
+            'invalid types' => ['resourceClass', (new Query())->withClass('resourceClass'),
                 [
                     'propertyInvalidType' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_NULL)])->withReadable(true)->withWritable(false),
                     'propertyNotRegisteredType' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_CALLABLE)])->withReadable(true)->withWritable(false),

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -483,7 +483,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('StringPageInfo', Argument::type(ObjectType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourcePaginatedCollectionType */
-        $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', $operation);
+        $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), $operation);
         $this->assertSame('StringCursorConnection', $resourcePaginatedCollectionType->name);
         $this->assertSame('Cursor connection for String.', $resourcePaginatedCollectionType->description);
 
@@ -538,7 +538,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('StringPaginationInfo', Argument::type(ObjectType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourcePaginatedCollectionType */
-        $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'StringResourceClass', $operation);
+        $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), $operation);
         $this->assertSame('StringPageConnection', $resourcePaginatedCollectionType->name);
         $this->assertSame('Page connection for String.', $resourcePaginatedCollectionType->description);
 

--- a/tests/Metadata/Extractor/DynamicResourceExtractorTest.php
+++ b/tests/Metadata/Extractor/DynamicResourceExtractorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Metadata\Extractor;
+
+use ApiPlatform\Metadata\Extractor\DynamicResourceExtractor;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
+use PHPUnit\Framework\TestCase;
+
+final class DynamicResourceExtractorTest extends TestCase
+{
+    public function testAddResource(): void
+    {
+        $dynamicResourceExtractor = new DynamicResourceExtractor();
+
+        $dynamicResourceName = $dynamicResourceExtractor->addResource(Dummy::class, ['description' => 'A description.']);
+
+        self::assertSame(ResourceMetadataCollection::DYNAMIC_RESOURCE_CLASS_PREFIX.Dummy::class, $dynamicResourceName);
+        self::assertSame([
+            $dynamicResourceName => [[
+                'class' => Dummy::class,
+                'description' => 'A description.',
+            ]],
+        ], $dynamicResourceExtractor->getResources());
+    }
+}

--- a/tests/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -209,4 +209,14 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertEquals($extraPropertiesResource[0]->getExtraProperties(), ['foo' => 'bar']);
         $this->assertEquals($extraPropertiesResource->getOperation('_api_ExtraPropertiesResource_get')->getExtraProperties(), ['foo' => 'bar']);
     }
+
+    public function testDynamic(): void
+    {
+        $attributeResourceMetadataCollectionFactory = new AttributesResourceMetadataCollectionFactory();
+
+        self::assertEquals(
+            new ResourceMetadataCollection(ResourceMetadataCollection::DYNAMIC_RESOURCE_CLASS_PREFIX.AttributeResource::class),
+            $attributeResourceMetadataCollectionFactory->create(ResourceMetadataCollection::DYNAMIC_RESOURCE_CLASS_PREFIX.AttributeResource::class)
+        );
+    }
 }

--- a/tests/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactoryTest.php
@@ -58,4 +58,19 @@ class PhpDocResourceMetadataCollectionFactoryTest extends TestCase
         $factory = new PhpDocResourceMetadataCollectionFactory($decorated);
         $this->assertSame('My dummy entity.', $factory->create(DummyEntity::class)[0]->getDescription());
     }
+
+    public function testDynamic(): void
+    {
+        $resourceCollection = new ResourceMetadataCollection(ResourceMetadataCollection::DYNAMIC_RESOURCE_CLASS_PREFIX.DummyEntity::class, [new ApiResource()]);
+        $decoratedProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $decoratedProphecy->create(ResourceMetadataCollection::DYNAMIC_RESOURCE_CLASS_PREFIX.DummyEntity::class)->willReturn($resourceCollection)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new PhpDocResourceMetadataCollectionFactory($decorated);
+
+        self::assertSame(
+            $resourceCollection,
+            $factory->create(ResourceMetadataCollection::DYNAMIC_RESOURCE_CLASS_PREFIX.DummyEntity::class)
+        );
+    }
 }

--- a/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -363,6 +363,8 @@ class ApiPlatformExtensionTest extends TestCase
             // metadata/resource.xml
             'api_platform.metadata.resource.metadata_collection_factory.attributes',
             'api_platform.metadata.resource.metadata_collection_factory.xml',
+            'api_platform.metadata.resource_extractor.dynamic',
+            'api_platform.metadata.resource.metadata_collection_factory.dynamic',
             'api_platform.metadata.resource.metadata_collection_factory.uri_template',
             'api_platform.metadata.resource.metadata_collection_factory.link',
             'api_platform.metadata.resource.metadata_collection_factory.operation_name',


### PR DESCRIPTION
See https://github.com/api-platform/core/issues/4613#issuecomment-1210634143.

Supersedes https://github.com/api-platform/core/pull/4930.

Fixes https://github.com/api-platform/api-platform/issues/2296.

The principal issue was mainly because the root operation was used instead of the nested resource one.

This PR also improves how GraphQL handles a nested resource when the query operation does not exist.
Instead of having a fallback on the REST operation (and an exception if it does not exist), it creates a "dynamic" resource having the default operations.
This dynamic resource is created using a new `DynamicExtractor` with an `addResource` method, which can take an optional configuration array.

In the future, I think this could be useful to control how a nested resource is handled by GraphQL (for instance by using the `ApiProperty` attribute).