### PR TITLE
fixed registration order of routes  and added operation name

### DIFF
--- a/src/Core/Upgrade/UpgradeApiResourceVisitor.php
+++ b/src/Core/Upgrade/UpgradeApiResourceVisitor.php
@@ -130,8 +130,8 @@ final class UpgradeApiResourceVisitor extends NodeVisitorAbstract
 
             $arguments = [];
             $operations = null === $this->resourceAnnotation->itemOperations && null === $this->resourceAnnotation->collectionOperations ? null : array_merge(
-                $this->legacyOperationsToOperations($this->getLegacyOperations()),
-                $this->legacyOperationsToOperations($this->getLegacyOperations(true), true)
+                $this->legacyOperationsToOperations($this->getLegacyOperations(true), true),
+                $this->legacyOperationsToOperations($this->getLegacyOperations())
             );
 
             if (null !== $operations) {
@@ -443,6 +443,9 @@ final class UpgradeApiResourceVisitor extends NodeVisitorAbstract
 
             $method = $operation['method'] ?? strtoupper($operationName);
             unset($operation['method']);
+            if(!in_array($operationName, ['get', 'post', 'put', 'patch', 'delete'])) {
+                $operation['name']= $operationName;
+            }
             $operations[] = $this->createOperation($this->getOperationNamespace($method, $isCollection), $operation);
         }
 


### PR DESCRIPTION
I have adjusted the order of the registration of the routes to avoid that itemOperations conflict with collection operation. For instance:
```
api/books/avaliable
api/books/{id}
```
instead of
```
api/books/{id}
api/books/avaliable
```

I also added the name of the operation that I use a lot in the "doctrine extension" and they are not there anymore than after the migration

| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- 2.7 for bugs related to the **backward compatibility layer**, if the bug was in 2.6 let's fix it on the 3.0 branch instead
- 3.0 for bug fixes
- main for new features

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
