### PR TITLE
fix: call class_alias only if interface doesn't exist

### DIFF
--- a/src/deprecation.php
+++ b/src/deprecation.php
@@ -12,8 +12,12 @@
 declare(strict_types=1);
 
 // Must be declared first!
-class_alias(ApiPlatform\Api\FilterInterface::class, ApiPlatform\Core\Api\FilterInterface::class);
-class_alias(ApiPlatform\Api\ResourceClassResolverInterface::class, ApiPlatform\Core\Api\ResourceClassResolverInterface::class);
+if (!interface_exists(ApiPlatform\Core\Api\FilterInterface::class)) {
+    class_alias(ApiPlatform\Api\FilterInterface::class, ApiPlatform\Core\Api\FilterInterface::class);
+}
+if (!interface_exists(ApiPlatform\Core\Api\ResourceClassResolverInterface::class)) {
+    class_alias(ApiPlatform\Api\ResourceClassResolverInterface::class, ApiPlatform\Core\Api\ResourceClassResolverInterface::class);
+}
 
 $deprecatedInterfaces = include 'deprecated_interfaces.php';
 foreach ($deprecatedInterfaces as $oldInterfaceName => $interfaceName) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | https://github.com/api-platform/api-platform/issues/2284
| License       | MIT
| Doc PR        | 

When using `opcache.preload` we get the following warnings:

```
PHP message: PHP Warning:  Cannot declare interface ApiPlatform\Core\Api\FilterInterface, because the name is already in use in /var/www/app.10xerp.com/website/vendor/api-platform/core/src/deprecation.php on line 15
PHP message: PHP Warning:  Cannot declare interface ApiPlatform\Core\Api\ResourceClassResolverInterface, because the name is already in use in /var/www/app.10xerp.com/website/vendor/api-platform/core/src/deprecation.php on line 16
```

The solution was to check if the interfaces already exist.