### PR TITLE
feat: use openapi array to validate filter parameters

### DIFF
--- a/src/Api/QueryParameterValidator/Validator/ArrayItems.php
+++ b/src/Api/QueryParameterValidator/Validator/ArrayItems.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Api\QueryParameterValidator\Validator;
 
 final class ArrayItems implements ValidatorInterface
 {
+    use CheckFilterDeprecationsTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -24,9 +26,11 @@ final class ArrayItems implements ValidatorInterface
             return [];
         }
 
-        $maxItems = $filterDescription['swagger']['maxItems'] ?? null;
-        $minItems = $filterDescription['swagger']['minItems'] ?? null;
-        $uniqueItems = $filterDescription['swagger']['uniqueItems'] ?? false;
+        $this->checkFilterDeprecations($filterDescription);
+
+        $maxItems = $filterDescription['openapi']['maxItems'] ?? $filterDescription['swagger']['maxItems'] ?? null;
+        $minItems = $filterDescription['openapi']['minItems'] ?? $filterDescription['swagger']['minItems'] ?? null;
+        $uniqueItems = $filterDescription['openapi']['uniqueItems'] ?? $filterDescription['swagger']['uniqueItems'] ?? false;
 
         $errorList = [];
 
@@ -60,7 +64,7 @@ final class ArrayItems implements ValidatorInterface
             return $value;
         }
 
-        $collectionFormat = $filterDescription['swagger']['collectionFormat'] ?? 'csv';
+        $collectionFormat = $filterDescription['openapi']['collectionFormat'] ?? $filterDescription['swagger']['collectionFormat'] ?? 'csv';
 
         return explode(self::getSeparator($collectionFormat), (string) $value) ?: []; // @phpstan-ignore-line
     }

--- a/src/Api/QueryParameterValidator/Validator/Bounds.php
+++ b/src/Api/QueryParameterValidator/Validator/Bounds.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Api\QueryParameterValidator\Validator;
 
 final class Bounds implements ValidatorInterface
 {
+    use CheckFilterDeprecationsTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -25,13 +27,15 @@ final class Bounds implements ValidatorInterface
             return [];
         }
 
-        $maximum = $filterDescription['swagger']['maximum'] ?? null;
-        $minimum = $filterDescription['swagger']['minimum'] ?? null;
+        $this->checkFilterDeprecations($filterDescription);
+
+        $maximum = $filterDescription['openapi']['maximum'] ?? $filterDescription['swagger']['maximum'] ?? null;
+        $minimum = $filterDescription['openapi']['minimum'] ?? $filterDescription['swagger']['minimum'] ?? null;
 
         $errorList = [];
 
         if (null !== $maximum) {
-            if (($filterDescription['swagger']['exclusiveMaximum'] ?? false) && $value >= $maximum) {
+            if (($filterDescription['openapi']['exclusiveMaximum'] ?? $filterDescription['swagger']['exclusiveMaximum'] ?? false) && $value >= $maximum) {
                 $errorList[] = sprintf('Query parameter "%s" must be less than %s', $name, $maximum);
             } elseif ($value > $maximum) {
                 $errorList[] = sprintf('Query parameter "%s" must be less than or equal to %s', $name, $maximum);
@@ -39,7 +43,7 @@ final class Bounds implements ValidatorInterface
         }
 
         if (null !== $minimum) {
-            if (($filterDescription['swagger']['exclusiveMinimum'] ?? false) && $value <= $minimum) {
+            if (($filterDescription['openapi']['exclusiveMinimum'] ?? $filterDescription['swagger']['exclusiveMinimum'] ?? false) && $value <= $minimum) {
                 $errorList[] = sprintf('Query parameter "%s" must be greater than %s', $name, $minimum);
             } elseif ($value < $minimum) {
                 $errorList[] = sprintf('Query parameter "%s" must be greater than or equal to %s', $name, $minimum);

--- a/src/Api/QueryParameterValidator/Validator/CheckFilterDeprecationsTrait.php
+++ b/src/Api/QueryParameterValidator/Validator/CheckFilterDeprecationsTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Api\QueryParameterValidator\Validator;
+
+/**
+ * @internal
+ */
+trait CheckFilterDeprecationsTrait
+{
+    protected function checkFilterDeprecations(array $filterDescription): void
+    {
+        if (\array_key_exists('swagger', $filterDescription)) {
+            trigger_deprecation(
+                'api-platform/core',
+                '3.0',
+                'Using the "swagger" key in filters description is deprecated, use "openapi" instead.'
+            );
+        }
+    }
+}

--- a/src/Api/QueryParameterValidator/Validator/Enum.php
+++ b/src/Api/QueryParameterValidator/Validator/Enum.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Api\QueryParameterValidator\Validator;
 
 final class Enum implements ValidatorInterface
 {
+    use CheckFilterDeprecationsTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -25,7 +27,9 @@ final class Enum implements ValidatorInterface
             return [];
         }
 
-        $enum = $filterDescription['swagger']['enum'] ?? null;
+        $this->checkFilterDeprecations($filterDescription);
+
+        $enum = $filterDescription['openapi']['enum'] ?? $filterDescription['swagger']['enum'] ?? null;
 
         if (null !== $enum && !\in_array($value, $enum, true)) {
             return [

--- a/src/Api/QueryParameterValidator/Validator/Length.php
+++ b/src/Api/QueryParameterValidator/Validator/Length.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Api\QueryParameterValidator\Validator;
 
 final class Length implements ValidatorInterface
 {
+    use CheckFilterDeprecationsTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -25,8 +27,10 @@ final class Length implements ValidatorInterface
             return [];
         }
 
-        $maxLength = $filterDescription['swagger']['maxLength'] ?? null;
-        $minLength = $filterDescription['swagger']['minLength'] ?? null;
+        $this->checkFilterDeprecations($filterDescription);
+
+        $maxLength = $filterDescription['openapi']['maxLength'] ?? $filterDescription['swagger']['maxLength'] ?? null;
+        $minLength = $filterDescription['openapi']['minLength'] ?? $filterDescription['swagger']['minLength'] ?? null;
 
         $errorList = [];
 

--- a/src/Api/QueryParameterValidator/Validator/MultipleOf.php
+++ b/src/Api/QueryParameterValidator/Validator/MultipleOf.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Api\QueryParameterValidator\Validator;
 
 final class MultipleOf implements ValidatorInterface
 {
+    use CheckFilterDeprecationsTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -25,7 +27,9 @@ final class MultipleOf implements ValidatorInterface
             return [];
         }
 
-        $multipleOf = $filterDescription['swagger']['multipleOf'] ?? null;
+        $this->checkFilterDeprecations($filterDescription);
+
+        $multipleOf = $filterDescription['openapi']['multipleOf'] ?? $filterDescription['swagger']['multipleOf'] ?? null;
 
         if (null !== $multipleOf && 0 !== ($value % $multipleOf)) {
             return [

--- a/src/Api/QueryParameterValidator/Validator/Pattern.php
+++ b/src/Api/QueryParameterValidator/Validator/Pattern.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\Api\QueryParameterValidator\Validator;
 
 final class Pattern implements ValidatorInterface
 {
+    use CheckFilterDeprecationsTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -25,7 +27,9 @@ final class Pattern implements ValidatorInterface
             return [];
         }
 
-        $pattern = $filterDescription['swagger']['pattern'] ?? null;
+        $this->checkFilterDeprecations($filterDescription);
+
+        $pattern = $filterDescription['openapi']['pattern'] ?? $filterDescription['swagger']['pattern'] ?? null;
 
         if (null !== $pattern && !preg_match($pattern, $value)) {
             return [

--- a/src/Api/QueryParameterValidator/Validator/Required.php
+++ b/src/Api/QueryParameterValidator/Validator/Required.php
@@ -17,6 +17,8 @@ use ApiPlatform\Util\RequestParser;
 
 final class Required implements ValidatorInterface
 {
+    use CheckFilterDeprecationsTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -34,8 +36,10 @@ final class Required implements ValidatorInterface
             ];
         }
 
+        $this->checkFilterDeprecations($filterDescription);
+
         // if query param is empty and the configuration does not allow it
-        if (!($filterDescription['swagger']['allowEmptyValue'] ?? false) && empty($this->requestGetQueryParameter($queryParameters, $name))) {
+        if (!($filterDescription['openapi']['allowEmptyValue'] ?? $filterDescription['swagger']['allowEmptyValue'] ?? false) && empty($this->requestGetQueryParameter($queryParameters, $name))) {
             return [
                 sprintf('Query parameter "%s" does not allow empty value', $name),
             ];

--- a/tests/Api/QueryParameterValidator/Validator/ArrayItemsTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/ArrayItemsTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
+ *
+ * @group legacy
  */
 class ArrayItemsTest extends TestCase
 {

--- a/tests/Api/QueryParameterValidator/Validator/BoundsTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/BoundsTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
- *
- * @group legacy
  */
 class BoundsTest extends TestCase
 {
@@ -41,6 +39,9 @@ class BoundsTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testNonMatchingMinimum(): void
     {
         $request = ['some_filter' => '9'];
@@ -82,6 +83,50 @@ class BoundsTest extends TestCase
         );
     }
 
+    public function testNonMatchingMinimumOpenApi(): void
+    {
+        $request = ['some_filter' => '9'];
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'openapi' => [
+                'minimum' => 10,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be greater than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'openapi' => [
+                'minimum' => 10,
+                'exclusiveMinimum' => false,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be greater than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'openapi' => [
+                'minimum' => 9,
+                'exclusiveMinimum' => true,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be greater than 9'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testMatchingMinimum(): void
     {
         $request = ['some_filter' => '10'];
@@ -109,6 +154,36 @@ class BoundsTest extends TestCase
         );
     }
 
+    public function testMatchingMinimumOpenApi(): void
+    {
+        $request = ['some_filter' => '10'];
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'openapi' => [
+                'minimum' => 10,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'openapi' => [
+                'minimum' => 9,
+                'exclusiveMinimum' => false,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testNonMatchingMaximum(): void
     {
         $request = ['some_filter' => '11'];
@@ -150,6 +225,50 @@ class BoundsTest extends TestCase
         );
     }
 
+    public function testNonMatchingMaximumOpenApi(): void
+    {
+        $request = ['some_filter' => '11'];
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'openapi' => [
+                'maximum' => 10,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be less than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'openapi' => [
+                'maximum' => 10,
+                'exclusiveMaximum' => false,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be less than or equal to 10'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'openapi' => [
+                'maximum' => 9,
+                'exclusiveMaximum' => true,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be less than 9'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testMatchingMaximum(): void
     {
         $request = ['some_filter' => '10'];
@@ -167,6 +286,33 @@ class BoundsTest extends TestCase
 
         $filterDefinition = [
             'swagger' => [
+                'maximum' => 10,
+                'exclusiveMaximum' => false,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingMaximumOpenApi(): void
+    {
+        $request = ['some_filter' => '10'];
+        $filter = new Bounds();
+
+        $filterDefinition = [
+            'openapi' => [
+                'maximum' => 10,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+
+        $filterDefinition = [
+            'openapi' => [
                 'maximum' => 10,
                 'exclusiveMaximum' => false,
             ],

--- a/tests/Api/QueryParameterValidator/Validator/BoundsTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/BoundsTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
+ *
+ * @group legacy
  */
 class BoundsTest extends TestCase
 {

--- a/tests/Api/QueryParameterValidator/Validator/EnumTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/EnumTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
+ *
+ * @group legacy
  */
 class EnumTest extends TestCase
 {

--- a/tests/Api/QueryParameterValidator/Validator/EnumTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/EnumTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
- *
- * @group legacy
  */
 class EnumTest extends TestCase
 {
@@ -41,6 +39,9 @@ class EnumTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testNonMatchingParameter(): void
     {
         $filter = new Enum();
@@ -57,12 +58,46 @@ class EnumTest extends TestCase
         );
     }
 
+    public function testNonMatchingParameterOpenApi(): void
+    {
+        $filter = new Enum();
+
+        $filterDefinition = [
+            'openapi' => [
+                'enum' => ['foo', 'bar'],
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must be one of "foo, bar"'],
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'foobar'])
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testMatchingParameter(): void
     {
         $filter = new Enum();
 
         $filterDefinition = [
             'swagger' => [
+                'enum' => ['foo', 'bar'],
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'foo'])
+        );
+    }
+
+    public function testMatchingParameterOpenApi(): void
+    {
+        $filter = new Enum();
+
+        $filterDefinition = [
+            'openapi' => [
                 'enum' => ['foo', 'bar'],
             ],
         ];

--- a/tests/Api/QueryParameterValidator/Validator/LengthTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/LengthTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
- *
- * @group legacy
  */
 class LengthTest extends TestCase
 {
@@ -41,6 +39,9 @@ class LengthTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testNonMatchingParameter(): void
     {
         $filter = new Length();
@@ -63,6 +64,31 @@ class LengthTest extends TestCase
         );
     }
 
+    public function testNonMatchingParameterOpenApi(): void
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'openapi' => [
+                'minLength' => 3,
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be greater than or equal to 3'],
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'ab'])
+        );
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be lower than or equal to 5'],
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcdef'])
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testNonMatchingParameterWithOnlyOneDefinition(): void
     {
         $filter = new Length();
@@ -90,6 +116,36 @@ class LengthTest extends TestCase
         );
     }
 
+    public function testNonMatchingParameterWithOnlyOneDefinitionOpenApi(): void
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'openapi' => [
+                'minLength' => 3,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be greater than or equal to 3'],
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'ab'])
+        );
+
+        $filterDefinition = [
+            'openapi' => [
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" length must be lower than or equal to 5'],
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcdef'])
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testMatchingParameter(): void
     {
         $filter = new Length();
@@ -114,6 +170,33 @@ class LengthTest extends TestCase
         );
     }
 
+    public function testMatchingParameterOpenApi(): void
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'openapi' => [
+                'minLength' => 3,
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abc'])
+        );
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcd'])
+        );
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcde'])
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testMatchingParameterWithOneDefinition(): void
     {
         $filter = new Length();
@@ -130,6 +213,31 @@ class LengthTest extends TestCase
 
         $filterDefinition = [
             'swagger' => [
+                'maxLength' => 5,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abcde'])
+        );
+    }
+
+    public function testMatchingParameterWithOneDefinitionOpenApi(): void
+    {
+        $filter = new Length();
+
+        $filterDefinition = [
+            'openapi' => [
+                'minLength' => 3,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, ['some_filter' => 'abc'])
+        );
+
+        $filterDefinition = [
+            'openapi' => [
                 'maxLength' => 5,
             ],
         ];

--- a/tests/Api/QueryParameterValidator/Validator/LengthTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/LengthTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
+ *
+ * @group legacy
  */
 class LengthTest extends TestCase
 {

--- a/tests/Api/QueryParameterValidator/Validator/MultipleOfTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/MultipleOfTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
+ *
+ * @group legacy
  */
 class MultipleOfTest extends TestCase
 {

--- a/tests/Api/QueryParameterValidator/Validator/MultipleOfTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/MultipleOfTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
- *
- * @group legacy
  */
 class MultipleOfTest extends TestCase
 {
@@ -42,6 +40,9 @@ class MultipleOfTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testNonMatchingParameter(): void
     {
         $request = ['some_filter' => '8'];
@@ -59,6 +60,26 @@ class MultipleOfTest extends TestCase
         );
     }
 
+    public function testNonMatchingParameterOpenApi(): void
+    {
+        $request = ['some_filter' => '8'];
+        $filter = new MultipleOf();
+
+        $filterDefinition = [
+            'openapi' => [
+                'multipleOf' => 3,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must multiple of 3'],
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testMatchingParameter(): void
     {
         $request = ['some_filter' => '8'];
@@ -66,6 +87,22 @@ class MultipleOfTest extends TestCase
 
         $filterDefinition = [
             'swagger' => [
+                'multipleOf' => 4,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $filterDefinition, $request)
+        );
+    }
+
+    public function testMatchingParameterOpenApi(): void
+    {
+        $request = ['some_filter' => '8'];
+        $filter = new MultipleOf();
+
+        $filterDefinition = [
+            'openapi' => [
                 'multipleOf' => 4,
             ],
         ];

--- a/tests/Api/QueryParameterValidator/Validator/PatternTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/PatternTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
+ *
+ * @group legacy
  */
 class PatternTest extends TestCase
 {

--- a/tests/Api/QueryParameterValidator/Validator/PatternTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/PatternTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Julien Deniau <julien.deniau@mapado.com>
- *
- * @group legacy
  */
 class PatternTest extends TestCase
 {
@@ -32,6 +30,9 @@ class PatternTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testFilterWithEmptyValue(): void
     {
         $filter = new Pattern();
@@ -53,6 +54,30 @@ class PatternTest extends TestCase
         );
     }
 
+    public function testFilterWithEmptyValueOpenApi(): void
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'openapi' => [
+                'pattern' => '/foo/',
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => ''])
+        );
+
+        $weirdParameter = new \stdClass();
+        $weirdParameter->foo = 'non string value should not exists';
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => $weirdParameter])
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testFilterWithZeroAsParameter(): void
     {
         $filter = new Pattern();
@@ -69,6 +94,25 @@ class PatternTest extends TestCase
         );
     }
 
+    public function testFilterWithZeroAsParameterOpenApi(): void
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'openapi' => [
+                'pattern' => '/foo/',
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must match pattern /foo/'],
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => '0'])
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testFilterWithNonMatchingValue(): void
     {
         $filter = new Pattern();
@@ -85,12 +129,46 @@ class PatternTest extends TestCase
         );
     }
 
+    public function testFilterWithNonMatchingValueOpenApi(): void
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'openapi' => [
+                'pattern' => '/foo/',
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" must match pattern /foo/'],
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => 'bar'])
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testFilterWithNonchingValue(): void
     {
         $filter = new Pattern();
 
         $explicitFilterDefinition = [
             'swagger' => [
+                'pattern' => '/foo \d+/',
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, ['some_filter' => 'this is a foo '.random_int(0, 10).' and it should match'])
+        );
+    }
+
+    public function testFilterWithNonchingValueOpenApi(): void
+    {
+        $filter = new Pattern();
+
+        $explicitFilterDefinition = [
+            'openapi' => [
                 'pattern' => '/foo \d+/',
             ],
         ];

--- a/tests/Api/QueryParameterValidator/Validator/RequiredTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/RequiredTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\TestCase;
  * Class RequiredTest.
  *
  * @author Julien Deniau <julien.deniau@mapado.com>
+ *
+ * @group legacy
  */
 class RequiredTest extends TestCase
 {

--- a/tests/Api/QueryParameterValidator/Validator/RequiredTest.php
+++ b/tests/Api/QueryParameterValidator/Validator/RequiredTest.php
@@ -20,8 +20,6 @@ use PHPUnit\Framework\TestCase;
  * Class RequiredTest.
  *
  * @author Julien Deniau <julien.deniau@mapado.com>
- *
- * @group legacy
  */
 class RequiredTest extends TestCase
 {
@@ -60,6 +58,9 @@ class RequiredTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testEmptyValueNotAllowed(): void
     {
         $request = ['some_filter' => ''];
@@ -87,6 +88,36 @@ class RequiredTest extends TestCase
         );
     }
 
+    public function testEmptyValueNotAllowedOpenApi(): void
+    {
+        $request = ['some_filter' => ''];
+        $filter = new Required();
+
+        $explicitFilterDefinition = [
+            'required' => true,
+            'openapi' => [
+                'allowEmptyValue' => false,
+            ],
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" does not allow empty value'],
+            $filter->validate('some_filter', $explicitFilterDefinition, $request)
+        );
+
+        $implicitFilterDefinition = [
+            'required' => true,
+        ];
+
+        $this->assertEquals(
+            ['Query parameter "some_filter" does not allow empty value'],
+            $filter->validate('some_filter', $implicitFilterDefinition, $request)
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testEmptyValueAllowed(): void
     {
         $request = ['some_filter' => ''];
@@ -95,6 +126,23 @@ class RequiredTest extends TestCase
         $explicitFilterDefinition = [
             'required' => true,
             'swagger' => [
+                'allowEmptyValue' => true,
+            ],
+        ];
+
+        $this->assertEmpty(
+            $filter->validate('some_filter', $explicitFilterDefinition, $request)
+        );
+    }
+
+    public function testEmptyValueAllowedOpenApi(): void
+    {
+        $request = ['some_filter' => ''];
+        $filter = new Required();
+
+        $explicitFilterDefinition = [
+            'required' => true,
+            'openapi' => [
                 'allowEmptyValue' => true,
             ],
         ];


### PR DESCRIPTION
The filter validators were only using the 'swagger' entry from the filter description. It should also use the 'openapi' entry, as swagger is deprecated.

| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | NA
| License       | MIT
| Doc PR        | NA

The filter validators were only using the 'swagger' entry from the
filter description. It should also use the 'openapi' entry, as swagger
is deprecated.
