### PR TITLE
fix(graphql): add filters from the nested resource metadata

### DIFF
--- a/src/GraphQl/Metadata/Factory/GraphQlNestedOperationResourceMetadataFactory.php
+++ b/src/GraphQl/Metadata/Factory/GraphQlNestedOperationResourceMetadataFactory.php
@@ -51,15 +51,6 @@ final class GraphQlNestedOperationResourceMetadataFactory implements ResourceMet
             shortName: $shortName
         );
 
-        if (class_exists($resourceClass)) {
-            $refl = new \ReflectionClass($resourceClass);
-            $attribute = $refl->getAttributes(ApiResource::class)[0] ?? null;
-            $attributeInstance = $attribute?->newInstance();
-            if ($filters = $attributeInstance?->getFilters()) {
-                $apiResource = $apiResource->withFilters($filters);
-            }
-        }
-
         $resourceMetadataCollection[0] = $this->addDefaultGraphQlOperations($apiResource);
 
         return $resourceMetadataCollection;

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -263,6 +263,10 @@ final class FieldsBuilder implements FieldsBuilderInterface
                     // If there is no query operation for a nested resource we force one to exist
                     $nestedResourceMetadataCollection = $this->graphQlNestedOperationResourceMetadataFactory->create($resourceClass);
                     $resourceOperation = $nestedResourceMetadataCollection->getOperation($isCollectionType ? 'collection_query' : 'item_query');
+                    // Add filters from the metadata defined on the resource itself.
+                    if ($filters = $resourceMetadataCollection[0]?->getFilters()) {
+                        $resourceOperation = $resourceOperation->withFilters($filters);
+                    }
                 }
             }
 

--- a/tests/GraphQl/Metadata/Factory/GraphQlNestedOperationResourceMetadataFactoryTest.php
+++ b/tests/GraphQl/Metadata/Factory/GraphQlNestedOperationResourceMetadataFactoryTest.php
@@ -38,7 +38,6 @@ final class GraphQlNestedOperationResourceMetadataFactoryTest extends TestCase
     {
         $metadataFactory = new GraphQlNestedOperationResourceMetadataFactory(['status' => 500]);
         $apiResource = $metadataFactory->create(RelatedDummy::class)[0];
-        $this->assertNotEmpty($apiResource->getFilters());
         $this->assertEquals('RelatedDummy', $apiResource->getShortName());
     }
 }

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -508,10 +508,10 @@ class FieldsBuilderTest extends TestCase
             }
             if ('propertyNestedResourceNoQuery' === $propertyName) {
                 $nestedResourceQueryOperation = new Query();
-                $this->resourceMetadataCollectionFactoryProphecy->create('nestedResourceNoQueryClass')->willReturn(new ResourceMetadataCollection('nestedResourceNoQueryClass', [(new ApiResource())->withDescription('A description.')->withGraphQlOperations([])]));
+                $this->resourceMetadataCollectionFactoryProphecy->create('nestedResourceNoQueryClass')->willReturn(new ResourceMetadataCollection('nestedResourceNoQueryClass', [(new ApiResource())->withDescription('A description.')->withFilters(['search_filter'])->withGraphQlOperations([])]));
                 $this->graphQlNestedOperationResourceMetadataFactoryProphecy->create('nestedResourceNoQueryClass')->shouldBeCalled()->willReturn(new ResourceMetadataCollection('nestedResourceNoQueryClass', [(new ApiResource())->withGraphQlOperations(['item_query' => $nestedResourceQueryOperation])]));
                 $this->typeConverterProphecy->convertType(Argument::type(Type::class), Argument::type('bool'), Argument::that(static fn (Operation $arg): bool => $arg->getName() === $operation->getName()), 'nestedResourceNoQueryClass', $resourceClass, $propertyName, $depth + 1)->willReturn(new ObjectType(['name' => 'objectType']));
-                $this->itemResolverFactoryProphecy->__invoke('nestedResourceNoQueryClass', $resourceClass, $nestedResourceQueryOperation)->willReturn(static function (): void {
+                $this->itemResolverFactoryProphecy->__invoke('nestedResourceNoQueryClass', $resourceClass, $nestedResourceQueryOperation->withFilters(['search_filter']))->willReturn(static function (): void {
                 });
             }
         }


### PR DESCRIPTION
Continuing https://github.com/api-platform/core/pull/5112.

See https://github.com/api-platform/core/pull/5112#discussion_r1014898804.

We use the metadata instead of relying on the attributes to handle all cases (XML, YAML...).