### PR TITLE
fix: use legacy iri converter for legacy resources

### DIFF
--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -548,3 +548,11 @@ Feature: Relations support
     }
     """
 
+  @createSchema
+  Scenario: Issue #5094
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/issue5094_resources" with body:
+    """
+    {"relation": "/issue5094_relations/1"}
+    """
+    Then the response status code should be 201

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -549,6 +549,7 @@ Feature: Relations support
     """
 
   @createSchema
+  @!mongodb
   Scenario: Issue #5094
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "POST" request to "/issue5094_resources" with body:

--- a/src/Core/Api/LegacyIriConverter.php
+++ b/src/Core/Api/LegacyIriConverter.php
@@ -57,21 +57,6 @@ final class LegacyIriConverter implements IriConverterInterface
      */
     public function getIriFromResource($item, int $referenceType = UrlGeneratorInterface::ABS_PATH, Operation $operation = null, array $context = []): ?string
     {
-        if (!$operation) {
-            return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
-        }
-        
-        $isSubresource = $operation->getExtraProperties()['is_legacy_subresource'] ?? false;
-        $isResource = $operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false;
-
-        if (!$isSubresource && !$isResource) {
-            return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
-        }
-
-        if (\is_string($item)) {
-            return $isSubresource ? $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context) : $this->legacyIriConverter->getIriFromResourceClass($item, $referenceType);
-        }
-
-        return $this->legacyIriConverter->getIriFromItem($item, $referenceType);
+        return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
     }
 }

--- a/src/Core/Api/LegacyIriConverter.php
+++ b/src/Core/Api/LegacyIriConverter.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Core\Api;
+
+use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * This IRI converter calls the legacy IriConverter on legacy resources.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @internal
+ */
+final class LegacyIriConverter implements IriConverterInterface
+{
+    private $legacyIriConverter;
+    private $iriConverter;
+
+    public function __construct(LegacyIriConverterInterface $legacyIriConverter, IriConverterInterface $iriConverter)
+    {
+        $this->legacyIriConverter = $legacyIriConverter;
+        $this->iriConverter = $iriConverter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null)
+    {
+        if (!$operation) {
+            return $this->iriConverter->getResourceFromIri($iri, $context);
+        }
+
+        if ($operation && !($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false) && !($operation->getExtraProperties()['is_legacy_subresource'] ?? false)) {
+            return $this->iriConverter->getResourceFromIri($iri, $context, $operation);
+        }
+
+        return $this->legacyIriConverter->getItemFromIri($iri, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIriFromResource($item, int $referenceType = UrlGeneratorInterface::ABS_PATH, Operation $operation = null, array $context = []): ?string
+    {
+        if (!$operation) {
+            return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
+        }
+
+        if ($operation && !($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false) && !($operation->getExtraProperties()['is_legacy_subresource'] ?? false)) {
+            return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
+        }
+
+        return $this->legacyIriConverter->getIriFromItem($item, $referenceType);
+    }
+}
+

--- a/src/Core/Api/LegacyIriConverter.php
+++ b/src/Core/Api/LegacyIriConverter.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\Operation;
  * This IRI converter calls the legacy IriConverter on legacy resources.
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
+ *
  * @internal
  */
 final class LegacyIriConverter implements IriConverterInterface
@@ -44,7 +45,7 @@ final class LegacyIriConverter implements IriConverterInterface
             return $this->iriConverter->getResourceFromIri($iri, $context);
         }
 
-        if ($operation && !($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false) && !($operation->getExtraProperties()['is_legacy_subresource'] ?? false)) {
+        if (!($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false) && !($operation->getExtraProperties()['is_legacy_subresource'] ?? false)) {
             return $this->iriConverter->getResourceFromIri($iri, $context, $operation);
         }
 
@@ -59,12 +60,18 @@ final class LegacyIriConverter implements IriConverterInterface
         if (!$operation) {
             return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
         }
+        
+        $isSubresource = $operation->getExtraProperties()['is_legacy_subresource'] ?? false;
+        $isResource = $operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false;
 
-        if ($operation && !($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false) && !($operation->getExtraProperties()['is_legacy_subresource'] ?? false)) {
+        if (!$isSubresource && !$isResource) {
             return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
+        }
+
+        if (\is_string($item)) {
+            return $isSubresource ? $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context) : $this->legacyIriConverter->getIriFromResourceClass($item, $referenceType);
         }
 
         return $this->legacyIriConverter->getIriFromItem($item, $referenceType);
     }
 }
-

--- a/src/Core/Api/LegacyIriConverter.php
+++ b/src/Core/Api/LegacyIriConverter.php
@@ -41,7 +41,7 @@ final class LegacyIriConverter implements IriConverterInterface
      */
     public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null)
     {
-        if (!$operation) {
+        if (!$operation && !($operation = $context['operation'] ?? null)) {
             return $this->iriConverter->getResourceFromIri($iri, $context);
         }
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -650,6 +650,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             try {
                 return $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getItemFromIri($value, $context + ['fetch_data' => true]) : $this->iriConverter->getResourceFromIri($value, $context + ['fetch_data' => true]);
             } catch (ItemNotFoundException $e) {
+                throw $e;
                 if (!$supportsPlainIdentifiers) {
                     throw new UnexpectedValueException($e->getMessage(), $e->getCode(), $e);
                 }

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -650,7 +650,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             try {
                 return $this->iriConverter instanceof LegacyIriConverterInterface ? $this->iriConverter->getItemFromIri($value, $context + ['fetch_data' => true]) : $this->iriConverter->getResourceFromIri($value, $context + ['fetch_data' => true]);
             } catch (ItemNotFoundException $e) {
-                throw $e;
                 if (!$supportsPlainIdentifiers) {
                     throw new UnexpectedValueException($e->getMessage(), $e->getCode(), $e);
                 }

--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -146,6 +146,20 @@
         </service>
         <service id="ApiPlatform\Api\IriConverterInterface" alias="api_platform.symfony.iri_converter" />
 
+        <service id="api_platform.iri_converter.legacy" class="ApiPlatform\Core\Bridge\Symfony\Routing\IriConverter" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory.legacy" />
+            <argument type="service" id="api_platform.item_data_provider" />
+            <argument type="service" id="api_platform.route_name_resolver" />
+            <argument type="service" id="api_platform.router" />
+            <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.identifiers_extractor.cached" />
+            <argument type="service" id="api_platform.subresource_data_provider" on-invalid="ignore" />
+            <argument type="service" id="api_platform.identifier.converter" on-invalid="ignore" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+        </service>
+
         <service id="api_platform.symfony.iri_converter.skolem" class="ApiPlatform\Symfony\Routing\SkolemIriConverter" public="false">
             <argument type="service" id="api_platform.router" />
         </service>

--- a/src/Symfony/Bundle/Resources/config/legacy/api.xml
+++ b/src/Symfony/Bundle/Resources/config/legacy/api.xml
@@ -45,19 +45,6 @@
             <argument type="service" id="api_platform.subresource_operation_factory" />
         </service>
 
-        <service id="api_platform.iri_converter.legacy" class="ApiPlatform\Core\Bridge\Symfony\Routing\IriConverter" public="false">
-            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
-            <argument type="service" id="api_platform.metadata.property.metadata_factory.legacy" />
-            <argument type="service" id="api_platform.item_data_provider" />
-            <argument type="service" id="api_platform.route_name_resolver" />
-            <argument type="service" id="api_platform.router" />
-            <argument type="service" id="api_platform.property_accessor" />
-            <argument type="service" id="api_platform.identifiers_extractor.cached" />
-            <argument type="service" id="api_platform.subresource_data_provider" on-invalid="ignore" />
-            <argument type="service" id="api_platform.identifier.converter" on-invalid="ignore" />
-            <argument type="service" id="api_platform.resource_class_resolver" />
-            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
-        </service>
         <service id="ApiPlatform\Core\Api\IriConverterInterface" alias="api_platform.iri_converter.legacy" />
 
         <service id="api_platform.listener.request.add_format" class="ApiPlatform\Symfony\EventListener\AddFormatListener">

--- a/src/Symfony/Bundle/Resources/config/v3/api.xml
+++ b/src/Symfony/Bundle/Resources/config/v3/api.xml
@@ -24,7 +24,7 @@
             <tag name="routing.loader" />
         </service>
 
-        <service id="api_platform.iri_converter">
+        <service id="api_platform.iri_converter" class="ApiPlatform\Core\Api\LegacyIriConverter">
             <argument type="service" id="api_platform.iri_converter.legacy" />
             <argument type="service" id="api_platform.symfony.iri_converter" />
         </service>

--- a/src/Symfony/Bundle/Resources/config/v3/api.xml
+++ b/src/Symfony/Bundle/Resources/config/v3/api.xml
@@ -24,6 +24,9 @@
             <tag name="routing.loader" />
         </service>
 
-        <service id="api_platform.iri_converter" alias="api_platform.symfony.iri_converter" />
+        <service id="api_platform.iri_converter">
+            <argument type="service" id="api_platform.iri_converter.legacy" />
+            <argument type="service" id="api_platform.symfony.iri_converter" />
+        </service>
     </services>
 </container>

--- a/tests/Fixtures/TestBundle/DataProvider/Issue5094RelationDataProvider.php
+++ b/tests/Fixtures/TestBundle/DataProvider/Issue5094RelationDataProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5094Relation;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Issue5094RelationDataProvider implements ItemDataProviderInterface, RestrictedDataProviderInterface
+{
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return Issue5094Relation::class === $resourceClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
+    {
+        return new Issue5094Relation((int) $id);
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue5094Relation.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue5094Relation.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+
+/**
+ * A legacy relation with a custom provider.
+ *
+ * @ApiResource
+ */
+class Issue5094Relation
+{
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @ApiProperty(identifier=true)
+     */
+    public $id;
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue5094Resource.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue5094Resource.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A legacy resource with a relation that has a custom data provider.
+ *
+ * @ApiResource
+ *
+ * @ORM\Entity
+ */
+class Issue5094Resource
+{
+    /**
+     * @var int|null The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var Issue5094Relation
+     */
+    public $relation;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Metadata/ProviderResourceMetadatatCollectionFactory.php
+++ b/tests/Fixtures/TestBundle/Metadata/ProviderResourceMetadatatCollectionFactory.php
@@ -18,12 +18,14 @@ use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\ContainNonResource as ContainNonResourceDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Taxon as TaxonDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ContainNonResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5094Relation;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ResourceInterface;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Taxon;
 use ApiPlatform\Tests\Fixtures\TestBundle\Model\ResourceInterface as ResourceInterfaceDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Model\SerializableResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\Model\TaxonInterface;
 use ApiPlatform\Tests\Fixtures\TestBundle\State\ContainNonResourceProvider;
+use ApiPlatform\Tests\Fixtures\TestBundle\State\Issue5094RelationProvider;
 use ApiPlatform\Tests\Fixtures\TestBundle\State\ResourceInterfaceImplementationProvider;
 use ApiPlatform\Tests\Fixtures\TestBundle\State\SerializableProvider;
 use ApiPlatform\Tests\Fixtures\TestBundle\State\TaxonItemProvider;
@@ -61,6 +63,10 @@ class ProviderResourceMetadatatCollectionFactory implements ResourceMetadataColl
 
         if (Taxon::class === $resourceClass || TaxonDocument::class === $resourceClass || TaxonInterface::class === $resourceClass) {
             return $this->setProvider($resourceMetadataCollection, TaxonItemProvider::class);
+        }
+
+        if (Issue5094Relation::class === $resourceClass) {
+            return $this->setProvider($resourceMetadataCollection, Issue5094RelationProvider::class);
         }
 
         return $resourceMetadataCollection;

--- a/tests/Fixtures/TestBundle/State/Issue5094RelationProvider.php
+++ b/tests/Fixtures/TestBundle/State/Issue5094RelationProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5094Relation;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Issue5094RelationProvider implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        return new Issue5094Relation((int) $uriVariables['id']);
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -165,6 +165,12 @@ services:
         tags:
             - { name: 'api_platform.item_data_provider' }
 
+    issue5094_relation.item_data_provider:
+        class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataProvider\Issue5094RelationDataProvider'
+        public: false
+        tags:
+            - { name: 'api_platform.item_data_provider' }
+
     serializable.item_data_provider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\DataProvider\SerializableItemDataProvider'
         public: false

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -107,6 +107,12 @@ services:
         tags:
             - { name: 'api_platform.state_provider' }
 
+    ApiPlatform\Tests\Fixtures\TestBundle\State\Issue5094RelationProvider:
+        class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\Issue5094RelationProvider'
+        public: false
+        tags:
+            -  { name: 'api_platform.state_provider' }
+
     ApiPlatform\Tests\Fixtures\TestBundle\State\DummyCollectionDtoProvider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\DummyCollectionDtoProvider'
         public: false

--- a/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -436,11 +436,11 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.metadata.resource.metadata_collection_factory.legacy_subresource_metadata',
             'api_platform.listener.view.write.legacy',
             'api_platform.listener.request.read.legacy',
+            'api_platform.iri_converter',
         ];
 
         $aliases = [
             // v3/api.xml
-            'api_platform.iri_converter',
             'ApiPlatform\Api\IriConverterInterface',
             'api_platform.identifiers_extractor',
             'ApiPlatform\Api\IdentifiersExtractorInterface',


### PR DESCRIPTION
when the backward compatibility layer is `false` we can still use legacy resources while upgrading and therefore the legacy IriConverter is needed as it calls legacy providers.

fixes https://github.com/api-platform/core/issues/5094