### PR TITLE
fix: securityPostDenormalize not working because clone is made after denormalization

### DIFF
--- a/features/authorization/deny.feature
+++ b/features/authorization/deny.feature
@@ -87,6 +87,33 @@ Feature: Authorization checking
     And the JSON node "ownerOnlyProperty" should exist
     And the JSON node "ownerOnlyProperty" should not be null
 
+  Scenario: An admin can create a secured resource with properties depending on themselves
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send a "POST" request to "/secured_dummy_with_properties_depending_on_themselves" with body:
+    """
+    {
+        "canUpdateProperty": false,
+        "property": false
+    }
+    """
+    Then the response status code should be 201
+
+  Scenario: A user cannot patch a secured property if not granted
+    When I add "Content-Type" header equal to "application/merge-patch+json"
+    And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send a "PATCH" request to "/secured_dummy_with_properties_depending_on_themselves/1" with body:
+    """
+    {
+        "canUpdateProperty": true,
+        "property": true
+    }
+    """
+    Then the response status code should be 200
+    And the JSON node "canUpdateProperty" should be true
+    And the JSON node "property" should be false
+
   Scenario: An admin can't see a secured owner-only property on objects they don't own
     When I add "Accept" header equal to "application/ld+json"
     And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -207,13 +207,14 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             throw new UnexpectedValueException(sprintf('Expected IRI or document for resource "%s", "%s" given.', $resourceClass, \gettype($data)));
         }
 
+        $previousObject = isset($objectToPopulate) ? clone $objectToPopulate : null;
+
         $object = parent::denormalize($data, $class, $format, $context);
 
         if (!$this->resourceClassResolver->isResourceClass($class)) {
             return $object;
         }
 
-        $previousObject = isset($objectToPopulate) ? clone $objectToPopulate : null;
         // Revert attributes that aren't allowed to be changed after a post-denormalize check
         foreach (array_keys($data) as $attribute) {
             if (!$this->canAccessAttributePostDenormalize($object, $previousObject, $attribute, $context)) {

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummyWithPropertiesDependingOnThemselves.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummyWithPropertiesDependingOnThemselves.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Secured resource with properties depending on themselves.
+ *
+ * @author Loïc Boursin <contact@loicboursin.fr>
+ */
+#[ApiResource(
+    operations: [
+        new Get(),
+        new Patch(inputFormats: ['json' => ['application/merge-patch+json'], 'jsonapi']),
+        new Post(security: 'is_granted("ROLE_ADMIN")'),
+    ]
+)]
+#[ORM\Entity]
+class SecuredDummyWithPropertiesDependingOnThemselves
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private bool $canUpdateProperty = false;
+
+    /**
+     * @var bool Special property, only writable when granted rights by another property
+     */
+    #[ApiProperty(securityPostDenormalize: 'previous_object and previous_object.getCanUpdateProperty()')]
+    #[ORM\Column]
+    private bool $property = false;
+
+    public function __construct()
+    {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCanUpdateProperty(): bool
+    {
+        return $this->canUpdateProperty;
+    }
+
+    public function setCanUpdateProperty(bool $canUpdateProperty): void
+    {
+        $this->canUpdateProperty = $canUpdateProperty;
+    }
+
+    public function getProperty(): bool
+    {
+        return $this->property;
+    }
+
+    public function setProperty(bool $property): void
+    {
+        $this->property = $property;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 3.0
| Tickets       | #5054 
| License       | MIT

Support for `security_post_denormalize` was added in https://github.com/api-platform/core/pull/4184.

At that moment, the clone to populate previousObject was made before denormalization. It worked well.

This [commit](https://github.com/api-platform/core/commit/87b61505d2f719fcf0d8613414d9e6aa436fd61f#diff-d87efa25fbf52904daa06047002652f08645e3ad4a7f4985ffeec5a7c8e39c4f) moved the clone after denormalization.

After upgrading to 3.0, using `security_post_denormalize` on a an `ApiProperty` was not working anymore. Moving the `$previousObject` line to its first position fixed the issue on my project.

I believe [this issue](https://github.com/api-platform/core/issues/5054) will be fixed too. 