### PR TITLE
feat: add GraphQL enum support

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,7 @@ $finder = PhpCsFixer\Finder::create()
     ->notPath('src/Annotation/ApiSubresource.php') // temporary
     ->notPath('tests/Fixtures/TestBundle/Entity/DummyPhp8.php') // temporary
     ->notPath('tests/Fixtures/TestBundle/Enum/GamePlayMode.php') // PHPDoc on enum cases
+    ->notPath('tests/Fixtures/TestBundle/Enum/GenderTypeEnum.php') // PHPDoc on enum cases
     ->append([
         'tests/Fixtures/app/console',
     ]);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,6 +24,7 @@ $finder = PhpCsFixer\Finder::create()
     ->notPath('src/Annotation/ApiResource.php') // temporary
     ->notPath('src/Annotation/ApiSubresource.php') // temporary
     ->notPath('tests/Fixtures/TestBundle/Entity/DummyPhp8.php') // temporary
+    ->notPath('tests/Fixtures/TestBundle/Enum/GamePlayMode.php') // PHPDoc on enum cases
     ->append([
         'tests/Fixtures/app/console',
     ]);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,6 +24,7 @@ $finder = PhpCsFixer\Finder::create()
     ->notPath('src/Annotation/ApiResource.php') // temporary
     ->notPath('src/Annotation/ApiSubresource.php') // temporary
     ->notPath('tests/Fixtures/TestBundle/Entity/DummyPhp8.php') // temporary
+    ->notPath('tests/Fixtures/TestBundle/Enum/EnumWithDescriptions.php') // PHPDoc on enum cases
     ->notPath('tests/Fixtures/TestBundle/Enum/GamePlayMode.php') // PHPDoc on enum cases
     ->notPath('tests/Fixtures/TestBundle/Enum/GenderTypeEnum.php') // PHPDoc on enum cases
     ->append([

--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -566,3 +566,58 @@ Feature: GraphQL introspection support
     And the JSON node "errors[0].debugMessage" should be equal to 'Type with id "VoDummyInspectionCursorConnection" is not present in the types container'
     And the JSON node "data.typeNotAvailable" should be null
     And the JSON node "data.typeOwner.fields[1].type.name" should be equal to "VoDummyInspectionCursorConnection"
+
+  Scenario: Introspect an enum
+    When I send the following GraphQL request:
+    """
+    {
+      person: __type(name: "Person") {
+        name
+        fields {
+          name
+          type {
+            name
+            description
+            enumValues {
+              name
+              description
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.person.fields[1].type.name" should be equal to "GenderTypeEnum"
+    #And the JSON node "data.person.fields[1].type.description" should be equal to "An enumeration of genders."
+    And the JSON node "data.person.fields[1].type.enumValues[0].name" should be equal to "MALE"
+    #And the JSON node "data.person.fields[1].type.enumValues[0].description" should be equal to "The male gender."
+    And the JSON node "data.person.fields[1].type.enumValues[1].name" should be equal to "FEMALE"
+    And the JSON node "data.person.fields[1].type.enumValues[1].description" should be equal to "The female gender."
+
+  Scenario: Introspect an enum resource
+    When I send the following GraphQL request:
+    """
+    {
+      videoGame: __type(name: "VideoGame") {
+        name
+        fields {
+          name
+          type {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.videoGame.fields[3].type.ofType.name" should be equal to "GamePlayMode"

--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -485,6 +485,69 @@ Feature: GraphQL mutation support
     And the JSON node "data.createDummy.dummy.arrayData[1]" should be equal to baz
     And the JSON node "data.createDummy.clientMutationId" should be equal to "myId"
 
+  Scenario: Create an item with an enum
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createPerson(input: {name: "Mob", genderType: FEMALE}) {
+        person {
+          id
+          name
+          genderType
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createPerson.person.id" should be equal to "/people/1"
+    And the JSON node "data.createPerson.person.name" should be equal to "Mob"
+    And the JSON node "data.createPerson.person.genderType" should be equal to "FEMALE"
+
+  Scenario: Create an item with an enum as a resource
+    When I send the following GraphQL request:
+    """
+    {
+      gamePlayModes {
+        id
+        name
+      }
+      gamePlayMode(id: "/game_play_modes/SINGLE_PLAYER") {
+        name
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.gamePlayModes" should have 3 elements
+    And the JSON node "data.gamePlayModes[2].id" should be equal to "/game_play_modes/SINGLE_PLAYER"
+    And the JSON node "data.gamePlayModes[2].name" should be equal to "SINGLE_PLAYER"
+    And the JSON node "data.gamePlayMode.name" should be equal to "SINGLE_PLAYER"
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createVideoGame(input: {name: "Baten Kaitos", playMode: "/game_play_modes/SINGLE_PLAYER"}) {
+        videoGame {
+          id
+          name
+          playMode {
+            id
+            name
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createVideoGame.videoGame.id" should be equal to "/video_games/1"
+    And the JSON node "data.createVideoGame.videoGame.name" should be equal to "Baten Kaitos"
+    And the JSON node "data.createVideoGame.videoGame.playMode.id" should be equal to "/game_play_modes/SINGLE_PLAYER"
+    And the JSON node "data.createVideoGame.videoGame.playMode.name" should be equal to "SINGLE_PLAYER"
+
   Scenario: Delete an item through a mutation
     When I send the following GraphQL request:
     """

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -73,6 +73,14 @@ Feature: Documentation support
       "nullable": true
     }
     """
+    And the "playMode" property exists for the OpenAPI class "VideoGame"
+    And the "playMode" property for the OpenAPI class "VideoGame" should be equal to:
+    """
+    {
+      "type": "string",
+      "format": "iri-reference"
+    }
+    """
     # Enable these tests when SF 4.4 / PHP 7.1 support is dropped
     #And the "isDummyBoolean" property exists for the OpenAPI class "DummyBoolean"
     #And the "isDummyBoolean" property is not read only for the OpenAPI class "DummyBoolean"

--- a/src/GraphQl/Type/FieldsBuilderEnumInterface.php
+++ b/src/GraphQl/Type/FieldsBuilderEnumInterface.php
@@ -19,10 +19,8 @@ use ApiPlatform\Metadata\GraphQl\Operation;
  * Interface implemented to build GraphQL fields.
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
- *
- * @deprecated Since API Platform 3.1. Use @see FieldsBuilderEnumInterface instead.
  */
-interface FieldsBuilderInterface
+interface FieldsBuilderEnumInterface
 {
     /**
      * Gets the fields of a node for a query.
@@ -53,6 +51,11 @@ interface FieldsBuilderInterface
      * Gets the fields of the type of the given resource.
      */
     public function getResourceObjectTypeFields(?string $resourceClass, Operation $operation, bool $input, int $depth = 0, ?array $ioMetadata = null): array;
+
+    /**
+     * Gets the fields (cases) of the enum.
+     */
+    public function getEnumFields(string $enumClass): array;
 
     /**
      * Resolve the args of a resource by resolving its types.

--- a/src/GraphQl/Type/SchemaBuilder.php
+++ b/src/GraphQl/Type/SchemaBuilder.php
@@ -32,8 +32,11 @@ use GraphQL\Type\Schema;
  */
 final class SchemaBuilder implements SchemaBuilderInterface
 {
-    public function __construct(private readonly ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly TypesFactoryInterface $typesFactory, private readonly TypesContainerInterface $typesContainer, private readonly FieldsBuilderInterface $fieldsBuilder)
+    public function __construct(private readonly ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly TypesFactoryInterface $typesFactory, private readonly TypesContainerInterface $typesContainer, private readonly FieldsBuilderEnumInterface|FieldsBuilderInterface $fieldsBuilder)
     {
+        if ($this->fieldsBuilder instanceof FieldsBuilderInterface) {
+            @trigger_error(sprintf('$fieldsBuilder argument of SchemaBuilder implementing "%s" is deprecated since API Platform 3.1. It has to implement "%s" instead.', FieldsBuilderInterface::class, FieldsBuilderEnumInterface::class), \E_USER_DEPRECATED);
+        }
     }
 
     public function getSchema(): Schema

--- a/src/GraphQl/Type/TypeBuilderEnumInterface.php
+++ b/src/GraphQl/Type/TypeBuilderEnumInterface.php
@@ -25,10 +25,8 @@ use Symfony\Component\PropertyInfo\Type;
  * Interface implemented to build a GraphQL type.
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
- *
- * @deprecated Since API Platform 3.1. Use @see TypeBuilderEnumInterface instead.
  */
-interface TypeBuilderInterface
+interface TypeBuilderEnumInterface
 {
     /**
      * Gets the object type of the given resource.
@@ -44,10 +42,13 @@ interface TypeBuilderInterface
 
     /**
      * Gets the type of a paginated collection of the given resource type.
-     *
-     * @deprecated Since API Platform 3.1. Use @see TypeBuilderEnumInterface::getPaginatedCollectionType() method instead.
      */
-    public function getResourcePaginatedCollectionType(GraphQLType $resourceType, string $resourceClass, Operation $operation): GraphQLType;
+    public function getPaginatedCollectionType(GraphQLType $resourceType, Operation $operation): GraphQLType;
+
+    /**
+     * Gets the type corresponding to an enum.
+     */
+    public function getEnumType(Operation $operation): GraphQLType;
 
     /**
      * Returns true if a type is a collection.

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -174,7 +174,10 @@ final class SchemaFactory implements SchemaFactoryInterface
             $propertySchema['externalDocs'] = ['url' => $iri];
         }
 
-        if (!isset($propertySchema['default']) && !empty($default = $propertyMetadata->getDefault())) {
+        // TODO: 3.0 support multiple types
+        $type = $propertyMetadata->getBuiltinTypes()[0] ?? null;
+
+        if (!isset($propertySchema['default']) && !empty($default = $propertyMetadata->getDefault()) && (null === $type?->getClassName() || !$this->isResourceClass($type->getClassName()))) {
             if ($default instanceof \BackedEnum) {
                 $default = $default->value;
             }
@@ -190,8 +193,6 @@ final class SchemaFactory implements SchemaFactoryInterface
         }
 
         $valueSchema = [];
-        // TODO: 3.0 support multiple types
-        $type = $propertyMetadata->getBuiltinTypes()[0] ?? null;
         if (null !== $type) {
             if ($isCollection = $type->isCollection()) {
                 $keyType = $type->getCollectionKeyTypes()[0] ?? null;

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -116,7 +116,7 @@ final class TypeFactory implements TypeFactoryInterface
                 'format' => 'binary',
             ];
         }
-        if (is_a($className, \BackedEnum::class, true)) {
+        if (!$this->isResourceClass($className) && is_a($className, \BackedEnum::class, true)) {
             $rEnum = new \ReflectionEnum($className);
             $enumCases = array_map(static fn (\ReflectionEnumBackedCase $rCase) => $rCase->getBackingValue(), $rEnum->getCases());
             if ($nullable) {

--- a/src/Metadata/ApiProperty.php
+++ b/src/Metadata/ApiProperty.php
@@ -20,7 +20,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT)]
 final class ApiProperty
 {
     /**

--- a/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
@@ -42,9 +42,30 @@ final class AttributePropertyMetadataFactory implements PropertyMetadataFactoryI
             }
         }
 
+        $reflectionClass = null;
+        $reflectionEnum = null;
+
         try {
             $reflectionClass = new \ReflectionClass($resourceClass);
         } catch (\ReflectionException) {
+        }
+        try {
+            $reflectionEnum = new \ReflectionEnum($resourceClass);
+        } catch (\ReflectionException) {
+        }
+
+        if (!$reflectionClass && !$reflectionEnum) {
+            return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
+        }
+
+        if ($reflectionEnum) {
+            if ($reflectionEnum->hasCase($property)) {
+                $reflectionCase = $reflectionEnum->getCase($property);
+                if ($attributes = $reflectionCase->getAttributes(ApiProperty::class)) {
+                    return $this->createMetadata($attributes[0]->newInstance(), $parentPropertyMetadata);
+                }
+            }
+
             return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
         }
 

--- a/tests/Fixtures/TestBundle/Document/Person.php
+++ b/tests/Fixtures/TestBundle/Document/Person.php
@@ -32,12 +32,13 @@ class Person
     #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
     private ?int $id = null;
 
+    #[ODM\Field(type: 'string', enumType: GenderTypeEnum::class, nullable: true)]
+    #[Groups(['people.pets'])]
+    public ?GenderTypeEnum $genderType = GenderTypeEnum::MALE;
+
     #[Groups(['people.pets'])]
     #[ODM\Field(type: 'string')]
     public string $name;
-
-    #[ODM\Field(type: 'string', enumType: GenderTypeEnum::class, nullable: true)]
-    public ?GenderTypeEnum $genderType = GenderTypeEnum::MALE;
 
     #[Groups(['people.pets'])]
     #[ODM\ReferenceMany(targetDocument: PersonToPet::class, mappedBy: 'person')]

--- a/tests/Fixtures/TestBundle/Document/VideoGame.php
+++ b/tests/Fixtures/TestBundle/Document/VideoGame.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GamePlayMode;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[ODM\Document]
+class VideoGame
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\Field(type: 'string')]
+    public string $name;
+
+    #[ODM\Field(type: 'string', enumType: GamePlayMode::class)]
+    public GamePlayMode $playMode = GamePlayMode::SINGLE_PLAYER;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Person.php
+++ b/tests/Fixtures/TestBundle/Entity/Person.php
@@ -35,6 +35,7 @@ class Person
     private ?int $id = null;
 
     #[ORM\Column(type: 'string', enumType: GenderTypeEnum::class, nullable: true)]
+    #[Groups(['people.pets'])]
     public ?GenderTypeEnum $genderType = GenderTypeEnum::MALE;
 
     #[ORM\Column(type: 'string')]

--- a/tests/Fixtures/TestBundle/Entity/VideoGame.php
+++ b/tests/Fixtures/TestBundle/Entity/VideoGame.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GamePlayMode;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[ORM\Entity]
+class VideoGame
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string')]
+    public string $name;
+
+    #[ORM\Column(type: 'string', enumType: GamePlayMode::class)]
+    public GamePlayMode $playMode = GamePlayMode::SINGLE_PLAYER;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Enum/EnumWithDescriptions.php
+++ b/tests/Fixtures/TestBundle/Enum/EnumWithDescriptions.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Enum;
+
+enum EnumWithDescriptions
+{
+    /**
+     * A short description for case one.
+     */
+    case ONE;
+
+    /**
+     * A short description for case two.
+     *
+     * A long description for case two.
+     */
+    case TWO;
+}

--- a/tests/Fixtures/TestBundle/Enum/GamePlayMode.php
+++ b/tests/Fixtures/TestBundle/Enum/GamePlayMode.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Enum;
+
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Tests\Fixtures\TestBundle\Metadata\Get;
+
+#[Get(description: 'Indicates whether this game is multi-player, co-op or single-player.', provider: self::class.'::getCase')]
+#[GetCollection(provider: self::class.'::getCases')]
+#[Query(provider: self::class.'::getCase')]
+#[QueryCollection(provider: self::class.'::getCases', paginationEnabled: false)]
+enum GamePlayMode: string
+{
+    /** Co-operative games, where you play on the same team with friends. */
+    case CO_OP = 'CoOp';
+
+    /** Requiring or allowing multiple human players to play simultaneously. */
+    case MULTI_PLAYER = 'MultiPlayer';
+
+    /** Which is played by a lone player. */
+    case SINGLE_PLAYER = 'SinglePlayer';
+
+    public function getId(): string
+    {
+        return $this->name;
+    }
+
+    public static function getCase(Operation $operation, array $uriVariables): GamePlayMode
+    {
+        $name = $uriVariables['id'] ?? null;
+
+        return \constant(self::class."::$name");
+    }
+
+    public static function getCases(): array
+    {
+        return self::cases();
+    }
+}

--- a/tests/Fixtures/TestBundle/Enum/GenderTypeEnum.php
+++ b/tests/Fixtures/TestBundle/Enum/GenderTypeEnum.php
@@ -13,8 +13,16 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Enum;
 
+use ApiPlatform\Metadata\ApiProperty;
+
+/**
+ * An enumeration of genders.
+ */
 enum GenderTypeEnum: string
 {
+    /** The male gender. */
     case MALE = 'male';
+
+    #[ApiProperty(description: 'The female gender.')]
     case FEMALE = 'female';
 }

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -78,6 +78,7 @@ api_platform:
     doctrine_mongodb_odm: false
     mapping:
         paths:
+            - '%kernel.project_dir%/../TestBundle/Enum'
             - '%kernel.project_dir%/../TestBundle/Model'
 
 parameters:

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\GraphQl\Type;
 
-use ApiPlatform\GraphQl\Type\FieldsBuilderInterface;
+use ApiPlatform\GraphQl\Type\FieldsBuilderEnumInterface;
 use ApiPlatform\GraphQl\Type\SchemaBuilder;
 use ApiPlatform\GraphQl\Type\TypesContainerInterface;
 use ApiPlatform\GraphQl\Type\TypesFactoryInterface;
@@ -42,15 +42,10 @@ class SchemaBuilderTest extends TestCase
     use ProphecyTrait;
 
     private ObjectProphecy $resourceNameCollectionFactoryProphecy;
-
     private ObjectProphecy $resourceMetadataCollectionFactoryProphecy;
-
     private ObjectProphecy $typesFactoryProphecy;
-
     private ObjectProphecy $typesContainerProphecy;
-
     private ObjectProphecy $fieldsBuilderProphecy;
-
     private SchemaBuilder $schemaBuilder;
 
     /**
@@ -62,7 +57,7 @@ class SchemaBuilderTest extends TestCase
         $this->resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $this->typesFactoryProphecy = $this->prophesize(TypesFactoryInterface::class);
         $this->typesContainerProphecy = $this->prophesize(TypesContainerInterface::class);
-        $this->fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $this->fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $this->schemaBuilder = new SchemaBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataCollectionFactoryProphecy->reveal(), $this->typesFactoryProphecy->reveal(), $this->typesContainerProphecy->reveal(), $this->fieldsBuilderProphecy->reveal());
     }
 

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\GraphQl\Type;
 
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
-use ApiPlatform\GraphQl\Type\FieldsBuilderInterface;
+use ApiPlatform\GraphQl\Type\FieldsBuilderEnumInterface;
 use ApiPlatform\GraphQl\Type\TypeBuilder;
 use ApiPlatform\GraphQl\Type\TypesContainerInterface;
 use ApiPlatform\Metadata\ApiResource;
@@ -26,6 +26,8 @@ use ApiPlatform\Metadata\GraphQl\Subscription;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GamePlayMode;
+use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ListOfType;
@@ -48,12 +50,9 @@ class TypeBuilderTest extends TestCase
     use ProphecyTrait;
 
     private ObjectProphecy $typesContainerProphecy;
-
     /** @var callable */
     private $defaultFieldResolver;
-
     private ObjectProphecy $fieldsBuilderLocatorProphecy;
-
     private TypeBuilder $typeBuilder;
 
     /**
@@ -93,7 +92,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
         $this->assertArrayHasKey('fields', $resourceObjectType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, false, 0, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $resourceObjectType->config['fields']();
@@ -119,7 +118,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
         $this->assertArrayHasKey('fields', $resourceObjectType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('outputClass', $operation, false, 0, ['class' => 'outputClass'])->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $resourceObjectType->config['fields']();
@@ -188,7 +187,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $wrappedType->config);
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, true, 0, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $wrappedType->config['fields']();
@@ -214,7 +213,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $wrappedType->config);
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, true, 1, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $wrappedType->config['fields']();
@@ -240,7 +239,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $wrappedType->config);
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, true, 0, null)
             ->shouldBeCalled()->willReturn(['clientMutationId' => GraphQLType::string()]);
         $fieldsBuilderProphecy->resolveResourceArgs([], $operation)->shouldBeCalled();
@@ -320,7 +319,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $wrappedType->config);
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, false, 0, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $wrappedType->config['fields']();
@@ -344,7 +343,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
         $this->assertArrayHasKey('fields', $resourceObjectType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, false, 1, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $resourceObjectType->config['fields']();
@@ -425,7 +424,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $wrappedType->config);
         $this->assertArrayHasKey('fields', $wrappedType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, false, 0, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $wrappedType->config['fields']();
@@ -449,7 +448,7 @@ class TypeBuilderTest extends TestCase
         $this->assertArrayHasKey('interfaces', $resourceObjectType->config);
         $this->assertArrayHasKey('fields', $resourceObjectType->config);
 
-        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderInterface::class);
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, false, 1, null)->shouldBeCalled();
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
         $resourceObjectType->config['fields']();
@@ -477,7 +476,7 @@ class TypeBuilderTest extends TestCase
         $this->assertSame(GraphQLType::string(), $resolvedType);
     }
 
-    public function testCursorBasedGetResourcePaginatedCollectionType(): void
+    public function testCursorBasedGetPaginatedCollectionType(): void
     {
         /** @var Operation $operation */
         $operation = (new Query())->withPaginationType('cursor');
@@ -487,7 +486,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('StringPageInfo', Argument::type(ObjectType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourcePaginatedCollectionType */
-        $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'test', $operation);
+        $resourcePaginatedCollectionType = $this->typeBuilder->getPaginatedCollectionType(GraphQLType::string(), $operation);
         $this->assertSame('StringCursorConnection', $resourcePaginatedCollectionType->name);
         $this->assertSame('Cursor connection for String.', $resourcePaginatedCollectionType->description);
 
@@ -533,7 +532,7 @@ class TypeBuilderTest extends TestCase
         $this->assertSame(GraphQLType::int(), $totalCountType->getWrappedType());
     }
 
-    public function testPageBasedGetResourcePaginatedCollectionType(): void
+    public function testPageBasedGetPaginatedCollectionType(): void
     {
         /** @var Operation $operation */
         $operation = (new Query())->withPaginationType('page');
@@ -542,7 +541,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('StringPaginationInfo', Argument::type(ObjectType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourcePaginatedCollectionType */
-        $resourcePaginatedCollectionType = $this->typeBuilder->getResourcePaginatedCollectionType(GraphQLType::string(), 'test', $operation);
+        $resourcePaginatedCollectionType = $this->typeBuilder->getPaginatedCollectionType(GraphQLType::string(), $operation);
         $this->assertSame('StringPageConnection', $resourcePaginatedCollectionType->name);
         $this->assertSame('Page connection for String.', $resourcePaginatedCollectionType->description);
 
@@ -566,6 +565,35 @@ class TypeBuilderTest extends TestCase
         $this->assertSame(GraphQLType::int(), $paginationInfoObjectTypeFields['lastPage']->getType()->getWrappedType());
         $this->assertInstanceOf(NonNull::class, $paginationInfoObjectTypeFields['totalCount']->getType());
         $this->assertSame(GraphQLType::int(), $paginationInfoObjectTypeFields['totalCount']->getType()->getWrappedType());
+    }
+
+    public function testGetEnumType(): void
+    {
+        $enumClass = GamePlayMode::class;
+        $enumName = 'GamePlayMode';
+        $enumDescription = 'GamePlayModeEnum description';
+        /** @var Operation $operation */
+        $operation = (new Operation())
+            ->withClass($enumClass)
+            ->withShortName($enumName)
+            ->withDescription('GamePlayModeEnum description');
+
+        $this->typesContainerProphecy->has('GamePlayModeEnum')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('GamePlayModeEnum', Argument::type(EnumType::class))->shouldBeCalled();
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
+        $enumValues = [
+            GamePlayMode::CO_OP->name => ['value' => GamePlayMode::CO_OP->value],
+            GamePlayMode::MULTI_PLAYER->name => ['value' => GamePlayMode::MULTI_PLAYER->value],
+            GamePlayMode::SINGLE_PLAYER->name => ['value' => GamePlayMode::SINGLE_PLAYER->value, 'description' => 'Which is played by a lone player.'],
+        ];
+        $fieldsBuilderProphecy->getEnumFields($enumClass)->willReturn($enumValues);
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->willReturn($fieldsBuilderProphecy->reveal());
+
+        self::assertEquals(new EnumType([
+            'name' => $enumName,
+            'description' => $enumDescription,
+            'values' => $enumValues,
+        ]), $this->typeBuilder->getEnumType($operation));
     }
 
     /**

--- a/tests/JsonSchema/TypeFactoryTest.php
+++ b/tests/JsonSchema/TypeFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\JsonSchema;
 
+use ApiPlatform\Api\ResourceClassResolverInterface;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\JsonSchema\TypeFactory;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GamePlayMode;
 use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -32,7 +34,10 @@ class TypeFactoryTest extends TestCase
      */
     public function testGetType(array $schema, Type $type): void
     {
-        $typeFactory = new TypeFactory();
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(GenderTypeEnum::class)->willReturn(false);
+        $resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
+        $typeFactory = new TypeFactory($resourceClassResolver->reveal());
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_OPENAPI)));
     }
 
@@ -54,8 +59,10 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['nullable' => true, 'type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
-        yield [['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
-        yield [['type' => 'string', 'enum' => ['male', 'female', null], 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
+        yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null], 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
+        yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-reference', 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable' => [
             ['nullable' => true, 'type' => 'array', 'items' => ['type' => 'string']],
@@ -155,7 +162,10 @@ class TypeFactoryTest extends TestCase
      */
     public function testGetTypeWithJsonSchemaSyntax(array $schema, Type $type): void
     {
-        $typeFactory = new TypeFactory();
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(GenderTypeEnum::class)->willReturn(false);
+        $resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
+        $typeFactory = new TypeFactory($resourceClassResolver->reveal());
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_JSON_SCHEMA)));
     }
 
@@ -177,8 +187,10 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['type' => ['string', 'null'], 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
-        yield [['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
-        yield [['type' => ['string', 'null'], 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
+        yield ['nullable enum' => ['type' => ['string', 'null'], 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
+        yield ['nullable enum resource' => ['type' => ['string', 'null'], 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable' => [
             ['type' => ['array', 'null'], 'items' => ['type' => 'string']],
@@ -271,7 +283,10 @@ class TypeFactoryTest extends TestCase
     /** @dataProvider openAPIV2TypeProvider */
     public function testGetTypeWithOpenAPIV2Syntax(array $schema, Type $type): void
     {
-        $typeFactory = new TypeFactory();
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(GenderTypeEnum::class)->willReturn(false);
+        $resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
+        $typeFactory = new TypeFactory($resourceClassResolver->reveal());
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_SWAGGER)));
     }
 
@@ -293,8 +308,10 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
-        yield [['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
-        yield [['type' => 'string', 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
+        yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
+        yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable, but ignored in OpenAPI V2' => [
             ['type' => 'array', 'items' => ['type' => 'string']],

--- a/tests/Metadata/Property/Factory/AttributePropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/AttributePropertyMetadataFactoryTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\AttributePropertyMetadataFactory;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyPhp8ApiPropertyAttribute;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -38,6 +39,9 @@ class AttributePropertyMetadataFactoryTest extends TestCase
 
         $metadata = $factory->create(DummyPhp8ApiPropertyAttribute::class, 'foo');
         $this->assertSame('a foo', $metadata->getDescription());
+
+        $metadata = $factory->create(GenderTypeEnum::class, 'FEMALE');
+        $this->assertSame('The female gender.', $metadata->getDescription());
     }
 
     public function testClassNotFound(): void


### PR DESCRIPTION
Fixes (partially) https://github.com/api-platform/core/issues/2254.

Minor changes:
- Attribute property metadata factory is now able to understand enum cases as well.
- It improves the OpenAPI enum support: resource classes are no longer considered as enum (see also [this blog post](https://les-tilleuls.coop/blog/exposez-vos-enums-avec-api-platform)).