### PR TITLE
Don't try to generate iri, if it is already defined in $context

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -203,17 +203,15 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             unset($context[self::IS_TRANSFORMED_TO_SAME_CLASS]);
         }
 
-        $iri = null;
         if ($this->resourceClassResolver->isResourceClass($resourceClass)) {
             $context = $this->initContext($resourceClass, $context);
-
-            if ($this->iriConverter instanceof LegacyIriConverterInterface) {
-                $iri = $this->iriConverter->getIriFromItem($object);
-            }
         }
 
+        $iri = null;
         if (isset($context['iri'])) {
             $iri = $context['iri'];
+        } elseif ($this->iriConverter instanceof LegacyIriConverterInterface) {
+            $iri = $this->iriConverter->getIriFromItem($object);
         } elseif ($this->iriConverter instanceof IriConverterInterface) {
             $iri = $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_URL, $context['operation'] ?? null, $context);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.x
| Tickets       | #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
After delete-item operation I would like to output deleted data, but the normalizer fails on generating `iri` with `PK=null`.
Previously the iri was not generated when passed with in `$context`.
