### PR TITLE
fix: fix a missing service definition in test environment

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/Compiler/DeprecateMercurePublisherPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/DeprecateMercurePublisherPass.php
@@ -27,9 +27,11 @@ final class DeprecateMercurePublisherPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $container
-            ->setAlias('api_platform.doctrine.listener.mercure.publish', 'api_platform.doctrine.orm.listener.mercure.publish')
-            ->setDeprecated(...$this->buildDeprecationArgs('2.6', 'Using "%alias_id%" service is deprecated since API Platform 2.6. Use "api_platform.doctrine.orm.listener.mercure.publish" instead.'));
+        if ($container->hasDefinition('api_platform.doctrine.listener.mercure.publish')) {
+            $container
+                ->setAlias('api_platform.doctrine.listener.mercure.publish', 'api_platform.doctrine.orm.listener.mercure.publish')
+                ->setDeprecated(...$this->buildDeprecationArgs('2.6', 'Using "%alias_id%" service is deprecated since API Platform 2.6. Use "api_platform.doctrine.orm.listener.mercure.publish" instead.'));
+        }
     }
 
     private function buildDeprecationArgs(string $version, string $message): array

--- a/tests/Symfony/Bundle/DependencyInjection/Compiler/DeprecateMercurePublisherPassTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/Compiler/DeprecateMercurePublisherPassTest.php
@@ -25,7 +25,7 @@ final class DeprecateMercurePublisherPassTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testProcess()
+    public function testProcess(): void
     {
         $deprecateMercurePublisherPass = new DeprecateMercurePublisherPass();
 
@@ -33,6 +33,10 @@ final class DeprecateMercurePublisherPassTest extends TestCase
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $aliasProphecy = $this->prophesize(Alias::class);
+
+        $containerBuilderProphecy
+            ->hasDefinition('api_platform.doctrine.listener.mercure.publish')
+            ->willReturn(true);
 
         $containerBuilderProphecy
             ->setAlias('api_platform.doctrine.listener.mercure.publish', 'api_platform.doctrine.orm.listener.mercure.publish')
@@ -47,6 +51,22 @@ final class DeprecateMercurePublisherPassTest extends TestCase
             ->setDeprecated(...$setDeprecatedArgs)
             ->willReturn($aliasProphecy->reveal())
             ->shouldBeCalled();
+
+        $deprecateMercurePublisherPass->process($containerBuilderProphecy->reveal());
+    }
+
+    public function testProcessWithoutDefinition(): void
+    {
+        $deprecateMercurePublisherPass = new DeprecateMercurePublisherPass();
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+
+        $containerBuilderProphecy
+            ->hasDefinition('api_platform.doctrine.listener.mercure.publish')
+            ->willReturn(false);
+
+        $containerBuilderProphecy
+            ->setAlias('api_platform.doctrine.listener.mercure.publish', 'api_platform.doctrine.orm.listener.mercure.publish')
+            ->shouldNotBeCalled();
 
         $deprecateMercurePublisherPass->process($containerBuilderProphecy->reveal());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | 


When running functional tests with api-platform 2.7, sylius 1.11 and not using Mercure, I got an error in service definition :

Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "api_platform.doctrine.orm.listener.mercure.publish".

