### PR TITLE
test: only allow Get operation through subresource

### DIFF
--- a/tests/Fixtures/TestBundle/Entity/Answer.php
+++ b/tests/Fixtures/TestBundle/Entity/Answer.php
@@ -28,7 +28,7 @@ use Symfony\Component\Serializer\Annotation as Serializer;
 /**
  * Answer.
  */
-#[ApiResource(operations: [new Get(), new Put(), new Patch(), new Delete(), new GetCollection(normalizationContext: ['groups' => ['foobar']])])]
+#[ApiResource(operations: [new Put(), new Patch(), new Delete(), new GetCollection(normalizationContext: ['groups' => ['foobar']])])]
 #[ApiResource(uriTemplate: '/answers/{id}/related_questions/{relatedQuestions}/answer{._format}', uriVariables: ['id' => new Link(fromClass: self::class, identifiers: ['id'], toProperty: 'answer'), 'relatedQuestions' => new Link(fromClass: Question::class, identifiers: ['id'], fromProperty: 'answer')], status: 200, operations: [new Get()])]
 #[ApiResource(uriTemplate: '/questions/{id}/answer{._format}', uriVariables: ['id' => new Link(fromClass: Question::class, identifiers: ['id'], fromProperty: 'answer')], status: 200, operations: [new Get()])]
 #[ORM\Entity]


### PR DESCRIPTION
**Not an actual PR**, onyl there for testing purpose :slightly_smiling_face: 

Relates to #5108

@soyuka here's the case I'm experimenting. If we assume we only want to be able to retrieve the answer through the related question, IriResolver is not able to create the iri, even tho a `Get` operation exists.

With the default `Get` operation, everything works fine