### PR TITLE
test: proof #5108 is working

### DIFF
--- a/features/main/sub_resource.feature
+++ b/features/main/sub_resource.feature
@@ -593,3 +593,20 @@ Feature: Sub-resource support
     }
     """
     Then the response status code should be 200
+
+    @createSchema
+    Scenario: Access settings through accounts only and show the correct Settings URI on an account (issue #5108)
+    Given there is an account with settings
+    And I send a "GET" request to "/accounts/1/settings"
+    Then the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Settings",
+      "@id": "/accounts/1/settings",
+      "@type": "Settings",
+      "id": 1
+    }
+    """
+    Then I send a "GET" request to "/accounts"
+
+

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Behat;
 use ApiPlatform\Tests\Fixtures\TestBundle\Doctrine\Orm\EntityManager;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\AbsoluteUrlDummy as AbsoluteUrlDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\AbsoluteUrlRelationDummy as AbsoluteUrlRelationDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Account as AccountDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Address as AddressDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Answer as AnswerDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Book as BookDocument;
@@ -81,6 +82,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelatedSecuredDummy as Relate
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelatedToDummyFriend as RelatedToDummyFriendDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelationEmbedder as RelationEmbedderDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\SecuredDummy as SecuredDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Settings as SettingsDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\SoMany as SoManyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Taxon as TaxonDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\ThirdLevel as ThirdLevelDocument;
@@ -89,6 +91,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\User as UserDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\WithJsonDummy as WithJsonDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AbsoluteUrlDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AbsoluteUrlRelationDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Account;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Address;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Answer;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Book;
@@ -158,6 +161,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedSecuredDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedToDummyFriend;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelationEmbedder;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\SecuredDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Settings;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Site;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\SoMany;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\SymfonyUuidDummy;
@@ -1976,6 +1980,15 @@ final class DoctrineContext implements Context
         $this->manager->flush();
     }
 
+    /**
+     * @Given there is an account with settings
+     */
+    public function thereIsAnAccountWithSettings(): void
+    {
+        $this->manager->persist($this->buildAccount());
+        $this->manager->flush();
+    }
+
     private function isOrm(): bool
     {
         return null !== $this->schemaTool;
@@ -2299,5 +2312,14 @@ final class DoctrineContext implements Context
     private function buildPayment(string $amount): Payment|PaymentDocument
     {
         return $this->isOrm() ? new Payment($amount) : new PaymentDocument($amount);
+    }
+
+    private function buildAccount(): Account|AccountDocument
+    {
+        $account = $this->isOrm() ? new Account() : new AccountDocument();
+        $settings = $this->isOrm() ? new Settings() : new SettingsDocument();
+        $account->setSettings($settings);
+
+        return $account;
     }
 }

--- a/tests/Fixtures/TestBundle/Document/Account.php
+++ b/tests/Fixtures/TestBundle/Document/Account.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document()]
+#[ApiResource(
+    operations: [
+        new Get(security: 'object.getUser()  == user'),
+        new GetCollection(),
+    ],
+)]
+class Account
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\ReferenceOne(targetDocument: Settings::class, cascade: ['persist'], storeAs: 'id')]
+    private ?Settings $settings = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+     public function getSettings(): ?Settings
+     {
+         return $this->settings;
+     }
+
+     public function setSettings(?Settings $settings): self
+     {
+         $this->settings = $settings;
+
+         return $this;
+     }
+}

--- a/tests/Fixtures/TestBundle/Document/Settings.php
+++ b/tests/Fixtures/TestBundle/Document/Settings.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Put;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * General account preferences.
+ */
+#[ODM\Document()]
+#[ApiResource(
+    uriTemplate: '/accounts/{id}/settings',
+    operations: [
+        new Get(),
+        new Put(),
+        new Patch(),
+    ],
+    uriVariables: [
+        'id' => new Link(
+            fromProperty: 'settings',
+            fromClass: Account::class
+        ),
+    ]
+)]
+class Settings
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\ReferenceOne(targetDocument: Account::class, cascade: ['persist'], inversedBy: 'settings', storeAs: 'id')]
+    #[ApiProperty(readable: false)]
+    private ?Account $account = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setAccount(Account $account): void
+    {
+        $this->account = $account;
+    }
+
+    public function getAccount(): ?Account
+    {
+        return $this->account;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Account.php
+++ b/tests/Fixtures/TestBundle/Entity/Account.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity()]
+#[ApiResource(
+    operations: [
+        new Get(security: 'object.getUser()  == user'),
+        new GetCollection(),
+    ],
+)]
+class Account
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\OneToOne(cascade: ['persist'], mappedBy: 'account')]
+    private ?Settings $settings = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSettings(): ?Settings
+    {
+        return $this->settings;
+    }
+
+    public function setSettings(?Settings $settings): self
+    {
+        $this->settings = $settings;
+        $this->settings->setAccount($this);
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Settings.php
+++ b/tests/Fixtures/TestBundle/Entity/Settings.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Put;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * General account preferences.
+ */
+#[ORM\Entity()]
+#[ApiResource(
+    uriTemplate: '/accounts/{id}/settings',
+    operations: [
+        new Get(),
+        new Put(),
+        new Patch(),
+    ],
+    uriVariables: [
+        'id' => new Link(
+            fromProperty: 'settings',
+            fromClass: Account::class
+        ),
+    ]
+)]
+class Settings
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\OneToOne(cascade: ['persist'], inversedBy: 'settings')]
+    #[ApiProperty(readable: false)]
+    private ?Account $account = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setAccount(Account $account): void
+    {
+        $this->account = $account;
+    }
+
+    public function getAccount(): ?Account
+    {
+        return $this->account;
+    }
+}


### PR DESCRIPTION
see #5108 for details

tldr: an inverse side relation is needed for API Platform to find the `Account` identifier and to fill the URI. 

Other option: decorate the IRI converter for this specific use case. 