### PR TITLE
Remove conflict with Elasticsearch used only on dev env

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/mongodb-odm": "^2.2",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/orm": "^2.6.4",
-        "elasticsearch/elasticsearch": "^7.11.0",
+        "elasticsearch/elasticsearch": "^7.11.0 <8.0",
         "friends-of-behat/mink-browserkit-driver": "^1.3.1",
         "friends-of-behat/mink-extension": "^2.2",
         "friends-of-behat/symfony-extension": "^2.1",
@@ -93,8 +93,7 @@
         "doctrine/common": "<2.7",
         "doctrine/dbal": "<2.10",
         "doctrine/mongodb-odm": "<2.2",
-        "doctrine/persistence": "<1.3",
-        "elasticsearch/elasticsearch": ">=8.0"
+        "doctrine/persistence": "<1.3"
     },
     "suggest": {
         "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | 
| License       | MIT
| Doc PR        | 

The elasticsearch package is required only for the dev environment, but a conflict with versions greater than v8 has been added, so it will block any installation of these versions of the package in other projects.