### PR TITLE
FIX on filter => add filter multiple values case insentive to description

### DIFF
--- a/src/Doctrine/Common/Filter/SearchFilterInterface.php
+++ b/src/Doctrine/Common/Filter/SearchFilterInterface.php
@@ -27,6 +27,11 @@ interface SearchFilterInterface
     public const STRATEGY_EXACT = 'exact';
 
     /**
+     * @var string Exact matching case-insensitive
+     */
+    public const STRATEGY_IEXACT = 'iexact';
+
+    /**
      * @var string The value must be contained in the field
      */
     public const STRATEGY_PARTIAL = 'partial';

--- a/src/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -66,7 +66,7 @@ trait SearchFilterTrait
                 $strategy = $this->getProperties()[$property] ?? self::STRATEGY_EXACT;
                 $filterParameterNames = [$propertyName];
 
-                if (self::STRATEGY_EXACT === $strategy) {
+                if (self::STRATEGY_EXACT === $strategy || self::STRATEGY_IEXACT === $strategy) {
                     $filterParameterNames[] = $propertyName.'[]';
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| License       | MIT

I'm using the iexact strategy with Search Filter but in my response on get-collection the ''hydra:search' node does not have the XXXX[] variable which is present with exact strategy.
I read the docs and saw this :
"Note: Search filters with the exact strategy can have multiple values for the same property (in this case the condition will be similar to a SQL IN clause)."
Does it mean that it is intend to not have it on iexact ? Because in the other hand, when i'm filtering with the ?XXXX[] = .....  it is working well.
I add here the filter to the description so i can get in the hydra:template in hydra:search.

I did not find the right way to add tests on this part, could someone help me on this ?

<!--
Branch: 
- 3.0 for bug fixes
-->
