### PR TITLE
feat(symfony): wire Symfony JsonEncoder if it exists

### DIFF
--- a/src/Symfony/Bundle/Resources/config/jsonld.xml
+++ b/src/Symfony/Bundle/Resources/config/jsonld.xml
@@ -45,6 +45,7 @@
 
         <service id="api_platform.jsonld.encoder" class="ApiPlatform\Serializer\JsonEncoder" public="false">
             <argument>jsonld</argument>
+            <argument type="service" id="serializer.json.encoder" on-invalid="null" />
 
             <tag name="serializer.encoder" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

While trying to decorate the `Symfony\Component\Serializer\Encoder\JsonEncoder` (service `serializer.json.encoder`) we found out that it is not used by `ApiPlatform\Core\Serializer\JsonEncoder` as a service since the argument is not defined and one is created instead https://github.com/api-platform/core/blob/main/src/Serializer/JsonEncoder.php#L36.
So we currently need to wire the argument ourselves in a compiler pass.

Should I add a test for this?