### PR TITLE
perf: use symfony default cache pool config in development environment

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -37,7 +37,6 @@ use ApiPlatform\Symfony\Validator\ValidationGroupsGeneratorInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Ramsey\Uuid\Uuid;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -504,14 +503,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
     private function registerCacheConfiguration(ContainerBuilder $container): void
     {
-        if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
-            $container->register('api_platform.cache.metadata.property', ArrayAdapter::class)->addTag('cache.pool');
-            $container->register('api_platform.cache.metadata.resource', ArrayAdapter::class)->addTag('cache.pool');
-            $container->register('api_platform.cache.metadata.resource_collection', ArrayAdapter::class)->addTag('cache.pool');
-            $container->register('api_platform.cache.route_name_resolver', ArrayAdapter::class)->addTag('cache.pool');
-            $container->register('api_platform.cache.identifiers_extractor', ArrayAdapter::class);
-            $container->register('api_platform.elasticsearch.cache.metadata.document', ArrayAdapter::class);
-        } else {
+        if (!$container->hasParameter('kernel.debug') || !$container->getParameter('kernel.debug')) {
             $container->removeDefinition('api_platform.cache_warmer.cache_pool_clearer');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | #4975
| License       | MIT

This PR allows to use Symfony default cache pool configuration in development environment instead of forcing ArrayAdapter. 
Change was introduced back in 2016 (#653) when Symfony 2.x required to manually clear cache after every configuration change.

Workaround proposed in #4975 (cache pool definition override) is no longer needed.
