### PR TITLE
Add groups filter whitelist info to swagger

### DIFF
--- a/src/Api/FilterInterface.php
+++ b/src/Api/FilterInterface.php
@@ -43,6 +43,11 @@ interface FilterInterface
      *          'type' => 'integer',
      *       ]
      *     ]
+     *   - schema (optional): schema definition,
+     *     e.g. 'schema' => [
+     *       'type' => 'string',
+     *       'enum' => ['value_1', 'value_2'],
+     *     ]
      * The description can contain additional data specific to a filter.
      *
      * @see \ApiPlatform\OpenApi\Factory\OpenApiFactory::getFiltersParameters

--- a/src/Serializer/Filter/GroupFilter.php
+++ b/src/Serializer/Filter/GroupFilter.php
@@ -58,13 +58,23 @@ final class GroupFilter implements FilterInterface
      */
     public function getDescription(string $resourceClass): array
     {
-        return [
-            "$this->parameterName[]" => [
-                'property' => null,
-                'type' => 'string',
-                'is_collection' => true,
-                'required' => false,
-            ],
+        $description = [
+            'property' => null,
+            'type' => 'string',
+            'is_collection' => true,
+            'required' => false,
         ];
+
+        if ($this->whitelist) {
+            $description['schema'] = [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                    'enum' => $this->whitelist,
+                ],
+            ];
+        }
+
+        return ["$this->parameterName[]" => $description];
     }
 }

--- a/tests/Serializer/Filter/GroupFilterTest.php
+++ b/tests/Serializer/Filter/GroupFilterTest.php
@@ -125,4 +125,26 @@ class GroupFilterTest extends TestCase
 
         $this->assertSame($expectedDescription, $groupFilter->getDescription(DummyGroup::class));
     }
+
+    public function testGetDescriptionWithWhitelist(): void
+    {
+        $groupFilter = new GroupFilter('custom_groups', false, ['default_group', 'another_default_group']);
+        $expectedDescription = [
+            'custom_groups[]' => [
+                'property' => null,
+                'type' => 'string',
+                'is_collection' => true,
+                'required' => false,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => ['default_group', 'another_default_group'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expectedDescription, $groupFilter->getDescription(DummyGroup::class));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main (would be nice to get it to 3.0)
| Tickets       | -
| License       | MIT
| Doc PR        | https://api-platform.com/docs/core/filters/#group-filter

Feature (or maybe bugfix 😅) currently missing. It improves the swagger documentation for the groups filter with the options which are whitelisted if any.

Example:
```
#[ApiFilter(
    \ApiPlatform\Serializer\Filter\GroupFilter::class,
    arguments: ['whitelist' => ['user_tuning:details', 'user_device:details']]
)]
```

Before:
<img width="515" alt="image" src="https://user-images.githubusercontent.com/438308/205058884-282430b3-ce10-40d1-a382-b9a35ae20262.png">

After:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/438308/205058761-8e59045c-9a5f-4e69-ad90-657524af4b03.png">


<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- 2.7 for bugs related to the **backward compatibility layer**, if the bug was in 2.6 let's fix it on the 3.0 branch instead
- 3.0 for bug fixes
- main for new features

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
