### PR TITLE
ci: fix mongod startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,9 +545,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Check
+      - name: Setup MongoDB
         run: |
-          sudo systemctl start mongod.service
+          sudo apt update
+          sudo apt install -y wget gnupg
+          wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+          sudo apt update
+          sudo apt install -y mongodb-org
+          sudo systemctl start mongod
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -900,9 +906,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Check
+      - name: Setup MongoDB
         run: |
-          sudo systemctl start mongod.service
+          sudo apt update
+          sudo apt install -y wget gnupg
+          wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+          sudo apt update
+          sudo apt install -y mongodb-org
+          sudo systemctl start mongod
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Ubuntu 22.04 runner image does not have MongoDB anymore: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md.