### PR TITLE
fix: do not add linked data for denormalizationContext

### DIFF
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -72,6 +72,10 @@ final class SchemaFactory implements SchemaFactoryInterface
             return $schema;
         }
 
+        if ('input' === $type) {
+            return $schema;
+        }
+
         $definitions = $schema->getDefinitions();
         if ($key = $schema->getRootDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -63,11 +63,21 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
 
     public function testExecuteWithJsonldFormatOption(): void
     {
-        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--operation' => '_api_/dummies/{id}{._format}_get', '--format' => 'jsonld', '--type' => 'output']);
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--operation' => '_api_/dummies{._format}_post', '--format' => 'jsonld', '--type' => 'output']);
         $result = $this->tester->getDisplay();
 
         $this->assertStringContainsString('@id', $result);
         $this->assertStringContainsString('@context', $result);
         $this->assertStringContainsString('@type', $result);
+    }
+
+    public function testExecuteWithJsonldTypeInput(): void
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--operation' => '_api_/dummies{._format}_post', '--format' => 'jsonld', '--type' => 'input']);
+        $result = $this->tester->getDisplay();
+
+        $this->assertStringNotContainsString('@id', $result);
+        $this->assertStringNotContainsString('@context', $result);
+        $this->assertStringNotContainsString('@type', $result);
     }
 }

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -63,7 +63,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
 
     public function testExecuteWithJsonldFormatOption(): void
     {
-        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--operation' => '_api_/dummies{._format}_post', '--format' => 'jsonld']);
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--operation' => '_api_/dummies/{id}{._format}_get', '--format' => 'jsonld', '--type' => 'output']);
         $result = $this->tester->getDisplay();
 
         $this->assertStringContainsString('@id', $result);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | https://github.com/api-platform/core/issues/5263
| License       | MIT
| Doc PR       | N/A

If I look in the generated schema for denormalizationContext i can see the required fields for '@id' and '@type'. Why do have this fields required for write operations? We don't need to pass this fields in a write request. If you used this schema on the client with typescript you need to write workarounds because you not sending this fields in the requests.
