### PR TITLE
refactor: HTTP cache configuration overhaul

### DIFF
--- a/src/HttpCache/PurgerInterface.php
+++ b/src/HttpCache/PurgerInterface.php
@@ -17,6 +17,8 @@ namespace ApiPlatform\HttpCache;
  * Purges resources from the cache.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated use {@see TagsHeadersProviderInterface} and {@see TagsInvalidatorInterface} instead
  */
 interface PurgerInterface
 {

--- a/src/HttpCache/TagsHeadersProvider.php
+++ b/src/HttpCache/TagsHeadersProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache;
+
+class TagsHeadersProvider implements TagsHeadersProviderInterface
+{
+    public function __construct(
+        private readonly string $headerName,
+        private readonly ?string $separator,
+    ) {
+    }
+
+    public function provideHeaders(array $tags): array
+    {
+        return [$this->headerName => null === $this->separator ? $tags : implode($this->separator, $tags)];
+    }
+}

--- a/src/HttpCache/TagsHeadersProviderInterface.php
+++ b/src/HttpCache/TagsHeadersProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache;
+
+interface TagsHeadersProviderInterface
+{
+    /**
+     * @param string[] $tags
+     *
+     * @return array<string, string>|array<string, string[]>
+     */
+    public function provideHeaders(array $tags): array;
+}

--- a/src/HttpCache/TagsInvalidator/Banner.php
+++ b/src/HttpCache/TagsInvalidator/Banner.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache\TagsInvalidator;
+
+use ApiPlatform\HttpCache\TagsInvalidatorInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class Banner implements TagsInvalidatorInterface
+{
+    /**
+     * @param HttpClientInterface[] $clients
+     */
+    public function __construct(
+        private readonly array $clients,
+        private readonly string $headerName,
+        private readonly int $maxHeaderLength,
+    ) {
+    }
+
+    public function invalidate(array $tags): void
+    {
+        foreach ($this->yieldHeaders($tags) as $header) {
+            foreach ($this->clients as $client) {
+                $client->request('BAN', '', ['headers' => [$this->headerName => $header]]);
+            }
+        }
+    }
+
+    private function yieldHeaders(array $tags): \Iterator
+    {
+        if (!$tags) {
+            return;
+        }
+
+        $tag = reset($tags);
+
+        while (true) {
+            $header = '';
+            $buffer = preg_quote($tag);
+
+            while (\strlen($buffer) + 8 <= $this->maxHeaderLength) {
+                $tag = next($tags);
+
+                if (null === key($tags)) { // @phpstan-ignore-line yes, key() can return null
+                    yield '('.$buffer.')($|\,)';
+
+                    return;
+                }
+
+                $header = $buffer;
+                $buffer .= '|'.preg_quote($tag);
+            }
+
+            if (!$header) {
+                throw new \Exception(sprintf('IRI "%s" is too long to fit the max header size (currently set to "%s").', $tag, $this->maxHeaderLength));
+            }
+
+            yield "({$header})($|\,)";
+        }
+    }
+}

--- a/src/HttpCache/TagsInvalidator/Purger.php
+++ b/src/HttpCache/TagsInvalidator/Purger.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache\TagsInvalidator;
+
+use ApiPlatform\HttpCache\TagsInvalidatorInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class Purger implements TagsInvalidatorInterface
+{
+    /**
+     * @param HttpClientInterface[] $clients
+     */
+    public function __construct(
+        private readonly array $clients,
+        private readonly string $headerName,
+        private readonly int $maxHeaderLength,
+        private readonly string $glue,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invalidate(array $tags): void
+    {
+        foreach ($this->yieldHeaders($tags) as $header) {
+            foreach ($this->clients as $client) {
+                $client->request('PURGE', '', ['headers' => [$this->headerName => $header]]);
+            }
+        }
+    }
+
+    /**
+     * Yield the tags in the minimum number of header values.
+     *
+     * @param string[] $tags
+     *
+     *@throws \Exception if a key is longer than the longest configured header value
+     *
+     * @return \Iterator<string|string[]>
+     */
+    private function yieldHeaders(array $tags): \Iterator
+    {
+        if (!$tags) {
+            return;
+        }
+
+        $header = implode($this->glue, $tags);
+        if (\strlen($header) <= $this->maxHeaderLength) {
+            yield $header;
+
+            return;
+        }
+
+        $glueLength = \strlen($this->glue);
+        $offset = 0;
+        $tag = reset($tags);
+        $tagLength = \strlen($tag);
+
+        while (true) {
+            $length = 0;
+            $bufferLength = $tagLength;
+
+            while ($bufferLength <= $this->maxHeaderLength) {
+                $tag = next($tags);
+                if (null === key($tags)) { // @phpstan-ignore-line yes, key() can return null
+                    yield substr($header, $offset);
+
+                    return;
+                }
+
+                $length = $bufferLength;
+                $tagLength = \strlen($tag);
+                $bufferLength += $glueLength + $tagLength;
+            }
+
+            if (!$length) {
+                throw new \Exception(sprintf('IRI "%s" is too long to fit the max header size (currently set to "%s").', $tag, $this->maxHeaderLength));
+            }
+
+            yield substr($header, $offset, $length);
+
+            $offset += $length + $glueLength;
+        }
+    }
+}

--- a/src/HttpCache/TagsInvalidatorInterface.php
+++ b/src/HttpCache/TagsInvalidatorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache;
+
+interface TagsInvalidatorInterface
+{
+    /**
+     * @param string[] $tags
+     */
+    public function invalidate(array $tags): void;
+}

--- a/src/HttpCache/VarnishPurger.php
+++ b/src/HttpCache/VarnishPurger.php
@@ -13,52 +13,26 @@ declare(strict_types=1);
 
 namespace ApiPlatform\HttpCache;
 
+use ApiPlatform\HttpCache\TagsInvalidator\Banner;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Purges Varnish.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated use a {@see Banner} instead
  */
-final class VarnishPurger implements PurgerInterface
+final class VarnishPurger extends Banner implements PurgerInterface
 {
     private const DEFAULT_VARNISH_MAX_HEADER_LENGTH = 8000;
-    private const REGEXP_PATTERN = '(%s)($|\,)';
-    private readonly int $maxHeaderLength;
 
     /**
      * @param HttpClientInterface[] $clients
      */
     public function __construct(private readonly array $clients, int $maxHeaderLength = self::DEFAULT_VARNISH_MAX_HEADER_LENGTH)
     {
-        $this->maxHeaderLength = $maxHeaderLength - mb_strlen(self::REGEXP_PATTERN) + 2; // 2 for %s
-    }
-
-    /**
-     * Calculate how many tags fit into the header.
-     *
-     * This assumes that the tags are separated by one character.
-     *
-     * From https://github.com/FriendsOfSymfony/FOSHttpCache/blob/2.8.0/src/ProxyClient/HttpProxyClient.php#L137
-     *
-     * @param string[] $escapedTags
-     * @param string   $glue        The concatenation string to use
-     *
-     * @return int Number of tags per tag invalidation request
-     */
-    private function determineTagsPerHeader(array $escapedTags, string $glue): int
-    {
-        if (mb_strlen(implode($glue, $escapedTags)) < $this->maxHeaderLength) {
-            return \count($escapedTags);
-        }
-        /*
-         * estimate the amount of tags to invalidate by dividing the max
-         * header length by the largest tag (minus the glue length)
-         */
-        $tagsize = max(array_map('mb_strlen', $escapedTags));
-        $gluesize = \strlen($glue);
-
-        return (int) floor(($this->maxHeaderLength + $gluesize) / ($tagsize + $gluesize)) ?: 1;
+        parent::__construct($this->clients, 'ApiPlatform-Ban-Regex', $maxHeaderLength);
     }
 
     /**
@@ -66,16 +40,7 @@ final class VarnishPurger implements PurgerInterface
      */
     public function purge(array $iris): void
     {
-        if (!$iris) {
-            return;
-        }
-
-        $chunkSize = $this->determineTagsPerHeader($iris, '|');
-
-        $irisChunks = array_chunk($iris, $chunkSize);
-        foreach ($irisChunks as $irisChunk) {
-            $this->purgeRequest($irisChunk);
-        }
+        $this->invalidate($iris);
     }
 
     /**
@@ -84,51 +49,5 @@ final class VarnishPurger implements PurgerInterface
     public function getResponseHeaders(array $iris): array
     {
         return ['Cache-Tags' => implode(',', $iris)];
-    }
-
-    private function purgeRequest(array $iris): void
-    {
-        // Create the regex to purge all tags in just one request
-        $parts = array_map(static fn ($iri): string => // here we should remove the prefix as it's not discriminent and cost a lot to compute
-preg_quote($iri), $iris);
-
-        foreach ($this->chunkRegexParts($parts) as $regex) {
-            $regex = sprintf(self::REGEXP_PATTERN, $regex);
-            $this->banRegex($regex);
-        }
-    }
-
-    private function banRegex(string $regex): void
-    {
-        foreach ($this->clients as $client) {
-            $client->request('BAN', '', ['headers' => ['ApiPlatform-Ban-Regex' => $regex]]);
-        }
-    }
-
-    private function chunkRegexParts(array $parts): iterable
-    {
-        if (1 === \count($parts)) {
-            yield $parts[0];
-
-            return;
-        }
-
-        $concatenatedParts = implode("\n", $parts);
-
-        if (\strlen($concatenatedParts) <= $this->maxHeaderLength) {
-            yield str_replace("\n", '|', $concatenatedParts);
-
-            return;
-        }
-
-        $lastSeparator = strrpos(substr($concatenatedParts, 0, $this->maxHeaderLength + 1), "\n");
-
-        $chunk = substr($concatenatedParts, 0, $lastSeparator);
-
-        yield str_replace("\n", '|', $chunk);
-
-        $nextParts = \array_slice($parts, substr_count($chunk, "\n") + 1);
-
-        yield from $this->chunkRegexParts($nextParts);
     }
 }

--- a/src/HttpCache/VarnishXKeyPurger.php
+++ b/src/HttpCache/VarnishXKeyPurger.php
@@ -13,14 +13,17 @@ declare(strict_types=1);
 
 namespace ApiPlatform\HttpCache;
 
+use ApiPlatform\HttpCache\TagsInvalidator\Purger;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Purges Varnish XKey.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated configure a {@see Purger} instead
  */
-final class VarnishXKeyPurger implements PurgerInterface
+final class VarnishXKeyPurger extends Purger implements PurgerInterface
 {
     private const VARNISH_MAX_HEADER_LENGTH = 8000;
 
@@ -29,77 +32,16 @@ final class VarnishXKeyPurger implements PurgerInterface
      */
     public function __construct(private readonly array $clients, private readonly int $maxHeaderLength = self::VARNISH_MAX_HEADER_LENGTH, private readonly string $xkeyGlue = ' ')
     {
+        parent::__construct($this->clients, 'xkey', $this->maxHeaderLength, $this->xkeyGlue);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function purge(array $iris): void
     {
-        if (!$iris) {
-            return;
-        }
-
-        $irisChunks = array_chunk($iris, \count($iris));
-
-        foreach ($irisChunks as $irisChunk) {
-            $this->purgeIris($irisChunk);
-        }
+        $this->invalidate($iris);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getResponseHeaders(array $iris): array
     {
         return ['xkey' => implode($this->xkeyGlue, $iris)];
-    }
-
-    private function purgeIris(array $iris): void
-    {
-        foreach ($this->chunkKeys($iris) as $keys) {
-            $this->purgeKeys($keys);
-        }
-    }
-
-    private function purgeKeys(string $keys): void
-    {
-        foreach ($this->clients as $client) {
-            $client->request('PURGE', '', ['headers' => ['xkey' => $keys]]);
-        }
-    }
-
-    private function chunkKeys(array $keys): iterable
-    {
-        $concatenatedKeys = implode($this->xkeyGlue, $keys);
-
-        // If all keys fit in the header, we can return them
-        if (\strlen($concatenatedKeys) <= $this->maxHeaderLength) {
-            yield $concatenatedKeys;
-
-            return;
-        }
-
-        $currentHeader = '';
-
-        foreach ($keys as $position => $key) {
-            if (\strlen((string) $key) > $this->maxHeaderLength) {
-                throw new \Exception(sprintf('IRI "%s" is too long to fit current max header length (currently set to "%s"). You can increase it using the "api_platform.http_cache.invalidation.max_header_length" parameter.', $key, $this->maxHeaderLength));
-            }
-
-            $headerCandidate = sprintf('%s%s%s', $currentHeader, $position > 0 ? $this->xkeyGlue : '', $key);
-
-            if (\strlen($headerCandidate) > $this->maxHeaderLength) {
-                $nextKeys = \array_slice($keys, $position, \count($keys) - $position);
-
-                yield $currentHeader;
-                yield from $this->chunkKeys($nextKeys);
-
-                break;
-            }
-
-            // Key can be added to header
-            $currentHeader .= sprintf('%s%s', $position > 0 ? $this->xkeyGlue : '', $key);
-        }
     }
 }

--- a/src/Symfony/Bundle/Resources/config/doctrine_orm_http_cache_invalidator.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_orm_http_cache_invalidator.xml
@@ -9,7 +9,7 @@
         <!-- Event listener -->
 
         <service id="api_platform.doctrine.listener.http_cache.purge" class="ApiPlatform\Doctrine\EventListener\PurgeHttpCacheListener">
-            <argument type="service" id="api_platform.http_cache.purger" />
+            <argument /> <!-- tags invalidator -->
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.property_accessor" />

--- a/src/Symfony/Bundle/Resources/config/http_cache_tags.xml
+++ b/src/Symfony/Bundle/Resources/config/http_cache_tags.xml
@@ -5,18 +5,10 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="api_platform.http_cache.purger.varnish" alias="api_platform.http_cache.purger.varnish.ban" public="false" />
-        <service id="api_platform.http_cache.purger.varnish.ban" class="ApiPlatform\HttpCache\VarnishPurger" public="false" />
-        <service id="api_platform.http_cache.purger.varnish.xkey" class="ApiPlatform\HttpCache\VarnishXKeyPurger" public="false">
-            <argument type="collection"/>
-            <argument>%api_platform.http_cache.invalidation.max_header_length%</argument>
-            <argument>%api_platform.http_cache.invalidation.xkey.glue%</argument>
-        </service>
-
         <service id="api_platform.http_cache.listener.response.add_tags" class="ApiPlatform\HttpCache\EventListener\AddTagsListener">
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" on-invalid="null" />
-            <argument type="service" id="api_platform.http_cache.purger" on-invalid="null" />
+            <argument /> <!-- headers provider -->
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-2" />
         </service>
     </services>

--- a/tests/Behat/HttpCacheContext.php
+++ b/tests/Behat/HttpCacheContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Behat;
 
+use ApiPlatform\Tests\Fixtures\InvalidatorSpy;
 use Behat\Behat\Context\Context;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -31,13 +32,14 @@ final class HttpCacheContext implements Context
      */
     public function irisShouldBePurged(string $iris): void
     {
-        $purger = $this->kernel->getContainer()->get('behat.driver.service_container')->get('test.api_platform.http_cache.purger');
+        /** @var InvalidatorSpy $invalidator */
+        $invalidator = $this->kernel->getContainer()->get('behat.driver.service_container')->get('api_platform.http_cache.invalidator_spy');
 
-        $purgedIris = implode(',', $purger->getIris());
-        $purger->clear();
+        $invalidatedTags = implode(',', $invalidator->getInvalidatedTags());
+        $invalidator->clear();
 
-        if ($iris !== $purgedIris) {
-            throw new ExpectationFailedException(sprintf('IRIs "%s" does not match expected "%s".', $purgedIris, $iris));
+        if ($iris !== $invalidatedTags) {
+            throw new ExpectationFailedException(sprintf('IRIs "%s" does not match expected "%s".', $invalidatedTags, $iris));
         }
     }
 }

--- a/tests/Fixtures/InvalidatorSpy.php
+++ b/tests/Fixtures/InvalidatorSpy.php
@@ -13,32 +13,27 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures;
 
-use ApiPlatform\HttpCache\PurgerInterface;
+use ApiPlatform\HttpCache\TagsInvalidatorInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class NullPurger implements PurgerInterface
+final class InvalidatorSpy implements TagsInvalidatorInterface
 {
-    private array $iris = [];
+    private array $tags = [];
 
-    public function purge(array $iris): void
+    public function invalidate(array $tags): void
     {
-        $this->iris = $iris;
+        $this->tags = $tags;
     }
 
-    public function getIris(): array
+    public function getInvalidatedTags(): array
     {
-        return $this->iris;
+        return $this->tags;
     }
 
     public function clear(): void
     {
-        $this->iris = [];
-    }
-
-    public function getResponseHeaders(array $iris): array
-    {
-        return ['Cache-Tags' => implode(',', $iris)];
+        $this->tags = [];
     }
 }

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -59,10 +59,9 @@ api_platform:
         ApiPlatform\Exception\InvalidArgumentException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST
         ApiPlatform\Exception\FilterValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST
     http_cache:
-        invalidation:
-            enabled: true
-            xkey: 
-                glue: ' '
+        tags:
+            invalidator:
+                id: api_platform.http_cache.invalidator_spy
     defaults:
         normalization_context: 
             skip_null_values: false
@@ -244,11 +243,8 @@ services:
     logger:
         class: Psr\Log\NullLogger
 
-    api_platform.http_cache.purger:
-        class: ApiPlatform\Tests\Fixtures\NullPurger
-        
-    test.api_platform.http_cache.purger:
-        alias: api_platform.http_cache.purger
+    api_platform.http_cache.invalidator_spy:
+        class: ApiPlatform\Tests\Fixtures\InvalidatorSpy
         public: true
         
     test.property_accessor:

--- a/tests/HttpCache/TagsHeadersProviderTest.php
+++ b/tests/HttpCache/TagsHeadersProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\HttpCache;
+
+use ApiPlatform\HttpCache\TagsHeadersProvider;
+use PHPUnit\Framework\TestCase;
+
+class TagsHeadersProviderTest extends TestCase
+{
+    public function testSingleHeader(): void
+    {
+        $provider = new TagsHeadersProvider('Cache-Tags', ',');
+
+        self::assertSame(['Cache-Tags' => '1,2,3'], $provider->provideHeaders(['1', '2', '3']));
+    }
+
+    public function testRepeatedHeader(): void
+    {
+        $provider = new TagsHeadersProvider('Cache-Tags', null);
+
+        self::assertSame(['Cache-Tags' => ['1', '2', '3']], $provider->provideHeaders(['1', '2', '3']));
+    }
+}

--- a/tests/HttpCache/TagsInvalidator/BannerTest.php
+++ b/tests/HttpCache/TagsInvalidator/BannerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\HttpCache\TagsInvalidator;
+
+use ApiPlatform\HttpCache\TagsInvalidator\Banner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class BannerTest extends TestCase
+{
+    public function testBanRequest(): void
+    {
+        $response = new MockResponse();
+        $client = new MockHttpClient($response);
+        $banner = new Banner([$client], 'ApiPlatform-Ban-Regex', 7500);
+
+        $banner->invalidate(['/1', '/2', '/3']);
+
+        self::assertSame('BAN', $response->getRequestMethod());
+
+        $headers = $response->getRequestOptions()['normalized_headers'];
+        self::assertArrayHasKey('apiplatform-ban-regex', $headers);
+        self::assertSame(['ApiPlatform-Ban-Regex: (/1|/2|/3)($|\,)'], $headers['apiplatform-ban-regex']);
+    }
+
+    public function testNoRequestIsSentWithoutTag(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $client = new MockHttpClient(static fn () => self::fail('No request should have been sent.'));
+        $banner = new Banner([$client], 'ApiPlatform-Ban-Regex', 7500);
+
+        $banner->invalidate([]);
+    }
+
+    /**
+     * @param string[] $tags
+     *
+     * @dataProvider provideTags
+     */
+    public function testHeaderDoNotOverflow(array $tags, int $maxHeaderSize, array $expectedHeadersValue): void
+    {
+        /** @var MockResponse[] $responses */
+        $responses = [];
+        $client = new MockHttpClient(static function () use (&$responses) {
+            return $responses[] = new MockResponse();
+        });
+        $banner = new Banner([$client], 'ApiPlatform-Ban-Regex', $maxHeaderSize);
+
+        $banner->invalidate($tags);
+
+        $actualHeadersValue = array_map(
+            static fn (MockResponse $response): string => substr($response->getRequestOptions()['normalized_headers']['apiplatform-ban-regex'][0], 23),
+            $responses
+        );
+        self::assertSame($expectedHeadersValue, $actualHeadersValue);
+    }
+
+    public function testExceptionIsThrownOnTooLongTag(): void
+    {
+        self::expectExceptionMessage('IRI "ThisTagIsTooLong" is too long to fit the max header size (currently set to "18").');
+
+        $client = new MockHttpClient();
+        $purger = new Banner([$client], 'ApiPlatform-Ban-Regex', 18);
+
+        $purger->invalidate(['ThisTagIsTooLong']);
+    }
+
+    public static function provideTags(): \Iterator
+    {
+        yield 'One header, not filled' => [['/1', '/2', '/3'], 20, ['(/1|/2|/3)($|\,)']];
+
+        yield 'One header, filled' => [['/1', '/2', '/3'], 16, ['(/1|/2|/3)($|\,)']];
+
+        yield 'Two headers, none filled' => [['/1', '/2', '/3'], 15, ['(/1|/2)($|\,)', '(/3)($|\,)']];
+
+        yield 'Two headers, first filled' => [['/1', '/2', '/3'], 13, ['(/1|/2)($|\,)', '(/3)($|\,)']];
+
+        yield 'Two headers, both filled' => [['/1', '/2', '/3', '/4'], 13, ['(/1|/2)($|\,)', '(/3|/4)($|\,)']];
+
+        yield 'Quoted tags' => [['/1-1', '/1-2', '/1-3', '/1-4'], 19, ['(/1\-1|/1\-2)($|\,)', '(/1\-3|/1\-4)($|\,)']];
+    }
+}

--- a/tests/HttpCache/TagsInvalidator/PurgerTest.php
+++ b/tests/HttpCache/TagsInvalidator/PurgerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\HttpCache\TagsInvalidator;
+
+use ApiPlatform\HttpCache\TagsInvalidator\Purger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class PurgerTest extends TestCase
+{
+    public function testPurgeRequest(): void
+    {
+        $response = new MockResponse();
+        $client = new MockHttpClient($response);
+        $purger = new Purger([$client], 'xkey', 7500, ' ');
+
+        $purger->invalidate(['/1', '/2', '/3']);
+
+        self::assertSame('PURGE', $response->getRequestMethod());
+
+        $headers = $response->getRequestOptions()['normalized_headers'];
+        self::assertArrayHasKey('xkey', $headers);
+        self::assertSame(['xkey: /1 /2 /3'], $headers['xkey']);
+    }
+
+    public function testNoRequestIsSentWithoutTag(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $client = new MockHttpClient(static fn () => self::fail('No request should have been sent.'));
+        $purger = new Purger([$client], 'xkey', 7500, ' ');
+
+        $purger->invalidate([]);
+    }
+
+    /**
+     * @param string[] $tags
+     *
+     * @dataProvider provideTags
+     */
+    public function testHeaderDoNotOverflow(array $tags, int $maxHeaderSize, string $glue, array $expectedHeadersValue): void
+    {
+        /** @var MockResponse[] $responses */
+        $responses = [];
+        $client = new MockHttpClient(static function () use (&$responses) {
+            return $responses[] = new MockResponse();
+        });
+        $purger = new Purger([$client], 'xkey', $maxHeaderSize, $glue);
+
+        $purger->invalidate($tags);
+
+        $actualHeadersValue = array_map(
+            static fn (MockResponse $response): string => substr($response->getRequestOptions()['normalized_headers']['xkey'][0], 6),
+            $responses
+        );
+        self::assertSame($expectedHeadersValue, $actualHeadersValue);
+    }
+
+    public function testExceptionIsThrownOnTooLongTag(): void
+    {
+        self::expectExceptionMessage('IRI "ThisTagIsTooLong" is too long to fit the max header size (currently set to "10").');
+
+        $client = new MockHttpClient();
+        $purger = new Purger([$client], 'xkey', 10, ' ');
+
+        $purger->invalidate(['ThisTagIsTooLong']);
+    }
+
+    public static function provideTags(): \Iterator
+    {
+        yield 'One header, not filled' => [['/1', '/2', '/3'], 10, ' ', ['/1 /2 /3']];
+
+        yield 'One header, filled' => [['/1', '/2', '/3'], 8, ' ', ['/1 /2 /3']];
+
+        yield 'Two headers, none filled' => [['/1', '/2', '/3'], 7, ' ', ['/1 /2', '/3']];
+
+        yield 'Two headers, first filled' => [['/1', '/2', '/3'], 5, ' ', ['/1 /2', '/3']];
+
+        yield 'Two headers, both filled' => [['/1', '/2', '/3', '/4'], 5, ' ', ['/1 /2', '/3 /4']];
+
+        yield 'Multibyte glue' => [['/1', '/2', '/3', '/4'], 5, ', ', ['/1', '/2', '/3', '/4']];
+    }
+}

--- a/tests/HttpCache/VarnishXKeyPurgerTest.php
+++ b/tests/HttpCache/VarnishXKeyPurgerTest.php
@@ -75,7 +75,7 @@ class VarnishXKeyPurgerTest extends TestCase
 
     public function testHeaderTooLong(): void
     {
-        $this->expectExceptionMessage('IRI "/foobar-long-foobar-toolong-foofoo-barbar" is too long to fit current max header length (currently set to "20"). You can increase it using the "api_platform.http_cache.invalidation.max_header_length" parameter.');
+        self::expectExceptionMessage('IRI "/foobar-long-foobar-toolong-foofoo-barbar" is too long to fit the max header size (currently set to "20").');
 
         $clientProphecy1 = $this->prophesize(ClientInterface::class);
         $clientProphecy1->request('PURGE', '', ['headers' => ['xkey' => '/foobar-long-foobar-toolong-foofoo-barbar']])->willReturn(new Response())->shouldNotBeCalled();

--- a/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -860,12 +860,10 @@ class ApiPlatformExtensionTest extends TestCase
             // http_cache.xml
             'api_platform.http_cache.listener.response.configure',
 
-            // doctrine_orm_http_cache_purger.xml
+            // doctrine_orm_http_cache_invalidator.xml
             'api_platform.doctrine.listener.http_cache.purge',
 
             // http_cache_tags.xml
-            'api_platform.http_cache.purger.varnish.xkey',
-            'api_platform.http_cache.purger.varnish.ban',
             'api_platform.http_cache.listener.response.add_tags',
         ];
 
@@ -874,13 +872,11 @@ class ApiPlatformExtensionTest extends TestCase
         // http_cache.xml
         $this->assertServiceHasTags('api_platform.http_cache.listener.response.configure', ['kernel.event_listener']);
 
-        // doctrine_orm_http_cache_purger.xml
+        // doctrine_orm_http_cache_invalidator.xml
         $this->assertServiceHasTags('api_platform.doctrine.listener.http_cache.purge', ['doctrine.event_listener']);
 
         // http_cache_tags.xml
         $this->assertServiceHasTags('api_platform.http_cache.listener.response.add_tags', ['kernel.event_listener']);
-
-        $this->assertContainerHasAlias('api_platform.http_cache.purger.varnish');
 
         $this->assertEquals([
             ['event' => 'preUpdate'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #4512
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/1678

By working to solve #4512 on @soyuka’s request I found many oddities which I addressed as well.

I took a pretty long time understanding how the HTTP cache configuration works because the naming really isn’t obvious.

By default, enabling `http_cache.invalidation` will only add tags to the API responses; you need to configure `http_cache.invalidation.varnish_urls` and an optional “purger” to effectively invalidate these tags. Now, the default purger actually leverages [Varnish banning feature](https://www.varnish-software.com/developers/tutorials/ban/), which does not really “purge” anything. It is also the purgers’ job to add tags to API responses, which definitively feels out of place.

As it breaks the SRP I deprecated the `PurgerInterface`. Its `purge` method is replaced by `TagsInvalidatorInterface::invalidate` and its `getResponseHeaders` is replaced by `TagsHeadersProviderInterface::provideHeaders`. This reflects the new configuration:

```yaml
api_platform:
    http_cache:
        tags: # Configure how tags are added to responses. This can be disabled if you don’t use a reverse proxy
            header: # Tags are added in a response header. This is currently the only implementation
                name: # Name of the header. Defaults to “Cache-Tags”
                separator: # String added between tags. Defaults to “,”
            invalidator: # Configure how tags are gonna be invalidated. Only one implementation can be selected. This is disabled by default
                id: # ID of one of your own implementation of “TagsInvalidatorInterface”
                banner: # Send BAN requests
                    header: # Configure the header containing the regex to ban
                        name: # Name of the header. Defaults to “ApiPlatform-Ban-Regex”
                        max_size: # Maximum size of the header. Defaults to 7500 bytes
                    urls: # URLs to send BAN requests to
                    client_options: # Options to add to the HTTP clients sending BAN requests
                purger: # Send PURGE requests
                    header: # Configure the header containing the tags to purge
                        name: # Name of the header. Defaults to “xkey”
                        max_size: # Maximum size of the header. Defaults to 7500 bytes
                        separator: # Tags separator. Defaults to “ ” (space)
                    urls: # URLs to send PURGE requests to
                    client_options: # Options to add to the HTTP clients sending PURGE requests

```

I provided a BC layer so everything should be working without any change.