### PR TITLE
fix(elasticsearch): check for indices only when enabled

### DIFF
--- a/src/Elasticsearch/Metadata/Resource/Factory/ElasticsearchProviderResourceMetadataCollectionFactory.php
+++ b/src/Elasticsearch/Metadata/Resource/Factory/ElasticsearchProviderResourceMetadataCollectionFactory.php
@@ -82,7 +82,7 @@ final class ElasticsearchProviderResourceMetadataCollectionFactory implements Re
 
     private function hasIndices(Operation $operation): bool
     {
-        if (false === $operation->getElasticsearch()) {
+        if (false === $operation->getElasticsearch() || null === $operation->getElasticsearch()) {
             return false;
         }
 


### PR DESCRIPTION
From #5264 but rebased against 3.0 