### PR TITLE
fix(deprecation): Use getContentTypeFormat when available

### DIFF
--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -86,15 +86,16 @@ final class EntrypointAction
             return [$query, $operationName, $variables];
         }
 
-        if ('json' === $request->getContentType()) {
+        $contentType = method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType();
+        if ('json' === $contentType) {
             return $this->parseData($query, $operationName, $variables, $request->getContent());
         }
 
-        if ('graphql' === $request->getContentType()) {
+        if ('graphql' === $contentType) {
             $query = $request->getContent();
         }
 
-        if (\in_array($request->getContentType(), ['multipart', 'form'], true)) {
+        if (\in_array($contentType, ['multipart', 'form'], true)) {
             return $this->parseMultipartRequest($query, $operationName, $variables, $request->request->all(), $request->files->all());
         }
 

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -72,7 +72,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
                 }
             }
 
-            if ('csv' === $request->getContentType()) {
+            if ('csv' === (method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType())) {
                 $context[CsvEncoder::AS_COLLECTION_KEY] = false;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | #5287 
| License       | MIT
| Doc PR        | n/a

If `getContentTypeFormat` us this instead of `getContentType`, branch 3.0 since I think 2.7 isn't compatible with 6.2? (not sure)
