### PR TITLE
Refactor $elasticsearch into a new $persistenceMeans option

### DIFF
--- a/features/elasticsearch/match_filter.feature
+++ b/features/elasticsearch/match_filter.feature
@@ -216,3 +216,216 @@ Feature: Match filter on collections from Elasticsearch
       }
     }
     """
+
+  Scenario: Match filter on a text property with new elasticsearch operations
+    When I send a "GET" request to "/books?message=Good%20job"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 2,
+          "minItems": 2,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/7cdadcda-3fb5-4312-9e32-72acba323cc0$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f91bca21-b5f8-405b-9b08-d5a5dc476a92$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?message=Good%20job$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Match filter on a text property with new elasticsearch operations
+    When I send a "GET" request to "/books?message%5B%5D=Good%20job&message%5B%5D=run"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/6d82a76c-8ba2-4e78-9ab3-6a456e4470c3$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/7cdadcda-3fb5-4312-9e32-72acba323cc0$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/9de3308c-6f82-4a57-a33c-4e3cd5d5a3f6$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:totalItem": {
+          "type": "string",
+          "pattern": "^4$"
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?message%5B%5D=Good%20job&message%5B%5D=run&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Match filter on a nested property of text type with new elasticsearch operations
+    When I send a "GET" request to "/books?library.firstName=Caroline"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 2,
+          "minItems": 2,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/6d82a76c-8ba2-4e78-9ab3-6a456e4470c3$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f91bca21-b5f8-405b-9b08-d5a5dc476a92$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?library.firstName=Caroline$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Combining match filters on properties of text type and a nested property of text type with new elasticsearch operations
+    When I send a "GET" request to "/books?message%5B%5D=Good%20job&message%5B%5D=run&library.firstName=Caroline"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 2,
+          "minItems": 2,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/6d82a76c-8ba2-4e78-9ab3-6a456e4470c3$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f91bca21-b5f8-405b-9b08-d5a5dc476a92$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?message%5B%5D=Good%20job&message%5B%5D=run&library.firstName=Caroline$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """

--- a/features/elasticsearch/order_filter.feature
+++ b/features/elasticsearch/order_filter.feature
@@ -357,3 +357,357 @@ Feature: Order filter on collections from Elasticsearch
       }
     }
     """
+
+  Scenario: Get collection ordered in ascending order on an identifier property with new elasticsearch operations
+    When I send a "GET" request to "/books?order%5Bid%5D=asc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/0acfd90d-5bfe-4e42-b708-dc38bf20677c$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/0cfe3d33-6116-416b-8c50-3b8319331998$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/1c9e0545-1b37-4a9a-83e0-30400d0b354e$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?order%5Bid%5D=asc&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Get collection ordered in descending order on an identifier property with new elasticsearch operations
+    When I send a "GET" request to "/books?order%5Bid%5D=desc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f91bca21-b5f8-405b-9b08-d5a5dc476a92$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f36a0026-0635-4865-86a6-5adb21d94d64$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f2e65123-e063-44a0-b640-b0a04554d19e$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?order%5Bid%5D=desc&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Get collection ordered in ascending order on an identifier property and in ascending order on a nested identifier property with new elasticsearch operations
+    When I send a "GET" request to "/books?order%5Blibrary.id%5D=asc&order%5Bid%5D=asc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/89601e1c-3ef2-4ef7-bca2-7511d38611c6$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/9da70727-d656-42d9-876a-1be6321f171b$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f36a0026-0635-4865-86a6-5adb21d94d64$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?order%5Blibrary.id%5D=asc&order%5Bid%5D=asc&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Get collection ordered in descending order on an identifier property and in ascending order on a nested identifier property with new elasticsearch operations
+    When I send a "GET" request to "/books?order%5Blibrary.id%5D=asc&order%5Bid%5D=desc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/f36a0026-0635-4865-86a6-5adb21d94d64$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/9da70727-d656-42d9-876a-1be6321f171b$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/89601e1c-3ef2-4ef7-bca2-7511d38611c6$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?order%5Blibrary.id%5D=asc&order%5Bid%5D=desc&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Get collection ordered in ascending order on an identifier property and in descending order on a nested identifier property with new elasticsearch operations
+    When I send a "GET" request to "/books?order%5Blibrary.id%5D=desc&order%5Bid%5D=asc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/3a1d02fa-2347-41ff-80ef-ed9b9c0efea9$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/1c9e0545-1b37-4a9a-83e0-30400d0b354e$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/7cdadcda-3fb5-4312-9e32-72acba323cc0$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?order%5Blibrary.id%5D=desc&order%5Bid%5D=asc&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Get collection ordered in descending order on an identifier property and in descending order on a nested identifier property with new elasticsearch operations
+    When I send a "GET" request to "/books?order%5Blibrary.id%5D=desc&order%5Bid%5D=desc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Book$"},
+        "@id": {"pattern": "^/books$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "additionalItems": false,
+          "maxItems": 3,
+          "minItems": 3,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/3a1d02fa-2347-41ff-80ef-ed9b9c0efea9$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/811e4d1c-df3f-4d24-a9da-2a28080c85f5$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "string",
+                  "pattern": "^/books/7cdadcda-3fb5-4312-9e32-72acba323cc0$"
+                }
+              }
+            }
+          ]
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/books\\?order%5Blibrary.id%5D=desc&order%5Bid%5D=desc&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """

--- a/features/elasticsearch/read.feature
+++ b/features/elasticsearch/read.feature
@@ -380,3 +380,380 @@ Feature: Retrieve from Elasticsearch
       }
     }
     """
+
+  Scenario: Get a resource with new elasticsearch operations
+    When I send a "GET" request to "/libraries/116b83f8-6c32-48d8-8e28-c5c247532d3f"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Library",
+      "@id": "/libraries/116b83f8-6c32-48d8-8e28-c5c247532d3f",
+      "@type": "Library",
+      "id": "116b83f8-6c32-48d8-8e28-c5c247532d3f",
+      "gender": "male",
+      "age": 31,
+      "firstName": "Kilian",
+      "lastName": "Jornet",
+      "registeredAt": "2009-09-01T00:00:00+00:00",
+      "books": [
+        {
+          "@id": "/books/f36a0026-0635-4865-86a6-5adb21d94d64",
+          "@type": "Book",
+          "id": "f36a0026-0635-4865-86a6-5adb21d94d64",
+          "date": "2017-01-01T01:01:01+00:00",
+          "message": "The north summit, Store Vengetind Thanks for t... These Top 10 Women of a fk... Francois is the field which."
+        },
+        {
+          "@id": "/books/89601e1c-3ef2-4ef7-bca2-7511d38611c6",
+          "@type": "Book",
+          "id": "89601e1c-3ef2-4ef7-bca2-7511d38611c6",
+          "date": "2017-02-02T02:02:02+00:00",
+          "message": "Great day in any endur... During the Himalayas were very talented skimo racer junior podiums, top 10."
+        },
+        {
+          "@id": "/books/9da70727-d656-42d9-876a-1be6321f171b",
+          "@type": "Book",
+          "id": "9da70727-d656-42d9-876a-1be6321f171b",
+          "date": "2017-03-03T03:03:03+00:00",
+          "message": "During the path and his Summits Of My Life project. Next Wednesday, Kilian Jornet..."
+        }
+      ]
+    }
+    """
+
+  Scenario: Get a not found exception with new elasticsearch operations
+    When I send a "GET" request to "/libraries/12345678-abcd-1234-abcdefgh"
+    Then the response status code should be 404
+
+  Scenario: Get the first page of a collection with new elasticsearch operations
+    When I send a "GET" request to "/books"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Book",
+      "@id": "/books",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/books/0acfd90d-5bfe-4e42-b708-dc38bf20677c",
+          "@type": "Book",
+          "id": "0acfd90d-5bfe-4e42-b708-dc38bf20677c",
+          "library": {
+            "@id": "/libraries/c81d5151-0d28-4b06-baeb-150bd2b2bbf8",
+            "@type": "Library",
+            "id": "c81d5151-0d28-4b06-baeb-150bd2b2bbf8",
+            "gender": "male",
+            "age": 35,
+            "firstName": "Anton",
+            "lastName": "Krupicka"
+          },
+          "date": "2017-08-08T08:08:08+00:00",
+          "message": "Whoever curates the Marathon yesterday. Truly inspiring stuff. The new is straight. Such a couple!"
+        },
+        {
+          "@id": "/books/0cfe3d33-6116-416b-8c50-3b8319331998",
+          "@type": "Book",
+          "id": "0cfe3d33-6116-416b-8c50-3b8319331998",
+          "library": {
+            "@id": "/libraries/15fce6f1-18fd-4ef6-acab-7e6a3333ec7f",
+            "@type": "Library",
+            "id": "15fce6f1-18fd-4ef6-acab-7e6a3333ec7f",
+            "gender": "male",
+            "age": 28,
+            "firstName": "Jim",
+            "lastName": "Walmsley"
+          },
+          "date": "2017-09-09T09:09:09+00:00",
+          "message": "Thanks! Fun day with Next up one of our 2018 cover: One look into what races we'll be running that they!"
+        },
+        {
+          "@id": "/books/1c9e0545-1b37-4a9a-83e0-30400d0b354e",
+          "@type": "Book",
+          "id": "1c9e0545-1b37-4a9a-83e0-30400d0b354e",
+          "library": {
+            "@id": "/libraries/fbf60054-004f-4d21-a178-cb364d1ef875",
+            "@type": "Library",
+            "id": "fbf60054-004f-4d21-a178-cb364d1ef875",
+            "gender": "male",
+            "age": 30,
+            "firstName": "Zach",
+            "lastName": "Miller"
+          },
+          "date": "2017-10-10T10:10:10+00:00",
+          "message": "Way to go for me I think it was great holiday season yourself!! I'm still working on the awesome as I."
+        }
+      ],
+      "hydra:totalItems": 20,
+      "hydra:view": {
+        "@id": "/books?page=1",
+        "@type": "hydra:PartialCollectionView",
+        "hydra:first": "/books?page=1",
+        "hydra:last": "/books?page=7",
+        "hydra:next": "/books?page=2"
+      },
+      "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "/books{?order[id],order[library.id],message,message[],library.firstName,library.firstName[]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "order[id]",
+            "property": "id",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "order[library.id]",
+            "property": "library.id",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "message",
+            "property": "message",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "message[]",
+            "property": "message",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "library.firstName",
+            "property": "library.firstName",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "library.firstName[]",
+            "property": "library.firstName",
+            "required": false
+          }
+        ]
+      }
+    }
+    """
+
+  Scenario: Get a page of a collection with new elasticsearch operations
+    When I send a "GET" request to "/books?page=3"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Book",
+      "@id": "/books",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/books/6d82a76c-8ba2-4e78-9ab3-6a456e4470c3",
+          "@type": "Book",
+          "id": "6d82a76c-8ba2-4e78-9ab3-6a456e4470c3",
+          "library": {
+            "@id": "/libraries/fa7d4578-6692-47ec-9346-a8ab25ca613c",
+            "@type": "Library",
+            "id": "fa7d4578-6692-47ec-9346-a8ab25ca613c",
+            "gender": "female",
+            "age": 42,
+            "firstName": "Caroline",
+            "lastName": "Chaverot"
+          },
+          "date": "2018-01-01T13:13:13+00:00",
+          "message": "Prior to not run in paradise ! I should have listened to ! What a little more of hesitation, I?"
+        },
+        {
+          "@id": "/books/7cdadcda-3fb5-4312-9e32-72acba323cc0",
+          "@type": "Book",
+          "id": "7cdadcda-3fb5-4312-9e32-72acba323cc0",
+          "library": {
+            "@id": "/libraries/fbf60054-004f-4d21-a178-cb364d1ef875",
+            "@type": "Library",
+            "id": "fbf60054-004f-4d21-a178-cb364d1ef875",
+            "gender": "male",
+            "age": 30,
+            "firstName": "Zach",
+            "lastName": "Miller"
+          },
+          "date": "2017-12-12T12:12:12+00:00",
+          "message": "Thanks! Thanks Senseman! Good luck at again! Open air sleeps! 669 now. Message me. You bet Kyle! PT: Try."
+        },
+        {
+          "@id": "/books/811e4d1c-df3f-4d24-a9da-2a28080c85f5",
+          "@type": "Book",
+          "id": "811e4d1c-df3f-4d24-a9da-2a28080c85f5",
+          "library": {
+            "@id": "/libraries/fbf60054-004f-4d21-a178-cb364d1ef875",
+            "@type": "Library",
+            "id": "fbf60054-004f-4d21-a178-cb364d1ef875",
+            "gender": "male",
+            "age": 30,
+            "firstName": "Zach",
+            "lastName": "Miller"
+          },
+          "date": "2017-11-11T11:11:11+00:00",
+          "message": "DES!!!!!!! For that in LA airport skills: chugging water, one-handed bathroom maneuvers, and the!"
+        }
+      ],
+      "hydra:totalItems": 20,
+      "hydra:view": {
+        "@id": "/books?page=3",
+        "@type": "hydra:PartialCollectionView",
+        "hydra:first": "/books?page=1",
+        "hydra:last": "/books?page=7",
+        "hydra:previous": "/books?page=2",
+        "hydra:next": "/books?page=4"
+      },
+      "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "/books{?order[id],order[library.id],message,message[],library.firstName,library.firstName[]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "order[id]",
+            "property": "id",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "order[library.id]",
+            "property": "library.id",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "message",
+            "property": "message",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "message[]",
+            "property": "message",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "library.firstName",
+            "property": "library.firstName",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "library.firstName[]",
+            "property": "library.firstName",
+            "required": false
+          }
+        ]
+      }
+    }
+    """
+
+  Scenario: Get the last page of a collection with new elasticsearch operations
+    When I send a "GET" request to "/books?page=7"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Book",
+      "@id": "/books",
+      "@type": "hydra:Collection",
+      "hydra:member": [
+        {
+          "@id": "/books/f36a0026-0635-4865-86a6-5adb21d94d64",
+          "@type": "Book",
+          "id": "f36a0026-0635-4865-86a6-5adb21d94d64",
+          "library": {
+            "@id": "/libraries/116b83f8-6c32-48d8-8e28-c5c247532d3f",
+            "@type": "Library",
+            "id": "116b83f8-6c32-48d8-8e28-c5c247532d3f",
+            "gender": "male",
+            "age": 31,
+            "firstName": "Kilian",
+            "lastName": "Jornet"
+          },
+          "date": "2017-01-01T01:01:01+00:00",
+          "message": "The north summit, Store Vengetind Thanks for t... These Top 10 Women of a fk... Francois is the field which."
+        },
+        {
+          "@id": "/books/f91bca21-b5f8-405b-9b08-d5a5dc476a92",
+          "@type": "Book",
+          "id": "f91bca21-b5f8-405b-9b08-d5a5dc476a92",
+          "library": {
+            "@id": "/libraries/fa7d4578-6692-47ec-9346-a8ab25ca613c",
+            "@type": "Library",
+            "id": "fa7d4578-6692-47ec-9346-a8ab25ca613c",
+            "gender": "female",
+            "age": 42,
+            "firstName": "Caroline",
+            "lastName": "Chaverot"
+          },
+          "date": "2018-02-02T14:14:14+00:00",
+          "message": "Good job girls ! Chacun de publier un outil innovant repertoriant des prochains championnats du!"
+        }
+      ],
+      "hydra:totalItems": 20,
+      "hydra:view": {
+        "@id": "/books?page=7",
+        "@type": "hydra:PartialCollectionView",
+        "hydra:first": "/books?page=1",
+        "hydra:last": "/books?page=7",
+        "hydra:previous": "/books?page=6"
+      },
+      "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "/books{?order[id],order[library.id],message,message[],library.firstName,library.firstName[]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "order[id]",
+            "property": "id",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "order[library.id]",
+            "property": "library.id",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "message",
+            "property": "message",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "message[]",
+            "property": "message",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "library.firstName",
+            "property": "library.firstName",
+            "required": false
+          },
+          {
+            "@type": "IriTemplateMapping",
+            "variable": "library.firstName[]",
+            "property": "library.firstName",
+            "required": false
+          }
+        ]
+      }
+    }
+    """

--- a/features/elasticsearch/term_filter.feature
+++ b/features/elasticsearch/term_filter.feature
@@ -262,3 +262,262 @@ Feature: Term filter on collections from Elasticsearch
       }
     }
     """
+
+  Scenario: Term filter on an identifier property with elasticsearch operations
+    When I send a "GET" request to "/libraries?id=%2Flibraries%2Fcf875c95-41ab-48df-af66-38c74db18f72"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Library$"},
+        "@id": {"pattern": "^/libraries$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 1,
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {"pattern": "^/libraries/cf875c95-41ab-48df-af66-38c74db18f72$"}
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/libraries\\?id=%2Flibraries%2Fcf875c95-41ab-48df-af66-38c74db18f72$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Term filter on a property of keyword type with elasticsearch operations
+    When I send a "GET" request to "/libraries?gender=female"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Library$"},
+        "@id": {"pattern": "^/libraries$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 3,
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/libraries/6a457188-d1ba-45e3-8509-81e5c66a5297$"},
+                  {"pattern": "^/libraries/89d4ae3d-73bc-4382-b01c-adf038f893c2$"},
+                  {"pattern": "^/libraries/cf875c95-41ab-48df-af66-38c74db18f72$"}
+                ]
+              },
+              "gender": {"pattern": "^female$"}
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/libraries\\?gender=female&page=1$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Combining term filters on a property of integer type and a property of keyword type with elasticsearch operations
+    When I send a "GET" request to "/libraries?age=42&gender=female"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Library$"},
+        "@id": {"pattern": "^/libraries$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2,
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/libraries/89d4ae3d-73bc-4382-b01c-adf038f893c2$"},
+                  {"pattern": "^/libraries/fa7d4578-6692-47ec-9346-a8ab25ca613c$"}
+                ]
+              },
+              "age": {
+                "type": "integer",
+                "maximum": 42,
+                "minimum": 42
+              }
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/libraries\\?age=42&gender=female$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Combining term filters on a property of integer type and a property of keyword type with elasticsearch operations
+    When I send a "GET" request to "/libraries?age=42&gender=male"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Library$"},
+        "@id": {"pattern": "^/libraries$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 0,
+          "minItems": 0
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/libraries\\?age=42&gender=male$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Term filter on a property of text type with elasticsearch operations
+    When I send a "GET" request to "/libraries?firstName=xavier"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Library$"},
+        "@id": {"pattern": "^/libraries$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 1,
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {"pattern": "^/libraries/f18eb7ab-6985-4e05-afd4-13a638c929d4$"},
+              "firstName": {"pattern": "^Xavier$"}
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/libraries\\?firstName=xavier$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Term filter on a nested identifier property with elasticsearch operations
+    When I send a "GET" request to "/libraries?books.id=%2Fbooks%2Fdcaef1db-225d-442b-960e-5de6984a44be"
+    Then the response should be in JSON
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Library$"},
+        "@id": {"pattern": "^/libraries$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 1,
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {"pattern": "^/libraries/89d4ae3d-73bc-4382-b01c-adf038f893c2$"}
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/libraries\\?books.id=%2Fbooks%2Fdcaef1db-225d-442b-960e-5de6984a44be$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """
+
+  Scenario: Term filter on a nested property of date type with elasticsearch operations
+    When I send a "GET" request to "/libraries?books.date=2018-02-02%2014%3A14%3A14"
+    Then the response should be in JSON
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Library$"},
+        "@id": {"pattern": "^/libraries$"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "maxItems": 1,
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {"pattern": "^/libraries/fa7d4578-6692-47ec-9346-a8ab25ca613c$"}
+            }
+          }
+        },
+        "hydra:view": {
+          "type": "object",
+          "properties": {
+            "@id": {"pattern": "^/libraries\\?books.date=2018-02-02%2014%3A14%3A14$"},
+            "@type": {"pattern": "^hydra:PartialCollectionView$"}
+          }
+        }
+      }
+    }
+    """

--- a/src/Elasticsearch/Metadata/Document/DocumentMetadata.php
+++ b/src/Elasticsearch/Metadata/Document/DocumentMetadata.php
@@ -17,8 +17,7 @@ namespace ApiPlatform\Elasticsearch\Metadata\Document;
  * Document metadata.
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html
- *
- * @experimental
+ * @deprecated
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */

--- a/src/Elasticsearch/Metadata/Document/Factory/AttributeDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/AttributeDocumentMetadataFactory.php
@@ -20,7 +20,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 /**
  * Creates document's metadata using the attribute configuration.
  *
- * @experimental
+ * @deprecated
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */

--- a/src/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
@@ -21,7 +21,7 @@ use Psr\Cache\CacheItemPoolInterface;
 /**
  * Caches document metadata.
  *
- * @experimental
+ * @deprecated
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */

--- a/src/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
@@ -24,8 +24,7 @@ use Elasticsearch\Common\Exceptions\Missing404Exception;
  * Creates document's metadata using indices from the cat APIs.
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html
- *
- * @experimental
+ * @deprecated
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */

--- a/src/Elasticsearch/Metadata/Document/Factory/ConfiguredDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/ConfiguredDocumentMetadataFactory.php
@@ -19,7 +19,7 @@ use ApiPlatform\Elasticsearch\Metadata\Document\DocumentMetadata;
 /**
  * Creates document's metadata using the mapping configuration.
  *
- * @experimental
+ * @deprecated
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */

--- a/src/Elasticsearch/Metadata/Document/Factory/DocumentMetadataFactoryInterface.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/DocumentMetadataFactoryInterface.php
@@ -19,7 +19,7 @@ use ApiPlatform\Elasticsearch\Metadata\Document\DocumentMetadata;
 /**
  * Creates a document metadata value object.
  *
- * @experimental
+ * @deprecated
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */

--- a/src/Elasticsearch/State/Options.php
+++ b/src/Elasticsearch/State/Options.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Elasticsearch\State;
+
+class Options implements OptionsInterface
+{
+    public function __construct(
+        protected ?string $index = null,
+        protected ?string $type = null,
+    ) {
+    }
+
+    public function getIndex(): ?string
+    {
+        return $this->index;
+    }
+
+    public function withIndex(?string $index): self
+    {
+        $self = clone $this;
+        $self->index = $index;
+
+        return $self;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function withType(?string $type): self
+    {
+        $self = clone $this;
+        $self->type = $type;
+
+        return $self;
+    }
+}

--- a/src/Elasticsearch/State/OptionsInterface.php
+++ b/src/Elasticsearch/State/OptionsInterface.php
@@ -11,9 +11,13 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Metadata\GraphQl;
+namespace ApiPlatform\Elasticsearch\State;
 
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-class Mutation extends Operation
+use ApiPlatform\State\OptionsInterface as AbstractOptionsInterface;
+
+interface OptionsInterface extends AbstractOptionsInterface
 {
+    public function getIndex(): ?string;
+
+    public function getType(): ?string;
 }

--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Metadata;
 
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 /**
  * Resource metadata attribute.
@@ -147,7 +148,8 @@ class ApiResource
         protected ?array $graphQlOperations = null,
         $provider = null,
         $processor = null,
-        protected array $extraProperties = []
+        protected array $extraProperties = [],
+        protected ?OptionsInterface $stateOptions = null,
     ) {
         $this->operations = null === $operations ? null : new Operations($operations);
         $this->provider = $provider;
@@ -616,11 +618,17 @@ class ApiResource
         return $self;
     }
 
+    /**
+     * @deprecated this will be removed in v4
+     */
     public function getElasticsearch(): ?bool
     {
         return $this->elasticsearch;
     }
 
+    /**
+     * @deprecated this will be removed in v4
+     */
     public function withElasticsearch(bool $elasticsearch): self
     {
         $self = clone $this;
@@ -1027,6 +1035,19 @@ class ApiResource
     {
         $self = clone $this;
         $self->extraProperties = $extraProperties;
+
+        return $self;
+    }
+
+    public function getStateOptions(): ?OptionsInterface
+    {
+        return $this->stateOptions;
+    }
+
+    public function withStateOptions(?OptionsInterface $stateOptions): self
+    {
+        $self = clone $this;
+        $self->stateOptions = $stateOptions;
 
         return $self;
     }

--- a/src/Metadata/Delete.php
+++ b/src/Metadata/Delete.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Delete extends HttpOperation implements DeleteOperationInterface
@@ -93,7 +94,8 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(self::METHOD_DELETE, ...\func_get_args());
     }

--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Extractor;
 
+use ApiPlatform\Elasticsearch\State\Options;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\GraphQl\DeleteMutation;
@@ -96,6 +97,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             'paginationViaCursor' => $this->buildPaginationViaCursor($resource),
             'exceptionToStatus' => $this->buildExceptionToStatus($resource),
             'queryParameterValidationEnabled' => $this->phpize($resource, 'queryParameterValidationEnabled', 'bool'),
+            'stateOptions' => $this->buildStateOptions($resource),
         ]);
     }
 
@@ -449,5 +451,22 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
         }
 
         return $data;
+    }
+
+    private function buildStateOptions(\SimpleXMLElement $resource): ?Options
+    {
+        $stateOptions = $resource->stateOptions ?? null;
+        if (!$stateOptions) {
+            return null;
+        }
+        $elasticsearchOptions = $stateOptions->elasticsearchOptions ?? null;
+        if ($elasticsearchOptions) {
+            return new Options(
+                isset($elasticsearchOptions['index']) ? (string) $elasticsearchOptions['index'] : null,
+                isset($elasticsearchOptions['type']) ? (string) $elasticsearchOptions['type'] : null,
+            );
+        }
+
+        return null;
     }
 }

--- a/src/Metadata/Extractor/YamlResourceExtractor.php
+++ b/src/Metadata/Extractor/YamlResourceExtractor.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Extractor;
 
+use ApiPlatform\Elasticsearch\State\Options;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\GraphQl\DeleteMutation;
@@ -122,6 +123,7 @@ final class YamlResourceExtractor extends AbstractResourceExtractor
             'uriVariables' => $this->buildUriVariables($resource),
             'inputFormats' => $this->buildArrayValue($resource, 'inputFormats'),
             'outputFormats' => $this->buildArrayValue($resource, 'outputFormats'),
+            'stateOptions' => $this->buildStateOptions($resource),
         ]);
     }
 
@@ -364,5 +366,25 @@ final class YamlResourceExtractor extends AbstractResourceExtractor
         }
 
         return $data ?: null;
+    }
+
+    private function buildStateOptions(array $resource): ?Options
+    {
+        $stateOptions = $resource['stateOptions'] ?? [];
+        if (!\is_array($stateOptions)) {
+            return null;
+        }
+
+        if (!$stateOptions) {
+            return null;
+        }
+
+        $configuration = reset($stateOptions);
+        switch (key($stateOptions)) {
+            case 'elasticsearchOptions':
+                return new Options($configuration['index'] ?? null, $configuration['type'] ?? null);
+        }
+
+        return null;
     }
 }

--- a/src/Metadata/Extractor/schema/resources.xsd
+++ b/src/Metadata/Extractor/schema/resources.xsd
@@ -383,6 +383,19 @@
         </xsd:sequence>
     </xsd:complexType>
 
+    <xsd:complexType name="stateOptions">
+        <xsd:choice>
+            <xsd:element ref="elasticsearchOptions"/>
+        </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:element name="elasticsearchOptions">
+        <xsd:complexType>
+            <xsd:attribute name="index" type="xsd:string"/>
+            <xsd:attribute name="type" type="xsd:string"/>
+        </xsd:complexType>
+    </xsd:element>
+
     <xsd:group name="base">
         <xsd:sequence>
             <xsd:element name="denormalizationContext" minOccurs="0" type="sequenceWithValues"/>
@@ -409,6 +422,7 @@
             <xsd:element name="options" minOccurs="0" type="sequenceWithValues"/>
             <xsd:element name="outputFormats" minOccurs="0" type="formats"/>
             <xsd:element name="paginationViaCursor" minOccurs="0" type="paginationViaCursor"/>
+            <xsd:element name="stateOptions" minOccurs="0" type="stateOptions"/>
             <xsd:element name="requirements" minOccurs="0" type="requirements"/>
             <xsd:element name="schemes" minOccurs="0" type="schemes"/>
             <xsd:element name="types" minOccurs="0" type="types"/>

--- a/src/Metadata/Get.php
+++ b/src/Metadata/Get.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Get extends HttpOperation
@@ -93,7 +94,8 @@ final class Get extends HttpOperation
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(self::METHOD_GET, ...\func_get_args());
     }

--- a/src/Metadata/GetCollection.php
+++ b/src/Metadata/GetCollection.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class GetCollection extends HttpOperation implements CollectionOperationInterface
@@ -96,9 +97,10 @@ final class GetCollection extends HttpOperation implements CollectionOperationIn
         $provider = null,
         $processor = null,
         array $extraProperties = [],
-        ?string $itemUriTemplate = null
+        ?string $itemUriTemplate = null,
+        ?OptionsInterface $stateOptions = null,
     ) {
-        parent::__construct(self::METHOD_GET, ...\func_get_args());
+        parent::__construct(self::METHOD_GET, $uriTemplate, $types, $formats, $inputFormats, $outputFormats, $uriVariables, $routePrefix, $routeName, $defaults, $requirements, $options, $stateless, $sunset, $acceptPatch, $status, $host, $schemes, $condition, $controller, $cacheHeaders, $hydraContext, $openapiContext, $openapi, $exceptionToStatus, $queryParameterValidationEnabled, $shortName, $class, $paginationEnabled, $paginationType, $paginationItemsPerPage, $paginationMaximumItemsPerPage, $paginationPartial, $paginationClientEnabled, $paginationClientItemsPerPage, $paginationClientPartial, $paginationFetchJoinCollection, $paginationUseOutputWalkers, $paginationViaCursor, $order, $description, $normalizationContext, $denormalizationContext, $security, $securityMessage, $securityPostDenormalize, $securityPostDenormalizeMessage, $securityPostValidation, $securityPostValidationMessage, $deprecationReason, $filters, $validationContext, $input, $output, $mercure, $messenger, $elasticsearch, $urlGenerationStrategy, $read, $deserialize, $validate, $write, $serialize, $fetchPartial, $forceEager, $priority, $name, $provider, $processor, $extraProperties, $stateOptions);
         $this->itemUriTemplate = $itemUriTemplate;
     }
 

--- a/src/Metadata/GraphQl/DeleteMutation.php
+++ b/src/Metadata/GraphQl/DeleteMutation.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\GraphQl;
 
 use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class DeleteMutation extends Mutation implements DeleteOperationInterface
@@ -70,7 +71,8 @@ class DeleteMutation extends Mutation implements DeleteOperationInterface
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        protected ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(...\func_get_args());
     }

--- a/src/Metadata/GraphQl/Operation.php
+++ b/src/Metadata/GraphQl/Operation.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Metadata\GraphQl;
 
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Operation as AbstractOperation;
+use ApiPlatform\State\OptionsInterface;
 
 class Operation extends AbstractOperation
 {
@@ -74,7 +75,8 @@ class Operation extends AbstractOperation
         ?string $name = null,
         ?string $provider = null,
         ?string $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        protected ?OptionsInterface $stateOptions = null,
     ) {
         // Abstract operation properties
         $this->shortName = $shortName;

--- a/src/Metadata/GraphQl/Query.php
+++ b/src/Metadata/GraphQl/Query.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\GraphQl;
 
+use ApiPlatform\State\OptionsInterface;
+
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class Query extends Operation
 {
@@ -37,7 +39,7 @@ class Query extends Operation
         ?bool $paginationClientPartial = null,
         ?bool $paginationFetchJoinCollection = null,
         ?bool $paginationUseOutputWalkers = null,
-        ?bool $paginationViaCursor = null,
+        ?array $paginationViaCursor = null,
         ?array $order = null,
         ?string $description = null,
         ?array $normalizationContext = null,
@@ -51,9 +53,11 @@ class Query extends Operation
         ?string $deprecationReason = null,
         ?array $filters = null,
         ?array $validationContext = null,
-        $input = null,
-        $output = null,
+        mixed $input = null,
+        mixed $output = null,
+        /** @var array|bool|string|null $mercure */
         $mercure = null,
+        /** @var bool|string|null $messenger */
         $messenger = null,
         ?bool $elasticsearch = null,
         ?int $urlGenerationStrategy = null,
@@ -66,10 +70,12 @@ class Query extends Operation
         ?bool $forceEager = null,
         ?int $priority = null,
         ?string $name = null,
+        /** @var (callable(): mixed)|string|null $provider */
         $provider = null,
+        /** @var (callable(): mixed)|string|null $processor */
         $processor = null,
         array $extraProperties = [],
-
+        ?OptionsInterface $stateOptions = null,
         protected ?bool $nested = null,
     ) {
         parent::__construct(...\func_get_args());

--- a/src/Metadata/GraphQl/QueryCollection.php
+++ b/src/Metadata/GraphQl/QueryCollection.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\GraphQl;
 
 use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class QueryCollection extends Query implements CollectionOperationInterface
@@ -71,6 +72,7 @@ final class QueryCollection extends Query implements CollectionOperationInterfac
         $provider = null,
         $processor = null,
         array $extraProperties = [],
+        protected ?OptionsInterface $stateOptions = null,
 
         protected ?bool $nested = null,
     ) {

--- a/src/Metadata/GraphQl/Subscription.php
+++ b/src/Metadata/GraphQl/Subscription.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\GraphQl;
 
+use ApiPlatform\State\OptionsInterface;
+
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Subscription extends Operation
 {
@@ -68,7 +70,8 @@ final class Subscription extends Operation
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        protected ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(...\func_get_args());
         $this->name = $name ?: 'update_subscription';

--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 class HttpOperation extends Operation
 {
@@ -146,7 +147,8 @@ class HttpOperation extends Operation
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        ?OptionsInterface $stateOptions = null,
     ) {
         $this->shortName = $shortName;
         $this->description = $description;
@@ -192,6 +194,7 @@ class HttpOperation extends Operation
         $this->provider = $provider;
         $this->processor = $processor;
         $this->extraProperties = $extraProperties;
+        $this->stateOptions = $stateOptions;
     }
 
     public function getMethod(): ?string

--- a/src/Metadata/NotExposed.php
+++ b/src/Metadata/NotExposed.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 /**
  * A NotExposed operation is an operation declared for internal usage,
@@ -101,7 +102,8 @@ final class NotExposed extends HttpOperation
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(...\func_get_args());
 

--- a/src/Metadata/Operation.php
+++ b/src/Metadata/Operation.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\State\OptionsInterface;
+
 abstract class Operation
 {
     use WithResourceTrait;
@@ -90,7 +92,8 @@ abstract class Operation
         protected ?string $name = null,
         $provider = null,
         $processor = null,
-        protected array $extraProperties = []
+        protected array $extraProperties = [],
+        protected ?OptionsInterface $stateOptions = null,
     ) {
         $this->input = $input;
         $this->output = $output;
@@ -687,6 +690,19 @@ abstract class Operation
     {
         $self = clone $this;
         $self->extraProperties = $extraProperties;
+
+        return $self;
+    }
+
+    public function getStateOptions(): ?OptionsInterface
+    {
+        return $this->stateOptions;
+    }
+
+    public function withStateOptions(?OptionsInterface $stateOptions): self
+    {
+        $self = clone $this;
+        $self->stateOptions = $stateOptions;
 
         return $self;
     }

--- a/src/Metadata/Patch.php
+++ b/src/Metadata/Patch.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Patch extends HttpOperation
@@ -94,7 +95,8 @@ final class Patch extends HttpOperation
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(self::METHOD_PATCH, ...\func_get_args());
     }

--- a/src/Metadata/Post.php
+++ b/src/Metadata/Post.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Post extends HttpOperation
@@ -97,7 +98,8 @@ final class Post extends HttpOperation
         $provider = null,
         $processor = null,
         array $extraProperties = [],
-        ?string $itemUriTemplate = null
+        ?string $itemUriTemplate = null,
+        ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(self::METHOD_POST, ...\func_get_args());
         $this->itemUriTemplate = $itemUriTemplate;

--- a/src/Metadata/Put.php
+++ b/src/Metadata/Put.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\State\OptionsInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Put extends HttpOperation
@@ -94,7 +95,8 @@ final class Put extends HttpOperation
         ?string $name = null,
         $provider = null,
         $processor = null,
-        array $extraProperties = []
+        array $extraProperties = [],
+        ?OptionsInterface $stateOptions = null,
     ) {
         parent::__construct(self::METHOD_PUT, ...\func_get_args());
     }

--- a/src/State/OptionsInterface.php
+++ b/src/State/OptionsInterface.php
@@ -11,9 +11,8 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Metadata\GraphQl;
+namespace ApiPlatform\State;
 
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-class Mutation extends Operation
+interface OptionsInterface
 {
 }

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Symfony\Bundle\DependencyInjection;
 
 use ApiPlatform\Doctrine\Common\Filter\OrderFilterInterface;
 use ApiPlatform\Elasticsearch\Metadata\Document\DocumentMetadata;
+use ApiPlatform\Elasticsearch\State\Options;
 use ApiPlatform\Exception\FilterValidationException;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\ApiResource;
@@ -422,6 +423,7 @@ final class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->arrayNode('mapping')
+                            ->setDeprecated('api-platform/core', '3.1', sprintf('The "%%node%%" option is deprecated. Configure an %s as $stateOptions.', Options::class))
                             ->normalizeKeys(false)
                             ->useAttributeAsKey('resource_class')
                             ->prototype('array')

--- a/src/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -102,28 +102,32 @@
         </service>
         <service id="ApiPlatform\Elasticsearch\Filter\OrderFilter" alias="api_platform.elasticsearch.order_filter" />
 
-        <service id="ApiPlatform\Elasticsearch\State\ItemProvider" class="ApiPlatform\Elasticsearch\State\ItemProvider" public="false">
+        <service id="api_platform.elasticsearch.state.item_provider" class="ApiPlatform\Elasticsearch\State\ItemProvider" public="false">
             <argument type="service" id="api_platform.elasticsearch.client" />
             <argument type="service" id="api_platform.elasticsearch.metadata.document.metadata_factory" />
             <argument type="service" id="serializer" />
 
+            <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Elasticsearch\State\ItemProvider"/>
             <tag name="api_platform.state_provider" priority="-100" />
         </service>
-        <service id="api_platform.state.item_provider" alias="ApiPlatform\Elasticsearch\State\ItemProvider" />
+        <service id="ApiPlatform\Elasticsearch\State\ItemProvider" alias="api_platform.elasticsearch.state.item_provider"/>
 
-        <service id="ApiPlatform\Elasticsearch\State\CollectionProvider" class="ApiPlatform\Elasticsearch\State\CollectionProvider" public="false">
+        <service id="api_platform.elasticsearch.state.collection_provider" class="ApiPlatform\Elasticsearch\State\CollectionProvider" public="false">
             <argument type="service" id="api_platform.elasticsearch.client" />
             <argument type="service" id="api_platform.elasticsearch.metadata.document.metadata_factory" />
             <argument type="service" id="serializer" />
             <argument type="service" id="api_platform.pagination" />
             <argument type="tagged" tag="api_platform.elasticsearch.request_body_search_extension.collection" />
 
+            <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Elasticsearch\State\CollectionProvider"/>
             <tag name="api_platform.state_provider" priority="-100" />
         </service>
+        <service id="ApiPlatform\Elasticsearch\State\CollectionProvider" alias="api_platform.elasticsearch.state.collection_provider"/>
 
         <service id="api_platform.elasticsearch.metadata.resource.metadata_collection_factory" class="ApiPlatform\Elasticsearch\Metadata\Resource\Factory\ElasticsearchProviderResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="40">
             <argument type="service" id="api_platform.elasticsearch.client" />
             <argument type="service" id="api_platform.elasticsearch.metadata.resource.metadata_collection_factory.inner" />
+            <argument>false</argument>
         </service>
 
     </services>

--- a/tests/Behat/ElasticsearchContext.php
+++ b/tests/Behat/ElasticsearchContext.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Behat;
 
-use ApiPlatform\Elasticsearch\Metadata\Document\DocumentMetadata;
 use Behat\Behat\Context\Context;
 use Elasticsearch\Client;
 use Symfony\Component\Finder\Finder;
@@ -114,9 +113,9 @@ final class ElasticsearchContext implements Context
 
             foreach (json_decode($file->getContents(), true, 512, \JSON_THROW_ON_ERROR) as $document) {
                 if (null === ($document['id'] ?? null)) {
-                    $bulk[] = ['index' => ['_index' => $index, '_type' => DocumentMetadata::DEFAULT_TYPE]];
+                    $bulk[] = ['index' => ['_index' => $index, '_type' => '_doc']];
                 } else {
-                    $bulk[] = ['create' => ['_index' => $index, '_type' => DocumentMetadata::DEFAULT_TYPE, '_id' => (string) $document['id']]];
+                    $bulk[] = ['create' => ['_index' => $index, '_type' => '_doc', '_id' => (string) $document['id']]];
                 }
 
                 $bulk[] = $document;

--- a/tests/Elasticsearch/State/CollectionProviderTest.php
+++ b/tests/Elasticsearch/State/CollectionProviderTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Elasticsearch\State;
 
 use ApiPlatform\Elasticsearch\Extension\RequestBodySearchCollectionExtensionInterface;
-use ApiPlatform\Elasticsearch\Metadata\Document\DocumentMetadata;
 use ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
 use ApiPlatform\Elasticsearch\Paginator;
 use ApiPlatform\Elasticsearch\State\CollectionProvider;
@@ -57,7 +56,6 @@ final class CollectionProviderTest extends TestCase
         ];
 
         $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);
-        $documentMetadataFactoryProphecy->create(Foo::class)->willReturn(new DocumentMetadata('foo'))->shouldBeCalled();
 
         $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $resourceMetadataCollectionFactoryProphecy->create(Foo::class)->willReturn(new ResourceMetadataCollection(Foo::class));
@@ -121,7 +119,7 @@ final class CollectionProviderTest extends TestCase
             ->willReturn($documents)
             ->shouldBeCalled();
 
-        $operation = (new Get())->withName('get')->withClass(Foo::class);
+        $operation = (new Get())->withName('get')->withClass(Foo::class)->withShortName('foo');
 
         $requestBodySearchCollectionExtensionProphecy = $this->prophesize(RequestBodySearchCollectionExtensionInterface::class);
         $requestBodySearchCollectionExtensionProphecy->applyToCollection([], Foo::class, $operation, $context)->willReturn([])->shouldBeCalled();

--- a/tests/Elasticsearch/State/ItemProviderTest.php
+++ b/tests/Elasticsearch/State/ItemProviderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Elasticsearch\State;
 
-use ApiPlatform\Elasticsearch\Metadata\Document\DocumentMetadata;
 use ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
 use ApiPlatform\Elasticsearch\Serializer\DocumentNormalizer;
 use ApiPlatform\Elasticsearch\State\ItemProvider;
@@ -48,7 +47,6 @@ final class ItemProviderTest extends TestCase
     public function testGetItem(): void
     {
         $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);
-        $documentMetadataFactoryProphecy->create(Foo::class)->willReturn(new DocumentMetadata('foo'))->shouldBeCalled();
 
         $document = [
             '_index' => 'foo',
@@ -74,13 +72,12 @@ final class ItemProviderTest extends TestCase
 
         $itemDataProvider = new ItemProvider($clientProphecy->reveal(), $documentMetadataFactoryProphecy->reveal(), $denormalizerProphecy->reveal());
 
-        self::assertSame($foo, $itemDataProvider->provide((new Get())->withClass(Foo::class), ['id' => 1]));
+        self::assertSame($foo, $itemDataProvider->provide((new Get())->withClass(Foo::class)->withShortName('foo'), ['id' => 1]));
     }
 
     public function testGetInexistantItem(): void
     {
         $documentMetadataFactoryProphecy = $this->prophesize(DocumentMetadataFactoryInterface::class);
-        $documentMetadataFactoryProphecy->create(Foo::class)->willReturn(new DocumentMetadata('foo'))->shouldBeCalled();
 
         $clientProphecy = $this->prophesize(Client::class);
         $clientProphecy->get(['client' => ['ignore' => 404], 'index' => 'foo', 'id' => '404'])->willReturn([
@@ -92,6 +89,6 @@ final class ItemProviderTest extends TestCase
 
         $itemDataProvider = new ItemProvider($clientProphecy->reveal(), $documentMetadataFactoryProphecy->reveal(), $this->prophesize(DenormalizerInterface::class)->reveal());
 
-        self::assertNull($itemDataProvider->provide((new Get())->withClass(Foo::class), ['id' => 404]));
+        self::assertNull($itemDataProvider->provide((new Get())->withClass(Foo::class)->withShortName('foo'), ['id' => 404]));
     }
 }

--- a/tests/Fixtures/Elasticsearch/Fixtures/book.json
+++ b/tests/Fixtures/Elasticsearch/Fixtures/book.json
@@ -1,0 +1,254 @@
+[
+  {
+    "id": "f36a0026-0635-4865-86a6-5adb21d94d64",
+    "library": {
+      "id": "116b83f8-6c32-48d8-8e28-c5c247532d3f",
+      "gender": "male",
+      "age": 31,
+      "firstName": "Kilian",
+      "lastName": "Jornet"
+    },
+    "date": "2017-01-01 01:01:01",
+    "message": "The north summit, Store Vengetind Thanks for t... These Top 10 Women of a fk... Francois is the field which."
+  },
+  {
+    "id": "89601e1c-3ef2-4ef7-bca2-7511d38611c6",
+    "library": {
+      "id": "116b83f8-6c32-48d8-8e28-c5c247532d3f",
+      "gender": "male",
+      "age": 31,
+      "firstName": "Kilian",
+      "lastName": "Jornet"
+    },
+    "date": "2017-02-02 02:02:02",
+    "message": "Great day in any endur... During the Himalayas were very talented skimo racer junior podiums, top 10."
+  },
+  {
+    "id": "9da70727-d656-42d9-876a-1be6321f171b",
+    "library": {
+      "id": "116b83f8-6c32-48d8-8e28-c5c247532d3f",
+      "gender": "male",
+      "age": 31,
+      "firstName": "Kilian",
+      "lastName": "Jornet"
+    },
+    "date": "2017-03-03 03:03:03",
+    "message": "During the path and his Summits Of My Life project. Next Wednesday, Kilian Jornet..."
+  },
+  {
+    "id": "5bc245d7-df50-4e2d-b26b-823e73372183",
+    "library": {
+      "id": "8a8c5855-83fb-48a8-8fc9-f5c59151b2cd",
+      "gender": "male",
+      "age": 32,
+      "firstName": "Francois",
+      "lastName": "D'Haene"
+    },
+    "date": "2017-04-04 04:04:04",
+    "message": "Quand on pourra laisser les ca... Plus que les jaime le => plus entre copains en parle depuis un sejour?"
+  },
+  {
+    "id": "f2e65123-e063-44a0-b640-b0a04554d19e",
+    "library": {
+      "id": "8a8c5855-83fb-48a8-8fc9-f5c59151b2cd",
+      "gender": "male",
+      "age": 32,
+      "firstName": "Francois",
+      "lastName": "D'Haene"
+    },
+    "date": "2017-05-05 05:05:05",
+    "message": "Vous avez passe pour les nuages aujourdhui mais surtout diffe... Cetait sûrement le poids limite va pas!"
+  },
+  {
+    "id": "86c41446-31d6-48a4-96e7-73e84ea283d3",
+    "library": {
+      "id": "f18eb7ab-6985-4e05-afd4-13a638c929d4",
+      "gender": "male",
+      "age": 30,
+      "firstName": "Xavier",
+      "lastName": "Thevenard"
+    },
+    "date": "2017-06-06 06:06:06",
+    "message": "L'entrainement sur les skis a commence depuis longtemps. Les apres-midi biathlon c'est le top!"
+  },
+  {
+    "id": "ce73f15a-8c96-46fe-8999-392460feb61b",
+    "library": {
+      "id": "c81d5151-0d28-4b06-baeb-150bd2b2bbf8",
+      "gender": "male",
+      "age": 35,
+      "firstName": "Anton",
+      "lastName": "Krupicka"
+    },
+    "date": "2017-07-07 07:07:07",
+    "message": "I want to officially join Punks & Poets crew with the wildly distorted death fuzz of Mt. Saint Vrain?"
+  },
+  {
+    "id": "0acfd90d-5bfe-4e42-b708-dc38bf20677c",
+    "library": {
+      "id": "c81d5151-0d28-4b06-baeb-150bd2b2bbf8",
+      "gender": "male",
+      "age": 35,
+      "firstName": "Anton",
+      "lastName": "Krupicka"
+    },
+    "date": "2017-08-08 08:08:08",
+    "message": "Whoever curates the Marathon yesterday. Truly inspiring stuff. The new is straight. Such a couple!"
+  },
+  {
+    "id": "0cfe3d33-6116-416b-8c50-3b8319331998",
+    "library": {
+      "id": "15fce6f1-18fd-4ef6-acab-7e6a3333ec7f",
+      "gender": "male",
+      "age": 28,
+      "firstName": "Jim",
+      "lastName": "Walmsley"
+    },
+    "date": "2017-09-09 09:09:09",
+    "message": "Thanks! Fun day with Next up one of our 2018 cover: One look into what races we'll be running that they!"
+  },
+  {
+    "id": "1c9e0545-1b37-4a9a-83e0-30400d0b354e",
+    "library": {
+      "id": "fbf60054-004f-4d21-a178-cb364d1ef875",
+      "gender": "male",
+      "age": 30,
+      "firstName": "Zach",
+      "lastName": "Miller"
+    },
+    "date": "2017-10-10 10:10:10",
+    "message": "Way to go for me I think it was great holiday season yourself!! I'm still working on the awesome as I."
+  },
+  {
+    "id": "811e4d1c-df3f-4d24-a9da-2a28080c85f5",
+    "library": {
+      "id": "fbf60054-004f-4d21-a178-cb364d1ef875",
+      "gender": "male",
+      "age": 30,
+      "firstName": "Zach",
+      "lastName": "Miller"
+    },
+    "date": "2017-11-11 11:11:11",
+    "message": "DES!!!!!!! For that in LA airport skills: chugging water, one-handed bathroom maneuvers, and the!"
+  },
+  {
+    "id": "7cdadcda-3fb5-4312-9e32-72acba323cc0",
+    "library": {
+      "id": "fbf60054-004f-4d21-a178-cb364d1ef875",
+      "gender": "male",
+      "age": 30,
+      "firstName": "Zach",
+      "lastName": "Miller"
+    },
+    "date": "2017-12-12 12:12:12",
+    "message": "Thanks! Thanks Senseman! Good luck at again! Open air sleeps! 669 now. Message me. You bet Kyle! PT: Try."
+  },
+  {
+    "id": "6d82a76c-8ba2-4e78-9ab3-6a456e4470c3",
+    "library": {
+      "id": "fa7d4578-6692-47ec-9346-a8ab25ca613c",
+      "gender": "female",
+      "age": 42,
+      "firstName": "Caroline",
+      "lastName": "Chaverot"
+    },
+    "date": "2018-01-01 13:13:13",
+    "message": "Prior to not run in paradise ! I should have listened to ! What a little more of hesitation, I?"
+  },
+  {
+    "id": "f91bca21-b5f8-405b-9b08-d5a5dc476a92",
+    "library": {
+      "id": "fa7d4578-6692-47ec-9346-a8ab25ca613c",
+      "gender": "female",
+      "age": 42,
+      "firstName": "Caroline",
+      "lastName": "Chaverot"
+    },
+    "date": "2018-02-02 14:14:14",
+    "message": "Good job girls ! Chacun de publier un outil innovant repertoriant des prochains championnats du!"
+  },
+  {
+    "id": "dcaef1db-225d-442b-960e-5de6984a44be",
+    "library": {
+      "id": "89d4ae3d-73bc-4382-b01c-adf038f893c2",
+      "gender": "female",
+      "age": 42,
+      "firstName": "Nuria",
+      "lastName": "Picas"
+    },
+    "date": "2018-03-03 15:15:15",
+    "message": "Avui fa que este año no iba a la izquierda... I have never felt so proud of Catalonia as on 1OCT. Perque?"
+  },
+  {
+    "id": "be28696d-9b28-488a-81f4-a4a7bc3beb65",
+    "library": {
+      "id": "89d4ae3d-73bc-4382-b01c-adf038f893c2",
+      "gender": "female",
+      "age": 42,
+      "firstName": "Nuria",
+      "lastName": "Picas"
+    },
+    "date": "2018-04-04 16:16:16",
+    "message": "Lactitud, la teva una cita, esteu tots i una camara com aquesta? Atents al proper sopar tertulia amb els?"
+  },
+  {
+    "id": "6947ce52-c85d-4786-a587-3966a936842b",
+    "library": {
+      "id": "cf875c95-41ab-48df-af66-38c74db18f72",
+      "gender": "female",
+      "age": 32,
+      "firstName": "Emelie",
+      "lastName": "Forsberg"
+    },
+    "date": "2018-05-05 17:17:17",
+    "message": "These time here! Ah such a thousand words then video Lets tune in! Join and enjoying winter baby! Just?"
+  },
+  {
+    "id": "d389bf11-9e90-4f02-bdb6-3591983b5830",
+    "library": {
+      "id": "cf875c95-41ab-48df-af66-38c74db18f72",
+      "gender": "female",
+      "age": 32,
+      "firstName": "Emelie",
+      "lastName": "Forsberg"
+    },
+    "date": "2018-06-06 18:18:18",
+    "message": "This was chose... Tomorrow! Lets tune in! Skilde inte mycket till segern. Hursomhelst starkt lopp av Emelie."
+  },
+  {
+    "id": "9de3308c-6f82-4a57-a33c-4e3cd5d5a3f6",
+    "library": {
+      "id": "6a457188-d1ba-45e3-8509-81e5c66a5297",
+      "gender": "female",
+      "age": 37,
+      "firstName": "Anna",
+      "lastName": "Frost"
+    },
+    "date": "2018-07-07 19:19:19",
+    "message": "In case you do! A humble beginning to traverse... Im so now until you can't tell how strong she run at!"
+  },
+  {
+    "id": "9de3308c-6f82-4a57-a33c-4e3cd5d5a3f6",
+    "library": {
+      "id": "6a457188-d1ba-45e3-8509-81e5c66a5297",
+      "gender": "female",
+      "age": 37,
+      "firstName": "Anna",
+      "lastName": "Frost"
+    },
+    "date": "2018-08-08 20:20:20",
+    "message": "Way to go to see friends out to crush it but one of since I was a speed record... The race of FREE trip for."
+  },
+  {
+    "id": "3a1d02fa-2347-41ff-80ef-ed9b9c0efea9",
+    "library": {
+      "id": "ff0e82ee-e8c9-40ec-82f3-122ef148d533",
+      "gender": "female",
+      "age": 29,
+      "firstName": "Ruth",
+      "lastName": "Croft"
+    },
+    "date": "2018-09-09 21:21:21",
+    "message": "An elcheapo alternative to Arrowtown with and you get the Routeburn debut & some of many lineups with."
+  }
+]

--- a/tests/Fixtures/Elasticsearch/Fixtures/library.json
+++ b/tests/Fixtures/Elasticsearch/Fixtures/library.json
@@ -1,0 +1,226 @@
+[
+  {
+    "id": "116b83f8-6c32-48d8-8e28-c5c247532d3f",
+    "gender": "male",
+    "age": 31,
+    "firstName": "Kilian",
+    "lastName": "Jornet",
+    "registeredAt": "2009-09-01",
+    "books": [
+      {
+        "id": "f36a0026-0635-4865-86a6-5adb21d94d64",
+        "date": "2017-01-01 01:01:01",
+        "message": "The north summit, Store Vengetind Thanks for t... These Top 10 Women of a fk... Francois is the field which."
+      },
+      {
+        "id": "89601e1c-3ef2-4ef7-bca2-7511d38611c6",
+        "date": "2017-02-02 02:02:02",
+        "message": "Great day in any endur... During the Himalayas were very talented skimo racer junior podiums, top 10."
+      },
+      {
+        "id": "9da70727-d656-42d9-876a-1be6321f171b",
+        "date": "2017-03-03 03:03:03",
+        "message": "During the path and his Summits Of My Life project. Next Wednesday, Kilian Jornet..."
+      }
+    ]
+  },
+  {
+    "id": "8a8c5855-83fb-48a8-8fc9-f5c59151b2cd",
+    "gender": "male",
+    "age": 32,
+    "firstName": "Francois",
+    "lastName": "D'Haene",
+    "registeredAt": "2014-08-01",
+    "books": [
+      {
+        "id": "5bc245d7-df50-4e2d-b26b-823e73372183",
+        "date": "2017-04-04 04:04:04",
+        "message": "Quand on pourra laisser les ca... Plus que les jaime le => plus entre copains en parle depuis un sejour?"
+      },
+      {
+        "id": "f2e65123-e063-44a0-b640-b0a04554d19e",
+        "date": "2017-05-05 05:05:05",
+        "message": "Vous avez passe pour les nuages aujourdhui mais surtout diffe... Cetait sûrement le poids limite va pas!"
+      }
+    ]
+  },
+  {
+    "id": "f18eb7ab-6985-4e05-afd4-13a638c929d4",
+    "gender": "male",
+    "age": 30,
+    "firstName": "Xavier",
+    "lastName": "Thevenard",
+    "registeredAt": "2013-09-02",
+    "books": [
+      {
+        "id": "86c41446-31d6-48a4-96e7-73e84ea283d3",
+        "date": "2017-06-06 06:06:06",
+        "message": "L'entrainement sur les skis a commence depuis longtemps. Les apres-midi biathlon c'est le top!"
+      }
+    ]
+  },
+  {
+    "id": "c81d5151-0d28-4b06-baeb-150bd2b2bbf8",
+    "gender": "male",
+    "age": 35,
+    "firstName": "Anton",
+    "lastName": "Krupicka",
+    "registeredAt": "2014-07-01",
+    "books": [
+      {
+        "id": "ce73f15a-8c96-46fe-8999-392460feb61b",
+        "date": "2017-07-07 07:07:07",
+        "message": "I want to officially join Punks & Poets crew with the wildly distorted death fuzz of Mt. Saint Vrain?"
+      },
+      {
+        "id": "0acfd90d-5bfe-4e42-b708-dc38bf20677c",
+        "date": "2017-08-08 08:08:08",
+        "message": "Whoever curates the Marathon yesterday. Truly inspiring stuff. The new is straight. Such a couple!"
+      }
+    ]
+  },
+  {
+    "id": "15fce6f1-18fd-4ef6-acab-7e6a3333ec7f",
+    "gender": "male",
+    "age": 28,
+    "firstName": "Jim",
+    "lastName": "Walmsley",
+    "registeredAt": "2011-07-01",
+    "books": [
+      {
+        "id": "0cfe3d33-6116-416b-8c50-3b8319331998",
+        "date": "2017-09-09 09:09:09",
+        "message": "Thanks! Fun day with Next up one of our 2018 cover: One look into what races we'll be running that they!"
+      }
+    ]
+  },
+  {
+    "id": "fbf60054-004f-4d21-a178-cb364d1ef875",
+    "gender": "male",
+    "age": 30,
+    "firstName": "Zach",
+    "lastName": "Miller",
+    "registeredAt": "2017-03-01",
+    "books": [
+      {
+        "id": "1c9e0545-1b37-4a9a-83e0-30400d0b354e",
+        "date": "2017-10-10 10:10:10",
+        "message": "Way to go for me I think it was great holiday season yourself!! I'm still working on the awesome as I."
+      },
+      {
+        "id": "811e4d1c-df3f-4d24-a9da-2a28080c85f5",
+        "date": "2017-11-11 11:11:11",
+        "message": "DES!!!!!!! For that in LA airport skills: chugging water, one-handed bathroom maneuvers, and the!"
+      },
+      {
+        "id": "7cdadcda-3fb5-4312-9e32-72acba323cc0",
+        "date": "2017-12-12 12:12:12",
+        "message": "Thanks! Thanks Senseman! Good luck at again! Open air sleeps! 669 now. Message me. You bet Kyle! PT: Try."
+      }
+    ]
+  },
+  {
+    "id": "fa7d4578-6692-47ec-9346-a8ab25ca613c",
+    "gender": "female",
+    "age": 42,
+    "firstName": "Caroline",
+    "lastName": "Chaverot",
+    "registeredAt": "2013-11-01",
+    "books": [
+      {
+        "id": "6d82a76c-8ba2-4e78-9ab3-6a456e4470c3",
+        "date": "2018-01-01 13:13:13",
+        "message": "Prior to not run in paradise ! I should have listened to ! What a little more of hesitation, I?"
+      },
+      {
+        "id": "f91bca21-b5f8-405b-9b08-d5a5dc476a92",
+        "date": "2018-02-02 14:14:14",
+        "message": "Good job girls ! Chacun de publier un outil innovant repertoriant des prochains championnats du!"
+      }
+    ]
+  },
+  {
+    "id": "89d4ae3d-73bc-4382-b01c-adf038f893c2",
+    "gender": "female",
+    "age": 42,
+    "firstName": "Nuria",
+    "lastName": "Picas",
+    "registeredAt": "2012-12-01",
+    "books": [
+      {
+        "id": "dcaef1db-225d-442b-960e-5de6984a44be",
+        "date": "2018-03-03 15:15:15",
+        "message": "Avui fa que este año no iba a la izquierda... I have never felt so proud of Catalonia as on 1OCT. Perque?"
+      },
+      {
+        "id": "be28696d-9b28-488a-81f4-a4a7bc3beb65",
+        "date": "2018-04-04 16:16:16",
+        "message": "Lactitud, la teva una cita, esteu tots i una camara com aquesta? Atents al proper sopar tertulia amb els?"
+      }
+    ]
+  },
+  {
+    "id": "cf875c95-41ab-48df-af66-38c74db18f72",
+    "gender": "female",
+    "age": 32,
+    "firstName": "Emelie",
+    "lastName": "Forsberg",
+    "registeredAt": "2012-07-01",
+    "books": [
+      {
+        "id": "6947ce52-c85d-4786-a587-3966a936842b",
+        "date": "2018-05-05 17:17:17",
+        "message": "These time here! Ah such a thousand words then video Lets tune in! Join and enjoying winter baby! Just?"
+      },
+      {
+        "id": "d389bf11-9e90-4f02-bdb6-3591983b5830",
+        "date": "2018-06-06 18:18:18",
+        "message": "This was chose... Tomorrow! Lets tune in! Skilde inte mycket till segern. Hursomhelst starkt lopp av Emelie."
+      }
+    ]
+  },
+  {
+    "id": "6a457188-d1ba-45e3-8509-81e5c66a5297",
+    "gender": "female",
+    "age": 37,
+    "firstName": "Anna",
+    "lastName": "Frost",
+    "registeredAt": "2010-07-01",
+    "books": [
+      {
+        "id": "9de3308c-6f82-4a57-a33c-4e3cd5d5a3f6",
+        "date": "2018-07-07 19:19:19",
+        "message": "In case you do! A humble beginning to traverse... Im so now until you can't tell how strong she run at!"
+      },
+      {
+        "id": "00cb98fa-b840-4ac5-bad5-9416885c117f",
+        "date": "2018-08-08 20:20:20",
+        "message": "Way to go to see friends out to crush it but one of since I was a speed record... The race of FREE trip for."
+      }
+    ]
+  },
+  {
+    "id": "df315796-aee2-437c-bb16-9f9de538e5ee",
+    "gender": "female",
+    "age": 34,
+    "firstName": "Rory",
+    "lastName": "Bosio",
+    "registeredAt": "2013-09-05",
+    "books": []
+  },
+  {
+    "id": "ff0e82ee-e8c9-40ec-82f3-122ef148d533",
+    "gender": "female",
+    "age": 29,
+    "firstName": "Ruth",
+    "lastName": "Croft",
+    "registeredAt": "2015-02-01",
+    "books": [
+      {
+        "id": "3a1d02fa-2347-41ff-80ef-ed9b9c0efea9",
+        "date": "2018-08-08 21:21:21",
+        "message": "An elcheapo alternative to Arrowtown with and you get the Routeburn debut & some of many lineups with."
+      }
+    ]
+  }
+]

--- a/tests/Fixtures/Elasticsearch/Mappings/book.json
+++ b/tests/Fixtures/Elasticsearch/Mappings/book.json
@@ -1,0 +1,37 @@
+{
+  "mappings": {
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "library": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "gender": {
+            "type": "keyword"
+          },
+          "age": {
+            "type": "integer"
+          },
+          "firstName": {
+            "type": "text"
+          },
+          "lastName": {
+            "type": "text"
+          }
+        },
+        "dynamic": "strict"
+      },
+      "date": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
+      },
+      "message": {
+        "type": "text"
+      }
+    },
+    "dynamic": "strict"
+  }
+}

--- a/tests/Fixtures/Elasticsearch/Mappings/library.json
+++ b/tests/Fixtures/Elasticsearch/Mappings/library.json
@@ -1,0 +1,42 @@
+{
+  "mappings": {
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "gender": {
+        "type": "keyword"
+      },
+      "age": {
+        "type": "integer"
+      },
+      "firstName": {
+        "type": "text"
+      },
+      "lastName": {
+        "type": "text"
+      },
+      "registeredAt": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "books": {
+        "type": "nested",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "date": {
+            "type": "date",
+            "format": "yyyy-MM-dd HH:mm:ss"
+          },
+          "message": {
+            "type": "text"
+          }
+        },
+        "dynamic": "strict"
+      }
+    },
+    "dynamic": "strict"
+  }
+}

--- a/tests/Fixtures/Elasticsearch/Model/Book.php
+++ b/tests/Fixtures/Elasticsearch/Model/Book.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\Elasticsearch\Model;
+
+use ApiPlatform\Elasticsearch\Filter\MatchFilter;
+use ApiPlatform\Elasticsearch\Filter\OrderFilter;
+use ApiPlatform\Elasticsearch\State\CollectionProvider;
+use ApiPlatform\Elasticsearch\State\ItemProvider;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(operations: [new Get(provider: ItemProvider::class), new GetCollection(provider: CollectionProvider::class)], normalizationContext: ['groups' => ['book:read']])]
+#[ApiFilter(OrderFilter::class, properties: ['id', 'library.id'])]
+#[ApiFilter(MatchFilter::class, properties: ['message', 'library.firstName'])]
+class Book
+{
+    #[Groups(['book:read', 'library:read'])]
+    #[ApiProperty(identifier: true)]
+    public ?string $id = null;
+
+    #[Groups(['book:read'])]
+    public ?Library $library = null;
+
+    #[Groups(['book:read', 'library:read'])]
+    public ?\DateTimeImmutable $date = null;
+
+    #[Groups(['book:read', 'library:read'])]
+    public ?string $message = null;
+}

--- a/tests/Fixtures/Elasticsearch/Model/Library.php
+++ b/tests/Fixtures/Elasticsearch/Model/Library.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\Elasticsearch\Model;
+
+use ApiPlatform\Elasticsearch\Filter\TermFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(normalizationContext: ['groups' => ['library:read']])]
+#[ApiFilter(TermFilter::class, properties: ['id', 'gender', 'age', 'firstName', 'books.id', 'books.date'])]
+class Library
+{
+    #[ApiProperty(identifier: true)]
+    #[Groups(['book:read', 'library:read'])]
+    public ?string $id = null;
+
+    #[Groups(['book:read', 'library:read'])]
+    public ?string $gender = null;
+
+    #[Groups(['book:read', 'library:read'])]
+    public ?int $age = null;
+
+    #[Groups(['book:read', 'library:read'])]
+    public ?string $firstName = null;
+
+    #[Groups(['book:read', 'library:read'])]
+    public ?string $lastName = null;
+
+    #[Groups(['library:read'])]
+    public ?\DateTimeInterface $registeredAt = null;
+
+    /** @var Book[] */
+    #[Groups(['library:read'])]
+    public array $books = [];
+}

--- a/tests/Metadata/Extractor/Adapter/XmlResourceAdapter.php
+++ b/tests/Metadata/Extractor/Adapter/XmlResourceAdapter.php
@@ -62,6 +62,7 @@ final class XmlResourceAdapter implements ResourceAdapterInterface
         'securityPostValidation',
         'securityPostValidationMessage',
         'queryParameterValidationEnabled',
+        'stateOptions',
     ];
 
     /**
@@ -466,6 +467,14 @@ XML_WRAP
         foreach ($values as $key => $value) {
             $node->addChild('format', $value)->addAttribute('name', $key);
         }
+    }
+
+    private function buildStateOptions(\SimpleXMLElement $resource, array $values): void
+    {
+        $node = $resource->addChild('stateOptions');
+        $childNode = $node->addChild(array_key_first($values));
+        $childNode->addAttribute('index', $values[array_key_first($values)]['index']);
+        $childNode->addAttribute('type', $values[array_key_first($values)]['type']);
     }
 
     private function buildValues(\SimpleXMLElement $resource, array $values): void

--- a/tests/Metadata/Extractor/ResourceMetadataCompatibilityTest.php
+++ b/tests/Metadata/Extractor/ResourceMetadataCompatibilityTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Metadata\Extractor;
 
+use ApiPlatform\Elasticsearch\State\Options;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Extractor\XmlResourceExtractor;
@@ -35,6 +36,7 @@ use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\OpenApi\Model\ExternalDocumentation;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\OpenApi\Model\RequestBody;
+use ApiPlatform\State\OptionsInterface;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Comment;
 use ApiPlatform\Tests\Metadata\Extractor\Adapter\ResourceAdapterInterface;
 use ApiPlatform\Tests\Metadata\Extractor\Adapter\XmlResourceAdapter;
@@ -165,6 +167,12 @@ final class ResourceMetadataCompatibilityTest extends TestCase
                 ],
             ],
             'mercure' => true,
+            'stateOptions' => [
+                'elasticsearchOptions' => [
+                    'index' => 'foo_index',
+                    'type' => 'foo_type',
+                ],
+            ],
             'graphQlOperations' => [
                 'mutations' => [
                     [
@@ -445,6 +453,7 @@ final class ResourceMetadataCompatibilityTest extends TestCase
         'openapiContext',
         'openapi',
         'paginationViaCursor',
+        'stateOptions',
     ];
 
     /**
@@ -653,5 +662,24 @@ final class ResourceMetadataCompatibilityTest extends TestCase
         }
 
         return $operations;
+    }
+
+    private function withStateOptions(array $values): ?OptionsInterface
+    {
+        if (!$values) {
+            return null;
+        }
+
+        if (1 !== \count($values)) {
+            throw new \InvalidArgumentException('Only one options can be configured at a time.');
+        }
+
+        $configuration = reset($values);
+        switch (key($values)) {
+            case 'elasticsearchOptions':
+                return new Options($configuration['index'] ?? null, $configuration['type'] ?? null);
+        }
+
+        throw new \LogicException(sprintf('Unsupported "%s" state options.', key($values)));
     }
 }

--- a/tests/Metadata/Extractor/XmlExtractorTest.php
+++ b/tests/Metadata/Extractor/XmlExtractorTest.php
@@ -98,6 +98,7 @@ class XmlExtractorTest extends TestCase
                     'provider' => null,
                     'read' => null,
                     'write' => null,
+                    'stateOptions' => null,
                 ],
                 [
                     'uriTemplate' => '/users/{author}/comments{._format}',
@@ -266,6 +267,7 @@ class XmlExtractorTest extends TestCase
                             'processor' => null,
                             'provider' => null,
                             'itemUriTemplate' => null,
+                            'stateOptions' => null,
                         ],
                         [
                             'name' => null,
@@ -362,6 +364,7 @@ class XmlExtractorTest extends TestCase
                             'priority' => null,
                             'processor' => null,
                             'provider' => null,
+                            'stateOptions' => null,
                         ],
                     ],
                     'graphQlOperations' => null,
@@ -370,6 +373,7 @@ class XmlExtractorTest extends TestCase
                     'provider' => null,
                     'read' => null,
                     'write' => null,
+                    'stateOptions' => null,
                 ],
             ],
         ], $extractor->getResources());

--- a/tests/Metadata/Extractor/YamlExtractorTest.php
+++ b/tests/Metadata/Extractor/YamlExtractorTest.php
@@ -98,6 +98,7 @@ class YamlExtractorTest extends TestCase
                     'provider' => null,
                     'read' => null,
                     'write' => null,
+                    'stateOptions' => null,
                 ],
             ],
             Program::class => [
@@ -166,6 +167,7 @@ class YamlExtractorTest extends TestCase
                     'provider' => null,
                     'read' => null,
                     'write' => null,
+                    'stateOptions' => null,
                 ],
                 [
                     'uriTemplate' => '/users/{author}/programs{._format}',
@@ -304,6 +306,7 @@ class YamlExtractorTest extends TestCase
                             'processor' => null,
                             'provider' => null,
                             'itemUriTemplate' => null,
+                            'stateOptions' => null,
                         ],
                         [
                             'name' => null,
@@ -381,6 +384,7 @@ class YamlExtractorTest extends TestCase
                             'priority' => null,
                             'processor' => null,
                             'provider' => null,
+                            'stateOptions' => null,
                         ],
                     ],
                     'graphQlOperations' => null,
@@ -388,6 +392,7 @@ class YamlExtractorTest extends TestCase
                     'provider' => null,
                     'read' => null,
                     'write' => null,
+                    'stateOptions' => null,
                 ],
             ],
             SingleFileConfigDummy::class => [
@@ -456,6 +461,7 @@ class YamlExtractorTest extends TestCase
                     'provider' => null,
                     'read' => null,
                     'write' => null,
+                    'stateOptions' => null,
                 ],
             ],
         ], $extractor->getResources());

--- a/tests/Metadata/Resource/Factory/OperationNameResourceMetadataFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/OperationNameResourceMetadataFactoryTest.php
@@ -42,15 +42,15 @@ class OperationNameResourceMetadataFactoryTest extends TestCase
         $this->assertEquals($operation->withName($expectedOperationName), $result->getOperation($expectedOperationName));
     }
 
-public function operationProvider(): array
-{
-    return [
-        [new Get(), '_api_a_get'],
-        [new Get(shortName: 'Foo'), '_api_Foo_get'],
-        [new Get(name: 'test'), 'test'],
-        [new Get(routePrefix: 'foo'), '_api_foo_get'],
-        [new Get(uriTemplate: '/foo'), '_api_/foo_get'],
-        [new Get(routePrefix: '/admin', uriTemplate: '/foo'), '_api_/admin/foo_get'],
-    ];
-}
+    public function operationProvider(): array
+    {
+        return [
+            [new Get(), '_api_a_get'],
+            [new Get(shortName: 'Foo'), '_api_Foo_get'],
+            [new Get(name: 'test'), 'test'],
+            [new Get(routePrefix: 'foo'), '_api_foo_get'],
+            [new Get(uriTemplate: '/foo'), '_api_/foo_get'],
+            [new Get(routePrefix: '/admin', uriTemplate: '/foo'), '_api_/admin/foo_get'],
+        ];
+    }
 }

--- a/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -33,8 +33,6 @@ use ApiPlatform\Elasticsearch\Extension\RequestBodySearchCollectionExtensionInte
 use ApiPlatform\Elasticsearch\Filter\MatchFilter;
 use ApiPlatform\Elasticsearch\Filter\TermFilter;
 use ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface;
-use ApiPlatform\Elasticsearch\State\CollectionProvider as ElasticsearchCollectionProvider;
-use ApiPlatform\Elasticsearch\State\ItemProvider as ElasticsearchItemProvider;
 use ApiPlatform\Exception\ExceptionInterface;
 use ApiPlatform\Exception\FilterValidationException;
 use ApiPlatform\Exception\InvalidArgumentException;
@@ -1048,8 +1046,8 @@ class ApiPlatformExtensionTest extends TestCase
 
         $services = [
             // elasticsearch.xml
-            ElasticsearchItemProvider::class,
-            ElasticsearchCollectionProvider::class,
+            'api_platform.elasticsearch.state.item_provider',
+            'api_platform.elasticsearch.state.collection_provider',
             'api_platform.elasticsearch.client',
             'api_platform.elasticsearch.cache.metadata.document',
             'api_platform.elasticsearch.metadata.document.metadata_factory.configured',
@@ -1076,6 +1074,8 @@ class ApiPlatformExtensionTest extends TestCase
             TermFilter::class,
             MatchFilter::class,
             \ApiPlatform\Elasticsearch\Filter\OrderFilter::class,
+            \ApiPlatform\Elasticsearch\State\ItemProvider::class,
+            \ApiPlatform\Elasticsearch\State\CollectionProvider::class,
         ];
 
         $this->assertContainerHas($services, $aliases);
@@ -1083,8 +1083,8 @@ class ApiPlatformExtensionTest extends TestCase
         // elasticsearch.xml
         $this->assertServiceHasTags('api_platform.elasticsearch.cache.metadata.document', ['cache.pool']);
         $this->assertServiceHasTags('api_platform.elasticsearch.normalizer.document', ['serializer.normalizer']);
-        $this->assertServiceHasTags(ElasticsearchItemProvider::class, ['api_platform.state_provider']);
-        $this->assertServiceHasTags(ElasticsearchCollectionProvider::class, ['api_platform.state_provider']);
+        $this->assertServiceHasTags('api_platform.elasticsearch.state.item_provider', ['api_platform.state_provider']);
+        $this->assertServiceHasTags('api_platform.elasticsearch.state.collection_provider', ['api_platform.state_provider']);
         $this->assertServiceHasTags('api_platform.elasticsearch.request_body_search_extension.constant_score_filter', ['api_platform.elasticsearch.request_body_search_extension.collection']);
         $this->assertServiceHasTags('api_platform.elasticsearch.request_body_search_extension.sort_filter', ['api_platform.elasticsearch.request_body_search_extension.collection']);
         $this->assertServiceHasTags('api_platform.elasticsearch.request_body_search_extension.sort', ['api_platform.elasticsearch.request_body_search_extension.collection']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #5279 
| License       | MIT
| Doc PR        | not yet

# Deprecations
- `ApiResource::$elasticsearch` and `Operation::$elasticsearch` were deprecated
- `src/Elasticsearch/Metadata/Document/Factory/*` and `src/Elasticsearch/Metadata/Document/DocumentMetadata` are deprecated
- `elasticsearch.mapping` config option is deprecated

# Feature
- `PersistenceMeansInterface` was created
- `ElasticsearchDocument` was created, which implements `PersistenceMeansInterface`
- `ApiResource::$persistenceMeans` and `Operation::$persistenceMeans` added

