### PR TITLE
fix: links require same id type

### DIFF
--- a/src/Doctrine/Orm/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Orm/State/LinksHandlerTrait.php
@@ -120,7 +120,14 @@ trait LinksHandlerTrait
             foreach ($identifierProperties as $identifierProperty) {
                 $placeholder = $queryNameGenerator->generateParameterName($identifierProperty);
                 $queryBuilder->andWhere("$joinAlias.$identifierProperty = :$placeholder");
-                $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $doctrineClassMetadata->getTypeOfField($identifierProperty));
+
+                if ($doctrineClassMetadata->hasAssociation($link->getToProperty())) {
+                    $associationTargetClass = $doctrineClassMetadata->getAssociationMapping($link->getToProperty())['targetEntity'];
+                    $associationTargetDoctrineClassMetadata = $manager->getClassMetadata($associationTargetClass);
+                    $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $associationTargetDoctrineClassMetadata->getTypeOfField($identifierProperty));
+                } else {
+                    $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $doctrineClassMetadata->getTypeOfField($identifierProperty));
+                }
             }
 
             $previousAlias = $joinAlias;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | #5269 
| License       | MIT
| Doc PR        | n/a

This PR fixes the issue where if you have multiple links, all of the ID properties must be of the same type (e.g. one is `UUID`, another is `string`).

TODO:
- [ ] Create a functional test case
