### PR TITLE
Fix default serializer context not passed to CollectionNormalizer

### DIFF
--- a/src/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Symfony/Bundle/Resources/config/hydra.xml
@@ -58,8 +58,6 @@
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument>null</argument>
-            <argument type="collection"/> <!-- default context -->
-
 
             <!-- Run after api_platform.jsonld.normalizer.object but before serializer.normalizer.object and serializer.denormalizer.array -->
             <tag name="serializer.normalizer" priority="-985" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       |  <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

Fix any `serializer.default_context` configuration not being passed to the CollectionNormalizer.

For example, because `serializer.default_context.preserve_empty_objects: true` is not passed, the serialization of empty objects is broken.