### PR TITLE
Fix/validation exception hydra title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v3.0.8
+
+### Bug fixes
+
+* [26040444e](https://github.com/api-platform/core/commit/26040444e6199674212418127fa045e34e7f9c4a) fix(graphql): dont add graphql operations when disabled (#5265)
+* [3d3c2c744](https://github.com/api-platform/core/commit/3d3c2c74452dc891d0892c851f0f730bced7759a) fix(graphql): link relations requires the property (#5169)
+* [ddeda9c93](https://github.com/api-platform/core/commit/ddeda9c93a1ad7ac1da432fd7e6551ab85953cc9) fix(normalizer): normalize items in related collection with concrete class (#5261)
+* [e73878570](https://github.com/api-platform/core/commit/e73878570d5b18ec7366be6c93f573a73d13b31c) fix(jsonschema): remove @id @type @context from input schema  (#5267)
+
 ## v3.0.7
 
 ### Bug fixes

--- a/src/Documentation/Action/DocumentationAction.php
+++ b/src/Documentation/Action/DocumentationAction.php
@@ -32,6 +32,7 @@ final class DocumentationAction
 
     public function __invoke(Request $request = null): DocumentationInterface
     {
+        $context = [];
         if (null !== $request) {
             $context = ['base_url' => $request->getBaseUrl()];
             if ($request->query->getBoolean('api_gateway')) {
@@ -41,7 +42,7 @@ final class DocumentationAction
         }
 
         if ('json' === $request?->getRequestFormat() && null !== $this->openApiFactory) {
-            return $this->openApiFactory->__invoke($context ?? []);
+            return $this->openApiFactory->__invoke($context);
         }
 
         return new Documentation($this->resourceNameCollectionFactory->create(), $this->title, $this->description, $this->version);

--- a/src/Symfony/Validator/Exception/ValidationException.php
+++ b/src/Symfony/Validator/Exception/ValidationException.php
@@ -23,9 +23,14 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  */
 final class ValidationException extends BaseValidationException implements ConstraintViolationListAwareExceptionInterface, \Stringable
 {
-    public function __construct(private readonly ConstraintViolationListInterface $constraintViolationList, string $message = '', int $code = 0, \Exception $previous = null)
+    public function __construct(private readonly ConstraintViolationListInterface $constraintViolationList, string $message = '', int $code = 0, \Exception $previous = null, private readonly string $hydraTitle = '')
     {
         parent::__construct($message ?: $this->__toString(), $code, $previous);
+    }
+
+    public function getHydraTitle(): string
+    {
+        return $this->hydraTitle;
     }
 
     public function getConstraintViolationList(): ConstraintViolationListInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | none
| License       | MIT
| Doc PR        | none
Update ValidationException to add the possibility to change the hydra:title message. All was provided but the context was never passed to the serializer. Didn't found a way to add a test to the ApiPlatform\Tests\Symfony\Validator\EventListener\ValidationExceptionListenerTest because it's way too complicated for me :(