### PR TITLE
fix(graphql): pass graphql enabled flag

### DIFF
--- a/src/Symfony/Bundle/Resources/config/metadata/yaml.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/yaml.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.yaml.inner" />
             <argument>%api_platform.defaults%</argument>
             <argument type="service" id="logger" on-invalid="null" />
+            <argument>%api_platform.graphql.enabled%</argument>
         </service>
 
         <service id="api_platform.metadata.property.metadata_factory.yaml" class="ApiPlatform\Metadata\Property\Factory\ExtractorPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="20" public="false">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0 <!-- see below -->
| Tickets       | #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

In that PR https://github.com/api-platform/core/pull/5265 was added `$graphQlEnabled` flag, but it hasn't been considered in `metadata/yaml.xml` config. It results in always false for that flag (as default). This PR fix that.
