### PR TITLE
Switch from deprecated “loose” email validation mode to “html5”

### DIFF
--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
@@ -84,7 +84,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
             'email' => [
                 new NotNull(),
                 new Length(['min' => 2, 'max' => 255]),
-                new Email(['mode' => Email::VALIDATION_MODE_LOOSE]),
+                new Email(['mode' => Email::VALIDATION_MODE_HTML5]),
             ],
             'phone' => new Optional([
                 new \Symfony\Component\Validator\Constraints\Type(['type' => 'string']),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follows https://github.com/symfony/symfony/pull/46518