### PR TITLE
Fix `PayloadArgumentResolver::resolve` return type

### DIFF
--- a/src/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
+++ b/src/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
@@ -59,7 +59,7 @@ final class PayloadArgumentResolver implements ArgumentValueResolverInterface
         return $inputClass === $class || is_subclass_of($inputClass, $class);
     }
 
-    public function resolve(Request $request, ArgumentMetadata $argument): \Generator
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield $request->attributes->get('data');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`ArgumentValueResolverInterface::resolve` return type always have been `iterable`.

There is no need to make it more specific, especially because we support PHP ≥ 7.1 and full covariance support was added with PHP 7.4.