### PR TITLE
feat: add context to XML parsing errors

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -52,7 +52,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             try {
                 simplexml_import_dom(XmlUtils::loadFile($path, XmlPropertyExtractor::SCHEMA));
             } catch (\InvalidArgumentException) {
-                throw new InvalidArgumentException(sprintf("Error while parsing %s:\n%s", $path, $e->getMessage()), $e->getCode(), $e);
+                throw new InvalidArgumentException(sprintf("Error while parsing %s: %s", $path, $e->getMessage()), $e->getCode(), $e);
             }
 
             // It's a property: ignore error

--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -52,7 +52,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             try {
                 simplexml_import_dom(XmlUtils::loadFile($path, XmlPropertyExtractor::SCHEMA));
             } catch (\InvalidArgumentException) {
-                throw new InvalidArgumentException("Error while parsing $path:\n". $e->getMessage(), $e->getCode(), $e);
+                throw new InvalidArgumentException("Error while parsing $path:\n".$e->getMessage(), $e->getCode(), $e);
             }
 
             // It's a property: ignore error

--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -52,7 +52,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             try {
                 simplexml_import_dom(XmlUtils::loadFile($path, XmlPropertyExtractor::SCHEMA));
             } catch (\InvalidArgumentException) {
-                throw new InvalidArgumentException(sprintf("Error while parsing %s: %s", $path, $e->getMessage()), $e->getCode(), $e);
+                throw new InvalidArgumentException(sprintf('Error while parsing %s: %s', $path, $e->getMessage()), $e->getCode(), $e);
             }
 
             // It's a property: ignore error

--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -52,7 +52,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             try {
                 simplexml_import_dom(XmlUtils::loadFile($path, XmlPropertyExtractor::SCHEMA));
             } catch (\InvalidArgumentException) {
-                throw new InvalidArgumentException("Error while parsing $path:\n".$e->getMessage(), $e->getCode(), $e);
+                throw new InvalidArgumentException(sprintf("Error while parsing %s:\n%s", $path, $e->getMessage()), $e->getCode(), $e);
             }
 
             // It's a property: ignore error

--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -52,7 +52,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             try {
                 simplexml_import_dom(XmlUtils::loadFile($path, XmlPropertyExtractor::SCHEMA));
             } catch (\InvalidArgumentException) {
-                throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+                throw new InvalidArgumentException("Error while parsing $path:\n". $e->getMessage(), $e->getCode(), $e);
             }
 
             // It's a property: ignore error

--- a/tests/Metadata/Extractor/XmlExtractorTest.php
+++ b/tests/Metadata/Extractor/XmlExtractorTest.php
@@ -393,7 +393,10 @@ class XmlExtractorTest extends TestCase
     public function getInvalidPaths(): array
     {
         return [
-            [__DIR__.'/xml/invalid/required_class.xml', "/^\[ERROR 1868\] Element '\{https:\/\/api-platform\.com\/schema\/metadata\/resources-3\.0\}resource': The attribute 'class' is required but missing\./"],
+            [
+                __DIR__.'/xml/invalid/required_class.xml',
+                "/^Error while parsing .+\/xml\/invalid\/required_class.xml:\n\[ERROR 1868\] Element '\{https:\/\/api-platform\.com\/schema\/metadata\/resources-3\.0\}resource': The attribute 'class' is required but missing\./",
+            ],
         ];
     }
 }

--- a/tests/Metadata/Extractor/XmlExtractorTest.php
+++ b/tests/Metadata/Extractor/XmlExtractorTest.php
@@ -395,7 +395,7 @@ class XmlExtractorTest extends TestCase
         return [
             [
                 __DIR__.'/xml/invalid/required_class.xml',
-                "/^Error while parsing .+\/xml\/invalid\/required_class.xml:\n\[ERROR 1868\] Element '\{https:\/\/api-platform\.com\/schema\/metadata\/resources-3\.0\}resource': The attribute 'class' is required but missing\./",
+                "/^Error while parsing .+\/xml\/invalid\/required_class.xml: \[ERROR 1868\] Element '\{https:\/\/api-platform\.com\/schema\/metadata\/resources-3\.0\}resource': The attribute 'class' is required but missing\./",
             ],
         ];
     }


### PR DESCRIPTION
Whenever an XML parsing error is found, the error message will be something like:

> [ERROR 1843] Element '{https://api-platform.com/schema/metadata/resources-3.0}operation': Character content other than whitespace is not allowed because the content type is 'element-only'. (in /var/www/ - line 28, column 0) in . (which is being imported from "/var/www/config/routes_api.php"). Make sure there is a loader supporting the "api_platform"
  type.

Which is terribly unhelpful. The only file mentioned is in this case is a general routes configuration file, which is absolutely unrelated to the issue at hand.

Yes, ideally one wouldn't be modifying several configuration files at the same time, but sometimes it does happen.

This commit simply adds the path where the error was found to the error message, so now it becomes:

> Error while parsing /var/www/src/config/api-platform/SomeResource.xml:
  [ERROR 1843] Element '{https://api-platform.com/schema/metadata/resources-3.0}operation': Character content other than whitespace is not allowed because the content type is 'element-only'. (in /var/www/ - line 28, column 0) in . (which is being imported from "/var/www/config/routes_api.php"). Make sure there is a loader supporting the "api_platform" type.

Now the user knows the error happens on `SomeResource.xml`, and there is less frustration. :)