### PR TITLE
fix typo in comment

### DIFF
--- a/src/deprecation.php
+++ b/src/deprecation.php
@@ -447,7 +447,7 @@ $deprecatedClassesWithoutAliases = [
 ];
 
 spl_autoload_register(function ($className) use ($deprecatedInterfaces, $deprecatedClassesWithoutAliases, $deprecatedClassesWithAliases) {
-    // We can not class alias when working with doctrine annotations
+    // We can not use class alias when working with doctrine annotations
     static $deprecatedAnnotations = [
         'ApiResource' => [ApiPlatform\Core\Annotation\ApiResource::class, ApiPlatform\Metadata\ApiResource::class],
         'ApiProperty' => [ApiPlatform\Core\Annotation\ApiProperty::class, ApiPlatform\Metadata\ApiProperty::class],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | no
| License       | MIT
| Doc PR        | no

It took inspiration from the previous sentence: https://github.com/api-platform/core/commit/ee864e2d8cc23d00c68ac861c859a888216d4372#diff-ad6b069705ee18edffce5eb4909fdd1014ef68c42fea8b336ea417e2ab25fe3b