### PR TITLE
 @philipsorst fix: Make annotation reader argument optional

### DIFF
--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -57,7 +57,7 @@
 
         <service id="api_platform.metadata.resource.metadata_collection_factory.filters" class="ApiPlatform\Metadata\Resource\Factory\FiltersResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="200" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.filters.inner" />
-            <argument type="service" id="annotation_reader" />
+            <argument type="service" id="annotation_reader" on-invalid="null" />
         </service>
 
         <service id="api_platform.metadata.resource.metadata_collection_factory.alternate_uri" class="ApiPlatform\Metadata\Resource\Factory\AlternateUriResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="200" public="false">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The constructor argument for the annotation reader in `FiltersResourceMetadataCollectionFactory` is optional (nullable), but the argument in the service definition is not and therefore fails if the `annotation_reader` service definition does not exist. Defining it as null if invalid should just fix this issue without changing anything when the annotation reader is available.