### PR TITLE
feat(graphql)!: add extra args for custom queries or mutations

### DIFF
--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -147,6 +147,9 @@ final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterfac
                 if ($input && $operation instanceof Mutation && null !== $mutationArgs = $operation->getArgs()) {
                     return $fieldsBuilder->resolveResourceArgs($mutationArgs, $operation) + ['clientMutationId' => $fields['clientMutationId']];
                 }
+                if ($input && $operation instanceof Mutation && null !== $extraMutationArgs = $operation->getExtraArgs()) {
+                    return $fields + $fieldsBuilder->resolveResourceArgs($extraMutationArgs, $operation);
+                }
 
                 return $fields;
             },

--- a/src/Metadata/Extractor/ResourceExtractorTrait.php
+++ b/src/Metadata/Extractor/ResourceExtractorTrait.php
@@ -85,6 +85,20 @@ trait ResourceExtractorTrait
         return $data;
     }
 
+    private function buildExtraArgs(\SimpleXMLElement $resource): ?array
+    {
+        if (!isset($resource->extraArgs->arg)) {
+            return null;
+        }
+
+        $data = [];
+        foreach ($resource->extraArgs->arg as $arg) {
+            $data[(string) $arg['id']] = $this->buildValues($arg->values);
+        }
+
+        return $data;
+    }
+
     private function buildValues(\SimpleXMLElement $resource): array
     {
         $data = [];

--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -423,6 +423,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             $data[] = array_merge($datum, [
                 'resolver' => $this->phpize($operation, 'resolver', 'string'),
                 'args' => $this->buildArgs($operation),
+                'extraArgs' => $this->buildExtraArgs($operation),
                 'class' => (string) $operation['class'],
                 'read' => $this->phpize($operation, 'read', 'bool'),
                 'deserialize' => $this->phpize($operation, 'deserialize', 'bool'),

--- a/src/Metadata/Extractor/YamlResourceExtractor.php
+++ b/src/Metadata/Extractor/YamlResourceExtractor.php
@@ -353,6 +353,7 @@ final class YamlResourceExtractor extends AbstractResourceExtractor
             $data[] = array_merge($datum, [
                 'resolver' => $this->phpize($operation, 'resolver', 'string'),
                 'args' => $operation['args'] ?? null,
+                'extraArgs' => $operation['extraArgs'] ?? null,
                 'class' => (string) $class,
                 'read' => $this->phpize($operation, 'read', 'bool'),
                 'deserialize' => $this->phpize($operation, 'deserialize', 'bool'),

--- a/src/Metadata/Extractor/schema/resources.xsd
+++ b/src/Metadata/Extractor/schema/resources.xsd
@@ -59,6 +59,7 @@
         <xsd:sequence minOccurs="0" maxOccurs="unbounded">
             <xsd:group ref="base"/>
             <xsd:element name="args" minOccurs="0" type="args"/>
+            <xsd:element name="extraArgs" minOccurs="0" type="args"/>
         </xsd:sequence>
         <xsd:attributeGroup ref="base"/>
         <xsd:attribute type="xsd:string" name="resolver"/>

--- a/src/Metadata/GraphQl/Operation.php
+++ b/src/Metadata/GraphQl/Operation.php
@@ -37,6 +37,7 @@ class Operation extends AbstractOperation
     public function __construct(
         protected ?string $resolver = null,
         protected ?array $args = null,
+        protected ?array $extraArgs = null,
         protected ?array $links = null,
 
         ?string $shortName = null,
@@ -156,6 +157,19 @@ class Operation extends AbstractOperation
     {
         $self = clone $this;
         $self->args = $args;
+
+        return $self;
+    }
+
+    public function getExtraArgs(): ?array
+    {
+        return $this->extraArgs;
+    }
+
+    public function withExtraArgs(?array $extraArgs = null): self
+    {
+        $self = clone $this;
+        $self->extraArgs = $extraArgs;
 
         return $self;
     }

--- a/src/Metadata/GraphQl/Query.php
+++ b/src/Metadata/GraphQl/Query.php
@@ -21,6 +21,7 @@ class Query extends Operation
     public function __construct(
         ?string $resolver = null,
         ?array $args = null,
+        ?array $extraArgs = null,
         ?array $links = null,
 
         ?string $shortName = null,
@@ -74,6 +75,7 @@ class Query extends Operation
         parent::__construct(
             resolver: $resolver,
             args: $args,
+            extraArgs: $extraArgs,
             links: $links,
             shortName: $shortName,
             class: $class,

--- a/src/Metadata/GraphQl/QueryCollection.php
+++ b/src/Metadata/GraphQl/QueryCollection.php
@@ -22,6 +22,7 @@ final class QueryCollection extends Query implements CollectionOperationInterfac
     public function __construct(
         ?string $resolver = null,
         ?array $args = null,
+        ?array $extraArgs = null,
         ?array $links = null,
 
         ?string $shortName = null,
@@ -75,6 +76,7 @@ final class QueryCollection extends Query implements CollectionOperationInterfac
         parent::__construct(
             resolver: $resolver,
             args: $args,
+            extraArgs: $extraArgs,
             links: $links,
             shortName: $shortName,
             class: $class,

--- a/src/Metadata/GraphQl/Subscription.php
+++ b/src/Metadata/GraphQl/Subscription.php
@@ -21,6 +21,7 @@ final class Subscription extends Operation
     public function __construct(
         ?string $resolver = null,
         ?array $args = null,
+        ?array $extraArgs = null,
         ?array $links = null,
 
         ?string $shortName = null,
@@ -72,6 +73,7 @@ final class Subscription extends Operation
         parent::__construct(
             resolver: $resolver,
             args: $args,
+            extraArgs: $extraArgs,
             links: $links,
             shortName: $shortName,
             class: $class,

--- a/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Document/DummyCustomMutation.php
@@ -28,23 +28,27 @@ use Symfony\Component\Serializer\Annotation\Groups;
     new Mutation(
         name: 'sum',
         resolver: 'app.graphql.mutation_resolver.dummy_custom',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']]
     ),
     new Mutation(
         name: 'sumNotPersisted',
         resolver: 'app.graphql.mutation_resolver.dummy_custom_not_persisted',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']]
     ),
     new Mutation(name: 'sumNoWriteCustomResult',
         resolver: 'app.graphql.mutation_resolver.dummy_custom_no_write_custom_result',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']],
         write: false
     ),
     new Mutation(name: 'sumOnlyPersist',
         resolver: 'app.graphql.mutation_resolver.dummy_custom_only_persist_document',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']],
         read: false,

--- a/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyCustomMutation.php
@@ -28,23 +28,27 @@ use Symfony\Component\Serializer\Annotation\Groups;
     new Mutation(
         name: 'sum',
         resolver: 'app.graphql.mutation_resolver.dummy_custom',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']]
     ),
     new Mutation(
         name: 'sumNotPersisted',
         resolver: 'app.graphql.mutation_resolver.dummy_custom_not_persisted',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']]
     ),
     new Mutation(name: 'sumNoWriteCustomResult',
         resolver: 'app.graphql.mutation_resolver.dummy_custom_no_write_custom_result',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']],
         write: false
     ),
     new Mutation(name: 'sumOnlyPersist',
         resolver: 'app.graphql.mutation_resolver.dummy_custom_only_persist',
+        extraArgs: ['id' => ['type' => 'ID!']],
         normalizationContext: ['groups' => ['result']],
         denormalizationContext: ['groups' => ['sum']],
         read: false,

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -697,24 +697,15 @@ class FieldsBuilderTest extends TestCase
                     'clientMutationId' => GraphQLType::string(),
                 ],
             ],
-            'mutation using input DTO' => ['resourceClass', (new Mutation())->withName('mutation')->withInput(GraphQLType::string()),
+            'custom mutation' => ['resourceClass', (new Mutation())->withResolver('resolver')->withName('mutation'),
                 [
-                    'property' => new ApiProperty(),
-                    'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withDescription('propertyBool description')->withReadable(false)->withWritable(true)->withDeprecationReason('not useful'),
-                    'propertySubresource' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withReadable(false)->withWritable(true),
+                    'propertyBool' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_BOOL)])->withDescription('propertyBool description')->withReadable(false)->withWritable(true),
                 ],
                 true, 0, null,
                 [
                     'propertyBool' => [
                         'type' => GraphQLType::nonNull(GraphQLType::string()),
                         'description' => 'propertyBool description',
-                        'args' => [],
-                        'resolve' => null,
-                        'deprecationReason' => 'not useful',
-                    ],
-                    'propertySubresource' => [
-                        'type' => GraphQLType::nonNull(GraphQLType::string()),
-                        'description' => null,
                         'args' => [],
                         'resolve' => null,
                         'deprecationReason' => null,

--- a/tests/Metadata/Extractor/Adapter/XmlResourceAdapter.php
+++ b/tests/Metadata/Extractor/Adapter/XmlResourceAdapter.php
@@ -410,6 +410,16 @@ XML_WRAP
         }
     }
 
+    private function buildExtraArgs(\SimpleXMLElement $resource, array $args): void
+    {
+        $child = $resource->addChild('extraArgs');
+        foreach ($args as $id => $values) {
+            $grandChild = $child->addChild('arg');
+            $grandChild->addAttribute('id', $id);
+            $this->buildValues($grandChild, $values);
+        }
+    }
+
     private function buildGraphQlOperations(\SimpleXMLElement $resource, array $values): void
     {
         $node = $resource->addChild('graphQlOperations');

--- a/tests/Metadata/Extractor/ResourceMetadataCompatibilityTest.php
+++ b/tests/Metadata/Extractor/ResourceMetadataCompatibilityTest.php
@@ -182,6 +182,12 @@ final class ResourceMetadataCompatibilityTest extends TestCase
                             'bar' => 'baz',
                         ],
                     ],
+                    'extraArgs' => [
+                        'bar' => [
+                            'type' => 'custom',
+                            'baz' => 'qux',
+                        ],
+                    ],
                     'shortName' => self::SHORT_NAME,
                     'description' => 'Creates a Comment.',
                     'class' => Mutation::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | https://github.com/api-platform/core/issues/5097 https://github.com/api-platform/core/issues/2736
| License       | MIT
| Doc PR        | TODO

This PR adds an `extraArgs` argument for GraphQL operations.
It also removes the generation of the required ID field in case of a custom query or mutation.
It is a slight BC break if the user relies on this required ID field.
It should be added back with the extra args if needed:

```php
#[ApiResource(graphQlOperations: [
    new Mutation(
        name: 'custom',
        resolver: Resolver::class,
        extraArgs: ['id' => ['type' => 'ID!']],
    ),
])]
```