### PR TITLE
get enum type correctly from TypesContainer

### DIFF
--- a/features/graphql/introspection.feature
+++ b/features/graphql/introspection.feature
@@ -590,7 +590,7 @@ Feature: GraphQL introspection support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
-    And the JSON node "data.person.fields[1].type.name" should be equal to "GenderTypeEnum"
+    And the JSON node "data.person.fields[1].type.name" should be equal to "GenderType"
     #And the JSON node "data.person.fields[1].type.description" should be equal to "An enumeration of genders."
     And the JSON node "data.person.fields[1].type.enumValues[0].name" should be equal to "MALE"
     #And the JSON node "data.person.fields[1].type.enumValues[0].description" should be equal to "The male gender."

--- a/src/GraphQl/Type/TypesContainer.php
+++ b/src/GraphQl/Type/TypesContainer.php
@@ -41,6 +41,10 @@ final class TypesContainer implements TypesContainerInterface
             return $this->graphqlTypes[$id];
         }
 
+        if ($this->has($id . 'Enum')) {
+            return $this->graphqlTypes[$id . 'Enum'];
+        }
+
         throw new TypeNotFoundException(sprintf('Type with id "%s" is not present in the types container', $id), $id);
     }
 

--- a/tests/Fixtures/TestBundle/Document/Person.php
+++ b/tests/Fixtures/TestBundle/Document/Person.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderType;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -32,9 +32,9 @@ class Person
     #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
     private ?int $id = null;
 
-    #[ODM\Field(type: 'string', enumType: GenderTypeEnum::class, nullable: true)]
+    #[ODM\Field(type: 'string', enumType: GenderType::class, nullable: true)]
     #[Groups(['people.pets'])]
-    public ?GenderTypeEnum $genderType = GenderTypeEnum::MALE;
+    public ?GenderType $genderType = GenderType::MALE;
 
     #[Groups(['people.pets'])]
     #[ODM\Field(type: 'string')]

--- a/tests/Fixtures/TestBundle/Entity/Person.php
+++ b/tests/Fixtures/TestBundle/Entity/Person.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderType;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -34,9 +34,9 @@ class Person
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     private ?int $id = null;
 
-    #[ORM\Column(type: 'string', enumType: GenderTypeEnum::class, nullable: true)]
+    #[ORM\Column(type: 'string', enumType: GenderType::class, nullable: true)]
     #[Groups(['people.pets'])]
-    public ?GenderTypeEnum $genderType = GenderTypeEnum::MALE;
+    public ?GenderType $genderType = GenderType::MALE;
 
     #[ORM\Column(type: 'string')]
     #[Groups(['people.pets'])]

--- a/tests/Fixtures/TestBundle/Enum/GenderType.php
+++ b/tests/Fixtures/TestBundle/Enum/GenderType.php
@@ -18,7 +18,7 @@ use ApiPlatform\Metadata\ApiProperty;
 /**
  * An enumeration of genders.
  */
-enum GenderTypeEnum: string
+enum GenderType: string
 {
     /** The male gender. */
     case MALE = 'male';

--- a/tests/GraphQl/Type/FieldsBuilderTest.php
+++ b/tests/GraphQl/Type/FieldsBuilderTest.php
@@ -33,7 +33,7 @@ use ApiPlatform\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\State\Pagination\Pagination;
-use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderType;
 use ApiPlatform\Tests\Fixtures\TestBundle\Serializer\NameConverter\CustomConverter;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
@@ -830,20 +830,20 @@ class FieldsBuilderTest extends TestCase
 
     public function testGetEnumFields(): void
     {
-        $enumClass = GenderTypeEnum::class;
+        $enumClass = GenderType::class;
 
-        $this->propertyMetadataFactoryProphecy->create($enumClass, GenderTypeEnum::MALE->name)->willReturn(new ApiProperty(
+        $this->propertyMetadataFactoryProphecy->create($enumClass, GenderType::MALE->name)->willReturn(new ApiProperty(
             description: 'Description of MALE case',
         ));
-        $this->propertyMetadataFactoryProphecy->create($enumClass, GenderTypeEnum::FEMALE->name)->willReturn(new ApiProperty(
+        $this->propertyMetadataFactoryProphecy->create($enumClass, GenderType::FEMALE->name)->willReturn(new ApiProperty(
             description: 'Description of FEMALE case',
         ));
 
         $enumFields = $this->fieldsBuilder->getEnumFields($enumClass);
 
         $this->assertSame([
-            GenderTypeEnum::MALE->name => ['value' => GenderTypeEnum::MALE->value, 'description' => 'Description of MALE case'],
-            GenderTypeEnum::FEMALE->name => ['value' => GenderTypeEnum::FEMALE->value, 'description' => 'Description of FEMALE case'],
+            GenderType::MALE->name => ['value' => GenderType::MALE->value, 'description' => 'Description of MALE case'],
+            GenderType::FEMALE->name => ['value' => GenderType::FEMALE->value, 'description' => 'Description of FEMALE case'],
         ], $enumFields);
     }
 

--- a/tests/GraphQl/Type/TypeConverterTest.php
+++ b/tests/GraphQl/Type/TypeConverterTest.php
@@ -25,7 +25,7 @@ use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
-use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderType;
 use ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Type\Definition\DateTimeType;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\ObjectType;
@@ -86,7 +86,7 @@ class TypeConverterTest extends TestCase
             [new Type(Type::BUILTIN_TYPE_ARRAY), false, 0, 'Iterable'],
             [new Type(Type::BUILTIN_TYPE_ITERABLE), false, 0, 'Iterable'],
             [new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateTimeInterface::class), false, 0, GraphQLType::string()],
-            [new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class), false, 0, new EnumType(['name' => 'GenderTypeEnum'])],
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderType::class), false, 0, new EnumType(['name' => 'GenderTypeEnum'])],
             [new Type(Type::BUILTIN_TYPE_OBJECT), false, 0, null],
             [new Type(Type::BUILTIN_TYPE_CALLABLE), false, 0, null],
             [new Type(Type::BUILTIN_TYPE_NULL), false, 0, null],

--- a/tests/GraphQl/Type/TypesContainerTest.php
+++ b/tests/GraphQl/Type/TypesContainerTest.php
@@ -52,6 +52,14 @@ class TypesContainerTest extends TestCase
         $this->assertSame($type, $this->typesContainer->get('test'));
     }
 
+    public function testGetEnum(): void
+    {
+        $type = $this->prophesize(GraphQLType::class)->reveal();
+
+        $this->typesContainer->set('testEnum', $type);
+        $this->assertSame($type, $this->typesContainer->get('test'));
+    }
+
     public function testGetTypeNotFound(): void
     {
         $this->expectException(TypeNotFoundException::class);

--- a/tests/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonSchema/SchemaFactoryTest.php
@@ -28,7 +28,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Tests\Fixtures\NotAResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\OverriddenOperationDummy;
-use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -69,7 +69,7 @@ class SchemaFactoryTest extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(NotAResource::class, 'foo', Argument::cetera())->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)])->withReadable(true));
         $propertyMetadataFactoryProphecy->create(NotAResource::class, 'bar', Argument::cetera())->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)])->withReadable(true)->withDefault('default_bar')->withExample('example_bar'));
-        $propertyMetadataFactoryProphecy->create(NotAResource::class, 'genderType', Argument::cetera())->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_OBJECT)])->withReadable(true)->withDefault(GenderTypeEnum::MALE));
+        $propertyMetadataFactoryProphecy->create(NotAResource::class, 'genderType', Argument::cetera())->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_OBJECT)])->withReadable(true)->withDefault(GenderType::MALE));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
@@ -146,11 +146,11 @@ class SchemaFactoryTest extends TestCase
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(OverriddenOperationDummy::class, 'alias', Argument::type('array'))->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)])->withReadable(true));
         $propertyMetadataFactoryProphecy->create(OverriddenOperationDummy::class, 'description', Argument::type('array'))->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)])->withReadable(true));
-        $propertyMetadataFactoryProphecy->create(OverriddenOperationDummy::class, 'genderType', Argument::type('array'))->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)])->withReadable(true)->withDefault(GenderTypeEnum::MALE));
+        $propertyMetadataFactoryProphecy->create(OverriddenOperationDummy::class, 'genderType', Argument::type('array'))->willReturn((new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderType::class)])->withReadable(true)->withDefault(GenderType::MALE));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(OverriddenOperationDummy::class)->willReturn(true);
-        $resourceClassResolverProphecy->isResourceClass(GenderTypeEnum::class)->willReturn(true);
+        $resourceClassResolverProphecy->isResourceClass(GenderType::class)->willReturn(true);
 
         $schemaFactory = new SchemaFactory($typeFactoryProphecy->reveal(), $resourceMetadataFactoryProphecy->reveal(), $propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), null, $resourceClassResolverProphecy->reveal());
         $resultSchema = $schemaFactory->buildSchema(OverriddenOperationDummy::class, 'json', Schema::TYPE_OUTPUT, null, null, ['groups' => $serializerGroup, AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]);

--- a/tests/JsonSchema/TypeFactoryTest.php
+++ b/tests/JsonSchema/TypeFactoryTest.php
@@ -19,7 +19,7 @@ use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\JsonSchema\TypeFactory;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GamePlayMode;
-use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -35,7 +35,7 @@ class TypeFactoryTest extends TestCase
     public function testGetType(array $schema, Type $type): void
     {
         $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolver->isResourceClass(GenderTypeEnum::class)->willReturn(false);
+        $resourceClassResolver->isResourceClass(GenderType::class)->willReturn(false);
         $resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
         $typeFactory = new TypeFactory($resourceClassResolver->reveal());
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_OPENAPI)));
@@ -59,8 +59,8 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['nullable' => true, 'type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
-        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
-        yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null], 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderType::class)];
+        yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null], 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderType::class)];
         yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
         yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-reference', 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
@@ -163,7 +163,7 @@ class TypeFactoryTest extends TestCase
     public function testGetTypeWithJsonSchemaSyntax(array $schema, Type $type): void
     {
         $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolver->isResourceClass(GenderTypeEnum::class)->willReturn(false);
+        $resourceClassResolver->isResourceClass(GenderType::class)->willReturn(false);
         $resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
         $typeFactory = new TypeFactory($resourceClassResolver->reveal());
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_JSON_SCHEMA)));
@@ -187,8 +187,8 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['type' => ['string', 'null'], 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
-        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
-        yield ['nullable enum' => ['type' => ['string', 'null'], 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderType::class)];
+        yield ['nullable enum' => ['type' => ['string', 'null'], 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderType::class)];
         yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
         yield ['nullable enum resource' => ['type' => ['string', 'null'], 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
@@ -284,7 +284,7 @@ class TypeFactoryTest extends TestCase
     public function testGetTypeWithOpenAPIV2Syntax(array $schema, Type $type): void
     {
         $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolver->isResourceClass(GenderTypeEnum::class)->willReturn(false);
+        $resourceClassResolver->isResourceClass(GenderType::class)->willReturn(false);
         $resourceClassResolver->isResourceClass(Argument::type('string'))->willReturn(true);
         $typeFactory = new TypeFactory($resourceClassResolver->reveal());
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_SWAGGER)));
@@ -308,8 +308,8 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
         yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
-        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
-        yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
+        yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderType::class)];
+        yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderType::class)];
         yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
         yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];

--- a/tests/Metadata/Property/Factory/AttributePropertyMetadataFactoryTest.php
+++ b/tests/Metadata/Property/Factory/AttributePropertyMetadataFactoryTest.php
@@ -18,7 +18,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\AttributePropertyMetadataFactory;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyPhp8ApiPropertyAttribute;
-use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -40,7 +40,7 @@ class AttributePropertyMetadataFactoryTest extends TestCase
         $metadata = $factory->create(DummyPhp8ApiPropertyAttribute::class, 'foo');
         $this->assertSame('a foo', $metadata->getDescription());
 
-        $metadata = $factory->create(GenderTypeEnum::class, 'FEMALE');
+        $metadata = $factory->create(GenderType::class, 'FEMALE');
         $this->assertSame('The female gender.', $metadata->getDescription());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | none

I faced problems in GraphQL queries when the field that should be queried is an Enum. This leads to errors because the Type could not be found.

![enum_types](https://user-images.githubusercontent.com/17310106/214570251-af8b723e-914b-444d-ba27-4ecfbd6c12f5.png)

Enums are stored with their name and the suffix `Enum` in the types container. So I added another case to `TypesContainer:get` method and everything works like a charm.