### PR TITLE
fix(graphql): name and key should be the same for an enum without Enum suffix in class name

### DIFF
--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -240,13 +240,12 @@ final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterfac
     public function getEnumType(Operation $operation): GraphQLType
     {
         $enumName = $operation->getShortName();
-        $enumKey = $enumName;
         if (!str_ends_with($enumName, 'Enum')) {
-            $enumKey = sprintf('%sEnum', $enumName);
+            $enumName = sprintf('%sEnum', $enumName);
         }
 
-        if ($this->typesContainer->has($enumKey)) {
-            return $this->typesContainer->get($enumKey);
+        if ($this->typesContainer->has($enumName)) {
+            return $this->typesContainer->get($enumName);
         }
 
         /** @var FieldsBuilderEnumInterface|FieldsBuilderInterface $fieldsBuilder */
@@ -268,7 +267,7 @@ final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterfac
         }
 
         $enumType = new EnumType($enumConfig);
-        $this->typesContainer->set($enumKey, $enumType);
+        $this->typesContainer->set($enumName, $enumType);
 
         return $enumType;
     }

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -590,7 +590,7 @@ class TypeBuilderTest extends TestCase
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->willReturn($fieldsBuilderProphecy->reveal());
 
         self::assertEquals(new EnumType([
-            'name' => $enumName,
+            'name' => 'GamePlayModeEnum',
             'description' => $enumDescription,
             'values' => $enumValues,
         ]), $this->typeBuilder->getEnumType($operation));


### PR DESCRIPTION
Supersedes https://github.com/api-platform/core/pull/5367.