### PR TITLE
fix(metadata): allow custom http status code for put

### DIFF
--- a/src/Symfony/EventListener/RespondListener.php
+++ b/src/Symfony/EventListener/RespondListener.php
@@ -90,7 +90,7 @@ final class RespondListener
         ) {
             $status = 301;
             $headers['Location'] = $this->iriConverter->getIriFromResource($request->attributes->get('data'), UrlGeneratorInterface::ABS_PATH, $operation);
-        } elseif (HttpOperation::METHOD_PUT === $method && !($attributes['previous_data'] ?? null) && $status === null) {
+        } elseif (HttpOperation::METHOD_PUT === $method && !($attributes['previous_data'] ?? null) && null === $status) {
             $status = Response::HTTP_CREATED;
         }
 

--- a/src/Symfony/EventListener/RespondListener.php
+++ b/src/Symfony/EventListener/RespondListener.php
@@ -90,7 +90,7 @@ final class RespondListener
         ) {
             $status = 301;
             $headers['Location'] = $this->iriConverter->getIriFromResource($request->attributes->get('data'), UrlGeneratorInterface::ABS_PATH, $operation);
-        } elseif (HttpOperation::METHOD_PUT === $method && !($attributes['previous_data'] ?? null)) {
+        } elseif (HttpOperation::METHOD_PUT === $method && !($attributes['previous_data'] ?? null) && $status === null) {
             $status = Response::HTTP_CREATED;
         }
 

--- a/tests/Symfony/EventListener/RespondListenerTest.php
+++ b/tests/Symfony/EventListener/RespondListenerTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Symfony\EventListener;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Symfony\EventListener\RespondListener;
@@ -225,6 +226,28 @@ class RespondListenerTest extends TestCase
         $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn(new ResourceMetadataCollection(Dummy::class, [
             new ApiResource(operations: [
                 'get' => new Get(status: Response::HTTP_ACCEPTED),
+            ]),
+        ]));
+
+        $listener = new RespondListener($resourceMetadataFactoryProphecy->reveal());
+        $listener->onKernelView($event);
+
+        $this->assertSame(Response::HTTP_ACCEPTED, $event->getResponse()->getStatusCode());
+    }
+
+    public function testSetCustomStatusForPut(): void
+    {
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_operation_name' => 'put', '_api_respond' => true], [], [], ['REQUEST_METHOD' => 'PUT']);
+        $event = new ViewEvent(
+            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            $request,
+            \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST,
+            'bar'
+        );
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn(new ResourceMetadataCollection(Dummy::class, [
+            new ApiResource(operations: [
+                'put' => new Put(status: Response::HTTP_ACCEPTED),
             ]),
         ]));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| License       | MIT

Fixes the possibility to use custom http status codes for the PUT methods. Currently, it returns 201 HTTP_CREATED.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- 2.7 for bugs related to the **backward compatibility layer**, if the bug was in 2.6 let's fix it on the 3.0 branch instead
- 3.0 for bug fixes
- main for new features

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
