### PR TITLE
fix(symfony): autoconfigure elasticsearch extension

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -66,6 +66,7 @@ parameters:
 		- src/Core/Bridge/Elasticsearch/DataProvider/Paginator.php
 		- src/Core/Bridge/Elasticsearch/Exception/IndexNotFoundException.php
 		- src/Core/Bridge/Elasticsearch/Exception/NonUniqueIdentifierException.php
+		- src/Core/Bridge/Elasticsearch/Extension/RequestBodySearchCollectionExtensionInterface.php
 		- src/Core/Bridge/Elasticsearch/Metadata/Document/DocumentMetadata.php
 		- src/Core/Bridge/Elasticsearch/Metadata/Document/Factory/AttributeDocumentMetadataFactory.php
 		- src/Core/Bridge/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -17,6 +17,7 @@ use ApiPlatform\Api\FilterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Annotation\ApiResource as ApiResourceAnnotation;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter as DoctrineOrmAbstractContextAwareFilter;
+use ApiPlatform\Core\Bridge\Elasticsearch\Extension\RequestBodySearchCollectionExtensionInterface as LegacyRequestBodySearchCollectionExtensionInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
@@ -913,6 +914,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $container->registerForAutoconfiguration(RequestBodySearchCollectionExtensionInterface::class)
+            ->addTag('api_platform.elasticsearch.request_body_search_extension.collection');
+
+        $container->registerForAutoconfiguration(LegacyRequestBodySearchCollectionExtensionInterface::class)
             ->addTag('api_platform.elasticsearch.request_body_search_extension.collection');
 
         $container->setParameter('api_platform.elasticsearch.hosts', $config['elasticsearch']['hosts']);


### PR DESCRIPTION
fixes #5363
