### PR TITLE
fix(openapi): fix openapi requestbody decoration

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -337,7 +337,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     'The "openapiContext" option is deprecated, use "openapi" instead.'
                 );
                 $openapiOperation = $openapiOperation->withRequestBody(new RequestBody($contextRequestBody['description'] ?? '', new \ArrayObject($contextRequestBody['content']), $contextRequestBody['required'] ?? false));
-            } elseif (\in_array($method, [HttpOperation::METHOD_PATCH, HttpOperation::METHOD_PUT, HttpOperation::METHOD_POST], true)) {
+            } elseif (null === $openapiOperation->getRequestBody() && \in_array($method, [HttpOperation::METHOD_PATCH, HttpOperation::METHOD_PUT, HttpOperation::METHOD_POST], true)) {
                 $operationInputSchemas = [];
                 foreach ($requestMimeTypes as $operationFormat) {
                     $operationInputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_INPUT, $operation, $schema, null, $forceSchemaCollection);

--- a/tests/OpenApi/Factory/OpenApiFactoryTest.php
+++ b/tests/OpenApi/Factory/OpenApiFactoryTest.php
@@ -168,6 +168,28 @@ class OpenApiFactoryTest extends TestCase
                                            ->withPaginationItemsPerPage(20)
                                        ->withPaginationMaximumItemsPerPage(80)
                                                ->withOperation($baseOperation),
+            'postDummyCollectionWithRequestBody' => (new Post())->withUriTemplate('/dummiesRequestBody')->withOperation($baseOperation)->withOpenapi(new OpenApiOperation(
+                requestBody: new RequestBody(
+                    description: 'List of Ids',
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'ids' => [
+                                        'type' => 'array',
+                                        'items' => ['type' => 'string'],
+                                        'example' => [
+                                            '1e677e04-d461-4389-bedc-6d1b665cc9d6',
+                                            '01111b43-f53a-4d50-8639-148850e5da19',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+            )),
         ])
         );
 
@@ -628,5 +650,49 @@ class OpenApiFactoryTest extends TestCase
                 ]),
             ]
         ), $paginatedPath->getGet());
+
+        $requestBodyPath = $paths->getPath('/dummiesRequestBody');
+        $this->assertEquals(new Operation(
+            'postDummyCollectionWithRequestBody',
+            ['Dummy'],
+            [
+                '201' => new Response(
+                    'Dummy resource created',
+                    new \ArrayObject([
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                    ]),
+                    null,
+                    new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
+                ),
+                '400' => new Response('Invalid input'),
+                '422' => new Response('Unprocessable entity'),
+            ],
+            'Creates a Dummy resource.',
+            'Creates a Dummy resource.',
+            null,
+            [],
+            new RequestBody(
+                'List of Ids',
+                new \ArrayObject([
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'ids' => [
+                                    'type' => 'array',
+                                    'items' => ['type' => 'string'],
+                                    'example' => [
+                                        '1e677e04-d461-4389-bedc-6d1b665cc9d6',
+                                        '01111b43-f53a-4d50-8639-148850e5da19',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]),
+                false
+            ),
+            deprecated: false,
+        ), $requestBodyPath->getPost());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | #5368
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Before : When adding a specific requestbody on an openapi declaration, it don't change the swagger/doc : 
![image](https://user-images.githubusercontent.com/49146882/215050851-f49c64bf-281d-48d0-b7b9-14c48ef7a85c.png)

After: The openapi doc is decorated : 
![image](https://user-images.githubusercontent.com/49146882/215051043-986e2eb9-7a12-41bf-82fb-71d4a43ff469.png)

