### PR TITLE
feat(openapi) : Adding option to addPath to keep custom sort.

### DIFF
--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -17,11 +17,13 @@ final class Paths
 {
     private array $paths = [];
 
-    public function addPath(string $path, PathItem $pathItem): void
+    public function addPath(string $path, PathItem $pathItem, bool $ksort = true): void
     {
         $this->paths[$path] = $pathItem;
 
-        ksort($this->paths);
+        if ($ksort) {
+            ksort($this->paths);
+        }
     }
 
     public function getPath(string $path): ?PathItem


### PR DESCRIPTION
We needed to change the order of path in the Open API auto generated documentation but the ksort was resetting the custom order. I added an option to bypass the ksort so we can keep our sort order.