### PR TITLE
feat(filter): proposal about uuid validation

### DIFF
--- a/src/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -18,7 +18,9 @@ use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Exception\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid as RamseyUuid;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Uid\Uuid as SymfonyUuid;
 
 /**
  * Trait for filtering the collection by given properties.
@@ -162,6 +164,17 @@ trait SearchFilterTrait
         foreach ($values as $value) {
             if (null !== $value && \in_array($type, (array) self::DOCTRINE_INTEGER_TYPE, true) && false === filter_var($value, \FILTER_VALIDATE_INT)) {
                 return false;
+            }
+
+            if (null !== $value && \in_array($type, (array) self::DOCTRINE_UUID_TYPE, true)) {
+                if (class_exists(RamseyUuid::class)) {
+                    return RamseyUuid::isValid($value);
+                }
+                if (class_exists(SymfonyUuid::class)) {
+                    return SymfonyUuid::isValid($value);
+                }
+
+                return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $value);
             }
         }
 

--- a/src/Doctrine/Odm/Filter/SearchFilter.php
+++ b/src/Doctrine/Odm/Filter/SearchFilter.php
@@ -41,6 +41,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
     use SearchFilterTrait;
 
     public const DOCTRINE_INTEGER_TYPE = [MongoDbType::INTEGER, MongoDbType::INT];
+    public const DOCTRINE_UUID_TYPE = [MongoDbType::BINDATAUUID, MongoDbType::BINDATAUUIDRFC4122];
 
     public function __construct(ManagerRegistry $managerRegistry, IriConverterInterface $iriConverter, ?IdentifiersExtractorInterface $identifiersExtractor, PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null, array $properties = null, NameConverterInterface $nameConverter = null)
     {

--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -26,6 +26,8 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Doctrine\UuidType as RamseyUuidType;
+use Symfony\Bridge\Doctrine\Types\UuidType as SymfonyUuidType;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
@@ -40,6 +42,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
     use SearchFilterTrait;
 
     public const DOCTRINE_INTEGER_TYPE = Types::INTEGER;
+    public const DOCTRINE_UUID_TYPE = [RamseyUuidType::NAME, SymfonyUuidType::NAME];
 
     public function __construct(ManagerRegistry $managerRegistry, IriConverterInterface $iriConverter, PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null, array $properties = null, IdentifiersExtractorInterface $identifiersExtractor = null, NameConverterInterface $nameConverter = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | No ticket
| License       | MIT
| Doc PR        | proposal not documented yet

Situation : 
Currently, if you filter on uuid typed field with SearchFilter and the uuid is not valid. You have a DriverException about SQL fail
(tested on Postgresql) 

> An exception occurred while executing a query: SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for type uuid: "bad-uuid"

Proposal : 
Catch as the int validation, the bad uuid with `hasValidValues`

So firstly, what do you think about that ?
And secondly, do you have idea to manage Custom UUID type from third dependency (Ramsey or Symfony) for make `DOCTRINE_UUID_TYPE` constant.
And third, I did not see some test currently the  `hasValidValues` behavior. Do you have some functional test about that ? I did not find them.