### PR TITLE
fix(standard-put) correct retrieval of the updated instance when the ORM id is not in the URI

### DIFF
--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -553,6 +553,31 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 400
     And the JSON node "hydra:description" should be equal to "Syntax error"
 
+  @!mongodb
+  Scenario: Replace an existing resource that doesn't expose its internal identifier
+    Given there is an HiddenIdentifierDummy object
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "PUT" request to "/hidden_identifier_dummies/prettyid" with body:
+    """
+    {
+      "foo": "A nice dummy"
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should be equal to "/hidden_identifier_dummies/prettyid"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/HiddenIdentifierDummy",
+      "@id": "/hidden_identifier_dummies/prettyid",
+      "@type": "HiddenIdentifierDummy",
+      "visibleId":"prettyid",
+      "foo": "A nice dummy"
+    }
+    """
+
   Scenario: Delete a resource
     When I send a "DELETE" request to "/dummies/1"
     Then the response status code should be 204

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -138,6 +138,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Foo;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FooDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FourthLevel;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Greeting;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\HiddenIdentifierDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\InitializeInput;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\InternalUser;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\IriOnlyDummy;
@@ -2124,6 +2125,19 @@ final class DoctrineContext implements Context
         $this->manager->persist($relationMultiple1);
         $this->manager->persist($relationMultiple2);
 
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is an HiddenIdentifierDummy object
+     */
+    public function thereIsAnHiddenIdentifierDummy(): void
+    {
+        $dummy = new HiddenIdentifierDummy();
+        $dummy->id = 1;
+        $dummy->visibleId = 'prettyid';
+        $dummy->foo = 'fooValue';
+        $this->manager->persist($dummy);
         $this->manager->flush();
     }
 

--- a/tests/Fixtures/TestBundle/Entity/HiddenIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/HiddenIdentifierDummy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(
+    operations            : [new Get(), new Put(allowCreate: true)],
+    normalizationContext  : ['groups' => 'HiddenIdentifierDummy::out'],
+    denormalizationContext: ['groups' => 'HiddenIdentifierDummy::in'],
+    extraProperties       : [
+        'standard_put' => true,
+    ],
+)]
+#[Entity]
+class HiddenIdentifierDummy
+{
+    #[Id]
+    #[Column]
+    #[ApiProperty(identifier: false)]
+    public ?int $id = null;
+
+    #[Column]
+    #[ApiProperty(identifier: true)]
+    #[Groups(['HiddenIdentifierDummy::out'])]
+    public ?string $visibleId = null;
+
+    #[Column]
+    #[Groups(['HiddenIdentifierDummy::out', 'HiddenIdentifierDummy::in'])]
+    public string $foo = '';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | stable
| Tickets       | https://github.com/api-platform/core/issues/5372

When using standard PUT for update, the doctrine PersistProcessor could only find the correct entity if its ORM id was present in the uriVariables. This PR tries to fix this using the previous_data present in the context instead of relying on uriVariables.

Additionnally...that's my first PR, so i'm not sure i did everything right. I included a simple behat test and those pass - phpunit tests were failing out of the box on something openapi-related, i didn't touch those.