### PR TITLE
fix : (standard-put) correct retrieval of the updated object when the ORM id is not in the URI.

### DIFF
--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -553,6 +553,31 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 400
     And the JSON node "hydra:description" should be equal to "Syntax error"
 
+  @!mongodb
+  Scenario: Replace an existing resource that doesn't expose its internal identifier
+    Given there is an HiddenIdentifierDummy object
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "PUT" request to "/hidden_identifier_dummies/prettyid" with body:
+    """
+    {
+      "foo": "A nice dummy"
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should be equal to "/hidden_identifier_dummies/prettyid"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/HiddenIdentifierDummy",
+      "@id": "/hidden_identifier_dummies/prettyid",
+      "@type": "HiddenIdentifierDummy",
+      "visibleId":"prettyid",
+      "foo": "A nice dummy"
+    }
+    """
+
   Scenario: Delete a resource
     When I send a "DELETE" request to "/dummies/1"
     Then the response status code should be 204

--- a/src/Doctrine/Common/State/PersistProcessor.php
+++ b/src/Doctrine/Common/State/PersistProcessor.php
@@ -52,10 +52,34 @@ final class PersistProcessor implements ProcessorInterface
         // https://github.com/doctrine/orm/issues/8461#issuecomment-1250233555
         if ($operation instanceof HttpOperation && HttpOperation::METHOD_PUT === $operation->getMethod() && ($operation->getExtraProperties()['standard_put'] ?? false)) {
             \assert(method_exists($manager, 'getReference'));
-            // TODO: the call to getReference is most likely to fail with complex identifiers
             $newData = $data;
             if (isset($context['previous_data'])) {
-                $newData = 1 === \count($uriVariables) ? $manager->getReference($class, current($uriVariables)) : clone $context['previous_data'];
+                // the correct entity need to be fetched, we need to get the ORM ids from previous data
+                $reflectionProperties = $this->getReflectionProperties($context['previous_data']);
+                $ormIds = [];
+                \assert(method_exists($manager, 'getClassMetadata'));
+                foreach ($manager->getClassMetadata($class)->getIdentifier() as $identifier) {
+                    if (\array_key_exists($identifier, $reflectionProperties)) {
+                        $value = $reflectionProperties[$identifier]->getValue($context['previous_data']);
+                    } else {
+                        // This id is not from current class, let's move up in class hierarchy
+                        $parent = (new \ReflectionObject($data))->getParentClass();
+                        while (!isset($value) && false !== $parent) {
+                            foreach ($parent->getProperties() as $property) {
+                                if ($property->name === $identifier) {
+                                    $value = $property->getValue($context['previous_data']);
+                                }
+                            }
+                            $parent = $parent->getParentClass();
+                        }
+                    }
+                    if (!isset($value)) {
+                        // can this actually happen? the identifier has to exist in the class hierarchy somewhere...
+                        throw new \Exception('identifier not found : '.$identifier);
+                    }
+                    $ormIds[$identifier] = $value;
+                }
+                $newData = $manager->getReference($class, $ormIds);
             }
 
             $identifiers = array_reverse($uriVariables);
@@ -79,7 +103,7 @@ final class PersistProcessor implements ProcessorInterface
             } else {
                 foreach ($reflectionProperties as $propertyName => $reflectionProperty) {
                     // Don't override the property if it's part of the subresource system
-                    if (isset($uriVariables[$propertyName])) {
+                    if (isset($uriVariables[$propertyName]) || isset($ormIds[$propertyName])) {
                         continue;
                     }
 

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -138,6 +138,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Foo;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FooDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FourthLevel;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Greeting;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\HiddenIdentifierDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\InitializeInput;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\InternalUser;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\IriOnlyDummy;
@@ -2124,6 +2125,19 @@ final class DoctrineContext implements Context
         $this->manager->persist($relationMultiple1);
         $this->manager->persist($relationMultiple2);
 
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there is an HiddenIdentifierDummy object
+     */
+    public function thereIsAnHiddenIdentifierDummy(): void
+    {
+        $dummy = new HiddenIdentifierDummy();
+        $dummy->id = 1;
+        $dummy->visibleId = 'prettyid';
+        $dummy->foo = 'fooValue';
+        $this->manager->persist($dummy);
         $this->manager->flush();
     }
 

--- a/tests/Fixtures/TestBundle/Entity/HiddenIdentifierDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/HiddenIdentifierDummy.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(
+    operations            : [new Get(), new Put(allowCreate: true)],
+    normalizationContext  : ['groups' => ['HiddenIdentifierDummy::out']],
+    denormalizationContext: ['groups' => ['HiddenIdentifierDummy::in']],
+    extraProperties       : [
+        'standard_put' => true,
+    ],
+)]
+#[Entity]
+class HiddenIdentifierDummy
+{
+    #[Id]
+    #[Column]
+    #[ApiProperty(identifier: false)]
+    public ?int $id = null;
+
+    #[Column]
+    #[ApiProperty(identifier: true)]
+    #[Groups(['HiddenIdentifierDummy::out'])]
+    public ?string $visibleId = null;
+
+    #[Column]
+    #[Groups(['HiddenIdentifierDummy::out', 'HiddenIdentifierDummy::in'])]
+    public string $foo = '';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | stable
| Tickets       | https://github.com/api-platform/core/issues/5372

When using standard PUT for update, the doctrine PersistProcessor could only find the correct entity if its ORM id was present in the uriVariables. This PR tries to fix this using the previous_data present in the context instead of relying on uriVariables.

I only included a simple behat test for this, it may be useful to add a phpunit for automatic coverage validation purposes but i wasn't sure how to approach this...and existing behat tests do seem to be covering the added code decently.