### PR TITLE
fix: map uriVariables to uriTemplate vars

### DIFF
--- a/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
@@ -185,7 +185,10 @@ final class UriTemplateResourceMetadataCollectionFactory implements ResourceMeta
                     $entityClass = $options->getEntityClass();
                 }
 
-                $newUriVariables[$variable] = (new Link())->withFromClass($entityClass)->withIdentifiers(['id'])->withParameterName($variable);
+                $newUriVariables[$variable] = (new Link())
+                    ->withFromClass($entityClass)
+                    ->withIdentifiers([property_exists($entityClass, $variable) ? $variable : 'id'])
+                    ->withParameterName($variable);
             }
 
             return $operation->withUriVariables($newUriVariables);

--- a/tests/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactoryTest.php
+++ b/tests/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactoryTest.php
@@ -121,6 +121,16 @@ class UriTemplateResourceMetadataCollectionFactoryTest extends TestCase
                         ),
                     ]
                 ),
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/attribute_resources/by_name/{name}',
+                ),
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/attribute_resources/{foo}',
+                ),
             ]),
         );
 
@@ -197,6 +207,20 @@ class UriTemplateResourceMetadataCollectionFactoryTest extends TestCase
                             routePrefix: '/prefix',
                             name: '_api_/prefix/attribute_resources/{id}{._format}_get'),
                     ]
+                ),
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/attribute_resources/by_name/{name}',
+                    uriVariables: ['name' => new Link(fromClass: AttributeResource::class, identifiers: ['name'], parameterName: 'name')],
+                    operations: [],
+                ),
+                new ApiResource(
+                    shortName: 'AttributeResource',
+                    class: AttributeResource::class,
+                    uriTemplate: '/attribute_resources/{foo}',
+                    uriVariables: ['foo' => new Link(fromClass: AttributeResource::class, identifiers: ['id'], parameterName: 'foo')],
+                    operations: [],
                 ),
             ]),
             $uriTemplateResourceMetadataCollectionFactory->create(AttributeResource::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| License       | MIT

This PR auto map the `uriVariables` to the `uriTemplate` vars if they exist in the target class
