### PR TITLE
FIX(metadata): In XmlResourceExtractor building request body content …

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -215,7 +215,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
         }
         $data['requestBody'] = isset($openapi->requestBody) ? new RequestBody(
             description: $this->phpize($openapi->requestBody, 'description', 'string'),
-            content: isset($openapi->requestBody->content->values) ? new \ArrayObject($this->buildValues($openapi->requestBody->values)) : null,
+            content: isset($openapi->requestBody->content->values) ? new \ArrayObject($this->buildValues($openapi->requestBody->content->values)) : null,
             required: $this->phpize($openapi->requestBody, 'required', 'bool'),
         ) : null;
 


### PR DESCRIPTION
closes #5402

Fix error in XmlResourceExtractor :

API Platform version(s) affected: 3.1.2

Description
When creating a custom operation with a specific request body in a resource in a XML file we have the following error :
In ResourceExtractorTrait.php line 91: Warning: foreach() argument must be of type array|object, null given

How to reproduce
Create a resource in a XML file with an operation with a specific request body

Possible Solution
Modification in the file src/Metadata/Extractor/XmlResourceExtractor.php line 218 change $this->buildValues($openapi->requestBody->values) to $this->buildValues($openapi->requestBody->content->values) : https://github.com/api-platform/core/blob/3.1/src/Metadata/Extractor/XmlResourceExtractor.php#L218

