### PR TITLE
fix: return type should be iterable

### DIFF
--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -29,5 +29,5 @@ interface ProviderInterface
      *
      * @return T|Pagination\PartialPaginatorInterface<T>|iterable<T>|null
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null;
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|iterable|null;
 }


### PR DESCRIPTION
... to match for example CollectionProvideres return type on pagination

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | 
