### PR TITLE
fix(serializer): propertyFilter should apply to arrays as well 

### DIFF
--- a/features/filter/property_filter.feature
+++ b/features/filter/property_filter.feature
@@ -18,3 +18,11 @@ Feature: Set properties to include
     And the JSON node "alias" should be equal to "Alias #0"
     And the JSON node "relatedDummy.name" should be equal to "RelatedDummy #1"
     And the JSON node "relatedDummies" should not exist
+
+  Scenario: Test property filter on not resource relations
+    When I send a "GET" request to "/dummy-with-array-of-objects/1?properties[notResourceObject][]=foo&properties[arrayOfNotResourceObjects][]=bar"
+    Then the JSON node "notResourceObject.foo" should be equal to "foo"
+    And the JSON node "notResourceObject.bar" should not exist
+    And the JSON node "arrayOfNotResourceObjects[0].foo" should not exist
+    And the JSON node "arrayOfNotResourceObjects[0].bar" should be equal to "bar"
+    And the JSON node "id" should not exist

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -640,6 +640,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return $this->serializer->normalize($attributeValue, $format, $childContext);
         }
 
+        if ($type && 'array' === $type->getBuiltinType()) {
+            $childContext = $this->createChildContext($context, $attribute, $format);
+            unset($childContext['iri'], $childContext['uri_variables']);
+
+            return $this->serializer->normalize($attributeValue, $format, $childContext);
+        }
+
         return $this->serializer->normalize($attributeValue, $format, $context);
     }
 

--- a/tests/Fixtures/TestBundle/ApiResource/DummyWithArrayOfNotResourceObjects.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DummyWithArrayOfNotResourceObjects.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\DummyNonResource;
+
+#[Get('/dummy-with-array-of-objects/{id}', filters: ['my_dummy.property'], provider: [DummyWithArrayOfNotResourceObjects::class, 'getData'])]
+class DummyWithArrayOfNotResourceObjects
+{
+    public function __construct(
+        public readonly int $id,
+        #[ApiProperty(genId: false)]
+        public readonly DummyNonResource $notResourceObject,
+        /** @var array<DummyNonResource> */
+        public readonly array $arrayOfNotResourceObjects
+    ) {
+    }
+
+    public static function getData(Operation $operation, array $uriVariables = []): self
+    {
+        return new self(
+            $uriVariables['id'],
+            new DummyNonResource('foo', 'foo'),
+            [
+                new DummyNonResource('bar', 'bar'),
+                new DummyNonResource('baz', 'baz'),
+            ]
+        );
+    }
+}

--- a/tests/Fixtures/TestBundle/Dto/DummyNonResource.php
+++ b/tests/Fixtures/TestBundle/Dto/DummyNonResource.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Dto;
+
+final class DummyNonResource
+{
+    public function __construct(
+        public ?string $foo = null,
+        public ?string $bar = null
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| License       | MIT

`PropertyFilter` does not presently work with arrays of objects which are not `ApiResource`: it just always serializes these objects as null arrays.

FYI I've tested with `ArrayCollection` of objects which are not `ApiResource` and it works like a charm