### PR TITLE
fix: use resource shortName when no operation guessed

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -290,7 +290,7 @@ final class SchemaFactory implements SchemaFactoryInterface
                         }
 
                         if (!$operation) {
-                            $operation = new HttpOperation();
+                            $operation = new HttpOperation(shortName: $resourceMetadata->getShortName());
                         }
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR fixes an issue when a shortName is set on a resource used as a subresource. The bug was introduced in https://github.com/api-platform/core/pull/4818/files

For example:

```php
<?php

declare(strict_types=1);

namespace App\Api\Resource;

#[ApiResource(
    shortName: 'Review',
    operations: [
        new Get(),
    ],
    provider: ReviewItemStateProvider::class,
    processor: StateProcessor::class,
)]
class ReviewResource
{
    public ?UuidV4 $id = null;

    #[ApiProperty(writable: false, readableLink: true)]
    public ?ReviewAnswerResource $answer = null;
}
```

has a dependency on `ReviewAnswerResource`. When this type was checked by the `TypeFactory`, a schema was generated by `JsonSchema/TypeFactory.php:L155`. This call to `buildSchema` is made with the `$operation` parameter set to `null`.

In `JsonSchema/SchemaFactory.php:L63` we're getting the metadata of the class and retrieving an operation. This operation was an uninitialized `HttpOperation` set at `JsonSchema/SchemaFactory.php:L293`. So when we're calling `JsonSchema/SchemaFactory.php::buildDefinitionName`, we have no operation shortName, hence the reflectionClass shortName is used (ReviewAnswerResource in this example), instead of the shortName set on the `ApiResource` attribute. 

By passing the resource shortName to this uninitialized HttpOperation, the issue is fixed and the generated OpenAPI schema is now the same as in API Platform 2.6 