### PR TITLE
fix(PropertyFilter): property filter description not shown in openapi

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -70,6 +70,7 @@ Feature: Documentation support
     And the OpenAPI class "User-user_user-write" exists
     And the OpenAPI class "UuidIdentifierDummy" exists
     And the OpenAPI class "ThirdLevel" exists
+    And the OpenAPI class "DummyCar" exists
     And the OpenAPI class "ParentDummy" doesn't exist
     And the OpenAPI class "UnknownDummy" doesn't exist
     And the OpenAPI path "/relation_embedders/{id}/custom" exists
@@ -111,6 +112,9 @@ Feature: Documentation support
     And the JSON node "paths./dummies.get.parameters[3].in" should be equal to "query"
     And the JSON node "paths./dummies.get.parameters[3].required" should be false
     And the JSON node "paths./dummies.get.parameters[3].schema.type" should be equal to "boolean"
+
+    And the JSON node "paths./dummy_cars.get.parameters[8].name" should be equal to "foobar[]"
+    And the JSON node "paths./dummy_cars.get.parameters[8].description" should be equal to "Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: foobar[]={propertyName}&foobar[]={anotherPropertyName}&foobar[{nestedPropertyParent}][]={nestedProperty}"
 
     # Subcollection - check filter on subResource
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[0].name" should be equal to "id"

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -76,6 +76,7 @@ final class PropertyFilter implements FilterInterface
                 'type' => 'string',
                 'is_collection' => true,
                 'required' => false,
+                'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$example,
                 'swagger' => [
                     'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: '.$example,
                     'name' => "$this->parameterName[]",

--- a/tests/Fixtures/TestBundle/Entity/DummyWithCollectDenormalizationErrors.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyWithCollectDenormalizationErrors.php
@@ -65,10 +65,10 @@ class DummyWithCollectDenormalizationErrors
         return $this->id;
     }
 
-   public function getFoo(): ?bool
-   {
-       return $this->foo;
-   }
+    public function getFoo(): ?bool
+    {
+        return $this->foo;
+    }
 
     public function setFoo(?bool $foo): void
     {

--- a/tests/Serializer/Filter/PropertyFilterTest.php
+++ b/tests/Serializer/Filter/PropertyFilterTest.php
@@ -218,6 +218,7 @@ class PropertyFilterTest extends TestCase
                 'type' => 'string',
                 'is_collection' => true,
                 'required' => false,
+                'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
                 'swagger' => [
                     'description' => 'Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: custom_properties[]={propertyName}&custom_properties[]={anotherPropertyName}&custom_properties[{nestedPropertyParent}][]={nestedProperty}',
                     'name' => 'custom_properties[]',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | https://github.com/api-platform/core/issues/5415
| License       | MIT
| Doc PR        |  N/A

PropertyFilter generated description is shown as parameter description in Openapi.