### PR TITLE
feat: declare ApiResource inside a symfony controller

### DIFF
--- a/features/symfony/controller_api_resource.feature
+++ b/features/symfony/controller_api_resource.feature
@@ -1,0 +1,54 @@
+Feature: ApiResource within Symfony controller
+  In order to use an ApiResource inside a Symfony controller 
+  As a developer
+  I should be able to use the API
+
+  Scenario: Send a GET request
+    When I send a "GET" request to "/api_resource_controller/1"
+    Then print last JSON response
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/ControllerResource",
+      "@id": "/api_resource_controller/1",
+      "@type": "ControllerResource",
+      "id": 1,
+      "name": "soyuka"
+    }
+    """
+
+  Scenario: Send a GET request in JSON
+    When I send a "GET" request to "/api_resource_controller_json/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {"id": 1, "name": "soyuka"}
+    """
+    
+  Scenario: Send a POST request 
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "POST" request to "/api_resource_controller" with body:
+    """
+    {
+      "name": "soyuka",
+      "id": "2"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/ControllerResource",
+      "@id": "/api_resource_controller/2",
+      "@type": "ControllerResource",
+      "id": 2,
+      "name": "soyuka"
+    }
+    """

--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -24,7 +24,7 @@ use ApiPlatform\State\OptionsInterface;
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
 class ApiResource extends Metadata
 {
     use WithResourceTrait;

--- a/src/Metadata/Resource/Factory/ArrayResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ArrayResourceNameCollectionFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\Resource\ResourceNameCollection;
+
+final class ArrayResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
+{
+    /**
+     * @param class-string[] $classes
+     */
+    public function __construct(private readonly array $classes, private readonly ?ResourceNameCollectionFactoryInterface $decorated = null)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(): ResourceNameCollection
+    {
+        $classes = $this->classes;
+        if ($this->decorated) {
+            foreach ($this->decorated->create() as $resourceClass) {
+                $classes[] = $resourceClass;
+            }
+        }
+
+        return new ResourceNameCollection($classes);
+    }
+}

--- a/src/Metadata/Resource/Factory/ControllerAttributeResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ControllerAttributeResourceMetadataCollectionFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class ControllerAttributeResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    /**
+     * @param array{controller: string, method: string, parameter: string} $controllerClass
+     */
+    public function __construct(private array $controllerClass = [], private readonly ?ResourceMetadataCollectionFactoryInterface $decorated = null)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = new ResourceMetadataCollection($resourceClass, []);
+
+        if ($this->decorated) {
+            $resourceMetadataCollection = $this->decorated->create($resourceClass);
+        }
+
+        if (!$routes = $this->controllerClass[$resourceClass] ?? null) {
+            return $resourceMetadataCollection;
+        }
+
+        foreach ($routes as $attribute) {
+            $reflectionController = new \ReflectionClass($attribute['controller']);
+            $reflectionMethod = $reflectionController->getMethod($attribute['method']);
+            foreach ($reflectionMethod->getParameters() as $reflectionParameter) {
+                if ($reflectionParameter->getName() !== $attribute['parameter']) {
+                    continue;
+                }
+
+                $attributes = $reflectionParameter->getAttributes(ApiResource::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+                if ($attributes[0] ?? false) {
+                    $apiResource = $attributes[0]->newInstance();
+                    break;
+                }
+            }
+
+            $shortName = (false !== $pos = strrpos($resourceClass, '\\')) ? substr($resourceClass, $pos + 1) : $resourceClass;
+            $apiResource = $apiResource->withClass($resourceClass)->withShortName($shortName);
+
+            if (!$apiResource->getOperations()) {
+                $apiResource = $apiResource->withOperations(new Operations([(new HttpOperation(routeName: $attribute['route_name'], name: $attribute['route_name']))->withResource($apiResource)]));
+            }
+
+            $resourceMetadataCollection[] = $apiResource;
+        }
+
+        return $resourceMetadataCollection;
+    }
+}

--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Symfony\Bundle;
 
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\AttributeFilterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\ControllerResourcePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
@@ -52,5 +53,6 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new MetadataAwareNameConverterPass());
         $container->addCompilerPass(new TestClientPass());
         $container->addCompilerPass(new AuthenticatorManagerPass());
+        $container->addCompilerPass(new ControllerResourcePass());
     }
 }

--- a/src/Symfony/Bundle/ArgumentResolver/ApiResourceArgumentResolver.php
+++ b/src/Symfony/Bundle/ArgumentResolver/ApiResourceArgumentResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Bundle\ArgumentResolver;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Symfony\EventListener\DenyAccessListener;
+use ApiPlatform\Symfony\EventListener\DeserializeListener;
+use ApiPlatform\Symfony\EventListener\ReadListener;
+use ApiPlatform\Symfony\EventListener\ValidateListener;
+use ApiPlatform\Symfony\EventListener\WriteListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @experimental
+ */
+final class ApiResourceArgumentResolver implements ValueResolverInterface
+{
+    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly HttpKernelInterface $httpKernel, private readonly DeserializeListener $deserializeListener, private ReadListener $readListener, private DenyAccessListener $denyAccessListener, private ValidateListener $validateListener, private WriteListener $writeListener)
+    {
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        $apiResource = $argument->getAttributesOfType(ApiResource::class);
+
+        if (!$apiResource) {
+            return [];
+        }
+
+        $metadata = $this->resourceMetadataCollectionFactory->create($argument->getType());
+        $operation = $metadata->getOperation($request->attributes->get('_route'));
+
+        // Check if the route param doesn't exist we don't want to fetch identifiers
+        $routeParams = $request->attributes->get('_route_params');
+        $uriVariable = array_keys($operation->getUriVariables())[0] ?? '';
+        if (!isset($routeParams[$uriVariable])) {
+            $operation = $operation->withUriVariables([]);
+        }
+
+        $request->attributes->set('_api_operation', $operation);
+        $request->attributes->set('_api_operation_name', $operation->getName());
+        $request->attributes->set('_api_resource_class', $operation->getClass());
+
+        $requestEvent = new RequestEvent($this->httpKernel, $request, HttpKernelInterface::MAIN_REQUEST);
+        $this->denyAccessListener->onSecurity($requestEvent);
+        $this->deserializeListener->onKernelRequest($requestEvent);
+        $this->denyAccessListener->onSecurityPostDenormalize($requestEvent);
+        $this->readListener->onKernelRequest($requestEvent);
+        $viewEvent = new ViewEvent($this->httpKernel, $request, HttpKernelInterface::MAIN_REQUEST, $request->attributes->get('data'));
+        $this->validateListener->onKernelView($viewEvent);
+        $this->denyAccessListener->onSecurityPostValidation($viewEvent);
+        $this->writeListener->onKernelView($viewEvent);
+
+        $operation = $metadata->getOperation();
+        $request->attributes->set('_api_operation', $operation);
+        $request->attributes->set('_api_operation_name', $operation->getName());
+
+        return [$request->attributes->get('data')];
+    }
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/ControllerResourcePass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/ControllerResourcePass.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
+
+use ApiPlatform\Exception\RuntimeException;
+use ApiPlatform\Metadata\ApiResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * Finds resources declared within controllers and builds a Controller <=> ApiResource link.
+ * This is then transformed into metadata within the ControllerAttributeResourceMetadataCollectionFactory.
+ *
+ * @internal
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class ControllerResourcePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws RuntimeException
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $attributes = [];
+        $resourceClasses = [];
+
+        foreach ($container->findTaggedServiceIds('controller.service_arguments') as $serviceId => $tags) {
+            $definition = $container->getDefinition($serviceId);
+            $reflection = new \ReflectionClass($controllerClass = $definition->getClass());
+
+            foreach ($reflection->getMethods() as $method) {
+                if (!$routeAttribute = $this->getRouteAttribute($method)) {
+                    continue;
+                }
+
+                foreach ($method->getParameters() as $parameter) {
+                    $type = $parameter->getType();
+
+                    if (!$type instanceof \ReflectionNamedType) {
+                        continue;
+                    }
+
+                    if (!$this->hasApiResourceAttribute($parameter)) {
+                        continue;
+                    }
+
+                    $class = $type->getName();
+                    $resourceClasses[] = $class;
+
+                    if (!isset($attributes[$class])) {
+                        $attributes[$class] = [];
+                    }
+
+                    $attributes[$class][] = [
+                        'controller' => $controllerClass,
+                        'method' => $method->getName(),
+                        'parameter' => $parameter->getName(),
+                        'route_name' => $routeAttribute->getName() ?? $this->getDefaultRouteName($reflection, $method),
+                    ];
+                }
+            }
+        }
+
+        $definition = $container->getDefinition('api_platform.metadata.resource.name_collection_factory.array');
+        $definition->setArgument(0, $resourceClasses);
+
+        $definition = $container->getDefinition('api_platform.metadata.resource.metadata_collection_factory.array');
+        $definition->setArgument(0, $attributes);
+    }
+
+    private function hasApiResourceAttribute(\ReflectionParameter $reflection): bool
+    {
+        if ($reflection->getAttributes(ApiResource::class, \ReflectionAttribute::IS_INSTANCEOF)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \ReflectionClass|\ReflectionMethod $reflection
+     */
+    private function getRouteAttribute(object $reflection): ?Route
+    {
+        $attributes = $reflection->getAttributes(Route::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+        if (!$attributes) {
+            return null;
+        }
+
+        return $attributes[0]->newInstance();
+    }
+
+    /**
+     * When need a link between the Route and the ApiResource, to do that we use the route name
+     * that symfony generates. Obviously if a route name is used inside the attribute we use it instead.
+     *
+     * @see https://github.com/symfony/symfony/blob/cb39a7fbff574350e5cc4858133ebb87191b12f0/src/Symfony/Bundle/FrameworkBundle/Routing/AnnotatedRouteControllerLoader.php#L42
+     */
+    private function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method): string
+    {
+        $name = str_replace('\\', '_', $class->name).'_'.$method->name;
+        $name = \function_exists('mb_strtolower') && preg_match('//u', $name) ? mb_strtolower($name, 'UTF-8') : strtolower($name);
+        $name = preg_replace('/(bundle|controller)_/', '_', $name);
+
+        if (str_ends_with($method->name, 'Action') || str_ends_with($method->name, '_action')) {
+            $name = preg_replace('/action(_\d+)?$/', '\\1', $name);
+        }
+
+        return str_replace('__', '_', $name);
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/argument_resolver.xml
+++ b/src/Symfony/Bundle/Resources/config/argument_resolver.xml
@@ -11,6 +11,17 @@
 
             <tag name="controller.argument_value_resolver" />
         </service>
+
+        <service id="api_platform.api_resource.argument_resolver.payload" class="ApiPlatform\Symfony\Bundle\ArgumentResolver\ApiResourceArgumentResolver" public="false">
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
+            <argument type="service" id="http_kernel" />
+            <argument type="service" id="api_platform.listener.request.deserialize" />
+            <argument type="service" id="api_platform.listener.request.read" />
+            <argument type="service" id="api_platform.security.listener.request.deny_access" />
+            <argument type="service" id="api_platform.listener.view.validate" />
+            <argument type="service" id="api_platform.listener.view.write" />
+            <tag name="controller.argument_value_resolver" />
+        </service>
     </services>
 
 </container>

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -63,6 +63,11 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.alternate_uri.inner" />
         </service>
 
+        <service id="api_platform.metadata.resource.metadata_collection_factory.array" class="ApiPlatform\Metadata\Resource\Factory\ControllerAttributeResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="700" public="false">
+            <argument type="collection"></argument>
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.array.inner" />
+        </service>
+
         <service id="api_platform.metadata.resource.metadata_collection_factory.deprecations" class="ApiPlatform\Metadata\Resource\Factory\DeprecationResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" public="false" decoration-priority="1000">
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.deprecations.inner" />
         </service>

--- a/src/Symfony/Bundle/Resources/config/metadata/resource_name.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource_name.xml
@@ -27,5 +27,10 @@
             <argument>%api_platform.resource_class_directories%</argument>
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory.attributes.inner" />
         </service>
+
+        <service id="api_platform.metadata.resource.name_collection_factory.array" class="ApiPlatform\Metadata\Resource\Factory\ArrayResourceNameCollectionFactory" decorates="api_platform.metadata.resource.name_collection_factory" public="false">
+            <argument type="collection"></argument>
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory.array.inner" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -183,8 +183,9 @@ final class IriConverter implements IriConverterInterface
             }
         }
 
+        $routeName = $operation instanceof HttpOperation ? ($operation->getRouteName() ?? $operation->getName()) : $operation->getName();
         try {
-            return $this->router->generate($operation->getName(), $identifiers, $operation->getUrlGenerationStrategy() ?? $referenceType);
+            return $this->router->generate($routeName, $identifiers, $operation->getUrlGenerationStrategy() ?? $referenceType);
         } catch (RoutingExceptionInterface $e) {
             throw new InvalidArgumentException(sprintf('Unable to generate an IRI for the item of type "%s"', $operation->getClass()), $e->getCode(), $e);
         }

--- a/tests/Fixtures/TestBundle/ApiResource/ControllerResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ControllerResource.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+class ControllerResource
+{
+    public $id;
+    public string $name;
+}

--- a/tests/Fixtures/TestBundle/Controller/Common/ApiResourceController.php
+++ b/tests/Fixtures/TestBundle/Controller/Common/ApiResourceController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Controller\Common;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ControllerResource;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ApiResourceController
+{
+    #[Route(path: '/api_resource_controller/{id}', format: 'jsonld')]
+    public function index(#[ApiResource(provider: [self::class, 'getData'])] ControllerResource $controllerResource): ControllerResource
+    {
+        return $controllerResource;
+    }
+
+    #[Route(path: '/api_resource_controller_json/{id}', format: 'json')]
+    public function indexJson(#[ApiResource(provider: [self::class, 'getData'])] ControllerResource $controllerResource): ControllerResource
+    {
+        return $controllerResource;
+    }
+
+    #[Route(methods: 'POST', path: '/api_resource_controller', format: 'jsonld')]
+    public function create(#[ApiResource(processor: [self::class, 'process'])] ControllerResource $controllerResource): ControllerResource
+    {
+        return $controllerResource;
+    }
+
+    public static function getData(Operation $operation, array $uriVariables = [], array $context = []): ControllerResource
+    {
+        $data = new ControllerResource();
+        $data->id = $uriVariables['id'];
+        $data->name = 'soyuka';
+
+        return $data;
+    }
+
+    public static function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ControllerResource
+    {
+        return $data;
+    }
+}

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -126,7 +126,7 @@ class AppKernel extends Kernel
             'session' => class_exists(SessionFactory::class) ? ['storage_factory_id' => 'session.storage.factory.mock_file'] : ['storage_id' => 'session.storage.mock_file'],
             'profiler' => [
                 'enabled' => true,
-                'collect' => false,
+                'collect' => true,
             ],
             'messenger' => $messengerConfig,
             'router' => ['utf8' => true],


### PR DESCRIPTION
After seeing https://github.com/symfony/symfony/pull/49518, we want to provide users a way of using our `ApiResource` within Symfony controllers. We have already all the stack needed to build APIs:

- security
- validation
- data retrieval
- deserialization
- serialization

This new feature allows to declare an `ApiResource` on a Controller argument like this:

```php
final class ApiResourceController
{
    #[Route(path: '/api_resource_controller/{id}', format: 'jsonld')]
    public function index(#[ApiResource(provider: [self::class, 'getData'])] ControllerResource $controllerResource): ControllerResource
    {
        return $controllerResource;
    }

    public static function getData(Operation $operation, array $uriVariables = [], array $context = []): ControllerResource
    {
        $data = new ControllerResource();
        $data->id = $uriVariables['id'];
        $data->name = 'soyuka';

        return $data;
    }
}
```