### PR TITLE
refactor(metadata): replace HttpOperation constants by raw strings

### DIFF
--- a/src/Doctrine/Common/State/PersistProcessor.php
+++ b/src/Doctrine/Common/State/PersistProcessor.php
@@ -50,7 +50,7 @@ final class PersistProcessor implements ProcessorInterface
         // PUT: reset the existing object managed by Doctrine and merge data sent by the user in it
         // This custom logic is needed because EntityManager::merge() has been deprecated and UPSERT isn't supported:
         // https://github.com/doctrine/orm/issues/8461#issuecomment-1250233555
-        if ($operation instanceof HttpOperation && HttpOperation::METHOD_PUT === $operation->getMethod() && ($operation->getExtraProperties()['standard_put'] ?? false)) {
+        if ($operation instanceof HttpOperation && 'PUT' === $operation->getMethod() && ($operation->getExtraProperties()['standard_put'] ?? false)) {
             \assert(method_exists($manager, 'getReference'));
             // TODO: the call to getReference is most likely to fail with complex identifiers
             $newData = $data;

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -225,7 +225,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
         $hydraOperations = [];
         foreach ($resourceMetadataCollection as $resourceMetadata) {
             foreach ($resourceMetadata->getOperations() as $operation) {
-                if ((HttpOperation::METHOD_POST === $operation->getMethod() || $operation instanceof CollectionOperationInterface) !== $collection) {
+                if (('POST' === $operation->getMethod() || $operation instanceof CollectionOperationInterface) !== $collection) {
                     continue;
                 }
 
@@ -241,7 +241,7 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
      */
     private function getHydraOperation(HttpOperation $operation, string $prefixedShortName): array
     {
-        $method = $operation->getMethod() ?: HttpOperation::METHOD_GET;
+        $method = $operation->getMethod() ?: 'GET';
 
         $hydraOperation = $operation->getHydraContext() ?? [];
         if ($operation->getDeprecationReason()) {

--- a/src/Metadata/Delete.php
+++ b/src/Metadata/Delete.php
@@ -94,7 +94,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         array $extraProperties = [],
     ) {
         parent::__construct(
-            method: self::METHOD_DELETE,
+            method: 'DELETE',
             uriTemplate: $uriTemplate,
             types: $types,
             formats: $formats,

--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -76,7 +76,7 @@ class HttpOperation extends Operation
      * @param string|callable|null   $processor {@see https://api-platform.com/docs/core/state-processors/#state-processors}
      */
     public function __construct(
-        protected string $method = self::METHOD_GET,
+        protected string $method = 'GET',
         protected ?string $uriTemplate = null,
         protected ?array $types = null,
         protected $formats = null,

--- a/src/Metadata/NotExposed.php
+++ b/src/Metadata/NotExposed.php
@@ -30,7 +30,7 @@ final class NotExposed extends HttpOperation
      * {@inheritdoc}
      */
     public function __construct(
-        string $method = self::METHOD_GET,
+        string $method = 'GET',
         ?string $uriTemplate = null,
         ?array $types = null,
         $formats = null,

--- a/src/Metadata/Patch.php
+++ b/src/Metadata/Patch.php
@@ -94,7 +94,7 @@ final class Patch extends HttpOperation
         array $extraProperties = [],
     ) {
         parent::__construct(
-            method: self::METHOD_PATCH,
+            method: 'PATCH',
             uriTemplate: $uriTemplate,
             types: $types,
             formats: $formats,

--- a/src/Metadata/Post.php
+++ b/src/Metadata/Post.php
@@ -95,7 +95,7 @@ final class Post extends HttpOperation
         private ?string $itemUriTemplate = null
     ) {
         parent::__construct(
-            method: self::METHOD_POST,
+            method: 'POST',
             uriTemplate: $uriTemplate,
             types: $types,
             formats: $formats,

--- a/src/Metadata/Put.php
+++ b/src/Metadata/Put.php
@@ -95,7 +95,7 @@ final class Put extends HttpOperation
         private ?bool $allowCreate = null,
     ) {
         parent::__construct(
-            method: self::METHOD_PUT,
+            method: 'PUT',
             uriTemplate: $uriTemplate,
             types: $types,
             formats: $formats,

--- a/src/Metadata/Resource/Factory/FormatsResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/FormatsResourceMetadataCollectionFactory.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Metadata\Resource\Factory;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Exception\ResourceClassNotFoundException;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 
@@ -69,7 +68,7 @@ final class FormatsResourceMetadataCollectionFactory implements ResourceMetadata
                 $operation = $operation->withFormats($this->normalizeFormats($operation->getFormats()));
             }
 
-            if (($isPatch = HttpOperation::METHOD_PATCH === $operation->getMethod()) && !$operation->getFormats() && !$operation->getInputFormats()) {
+            if (($isPatch = 'PATCH' === $operation->getMethod()) && !$operation->getFormats() && !$operation->getInputFormats()) {
                 $operation = $operation->withInputFormats($this->patchFormats);
             }
 

--- a/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
@@ -60,7 +60,7 @@ final class NotExposedOperationResourceMetadataCollectionFactory implements Reso
 
             foreach ($operations as $operation) {
                 // An item operation has been found, nothing to do anymore in this factory
-                if ((HttpOperation::METHOD_GET === $operation->getMethod() && !$operation instanceof CollectionOperationInterface) || ($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false)) {
+                if (('GET' === $operation->getMethod() && !$operation instanceof CollectionOperationInterface) || ($operation->getExtraProperties()['is_legacy_resource_metadata'] ?? false)) {
                     return $resourceMetadataCollection;
                 }
             }

--- a/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/UriTemplateResourceMetadataCollectionFactory.php
@@ -149,7 +149,7 @@ final class UriTemplateResourceMetadataCollectionFactory implements ResourceMeta
         $operation = $this->normalizeUriVariables($operation);
 
         if (!($uriTemplate = $operation->getUriTemplate())) {
-            if ($operation instanceof HttpOperation && HttpOperation::METHOD_POST === $operation->getMethod()) {
+            if ($operation instanceof HttpOperation && 'POST' === $operation->getMethod()) {
                 return $operation->withUriVariables([]);
             }
 
@@ -207,7 +207,7 @@ final class UriTemplateResourceMetadataCollectionFactory implements ResourceMeta
             }
 
             // We generated this operation but there're some missing identifiers
-            $uriVariables = HttpOperation::METHOD_POST === $operation->getMethod() || $operation instanceof CollectionOperationInterface ? [] : $operation->getUriVariables();
+            $uriVariables = 'POST' === $operation->getMethod() || $operation instanceof CollectionOperationInterface ? [] : $operation->getUriVariables();
 
             foreach ($diff as $key) {
                 $uriVariables[$key] = $this->linkFactory->createLinkFromProperty($operation, $key);

--- a/src/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Metadata/Resource/ResourceMetadataCollection.php
@@ -59,8 +59,8 @@ final class ResourceMetadataCollection extends \ArrayObject
 
             foreach ($metadata->getOperations() ?? [] as $name => $operation) {
                 $isCollection = $operation instanceof CollectionOperationInterface;
-                $method = $operation->getMethod() ?? HttpOperation::METHOD_GET;
-                $isGetOperation = HttpOperation::METHOD_GET === $method || HttpOperation::METHOD_OPTIONS === $method || HttpOperation::METHOD_HEAD === $method;
+                $method = $operation->getMethod() ?? 'GET';
+                $isGetOperation = 'GET' === $method || 'OPTIONS' === $method || 'HEAD' === $method;
                 if ('' === $operationName && $isGetOperation && ($forceCollection ? $isCollection : !$isCollection)) {
                     return $this->operationCache[$httpCacheKey] = $operation;
                 }

--- a/src/Metadata/Tests/Fixtures/Metadata/Get.php
+++ b/src/Metadata/Tests/Fixtures/Metadata/Get.php
@@ -23,6 +23,6 @@ final class Get extends HttpOperation
      */
     public function __construct(...$args)
     {
-        parent::__construct(self::METHOD_GET, ...$args);
+        parent::__construct('GET', ...$args);
     }
 }

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -150,7 +150,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             }
 
             $path = $this->getPath($path);
-            $method = $operation->getMethod() ?? HttpOperation::METHOD_GET;
+            $method = $operation->getMethod() ?? 'GET';
 
             if (!\in_array($method, PathItem::$methods, true)) {
                 continue;
@@ -267,7 +267,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                 $openapiOperation = $openapiOperation->withParameter($parameter);
             }
 
-            if ($operation instanceof CollectionOperationInterface && HttpOperation::METHOD_POST !== $method) {
+            if ($operation instanceof CollectionOperationInterface && 'POST' !== $method) {
                 foreach (array_merge($this->getPaginationParameters($operation), $this->getFiltersParameters($operation)) as $parameter) {
                     if ($this->hasParameter($openapiOperation, $parameter)) {
                         continue;
@@ -280,11 +280,11 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $existingResponses = $openapiOperation?->getResponses() ?: [];
             // Create responses
             switch ($method) {
-                case HttpOperation::METHOD_GET:
+                case 'GET':
                     $successStatus = (string) $operation->getStatus() ?: 200;
                     $openapiOperation = $this->buildOpenApiResponse($existingResponses, $successStatus, sprintf('%s %s', $resourceShortName, $operation instanceof CollectionOperationInterface ? 'collection' : 'resource'), $openapiOperation, $operation, $responseMimeTypes, $operationOutputSchemas);
                     break;
-                case HttpOperation::METHOD_POST:
+                case 'POST':
                     $successStatus = (string) $operation->getStatus() ?: 201;
 
                     $openapiOperation = $this->buildOpenApiResponse($existingResponses, $successStatus, sprintf('%s resource created', $resourceShortName), $openapiOperation, $operation, $responseMimeTypes, $operationOutputSchemas, $resourceMetadataCollection);
@@ -293,8 +293,8 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
                     $openapiOperation = $this->buildOpenApiResponse($existingResponses, '422', 'Unprocessable entity', $openapiOperation);
                     break;
-                case HttpOperation::METHOD_PATCH:
-                case HttpOperation::METHOD_PUT:
+                case 'PATCH':
+                case 'PUT':
                     $successStatus = (string) $operation->getStatus() ?: 200;
                     $openapiOperation = $this->buildOpenApiResponse($existingResponses, $successStatus, sprintf('%s resource updated', $resourceShortName), $openapiOperation, $operation, $responseMimeTypes, $operationOutputSchemas, $resourceMetadataCollection);
                     $openapiOperation = $this->buildOpenApiResponse($existingResponses, '400', 'Invalid input', $openapiOperation);
@@ -303,7 +303,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     }
                     $openapiOperation = $this->buildOpenApiResponse($existingResponses, '422', 'Unprocessable entity', $openapiOperation);
                     break;
-                case HttpOperation::METHOD_DELETE:
+                case 'DELETE':
                     $successStatus = (string) $operation->getStatus() ?: 204;
 
                     $openapiOperation = $this->buildOpenApiResponse($existingResponses, $successStatus, sprintf('%s resource deleted', $resourceShortName), $openapiOperation);
@@ -311,7 +311,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     break;
             }
 
-            if (!$operation instanceof CollectionOperationInterface && HttpOperation::METHOD_POST !== $operation->getMethod()) {
+            if (!$operation instanceof CollectionOperationInterface && 'POST' !== $operation->getMethod()) {
                 if (!isset($existingResponses[404])) {
                     $openapiOperation = $openapiOperation->withResponse(404, new Response('Resource not found'));
                 }
@@ -341,7 +341,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     'The "openapiContext" option is deprecated, use "openapi" instead.'
                 );
                 $openapiOperation = $openapiOperation->withRequestBody(new RequestBody($contextRequestBody['description'] ?? '', new \ArrayObject($contextRequestBody['content']), $contextRequestBody['required'] ?? false));
-            } elseif (null === $openapiOperation->getRequestBody() && \in_array($method, [HttpOperation::METHOD_PATCH, HttpOperation::METHOD_PUT, HttpOperation::METHOD_POST], true)) {
+            } elseif (null === $openapiOperation->getRequestBody() && \in_array($method, ['PATCH', 'PUT', 'POST'], true)) {
                 $operationInputSchemas = [];
                 foreach ($requestMimeTypes as $operationFormat) {
                     $operationInputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_INPUT, $operation, $schema, null, $forceSchemaCollection);
@@ -349,7 +349,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     $this->appendSchemaDefinitions($schemas, $operationInputSchema->getDefinitions());
                 }
 
-                $openapiOperation = $openapiOperation->withRequestBody(new RequestBody(sprintf('The %s %s resource', HttpOperation::METHOD_POST === $method ? 'new' : 'updated', $resourceShortName), $this->buildContent($requestMimeTypes, $operationInputSchemas), true));
+                $openapiOperation = $openapiOperation->withRequestBody(new RequestBody(sprintf('The %s %s resource', 'POST' === $method ? 'new' : 'updated', $resourceShortName), $this->buildContent($requestMimeTypes, $operationInputSchemas), true));
             }
 
             // TODO Remove in 4.0
@@ -492,12 +492,12 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         foreach ($resourceMetadataCollection as $resource) {
             foreach ($resource->getOperations() as $operationName => $operation) {
                 $parameters = [];
-                $method = $operation instanceof HttpOperation ? $operation->getMethod() : HttpOperation::METHOD_GET;
+                $method = $operation instanceof HttpOperation ? $operation->getMethod() : 'GET';
                 if (
                     $operationName === $operation->getName() ||
                     isset($links[$operationName]) ||
                     $operation instanceof CollectionOperationInterface ||
-                    HttpOperation::METHOD_GET !== $method
+                    'GET' !== $method
                 ) {
                     continue;
                 }

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -85,7 +85,7 @@ class OpenApiFactoryTest extends TestCase
             'getDummyItem' => (new Get())->withUriTemplate('/dummies/{id}')->withOperation($baseOperation)->withUriVariables(['id' => (new Link())->withFromClass(Dummy::class)->withIdentifiers(['id'])]),
             'putDummyItem' => (new Put())->withUriTemplate('/dummies/{id}')->withOperation($baseOperation)->withUriVariables(['id' => (new Link())->withFromClass(Dummy::class)->withIdentifiers(['id'])]),
             'deleteDummyItem' => (new Delete())->withUriTemplate('/dummies/{id}')->withOperation($baseOperation)->withUriVariables(['id' => (new Link())->withFromClass(Dummy::class)->withIdentifiers(['id'])]),
-            'customDummyItem' => (new HttpOperation())->withMethod(HttpOperation::METHOD_HEAD)->withUriTemplate('/foo/{id}')->withOperation($baseOperation)->withUriVariables(['id' => (new Link())->withFromClass(Dummy::class)->withIdentifiers(['id'])])->withOpenapi(new OpenApiOperation(
+            'customDummyItem' => (new HttpOperation())->withMethod('HEAD')->withUriTemplate('/foo/{id}')->withOperation($baseOperation)->withUriVariables(['id' => (new Link())->withFromClass(Dummy::class)->withIdentifiers(['id'])])->withOpenapi(new OpenApiOperation(
                 tags: ['Dummy', 'Profile'],
                 responses: [
                     '202' => new OpenApiResponse(

--- a/src/Symfony/EventListener/DeserializeListener.php
+++ b/src/Symfony/EventListener/DeserializeListener.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\EventListener;
 
 use ApiPlatform\Api\FormatMatcher;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\Symfony\Validator\Exception\ValidationException;
@@ -88,9 +87,9 @@ final class DeserializeListener
         if (
             null !== $data &&
             (
-                HttpOperation::METHOD_POST === $method ||
-                HttpOperation::METHOD_PATCH === $method ||
-                (HttpOperation::METHOD_PUT === $method && !($operation->getExtraProperties()['standard_put'] ?? false))
+                'POST' === $method ||
+                'PATCH' === $method ||
+                ('PUT' === $method && !($operation->getExtraProperties()['standard_put'] ?? false))
             )
         ) {
             $context[AbstractNormalizer::OBJECT_TO_POPULATE] = $data;

--- a/src/Symfony/EventListener/ReadListener.php
+++ b/src/Symfony/EventListener/ReadListener.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Symfony\EventListener;
 use ApiPlatform\Api\UriVariablesConverterInterface;
 use ApiPlatform\Exception\InvalidIdentifierException;
 use ApiPlatform\Exception\InvalidUriVariableException;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Serializer\SerializerContextBuilderInterface;
@@ -97,7 +96,7 @@ final class ReadListener
         if (
             null === $data &&
             (
-                HttpOperation::METHOD_PUT !== $operation->getMethod() ||
+                'PUT' !== $operation->getMethod() ||
                 ($operation instanceof Put && !($operation->getAllowCreate() ?? false))
             )
         ) {

--- a/src/Symfony/EventListener/RespondListener.php
+++ b/src/Symfony/EventListener/RespondListener.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Symfony\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Util\OperationRequestInitiatorTrait;
@@ -91,7 +90,7 @@ final class RespondListener
         ) {
             $status = 301;
             $headers['Location'] = $this->iriConverter->getIriFromResource($request->attributes->get('data'), UrlGeneratorInterface::ABS_PATH, $operation);
-        } elseif (HttpOperation::METHOD_PUT === $method && !($attributes['previous_data'] ?? null) && null === $status && ($operation instanceof Put && ($operation->getAllowCreate() ?? false))) {
+        } elseif ('PUT' === $method && !($attributes['previous_data'] ?? null) && null === $status && ($operation instanceof Put && ($operation->getAllowCreate() ?? false))) {
             $status = Response::HTTP_CREATED;
         }
 
@@ -100,7 +99,7 @@ final class RespondListener
         if ($request->attributes->has('_api_write_item_iri')) {
             $headers['Content-Location'] = $request->attributes->get('_api_write_item_iri');
 
-            if ((Response::HTTP_CREATED === $status || (300 <= $status && $status < 400)) && HttpOperation::METHOD_POST === $method) {
+            if ((Response::HTTP_CREATED === $status || (300 <= $status && $status < 400)) && 'POST' === $method) {
                 $headers['Location'] = $request->attributes->get('_api_write_item_iri');
             }
         }

--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\Routing;
 
 use ApiPlatform\Exception\RuntimeException;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use Symfony\Component\Config\FileLocator;
@@ -97,7 +96,7 @@ final class ApiLoader extends Loader
                         $operation->getOptions() ?? [],
                         $operation->getHost() ?? '',
                         $operation->getSchemes() ?? [],
-                        [$operation->getMethod() ?? HttpOperation::METHOD_GET],
+                        [$operation->getMethod() ?? 'GET'],
                         $operation->getCondition() ?? ''
                     );
 

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -138,7 +138,7 @@ final class IriConverter implements IriConverterInterface
         // In symfony the operation name is the route name, try to find one if none provided
         if (
             !$operation->getName()
-            || ($operation instanceof HttpOperation && HttpOperation::METHOD_POST === $operation->getMethod())
+            || ($operation instanceof HttpOperation && 'POST' === $operation->getMethod())
         ) {
             $forceCollection = $operation instanceof CollectionOperationInterface;
             try {

--- a/tests/Fixtures/TestBundle/Metadata/Get.php
+++ b/tests/Fixtures/TestBundle/Metadata/Get.php
@@ -23,6 +23,6 @@ final class Get extends HttpOperation
      */
     public function __construct(...$args)
     {
-        parent::__construct(self::METHOD_GET, ...$args);
+        parent::__construct('GET', ...$args);
     }
 }


### PR DESCRIPTION
As spoken with @chalasr there are string hardcoded operation request which could be replaced with the HttpOperation request const

Maybe this isn't what you want but I thought this would be good to replace those.
I'll gladly take any advice.

I don't know to which branch this should be merged so I'd like your advice.