### PR TITLE
Fixing issue in ORM/LinkHandlerTrait : Wrong class metadata

### DIFF
--- a/src/Doctrine/Orm/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Orm/State/LinksHandlerTrait.php
@@ -49,30 +49,29 @@ trait LinksHandlerTrait
                 continue;
             }
 
+            $fromClassMetadata = $manager->getClassMetadata($link->getFromClass());
             $identifierProperties = $link->getIdentifiers();
             $hasCompositeIdentifiers = 1 < \count($identifierProperties);
 
             if (!$link->getFromProperty() && !$link->getToProperty()) {
-                $doctrineClassMetadata = $manager->getClassMetadata($link->getFromClass());
                 $currentAlias = $link->getFromClass() === $entityClass ? $alias : $queryNameGenerator->generateJoinAlias($alias);
 
                 foreach ($identifierProperties as $identifierProperty) {
                     $placeholder = $queryNameGenerator->generateParameterName($identifierProperty);
                     $queryBuilder->andWhere("$currentAlias.$identifierProperty = :$placeholder");
-                    $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $doctrineClassMetadata->getTypeOfField($identifierProperty));
+                    $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $fromClassMetadata->getTypeOfField($identifierProperty));
                 }
 
                 $previousAlias = $currentAlias;
-                $previousJoinProperties = $doctrineClassMetadata->getIdentifierFieldNames();
+                $previousJoinProperties = $fromClassMetadata->getIdentifierFieldNames();
                 continue;
             }
 
             $joinProperties = $doctrineClassMetadata->getIdentifierFieldNames();
 
             if ($link->getFromProperty() && !$link->getToProperty()) {
-                $doctrineClassMetadata = $manager->getClassMetadata($link->getFromClass());
                 $joinAlias = $queryNameGenerator->generateJoinAlias('m');
-                $associationMapping = $doctrineClassMetadata->getAssociationMapping($link->getFromProperty()); // @phpstan-ignore-line
+                $associationMapping = $fromClassMetadata->getAssociationMapping($link->getFromProperty()); // @phpstan-ignore-line
                 $relationType = $associationMapping['type'];
 
                 if ($relationType & ClassMetadataInfo::TO_MANY) {
@@ -81,7 +80,7 @@ trait LinksHandlerTrait
                     foreach ($identifierProperties as $identifierProperty) {
                         $placeholder = $queryNameGenerator->generateParameterName($identifierProperty);
                         $whereClause[] = "$nextAlias.{$identifierProperty} = :$placeholder";
-                        $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $doctrineClassMetadata->getTypeOfField($identifierProperty));
+                        $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $fromClassMetadata->getTypeOfField($identifierProperty));
                     }
 
                     $property = $associationMapping['mappedBy'] ?? $joinProperties[0];
@@ -106,7 +105,7 @@ trait LinksHandlerTrait
                 foreach ($identifierProperties as $identifierProperty) {
                     $placeholder = $queryNameGenerator->generateParameterName($identifierProperty);
                     $queryBuilder->andWhere("$joinAlias.$identifierProperty = :$placeholder");
-                    $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $doctrineClassMetadata->getTypeOfField($identifierProperty));
+                    $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $fromClassMetadata->getTypeOfField($identifierProperty));
                 }
 
                 $previousAlias = $joinAlias;
@@ -120,7 +119,7 @@ trait LinksHandlerTrait
             foreach ($identifierProperties as $identifierProperty) {
                 $placeholder = $queryNameGenerator->generateParameterName($identifierProperty);
                 $queryBuilder->andWhere("$joinAlias.$identifierProperty = :$placeholder");
-                $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $doctrineClassMetadata->getTypeOfField($identifierProperty));
+                $queryBuilder->setParameter($placeholder, $this->getIdentifierValue($identifiers, $hasCompositeIdentifiers ? $identifierProperty : null), $fromClassMetadata->getTypeOfField($identifierProperty));
             }
 
             $previousAlias = $joinAlias;


### PR DESCRIPTION
When provided with both a fromProperty and toProperty in a link, the wrong class metadata was used to find the type of the identifier parameters (line 123).

| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Tickets       | No
| License       | MIT

$doctrineClassMetadata was used for both the resource class and the fromClass which was confusing, I renamed the latter to fromClassMetadata in order to clarify things up.
