### PR TITLE
fix(jsonschema): access related subschema on readableLink

### DIFF
--- a/src/JsonSchema/Tests/TypeFactoryTest.php
+++ b/src/JsonSchema/Tests/TypeFactoryTest.php
@@ -399,7 +399,7 @@ class TypeFactoryTest extends TestCase
     {
         $schemaFactoryProphecy = $this->prophesize(SchemaFactoryInterface::class);
 
-        $schemaFactoryProphecy->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, Argument::type(Schema::class), ['foo' => 'bar'], false)->will(function (array $args) {
+        $schemaFactoryProphecy->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, Argument::type(Schema::class), Argument::type('array'), false)->will(function (array $args) {
             $args[4]['$ref'] = 'ref';
 
             return $args[4];

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -152,6 +152,7 @@ final class TypeFactory implements TypeFactoryInterface
             throw new \LogicException('The schema factory must be injected by calling the "setSchemaFactory" method.');
         }
 
+        $serializerContext += [SchemaFactory::FORCE_SUBSCHEMA => true];
         $subSchema = $this->schemaFactory->buildSchema($className, $format, Schema::TYPE_OUTPUT, null, $subSchema, $serializerContext, false);
 
         return ['$ref' => $subSchema['$ref']];

--- a/tests/Fixtures/TestBundle/ApiResource/Issue5501/BrokenDocs.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue5501/BrokenDocs.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5501;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            normalizationContext: ['groups' => ['location:read_collection']]
+        ),
+    ]
+)]
+class BrokenDocs
+{
+    public ?int $id = null;
+
+    /**
+     * @var ?ArrayCollection<Related>
+     */
+    #[Groups(['location:write', 'location:read_collection'])]
+    public ?ArrayCollection $locations;
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue5501/Related.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue5501/Related.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5501;
+
+use ApiPlatform\Metadata\ApiResource;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(operations: [])]
+class Related
+{
+    #[Groups(['location:write', 'location:read_collection'])]
+    public ?string $name = null;
+}

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -80,4 +80,17 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $this->assertStringNotContainsString('@context', $result);
         $this->assertStringNotContainsString('@type', $result);
     }
+
+    /**
+     * Test issue #5501, the locations relation inside BrokenDocs is a Resource (named Related) but its only operation is a NotExposed.
+     * Still, serializer groups are set, and therefore it is a "readableLink" so we actually want to compute the schema, even if it's not accessible
+     * directly, it is accessible through that relation.
+     */
+    public function testExecuteWithNotExposedResourceAndReadableLink(): void
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5501\BrokenDocs', '--type' => 'output']);
+        $result = $this->tester->getDisplay();
+
+        $this->assertStringContainsString('Related.jsonld-location.read_collection', $result);
+    }
 }


### PR DESCRIPTION
fixes #5501

The locations relation inside BrokenDocs is a Resource (named Related) but its only operation is a NotExposed. Still, serializer groups are set, and therefore it is a "readableLink" so we actually want to compute the schema, even if it's not accessible directly, it is accessible through that relation.