### PR TITLE
draft: fix(UriVariable): fix string being cast to int

### DIFF
--- a/src/Api/UriVariableTransformer/IntegerUriVariableTransformer.php
+++ b/src/Api/UriVariableTransformer/IntegerUriVariableTransformer.php
@@ -18,9 +18,9 @@ use Symfony\Component\PropertyInfo\Type;
 
 final class IntegerUriVariableTransformer implements UriVariableTransformerInterface
 {
-    public function transform(mixed $value, array $types, array $context = []): int
+    public function transform(mixed $value, array $types, array $context = []): int|string
     {
-        return (int) $value;
+        return is_numeric($value) ? (int) $value : $value;
     }
 
     public function supportsTransformation(mixed $value, array $types, array $context = []): bool

--- a/src/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Metadata/Resource/ResourceMetadataCollection.php
@@ -89,9 +89,9 @@ final class ResourceMetadataCollection extends \ArrayObject
         }
 
         // Idea:
-//         if ($metadata) {
-//             return (new class extends HttpOperation {})->withResource($metadata);
-//         }
+        //         if ($metadata) {
+        //             return (new class extends HttpOperation {})->withResource($metadata);
+        //         }
 
         $this->handleNotFound($operationName, $metadata);
     }

--- a/tests/Api/UriVariableTransformer/IntegerUriVariableTransformerTest.php
+++ b/tests/Api/UriVariableTransformer/IntegerUriVariableTransformerTest.php
@@ -23,6 +23,11 @@ class IntegerUriVariableTransformerTest extends TestCase
         $this->assertSame(2, (new IntegerUriVariableTransformer())->transform('2', ['int']));
     }
 
+    public function testCastString(): void
+    {
+        $this->assertSame('7foo', (new IntegerUriVariableTransformer())->transform('7foo', ['int']));
+    }
+
     public function testSupportsTransformation(): void
     {
         $normalizer = new IntegerUriVariableTransformer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |3.1 <!-- see below -->
| Tickets       | #5396 <!-- please link related issues if existing -->
| License       | MIT

When passing multiple UriVariables, it is possible that a string, such as a key, could be cast to an integer (e.g., '73foo'). To avoid any potential issues, a check is performed before the cast as a workaround.
