### PR TITLE
fix: class already declared with preloading

### DIFF
--- a/src/Metadata/FilterInterface.php
+++ b/src/Metadata/FilterInterface.php
@@ -55,4 +55,6 @@ interface FilterInterface
     public function getDescription(string $resourceClass): array;
 }
 
-class_alias(FilterInterface::class, \ApiPlatform\Api\FilterInterface::class);
+if (!interface_exists(\ApiPlatform\Api\FilterInterface::class)) {
+    class_alias(FilterInterface::class, \ApiPlatform\Api\FilterInterface::class);
+}

--- a/src/Metadata/Operation/PathSegmentNameGeneratorInterface.php
+++ b/src/Metadata/Operation/PathSegmentNameGeneratorInterface.php
@@ -30,4 +30,6 @@ interface PathSegmentNameGeneratorInterface
     public function getSegmentName(string $name, bool $collection = true): string;
 }
 
-class_alias(PathSegmentNameGeneratorInterface::class, \ApiPlatform\Operation\PathSegmentNameGeneratorInterface::class);
+if (!interface_exists(\ApiPlatform\Operation\PathSegmentNameGeneratorInterface::class)) {
+    class_alias(PathSegmentNameGeneratorInterface::class, \ApiPlatform\Operation\PathSegmentNameGeneratorInterface::class);
+}

--- a/src/Metadata/ResourceClassResolverInterface.php
+++ b/src/Metadata/ResourceClassResolverInterface.php
@@ -38,4 +38,6 @@ interface ResourceClassResolverInterface
     public function isResourceClass(string $type): bool;
 }
 
-class_alias(ResourceClassResolverInterface::class, \ApiPlatform\Api\ResourceClassResolverInterface::class);
+if (!interface_exists(\ApiPlatform\Api\ResourceClassResolverInterface::class)) {
+    class_alias(ResourceClassResolverInterface::class, \ApiPlatform\Api\ResourceClassResolverInterface::class);
+}

--- a/src/OpenApi/Command/OpenApiCommand.php
+++ b/src/OpenApi/Command/OpenApiCommand.php
@@ -77,4 +77,6 @@ final class OpenApiCommand extends Command
     }
 }
 
-class_alias(OpenApiCommand::class, \ApiPlatform\Symfony\Bundle\Command\OpenApiCommand::class);
+if (!class_exists(\ApiPlatform\Symfony\Bundle\Command\OpenApiCommand::class)) {
+    class_alias(OpenApiCommand::class, \ApiPlatform\Symfony\Bundle\Command\OpenApiCommand::class);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | [#... <!-- please link related issues if existing -->](https://github.com/api-platform/core/issues/5522)
| License       | MIT
| Doc PR        | 

Error with PHP opacache preload :
`Warning: Cannot declare interface ApiPlatform\Api\FilterInterface, because the name is already in use`