### PR TITLE
fix: wrong contributors link in composer.json

### DIFF
--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "API Platform Community",
-      "homepage": "https://api-platform.com/contributors"
+      "homepage": "https://api-platform.com/community/contributors"
     }
   ],
   "require": {

--- a/src/Metadata/composer.json
+++ b/src/Metadata/composer.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "API Platform Community",
-      "homepage": "https://api-platform.com/contributors"
+      "homepage": "https://api-platform.com/community/contributors"
     }
   ],
   "require": {

--- a/src/OpenApi/composer.json
+++ b/src/OpenApi/composer.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "API Platform Community",
-            "homepage": "https://api-platform.com/contributors"
+            "homepage": "https://api-platform.com/community/contributors"
         }
     ],
     "require": {

--- a/src/State/composer.json
+++ b/src/State/composer.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "API Platform Community",
-            "homepage": "https://api-platform.com/contributors"
+            "homepage": "https://api-platform.com/community/contributors"
         }
     ],
     "require": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| License       | MIT

The link to the contributors' page in some composer.json files is incorrect, changed it for the right one : [https://api-platform.com/community/contributors](https://api-platform.com/community/contributors%60)