### PR TITLE
fix(hydra): prevent adding Link header when docs is disabled

### DIFF
--- a/src/Hydra/EventListener/AddLinkHeaderListener.php
+++ b/src/Hydra/EventListener/AddLinkHeaderListener.php
@@ -29,7 +29,7 @@ final class AddLinkHeaderListener
 {
     use CorsTrait;
 
-    public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
+    public function __construct(private readonly UrlGeneratorInterface $urlGenerator, private readonly bool $enableDocs)
     {
     }
 
@@ -41,6 +41,11 @@ final class AddLinkHeaderListener
         $request = $event->getRequest();
         // Prevent issues with NelmioCorsBundle
         if ($this->isPreflightRequest($request)) {
+            return;
+        }
+
+        // Prevent adding Link header when docs is disabled
+        if (!$this->enableDocs) {
             return;
         }
 

--- a/src/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Metadata/Resource/ResourceMetadataCollection.php
@@ -89,9 +89,9 @@ final class ResourceMetadataCollection extends \ArrayObject
         }
 
         // Idea:
-//         if ($metadata) {
-//             return (new class extends HttpOperation {})->withResource($metadata);
-//         }
+        //         if ($metadata) {
+        //             return (new class extends HttpOperation {})->withResource($metadata);
+        //         }
 
         $this->handleNotFound($operationName, $metadata);
     }

--- a/src/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Symfony/Bundle/Resources/config/hydra.xml
@@ -24,6 +24,7 @@
 
         <service id="api_platform.hydra.listener.response.add_link_header" class="ApiPlatform\Hydra\EventListener\AddLinkHeaderListener">
             <argument type="service" id="api_platform.router" />
+            <argument>%api_platform.enable_docs%</argument>
 
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | #5528 
| License       | MIT
| Doc PR        | NA

Hello,

This PR aims to fix #5528.
Should I handle the backward compatibility as explained [here](https://symfony.com/doc/current/contributing/code/bc.html#add-argument-public-method)?
