### PR TITLE
fix(symfony): update for PHPUnit 10

### DIFF
--- a/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
+++ b/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
@@ -31,6 +31,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\Parser\Php7;
 use PhpParser\PrettyPrinter\Standard;
 use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -215,7 +216,7 @@ This will remove "ApiPlatform\Core\Annotation\ApiResource" annotation/attribute 
     private function printDiff(string $oldCode, string $newCode, OutputInterface $output): void
     {
         $consoleFormatter = new ColorConsoleDiffFormatter();
-        $differ = new Differ();
+        $differ = new Differ(new UnifiedDiffOutputBuilder());
         $diff = $differ->diff($oldCode, $newCode);
         $output->write($consoleFormatter->format($diff));
     }

--- a/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
+++ b/src/Core/Bridge/Symfony/Bundle/Command/UpgradeApiResourceCommand.php
@@ -216,7 +216,7 @@ This will remove "ApiPlatform\Core\Annotation\ApiResource" annotation/attribute 
     private function printDiff(string $oldCode, string $newCode, OutputInterface $output): void
     {
         $consoleFormatter = new ColorConsoleDiffFormatter();
-        $differ = new Differ(new UnifiedDiffOutputBuilder());
+        $differ = class_exists(UnifiedDiffOutputBuilder::class) ? new Differ(new UnifiedDiffOutputBuilder()) :  new Differ();
         $diff = $differ->diff($oldCode, $newCode);
         $output->write($consoleFormatter->format($diff));
     }


### PR DESCRIPTION
The Differ now expects a output builder as mandatory argument.

Fixes #5426

| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see below -->
| Tickets       | #5426 <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Update the `UpgradeApiResourceCommand` for changes in PHPUnit 10.