### PR TITLE
Fix OpenApiCommand autoload issue

### DIFF
--- a/src/Symfony/Bundle/Command/OpenApiCommand.php
+++ b/src/Symfony/Bundle/Command/OpenApiCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\Bundle\Command;
 
 class_exists(\ApiPlatform\OpenApi\Command\OpenApiCommand::class);
+class_alias(\ApiPlatform\OpenApi\Command\OpenApiCommand::class, \ApiPlatform\Symfony\Bundle\Command\OpenApiCommand::class);
 
 if (false) {
     final class OpenApiCommand extends \ApiPlatform\OpenApi\Command\OpenApiCommand


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | #5567
| License       | MIT

This PR fixes #5567 by aliasing the class which is now no longer found by the autoloader.

Should we trigger a deprecation or something if this file is required?