### PR TITLE
feat(tests): add a method to generate the IRI from a resource

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -99,4 +99,15 @@ abstract class ApiTestCase extends KernelTestCase
 
         return $iriConverter->getIriFromResource($item);
     }
+    
+    /**
+     * Generate the IRI of a resource item.
+     */
+    protected function getIriForResource(object $resource): ?string
+    {
+        /** @var IriConverterInterface $iriConverter */
+        $iriConverter = static::getContainer()->get('api_platform.iri_converter');
+
+        return $iriConverter->getIriFromResource($resource);
+    }
 }

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -94,7 +94,7 @@ abstract class ApiTestCase extends KernelTestCase
             return null;
         }
 
-        return $this->getIriForResource($item);
+        return $this->getIriFromResource($item);
     }
 
     /**

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -94,10 +94,7 @@ abstract class ApiTestCase extends KernelTestCase
             return null;
         }
 
-        /** @var IriConverterInterface $iriConverter */
-        $iriConverter = $container->get('api_platform.iri_converter');
-
-        return $iriConverter->getIriFromResource($item);
+        return $this->getIriForResource($item);
     }
 
     /**

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -100,7 +100,7 @@ abstract class ApiTestCase extends KernelTestCase
     /**
      * Generate the IRI of a resource item.
      */
-    protected function getIriForResource(object $resource): ?string
+    protected function getIriFromResource(object $resource): ?string
     {
         /** @var IriConverterInterface $iriConverter */
         $iriConverter = static::getContainer()->get('api_platform.iri_converter');

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -99,7 +99,7 @@ abstract class ApiTestCase extends KernelTestCase
 
         return $iriConverter->getIriFromResource($item);
     }
-    
+
     /**
      * Generate the IRI of a resource item.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       |
| License       | MIT
| Doc PR        | 

Use case: 

```php
$code = CouponCodeFactory::createOne(['code' => 'FOOBAR_123']);

$response = $client->request('POST', '/cart', [
    'json' => [
        ...
        'code' => getIriForResource($code->object()), // Instead of findIriBy(['code' => 'FOOBAR_123']) or manually generating IRI                
    ],
]);

self::assertResponseIsSuccessful();

```
