### PR TITLE
fix: allows changing getters and setters without breaks

### DIFF
--- a/features/jsonld/getter_setter_renaming.feature
+++ b/features/jsonld/getter_setter_renaming.feature
@@ -1,0 +1,25 @@
+Feature: Resource should contain one field for each property
+  In order to use API resource
+  As a developer
+  I need to have one field exposed for each property (which take getter/setter name)
+
+  @createSchema
+  Scenario: I should be able to POST a new entity
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    When I send a "POST" request to "/entity_with_renamed_getter_and_setters" with body:
+    """
+    {
+      "firstnameOnly": "Sarah"
+    }
+    """
+    Then the response status code should be 201
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/EntityWithRenamedGetterAndSetter",
+      "@id": "/entity_with_renamed_getter_and_setters",
+      "@type": "EntityWithRenamedGetterAndSetter",
+      "firstnameOnly": "Sarah"
+    }
+    """

--- a/tests/Fixtures/TestBundle/ApiResource/EntityWithRenamedGetterAndSetter.php
+++ b/tests/Fixtures/TestBundle/ApiResource/EntityWithRenamedGetterAndSetter.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Operation;
+
+#[ApiResource(provider: [self::class, 'provide'])]
+class EntityWithRenamedGetterAndSetter
+{
+    private string $name;
+
+    public function getFirstnameOnly(): string
+    {
+        return $this->name;
+    }
+
+    public function setFirstnameOnly(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        return $context;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | 
| License       | MIT

This PR tests that no field is added to the resource when renaming the getter and setter of a private property
. (related https://github.com/api-platform/api-platform/issues/2426).

