### PR TITLE
fix: generate IRI with datetime identifier

### DIFF
--- a/features/main/datetime_identifier.feature
+++ b/features/main/datetime_identifier.feature
@@ -1,0 +1,25 @@
+Feature: Resource should generate an IRI for an item with a datetime identifier
+  In order to use API resource
+  As a developer
+  I need to be able to create an item with a datetime identifier and have an IRI generated
+
+  @createSchema
+  Scenario: I should be able to POST a new entity
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    When I send a "POST" request to "/entity_with_date_time_identifiers" with body:
+    """
+    {
+      "day": "2022-05-22T14:38:16.164Z"
+    }
+    """
+    Then the response status code should be 201
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/EntityWithDateTimeIdentifier",
+      "@id": "/entity_with_date_time_identifiers/2022-05-22-14-38-16",
+      "@type": "EntityWithDateTimeIdentifier",
+      "day": "2022-05-22T14:38:16+00:00"
+    }
+    """

--- a/src/Api/IdentifiersExtractor.php
+++ b/src/Api/IdentifiersExtractor.php
@@ -159,6 +159,10 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
             return (string) $identifierValue->value;
         }
 
+        if ($identifierValue instanceof \DateTimeInterface) {
+            return $identifierValue->format('Y-m-d-H-i-s');
+        }
+
         throw new RuntimeException(sprintf('We were not able to resolve the identifier matching parameter "%s".', $parameterName));
     }
 }

--- a/tests/Fixtures/TestBundle/ApiResource/EntityWithDateTimeIdentifier.php
+++ b/tests/Fixtures/TestBundle/ApiResource/EntityWithDateTimeIdentifier.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Operation;
+
+#[ApiResource(provider: [self::class, 'provide'])]
+class EntityWithDateTimeIdentifier
+{
+    #[ApiProperty(identifier: true)]
+    private ?\DateTimeInterface $day;
+
+    public function __construct($day)
+    {
+        $this->setDay($day);
+    }
+
+    public function getDay(): ?\DateTimeInterface
+    {
+        return $this->day;
+    }
+
+    public function setDay(?\DateTimeInterface $day): void
+    {
+        $this->day = $day;
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        return $context;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | 
| License       | MIT

This PR allows to create an item with a datetime identifier. 
Related to https://github.com/api-platform/api-platform/issues/2444