### PR TITLE
fix: enable API Platform integration in LexikJWTAuthenticationBundle

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -81,6 +81,13 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
                 ],
             ]);
         }
+        if (isset($container->getExtensions()['lexik_jwt_authentication'])) {
+            $container->prependExtensionConfig('lexik_jwt_authentication', [
+                'api_platform' => [
+                    'enabled' => true,
+                ],
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
After https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1119, the API Platform integration is not enabled automatically anymore.
Doing this should solve it.