### PR TITLE
[WIP] Update AbstractConstraintViolationListNormalizer.php

### DIFF
--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -45,6 +45,13 @@ abstract class AbstractConstraintViolationListNormalizer implements NormalizerIn
     {
         return static::FORMAT === $format && $data instanceof ConstraintViolationListInterface;
     }
+    
+    public function getSupportedTypes(?string $format)
+    {
+        return [
+            ConstraintViolationListInterface::class => $this->hasCacheableSupportsMethod(),
+        ];
+    }
 
     public function hasCacheableSupportsMethod(): bool
     {


### PR DESCRIPTION
Add getSupportedTypes method

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #5610
| License       | MIT

See the article https://symfony.com/blog/new-in-symfony-6-3-performance-improvements#improved-performance-of-serializer-normalizers-denormalizers

_In Symfony 6.3, we've added a getSupportedTypes(?string $format): array method to normalizers/denormalizers so they can declare the type of objects that they can handle and whether they are cacheable._

Need help for others Normalizers