### PR TITLE
[RFC] Native UID support in search filter

### DIFF
--- a/src/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -19,6 +19,7 @@ use ApiPlatform\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Exception\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Uid\AbstractUid;
 
 /**
  * Trait for filtering the collection by given properties.
@@ -124,7 +125,9 @@ trait SearchFilterTrait
             $iriConverter = $this->getIriConverter();
             $item = $iriConverter->getResourceFromIri($value, ['fetch_data' => false]);
 
-            return $this->getPropertyAccessor()->getValue($item, 'id');
+            $id = $this->getPropertyAccessor()->getValue($item, 'id');
+
+            return ($id instanceof AbstractUid) ? $id->toBinary() : $id;
         } catch (InvalidArgumentException) {
             // Do nothing, return the raw value
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | https://github.com/api-platform/api-platform/issues/1958 https://github.com/api-platform/api-platform/issues/2134 https://github.com/api-platform/core/pull/4313 https://github.com/api-platform/core/issues/4656
| License       | MIT

Hello there,

Given:
- The [wide and growing](https://github.com/api-platform/core/issues?q=ulid) adoption of Ulids as primary keys
- The fact that using Ulids instead of integers as primary keys [is encouraged for security and scalability concerns](https://medium.com/@galopintitouan/auto-increment-is-the-devil-using-uuids-in-symfony-and-doctrine-71763721b9a9)
- The usage of `symfony/uid` is natively supported in API-Platform as of https://github.com/api-platform/core/pull/3715
- Docrtrine's `SearchFilter` **currently doesn't work with Ulids** as they're serialized as strings instead of binaries when used in DQL queries
- Current proposal to tackle this is to create a duplicate `SearchFilter`, specifically for handling Ulids, which is tedious and has to be done for every project, without any kind of standardization
- Fixing this seems at first glance **as easy as this PR**, may seem crappy/hacky at first sight but actually means "we support scalars _or_ Uids, just like Symfony does"

I know there have been lots of dicussions, even PRs in the past regarding this, at a time when the UID component was more or less experimental and not a lot of people used it, but I think things have changed since then.
Is it something you could reconsider?