### PR TITLE
fix: filters don't have to  implement the "legacy" FilterInterface

### DIFF
--- a/src/Metadata/ApiFilter.php
+++ b/src/Metadata/ApiFilter.php
@@ -34,7 +34,7 @@ final class ApiFilter
         public array $properties = [],
         public array $arguments = [],
     ) {
-        if (!is_a($this->filterClass, FilterInterface::class, true) || !is_a($this->filterClass, LegacyFilterInterface::class, true)) {
+        if (!is_a($this->filterClass, FilterInterface::class, true) && !is_a($this->filterClass, LegacyFilterInterface::class, true)) {
             throw new InvalidArgumentException(sprintf('The filter class "%s" does not implement "%s". Did you forget a use statement?', $this->filterClass, FilterInterface::class));
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1

Simple fix, filters need to implement either the legacy FilterInterface or the new one, not both.