### PR TITLE
fix: urlencode "+" sign before processing query parameters

### DIFF
--- a/src/Util/RequestParser.php
+++ b/src/Util/RequestParser.php
@@ -79,6 +79,11 @@ final class RequestParser
 
             $keyValuePair = explode('=', $param, 2);
 
+            // Encode "+" sign so it's not decoded to a space afterward.
+            if (isset($keyValuePair[1])) {
+                $keyValuePair[1] = str_replace('+', '%2B', $keyValuePair[1]);
+            }
+
             // GET parameters, that are submitted from a HTML form, encode spaces as "+" by default (as defined in enctype application/x-www-form-urlencoded).
             // PHP also converts "+" to spaces when filling the global _GET or when using the function parse_str. This is why we use urldecode and then normalize to
             // RFC 3986 with rawurlencode.

--- a/tests/Util/RequestParserTest.php
+++ b/tests/Util/RequestParserTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Tests\Util;
 
 use ApiPlatform\Util\RequestParser;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
@@ -27,6 +28,15 @@ class RequestParserTest extends TestCase
     public function testParseRequestParams(string $source, array $expected): void
     {
         $actual = RequestParser::parseRequestParams($source);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider getQueryStringProvider
+     */
+    public function testGetQueryString(Request $request, ?string $expected): void
+    {
+        $actual = RequestParser::getQueryString($request);
         $this->assertSame($expected, $actual);
     }
 
@@ -43,6 +53,18 @@ class RequestParserTest extends TestCase
 
             // urlencoded [] (square brackets) in query string.
             ['a%5B1%5D=%2525', ['a' => ['1' => '%25']]],
+        ];
+    }
+
+    public function getQueryStringProvider(): array
+    {
+        return [
+            'No query string' => [new Request(), null],
+            'With missing param' => [new Request(server: ['QUERY_STRING' => 'foo=bar&']), 'foo=bar'],
+            'With no param key' => [new Request(server: ['QUERY_STRING' => 'foo=bar&=baz']), 'foo=bar'],
+            'With space' => [new Request(server: ['QUERY_STRING' => 'foo=bar baz&key=value']), 'foo=bar%20baz&key=value'],
+            'With urlencoded + (plus)' => [new Request(server: ['QUERY_STRING' => 'date=2000-01-01T00%3A00%3A00%2B00%3A00&key=value']), 'date=2000-01-01T00%3A00%3A00%2B00%3A00&key=value'],
+            'With not urlencoded + (plus)' => [new Request(server: ['QUERY_STRING' => 'date=2000-01-01T00:00:00+00:00&key=value']), 'date=2000-01-01T00%3A00%3A00%2B00%3A00&key=value'],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When sending a request with a date in DATE_ATOM (e.g. `2000-01-01T00:00:00+00:00`) format, the plus sign was stripped and replaced by a space. 
This occurred in tests when sending the unencoded request to a client.

This PR adds tests for the `getQueryString` method and fixes the issue.

Tests are failing but it seems unrelated