### PR TITLE
fix: IriConverterInterface DI & deprecation

### DIFF
--- a/src/Core/Api/IriConverterInterface.php
+++ b/src/Core/Api/IriConverterInterface.php
@@ -22,6 +22,8 @@ use ApiPlatform\Exception\RuntimeException;
  * Converts item and resources to IRI and vice versa.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated Since Api Platform 2.7, use ApiPlatform\Api\IriConverterInterface instead.
  */
 interface IriConverterInterface
 {

--- a/src/Core/Api/LegacyIriConverter.php
+++ b/src/Core/Api/LegacyIriConverter.php
@@ -21,6 +21,8 @@ use ApiPlatform\Metadata\Operation;
 /**
  * This IRI converter calls the legacy IriConverter on legacy resources.
  *
+ * It also replaces the new iri converter when BC flag is ON to allow using the new interface without new metadata system.
+ *
  * @author Antoine Bluchet <soyuka@gmail.com>
  *
  * @internal
@@ -30,7 +32,7 @@ final class LegacyIriConverter implements IriConverterInterface
     private $legacyIriConverter;
     private $iriConverter;
 
-    public function __construct(LegacyIriConverterInterface $legacyIriConverter, IriConverterInterface $iriConverter)
+    public function __construct(LegacyIriConverterInterface $legacyIriConverter, IriConverterInterface $iriConverter = null)
     {
         $this->legacyIriConverter = $legacyIriConverter;
         $this->iriConverter = $iriConverter;
@@ -41,6 +43,10 @@ final class LegacyIriConverter implements IriConverterInterface
      */
     public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null)
     {
+        if (null === $this->iriConverter) {
+            return $this->legacyIriConverter->getItemFromIri($iri, $context);
+        }
+
         if (!$operation && !($operation = $context['operation'] ?? null)) {
             return $this->iriConverter->getResourceFromIri($iri, $context);
         }
@@ -57,6 +63,10 @@ final class LegacyIriConverter implements IriConverterInterface
      */
     public function getIriFromResource($item, int $referenceType = UrlGeneratorInterface::ABS_PATH, Operation $operation = null, array $context = []): ?string
     {
+        if (null === $this->iriConverter) {
+            return \is_string($item) ? $this->legacyIriConverter->getIriFromResourceClass($item, $referenceType) : $this->legacyIriConverter->getIriFromItem($item, $referenceType);
+        }
+
         return $this->iriConverter->getIriFromResource($item, $referenceType, $operation, $context);
     }
 }

--- a/src/Core/Bridge/Symfony/Routing/IriConverter.php
+++ b/src/Core/Bridge/Symfony/Routing/IriConverter.php
@@ -31,7 +31,6 @@ use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Exception\InvalidIdentifierException;
 use ApiPlatform\Exception\ItemNotFoundException;
 use ApiPlatform\Exception\RuntimeException;
-use ApiPlatform\Symfony\Routing\IriConverter as NewIriConverter;
 use ApiPlatform\Util\AttributesExtractor;
 use ApiPlatform\Util\ResourceClassInfoTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -43,6 +42,8 @@ use Symfony\Component\Routing\RouterInterface;
  * {@inheritdoc}
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated Since Api Platform 2.7, use ApiPlatform\Symfony\Routing\IriConverter instead.
  */
 final class IriConverter implements IriConverterInterface
 {
@@ -63,8 +64,6 @@ final class IriConverter implements IriConverterInterface
         $this->resourceClassResolver = $resourceClassResolver;
         $this->identifiersExtractor = $identifiersExtractor ?: new IdentifiersExtractor($propertyNameCollectionFactory, $propertyMetadataFactory, $propertyAccessor ?? PropertyAccess::createPropertyAccessor());
         $this->resourceMetadataFactory = $resourceMetadataFactory;
-
-        trigger_deprecation('api-platform/core', '2.7', sprintf('The service "%s" is deprecated, use %s instead.', self::class, NewIriConverter::class));
     }
 
     /**

--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Symfony\Bundle;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DeprecateLegacyIriConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DeprecateMercurePublisherPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
@@ -54,6 +55,7 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new MetadataAwareNameConverterPass());
         $container->addCompilerPass(new TestClientPass());
         $container->addCompilerPass(new AuthenticatorManagerPass());
+        $container->addCompilerPass(new DeprecateLegacyIriConverterPass());
     }
 }
 

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/DeprecateLegacyIriConverterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/DeprecateLegacyIriConverterPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal calls `setDeprecated` method with valid arguments depending on which version of symfony/dependency-injection is used
+ */
+final class DeprecateLegacyIriConverterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasAlias(IriConverterInterface::class)) {
+            $container
+                ->getAlias(IriConverterInterface::class)
+                ->setDeprecated(...$this->buildDeprecationArgs('Using "%alias_id%" is deprecated since API Platform 2.7. Use "ApiPlatform\Api\IriConverterInterface" instead.'));
+        }
+
+        if ($container->hasDefinition(IriConverterInterface::class)) {
+            $container
+                ->getDefinition(IriConverterInterface::class)
+                ->setDeprecated(...$this->buildDeprecationArgs('Using "%service_id%" is deprecated since API Platform 2.7. Use "ApiPlatform\Api\IriConverterInterface" instead.'));
+        }
+
+        if ($container->hasDefinition('api_platform.iri_converter.legacy')) {
+            $container
+                ->getDefinition('api_platform.iri_converter.legacy')
+                ->setDeprecated(...$this->buildDeprecationArgs('Using "%service_id%" is deprecated since API Platform 2.7. Use "ApiPlatform\Api\IriConverterInterface" instead.'));
+        }
+    }
+
+    private function buildDeprecationArgs(string $message): array
+    {
+        return method_exists(BaseNode::class, 'getDeprecation')
+            ? ['api-platform/core', '2.7', $message]
+            : [$message];
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -159,6 +159,7 @@
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
         </service>
+        <service id="ApiPlatform\Core\Api\IriConverterInterface" alias="api_platform.iri_converter.legacy" />
 
         <service id="api_platform.symfony.iri_converter.skolem" class="ApiPlatform\Symfony\Routing\SkolemIriConverter" public="false">
             <argument type="service" id="api_platform.router" />

--- a/src/Symfony/Bundle/Resources/config/legacy/api.xml
+++ b/src/Symfony/Bundle/Resources/config/legacy/api.xml
@@ -45,7 +45,9 @@
             <argument type="service" id="api_platform.subresource_operation_factory" />
         </service>
 
-        <service id="ApiPlatform\Core\Api\IriConverterInterface" alias="api_platform.iri_converter.legacy" />
+        <service id="api_platform.symfony.iri_converter" class="ApiPlatform\Core\Api\LegacyIriConverter" public="false">
+            <argument type="service" id="api_platform.iri_converter.legacy"/>
+        </service>
 
         <service id="api_platform.listener.request.add_format" class="ApiPlatform\Symfony\EventListener\AddFormatListener">
             <argument type="service" id="api_platform.negotiator" />

--- a/src/Symfony/Bundle/Resources/config/legacy/backward_compatibility.xml
+++ b/src/Symfony/Bundle/Resources/config/legacy/backward_compatibility.xml
@@ -13,9 +13,8 @@
         <service id="api_platform.cache.metadata.property" alias="api_platform.cache.metadata.property.legacy"/>
         <service id="api_platform.cache.metadata.resource" alias="api_platform.cache.metadata.resource.legacy"/>
         <service id="api_platform.openapi.factory" alias="api_platform.openapi.factory.legacy" />
-        <service id="ApiPlatform\Api\IriConverterInterface" alias="api_platform.iri_converter" />
+        <service id="ApiPlatform\Api\IriConverterInterface" alias="api_platform.symfony.iri_converter" />
 
-        
         <service id="ApiPlatform\Core\Serializer\SerializerContextBuilderInterface" alias="ApiPlatform\Serializer\SerializerContextBuilderInterface" />
         <service id="ApiPlatform\Core\Api\ResourceClassResolverInterface" alias="ApiPlatform\Api\ResourceClassResolverInterface" />
         <service id="ApiPlatform\Core\Api\UrlGeneratorInterface" alias="ApiPlatform\Api\UrlGeneratorInterface" />

--- a/tests/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Symfony\Bundle\ApiPlatformBundle;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DeprecateLegacyIriConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DeprecateMercurePublisherPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\FilterPass;
@@ -52,6 +53,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(MetadataAwareNameConverterPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(TestClientPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(AuthenticatorManagerPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(DeprecateLegacyIriConverterPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
 
         $bundle = new ApiPlatformBundle();
         $bundle->build($containerProphecy->reveal());

--- a/tests/Symfony/Bundle/DependencyInjection/Compiler/DeprecateLegacyIriConverterPassTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/Compiler/DeprecateLegacyIriConverterPassTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Symfony\Bundle\DependencyInjection\Compiler;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Tests\ProphecyTrait;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\DeprecateLegacyIriConverterPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class DeprecateLegacyIriConverterPassTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testProcess(): void
+    {
+        $deprecateIriConverterPass = new DeprecateLegacyIriConverterPass();
+
+        $this->assertInstanceOf(CompilerPassInterface::class, $deprecateIriConverterPass);
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $aliasProphecy = $this->prophesize(Alias::class);
+        $definitionProphecy = $this->prophesize(Definition::class);
+
+        $containerBuilderProphecy
+            ->hasDefinition(IriConverterInterface::class)
+            ->willReturn(true);
+
+        $containerBuilderProphecy
+            ->hasAlias(IriConverterInterface::class)
+            ->willReturn(true);
+
+        $containerBuilderProphecy
+            ->hasDefinition('api_platform.iri_converter.legacy')
+            ->willReturn(true);
+
+        $containerBuilderProphecy
+            ->getDefinition(IriConverterInterface::class)
+            ->willReturn($definitionProphecy->reveal())
+            ->shouldBeCalled();
+
+        $containerBuilderProphecy
+            ->getAlias(IriConverterInterface::class)
+            ->willReturn($aliasProphecy->reveal())
+            ->shouldBeCalled();
+
+        $containerBuilderProphecy
+            ->getDefinition('api_platform.iri_converter.legacy')
+            ->willReturn($definitionProphecy->reveal())
+            ->shouldBeCalled();
+
+        $setDeprecatedAliasArgs = method_exists(BaseNode::class, 'getDeprecation')
+            ? ['api-platform/core', '2.7', 'Using "%alias_id%" is deprecated since API Platform 2.7. Use "ApiPlatform\Api\IriConverterInterface" instead.']
+            : ['Using "%alias_id%" is deprecated since API Platform 2.7. Use "ApiPlatform\Api\IriConverterInterface" instead.'];
+
+        $setDeprecatedDefinitionArgs = method_exists(BaseNode::class, 'getDeprecation')
+            ? ['api-platform/core', '2.7', 'Using "%service_id%" is deprecated since API Platform 2.7. Use "ApiPlatform\Api\IriConverterInterface" instead.']
+            : ['Using "%service_id%" is deprecated since API Platform 2.7. Use "ApiPlatform\Api\IriConverterInterface" instead.'];
+
+        $aliasProphecy
+            ->setDeprecated(...$setDeprecatedAliasArgs)
+            ->willReturn($aliasProphecy->reveal())
+            ->shouldBeCalled();
+
+        $definitionProphecy
+            ->setDeprecated(...$setDeprecatedDefinitionArgs)
+            ->willReturn($definitionProphecy->reveal())
+            ->shouldBeCalled();
+
+        $deprecateIriConverterPass->process($containerBuilderProphecy->reveal());
+    }
+
+    public function testProcessWithoutDefinition(): void
+    {
+        $deprecateIriConverterPass = new DeprecateLegacyIriConverterPass();
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+
+        $containerBuilderProphecy
+            ->hasDefinition(IriConverterInterface::class)
+            ->willReturn(false);
+
+        $containerBuilderProphecy
+            ->hasAlias(IriConverterInterface::class)
+            ->willReturn(false);
+
+        $containerBuilderProphecy
+            ->hasDefinition('api_platform.iri_converter.legacy')
+            ->willReturn(false);
+
+        $containerBuilderProphecy
+            ->getDefinition(IriConverterInterface::class)
+            ->shouldNotBeCalled();
+
+        $containerBuilderProphecy
+            ->getAlias(IriConverterInterface::class)
+            ->shouldNotBeCalled();
+
+        $containerBuilderProphecy
+            ->getDefinition('api_platform.iri_converter.legacy')
+            ->shouldNotBeCalled();
+
+        $deprecateIriConverterPass->process($containerBuilderProphecy->reveal());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #5620 
| License       | MIT

Hello, proposing a fix for an issue with dependency injection of  `ApiPlatform\Api\IriConverterInterface` & deprecation of `ApiPlatform\Core\Api\IriConverterInterface`. I'm open to discussion if you don't like the proposed solution ofc 🙂 

## The problem:

When BC flag is ON, we receive this deprecation notice
> Since api-platform/core 2.7: The service "ApiPlatform\Core\Bridge\Symfony\Routing\IriConverter" is deprecated, use "ApiPlatform\Symfony\Routing\IriConverter" instead.

There's a few issues with this deprecation imo:

### About DI:
* The message only mentions the concrete class, while user is probably referencing interfaces or service id `api_platform.iri_converter`. Actually both mentioned services does not exist with this id in container, which is confusing.
* Trying to inject the suggested service `ApiPlatform\Symfony\Routing\IriConverter` will crash at compile time because this service does not exist (which is expected)
* Trying to inject the interface implemented by this service `ApiPlatform\Api\IriConverterInterface`, as suggested by the compile time error message (service not existing, try changing the type hint to ...), leads to a type error at *runtime*, due to a misconfiguration (I think) the service referenced by alias `ApiPlatform\Api\IriConverterInterface` does not implement that interface. It is currently referencing `api_platform.iri_converter` which in turns reference `api_platform.iri_converter.legacy` which implements the old `ApiPlatform\Core\Api\IriConverterInterface`
* Trying to inject manually from the service id `api_platform.symfony.iri_converter` leads to another compile time error, because this service has a dependency on non existant services (the new metadata system)

At the end, we cannot get rid of the deprecation as long as BC flag is kept ON, i.e cannot use the new interface, which I think is an issue for a smooth upgrade.

### About deprecation, having the deprecation triggered from constructor has a few drawbacks:
* The deprecation does not show up in userland when running `bin/console debug:container --deprecations`
* The deprecation is triggered when going through the concrete class, while we should be interested in triggering deprecations for *references* to the service, since it can legitimately be used through `ApiPlatform\Core\Api\LegacyIriConverter` (which is now used with BC flag ON with the proposed DI solution below)
* It does not adhere to [Symfony convention](https://symfony.com/doc/current/contributing/code/conventions.html#deprecating-code) (When deprecating a whole class the trigger_deprecation() call should be placed after the use declarations)


## Proposed solution:

### About DI:
Make service `api_platform.symfony.iri_converter` available through `ApiPlatform\Api\IriConverterInterface` when BC flag is ON by using an implementation compatible with old metadata and new interface, e.g `ApiPlatform\Core\Api\LegacyIriConverter`.

### About deprecation:
Mark the old aliases/services as deprected instead of triggering deprecation from constructor (adding a compiler pass to deal with the different versions of `symfony/dependency-injection`). The has the advantage of showing all userland references to the deprecated service when running `bin/console debug:container --deprecations`, and users can easily get rid of the deprecation just by using the new interface
