### PR TITLE
feat: replace doctrine/inflector by symfony/string

### DIFF
--- a/src/Metadata/Util/Inflector.php
+++ b/src/Metadata/Util/Inflector.php
@@ -49,7 +49,8 @@ final class Inflector
     public static function pluralize(string $word): string
     {
         if (class_exists(EnglishInflector::class)) {
-            return (new EnglishInflector())->pluralize($word)[0];
+            $pluralize = (new EnglishInflector())->pluralize($word);
+            return end($pluralize);
         }
 
         return self::getInstance()->pluralize($word);

--- a/src/Metadata/Util/Inflector.php
+++ b/src/Metadata/Util/Inflector.php
@@ -13,19 +13,19 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Util;
 
-use Doctrine\Inflector\Inflector as InflectorObject;
+use Doctrine\Inflector\Inflector as LegacyInflector;
 use Doctrine\Inflector\InflectorFactory;
+use Symfony\Component\String\Inflector\EnglishInflector;
+use Symfony\Component\String\UnicodeString;
 
 /**
- * Facade for Doctrine Inflector.
- *
  * @internal
  */
 final class Inflector
 {
-    private static ?InflectorObject $instance = null;
+    private static ?LegacyInflector $instance = null;
 
-    private static function getInstance(): InflectorObject
+    private static function getInstance(): LegacyInflector
     {
         return self::$instance
             ?? self::$instance = InflectorFactory::create()->build();
@@ -36,6 +36,10 @@ final class Inflector
      */
     public static function tableize(string $word): string
     {
+        if (class_exists(UnicodeString::class)) {
+            return (new UnicodeString($word))->snake()->toString();
+        }
+
         return self::getInstance()->tableize($word);
     }
 
@@ -44,6 +48,10 @@ final class Inflector
      */
     public static function pluralize(string $word): string
     {
+        if (class_exists(EnglishInflector::class)) {
+            return (new EnglishInflector())->pluralize($word)[0];
+        }
+
         return self::getInstance()->pluralize($word);
     }
 }

--- a/src/Metadata/Util/Inflector.php
+++ b/src/Metadata/Util/Inflector.php
@@ -23,6 +23,7 @@ use Symfony\Component\String\UnicodeString;
  */
 final class Inflector
 {
+    private static bool $keepLegacyInflector;
     private static ?LegacyInflector $instance = null;
 
     private static function getInstance(): LegacyInflector
@@ -31,12 +32,17 @@ final class Inflector
             ?? self::$instance = InflectorFactory::create()->build();
     }
 
+    public static function keepLegacyInflector(bool $keepLegacyInflector): void
+    {
+        self::$keepLegacyInflector = $keepLegacyInflector;
+    }
+
     /**
      * @see InflectorObject::tableize()
      */
     public static function tableize(string $word): string
     {
-        if (class_exists(UnicodeString::class)) {
+        if (!self::$keepLegacyInflector) {
             return (new UnicodeString($word))->snake()->toString();
         }
 
@@ -48,7 +54,7 @@ final class Inflector
      */
     public static function pluralize(string $word): string
     {
-        if (class_exists(EnglishInflector::class)) {
+        if (!self::$keepLegacyInflector) {
             $pluralize = (new EnglishInflector())->pluralize($word);
             return end($pluralize);
         }

--- a/src/Metadata/composer.json
+++ b/src/Metadata/composer.json
@@ -31,7 +31,8 @@
     "doctrine/inflector": "^2.0",
     "psr/cache": "^3.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
-    "symfony/property-info": "^6.1"
+    "symfony/property-info": "^6.1",
+    "symfony/string": "^6.1"
   },
   "require-dev": {
     "phpstan/phpdoc-parser": "^1.16",

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -55,7 +55,6 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
-use Symfony\Component\String\UnicodeString;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -31,14 +31,13 @@ use ApiPlatform\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\GraphQl\Type\Definition\TypeInterface as GraphQlTypeInterface;
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Util\Inflector as MetadataInflector;
+use ApiPlatform\Metadata\Util\Inflector;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Symfony\GraphQl\Resolver\Factory\DataCollectorResolverFactory;
 use ApiPlatform\Symfony\Validator\Exception\ValidationException;
 use ApiPlatform\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRestrictionMetadataInterface;
 use ApiPlatform\Symfony\Validator\ValidationGroupsGeneratorInterface;
-use ApiPlatform\Util\Inflector;
 use Doctrine\Persistence\ManagerRegistry;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
@@ -797,11 +796,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     {
         if ($config['keep_legacy_inflector']) {
             Inflector::keepLegacyInflector(true);
-            MetadataInflector::keepLegacyInflector(true);
             trigger_deprecation('api-platform/core', '3.2', 'Using doctrine/inflector is deprecated since API Platform 3.2 and will be removed in API Platform 4. Use symfony/string instead. Run "composer require symfony/string" and set "keep_legacy_inflector" to false in config.');
         } else {
             Inflector::keepLegacyInflector(false);
-            MetadataInflector::keepLegacyInflector(false);
         }
     }
 }

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -54,6 +54,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Symfony\Component\String\UnicodeString;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -141,6 +142,8 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         if (!$container->has('api_platform.state.item_provider')) {
             $container->setAlias('api_platform.state.item_provider', 'api_platform.state_provider.object');
         }
+
+        $this->triggerDeprecations();
     }
 
     private function registerCommonConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader, array $formats, array $patchFormats, array $errorFormats): void
@@ -785,5 +788,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     private function registerArgumentResolverConfiguration(XmlFileLoader $loader): void
     {
         $loader->load('argument_resolver.xml');
+    }
+
+    private function triggerDeprecations(): void
+    {
+        if (!class_exists(UnicodeString::class)) {
+            trigger_deprecation('api-platform/core', '3.2', 'Using doctrine/inflector is deprecated since API Platform 3.2 and will be removed in API Platform 4. Use symfony/string instead. Run "composer require symfony/string".');
+        }
     }
 }

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -109,6 +109,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_entrypoint')->defaultTrue()->info('Enable the entrypoint')->end()
                 ->booleanNode('enable_docs')->defaultTrue()->info('Enable the docs')->end()
                 ->booleanNode('enable_profiler')->defaultTrue()->info('Enable the data collector and the WebProfilerBundle integration.')->end()
+                ->booleanNode('keep_legacy_inflector')->defaultTrue()->info('Keep doctrine/inflector instead of symfony/string to generate plurals for routes.')->end()
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -49,7 +49,8 @@ final class Inflector
     public static function pluralize(string $word): string
     {
         if (class_exists(EnglishInflector::class)) {
-            return (new EnglishInflector())->pluralize($word)[0];
+            $pluralize = (new EnglishInflector())->pluralize($word);
+            return end($pluralize);
         }
 
         return self::getInstance()->pluralize($word);

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -13,19 +13,19 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Util;
 
-use Doctrine\Inflector\Inflector as InflectorObject;
+use Doctrine\Inflector\Inflector as LegacyInflector;
 use Doctrine\Inflector\InflectorFactory;
+use Symfony\Component\String\Inflector\EnglishInflector;
+use Symfony\Component\String\UnicodeString;
 
 /**
- * Facade for Doctrine Inflector.
- *
  * @internal
  */
 final class Inflector
 {
-    private static ?InflectorObject $instance = null;
+    private static ?LegacyInflector $instance = null;
 
-    private static function getInstance(): InflectorObject
+    private static function getInstance(): LegacyInflector
     {
         return self::$instance
             ?? self::$instance = InflectorFactory::create()->build();
@@ -36,6 +36,10 @@ final class Inflector
      */
     public static function tableize(string $word): string
     {
+        if (class_exists(UnicodeString::class)) {
+            return (new UnicodeString($word))->snake()->toString();
+        }
+
         return self::getInstance()->tableize($word);
     }
 
@@ -44,6 +48,10 @@ final class Inflector
      */
     public static function pluralize(string $word): string
     {
+        if (class_exists(EnglishInflector::class)) {
+            return (new EnglishInflector())->pluralize($word)[0];
+        }
+
         return self::getInstance()->pluralize($word);
     }
 }

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -23,6 +23,7 @@ use Symfony\Component\String\UnicodeString;
  */
 final class Inflector
 {
+    private static bool $keepLegacyInflector;
     private static ?LegacyInflector $instance = null;
 
     private static function getInstance(): LegacyInflector
@@ -31,12 +32,17 @@ final class Inflector
             ?? self::$instance = InflectorFactory::create()->build();
     }
 
+    public static function keepLegacyInflector(bool $keepLegacyInflector): void
+    {
+        self::$keepLegacyInflector = $keepLegacyInflector;
+    }
+
     /**
      * @see InflectorObject::tableize()
      */
     public static function tableize(string $word): string
     {
-        if (class_exists(UnicodeString::class)) {
+        if (!self::$keepLegacyInflector) {
             return (new UnicodeString($word))->snake()->toString();
         }
 
@@ -48,7 +54,7 @@ final class Inflector
      */
     public static function pluralize(string $word): string
     {
-        if (class_exists(EnglishInflector::class)) {
+        if (!self::$keepLegacyInflector) {
             $pluralize = (new EnglishInflector())->pluralize($word);
             return end($pluralize);
         }

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -15,15 +15,12 @@ namespace ApiPlatform\Util;
 
 use Doctrine\Inflector\Inflector as LegacyInflector;
 use Doctrine\Inflector\InflectorFactory;
-use Symfony\Component\String\Inflector\EnglishInflector;
-use Symfony\Component\String\UnicodeString;
 
 /**
  * @internal
  */
 final class Inflector
 {
-    private static bool $keepLegacyInflector;
     private static ?LegacyInflector $instance = null;
 
     private static function getInstance(): LegacyInflector
@@ -32,20 +29,11 @@ final class Inflector
             ?? self::$instance = InflectorFactory::create()->build();
     }
 
-    public static function keepLegacyInflector(bool $keepLegacyInflector): void
-    {
-        self::$keepLegacyInflector = $keepLegacyInflector;
-    }
-
     /**
      * @see InflectorObject::tableize()
      */
     public static function tableize(string $word): string
     {
-        if (!self::$keepLegacyInflector) {
-            return (new UnicodeString($word))->snake()->toString();
-        }
-
         return self::getInstance()->tableize($word);
     }
 
@@ -54,11 +42,6 @@ final class Inflector
      */
     public static function pluralize(string $word): string
     {
-        if (!self::$keepLegacyInflector) {
-            $pluralize = (new EnglishInflector())->pluralize($word);
-            return end($pluralize);
-        }
-
         return self::getInstance()->pluralize($word);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | main
| Tickets       | #5636 
| License       | MIT

Replace `doctrine/inflector` dependance to pluralize and tableize to `symfony/string`

Introduce new config flag `keep_legacy_inflector` to keep the old inflector or to switch to symfony/string by passing the config to `false`