### PR TITLE
fix(JsonSchema): fix reDoc json sample values

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -100,7 +100,7 @@ Feature: Documentation support
     """
     {
       "type": "string",
-      "format": "iri-reference"
+      "format": "iri-template"
     }
     """
     # Enable these tests when SF 4.4 / PHP 7.1 support is dropped
@@ -183,26 +183,26 @@ Feature: Documentation support
                     "properties": {
                         "@id": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "@type": {
                             "type": "string"
                         },
                         "hydra:first": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "hydra:last": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "hydra:previous": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         },
                         "hydra:next": {
                             "type": "string",
-                            "format": "iri-reference"
+                            "format": "iri-template"
                         }
                     },
                     "example": {

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -183,26 +183,26 @@ Feature: Documentation support
                     "properties": {
                         "@id": {
                             "type": "string",
-                            "format": "iri-template"
+                            "format": "iri-reference"
                         },
                         "@type": {
                             "type": "string"
                         },
                         "hydra:first": {
                             "type": "string",
-                            "format": "iri-template"
+                            "format": "iri-reference"
                         },
                         "hydra:last": {
                             "type": "string",
-                            "format": "iri-template"
+                            "format": "iri-reference"
                         },
                         "hydra:previous": {
                             "type": "string",
-                            "format": "iri-template"
+                            "format": "iri-reference"
                         },
                         "hydra:next": {
                             "type": "string",
-                            "format": "iri-template"
+                            "format": "iri-reference"
                         }
                     },
                     "example": {

--- a/src/JsonSchema/Tests/TypeFactoryTest.php
+++ b/src/JsonSchema/Tests/TypeFactoryTest.php
@@ -57,12 +57,12 @@ class TypeFactoryTest extends TestCase
         yield [['nullable' => true, 'type' => 'string', 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, true, \DateTimeImmutable::class)];
         yield [['type' => 'string', 'format' => 'duration'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateInterval::class)];
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
-        yield [['nullable' => true, 'type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
+        yield [['nullable' => true, 'type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
         yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
         yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null], 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
-        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
-        yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-reference', 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
+        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
+        yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-template', 'nullable' => true], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable' => [
             ['nullable' => true, 'type' => 'array', 'items' => ['type' => 'string']],
@@ -185,12 +185,12 @@ class TypeFactoryTest extends TestCase
         yield [['type' => ['string', 'null'], 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, true, \DateTimeImmutable::class)];
         yield [['type' => 'string', 'format' => 'duration'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateInterval::class)];
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
-        yield [['type' => ['string', 'null'], 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
+        yield [['type' => ['string', 'null'], 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
         yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
         yield ['nullable enum' => ['type' => ['string', 'null'], 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
-        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
-        yield ['nullable enum resource' => ['type' => ['string', 'null'], 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
+        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
+        yield ['nullable enum resource' => ['type' => ['string', 'null'], 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable' => [
             ['type' => ['array', 'null'], 'items' => ['type' => 'string']],
@@ -306,12 +306,12 @@ class TypeFactoryTest extends TestCase
         yield [['type' => 'string', 'format' => 'date-time'], new Type(Type::BUILTIN_TYPE_OBJECT, true, \DateTimeImmutable::class)];
         yield [['type' => 'string', 'format' => 'duration'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateInterval::class)];
         yield [['type' => 'string', 'format' => 'binary'], new Type(Type::BUILTIN_TYPE_OBJECT, false, \SplFileInfo::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
-        yield [['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)];
+        yield [['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class)];
         yield ['enum' => ['type' => 'string', 'enum' => ['male', 'female']], new Type(Type::BUILTIN_TYPE_OBJECT, false, GenderTypeEnum::class)];
         yield ['nullable enum' => ['type' => 'string', 'enum' => ['male', 'female', null]], new Type(Type::BUILTIN_TYPE_OBJECT, true, GenderTypeEnum::class)];
-        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
-        yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-reference'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
+        yield ['enum resource' => ['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, false, GamePlayMode::class)];
+        yield ['nullable enum resource' => ['type' => 'string', 'format' => 'iri-template'], new Type(Type::BUILTIN_TYPE_OBJECT, true, GamePlayMode::class)];
         yield [['type' => 'array', 'items' => ['type' => 'string']], new Type(Type::BUILTIN_TYPE_STRING, false, null, true)];
         yield 'array can be itself nullable, but ignored in OpenAPI V2' => [
             ['type' => 'array', 'items' => ['type' => 'string']],

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -139,7 +139,7 @@ final class TypeFactory implements TypeFactoryInterface
         if (true !== $readableLink && $this->isResourceClass($className)) {
             return [
                 'type' => 'string',
-                'format' => 'iri-reference',
+                'format' => 'iri-template',
             ];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | -
| License       | MIT

Actually it fixes the same bug as in that [PR](https://github.com/api-platform/core/pull/4681) but for JSON.

![image](https://github.com/api-platform/core/assets/13186130/9ddfe37f-9c2a-4a76-9768-e60473cf3e97)

