### PR TITLE
fix(elasticsearch): fix filtering on nested fields

### DIFF
--- a/src/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -82,7 +82,9 @@ trait FieldDatatypeTrait
             && null !== ($className = $type->getClassName())
             && $this->resourceClassResolver->isResourceClass($className)
         ) {
-            return $currentProperty;
+            $nestedPath = $this->getNestedFieldPath($className, implode('.', $properties));
+
+            return null === $nestedPath ? $currentProperty : "$currentProperty.$nestedPath";
         }
 
         return null;

--- a/src/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -73,7 +73,7 @@ trait FieldDatatypeTrait
         ) {
             $nestedPath = $this->getNestedFieldPath($nextResourceClass, implode('.', $properties));
 
-            return null === $nestedPath ? $nestedPath : "$currentProperty.$nestedPath";
+            return null === $nestedPath ? $currentProperty : "$currentProperty.$nestedPath";
         }
 
         if (

--- a/tests/Elasticsearch/Filter/MatchFilterTest.php
+++ b/tests/Elasticsearch/Filter/MatchFilterTest.php
@@ -87,7 +87,7 @@ class MatchFilterTest extends TestCase
         );
     }
 
-    public function testApplyWithNestedProperty(): void
+    public function testApplyWithNestedArrayProperty(): void
     {
         $fooType = new Type(Type::BUILTIN_TYPE_ARRAY, false, Foo::class, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, Foo::class));
         $barType = new Type(Type::BUILTIN_TYPE_STRING);
@@ -114,6 +114,38 @@ class MatchFilterTest extends TestCase
         );
 
         self::assertEquals(
+            ['bool' => ['must' => [['nested' => ['path' => 'foo', 'query' => ['match' => ['foo.bar' => 'Krupicka']]]]]]],
+            $matchFilter->apply([], Foo::class, null, ['filters' => ['foo.bar' => 'Krupicka']])
+        );
+    }
+
+    public function testApplyWithNestedObjectProperty(): void
+    {
+        $fooType = new Type(Type::BUILTIN_TYPE_OBJECT, false, Foo::class);
+        $barType = new Type(Type::BUILTIN_TYPE_STRING);
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'foo')->willReturn((new ApiProperty())->withBuiltinTypes([$fooType]))->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'bar')->willReturn((new ApiProperty())->withBuiltinTypes([$barType]))->shouldBeCalled();
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(Foo::class)->willReturn(true)->shouldBeCalled();
+
+        $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
+        $nameConverterProphecy->normalize('foo.bar', Foo::class, null, Argument::type('array'))->willReturn('foo.bar')->shouldBeCalled();
+        $nameConverterProphecy->normalize('foo', Foo::class, null, Argument::type('array'))->willReturn('foo')->shouldBeCalled();
+
+        $matchFilter = new MatchFilter(
+            $this->prophesize(PropertyNameCollectionFactoryInterface::class)->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $this->prophesize(IriConverterInterface::class)->reveal(),
+            $this->prophesize(PropertyAccessorInterface::class)->reveal(),
+            $nameConverterProphecy->reveal(),
+            ['foo.bar' => null]
+        );
+
+        self::assertSame(
             ['bool' => ['must' => [['nested' => ['path' => 'foo', 'query' => ['match' => ['foo.bar' => 'Krupicka']]]]]]],
             $matchFilter->apply([], Foo::class, null, ['filters' => ['foo.bar' => 'Krupicka']])
         );

--- a/tests/Elasticsearch/Filter/TermFilterTest.php
+++ b/tests/Elasticsearch/Filter/TermFilterTest.php
@@ -87,7 +87,7 @@ class TermFilterTest extends TestCase
         );
     }
 
-    public function testApplyWithNestedProperty(): void
+    public function testApplyWithNestedArrayProperty(): void
     {
         $fooType = new Type(Type::BUILTIN_TYPE_ARRAY, false, Foo::class, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, Foo::class));
         $barType = new Type(Type::BUILTIN_TYPE_STRING);
@@ -114,6 +114,38 @@ class TermFilterTest extends TestCase
         );
 
         self::assertEquals(
+            ['bool' => ['must' => [['nested' => ['path' => 'foo', 'query' => ['term' => ['foo.bar' => 'Krupicka']]]]]]],
+            $termFilter->apply([], Foo::class, null, ['filters' => ['foo.bar' => 'Krupicka']])
+        );
+    }
+
+    public function testApplyWithNestedObjectProperty(): void
+    {
+        $fooType = new Type(Type::BUILTIN_TYPE_OBJECT, false, Foo::class);
+        $barType = new Type(Type::BUILTIN_TYPE_STRING);
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'foo')->willReturn((new ApiProperty())->withBuiltinTypes([$fooType]))->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'bar')->willReturn((new ApiProperty())->withBuiltinTypes([$barType]))->shouldBeCalled();
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(Foo::class)->willReturn(true)->shouldBeCalled();
+
+        $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);
+        $nameConverterProphecy->normalize('foo.bar', Foo::class, null, Argument::type('array'))->willReturn('foo.bar')->shouldBeCalled();
+        $nameConverterProphecy->normalize('foo', Foo::class, null, Argument::type('array'))->willReturn('foo')->shouldBeCalled();
+
+        $termFilter = new TermFilter(
+            $this->prophesize(PropertyNameCollectionFactoryInterface::class)->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $this->prophesize(IriConverterInterface::class)->reveal(),
+            $this->prophesize(PropertyAccessorInterface::class)->reveal(),
+            $nameConverterProphecy->reveal(),
+            ['foo.bar' => null]
+        );
+
+        self::assertSame(
             ['bool' => ['must' => [['nested' => ['path' => 'foo', 'query' => ['term' => ['foo.bar' => 'Krupicka']]]]]]],
             $termFilter->apply([], Foo::class, null, ['filters' => ['foo.bar' => 'Krupicka']])
         );

--- a/tests/Elasticsearch/Util/FieldDatatypeTraitTest.php
+++ b/tests/Elasticsearch/Util/FieldDatatypeTraitTest.php
@@ -32,6 +32,7 @@ class FieldDatatypeTraitTest extends TestCase
         $fieldDatatype = $this->getValidFieldDatatype();
 
         self::assertSame('foo.bar', $fieldDatatype->getNestedFieldPath(Foo::class, 'foo.bar.baz'));
+        self::assertSame('foo', $fieldDatatype->getNestedFieldPath(Foo::class, 'foo.baz'));
         self::assertNull($fieldDatatype->getNestedFieldPath(Foo::class, 'baz'));
     }
 
@@ -72,6 +73,7 @@ class FieldDatatypeTraitTest extends TestCase
         $fieldDatatype = $this->getValidFieldDatatype();
 
         self::assertTrue($fieldDatatype->isNestedField(Foo::class, 'foo.bar.baz'));
+        self::assertTrue($fieldDatatype->isNestedField(Foo::class, 'foo.baz'));
         self::assertFalse($fieldDatatype->isNestedField(Foo::class, 'baz'));
     }
 

--- a/tests/Elasticsearch/Util/FieldDatatypeTraitTest.php
+++ b/tests/Elasticsearch/Util/FieldDatatypeTraitTest.php
@@ -79,10 +79,12 @@ class FieldDatatypeTraitTest extends TestCase
     {
         $fooType = new Type(Type::BUILTIN_TYPE_OBJECT, false, Foo::class);
         $barType = new Type(Type::BUILTIN_TYPE_ARRAY, false, Foo::class, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, Foo::class));
+        $bazType = new Type(Type::BUILTIN_TYPE_STRING, false, Foo::class);
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Foo::class, 'foo')->willReturn((new ApiProperty())->withBuiltinTypes([$fooType]))->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(Foo::class, 'bar')->willReturn((new ApiProperty())->withBuiltinTypes([$barType]))->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Foo::class, 'baz')->willReturn((new ApiProperty())->withBuiltinTypes([$bazType]));
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(Foo::class)->willReturn(true)->shouldBeCalled();

--- a/tests/Elasticsearch/Util/FieldDatatypeTraitTest.php
+++ b/tests/Elasticsearch/Util/FieldDatatypeTraitTest.php
@@ -36,6 +36,15 @@ class FieldDatatypeTraitTest extends TestCase
         self::assertNull($fieldDatatype->getNestedFieldPath(Foo::class, 'baz'));
     }
 
+    public function testGetNestedFieldInNestedCollection(): void
+    {
+        $fieldDatatype = $this->getValidFieldDatatype();
+
+        self::assertSame('bar.foo', $fieldDatatype->getNestedFieldPath(Foo::class, 'bar.foo.baz'));
+        self::assertSame('bar', $fieldDatatype->getNestedFieldPath(Foo::class, 'bar.foo'));
+        self::assertNull($fieldDatatype->getNestedFieldPath(Foo::class, 'baz'));
+    }
+
     public function testGetNestedFieldPathWithPropertyNotFound(): void
     {
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | api-platform/api-platform/issues/1375 and #5642
| License       | MIT
| Doc PR        | n/a

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

This PR implements the following changes to support filtering on paths like `foo.bar.baz`:

1. If `foo` is an object, `isNestedField()` now returns `true` instead of `false`
2. If `foo` is an object, `getNestedFieldPath()` now returns `"foo.bar"` instead of `null`
3. If `foo` is a collection, `getNestedFieldPath()` now returns `"foo.bar"` instead of just `"foo"` (matching the behavior if `foo` is an object)


As a result, filtering on deeply-nested paths (with 3 or more levels) now produces the following query:

<!--
```diff
 {
     "nested": {
         "path": "foo",
         "query": {
-            "term": {"foo.bar.baz": "qux"}
+            "nested": {
+                "path": "foo.bar",
+                "query": {
+                    "term": {"foo.bar.baz": "qux"}
+                }
            }
         }
     }
 }
```

⚠️  I am not yet 100% sure that this last change is fully backward-compatible for all use cases, including non-nested mappings. I would greatly appreciate a second opinion on this.  Worst-case, we can drop that last commit which will result in this change which seems less correct for `nested` mappings but should still work:
-->

```diff
 {
     "nested": {
-        "path": "foo",
+        "path": "foo.bar",
         "query": {
             "term": {"foo.bar.baz": "qux"}
            }
         }
     }
 }
```