### PR TITLE
feat(Serializer): update MissingConstructorArgumentsException message

### DIFF
--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -155,7 +155,7 @@ Feature: Value object as ApiResource
           "pattern": "^An error occurred$"
         },
         "hydra:description": {
-          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\\$drivers\".$"
+          "pattern": "Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\\$drivers\".$"
         }
       },
       "required": [

--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -155,7 +155,7 @@ Feature: Value object as ApiResource
           "pattern": "^An error occurred$"
         },
         "hydra:description": {
-          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\$drivers\".$"
+          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\\$drivers\".$"
         }
       },
       "required": [

--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -155,7 +155,7 @@ Feature: Value object as ApiResource
           "pattern": "^An error occurred$"
         },
         "hydra:description": {
-          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires  the following parameters to be present : \"drivers\".$"
+          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"drivers\".$"
         }
       },
       "required": [

--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -155,7 +155,7 @@ Feature: Value object as ApiResource
           "pattern": "^An error occurred$"
         },
         "hydra:description": {
-          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"drivers\".$"
+          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\$drivers\".$"
         }
       },
       "required": [

--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -155,7 +155,7 @@ Feature: Value object as ApiResource
           "pattern": "^An error occurred$"
         },
         "hydra:description": {
-          "pattern": "Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\\$drivers\".$"
+          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\\$drivers\".$"
         }
       },
       "required": [

--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -155,7 +155,7 @@ Feature: Value object as ApiResource
           "pattern": "^An error occurred$"
         },
         "hydra:description": {
-          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires parameter \"drivers\" to be present.$"
+          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires  the following parameters to be present : \"drivers\".$"
         }
       },
       "required": [

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -338,7 +338,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 }
             }
 
-            if (\count($missingConstructorArguments) > 0) {
+            if ($missingConstructorArguments) {
                 throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires the following parameters to be present : "$%s".', $class, implode('", "$', $missingConstructorArguments)), 0, null, $missingConstructorArguments, $class);
             }
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -330,7 +330,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                     $params[] = $constructorParameter->getDefaultValue();
                 } else {
                     if (!isset($context['not_normalizable_value_exceptions'])) {
-                        $missingConstructorParameters[] = $constructorParameter->getName();
+                        $missingConstructorParameters[] = $constructorParameter->name;
                     }
 
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name), $data, ['unknown'], $context['deserialization_path'] ?? null, true);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -295,7 +295,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $constructorParameters = $constructor->getParameters();
 
             $params = [];
-            $missingConstructorParameters = [];
+            $missingConstructorArguments = [];
             foreach ($constructorParameters as $constructorParameter) {
                 $paramName = $constructorParameter->name;
                 $key = $this->nameConverter ? $this->nameConverter->normalize($paramName, $class, $format, $context) : $paramName;
@@ -330,7 +330,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                     $params[] = $constructorParameter->getDefaultValue();
                 } else {
                     if (!isset($context['not_normalizable_value_exceptions'])) {
-                        $missingConstructorParameters[] = $constructorParameter->getName();
+                        $missingConstructorArguments[] = $constructorParameter->name;
                     }
 
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name), $data, ['unknown'], $context['deserialization_path'] ?? null, true);
@@ -338,8 +338,8 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 }
             }
 
-            if (\count($missingConstructorParameters) > 0) {
-                throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires the following parameters to be present : "$%s".', $class, implode('", "$', $missingConstructorParameters)), 0, null, $missingConstructorParameters, $class);
+            if (\count($missingConstructorArguments) > 0) {
+                throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires the following parameters to be present : "$%s".', $class, implode('", "$', $missingConstructorArguments)), 0, null, $missingConstructorArguments, $class);
             }
 
             if (\count($context['not_normalizable_value_exceptions'] ?? []) > 0) {

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -330,7 +330,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                     $params[] = $constructorParameter->getDefaultValue();
                 } else {
                     if (!isset($context['not_normalizable_value_exceptions'])) {
-                        $missingConstructorParameters[] = $constructorParameter->name;
+                        $missingConstructorParameters[] = $constructorParameter->getName();
                     }
 
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name), $data, ['unknown'], $context['deserialization_path'] ?? null, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Have found that if validation attributes are specified on DTOs or if the `Valid()` constraint is used on not api-resource property (just an entity in example) then Symfony's [AbstractNormalizer](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php) is used and it has a bit different `MissingConstructorArgumentsException` [exception message that also contains the list of missed arguments](https://github.com/symfony/symfony/blob/9b2ac59e8a373e983157f9a57de8ae951cc1a3ba/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php#L414).
But in ApiPlatform this exception has another [message and it contains only the first one of missed arguments in it](https://github.com/api-platform/core/blob/4ef0ef856ced658ac942fd6a2c6f7c5c563078d1/src/Serializer/AbstractItemNormalizer.php#L312).
This way someone, who relies on this message, in example, to convert it to something like validation error in the response, will get different messages.
So I want to suggest to make this message and its parameters consistent with Symfony's one.

The example of the new message:
```
Cannot create an instance of "App\Entity\Book" from serialized data because its constructor requires the following parameters to be present : "$author", "$name".
```

Not sure that it is the BC break, but correct me if it is.

PS: Sorry, have no idea how to make `commitlint` happy, I've tried (seems it always takes the commit message from the first commit) :)
