### PR TITLE
ci(commitlint): fix resolving the commit message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   COVERAGE: '0'
   SYMFONY_DEPRECATIONS_HELPER: max[self]=0
-# a line for test
+
 jobs:
   commitlint:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   COVERAGE: '0'
   SYMFONY_DEPRECATIONS_HELPER: max[self]=0
-
+# a line for test
 jobs:
   commitlint:
     if: github.event_name == 'pull_request'
@@ -27,7 +27,7 @@ jobs:
         run: | 
             commit=$(gh api \
               /repos/${{ github.repository }}/pulls/${{github.event.number}}/commits \
-              | jq -r '.[0].commit.message' \
+              | jq -r '.[-1].commit.message' \
               | head -n 1)
             # we can't use npx see https://github.com/conventional-changelog/commitlint/issues/613
             echo '{}' > package.json


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| License       | MIT

Yeah, 
this PR fixes the issue with `commitlint` in CI I've stacked in my #5638 and #5649 PRs, before - it always takes the message of the first commit in the PR and new commits or force-push with the new commit message didn't help to fix this check.
So now, as you can see with commits in this PR it is fixed. :)