### PR TITLE
fix(openapi): fix custom filter when key "type" is not set

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -565,7 +565,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             }
 
             foreach ($filter->getDescription($entityClass) as $name => $data) {
-                $schema = $data['schema'] ?? (\in_array($data['type'], Type::$builtinTypes, true) ? $this->jsonSchemaTypeFactory->getType(new Type($data['type'], false, null, $data['is_collection'] ?? false)) : ['type' => 'string']);
+                $schema = $data['schema'] ?? (\in_array($data['type'] ?? false, Type::$builtinTypes, true) ? $this->jsonSchemaTypeFactory->getType(new Type($data['type'], false, null, $data['is_collection'] ?? false)) : ['type' => 'string']);
 
                 $parameters[] = new Parameter(
                     $name,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 3.1
| Tickets       | [Issue #5654](https://github.com/api-platform/core/issues/5654)
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Please read [this issue](https://github.com/api-platform/core/issues/5654) to understand and reproduce.

This is the exception I came across while creating a new custom filter :

![bug-5654](https://github.com/api-platform/core/assets/8001284/b7ec3a15-b53b-49c5-b61b-9c9a8d9bb2fe)