### PR TITLE
Fix(GraphQL): Add cache_key in item normalizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ concurrency:
 
 env:
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  COVERAGE: '0'
   SYMFONY_DEPRECATIONS_HELPER: max[self]=0
 
 jobs:
@@ -34,13 +33,13 @@ jobs:
             npm install --no-fund --no-audit @commitlint/config-conventional @commitlint/cli
             echo $commit | ./node_modules/.bin/commitlint -g .commitlintrc
   php-cs-fixer:
-    name: PHP-cs-fixer (PHP ${{ matrix.php }})
+    name: PHP CS Fixer (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
         php:
-          - '8.1'
+          - '8.2'
       fail-fast: false
     steps:
       - name: Checkout
@@ -147,9 +146,6 @@ jobs:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-      - name: Enable code coverage
-        if: matrix.coverage
-        run: echo "COVERAGE=1" >> $GITHUB_ENV
       - name: Update project dependencies
         run: composer update --no-interaction --no-progress --ansi
       - name: Install PHPUnit
@@ -157,13 +153,7 @@ jobs:
       - name: Clear test app cache
         run: tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
-        run: |
-          mkdir -p build/logs/phpunit
-          if [ "$COVERAGE" = '1' ]; then
-            vendor/bin/simple-phpunit --log-junit build/logs/phpunit/junit.xml --coverage-clover build/logs/phpunit/clover.xml
-          else
-            vendor/bin/simple-phpunit --log-junit build/logs/phpunit/junit.xml
-          fi
+        run: vendor/bin/simple-phpunit --log-junit build/logs/phpunit/junit.xml ${{ matrix.coverage && '--coverage-clover build/logs/phpunit/clover.xml' || '' }}
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v3
@@ -255,23 +245,16 @@ jobs:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-      - name: Enable code coverage
-        if: matrix.coverage
-        run: echo "COVERAGE=1" >> $GITHUB_ENV
       - name: Update project dependencies
         run: composer update --no-interaction --no-progress --ansi
       - name: Install PHPUnit
         run: vendor/bin/simple-phpunit --version
       - name: Clear test app cache
         run: tests/Fixtures/app/console cache:clear --ansi
-      - name: Run Behat tests (PHP 8)
+      - name: Run Behat tests (PHP ${{ matrix.php }})
         run: |
           mkdir -p build/logs/behat
-          if [ "$COVERAGE" = '1' ]; then
-            vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default-coverage --no-interaction
-          else
-            vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=default --no-interaction
-          fi
+          vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --no-interaction ${{ matrix.coverage && '--profile=default-coverage' || '--profile=default' }}
       - name: Merge code coverage reports
         if: matrix.coverage
         run: |
@@ -457,8 +440,6 @@ jobs:
           extensions: intl, bcmath, curl, openssl, mbstring, mongodb
           coverage: pcov
           ini-values: memory_limit=-1
-      - name: Enable code coverage
-        run: echo "COVERAGE=1" >> $GITHUB_ENV
       - name: Get composer cache directory
         id: composercache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -480,11 +461,7 @@ jobs:
       - name: Run Behat tests
         run: |
           mkdir -p build/logs/behat
-          if [ "$COVERAGE" = '1' ]; then
-            vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=mongodb-coverage --no-interaction
-          else
-            vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=mongodb --no-interaction
-          fi
+          vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --profile=mongodb-coverage --no-interaction
       - name: Merge code coverage reports
         run: |
           wget -qO /usr/local/bin/phpcov https://phar.phpunit.de/phpcov.phar

--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -99,6 +99,23 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
             'readableLink' => 'is',
             'required' => 'is',
             'identifier' => 'is',
+            'default' => 'get',
+            'example' => 'get',
+            'deprecationReason' => 'get',
+            'fetchable' => 'is',
+            'fetchEager' => 'get',
+            'jsonldContext' => 'get',
+            'openapiContext' => 'get',
+            'jsonSchemaContext' => 'get',
+            'push' => 'get',
+            'security' => 'get',
+            'securityPostDenormalize' => 'get',
+            'types' => 'get',
+            'builtinTypes' => 'get',
+            'schema' => 'get',
+            'initializable' => 'is',
+            'genId' => 'get',
+            'extraProperties' => 'get',
         ];
 
         foreach ($metadataAccessors as $metadataKey => $accessorPrefix) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | ¤
| License       | MIT
| Doc PR        | ¤

Hello everyone,
it looks like the localCache in the Serializer is not used for the GraphQL ItemNormalizer, as it's done in the other normalizers.
This small fix reduces the calls to `getAttributes` from the Serializer.