### PR TITLE
fix: handle item iri with identifiers in LegacyIriConverter

### DIFF
--- a/src/Core/Api/LegacyIriConverter.php
+++ b/src/Core/Api/LegacyIriConverter.php
@@ -65,7 +65,7 @@ final class LegacyIriConverter implements IriConverterInterface
     public function getIriFromResource($item, int $referenceType = UrlGeneratorInterface::ABS_PATH, Operation $operation = null, array $context = []): ?string
     {
         if (null === $this->iriConverter) {
-            if (array_key_exists('uri_variables', $context) && $identifiers = $context['uri_variables']) {
+            if ($identifiers = ($context['uri_variables'] ?? null)) {
                 try {
                     return $this->legacyIriConverter->getItemIriFromResourceClass($item, $identifiers, $referenceType);
                 }

--- a/src/Core/Api/LegacyIriConverter.php
+++ b/src/Core/Api/LegacyIriConverter.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Core\Api;
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Core\Api\IriConverterInterface as LegacyIriConverterInterface;
+use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Operation;
 
 /**
@@ -64,6 +65,14 @@ final class LegacyIriConverter implements IriConverterInterface
     public function getIriFromResource($item, int $referenceType = UrlGeneratorInterface::ABS_PATH, Operation $operation = null, array $context = []): ?string
     {
         if (null === $this->iriConverter) {
+            if (array_key_exists('uri_variables', $context) && $identifiers = $context['uri_variables']) {
+                try {
+                    return $this->legacyIriConverter->getItemIriFromResourceClass($item, $identifiers, $referenceType);
+                }
+                catch (InvalidArgumentException $e) {
+                }
+            }
+
             return \is_string($item) ? $this->legacyIriConverter->getIriFromResourceClass($item, $referenceType) : $this->legacyIriConverter->getIriFromItem($item, $referenceType);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #5620 
| License       | MIT

Hello, a small fix for when using the `\ApiPlatform\Core\Api\LegacyIriConverter`

## The Problem:
#5630 Introduced a nice way to fix the IriConverterInterface deprecation before turning off the `metadata_backward_compatibility_layer`. 

One issue I ran into is that `LegacyIriConverter::getIriFromResource` decides if the iri will be Item level or Collection level solely based on if the given `$item` parameter is a string vs an object.

With this methodology, I would have instantiate a new object just to trigger the Item level iri conversion.
(To compare, The new IriConverterInterface handles this decision smartly, using the metadata of the Operation and the given Object).

## Proposed solution
Previously, the old IriConverterInterface had 2 distinct methods to split this (`getItemIriFromResourceClass` and `getIriFromResourceClass`)— the only difference being an extra parameter `array $identifiers`.

This adds back the ability to identify a Resource based on className + identifiers.
