### PR TITLE
feat: referencing context via http header link

### DIFF
--- a/features/jsonld/context_in_link.feature
+++ b/features/jsonld/context_in_link.feature
@@ -1,0 +1,18 @@
+Feature: JSON-LD context in link
+  As a client software developer
+  I need to access to a JSON-LD context describing data types in header response
+
+  Scenario: Retrieve a Resource with "context_in_link" flag set to true
+    When I send a "GET" request to "/context_in_links"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Link" should be equal to '<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation",</contexts/ContextInLink>; rel="http://www.w3.org/ns/json-ld#context"'
+    And the JSON should be equal to:
+    """
+    {
+      "@id": "/context_in_links",
+      "@type": "hydra:Collection",
+      "hydra:totalItems": 0,
+      "hydra:member": []
+    }
+    """

--- a/src/JsonLd/ContextBuilderInterface.php
+++ b/src/JsonLd/ContextBuilderInterface.php
@@ -29,6 +29,7 @@ interface ContextBuilderInterface
     public const XML_NS = 'http://www.w3.org/2001/XMLSchema#';
     public const OWL_NS = 'http://www.w3.org/2002/07/owl#';
     public const SCHEMA_ORG_NS = 'https://schema.org/';
+    public const JSONLD_NS = 'http://www.w3.org/ns/json-ld#';
 
     /**
      * Gets the base context.

--- a/src/JsonLd/Serializer/JsonLdContextTrait.php
+++ b/src/JsonLd/Serializer/JsonLdContextTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\JsonLd\Serializer;
 
+use ApiPlatform\Exception\ResourceClassNotFoundException;
 use ApiPlatform\JsonLd\AnonymousContextBuilderInterface;
 use ApiPlatform\JsonLd\ContextBuilderInterface;
 
@@ -27,6 +28,8 @@ trait JsonLdContextTrait
 {
     /**
      * Updates the given JSON-LD document to add its @context key.
+     *
+     * @throws ResourceClassNotFoundException
      */
     private function addJsonLdContext(ContextBuilderInterface $contextBuilder, string $resourceClass, array &$context, array $data = []): array
     {
@@ -37,12 +40,16 @@ trait JsonLdContextTrait
         $context['jsonld_has_context'] = true;
 
         if (isset($context['jsonld_embed_context'])) {
-            $data['@context'] = $contextBuilder->getResourceContext($resourceClass);
+            if (!isset($context['operation']) || true !== $context['operation']->getContextInLink()) {
+                $data['@context'] = $contextBuilder->getResourceContext($resourceClass);
+            }
 
             return $data;
         }
 
-        $data['@context'] = $contextBuilder->getResourceContextUri($resourceClass);
+        if (!isset($context['operation']) || true !== $context['operation']->getContextInLink()) {
+            $data['@context'] = $contextBuilder->getResourceContextUri($resourceClass);
+        }
 
         return $data;
     }

--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -143,6 +143,7 @@ class ApiResource extends Metadata
         $processor = null,
         protected ?OptionsInterface $stateOptions = null,
         protected array $extraProperties = [],
+        protected ?bool $contextInLink = null,
     ) {
         parent::__construct(
             shortName: $shortName,
@@ -182,7 +183,8 @@ class ApiResource extends Metadata
             provider: $provider,
             processor: $processor,
             stateOptions: $stateOptions,
-            extraProperties: $extraProperties
+            extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
 
         $this->operations = null === $operations ? null : new Operations($operations);

--- a/src/Metadata/Delete.php
+++ b/src/Metadata/Delete.php
@@ -92,6 +92,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         $processor = null,
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             method: 'DELETE',
@@ -137,6 +138,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
             description: $description,
             normalizationContext: $normalizationContext,
             denormalizationContext: $denormalizationContext,
+            collectDenormalizationErrors: $collectDenormalizationErrors,
             security: $security,
             securityMessage: $securityMessage,
             securityPostDenormalize: $securityPostDenormalize,
@@ -163,9 +165,9 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
             name: $name,
             provider: $provider,
             processor: $processor,
-            extraProperties: $extraProperties,
-            collectDenormalizationErrors: $collectDenormalizationErrors,
             stateOptions: $stateOptions,
+            extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 }

--- a/src/Metadata/Get.php
+++ b/src/Metadata/Get.php
@@ -92,6 +92,7 @@ final class Get extends HttpOperation
         $processor = null,
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             uriTemplate: $uriTemplate,
@@ -165,6 +166,7 @@ final class Get extends HttpOperation
             processor: $processor,
             stateOptions: $stateOptions,
             extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 }

--- a/src/Metadata/GetCollection.php
+++ b/src/Metadata/GetCollection.php
@@ -93,6 +93,7 @@ final class GetCollection extends HttpOperation implements CollectionOperationIn
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
         private ?string $itemUriTemplate = null,
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             uriTemplate: $uriTemplate,
@@ -164,8 +165,9 @@ final class GetCollection extends HttpOperation implements CollectionOperationIn
             name: $name,
             provider: $provider,
             processor: $processor,
-            extraProperties: $extraProperties,
             stateOptions: $stateOptions,
+            extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 

--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -149,6 +149,7 @@ class HttpOperation extends Operation
         $processor = null,
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             shortName: $shortName,
@@ -195,7 +196,8 @@ class HttpOperation extends Operation
             provider: $provider,
             processor: $processor,
             stateOptions: $stateOptions,
-            extraProperties: $extraProperties
+            extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -69,7 +69,8 @@ abstract class Metadata
         protected $provider = null,
         protected $processor = null,
         protected ?OptionsInterface $stateOptions = null,
-        protected array $extraProperties = []
+        protected array $extraProperties = [],
+        protected ?bool $contextInLink = null,
     ) {
     }
 
@@ -575,6 +576,19 @@ abstract class Metadata
     {
         $self = clone $this;
         $self->extraProperties = $extraProperties;
+
+        return $self;
+    }
+
+    public function getContextInLink(): ?bool
+    {
+        return $this->contextInLink;
+    }
+
+    public function withContextInLink(bool $contextInLink): static
+    {
+        $self = clone $this;
+        $self->contextInLink = $contextInLink;
 
         return $self;
     }

--- a/src/Metadata/NotExposed.php
+++ b/src/Metadata/NotExposed.php
@@ -105,6 +105,7 @@ final class NotExposed extends HttpOperation
         $processor = null,
         array $extraProperties = [],
         OptionsInterface $stateOptions = null,
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             method: $method,
@@ -179,6 +180,7 @@ final class NotExposed extends HttpOperation
             processor: $processor,
             stateOptions: $stateOptions,
             extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 }

--- a/src/Metadata/Operation.php
+++ b/src/Metadata/Operation.php
@@ -106,6 +106,7 @@ abstract class Operation extends Metadata
         protected $processor = null,
         protected ?OptionsInterface $stateOptions = null,
         protected array $extraProperties = [],
+        public ?bool $contextInLink = null,
     ) {
         parent::__construct(
             shortName: $shortName,
@@ -146,6 +147,7 @@ abstract class Operation extends Metadata
             processor: $processor,
             stateOptions: $stateOptions,
             extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 

--- a/src/Metadata/Patch.php
+++ b/src/Metadata/Patch.php
@@ -92,6 +92,7 @@ final class Patch extends HttpOperation
         $processor = null,
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             method: 'PATCH',
@@ -165,7 +166,8 @@ final class Patch extends HttpOperation
             provider: $provider,
             processor: $processor,
             stateOptions: $stateOptions,
-            extraProperties: $extraProperties
+            extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 }

--- a/src/Metadata/Post.php
+++ b/src/Metadata/Post.php
@@ -92,7 +92,8 @@ final class Post extends HttpOperation
         $processor = null,
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
-        private ?string $itemUriTemplate = null
+        private ?string $itemUriTemplate = null,
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             method: 'POST',
@@ -166,7 +167,8 @@ final class Post extends HttpOperation
             provider: $provider,
             processor: $processor,
             stateOptions: $stateOptions,
-            extraProperties: $extraProperties
+            extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 

--- a/src/Metadata/Put.php
+++ b/src/Metadata/Put.php
@@ -93,6 +93,7 @@ final class Put extends HttpOperation
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
         private ?bool $allowCreate = null,
+        bool $contextInLink = null,
     ) {
         parent::__construct(
             method: 'PUT',
@@ -166,7 +167,8 @@ final class Put extends HttpOperation
             provider: $provider,
             processor: $processor,
             stateOptions: $stateOptions,
-            extraProperties: $extraProperties
+            extraProperties: $extraProperties,
+            contextInLink: $contextInLink,
         );
     }
 

--- a/tests/Fixtures/TestBundle/ApiResource/ContextInLink.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ContextInLink.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ContextInLinkEntity;
+
+#[ApiResource(stateOptions: new Options(entityClass: ContextInLinkEntity::class), contextInLink: true)]
+final class ContextInLink
+{
+    public int $id;
+}

--- a/tests/Fixtures/TestBundle/Entity/ContextInLinkEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/ContextInLinkEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ContextInLinkEntity
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public $id;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT

Add `context_in_link` operation flag to enable referencing context via header link instead of body response


