### PR TITLE
Allow defining controller as a class method (controller: 'Foo::barAction')

### DIFF
--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -79,8 +79,11 @@ final class ApiLoader extends Loader
                         $path = str_replace('{._format}', '.{_format}', $path);
                     }
 
-                    if (($controller = $operation->getController()) && !$this->container->has($controller)) {
-                        throw new RuntimeException(sprintf('There is no builtin action for the "%s" operation. You need to define the controller yourself.', $operationName));
+                    if ($controller = $operation->getController()) {
+                        $controllerId = explode('::', $controller)[0];
+                        if (!$this->container->has($controllerId)) {
+                            throw new RuntimeException(sprintf('There is no builtin action for the "%s" operation. You need to define the controller yourself.', $operationName));
+                        }
                     }
 
                     $route = new Route(

--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -82,7 +82,7 @@ final class ApiLoader extends Loader
                     if ($controller = $operation->getController()) {
                         $controllerId = explode('::', $controller)[0];
                         if (!$this->container->has($controllerId)) {
-                            throw new RuntimeException(sprintf('There is no builtin action for the "%s" operation. You need to define the controller yourself.', $operationName));
+                            throw new RuntimeException(sprintf('Operation "%s" is defining an unknown service as controller "%s". Make sure it is properly registered in the dependency injection container.', $operationName, $controllerId));
                         }
                     }
 

--- a/tests/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Symfony/Routing/ApiLoaderTest.php
@@ -257,6 +257,20 @@ class ApiLoaderTest extends TestCase
         );
     }
 
+    public function testApiLoaderWithUndefinedControllerService(): void
+    {
+        $this->expectExceptionObject(new \RuntimeException('Operation "api_dummies_my_undefined_controller_method_item" is defining an unknown service as controller "Foo\\Bar\\MyUndefinedController". Make sure it is properly registered in the dependency injection container.'));
+
+        $resourceCollection = new ResourceMetadataCollection(Dummy::class, [
+            (new ApiResource())->withShortName('dummy')->withOperations(new Operations([
+                'api_dummies_my_undefined_controller_method_item' => (new Get())->withUriTemplate('/foo')->withController('Foo\\Bar\\MyUndefinedController::method'),
+            ])),
+        ]);
+
+        $routeCollection = $this->getApiLoaderWithResourceMetadataCollection($resourceCollection)->load(null);
+        $routeCollection->get('api_dummies_my_undefined_controller_method_item');
+    }
+
     private function getApiLoaderWithResourceMetadataCollection(ResourceMetadataCollection $resourceCollection): ApiLoader
     {
         $routingConfig = __DIR__.'/../../../src/Symfony/Bundle/Resources/config/routing';
@@ -277,6 +291,7 @@ class ApiLoaderTest extends TestCase
         foreach ($possibleArguments as $possibleArgument) {
             $containerProphecy->has($possibleArgument)->willReturn(true);
         }
+        $containerProphecy->has('Foo\\Bar\\MyUndefinedController')->willReturn(false);
 
         $containerProphecy->has(Argument::type('string'))->willReturn(false);
 

--- a/tests/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Symfony/Routing/ApiLoaderTest.php
@@ -64,6 +64,7 @@ class ApiLoaderTest extends TestCase
                 'api_dummies_my_path_op_collection' => (new GetCollection())->withUriTemplate('some/custom/path'),
                 // Custom path
                 'api_dummies_my_stateless_op_collection' => (new GetCollection())->withUriTemplate('/dummies.{_format}')->withStateless(true),
+                'api_dummies_my_controller_method_item' => (new Get())->withUriTemplate('/foo')->withController('Foo\\Bar\\MyController::method'),
             ])),
         ]);
 
@@ -180,6 +181,21 @@ class ApiLoaderTest extends TestCase
             ),
             $routeCollection->get('api_dummies_my_stateless_op_collection')
         );
+
+        $this->assertEquals(
+            $this->getRoute(
+                '/foo',
+                'Foo\\Bar\\MyController::method',
+                null,
+                RelatedDummyEntity::class,
+                [],
+                'api_dummies_my_controller_method_item',
+                [],
+                ['GET'],
+                []
+            ),
+            $routeCollection->get('api_dummies_my_controller_method_item')
+        );
     }
 
     public function testApiLoaderWithPrefix(): void
@@ -254,6 +270,7 @@ class ApiLoaderTest extends TestCase
             'api_platform.action.get_item',
             'api_platform.action.put_item',
             'api_platform.action.delete_item',
+            'Foo\\Bar\\MyController',
         ];
         $containerProphecy = $this->prophesize(ContainerInterface::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features
| Tickets       | 
| License       | MIT
| Doc PR        |

Prior to Api Platform 3, it was possible to define operation controller as a class method (using the `class::method` notation).

This seems to not work anymore in version 3, only controller class containing an `__invoke` method seems to be supported.

I have not performed a thorough examination of the code base, however the ApiLoaderTest doesn't present any usage of the mentioned notation. 