### PR TITLE
fix: enable to update all keys in metadata

### DIFF
--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -99,6 +99,23 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
             'readableLink' => 'is',
             'required' => 'is',
             'identifier' => 'is',
+            'default' => 'get',
+            'example' => 'get',
+            'deprecationReason' => 'get',
+            'fetchable' => 'is',
+            'fetchEager' => 'get',
+            'jsonldContext' => 'get',
+            'openapiContext' => 'get',
+            'jsonSchemaContext' => 'get',
+            'push' => 'get',
+            'security' => 'get',
+            'securityPostDenormalize' => 'get',
+            'types' => 'get',
+            'builtinTypes' => 'get',
+            'schema' => 'get',
+            'initializable' => 'is',
+            'genId' => 'get',
+            'extraProperties' => 'get',
         ];
 
         foreach ($metadataAccessors as $metadataKey => $accessorPrefix) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | #5482
| License       | MIT
| Doc PR        | -

This PR fixes #5482.

Because `ExtractorPropertyMetadataFactory::update()` method was updating only some of the properties of the `ApiProperty` class, so in decorated factories, metadata such as `openapiContext` were not being updated.