### PR TITLE
fix: unset force_resource_class context item when serializing a relation

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -621,7 +621,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
             $resourceClass = $this->resourceClassResolver->getResourceClass($attributeValue, $className);
             $childContext = $this->createChildContext($context, $attribute, $format);
-            unset($childContext['iri'], $childContext['uri_variables'], $childContext['resource_class'], $childContext['operation']);
+            unset(
+                $childContext['iri'],
+                $childContext['uri_variables'],
+                $childContext['resource_class'],
+                $childContext['force_resource_class'],
+                $childContext['operation'],
+            );
 
             return $this->normalizeCollectionOfRelations($propertyMetadata, $attributeValue, $resourceClass, $format, $childContext);
         }
@@ -650,8 +656,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             throw new LogicException(sprintf('The injected serializer must be an instance of "%s".', NormalizerInterface::class));
         }
 
-        unset($context['resource_class']);
-        unset($context['force_resource_class']);
+        unset(
+            $context['resource_class'],
+            $context['force_resource_class'],
+        );
 
         if ($type && $type->getClassName()) {
             $childContext = $this->createChildContext($context, $attribute, $format);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This patch makes the test suite green for the main branch. I'm not sure why the tests aren't broken in 3.1 but it should...
I think that this branch has been missed in https://github.com/api-platform/core/pull/5542.

@soyuka can you double-check that the rationale for this fix is good? 