### PR TITLE
test: fix a bug in DummyDtoInputOutputProvider

### DIFF
--- a/tests/Fixtures/TestBundle/State/DummyDtoInputOutputProvider.php
+++ b/tests/Fixtures/TestBundle/State/DummyDtoInputOutputProvider.php
@@ -19,6 +19,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\DummyDtoInputOutput as DummyD
 use ApiPlatform\Tests\Fixtures\TestBundle\Dto\Document\OutputDto as OutputDtoDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Dto\OutputDto;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyDtoInputOutput;
+use Doctrine\Common\Collections\Collection;
 
 final class DummyDtoInputOutputProvider implements ProviderInterface
 {
@@ -38,7 +39,7 @@ final class DummyDtoInputOutputProvider implements ProviderInterface
         $outputDto->id = $data->id;
         $outputDto->baz = $data->num;
         $outputDto->bat = $data->str;
-        $outputDto->relatedDummies = (array) $data->relatedDummies;
+        $outputDto->relatedDummies = $data->relatedDummies instanceof Collection ? $data->relatedDummies : (array) $data->relatedDummies;
 
         return $outputDto;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

`ApiTestCaseTest::testAssertMatchesResourceItemJsonSchemaOutput` is rightfully failing on my machine. I wonder why it doesn't break the CI.