### PR TITLE
test: compatibility with PHPUnit 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,7 +620,8 @@ jobs:
       - name: Clear test app cache
         run: tests/Fixtures/app/console cache:clear --ansi
       - name: Run PHPUnit tests
-        run: vendor/bin/simple-phpunit
+        # The PHPUnit Bridge doesn't support PHPUnit 10 yet: https://github.com/symfony/symfony/issues/49069
+        run: vendor/bin/phpunit -c phpunit10.xml.dist
 
   behat-symfony-next:
     name: Behat (PHP ${{ matrix.php }}) (Symfony dev)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 /.phpunit.result.cache
+/.phpunit.cache/
 /build/
 /composer.lock
 /composer.phar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ Both `simple-phpunit` and `behat` are development dependencies and should be ava
 
 To launch unit tests:
 
-    vendor/bin/simple-phpunit --stop-on-failure -vvv
+    vendor/bin/simple-phpunit --stop-on-defect -vvv
 
 If you want coverage, you will need the `pcov` PHP extension and run:
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,12 @@
             "homepage": "https://dunglas.fr"
         }
     ],
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/dunglas/prophecy-phpunit"
+        }
+    ],
     "require": {
         "php": ">=8.1",
         "doctrine/inflector": "^1.0 || ^2.0",
@@ -44,7 +50,7 @@
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "justinrainbow/json-schema": "^5.2.1",
-        "phpspec/prophecy-phpunit": "^2.0",
+        "phpspec/prophecy-phpunit": "^2.0 | dev-feat/static as 2.99.99",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpdoc-parser": "^1.13",
         "phpstan/phpstan": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "justinrainbow/json-schema": "^5.2.1",
-        "phpspec/prophecy-phpunit": "^2.0 | dev-feat/static as 2.99.99",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpdoc-parser": "^1.13",
         "phpstan/phpstan": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,6 @@
             "homepage": "https://dunglas.fr"
         }
     ],
-    "repositories": [
-        {
-            "type": "github",
-            "url": "https://github.com/dunglas/prophecy-phpunit"
-        }
-    ],
     "require": {
         "php": ">=8.1",
         "doctrine/inflector": "^1.0 || ^2.0",
@@ -34,7 +28,7 @@
     },
     "require-dev": {
         "behat/behat": "^3.1",
-        "behat/mink": "^1.9@dev",
+        "behat/mink": "^1.9",
         "doctrine/cache": "^1.11 || ^2.1",
         "doctrine/common": "^3.2.2",
         "doctrine/data-fixtures": "^1.2.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" bootstrap="tests/Fixtures/app/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" backupGlobals="false" bootstrap="tests/Fixtures/app/bootstrap.php" colors="true">
     <php>
         <ini name="error_reporting" value="-1" />
         <ini name="memory_limit" value="-1" />

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" backupGlobals="false" bootstrap="tests/Fixtures/app/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache">
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <ini name="memory_limit" value="-1"/>
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0&amp;ignoreFile=./tests/.ignored-deprecations"/>
+    <!-- This is necessary for GitHub Actions to work properly -->
+    <server name="SYMFONY_PHPUNIT_DIR" value="vendor/bin/.phpunit"/>
+    <server name="SYMFONY_PHPUNIT_REMOVE" value="symfony/yaml"/>
+    <server name="KERNEL_DIR" value="tests/Fixtures/app/"/>
+    <server name="KERNEL_CLASS" value="AppKernel"/>
+    <env name="APP_ENV" value="test"/>
+  </php>
+
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+
+  <groups>
+    <exclude>
+      <group>mongodb</group>
+    </exclude>
+  </groups>
+
+  <source>
+    <include>
+      <directory>.</directory>
+    </include>
+    <exclude>
+      <directory>features</directory>
+      <directory>tests</directory>
+      <directory>vendor</directory>
+      <file>.php-cs-fixer.dist.php</file>
+    </exclude>
+  </source>
+</phpunit>

--- a/src/JsonSchema/Tests/SchemaTest.php
+++ b/src/JsonSchema/Tests/SchemaTest.php
@@ -44,7 +44,7 @@ class SchemaTest extends TestCase
         $this->assertSame('Foo', $schema->getItemsDefinitionKey());
     }
 
-    public function versionProvider(): iterable
+    public static function versionProvider(): iterable
     {
         yield [Schema::VERSION_JSON_SCHEMA, '#/definitions/Foo'];
         yield [Schema::VERSION_SWAGGER, '#/definitions/Foo'];
@@ -85,7 +85,7 @@ class SchemaTest extends TestCase
         $this->assertArrayNotHasKey('components', $schema->getArrayCopy(false));
     }
 
-    public function definitionsDataProvider(): iterable
+    public static function definitionsDataProvider(): iterable
     {
         yield [Schema::VERSION_OPENAPI,  ['foo' => []]];
         yield [Schema::VERSION_JSON_SCHEMA,  ['foo' => []]];

--- a/src/JsonSchema/Tests/TypeFactoryTest.php
+++ b/src/JsonSchema/Tests/TypeFactoryTest.php
@@ -412,10 +412,10 @@ class TypeFactoryTest extends TestCase
     }
 
     /** @dataProvider classTypeWithNullabilityDataProvider */
-    public function testGetClassTypeWithNullability(array $expected, SchemaFactoryInterface $schemaFactory, Schema $schema): void
+    public function testGetClassTypeWithNullability(array $expected, callable $schemaFactoryFactory, Schema $schema): void
     {
         $typeFactory = new TypeFactory();
-        $typeFactory->setSchemaFactory($schemaFactory);
+        $typeFactory->setSchemaFactory($schemaFactoryFactory($this));
 
         self::assertEquals(
             $expected,
@@ -425,7 +425,8 @@ class TypeFactoryTest extends TestCase
 
     public static function classTypeWithNullabilityDataProvider(): iterable
     {
-        $schemaFactory = $this->createSchemaFactoryMock($schema = new Schema());
+        $schema = new Schema();
+        $schemaFactoryFactory = fn (self $that): SchemaFactoryInterface => $that->createSchemaFactoryMock($schema);
 
         yield 'JSON-Schema version' => [
             [
@@ -434,11 +435,12 @@ class TypeFactoryTest extends TestCase
                     ['type' => 'null'],
                 ],
             ],
-            $schemaFactory,
+            $schemaFactoryFactory,
             $schema,
         ];
 
-        $schemaFactory = $this->createSchemaFactoryMock($schema = new Schema(Schema::VERSION_OPENAPI));
+        $schema = new Schema(Schema::VERSION_OPENAPI);
+        $schemaFactoryFactory = fn (self $that): SchemaFactoryInterface => $that->createSchemaFactoryMock($schema);
 
         yield 'OpenAPI < 3.1 version' => [
             [
@@ -447,7 +449,7 @@ class TypeFactoryTest extends TestCase
                 ],
                 'nullable' => true,
             ],
-            $schemaFactory,
+            $schemaFactoryFactory,
             $schema,
         ];
     }

--- a/src/JsonSchema/Tests/TypeFactoryTest.php
+++ b/src/JsonSchema/Tests/TypeFactoryTest.php
@@ -41,7 +41,7 @@ class TypeFactoryTest extends TestCase
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_OPENAPI)));
     }
 
-    public function typeProvider(): iterable
+    public static function typeProvider(): iterable
     {
         yield [['type' => 'integer'], new Type(Type::BUILTIN_TYPE_INT)];
         yield [['nullable' => true, 'type' => 'integer'], new Type(Type::BUILTIN_TYPE_INT, true)];
@@ -169,7 +169,7 @@ class TypeFactoryTest extends TestCase
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_JSON_SCHEMA)));
     }
 
-    public function jsonSchemaTypeProvider(): iterable
+    public static function jsonSchemaTypeProvider(): iterable
     {
         yield [['type' => 'integer'], new Type(Type::BUILTIN_TYPE_INT)];
         yield [['type' => ['integer', 'null']], new Type(Type::BUILTIN_TYPE_INT, true)];
@@ -290,7 +290,7 @@ class TypeFactoryTest extends TestCase
         $this->assertEquals($schema, $typeFactory->getType($type, 'json', null, null, new Schema(Schema::VERSION_SWAGGER)));
     }
 
-    public function openAPIV2TypeProvider(): iterable
+    public static function openAPIV2TypeProvider(): iterable
     {
         yield [['type' => 'integer'], new Type(Type::BUILTIN_TYPE_INT)];
         yield [['type' => 'integer'], new Type(Type::BUILTIN_TYPE_INT, true)];
@@ -423,7 +423,7 @@ class TypeFactoryTest extends TestCase
         );
     }
 
-    public function classTypeWithNullabilityDataProvider(): iterable
+    public static function classTypeWithNullabilityDataProvider(): iterable
     {
         $schemaFactory = $this->createSchemaFactoryMock($schema = new Schema());
 

--- a/src/Metadata/Tests/Extractor/PropertyMetadataCompatibilityTest.php
+++ b/src/Metadata/Tests/Extractor/PropertyMetadataCompatibilityTest.php
@@ -93,7 +93,7 @@ final class PropertyMetadataCompatibilityTest extends TestCase
         $this->assertEquals($this->buildApiProperty(), $property);
     }
 
-    public function getExtractors(): array
+    public static function getExtractors(): array
     {
         return [
             [XmlPropertyExtractor::class, new XmlPropertyAdapter()],

--- a/src/Metadata/Tests/Extractor/ResourceMetadataCompatibilityTest.php
+++ b/src/Metadata/Tests/Extractor/ResourceMetadataCompatibilityTest.php
@@ -515,7 +515,7 @@ final class ResourceMetadataCompatibilityTest extends TestCase
         $this->assertEquals(new ResourceMetadataCollection(self::RESOURCE_CLASS, $this->buildApiResources()), $collection);
     }
 
-    public function getExtractors(): array
+    public static function getExtractors(): array
     {
         return [
             [XmlResourceExtractor::class, new XmlResourceAdapter()],

--- a/src/Metadata/Tests/Extractor/XmlExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/XmlExtractorTest.php
@@ -394,7 +394,7 @@ class XmlExtractorTest extends TestCase
         (new XmlResourceExtractor([$path]))->getResources();
     }
 
-    public function getInvalidPaths(): array
+    public static function getInvalidPaths(): array
     {
         return [
             [

--- a/src/Metadata/Tests/Extractor/YamlExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/YamlExtractorTest.php
@@ -536,7 +536,7 @@ class YamlExtractorTest extends TestCase
         (new YamlResourceExtractor([$path]))->getResources();
     }
 
-    public function getInvalidPaths(): array
+    public static function getInvalidPaths(): array
     {
         return [
             [__DIR__.'/yaml/invalid/invalid_resources.yaml', '"resources" setting is expected to be null or an array, string given in "'.__DIR__.'/yaml/invalid/invalid_resources.yaml".'],

--- a/src/Metadata/Tests/Property/Factory/SerializerPropertyMetadataFactoryTest.php
+++ b/src/Metadata/Tests/Property/Factory/SerializerPropertyMetadataFactoryTest.php
@@ -32,7 +32,7 @@ class SerializerPropertyMetadataFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function groupsProvider(): array
+    public static function groupsProvider(): array
     {
         return [
             [['dummy_read'], ['dummy_write']],

--- a/src/Metadata/Tests/Resource/Factory/FormatsResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/FormatsResourceMetadataCollectionFactoryTest.php
@@ -39,7 +39,7 @@ class FormatsResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function createProvider(): iterable
+    public static function createProvider(): iterable
     {
         yield [
             new ApiResource(

--- a/src/Metadata/Tests/Resource/Factory/InputOutputResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/InputOutputResourceMetadataCollectionFactoryTest.php
@@ -39,7 +39,7 @@ class InputOutputResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertSame($expected, $factory->create('Foo')[0]->getInput());
     }
 
-    public function getAttributes(): array
+    public static function getAttributes(): array
     {
         return [
             // no input class defined

--- a/src/Metadata/Tests/Resource/Factory/LinkFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/LinkFactoryTest.php
@@ -58,7 +58,7 @@ final class LinkFactoryTest extends TestCase
         );
     }
 
-    public function provideCreateLinksFromIdentifiersCases(): \Generator
+    public static function provideCreateLinksFromIdentifiersCases(): \Generator
     {
         yield 'no identifiers no id' => [
             ['slug'],
@@ -111,7 +111,7 @@ final class LinkFactoryTest extends TestCase
         );
     }
 
-    public function provideCreateLinksFromAttributesCases(): \Generator
+    public static function provideCreateLinksFromAttributesCases(): \Generator
     {
         yield 'no builtin types' => [
             [],

--- a/src/Metadata/Tests/Resource/Factory/OperationNameResourceMetadataFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/OperationNameResourceMetadataFactoryTest.php
@@ -42,7 +42,7 @@ class OperationNameResourceMetadataFactoryTest extends TestCase
         $this->assertEquals($operation->withName($expectedOperationName), $result->getOperation($expectedOperationName));
     }
 
-    public function operationProvider(): array
+    public static function operationProvider(): array
     {
         return [
             [new Get(), '_api_a_get'],

--- a/src/Metadata/Tests/Resource/OperationTest.php
+++ b/src/Metadata/Tests/Resource/OperationTest.php
@@ -47,7 +47,7 @@ final class OperationTest extends TestCase
         $this->assertInstanceOf(Operation::class, $operation);
     }
 
-    public function operationProvider(): \Generator
+    public static function operationProvider(): \Generator
     {
         $args = [];
 

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -55,7 +55,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
 
     protected function doTestApply(?array $properties, array $filterParameters, array $expectedPipeline, callable $filterFactory = null, string $resourceClass = null): void
     {
-        $filterFactory ??= ($this->filterClass)(...);
+        $filterFactory ??= fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): FilterInterface => new ($this->filterClass)($that, $managerRegistry, null, $properties);
 
         $repository = $this->repository;
         if ($resourceClass) {

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -69,7 +69,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
         }
         $resourceClass = $resourceClass ?: $this->resourceClass;
         $aggregationBuilder = $repository->createAggregationBuilder();
-        $filterCallable = $filterFactory($this->managerRegistry, $properties);
+        $filterCallable = $filterFactory($this->managerRegistry, $properties, $this);
         $context = ['filters' => $filterParameters];
         $filterCallable->apply($aggregationBuilder, $resourceClass, null, $context);
         $pipeline = [];
@@ -86,5 +86,5 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
         return new $this->filterClass($this->managerRegistry, null, $properties);
     }
 
-    abstract public function provideApplyTestData(): array;
+    abstract public static function provideApplyTestData(): array;
 }

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -55,7 +55,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
 
     protected function doTestApply(?array $properties, array $filterParameters, array $expectedPipeline, callable $filterFactory = null, string $resourceClass = null): void
     {
-        $filterFactory ??= fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): FilterInterface => new ($this->filterClass)($that, $managerRegistry, null, $properties);
+        $filterFactory ??= fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): FilterInterface => new ($this->filterClass)($managerRegistry, null, $properties);
 
         $repository = $this->repository;
         if ($resourceClass) {
@@ -63,7 +63,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
         }
         $resourceClass = $resourceClass ?: $this->resourceClass;
         $aggregationBuilder = $repository->createAggregationBuilder();
-        $filterCallable = $filterFactory($this, $this->managerRegistry, $properties, $this);
+        $filterCallable = $filterFactory($this, $this->managerRegistry, $properties);
         $context = ['filters' => $filterParameters];
         $filterCallable->apply($aggregationBuilder, $resourceClass, null, $context);
         $pipeline = [];

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -55,13 +55,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
 
     protected function doTestApply(?array $properties, array $filterParameters, array $expectedPipeline, callable $filterFactory = null, string $resourceClass = null): void
     {
-        if (null === $filterFactory) {
-            $filterFactory = function (ManagerRegistry $managerRegistry, array $properties = null): FilterInterface {
-                $filterClass = $this->filterClass;
-
-                return new $filterClass($this, $managerRegistry, null, $properties);
-            };
-        }
+        $filterFactory ??= ($this->filterClass)(...);
 
         $repository = $this->repository;
         if ($resourceClass) {
@@ -69,7 +63,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
         }
         $resourceClass = $resourceClass ?: $this->resourceClass;
         $aggregationBuilder = $repository->createAggregationBuilder();
-        $filterCallable = $filterFactory($this->managerRegistry, $properties, $this);
+        $filterCallable = $filterFactory($this, $this->managerRegistry, $properties, $this);
         $context = ['filters' => $filterParameters];
         $filterCallable->apply($aggregationBuilder, $resourceClass, null, $context);
         $pipeline = [];

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -59,7 +59,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
             $filterFactory = function (ManagerRegistry $managerRegistry, array $properties = null): FilterInterface {
                 $filterClass = $this->filterClass;
 
-                return new $filterClass($managerRegistry, null, $properties);
+                return new $filterClass($this, $managerRegistry, null, $properties);
             };
         }
 

--- a/src/Test/DoctrineOrmFilterTestCase.php
+++ b/src/Test/DoctrineOrmFilterTestCase.php
@@ -33,7 +33,7 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
 
     protected string $resourceClass = Dummy::class;
 
-    protected string $alias = 'o';
+    protected const ALIAS = 'o';
 
     protected string $filterClass;
 
@@ -56,11 +56,7 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
     protected function doTestApply(?array $properties, array $filterParameters, string $expectedDql, array $expectedParameters = null, callable $filterFactory = null, string $resourceClass = null): void
     {
         if (null === $filterFactory) {
-            $filterFactory = function (ManagerRegistry $managerRegistry, array $properties = null): FilterInterface {
-                $filterClass = $this->filterClass;
-
-                return new $filterClass($managerRegistry, null, $properties);
-            };
+            $filterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): FilterInterface => new ($this->filterClass)($managerRegistry, null, $properties);
         }
 
         $repository = $this->repository;
@@ -69,8 +65,8 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
             $repository = $this->managerRegistry->getManagerForClass($resourceClass)->getRepository($resourceClass);
         }
         $resourceClass = $resourceClass ?: $this->resourceClass;
-        $queryBuilder = $repository->createQueryBuilder($this->alias);
-        $filterCallable = $filterFactory($this->managerRegistry, $properties);
+        $queryBuilder = $repository->createQueryBuilder(static::ALIAS);
+        $filterCallable = $filterFactory($this, $this->managerRegistry, $properties);
         $filterCallable->apply($queryBuilder, new QueryNameGenerator(), $resourceClass, null, ['filters' => $filterParameters]);
 
         $this->assertSame($expectedDql, $queryBuilder->getQuery()->getDQL());
@@ -92,5 +88,5 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
         return new $this->filterClass($this->managerRegistry, null, $properties);
     }
 
-    abstract public function provideApplyTestData(): array;
+    abstract public static function provideApplyTestData(): array;
 }

--- a/tests/Action/ExceptionActionTest.php
+++ b/tests/Action/ExceptionActionTest.php
@@ -124,7 +124,7 @@ class ExceptionActionTest extends TestCase
         $this->assertTrue($response->headers->contains('X-Frame-Options', 'deny'));
     }
 
-    public function provideOperationExceptionToStatusCases(): \Generator
+    public static function provideOperationExceptionToStatusCases(): \Generator
     {
         yield 'no mapping' => [
             [],

--- a/tests/Api/CompositeIdentifierParserTest.php
+++ b/tests/Api/CompositeIdentifierParserTest.php
@@ -28,7 +28,7 @@ class CompositeIdentifierParserTest extends TestCase
         }
     }
 
-    public function variousIdentifiers(): array
+    public static function variousIdentifiers(): array
     {
         return [[[
             'a=bd;dc=d' => ['a' => 'bd', 'dc' => 'd'],
@@ -52,7 +52,7 @@ class CompositeIdentifierParserTest extends TestCase
         }
     }
 
-    public function compositeIdentifiers(): array
+    public static function compositeIdentifiers(): array
     {
         return [[[
             'a=bd;dc=d' => ['a' => 'bd', 'dc' => 'd'],

--- a/tests/Api/QueryParameterValidator/QueryParameterValidatorTest.php
+++ b/tests/Api/QueryParameterValidator/QueryParameterValidatorTest.php
@@ -48,6 +48,8 @@ class QueryParameterValidatorTest extends TestCase
 
     /**
      * unsafe method should not use filter validations.
+     *
+     * @doesNotPerformAssertions
      */
     public function testOnKernelRequestWithUnsafeMethod(): void
     {
@@ -58,6 +60,8 @@ class QueryParameterValidatorTest extends TestCase
 
     /**
      * If the tested filter is non-existent, then nothing should append.
+     *
+     * @doesNotPerformAssertions
      */
     public function testOnKernelRequestWithWrongFilter(): void
     {

--- a/tests/Doctrine/Common/Filter/BooleanFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/BooleanFilterTestTrait.php
@@ -49,7 +49,7 @@ trait BooleanFilterTestTrait
         ], $filter->getDescription($this->resourceClass));
     }
 
-    private function provideApplyTestArguments(): array
+    private static function provideApplyTestArguments(): array
     {
         return [
             'string ("true")' => [

--- a/tests/Doctrine/Common/Filter/DateFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/DateFilterTestTrait.php
@@ -47,7 +47,7 @@ trait DateFilterTestTrait
         ], $filter->getDescription($this->resourceClass));
     }
 
-    private function provideApplyTestArguments(): array
+    private static function provideApplyTestArguments(): array
     {
         return [
             'after (all properties enabled)' => [

--- a/tests/Doctrine/Common/Filter/ExistsFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/ExistsFilterTestTrait.php
@@ -31,7 +31,7 @@ trait ExistsFilterTestTrait
         ], $filter->getDescription($this->resourceClass));
     }
 
-    private function provideApplyTestArguments(): array
+    private static function provideApplyTestArguments(): array
     {
         return [
             'valid values' => [

--- a/tests/Doctrine/Common/Filter/NumericFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/NumericFilterTestTrait.php
@@ -87,7 +87,7 @@ trait NumericFilterTestTrait
         ], $filter->getDescription($this->resourceClass));
     }
 
-    private function provideApplyTestArguments(): array
+    private static function provideApplyTestArguments(): array
     {
         return [
             'numeric string (positive integer)' => [

--- a/tests/Doctrine/Common/Filter/OrderFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/OrderFilterTestTrait.php
@@ -51,7 +51,7 @@ trait OrderFilterTestTrait
         ], $filter->getDescription($this->resourceClass));
     }
 
-    private function provideApplyTestArguments(): array
+    private static function provideApplyTestArguments(): array
     {
         return [
             'valid values' => [

--- a/tests/Doctrine/Common/Filter/RangeFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/RangeFilterTestTrait.php
@@ -18,7 +18,7 @@ namespace ApiPlatform\Tests\Doctrine\Common\Filter;
  */
 trait RangeFilterTestTrait
 {
-    private function provideApplyTestArguments(): array
+    private static function provideApplyTestArguments(): array
     {
         return [
             'between' => [

--- a/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/SearchFilterTestTrait.php
@@ -21,7 +21,7 @@ trait SearchFilterTestTrait
 {
     public function testGetDescription(): void
     {
-        $filter = $this->buildSearchFilter($this->managerRegistry, [
+        $filter = $this->buildSearchFilter($this, $this->managerRegistry, [
             'id' => null,
             'name' => null,
             'alias' => null,
@@ -179,7 +179,7 @@ trait SearchFilterTestTrait
         ], $filter->getDescription($this->resourceClass));
     }
 
-    private function provideApplyTestArguments(): array
+    private static function provideApplyTestArguments(): array
     {
         return [
             'exact' => [

--- a/tests/Doctrine/Common/State/PersistProcessorTest.php
+++ b/tests/Doctrine/Common/State/PersistProcessorTest.php
@@ -81,7 +81,7 @@ class PersistProcessorTest extends TestCase
         $this->assertSame($dummy, $result);
     }
 
-    public function getTrackingPolicyParameters(): array
+    public static function getTrackingPolicyParameters(): array
     {
         return [
             'deferred explicit ORM' => [ClassMetadataInfo::class, true, true],

--- a/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -99,8 +99,8 @@ class PurgeHttpCacheListenerTest extends TestCase
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->isReadable(Argument::type(Dummy::class), 'relatedDummy')->willReturn(true);
         $propertyAccessorProphecy->isReadable(Argument::type(Dummy::class), 'relatedOwningDummy')->willReturn(false);
-        $propertyAccessorProphecy->getValue(Argument::type(Dummy::class), 'relatedDummy')->shouldBeCalled();
-        $propertyAccessorProphecy->getValue(Argument::type(Dummy::class), 'relatedOwningDummy')->shouldNotBeCalled();
+        $propertyAccessorProphecy->getValue(Argument::type(Dummy::class), 'relatedDummy')->willReturn(null)->shouldBeCalled();
+        $propertyAccessorProphecy->getValue(Argument::type(Dummy::class), 'relatedOwningDummy')->willReturn(null)->shouldNotBeCalled();
 
         $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal());
         $listener->onFlush($eventArgs);

--- a/tests/Doctrine/Odm/Filter/BooleanFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/BooleanFilterTest.php
@@ -30,10 +30,10 @@ class BooleanFilterTest extends DoctrineMongoDbOdmFilterTestCase
     protected string $filterClass = BooleanFilter::class;
     protected string $resourceClass = Dummy::class;
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'string ("true")' => [
                     [

--- a/tests/Doctrine/Odm/Filter/DateFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/DateFilterTest.php
@@ -31,10 +31,10 @@ class DateFilterTest extends DoctrineMongoDbOdmFilterTestCase
     protected string $filterClass = DateFilter::class;
     protected string $resourceClass = Dummy::class;
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'after (all properties enabled)' => [
                     [

--- a/tests/Doctrine/Odm/Filter/ExistsFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/ExistsFilterTest.php
@@ -116,8 +116,8 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
 
     public static function provideApplyTestData(): array
     {
-        $existsFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'exists');
-        $customExistsFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'customExists');
+        $existsFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'exists');
+        $customExistsFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'customExists');
 
         return array_merge_recursive(
             self::provideApplyTestArguments(),

--- a/tests/Doctrine/Odm/Filter/ExistsFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/ExistsFilterTest.php
@@ -114,13 +114,13 @@ class ExistsFilterTest extends DoctrineMongoDbOdmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         $existsFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'exists');
         $customExistsFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'customExists');
 
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'valid values' => [
                     [

--- a/tests/Doctrine/Odm/Filter/NumericFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/NumericFilterTest.php
@@ -74,10 +74,10 @@ class NumericFilterTest extends DoctrineMongoDbOdmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'numeric string (positive integer)' => [
                     [

--- a/tests/Doctrine/Odm/Filter/OrderFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/OrderFilterTest.php
@@ -233,13 +233,13 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         $orderFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'order', null, $properties);
         $customOrderFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'customOrder', null, $properties);
 
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'valid values' => [
                     [

--- a/tests/Doctrine/Odm/Filter/OrderFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/OrderFilterTest.php
@@ -235,8 +235,8 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
 
     public static function provideApplyTestData(): array
     {
-        $orderFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'order', null, $properties);
-        $customOrderFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'customOrder', null, $properties);
+        $orderFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'order', null, $properties);
+        $customOrderFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'customOrder', null, $properties);
 
         return array_merge_recursive(
             self::provideApplyTestArguments(),

--- a/tests/Doctrine/Odm/Filter/RangeFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/RangeFilterTest.php
@@ -438,10 +438,10 @@ class RangeFilterTest extends DoctrineMongoDbOdmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'between' => [
                     [

--- a/tests/Doctrine/Odm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/SearchFilterTest.php
@@ -41,7 +41,7 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
 
     public function testGetDescriptionDefaultFields(): void
     {
-        $filter = $this->buildSearchFilter($this->managerRegistry);
+        $filter = self::buildSearchFilter($this, $this->managerRegistry);
 
         $this->assertEquals([
             'id' => [
@@ -271,12 +271,12 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
-        $filterFactory = $this->buildSearchFilter(...);
+        $filterFactory = self::buildSearchFilter(...);
 
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'exact' => [
                     [
@@ -753,10 +753,10 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
         );
     }
 
-    protected function buildSearchFilter(ManagerRegistry $managerRegistry, array $properties = null): SearchFilter
+    protected static function buildSearchFilter(self $that, ManagerRegistry $managerRegistry, array $properties = null): SearchFilter
     {
-        $relatedDummyProphecy = $this->prophesize(RelatedDummy::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $relatedDummyProphecy = $that->prophesize(RelatedDummy::class);
+        $iriConverterProphecy = $that->prophesize(IriConverterInterface::class);
 
         $iriConverterProphecy->getResourceFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
             if (str_contains((string) $args[0], '/related_dummies')) {

--- a/tests/Doctrine/Odm/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactoryTest.php
+++ b/tests/Doctrine/Odm/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactoryTest.php
@@ -90,7 +90,7 @@ final class DoctrineMongoDbOdmResourceCollectionMetadataFactoryTest extends Test
         $this->assertSame($expectedProcessor, $resourceMetadataCollection->getOperation('graphql_'.$operation->getName())->getProcessor());
     }
 
-    public function operationProvider(): iterable
+    public static function operationProvider(): iterable
     {
         $default = (new Get())->withName('get')->withClass(Dummy::class);
 

--- a/tests/Doctrine/Odm/PaginatorTest.php
+++ b/tests/Doctrine/Odm/PaginatorTest.php
@@ -201,7 +201,7 @@ class PaginatorTest extends TestCase
         return new Paginator($iterator->reveal(), $documentManager->getUnitOfWork(), Dummy::class, $pipeline);
     }
 
-    public function initializeProvider(): array
+    public static function initializeProvider(): array
     {
         return [
             'First of three pages of 15 items each' => [0, 15, 42, 1, 3],

--- a/tests/Doctrine/Odm/PropertyInfo/DoctrineExtractorTest.php
+++ b/tests/Doctrine/Odm/PropertyInfo/DoctrineExtractorTest.php
@@ -138,7 +138,7 @@ class DoctrineExtractorTest extends TestCase
         $this->assertNull($this->createExtractor()->getTypes(DoctrineEnum::class, 'enumCustom'));
     }
 
-    public function typesProvider(): array
+    public static function typesProvider(): array
     {
         return [
             ['id', [new Type(Type::BUILTIN_TYPE_STRING)]],

--- a/tests/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -841,7 +841,7 @@ class EagerLoadingExtensionTest extends TestCase
         $eagerExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class, new GetCollection(normalizationContext: [AbstractNormalizer::GROUPS => 'foo']), $context);
     }
 
-    public function provideExistingJoinCases(): iterable
+    public static function provideExistingJoinCases(): iterable
     {
         yield [Join::LEFT_JOIN];
         yield [Join::INNER_JOIN];

--- a/tests/Doctrine/Orm/Extension/PaginationExtensionTest.php
+++ b/tests/Doctrine/Orm/Extension/PaginationExtensionTest.php
@@ -395,7 +395,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertSame($expected, $doctrinePaginator->getFetchJoinCollection());
     }
 
-    public function fetchJoinCollectionProvider(): array
+    public static function fetchJoinCollectionProvider(): array
     {
         return [
             'collection disabled' => [false, ['operation_name' => 'get'], false],
@@ -445,7 +445,7 @@ class PaginationExtensionTest extends TestCase
         $this->assertSame($expected, $doctrinePaginator->getUseOutputWalkers());
     }
 
-    public function fetchUseOutputWalkersProvider(): array
+    public static function fetchUseOutputWalkersProvider(): array
     {
         return [
             'collection disabled' => [false, ['operation_name' => 'get'], false],

--- a/tests/Doctrine/Orm/Filter/BooleanFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/BooleanFilterTest.php
@@ -27,10 +27,10 @@ class BooleanFilterTest extends DoctrineOrmFilterTestCase
 
     protected string $filterClass = BooleanFilter::class;
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'string ("true")' => [
                     sprintf('SELECT o FROM %s o WHERE o.dummyBoolean = :dummyBoolean_p1', Dummy::class),

--- a/tests/Doctrine/Orm/Filter/DateFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/DateFilterTest.php
@@ -57,10 +57,10 @@ class DateFilterTest extends DoctrineOrmFilterTestCase
         $this->assertInstanceOf(\DateTimeImmutable::class, $queryBuilder->getParameters()[0]->getValue());
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'after (all properties enabled)' => [
                     sprintf('SELECT o FROM %s o WHERE o.dummyDate >= :dummyDate_p1', Dummy::class),

--- a/tests/Doctrine/Orm/Filter/ExistsFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/ExistsFilterTest.php
@@ -92,13 +92,13 @@ class ExistsFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
-        $existsFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'exists');
-        $customExistsFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'customExists');
+        $existsFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'exists');
+        $customExistsFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): ExistsFilter => new ExistsFilter($managerRegistry, null, $properties, 'customExists');
 
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'valid values' => [
                     sprintf('SELECT o FROM %s o WHERE o.description IS NOT NULL', Dummy::class),

--- a/tests/Doctrine/Orm/Filter/NumericFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/NumericFilterTest.php
@@ -71,10 +71,10 @@ class NumericFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'numeric string (positive integer)' => [
                     sprintf('SELECT o FROM %s o WHERE o.dummyPrice = :dummyPrice_p1', Dummy::class),

--- a/tests/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -294,13 +294,13 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription(EmbeddedDummy::class));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
-        $orderFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'order', null, $properties);
-        $customOrderFilterFactory = fn (ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'customOrder', null, $properties);
+        $orderFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'order', null, $properties);
+        $customOrderFilterFactory = fn (self $that, ManagerRegistry $managerRegistry, array $properties = null): OrderFilter => new OrderFilter($managerRegistry, 'customOrder', null, $properties);
 
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'valid values' => [
                     sprintf('SELECT o FROM %s o ORDER BY o.id ASC, o.name DESC', Dummy::class),

--- a/tests/Doctrine/Orm/Filter/RangeFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/RangeFilterTest.php
@@ -335,10 +335,10 @@ class RangeFilterTest extends DoctrineOrmFilterTestCase
         ], $filter->getDescription($this->resourceClass));
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'between' => [
                     sprintf('SELECT o FROM %s o WHERE o.dummyPrice BETWEEN :dummyPrice_p1_1 AND :dummyPrice_p1_2', Dummy::class),

--- a/tests/Doctrine/Orm/Filter/SearchFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/SearchFilterTest.php
@@ -36,12 +36,12 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     use ProphecyTrait;
     use SearchFilterTestTrait;
 
-    protected string $alias = 'oo';
+    protected const ALIAS = 'oo';
     protected string $filterClass = SearchFilter::class;
 
     public function testGetDescriptionDefaultFields(): void
     {
-        $filter = $this->buildSearchFilter($this->managerRegistry);
+        $filter = self::buildSearchFilter($this, $this->managerRegistry);
 
         $this->assertEquals([
             'id' => [
@@ -219,14 +219,14 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     {
         $filters = ['relatedDummy.symfony' => 'foo'];
 
-        $queryBuilder = $this->repository->createQueryBuilder($this->alias);
-        $filter = $this->buildSearchFilter($this->managerRegistry, ['relatedDummy.symfony' => null]);
+        $queryBuilder = $this->repository->createQueryBuilder(static::ALIAS);
+        $filter = self::buildSearchFilter($this, $this->managerRegistry, ['relatedDummy.symfony' => null]);
 
-        $queryBuilder->innerJoin(sprintf('%s.relatedDummy', $this->alias), 'relateddummy_a1');
+        $queryBuilder->innerJoin(sprintf('%s.relatedDummy', static::ALIAS), 'relateddummy_a1');
         $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, new Get(), ['filters' => $filters]);
 
         $actual = strtolower($queryBuilder->getQuery()->getDQL());
-        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s inner join %1$s.relatedDummy relateddummy_a1 WHERE relateddummy_a1.symfony = :symfony_p1', $this->alias, Dummy::class));
+        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s inner join %1$s.relatedDummy relateddummy_a1 WHERE relateddummy_a1.symfony = :symfony_p1', static::ALIAS, Dummy::class));
         $this->assertSame($actual, $expected);
     }
 
@@ -234,15 +234,15 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     {
         $filters = ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '2'];
 
-        $queryBuilder = $this->repository->createQueryBuilder($this->alias);
-        $filter = $this->buildSearchFilter($this->managerRegistry, ['relatedDummy.symfony' => null, 'relatedDummy.thirdLevel.level' => null]);
+        $queryBuilder = $this->repository->createQueryBuilder(static::ALIAS);
+        $filter = self::buildSearchFilter($this, $this->managerRegistry, ['relatedDummy.symfony' => null, 'relatedDummy.thirdLevel.level' => null]);
 
-        $queryBuilder->innerJoin(sprintf('%s.relatedDummy', $this->alias), 'relateddummy_a1');
+        $queryBuilder->innerJoin(sprintf('%s.relatedDummy', static::ALIAS), 'relateddummy_a1');
         $queryBuilder->innerJoin('relateddummy_a1.thirdLevel', 'thirdLevel_a1');
 
         $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, new Get(), ['filters' => $filters]);
         $actual = strtolower($queryBuilder->getQuery()->getDQL());
-        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s inner join %1$s.relatedDummy relateddummy_a1 inner join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', $this->alias, Dummy::class));
+        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s inner join %1$s.relatedDummy relateddummy_a1 inner join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', static::ALIAS, Dummy::class));
         $this->assertSame($actual, $expected);
     }
 
@@ -250,14 +250,14 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
     {
         $filters = ['relatedDummy.symfony' => 'foo', 'relatedDummy.thirdLevel.level' => '3'];
 
-        $queryBuilder = $this->repository->createQueryBuilder($this->alias);
-        $queryBuilder->leftJoin(sprintf('%s.relatedDummy', $this->alias), 'relateddummy_a1');
+        $queryBuilder = $this->repository->createQueryBuilder(static::ALIAS);
+        $queryBuilder->leftJoin(sprintf('%s.relatedDummy', static::ALIAS), 'relateddummy_a1');
 
-        $filter = $this->buildSearchFilter($this->managerRegistry, ['relatedDummy.symfony' => null, 'relatedDummy.thirdLevel.level' => null]);
+        $filter = self::buildSearchFilter($this, $this->managerRegistry, ['relatedDummy.symfony' => null, 'relatedDummy.thirdLevel.level' => null]);
         $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, new Get(), ['filters' => $filters]);
 
         $actual = strtolower($queryBuilder->getQuery()->getDQL());
-        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s left join %1$s.relatedDummy relateddummy_a1 left join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', $this->alias, Dummy::class));
+        $expected = strtolower(sprintf('SELECT %s FROM %s %1$s left join %1$s.relatedDummy relateddummy_a1 left join relateddummy_a1.thirdLevel thirdLevel_a1 WHERE relateddummy_a1.symfony = :symfony_p1 and thirdLevel_a1.level = :level_p2', static::ALIAS, Dummy::class));
         $this->assertSame($actual, $expected);
     }
 
@@ -267,37 +267,37 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
 
         $queryBuilder = $this->repository->createQueryBuilder('somealias');
 
-        $filter = $this->buildSearchFilter($this->managerRegistry, ['id' => null, 'name' => null]);
+        $filter = self::buildSearchFilter($this, $this->managerRegistry, ['id' => null, 'name' => null]);
         $filter->apply($queryBuilder, new QueryNameGenerator(), $this->resourceClass, new Get(), ['filters' => $filters]);
 
         $expectedDql = sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', 'somealias', Dummy::class);
         $this->assertSame($expectedDql, $queryBuilder->getQuery()->getDQL());
     }
 
-    public function provideApplyTestData(): array
+    public static function provideApplyTestData(): array
     {
-        $filterFactory = $this->buildSearchFilter(...);
+        $filterFactory = self::buildSearchFilter(...);
 
         return array_merge_recursive(
-            $this->provideApplyTestArguments(),
+            self::provideApplyTestArguments(),
             [
                 'exact' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', static::ALIAS, Dummy::class),
                     ['name_p1' => 'exact'],
                     $filterFactory,
                 ],
                 'exact (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) = LOWER(:name_p1)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) = LOWER(:name_p1)', static::ALIAS, Dummy::class),
                     ['name_p1' => 'exact'],
                     $filterFactory,
                 ],
                 'exact (case insensitive, with special characters)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) = LOWER(:name_p1)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) = LOWER(:name_p1)', static::ALIAS, Dummy::class),
                     ['name_p1' => 'exact (special)'],
                     $filterFactory,
                 ],
                 'exact (multiple values)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN(:name_p1)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name IN(:name_p1)', static::ALIAS, Dummy::class),
                     [
                         'name_p1' => [
                             'CaSE',
@@ -307,7 +307,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'exact (multiple values; case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) IN(:name_p1)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) IN(:name_p1)', static::ALIAS, Dummy::class),
                     [
                         'name_p1' => [
                             'case',
@@ -317,27 +317,27 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'invalid property' => [
-                    sprintf('SELECT %s FROM %s %1$s', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s', static::ALIAS, Dummy::class),
                     [],
                     $filterFactory,
                 ],
                 'invalid values for relations' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name = :name_p1', static::ALIAS, Dummy::class),
                     [],
                     $filterFactory,
                 ],
                 'partial' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0, \'%%\')', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0, \'%%\')', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'partial (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\'))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\'))', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'partial (multiple values)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%%\', :name_p1_1, \'%%\')', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%%\', :name_p1_1, \'%%\')', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'CaSE',
                         'name_p1_1' => 'SENSitive',
@@ -345,7 +345,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'partial (multiple values; case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1, \'%%\'))', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'case',
                         'name_p1_1' => 'insensitive',
@@ -353,7 +353,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'partial (multiple almost same values; case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1, \'%%\'))', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'blue car',
                         'name_p1_1' => 'blue car',
@@ -361,17 +361,17 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'start' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\')', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\')', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'start (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\'))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\'))', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'start (multiple values)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(:name_p1_1, \'%%\')', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(:name_p1_1, \'%%\')', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'CaSE',
                         'name_p1_1' => 'SENSitive',
@@ -379,7 +379,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'start (multiple values; case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_1, \'%%\'))', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'case',
                         'name_p1_1' => 'insensitive',
@@ -387,17 +387,17 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'end' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0)', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'end (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0))', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'end (multiple values)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0) OR %1$s.name LIKE CONCAT(\'%%\', :name_p1_1)', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0) OR %1$s.name LIKE CONCAT(\'%%\', :name_p1_1)', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'CaSE',
                         'name_p1_1' => 'SENSitive',
@@ -405,7 +405,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'end (multiple values; case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0)) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0)) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_1))', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'case',
                         'name_p1_1' => 'insensitive',
@@ -413,17 +413,17 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'word_start' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_0, \'%%\')', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_0, \'%%\')', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'word_start (case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_0, \'%%\'))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_0, \'%%\'))', static::ALIAS, Dummy::class),
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
                 'word_start (multiple values)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE (%1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_0, \'%%\')) OR (%1$s.name LIKE CONCAT(:name_p1_1, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_1, \'%%\'))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE (%1$s.name LIKE CONCAT(:name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_0, \'%%\')) OR (%1$s.name LIKE CONCAT(:name_p1_1, \'%%\') OR %1$s.name LIKE CONCAT(\'%% \', :name_p1_1, \'%%\'))', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'CaSE',
                         'name_p1_1' => 'SENSitive',
@@ -431,7 +431,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'word_start (multiple values; case insensitive)' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE (LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_0, \'%%\'))) OR (LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_1, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_1, \'%%\')))', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE (LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_0, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_0, \'%%\'))) OR (LOWER(%1$s.name) LIKE LOWER(CONCAT(:name_p1_1, \'%%\')) OR LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%% \', :name_p1_1, \'%%\')))', static::ALIAS, Dummy::class),
                     [
                         'name_p1_0' => 'case',
                         'name_p1_1' => 'insensitive',
@@ -439,7 +439,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'invalid value for relation' => [
-                    sprintf('SELECT %s FROM %s %1$s', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s', static::ALIAS, Dummy::class),
                     [],
                     $filterFactory,
                 ],
@@ -452,17 +452,17 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     [
                         'relatedDummy' => '/related_dummie/1',
                     ],
-                    sprintf('SELECT %s FROM %s %1$s', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s', static::ALIAS, Dummy::class),
                     [],
                     $filterFactory,
                 ],
                 'IRI value for relation' => [
-                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummy relatedDummy_a1 WHERE relatedDummy_a1.id = :id_p1', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummy relatedDummy_a1 WHERE relatedDummy_a1.id = :id_p1', static::ALIAS, Dummy::class),
                     ['id_p1' => 1],
                     $filterFactory,
                 ],
                 'mixed IRI and entity ID values for relations' => [
-                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummies relatedDummies_a1 WHERE %1$s.relatedDummy IN(:relatedDummy_p1) AND relatedDummies_a1.id = :id_p2', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummies relatedDummies_a1 WHERE %1$s.relatedDummy IN(:relatedDummy_p1) AND relatedDummies_a1.id = :id_p2', static::ALIAS, Dummy::class),
                     [
                         'relatedDummy_p1' => [1, 2],
                         'id_p2' => 1,
@@ -470,7 +470,7 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'nested property' => [
-                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummy relatedDummy_a1 WHERE %1$s.name = :name_p1 AND relatedDummy_a1.symfony = :symfony_p2', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedDummy relatedDummy_a1 WHERE %1$s.name = :name_p1 AND relatedDummy_a1.symfony = :symfony_p2', static::ALIAS, Dummy::class),
                     [
                         'name_p1' => 'exact',
                         'symfony_p2' => 'exact',
@@ -478,24 +478,24 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     $filterFactory,
                 ],
                 'empty nested property' => [
-                    sprintf('SELECT %s FROM %s %1$s', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s', static::ALIAS, Dummy::class),
                     [],
                     $filterFactory,
                 ],
                 'integer value' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.age = :age_p1', $this->alias, RelatedDummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.age = :age_p1', static::ALIAS, RelatedDummy::class),
                     ['age_p1' => 46],
                     $filterFactory,
                     RelatedDummy::class,
                 ],
                 'related owned one-to-one association' => [
-                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedOwnedDummy relatedOwnedDummy_a1 WHERE relatedOwnedDummy_a1.id = :id_p1', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s INNER JOIN %1$s.relatedOwnedDummy relatedOwnedDummy_a1 WHERE relatedOwnedDummy_a1.id = :id_p1', static::ALIAS, Dummy::class),
                     ['id_p1' => 1],
                     $filterFactory,
                     Dummy::class,
                 ],
                 'related owning one-to-one association' => [
-                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.relatedOwningDummy = :relatedOwningDummy_p1', $this->alias, Dummy::class),
+                    sprintf('SELECT %s FROM %s %1$s WHERE %1$s.relatedOwningDummy = :relatedOwningDummy_p1', static::ALIAS, Dummy::class),
                     ['relatedOwningDummy_p1' => 1],
                     $filterFactory,
                     Dummy::class,
@@ -504,10 +504,10 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
         );
     }
 
-    protected function buildSearchFilter(ManagerRegistry $managerRegistry, array $properties = null): SearchFilter
+    protected static function buildSearchFilter(self $that, ManagerRegistry $managerRegistry, array $properties = null): SearchFilter
     {
-        $relatedDummyProphecy = $this->prophesize(RelatedDummy::class);
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $relatedDummyProphecy = $that->prophesize(RelatedDummy::class);
+        $iriConverterProphecy = $that->prophesize(IriConverterInterface::class);
 
         $iriConverterProphecy->getResourceFromIri(Argument::type('string'), ['fetch_data' => false])->will(function ($args) use ($relatedDummyProphecy) {
             if (str_contains((string) $args[0], '/related_dummies')) {

--- a/tests/Doctrine/Orm/Metadata/Resource/DoctrineOrmResourceCollectionMetadataFactoryTest.php
+++ b/tests/Doctrine/Orm/Metadata/Resource/DoctrineOrmResourceCollectionMetadataFactoryTest.php
@@ -78,7 +78,7 @@ class DoctrineOrmResourceCollectionMetadataFactoryTest extends TestCase
         $this->assertSame($expectedProcessor, $resourceMetadataCollection->getOperation('graphql_'.$operation->getName())->getProcessor());
     }
 
-    public function operationProvider(): iterable
+    public static function operationProvider(): iterable
     {
         $default = (new Get())->withName('get')->withClass(Dummy::class);
 

--- a/tests/Doctrine/Orm/PaginatorTest.php
+++ b/tests/Doctrine/Orm/PaginatorTest.php
@@ -90,7 +90,7 @@ class PaginatorTest extends TestCase
         new Paginator($doctrinePaginator->reveal());
     }
 
-    public function initializeProvider(): array
+    public static function initializeProvider(): array
     {
         return [
             'First of three pages of 15 items each' => [0, 15, 42, 1, 3],

--- a/tests/Doctrine/Orm/Util/QueryBuilderHelperTest.php
+++ b/tests/Doctrine/Orm/Util/QueryBuilderHelperTest.php
@@ -130,7 +130,7 @@ class QueryBuilderHelperTest extends TestCase
         $this->assertSame(RelatedDummy::class, $actual);
     }
 
-    public function provideAddJoinOnce(): \Iterator
+    public static function provideAddJoinOnce(): \Iterator
     {
         yield [
             null,

--- a/tests/Elasticsearch/Metadata/Resource/Factory/ElasticsearchProviderResourceMetadataCollectionFactoryTest.php
+++ b/tests/Elasticsearch/Metadata/Resource/Factory/ElasticsearchProviderResourceMetadataCollectionFactoryTest.php
@@ -91,7 +91,7 @@ class ElasticsearchProviderResourceMetadataCollectionFactoryTest extends TestCas
         self::assertEquals($expectedResult, $elasticsearchResult);
     }
 
-    public function elasticsearchProvider(): array
+    public static function elasticsearchProvider(): array
     {
         return [
             'elasticsearch: false' => [false, 0, false],

--- a/tests/Elasticsearch/Serializer/ItemNormalizerTest.php
+++ b/tests/Elasticsearch/Serializer/ItemNormalizerTest.php
@@ -148,7 +148,23 @@ final class ItemNormalizerTest extends TestCase
             $this->markTestSkipped('Symfony Serializer < 6.3');
         }
 
-        $this->normalizerProphecy->getSupportedTypes(Argument::any())->willReturn(['*' => true]);
+        // TODO: use prophecy when getSupportedTypes() will be added to the interface
+        $this->itemNormalizer = new ItemNormalizer(new class() implements NormalizerInterface {
+            public function normalize(mixed $object, string $format = null, array $context = [])
+            {
+                return null;
+            }
+
+            public function supportsNormalization(mixed $data, string $format = null): bool
+            {
+                return true;
+            }
+
+            public function getSupportedTypes(?string $format): array
+            {
+                return ['*' => true];
+            }
+        });
 
         $this->assertEmpty($this->itemNormalizer->getSupportedTypes('json'));
         $this->assertSame(['*' => true], $this->itemNormalizer->getSupportedTypes($this->itemNormalizer::FORMAT));

--- a/tests/Elasticsearch/Util/ElasticsearchVersionTest.php
+++ b/tests/Elasticsearch/Util/ElasticsearchVersionTest.php
@@ -26,7 +26,7 @@ class ElasticsearchVersionTest extends TestCase
         self::assertSame($expected, ElasticsearchVersion::supportsMappingType($version));
     }
 
-    public function supportsDocumentTypeProvider(): \Generator
+    public static function supportsDocumentTypeProvider(): \Generator
     {
         yield 'ES 5' => ['5.5.0', true];
         yield 'ES 5 dev' => ['5.x', true];

--- a/tests/GraphQl/Action/EntrypointActionTest.php
+++ b/tests/GraphQl/Action/EntrypointActionTest.php
@@ -114,7 +114,7 @@ class EntrypointActionTest extends TestCase
         $this->assertSame($expectedResponse->getContent(), $mockedEntrypoint($request)->getContent());
     }
 
-    public function multipartRequestProvider(): array
+    public static function multipartRequestProvider(): array
     {
         $file = new UploadedFile(
             __DIR__.'/Fixtures/test.gif',

--- a/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
+++ b/tests/GraphQl/Resolver/Factory/ItemResolverFactoryTest.php
@@ -95,7 +95,7 @@ class ItemResolverFactoryTest extends TestCase
         $this->assertSame($serializeStageData, ($this->itemResolverFactory)($resourceClass, $rootClass, $operation)($source, $args, null, $info));
     }
 
-    public function itemResourceProvider(): array
+    public static function itemResourceProvider(): array
     {
         return [
             'nominal' => [\stdClass::class, \stdClass::class, new \stdClass()],

--- a/tests/GraphQl/Resolver/Stage/DeserializeStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/DeserializeStageTest.php
@@ -82,7 +82,7 @@ class DeserializeStageTest extends TestCase
         $this->assertSame($denormalizedData, $result);
     }
 
-    public function objectToPopulateProvider(): array
+    public static function objectToPopulateProvider(): array
     {
         return [
             'null' => [null, ['denormalization' => true]],

--- a/tests/GraphQl/Resolver/Stage/ReadStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/ReadStageTest.php
@@ -73,7 +73,7 @@ class ReadStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function contextProvider(): array
+    public static function contextProvider(): array
     {
         return [
             'item context' => [['is_collection' => false], null],
@@ -113,7 +113,7 @@ class ReadStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function itemProvider(): array
+    public static function itemProvider(): array
     {
         $item = new \stdClass();
 
@@ -160,7 +160,7 @@ class ReadStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function itemMutationOrSubscriptionProvider(): array
+    public static function itemMutationOrSubscriptionProvider(): array
     {
         $item = new \stdClass();
 
@@ -240,7 +240,7 @@ array_search('some.field', array_keys($args['filters']['order']), true) <
         array_search('localField', array_keys($args['filters']['order']), true)))->shouldHaveBeenCalled();
     }
 
-    public function collectionProvider(): array
+    public static function collectionProvider(): array
     {
         return [
             'no root class' => [[], null, null, [], []],

--- a/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
+++ b/tests/GraphQl/Resolver/Stage/SerializeStageTest.php
@@ -66,7 +66,7 @@ class SerializeStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function applyDisabledProvider(): array
+    public static function applyDisabledProvider(): array
     {
         return [
             'item' => [new Query(), false, null],
@@ -105,26 +105,24 @@ class SerializeStageTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function applyProvider(): array
+    public static function applyProvider(): iterable
     {
         $defaultContext = [
             'args' => [],
-            'info' => $this->prophesize(ResolveInfo::class)->reveal(),
+            'info' => self::createStub(ResolveInfo::class),
         ];
 
-        return [
-            'item' => [new \stdClass(), 'item_query', $defaultContext + ['is_collection' => false, 'is_mutation' => false, 'is_subscription' => false], false, ['normalized_item']],
-            'collection without pagination' => [[new \stdClass(), new \stdClass()], 'collection_query', $defaultContext + ['is_collection' => true, 'is_mutation' => false, 'is_subscription' => false], false, [['normalized_item'], ['normalized_item']]],
-            'mutation' => [new \stdClass(), 'create', array_merge($defaultContext, ['args' => ['input' => ['clientMutationId' => 'clientMutationId']], 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false]), false, ['shortName' => ['normalized_item'], 'clientMutationId' => 'clientMutationId']],
-            'delete mutation' => [new \stdClass(), 'delete', array_merge($defaultContext, ['args' => ['input' => ['id' => '/iri/4']], 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false]), false, ['shortName' => ['id' => '/iri/4'], 'clientMutationId' => null]],
-            'subscription' => [new \stdClass(), 'update', array_merge($defaultContext, ['args' => ['input' => ['clientSubscriptionId' => 'clientSubscriptionId']], 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true]), false, ['shortName' => ['normalized_item'], 'clientSubscriptionId' => 'clientSubscriptionId']],
-        ];
+        yield 'item' => [new \stdClass(), 'item_query', $defaultContext + ['is_collection' => false, 'is_mutation' => false, 'is_subscription' => false], false, ['normalized_item']];
+        yield 'collection without pagination' => [[new \stdClass(), new \stdClass()], 'collection_query', $defaultContext + ['is_collection' => true, 'is_mutation' => false, 'is_subscription' => false], false, [['normalized_item'], ['normalized_item']]];
+        yield 'mutation' => [new \stdClass(), 'create', array_merge($defaultContext, ['args' => ['input' => ['clientMutationId' => 'clientMutationId']], 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false]), false, ['shortName' => ['normalized_item'], 'clientMutationId' => 'clientMutationId']];
+        yield 'delete mutation' => [new \stdClass(), 'delete', array_merge($defaultContext, ['args' => ['input' => ['id' => '/iri/4']], 'is_collection' => false, 'is_mutation' => true, 'is_subscription' => false]), false, ['shortName' => ['id' => '/iri/4'], 'clientMutationId' => null]];
+        yield 'subscription' => [new \stdClass(), 'update', array_merge($defaultContext, ['args' => ['input' => ['clientSubscriptionId' => 'clientSubscriptionId']], 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => true]), false, ['shortName' => ['normalized_item'], 'clientSubscriptionId' => 'clientSubscriptionId']];
     }
 
     /**
      * @dataProvider applyCollectionWithPaginationProvider
      */
-    public function testApplyCollectionWithPagination(iterable $collection, array $args, ?array $expectedResult, string $expectedExceptionClass = null, string $expectedExceptionMessage = null): void
+    public function testApplyCollectionWithPagination(iterable|callable $collection, array $args, ?array $expectedResult, string $expectedExceptionClass = null, string $expectedExceptionMessage = null): void
     {
         $operationName = 'collection_query';
         $resourceClass = 'myResource';
@@ -133,7 +131,7 @@ class SerializeStageTest extends TestCase
             'is_mutation' => false,
             'is_subscription' => false,
             'args' => $args,
-            'info' => $this->prophesize(ResolveInfo::class)->reveal(),
+            'info' => self::createStub(ResolveInfo::class),
         ];
 
         /** @var Operation $operation */
@@ -149,31 +147,34 @@ class SerializeStageTest extends TestCase
             $this->expectExceptionMessage($expectedExceptionMessage);
         }
 
-        $result = ($this->createSerializeStage(true))($collection, $resourceClass, $operation, $context);
+        $result = ($this->createSerializeStage(true))(\is_callable($collection) ? $collection($this) : $collection, $resourceClass, $operation, $context);
 
         $this->assertSame($expectedResult, $result);
     }
 
-    public function applyCollectionWithPaginationProvider(): array
+    public static function applyCollectionWithPaginationProvider(): iterable
     {
-        $partialPaginatorProphecy = $this->prophesize(PartialPaginatorInterface::class);
-        $partialPaginatorProphecy->count()->willReturn(2);
-        $partialPaginatorProphecy->valid()->willReturn(false);
+        $partialPaginatorFactory = function (self $that): PartialPaginatorInterface {
+            $partialPaginatorProphecy = $that->prophesize(PartialPaginatorInterface::class);
+            $partialPaginatorProphecy->count()->willReturn(2);
+            $partialPaginatorProphecy->valid()->willReturn(false);
+            $partialPaginatorProphecy->rewind();
 
-        return [
-            'not paginator' => [[], [], null, \LogicException::class, 'Collection returned by the collection data provider must implement ApiPlatform\State\Pagination\PaginatorInterface'],
-            'empty paginator' => [new ArrayPaginator([], 0, 0), [], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => null, 'endCursor' => null, 'hasNextPage' => false, 'hasPreviousPage' => false]]],
-            'paginator' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 0, 2), [], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MA=='], ['node' => ['normalized_item'], 'cursor' => 'MQ==']], 'pageInfo' => ['startCursor' => 'MA==', 'endCursor' => 'MQ==', 'hasNextPage' => true, 'hasPreviousPage' => false]]],
-            'paginator with after cursor' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 1, 2), ['after' => 'MA=='], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ=='], ['node' => ['normalized_item'], 'cursor' => 'Mg==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]]],
-            'paginator with bad after cursor' => [new ArrayPaginator([], 0, 0), ['after' => '-'], null, \UnexpectedValueException::class, 'Cursor - is invalid'],
-            'paginator with empty after cursor' => [new ArrayPaginator([], 0, 0), ['after' => ''], null, \UnexpectedValueException::class, 'Empty cursor is invalid'],
-            'paginator with before cursor' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 1, 1), ['before' => 'Mg=='], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'MQ==', 'hasNextPage' => true, 'hasPreviousPage' => true]]],
-            'paginator with bad before cursor' => [new ArrayPaginator([], 0, 0), ['before' => '-'], null, \UnexpectedValueException::class, 'Cursor - is invalid'],
-            'paginator with empty before cursor' => [new ArrayPaginator([], 0, 0), ['before' => ''], null, \UnexpectedValueException::class, 'Empty cursor is invalid'],
-            'paginator with last' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 1, 2), ['last' => 2], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ=='], ['node' => ['normalized_item'], 'cursor' => 'Mg==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]]],
-            'partial paginator' => [$partialPaginatorProphecy->reveal(), [], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => 'MA==', 'endCursor' => 'MQ==', 'hasNextPage' => false, 'hasPreviousPage' => false]]],
-            'partial paginator with after cursor' => [$partialPaginatorProphecy->reveal(), ['after' => 'MA=='], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]]],
-        ];
+            return $partialPaginatorProphecy->reveal();
+        };
+
+        yield 'not paginator' => [[], [], null, \LogicException::class, 'Collection returned by the collection data provider must implement ApiPlatform\State\Pagination\PaginatorInterface'];
+        yield 'empty paginator' => [new ArrayPaginator([], 0, 0), [], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => null, 'endCursor' => null, 'hasNextPage' => false, 'hasPreviousPage' => false]]];
+        yield 'paginator' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 0, 2), [], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MA=='], ['node' => ['normalized_item'], 'cursor' => 'MQ==']], 'pageInfo' => ['startCursor' => 'MA==', 'endCursor' => 'MQ==', 'hasNextPage' => true, 'hasPreviousPage' => false]]];
+        yield 'paginator with after cursor' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 1, 2), ['after' => 'MA=='], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ=='], ['node' => ['normalized_item'], 'cursor' => 'Mg==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]]];
+        yield 'paginator with bad after cursor' => [new ArrayPaginator([], 0, 0), ['after' => '-'], null, \UnexpectedValueException::class, 'Cursor - is invalid'];
+        yield 'paginator with empty after cursor' => [new ArrayPaginator([], 0, 0), ['after' => ''], null, \UnexpectedValueException::class, 'Empty cursor is invalid'];
+        yield 'paginator with before cursor' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 1, 1), ['before' => 'Mg=='], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'MQ==', 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+        yield 'paginator with bad before cursor' => [new ArrayPaginator([], 0, 0), ['before' => '-'], null, \UnexpectedValueException::class, 'Cursor - is invalid'];
+        yield 'paginator with empty before cursor' => [new ArrayPaginator([], 0, 0), ['before' => ''], null, \UnexpectedValueException::class, 'Empty cursor is invalid'];
+        yield 'paginator with last' => [new ArrayPaginator([new \stdClass(), new \stdClass(), new \stdClass()], 1, 2), ['last' => 2], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ=='], ['node' => ['normalized_item'], 'cursor' => 'Mg==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]]];
+        yield 'partial paginator' => [$partialPaginatorFactory, [], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => 'MA==', 'endCursor' => 'MQ==', 'hasNextPage' => false, 'hasPreviousPage' => false]]];
+        yield 'partial paginator with after cursor' => [$partialPaginatorFactory, ['after' => 'MA=='], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]]];
     }
 
     public function testApplyBadNormalizedData(): void

--- a/tests/GraphQl/Serializer/Exception/HttpExceptionNormalizerTest.php
+++ b/tests/GraphQl/Serializer/Exception/HttpExceptionNormalizerTest.php
@@ -51,7 +51,7 @@ class HttpExceptionNormalizerTest extends TestCase
         }
     }
 
-    public function exceptionProvider(): array
+    public static function exceptionProvider(): array
     {
         $exceptionMessage = 'exception message';
 

--- a/tests/GraphQl/Type/SchemaBuilderTest.php
+++ b/tests/GraphQl/Type/SchemaBuilderTest.php
@@ -100,7 +100,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame($typeFoo, $schema->getType('Foo'));
     }
 
-    public function schemaProvider(): array
+    public static function schemaProvider(): array
     {
         return [
             'no graphql configuration' => [$resourceClass = 'resourceClass', new ResourceMetadataCollection($resourceClass, [new ApiResource()]),

--- a/tests/GraphQl/Type/TypeBuilderTest.php
+++ b/tests/GraphQl/Type/TypeBuilderTest.php
@@ -143,7 +143,7 @@ class TypeBuilderTest extends TestCase
         $this->assertSame($shortName, $resourceObjectType->name);
     }
 
-    public function resourceObjectTypeQuerySerializationGroupsProvider(): array
+    public static function resourceObjectTypeQuerySerializationGroupsProvider(): array
     {
         return [
             'same serialization groups for item_query and collection_query' => [
@@ -601,7 +601,7 @@ class TypeBuilderTest extends TestCase
         $this->assertSame($expectedIsCollection, $this->typeBuilder->isCollection($type));
     }
 
-    public function typesProvider(): array
+    public static function typesProvider(): array
     {
         return [
             [new Type(Type::BUILTIN_TYPE_BOOL), false],

--- a/tests/GraphQl/Type/TypeConverterTest.php
+++ b/tests/GraphQl/Type/TypeConverterTest.php
@@ -76,7 +76,7 @@ class TypeConverterTest extends TestCase
         $this->assertSame($expectedGraphqlType, $graphqlType);
     }
 
-    public function convertTypeProvider(): array
+    public static function convertTypeProvider(): array
     {
         return [
             [new Type(Type::BUILTIN_TYPE_BOOL), false, 0, GraphQLType::boolean()],
@@ -187,7 +187,7 @@ class TypeConverterTest extends TestCase
         $this->assertSame($expectedGraphqlType, $graphqlType);
     }
 
-    public function convertTypeResourceProvider(): array
+    public static function convertTypeResourceProvider(): array
     {
         return [
             [new Type(Type::BUILTIN_TYPE_OBJECT, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'dummyValue')), new ObjectType(['name' => 'resourceObjectType', 'fields' => []])],
@@ -206,7 +206,7 @@ class TypeConverterTest extends TestCase
         $this->assertEquals($expectedGraphqlType, $this->typeConverter->resolveType($type));
     }
 
-    public function resolveTypeProvider(): array
+    public static function resolveTypeProvider(): array
     {
         return [
             ['String', GraphQLType::string()],
@@ -234,7 +234,7 @@ class TypeConverterTest extends TestCase
         $this->typeConverter->resolveType($type);
     }
 
-    public function resolveTypeInvalidProvider(): array
+    public static function resolveTypeInvalidProvider(): array
     {
         return [
             ['float?', '"float?" is not a valid GraphQL type.'],

--- a/tests/HttpCache/VarnishPurgerTest.php
+++ b/tests/HttpCache/VarnishPurgerTest.php
@@ -111,7 +111,7 @@ class VarnishPurgerTest extends TestCase
         self::assertSame($regexesToSend, $client->sentRegexes); // @phpstan-ignore-line
     }
 
-    public function provideChunkHeaderCases(): \Generator
+    public static function provideChunkHeaderCases(): \Generator
     {
         yield 'no iri' => [
             50,

--- a/tests/HttpCache/VarnishXKeyPurgerTest.php
+++ b/tests/HttpCache/VarnishXKeyPurgerTest.php
@@ -141,7 +141,7 @@ class VarnishXKeyPurgerTest extends TestCase
         self::assertSame($keysToSend, $client->sentKeys); // @phpstan-ignore-line
     }
 
-    public function provideChunkHeaderCases(): \Generator
+    public static function provideChunkHeaderCases(): \Generator
     {
         yield 'no iri' => [
             50,

--- a/tests/Hydra/EventListener/AddLinkHeaderListenerTest.php
+++ b/tests/Hydra/EventListener/AddLinkHeaderListenerTest.php
@@ -52,7 +52,7 @@ class AddLinkHeaderListenerTest extends TestCase
         $this->assertSame($expected, (new HttpHeaderSerializer())->serialize($request->attributes->get('_links')->getLinks()));
     }
 
-    public function provider(): \Iterator
+    public static function provider(): \Iterator
     {
         yield ['<http://example.com/docs>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"', new Request()];
         yield ['<https://demo.mercure.rocks/hub>; rel="mercure",<http://example.com/docs>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"', new Request([], [], ['_links' => new GenericLinkProvider([new Link('mercure', 'https://demo.mercure.rocks/hub')])])];

--- a/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
+++ b/tests/Hydra/Serializer/CollectionFiltersNormalizerTest.php
@@ -47,9 +47,7 @@ class CollectionFiltersNormalizerTest extends TestCase
     public function testSupportsNormalization(): void
     {
         $decoratedProphecy = $this->prophesize(NormalizerInterface::class);
-        if (method_exists(Serializer::class, 'getSupportedTypes')) {
-            $decoratedProphecy->getSupportedTypes(Argument::any())->willReturn(['*' => true]);
-        } else {
+        if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $decoratedProphecy->willImplement(CacheableSupportsMethodInterface::class);
             $decoratedProphecy->hasCacheableSupportsMethod()->willReturn(true)->shouldBeCalled();
         }
@@ -59,14 +57,12 @@ class CollectionFiltersNormalizerTest extends TestCase
             $decoratedProphecy->reveal(),
             $this->prophesize(ResourceMetadataCollectionFactoryInterface::class)->reveal(),
             $this->prophesize(ResourceClassResolverInterface::class)->reveal(),
-            $this->prophesize(ContainerInterface::class)->reveal()
+            $this->prophesize(ContainerInterface::class)->reveal(),
         );
 
         $this->assertTrue($normalizer->supportsNormalization('foo', 'abc'));
 
-        if (method_exists(Serializer::class, 'getSupportedTypes')) {
-            $this->assertSame(['*' => true], $normalizer->getSupportedTypes('jsonld'));
-        } else {
+        if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $this->assertTrue($normalizer->hasCacheableSupportsMethod());
         }
     }
@@ -337,5 +333,37 @@ class CollectionFiltersNormalizerTest extends TestCase
             'resource_class' => Dummy::class,
             'operation_name' => 'get',
         ]));
+    }
+
+    public function testGetSupportedTypes(): void
+    {
+        if (!method_exists(Serializer::class, 'getSupportedTypes')) {
+            $this->markTestSkipped('Symfony Serializer < 6.3');
+        }
+
+        // TODO: use prophecy when getSupportedTypes() will be added to the interface
+        $normalizer = new CollectionFiltersNormalizer(
+            new class() implements NormalizerInterface {
+                public function normalize(mixed $object, string $format = null, array $context = [])
+                {
+                    return null;
+                }
+
+                public function supportsNormalization(mixed $data, string $format = null): bool
+                {
+                    return true;
+                }
+
+                public function getSupportedTypes(?string $format): array
+                {
+                    return ['*' => true];
+                }
+            },
+            $this->prophesize(ResourceMetadataCollectionFactoryInterface::class)->reveal(),
+            $this->prophesize(ResourceClassResolverInterface::class)->reveal(),
+            $this->prophesize(ContainerInterface::class)->reveal(),
+        );
+
+        $this->assertSame(['*' => true], $normalizer->getSupportedTypes('jsonld'));
     }
 }

--- a/tests/Hydra/Serializer/ErrorNormalizerTest.php
+++ b/tests/Hydra/Serializer/ErrorNormalizerTest.php
@@ -84,7 +84,7 @@ class ErrorNormalizerTest extends TestCase
         $this->assertSame($expected, $normalizer->normalize($exception, null, ['statusCode' => $status]));
     }
 
-    public function providerStatusCode(): \Iterator
+    public static function providerStatusCode(): \Iterator
     {
         yield [Response::HTTP_INTERNAL_SERVER_ERROR, 'Sensitive SQL error displayed', false];
         yield [Response::HTTP_GATEWAY_TIMEOUT, 'Sensitive server error displayed', false];

--- a/tests/JsonApi/Serializer/ErrorNormalizerTest.php
+++ b/tests/JsonApi/Serializer/ErrorNormalizerTest.php
@@ -110,7 +110,7 @@ class ErrorNormalizerTest extends TestCase
         $this->assertSame($expected, $normalizer->normalize($exception, ErrorNormalizer::FORMAT, ['statusCode' => $status]));
     }
 
-    public function errorProvider(): array
+    public static function errorProvider(): array
     {
         return [
             [Response::HTTP_INTERNAL_SERVER_ERROR, 'Sensitive SQL error displayed', false],

--- a/tests/JsonApi/Serializer/ReservedAttributeNameConverterTest.php
+++ b/tests/JsonApi/Serializer/ReservedAttributeNameConverterTest.php
@@ -29,7 +29,7 @@ class ReservedAttributeNameConverterTest extends TestCase
         $this->reservedAttributeNameConverter = new ReservedAttributeNameConverter(new CustomConverter());
     }
 
-    public function propertiesProvider(): array
+    public static function propertiesProvider(): array
     {
         return [
             ['id', '_id'],

--- a/tests/Problem/Serializer/ErrorNormalizerTest.php
+++ b/tests/Problem/Serializer/ErrorNormalizerTest.php
@@ -96,7 +96,7 @@ class ErrorNormalizerTest extends TestCase
         $this->assertSame($expected, $normalizer->normalize($exception, null, ['statusCode' => $status]));
     }
 
-    public function providerStatusCode(): \Iterator
+    public static function providerStatusCode(): \Iterator
     {
         yield [Response::HTTP_INTERNAL_SERVER_ERROR, 'Sensitive SQL error displayed', false];
         yield [Response::HTTP_GATEWAY_TIMEOUT, 'Sensitive server error displayed', false];

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -718,6 +718,8 @@ class AbstractItemNormalizerTest extends TestCase
 
     public function testCanDenormalizeInputClassWithDifferentFieldsThanResourceClass(): void
     {
+        $this->markTestSkipped('TODO: check why this test has been commented');
+
         // $data = [
         //     'dummyName' => 'Dummy Name',
         // ];

--- a/tests/State/Pagination/ArrayPaginatorTest.php
+++ b/tests/State/Pagination/ArrayPaginatorTest.php
@@ -35,7 +35,7 @@ class ArrayPaginatorTest extends TestCase
         $this->assertCount($currentItems, $paginator);
     }
 
-    public function initializeProvider(): array
+    public static function initializeProvider(): array
     {
         return [
             'First of three pages of 3 items each' => [[0, 1, 2, 3, 4, 5, 6], 0, 3, 3, 7, 1, 3],

--- a/tests/State/Pagination/TraversablePaginatorTest.php
+++ b/tests/State/Pagination/TraversablePaginatorTest.php
@@ -42,7 +42,7 @@ class TraversablePaginatorTest extends TestCase
         self::assertSame($results, iterator_to_array($paginator));
     }
 
-    public function initializeProvider(): array
+    public static function initializeProvider(): array
     {
         return [
             'First of three pages of 3 items each' => [[0, 1, 2, 3, 4, 5, 6], 1, 3, 7, 3, 3],

--- a/tests/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
+++ b/tests/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
@@ -36,9 +36,9 @@ class PayloadArgumentResolverTest extends KernelTestCase
     public function testItSupportsRequestWithPayloadOfExpectedType(): void
     {
         $resolver = $this->createArgumentResolver();
-        $argument = $this->createArgumentMetadata(ResourceImplementation::class);
+        $argument = self::createArgumentMetadata(ResourceImplementation::class);
 
-        $request = $this->createRequest('PUT', [
+        $request = static::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -50,9 +50,9 @@ class PayloadArgumentResolverTest extends KernelTestCase
     public function testItSupportsRequestWithPayloadOfChildType(): void
     {
         $resolver = $this->createArgumentResolver();
-        $argument = $this->createArgumentMetadata(ResourceInterface::class);
+        $argument = self::createArgumentMetadata(ResourceInterface::class);
 
-        $request = $this->createRequest('PUT', [
+        $request = static::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -64,9 +64,9 @@ class PayloadArgumentResolverTest extends KernelTestCase
     public function testItSupportsRequestWithDtoAsInput(): void
     {
         $resolver = $this->createArgumentResolver();
-        $argument = $this->createArgumentMetadata(NotResource::class);
+        $argument = self::createArgumentMetadata(NotResource::class);
 
-        $request = $this->createRequest('PUT', [
+        $request = static::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update_with_dto',
             'data' => new NotResource(),
@@ -82,7 +82,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
     {
         $resolver = $this->createArgumentResolver();
 
-        $request = $this->createRequest('PUT', [
+        $request = static::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -97,7 +97,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
     public function testItDoesNotSupportRequestWithoutPayloadOfExpectedType(Request $request): void
     {
         $resolver = $this->createArgumentResolver();
-        $argument = $this->createArgumentMetadata(ResourceInterface::class);
+        $argument = self::createArgumentMetadata(ResourceInterface::class);
 
         $this->assertFalse($resolver->supports($request, $argument));
     }
@@ -105,9 +105,9 @@ class PayloadArgumentResolverTest extends KernelTestCase
     public function testItResolvesArgumentFromRequestWithDataOfExpectedType(): void
     {
         $resolver = $this->createArgumentResolver();
-        $argument = $this->createArgumentMetadata(ResourceImplementation::class);
+        $argument = self::createArgumentMetadata(ResourceImplementation::class);
 
-        $request = $this->createRequest('PUT', [
+        $request = static::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -124,7 +124,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         $resolver = $this->createArgumentResolver();
         $argument = $this->createArgumentMetadata(ResourceInterface::class);
 
-        $request = $this->createRequest('PUT', [
+        $request = static::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -136,51 +136,51 @@ class PayloadArgumentResolverTest extends KernelTestCase
         );
     }
 
-    public function provideUnsupportedRequests(): iterable
+    public static function provideUnsupportedRequests(): iterable
     {
-        yield 'GET request' => [$this->createRequest('GET', [
+        yield 'GET request' => [static::createRequest('GET', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'HEAD request' => [$this->createRequest('HEAD', [
+        yield 'HEAD request' => [static::createRequest('HEAD', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'OPTIONS request' => [$this->createRequest('OPTIONS', [
+        yield 'OPTIONS request' => [static::createRequest('OPTIONS', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'TRACE request' => [$this->createRequest('TRACE', [
+        yield 'TRACE request' => [static::createRequest('TRACE', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'DELETE request' => [$this->createRequest('DELETE', [
+        yield 'DELETE request' => [static::createRequest('DELETE', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'request without attributes' => [$this->createRequest('PUT', [])];
+        yield 'request without attributes' => [static::createRequest('PUT', [])];
 
-        yield 'request on operation with deserialization disabled' => [$this->createRequest('PUT', [
+        yield 'request on operation with deserialization disabled' => [static::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update_no_deserialize',
             'data' => new ResourceImplementation(),
         ])];
     }
 
-    public function provideUnsupportedArguments(): iterable
+    public static function provideUnsupportedArguments(): iterable
     {
-        yield 'argument without type declaration' => [$this->createArgumentMetadata()];
-        yield 'variadic argument' => [$this->createArgumentMetadata(ResourceImplementation::class, true)];
+        yield 'argument without type declaration' => [self::createArgumentMetadata()];
+        yield 'variadic argument' => [self::createArgumentMetadata(ResourceImplementation::class, true)];
     }
 
     /**
@@ -198,12 +198,12 @@ class PayloadArgumentResolverTest extends KernelTestCase
         self::assertSame($expectedArguments, $arguments);
     }
 
-    public function provideIntegrationCases(): iterable
+    public static function provideIntegrationCases(): iterable
     {
         $resource = new ResourceImplementation();
 
         yield 'simple' => [
-            $this->createRequest('PUT', [
+            static::createRequest('PUT', [
                 '_api_resource_class' => ResourceImplementation::class,
                 '_api_operation_name' => '_api_/resource_implementations{._format}_put',
                 'data' => $resource,
@@ -213,7 +213,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         ];
 
         yield 'with another argument named $data' => [
-            $this->createRequest('PUT', [
+            static::createRequest('PUT', [
                 '_api_resource_class' => ResourceImplementation::class,
                 '_api_operation_name' => '_api_/resource_implementations{._format}_put',
                 'data' => $resource,
@@ -265,7 +265,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         );
     }
 
-    private function createRequest(string $method, array $attributes): Request
+    private static function createRequest(string $method, array $attributes): Request
     {
         $request = Request::create('/foo', $method);
         $request->attributes->replace($attributes);
@@ -273,7 +273,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         return $request;
     }
 
-    private function createArgumentMetadata(string $type = null, bool $isVariadic = false): ArgumentMetadata
+    private static function createArgumentMetadata(string $type = null, bool $isVariadic = false): ArgumentMetadata
     {
         return new ArgumentMetadata('foo', $type, $isVariadic, false, null);
     }

--- a/tests/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
+++ b/tests/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
@@ -38,7 +38,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         $resolver = $this->createArgumentResolver();
         $argument = self::createArgumentMetadata(ResourceImplementation::class);
 
-        $request = static::createRequest('PUT', [
+        $request = self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -52,7 +52,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         $resolver = $this->createArgumentResolver();
         $argument = self::createArgumentMetadata(ResourceInterface::class);
 
-        $request = static::createRequest('PUT', [
+        $request = self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -66,7 +66,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         $resolver = $this->createArgumentResolver();
         $argument = self::createArgumentMetadata(NotResource::class);
 
-        $request = static::createRequest('PUT', [
+        $request = self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update_with_dto',
             'data' => new NotResource(),
@@ -82,7 +82,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
     {
         $resolver = $this->createArgumentResolver();
 
-        $request = static::createRequest('PUT', [
+        $request = self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -107,7 +107,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         $resolver = $this->createArgumentResolver();
         $argument = self::createArgumentMetadata(ResourceImplementation::class);
 
-        $request = static::createRequest('PUT', [
+        $request = self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -124,7 +124,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         $resolver = $this->createArgumentResolver();
         $argument = $this->createArgumentMetadata(ResourceInterface::class);
 
-        $request = static::createRequest('PUT', [
+        $request = self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
@@ -138,39 +138,39 @@ class PayloadArgumentResolverTest extends KernelTestCase
 
     public static function provideUnsupportedRequests(): iterable
     {
-        yield 'GET request' => [static::createRequest('GET', [
+        yield 'GET request' => [self::createRequest('GET', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'HEAD request' => [static::createRequest('HEAD', [
+        yield 'HEAD request' => [self::createRequest('HEAD', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'OPTIONS request' => [static::createRequest('OPTIONS', [
+        yield 'OPTIONS request' => [self::createRequest('OPTIONS', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'TRACE request' => [static::createRequest('TRACE', [
+        yield 'TRACE request' => [self::createRequest('TRACE', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'DELETE request' => [static::createRequest('DELETE', [
+        yield 'DELETE request' => [self::createRequest('DELETE', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update',
             'data' => new ResourceImplementation(),
         ])];
 
-        yield 'request without attributes' => [static::createRequest('PUT', [])];
+        yield 'request without attributes' => [self::createRequest('PUT', [])];
 
-        yield 'request on operation with deserialization disabled' => [static::createRequest('PUT', [
+        yield 'request on operation with deserialization disabled' => [self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update_no_deserialize',
             'data' => new ResourceImplementation(),
@@ -203,7 +203,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         $resource = new ResourceImplementation();
 
         yield 'simple' => [
-            static::createRequest('PUT', [
+            self::createRequest('PUT', [
                 '_api_resource_class' => ResourceImplementation::class,
                 '_api_operation_name' => '_api_/resource_implementations{._format}_put',
                 'data' => $resource,
@@ -213,7 +213,7 @@ class PayloadArgumentResolverTest extends KernelTestCase
         ];
 
         yield 'with another argument named $data' => [
-            static::createRequest('PUT', [
+            self::createRequest('PUT', [
                 '_api_resource_class' => ResourceImplementation::class,
                 '_api_operation_name' => '_api_/resource_implementations{._format}_put',
                 'data' => $resource,

--- a/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -309,7 +309,7 @@ class ApiPlatformExtensionTest extends TestCase
         $this->assertServiceHasTags('api_platform.symfony.uri_variables.transformer.uuid', ['api_platform.uri_variables.transformer']);
     }
 
-    public function dataProviderCommonConfigurationAliasNameConverter(): \Iterator
+    public static function dataProviderCommonConfigurationAliasNameConverter(): \Iterator
     {
         yield ['dummyValue', true];
         yield [null, false];
@@ -1125,6 +1125,9 @@ class ApiPlatformExtensionTest extends TestCase
         $config = self::DEFAULT_CONFIG;
         $config['api_platform']['maker']['enabled'] = true;
         (new ApiPlatformExtension())->load($config, $this->container);
+
+        $this->assertTrue($this->container->has('api_platform.maker.command.state_processor'));
+        $this->assertTrue($this->container->has('api_platform.maker.command.state_provider'));
     }
 
     public function testArgumentResolverConfiguration(): void
@@ -1137,7 +1140,7 @@ class ApiPlatformExtensionTest extends TestCase
             'api_platform.argument_resolver.payload',
         ];
 
-        $this->assertContainerHas($services, []);
+        $this->assertContainerHas($services);
 
         // argument_resolver.xml
         $this->assertServiceHasTags('api_platform.argument_resolver.payload', ['controller.argument_value_resolver']);
@@ -1245,6 +1248,8 @@ class ApiPlatformExtensionTest extends TestCase
 
     /**
      * @group legacy
+     *
+     * @doesNotPerformAssertions
      */
     public function testLegacyOpenApiApiKeysConfiguration(): void
     {

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -220,7 +220,7 @@ class ConfigurationTest extends TestCase
         ], $config);
     }
 
-    public function invalidHttpStatusCodeProvider(): array
+    public static function invalidHttpStatusCodeProvider(): array
     {
         return [
             [0],
@@ -247,7 +247,7 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
-    public function invalidHttpStatusCodeValueProvider(): array
+    public static function invalidHttpStatusCodeValueProvider(): array
     {
         return [
             [true],

--- a/tests/Symfony/Bundle/EventListener/SwaggerUiListenerTest.php
+++ b/tests/Symfony/Bundle/EventListener/SwaggerUiListenerTest.php
@@ -40,7 +40,7 @@ class SwaggerUiListenerTest extends TestCase
         $this->assertSame($controller, $request->attributes->get('_controller'));
     }
 
-    public function getParameters(): array
+    public static function getParameters(): array
     {
         $respondRequest = new Request([], [], ['_api_respond' => true]);
         $respondRequest->setRequestFormat('html');

--- a/tests/Symfony/Bundle/SwaggerUi/SwaggerUiActionTest.php
+++ b/tests/Symfony/Bundle/SwaggerUi/SwaggerUiActionTest.php
@@ -50,7 +50,7 @@ class SwaggerUiActionTest extends TestCase
     /**
      * @dataProvider getInvokeParameters
      */
-    public function testInvoke(Request $request, $twigProphecy): void
+    public function testInvoke(Request $request, callable $twigFactory): void
     {
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $resourceMetadataFactoryProphecy->create('Foo')->willReturn(new ResourceMetadataCollection('Foo', [
@@ -71,7 +71,7 @@ class SwaggerUiActionTest extends TestCase
 
         $action = new SwaggerUiAction(
             $resourceMetadataFactoryProphecy->reveal(),
-            $twigProphecy->reveal(),
+            $twigFactory($this),
             $urlGeneratorProphecy->reveal(),
             $normalizerProphecy->reveal(),
             $openApiFactoryProphecy->reveal(),
@@ -82,85 +82,91 @@ class SwaggerUiActionTest extends TestCase
         $action($request);
     }
 
-    public function getInvokeParameters(): array
+    public static function getInvokeParameters(): iterable
     {
-        $twigCollectionProphecy = $this->prophesize(TwigEnvironment::class);
-        $twigCollectionProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [
-            'title' => 'title',
-            'description' => '',
-            'formats' => ['jsonld' => ['application/ld+json']],
-            'showWebby' => true,
-            'swaggerUiEnabled' => false,
-            'reDocEnabled' => false,
-            'graphQlEnabled' => false,
-            'graphiQlEnabled' => false,
-            'graphQlPlaygroundEnabled' => false,
-            'assetPackage' => null,
-            'swagger_data' => [
-                'url' => '/url',
-                'spec' => self::SPEC,
-                'oauth' => [
-                    'enabled' => false,
-                    'clientId' => '',
-                    'clientSecret' => '',
-                    'type' => '',
-                    'flow' => '',
-                    'tokenUrl' => '',
-                    'authorizationUrl' => '',
-                    'scopes' => [],
-                    'pkce' => false,
+        $twigCollectionFactory = function (self $that): TwigEnvironment {
+            $twigCollectionProphecy = $that->prophesize(TwigEnvironment::class);
+            $twigCollectionProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [
+                'title' => 'title',
+                'description' => '',
+                'formats' => ['jsonld' => ['application/ld+json']],
+                'showWebby' => true,
+                'swaggerUiEnabled' => false,
+                'reDocEnabled' => false,
+                'graphQlEnabled' => false,
+                'graphiQlEnabled' => false,
+                'graphQlPlaygroundEnabled' => false,
+                'assetPackage' => null,
+                'swagger_data' => [
+                    'url' => '/url',
+                    'spec' => self::SPEC,
+                    'oauth' => [
+                        'enabled' => false,
+                        'clientId' => '',
+                        'clientSecret' => '',
+                        'type' => '',
+                        'flow' => '',
+                        'tokenUrl' => '',
+                        'authorizationUrl' => '',
+                        'scopes' => [],
+                        'pkce' => false,
+                    ],
+                    'extraConfiguration' => [],
+                    'shortName' => 'F',
+                    'operationId' => 'getFCollection',
+                    'id' => null,
+                    'queryParameters' => [],
+                    'path' => '/fs',
+                    'method' => 'get',
                 ],
-                'extraConfiguration' => [],
-                'shortName' => 'F',
-                'operationId' => 'getFCollection',
-                'id' => null,
-                'queryParameters' => [],
-                'path' => '/fs',
-                'method' => 'get',
-            ],
-        ])->shouldBeCalled()->willReturn('');
+            ])->shouldBeCalled()->willReturn('');
 
-        $twigItemProphecy = $this->prophesize(TwigEnvironment::class);
-        $twigItemProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [
-            'title' => 'title',
-            'description' => '',
-            'formats' => ['jsonld' => ['application/ld+json']],
-            'swaggerUiEnabled' => false,
-            'showWebby' => true,
-            'reDocEnabled' => false,
-            'graphQlEnabled' => false,
-            'graphiQlEnabled' => false,
-            'graphQlPlaygroundEnabled' => false,
-            'assetPackage' => null,
-            'swagger_data' => [
-                'url' => '/url',
-                'spec' => self::SPEC,
-                'oauth' => [
-                    'enabled' => false,
-                    'clientId' => null,
-                    'clientSecret' => null,
-                    'type' => '',
-                    'flow' => '',
-                    'tokenUrl' => '',
-                    'authorizationUrl' => '',
-                    'scopes' => [],
-                    'pkce' => false,
+            return $twigCollectionProphecy->reveal();
+        };
+
+        $twigItemFactory = function (self $that): TwigEnvironment {
+            $twigItemProphecy = $that->prophesize(TwigEnvironment::class);
+            $twigItemProphecy->render('@ApiPlatform/SwaggerUi/index.html.twig', [
+                'title' => 'title',
+                'description' => '',
+                'formats' => ['jsonld' => ['application/ld+json']],
+                'swaggerUiEnabled' => false,
+                'showWebby' => true,
+                'reDocEnabled' => false,
+                'graphQlEnabled' => false,
+                'graphiQlEnabled' => false,
+                'graphQlPlaygroundEnabled' => false,
+                'assetPackage' => null,
+                'swagger_data' => [
+                    'url' => '/url',
+                    'spec' => self::SPEC,
+                    'oauth' => [
+                        'enabled' => false,
+                        'clientId' => null,
+                        'clientSecret' => null,
+                        'type' => '',
+                        'flow' => '',
+                        'tokenUrl' => '',
+                        'authorizationUrl' => '',
+                        'scopes' => [],
+                        'pkce' => false,
+                    ],
+                    'extraConfiguration' => [],
+                    'shortName' => 'F',
+                    'operationId' => 'getFItem',
+                    'id' => null,
+                    'queryParameters' => [],
+                    'path' => '/fs/{id}',
+                    'method' => 'get',
                 ],
-                'extraConfiguration' => [],
-                'shortName' => 'F',
-                'operationId' => 'getFItem',
-                'id' => null,
-                'queryParameters' => [],
-                'path' => '/fs/{id}',
-                'method' => 'get',
-            ],
-        ])->shouldBeCalled()->willReturn('');
+            ])->shouldBeCalled()->willReturn('');
 
-        return [
-            [new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation_name' => 'getFCollection']), $twigCollectionProphecy],
-            [new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation_name' => 'getFItem']), $twigItemProphecy],
-            [new Request([], [], ['_api_resource_class' => 'Foo'], [], [], ['REQUEST_URI' => '/docs', 'SCRIPT_FILENAME' => '/docs']), $twigItemProphecy],
-        ];
+            return $twigItemProphecy->reveal();
+        };
+
+        yield [new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation_name' => 'getFCollection']), $twigCollectionFactory];
+        yield [new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation_name' => 'getFItem']), $twigItemFactory];
+        yield [new Request([], [], ['_api_resource_class' => 'Foo'], [], [], ['REQUEST_URI' => '/docs', 'SCRIPT_FILENAME' => '/docs']), $twigItemFactory];
     }
 
     /**
@@ -227,7 +233,7 @@ class SwaggerUiActionTest extends TestCase
         $action($request);
     }
 
-    public function getDoNotRunCurrentRequestParameters(): iterable
+    public static function getDoNotRunCurrentRequestParameters(): iterable
     {
         $nonSafeRequest = new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation_name' => 'post']);
         $nonSafeRequest->setMethod('POST');

--- a/tests/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Symfony/Bundle/Test/ClientTest.php
@@ -104,7 +104,7 @@ class ClientTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
     }
 
-    public function authBasicProvider(): iterable
+    public static function authBasicProvider(): iterable
     {
         yield ['dunglas:kevin'];
         yield [['dunglas', 'kevin']];

--- a/tests/Symfony/Bundle/Test/ResponseTest.php
+++ b/tests/Symfony/Bundle/Test/ResponseTest.php
@@ -55,7 +55,7 @@ class ResponseTest extends TestCase
         $response->getContent();
     }
 
-    public function errorProvider(): iterable
+    public static function errorProvider(): iterable
     {
         yield [ServerException::class, 500];
         yield [ClientException::class, 400];

--- a/tests/Symfony/EventListener/AddLinkHeaderListenerTest.php
+++ b/tests/Symfony/EventListener/AddLinkHeaderListenerTest.php
@@ -72,7 +72,7 @@ class AddLinkHeaderListenerTest extends TestCase
         $this->assertSame($expected, (new HttpHeaderSerializer())->serialize($request->attributes->get('_links')->getLinks()));
     }
 
-    public function addProvider(): array
+    public static function addProvider(): array
     {
         return [
             ['<https://managed.mercure.rocks/.well-known/mercure>; rel="mercure"', new Request([], [], ['_api_resource_class' => Dummy::class, '_api_operation_name' => 'get'])],
@@ -105,7 +105,7 @@ class AddLinkHeaderListenerTest extends TestCase
         $this->assertNull($request->attributes->get('_links'));
     }
 
-    public function doNotAddProvider(): array
+    public static function doNotAddProvider(): array
     {
         return [
             [new Request()],

--- a/tests/Symfony/EventListener/DeserializeListenerTest.php
+++ b/tests/Symfony/EventListener/DeserializeListenerTest.php
@@ -209,7 +209,7 @@ class DeserializeListenerTest extends TestCase
         $listener->onKernelRequest($eventProphecy->reveal());
     }
 
-    public function methodProvider(): iterable
+    public static function methodProvider(): iterable
     {
         yield ['POST', false];
         yield ['PUT', true];

--- a/tests/Symfony/EventListener/ExceptionListenerTest.php
+++ b/tests/Symfony/EventListener/ExceptionListenerTest.php
@@ -43,7 +43,7 @@ class ExceptionListenerTest extends TestCase
         $listener->onKernelException($event);
     }
 
-    public function getRequest(): array
+    public static function getRequest(): array
     {
         return [
             [new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation_name' => 'get'])],

--- a/tests/Symfony/Maker/MakeStateProcessorTest.php
+++ b/tests/Symfony/Maker/MakeStateProcessorTest.php
@@ -56,7 +56,7 @@ class MakeStateProcessorTest extends KernelTestCase
         $this->assertStringContainsString('Next: Open your new state processor class and start customizing it.', $display);
     }
 
-    public function stateProcessorProvider(): \Generator
+    public static function stateProcessorProvider(): \Generator
     {
         yield 'Generate state processor' => [
             'isInteractive' => true,

--- a/tests/Symfony/Maker/MakeStateProviderTest.php
+++ b/tests/Symfony/Maker/MakeStateProviderTest.php
@@ -56,7 +56,7 @@ class MakeStateProviderTest extends KernelTestCase
         $this->assertStringContainsString('Next: Open your new state provider class and start customizing it.', $display);
     }
 
-    public function stateProviderDataProvider(): \Generator
+    public static function stateProviderDataProvider(): \Generator
     {
         yield 'Generate state provider' => [
             'isInteractive' => true,

--- a/tests/Symfony/Security/ResourceAccessCheckerTest.php
+++ b/tests/Symfony/Security/ResourceAccessCheckerTest.php
@@ -56,7 +56,7 @@ class ResourceAccessCheckerTest extends TestCase
         $this->assertSame($granted, $checker->isGranted(Dummy::class, 'is_granted("ROLE_ADMIN")'));
     }
 
-    public function getGranted(): array
+    public static function getGranted(): array
     {
         return [[true], [false]];
     }

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestrictionTest.php
@@ -44,7 +44,7 @@ final class PropertySchemaChoiceRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaChoiceRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported' => [new Choice(['choices' => ['a', 'b']]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)]), true];
 
@@ -60,7 +60,7 @@ final class PropertySchemaChoiceRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaChoiceRestriction->create($constraint, $propertyMetadata));
     }
 
-    public function createProvider(): \Generator
+    public static function createProvider(): \Generator
     {
         yield 'single string choice' => [new Choice(['choices' => ['a', 'b']]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)]), ['enum' => ['a', 'b']]];
         yield 'multi string choice' => [new Choice(['choices' => ['a', 'b'], 'multiple' => true]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)]), ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ['a', 'b']]]];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
@@ -59,7 +59,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaCollectionRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported' => [new Collection(['fields' => []]), new ApiProperty(), true];
 
@@ -74,7 +74,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaCollectionRestriction->create($constraint, $propertyMetadata));
     }
 
-    public function createProvider(): \Generator
+    public static function createProvider(): \Generator
     {
         yield 'empty' => [new Collection(['fields' => []]), new ApiProperty(), ['type' => 'object', 'properties' => [], 'additionalProperties' => false]];
 

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCountRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCountRestrictionTest.php
@@ -43,7 +43,7 @@ final class PropertySchemaCountRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaCountRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported' => [new Count(['min' => 1]), new ApiProperty(), true];
         yield 'not supported' => [new Positive(), new ApiProperty(), false];
@@ -57,7 +57,7 @@ final class PropertySchemaCountRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaCountRestriction->create($constraint, $propertyMetadata));
     }
 
-    public function createProvider(): \Generator
+    public static function createProvider(): \Generator
     {
         yield 'min items' => [new Count(['min' => 1]), new ApiProperty(), ['minItems' => 1]];
         yield 'max items' => [new Count(['max' => 10]), new ApiProperty(), ['maxItems' => 10]];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormatTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaFormatTest.php
@@ -45,7 +45,7 @@ final class PropertySchemaFormatTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaFormatRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'email' => [new Email(), new ApiProperty(), true];
         yield 'url' => [new Url(), new ApiProperty(), true];
@@ -68,7 +68,7 @@ final class PropertySchemaFormatTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaFormatRestriction->create($constraint, $propertyMetadata));
     }
 
-    public function createProvider(): \Generator
+    public static function createProvider(): \Generator
     {
         yield 'email' => [new Email(), new ApiProperty(), ['format' => 'email']];
         yield 'url' => [new Url(), new ApiProperty(), ['format' => 'uri']];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestrictionTest.php
@@ -45,7 +45,7 @@ final class PropertySchemaGreaterThanOrEqualRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaGreaterThanOrEqualRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported int' => [new GreaterThanOrEqual(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]), true];
         yield 'supported float' => [new GreaterThanOrEqual(['value' => 10.99]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_FLOAT)]), true];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestrictionTest.php
@@ -46,7 +46,7 @@ final class PropertySchemaGreaterThanRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaGreaterThanRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported int' => [new GreaterThan(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]), true];
         yield 'supported float' => [new GreaterThan(['value' => 10.99]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_FLOAT)]), true];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestrictionTest.php
@@ -45,7 +45,7 @@ final class PropertySchemaLessThanOrEqualRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaLessThanOrEqualRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported int' => [new LessThanOrEqual(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]), true];
         yield 'supported float' => [new LessThanOrEqual(['value' => 10.99]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_FLOAT)]), true];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestrictionTest.php
@@ -45,7 +45,7 @@ final class PropertySchemaLessThanRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaLessThanRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported int' => [new LessThan(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]), true];
         yield 'supported float' => [new LessThan(['value' => 10.99]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_FLOAT)]), true];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaOneOfRestrictionTest.php
@@ -50,7 +50,7 @@ final class PropertySchemaOneOfRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaOneOfRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         if (!class_exists(AtLeastOneOf::class)) {
             return;
@@ -68,7 +68,7 @@ final class PropertySchemaOneOfRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaOneOfRestriction->create($constraint, $propertyMetadata));
     }
 
-    public function createProvider(): \Generator
+    public static function createProvider(): \Generator
     {
         yield 'empty' => [new AtLeastOneOf(['constraints' => []]), new ApiProperty(), []];
 

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestrictionTest.php
@@ -44,7 +44,7 @@ final class PropertySchemaRangeRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaRangeRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported int' => [new Range(['min' => 1, 'max' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]), true];
         yield 'supported float' => [new Range(['min' => 1, 'max' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_FLOAT)]), true];
@@ -61,7 +61,7 @@ final class PropertySchemaRangeRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaRangeRestriction->create($constraint, $propertyMetadata));
     }
 
-    public function createProvider(): \Generator
+    public static function createProvider(): \Generator
     {
         yield 'int min' => [new Range(['min' => 1]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]), ['minimum' => 1]];
         yield 'int max' => [new Range(['max' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]), ['maximum' => 10]];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRegexRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRegexRestrictionTest.php
@@ -43,7 +43,7 @@ final class PropertySchemaRegexRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaRegexRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported' => [new Regex(['pattern' => '/^[0-9]+$/']), new ApiProperty(), true];
         yield 'supported too' => [new Regex(['pattern' => '/[0-9]/', 'match' => false]), new ApiProperty(), true];
@@ -58,7 +58,7 @@ final class PropertySchemaRegexRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaRegexRestriction->create($constraint, $propertyMetadata));
     }
 
-    public function createProvider(): \Generator
+    public static function createProvider(): \Generator
     {
         yield 'anchored' => [new Regex(['pattern' => '/^[0-9]+$/']), new ApiProperty(), ['pattern' => '^([0-9]+)$']];
         yield 'not anchored' => [new Regex(['pattern' => '/[0-9]/']), new ApiProperty(), ['pattern' => '^(.*[0-9].*)$']];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaUniqueRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaUniqueRestrictionTest.php
@@ -43,7 +43,7 @@ final class PropertySchemaUniqueRestrictionTest extends TestCase
         self::assertSame($expectedResult, $this->propertySchemaUniqueRestriction->supports($constraint, $propertyMetadata));
     }
 
-    public function supportsProvider(): \Generator
+    public static function supportsProvider(): \Generator
     {
         yield 'supported' => [new Unique(), new ApiProperty(), true];
 

--- a/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -337,7 +337,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedSchema, $schema);
     }
 
-    public function providePropertySchemaFormatCases(): \Generator
+    public static function providePropertySchemaFormatCases(): \Generator
     {
         yield ['dummyEmail', DummyValidatedEntity::class, ['format' => 'email']];
         yield ['dummyUuid', DummyValidatedEntity::class, ['format' => 'uuid']];
@@ -490,7 +490,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedSchema, $schema);
     }
 
-    public function provideRangeConstraintCases(): \Generator
+    public static function provideRangeConstraintCases(): \Generator
     {
         yield 'min int' => ['type' => new Type(Type::BUILTIN_TYPE_INT), 'property' => 'dummyIntMin', 'expectedSchema' => ['minimum' => 1]];
         yield 'max int' => ['type' => new Type(Type::BUILTIN_TYPE_INT), 'property' => 'dummyIntMax', 'expectedSchema' => ['maximum' => 10]];
@@ -528,7 +528,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedSchema, $schema);
     }
 
-    public function provideChoiceConstraintCases(): \Generator
+    public static function provideChoiceConstraintCases(): \Generator
     {
         yield 'single choice' => ['propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)]), 'property' => 'dummySingleChoice', 'expectedSchema' => ['enum' => ['a', 'b']]];
         yield 'single choice callback' => ['propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)]), 'property' => 'dummySingleChoiceCallback', 'expectedSchema' => ['enum' => ['a', 'b', 'c', 'd']]];
@@ -567,7 +567,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedSchema, $schema);
     }
 
-    public function provideCountConstraintCases(): \Generator
+    public static function provideCountConstraintCases(): \Generator
     {
         yield 'min' => ['property' => 'dummyMin', 'expectedSchema' => ['minItems' => 1]];
         yield 'max' => ['property' => 'dummyMax', 'expectedSchema' => ['maxItems' => 10]];
@@ -670,7 +670,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedSchema, $schema);
     }
 
-    public function provideNumericConstraintCases(): \Generator
+    public static function provideNumericConstraintCases(): \Generator
     {
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]),

--- a/tests/Util/RequestParserTest.php
+++ b/tests/Util/RequestParserTest.php
@@ -30,7 +30,7 @@ class RequestParserTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function parseRequestParamsProvider(): array
+    public static function parseRequestParamsProvider(): array
     {
         return [
             ['gerard.name=dargent', ['gerard.name' => 'dargent']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The hack using factories to create mocks in data providers could be reverted if https://github.com/phpspec/prophecy-phpunit/pull/56 get merged.
Using the Symfony PHPUnit bridge for PHPUnit 10 is blocked by https://github.com/symfony/symfony/issues/49069.