### PR TITLE
fix(openapi): correctly output OpenAPI parameters

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -370,6 +370,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                         'externalDocs' => new ExternalDocumentation(description: $value['description'] ?? '', url: $value['url'] ?? ''),
                         'requestBody' => new RequestBody(description: $value['description'] ?? '', content: isset($value['content']) ? new \ArrayObject($value['content'] ?? []) : null, required: $value['required'] ?? false),
                         'callbacks' => new \ArrayObject($value ?? []),
+                        'parameters' => $openapiOperation->getParameters(),
                         default => $value,
                     };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR fixes following bug:

When parameters are set in openapiContext for some operations with some filters applied, the filter parameters are lost and only the parameters set in openapiContext are output to OpenAPI.

The cause of this bug was as follows. Even though the pagination and filter parameters are merged at [here](https://github.com/api-platform/core/blob/24133dfecb584e50e26503d852c654fe2224e45d/src/OpenApi/Factory/OpenApiFactory.php#L275-L283), they are reset to openapiContext parameters value at [here](https://github.com/api-platform/core/blob/24133dfecb584e50e26503d852c654fe2224e45d/src/OpenApi/Factory/OpenApiFactory.php#L369-L374).