### PR TITLE
fix: perf regression with Symfony 6.3 

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -92,7 +92,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     {
         return [
             'object' => true,
-            'native-array' => true,
         ];
     }
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -90,7 +90,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
     public function getSupportedTypes(?string $format): array
     {
-        return ['*' => true];
+        return [
+            'object' => true,
+            'native-array' => true,
+        ];
     }
 
     /**

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -99,7 +99,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization($dummy, 'xml'));
         $this->assertFalse($normalizer->supportsNormalization($std, $normalizer::FORMAT));
         $this->assertEmpty($normalizer->getSupportedTypes('xml'));
-        $this->assertSame(['object' => true, 'native-array' => true], $normalizer->getSupportedTypes($normalizer::FORMAT));
+        $this->assertSame(['object' => true], $normalizer->getSupportedTypes($normalizer::FORMAT));
 
         if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $this->assertTrue($normalizer->hasCacheableSupportsMethod());

--- a/tests/Hal/Serializer/ItemNormalizerTest.php
+++ b/tests/Hal/Serializer/ItemNormalizerTest.php
@@ -99,7 +99,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization($dummy, 'xml'));
         $this->assertFalse($normalizer->supportsNormalization($std, $normalizer::FORMAT));
         $this->assertEmpty($normalizer->getSupportedTypes('xml'));
-        $this->assertSame(['*' => true], $normalizer->getSupportedTypes($normalizer::FORMAT));
+        $this->assertSame(['object' => true, 'native-array' => true], $normalizer->getSupportedTypes($normalizer::FORMAT));
 
         if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $this->assertTrue($normalizer->hasCacheableSupportsMethod());

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -87,7 +87,7 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
         $this->assertFalse($normalizer->supportsNormalization([]));
-        $this->assertSame(['*' => true], $normalizer->getSupportedTypes('any'));
+        $this->assertSame(['object' => true, 'native-array' => true], $normalizer->getSupportedTypes('any'));
 
         if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $this->assertTrue($normalizer->hasCacheableSupportsMethod());

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -87,7 +87,7 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
         $this->assertFalse($normalizer->supportsNormalization([]));
-        $this->assertSame(['object' => true, 'native-array' => true], $normalizer->getSupportedTypes('any'));
+        $this->assertSame(['object' => true], $normalizer->getSupportedTypes('any'));
 
         if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $this->assertTrue($normalizer->hasCacheableSupportsMethod());

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -78,7 +78,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
-        $this->assertSame(['*' => true], $normalizer->getSupportedTypes('any'));
+        $this->assertSame(['object' => true, 'native-array' => true], $normalizer->getSupportedTypes('any'));
 
         if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $this->assertTrue($normalizer->hasCacheableSupportsMethod());

--- a/tests/Serializer/ItemNormalizerTest.php
+++ b/tests/Serializer/ItemNormalizerTest.php
@@ -78,7 +78,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
-        $this->assertSame(['object' => true, 'native-array' => true], $normalizer->getSupportedTypes('any'));
+        $this->assertSame(['object' => true], $normalizer->getSupportedTypes('any'));
 
         if (!method_exists(Serializer::class, 'getSupportedTypes')) {
             $this->assertTrue($normalizer->hasCacheableSupportsMethod());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes n/a
| License       | MIT
| Doc PR        | n/a

The switch to the new `NormalizerInterface::getSupportedTypes()` system provided by Symfony in #5672 introduced a performance regression.

Symfony 6.2 + API Platform 3.1.12 (faster) VS Symfony 6.3 + API Platform 3.1.13

<img width="877" alt="image" src="https://github.com/api-platform/core/assets/57224/426d1bac-84fe-4cbe-8c02-0db8a6276ec3">

With this patch fixes the issue: Symfony 6.2 + API Platform 3.11.12 VS Symfony 6.3 + API Platform with this patch

<img width="606" alt="image" src="https://github.com/api-platform/core/assets/57224/9a2b7192-0c88-4c8e-aa08-1eeb8e435fb2">
