### PR TITLE
fix(metadata): generated NotExposed operation should inherit resource options

### DIFF
--- a/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
@@ -28,6 +28,8 @@ use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
  */
 final class NotExposedOperationResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {
+    use OperationDefaultsTrait;
+
     public static $skolemUriTemplate = '/.well-known/genid/{id}';
 
     private $linkFactory;
@@ -69,13 +71,13 @@ final class NotExposedOperationResourceMetadataCollectionFactory implements Reso
         // No item operation has been found on all resources for resource class: generate one on the last resource
         // Helpful to generate an IRI for a resource without declaring the Get operation
         /** @var HttpOperation $operation */
-        $operation = (new NotExposed())->withClass($resource->getClass())->withShortName($resource->getShortName()); // @phpstan-ignore-line $resource is defined if count > 0
+        [$key, $operation] = $this->getOperationWithDefaults($resource, new NotExposed(), true, ['uriTemplate']); // @phpstan-ignore-line $resource is defined if count > 0
 
         if (!$this->linkFactory->createLinksFromIdentifiers($operation)) {
             $operation = $operation->withUriTemplate(self::$skolemUriTemplate);
         }
 
-        $operations->add(sprintf('_api_%s_get', $operation->getShortName()), $operation)->sort(); // @phpstan-ignore-line $operation exists
+        $operations->add($key, $operation)->sort(); // @phpstan-ignore-line $operation exists
 
         return $resourceMetadataCollection;
     }

--- a/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -154,11 +154,15 @@ trait OperationDefaultsTrait
         return $resource->withGraphQlOperations($graphQlOperations);
     }
 
-    private function getOperationWithDefaults(ApiResource $resource, Operation $operation, bool $generated = false): array
+    private function getOperationWithDefaults(ApiResource $resource, Operation $operation, bool $generated = false, array $ignoredOptions = []): array
     {
         // Inherit from resource defaults
         foreach (get_class_methods($resource) as $methodName) {
             if (!str_starts_with($methodName, 'get')) {
+                continue;
+            }
+
+            if (\in_array(lcfirst(substr($methodName, 3)), $ignoredOptions, true)) {
                 continue;
             }
 
@@ -203,7 +207,6 @@ trait OperationDefaultsTrait
             $operation = $operation->withName($operation->getRouteName());
         }
 
-        $path = ($operation->getRoutePrefix() ?? '').($operation->getUriTemplate() ?? '');
         $operationName = $operation->getName() ?? $this->getDefaultOperationName($operation, $resource->getClass());
 
         return [

--- a/src/Metadata/Tests/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactoryTest.php
@@ -182,7 +182,7 @@ class NotExposedOperationResourceMetadataCollectionFactoryTest extends TestCase
                     shortName: 'AttributeResource',
                     operations: [
                         '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
-                        '_api_AttributeResource_get' => new NotExposed(controller: 'api_platform.action.not_exposed', shortName: 'AttributeResource', class: AttributeResource::class, output: false, read: false),
+                        '_api_AttributeResource_get' => new NotExposed(controller: 'api_platform.action.not_exposed', shortName: 'AttributeResource', class: AttributeResource::class, output: false, read: false, extraProperties: ['generated_operation' => true]),
                     ],
                     class: AttributeResource::class
                 ),
@@ -206,6 +206,8 @@ class NotExposedOperationResourceMetadataCollectionFactoryTest extends TestCase
                 ),
                 new ApiResource(
                     shortName: 'AttributeResource',
+                    types: ['https://schema.org/Book'],
+                    uriTemplate: '/custom_api_resources', // uriTemplate should not be inherited on NotExposed operation
                     operations: [
                         '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
                     ],
@@ -224,9 +226,11 @@ class NotExposedOperationResourceMetadataCollectionFactoryTest extends TestCase
                 ),
                 new ApiResource(
                     shortName: 'AttributeResource',
+                    uriTemplate: '/custom_api_resources',
+                    types: ['https://schema.org/Book'],
                     operations: [
                         '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
-                        '_api_AttributeResource_get' => new NotExposed(uriTemplate: '/.well-known/genid/{id}', controller: 'api_platform.action.not_exposed', shortName: 'AttributeResource', class: AttributeResource::class, output: false, read: false),
+                        '_api_AttributeResource_get' => new NotExposed(uriTemplate: '/.well-known/genid/{id}', controller: 'api_platform.action.not_exposed', shortName: 'AttributeResource', class: AttributeResource::class, output: false, read: false, extraProperties: ['generated_operation' => true], types: ['https://schema.org/Book']),
                     ],
                     class: AttributeResource::class
                 ),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       |
| License       | MIT
| Doc PR        |

When a NotExposed operation is generated in the metadata, it should inherit the resource options.