### PR TITLE
fix(doctrine): use stateOptions only within doctrine context

### DIFF
--- a/features/doctrine/separated_resource.feature
+++ b/features/doctrine/separated_resource.feature
@@ -5,7 +5,7 @@ Feature: Use state options to use an entity that is not a resource
 
   @!mongodb
   @createSchema
-  Scenario: Get collection 
+  Scenario: Get collection
     Given there are 5 separated entities
     When I send a "GET" request to "/separated_entities"
     Then the response status code should be 200
@@ -35,7 +35,7 @@ Feature: Use state options to use an entity that is not a resource
 
   @!mongodb
   @createSchema
-  Scenario: Get ordered collection 
+  Scenario: Get ordered collection
     Given there are 5 separated entities
     When I send a "GET" request to "/separated_entities?order[value]=desc"
     Then the response status code should be 200
@@ -45,10 +45,32 @@ Feature: Use state options to use an entity that is not a resource
 
   @!mongodb
   @createSchema
-  Scenario: Get item 
+  Scenario: Get item
     Given there are 5 separated entities
     When I send a "GET" request to "/separated_entities/1"
-    Then print last JSON response
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @!mongodb
+  @createSchema
+  Scenario: Get item
+    Given there are 5 separated entities
+    When I send a "GET" request to "/separated_entities/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @!mongodb
+  @createSchema
+  Scenario: Get all EntityClassAndCustomProviderResources
+    Given there are 1 separated entities
+    When I send a "GET" request to "/entityClassAndCustomProviderResources"
+    Then the response status code should be 200
+
+  @!mongodb
+  @createSchema
+  Scenario: Get one EntityClassAndCustomProviderResource
+    Given there are 1 separated entities
+    When I send a "GET" request to "/entityClassAndCustomProviderResources/1"
+    Then the response status code should be 200

--- a/features/main/crud_uri_variables.feature
+++ b/features/main/crud_uri_variables.feature
@@ -200,15 +200,3 @@ Feature: Uri Variables
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/companies/1/employees/2"
     Then the response status code should be 404
-
-  @!mongodb
-  Scenario: Get all EntityClassAndCustomProviderResources
-    Given there are 1 separated entities
-    When I send a "GET" request to "/entityClassAndCustomProviderResources"
-    Then the response status code should be 200
-
-  @!mongodb
-  Scenario: Get one EntityClassAndCustomProviderResource
-    Given there are 1 separated entities
-    When I send a "GET" request to "/entityClassAndCustomProviderResources/1"
-    Then the response status code should be 200

--- a/src/Metadata/Resource/Factory/LinkFactory.php
+++ b/src/Metadata/Resource/Factory/LinkFactory.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Resource\Factory;
 
-use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Link;
@@ -59,12 +58,7 @@ final class LinkFactory implements LinkFactoryInterface, PropertyLinkFactoryInte
             return [];
         }
 
-        $entityClass = $resourceClass;
-        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
-            $entityClass = $options->getEntityClass();
-        }
-
-        $link = (new Link())->withFromClass($entityClass)->withIdentifiers($identifiers);
+        $link = (new Link())->withFromClass($resourceClass)->withIdentifiers($identifiers);
         $parameterName = $identifiers[0];
 
         if (1 < \count($identifiers)) {

--- a/tests/Fixtures/TestBundle/ApiResource/EntityClassAndCustomProviderResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/EntityClassAndCustomProviderResource.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\State\Options;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -25,7 +24,6 @@ use ApiPlatform\Tests\Fixtures\TestBundle\State\EntityClassAndCustomProviderReso
     operations: [
         new Get(
             uriTemplate: '/entityClassAndCustomProviderResources/{id}',
-            uriVariables: ['id']
         ),
         new GetCollection(
             uriTemplate: '/entityClassAndCustomProviderResources'
@@ -36,8 +34,6 @@ use ApiPlatform\Tests\Fixtures\TestBundle\State\EntityClassAndCustomProviderReso
 )]
 class EntityClassAndCustomProviderResource
 {
-    #[ApiProperty(identifier: true)]
     public ?int $id;
-
     public ?string $value;
 }

--- a/tests/Fixtures/TestBundle/State/EntityClassAndCustomProviderResourceProvider.php
+++ b/tests/Fixtures/TestBundle/State/EntityClassAndCustomProviderResourceProvider.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
 
 use ApiPlatform\Doctrine\Orm\State\CollectionProvider;
 use ApiPlatform\Doctrine\Orm\State\ItemProvider;
-use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Exception\ItemNotFoundException;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Operation;
@@ -39,7 +38,6 @@ class EntityClassAndCustomProviderResourceProvider implements ProviderInterface
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
-        $operation = ($stateOptions = $operation->getStateOptions()) instanceof Options ? $operation->withClass($stateOptions->getEntityClass()) : $operation;
         if ($operation instanceof CollectionOperationInterface) {
             $data = $this->collectionProvider->provide(
                 $operation,


### PR DESCRIPTION
@weaverryan we are already using the correct `fromClass` inside the doctrine Link Factory, therefore I removed the change within the MetadataFactory. Note that we had a test but we were declaring uriTemplates manually, and it wasn't overridden :).