### PR TITLE
feat(doctrine): stateOptions can handleLinks for query optimization

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -17,6 +17,7 @@ $finder = PhpCsFixer\Finder::create()
         'src/Core/Bridge/Symfony/Maker/Resources/skeleton',
         'tests/Fixtures/app/var',
         'docs/guides',
+        'docs/var',
     ])
     ->notPath('src/Symfony/Bundle/DependencyInjection/Configuration.php')
     ->notPath('src/Annotation/ApiFilter.php') // temporary

--- a/features/doctrine/handle_links.feature
+++ b/features/doctrine/handle_links.feature
@@ -1,0 +1,17 @@
+Feature: Use a link handler to retrieve a resource
+
+  @createSchema
+  Scenario: Get collection
+    Given there are a few link handled dummies
+    When I send a "GET" request to "/link_handled_dummies"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hydra:totalItems" should be equal to 1
+
+  @createSchema
+  Scenario: Get item
+    Given there are a few link handled dummies
+    When I send a "GET" request to "/link_handled_dummies/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "slug" should be equal to "foo"

--- a/features/doctrine/separated_resource.feature
+++ b/features/doctrine/separated_resource.feature
@@ -54,15 +54,6 @@ Feature: Use state options to use an entity that is not a resource
 
   @!mongodb
   @createSchema
-  Scenario: Get item
-    Given there are 5 separated entities
-    When I send a "GET" request to "/separated_entities/1"
-    Then the response status code should be 200
-    And the response should be in JSON
-    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-
-  @!mongodb
-  @createSchema
   Scenario: Get all EntityClassAndCustomProviderResources
     Given there are 1 separated entities
     When I send a "GET" request to "/entityClassAndCustomProviderResources"
@@ -74,3 +65,52 @@ Feature: Use state options to use an entity that is not a resource
     Given there are 1 separated entities
     When I send a "GET" request to "/entityClassAndCustomProviderResources/1"
     Then the response status code should be 200
+
+  @mongodb
+  @createSchema
+  Scenario: Get collection
+    Given there are 5 separated entities
+    When I send a "GET" request to "/separated_documents"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    Then the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/SeparatedDocument"},
+        "@id": {"pattern": "^/separated_documents"},
+        "@type": {"pattern": "^hydra:Collection$"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "hydra:totalItems": {"type":"number"},
+        "hydra:view": {
+          "type": "object"
+        }
+      }
+    }
+    """
+
+  @mongodb
+  @createSchema
+  Scenario: Get ordered collection
+    Given there are 5 separated entities
+    When I send a "GET" request to "/separated_documents?order[value]=desc"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the JSON node "hydra:member[0].value" should be equal to "5"
+
+  @mongodb
+  @createSchema
+  Scenario: Get item
+    Given there are 5 separated entities
+    When I send a "GET" request to "/separated_documents/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"

--- a/src/Doctrine/Common/Filter/OrderFilterTrait.php
+++ b/src/Doctrine/Common/Filter/OrderFilterTrait.php
@@ -39,8 +39,8 @@ trait OrderFilterTrait
         $description = [];
 
         $properties = $this->getProperties();
-        if (null === $properties) {
-            $properties = array_fill_keys($this->getClassMetadata($resourceClass)->getFieldNames(), null);
+        if (null === $properties && $fieldNames = $this->getClassMetadata($resourceClass)->getFieldNames()) {
+            $properties = array_fill_keys($fieldNames, null);
         }
 
         foreach ($properties as $property => $propertyOptions) {

--- a/src/Doctrine/Common/PropertyHelperTrait.php
+++ b/src/Doctrine/Common/PropertyHelperTrait.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Doctrine\Common;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
@@ -25,7 +24,10 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  */
 trait PropertyHelperTrait
 {
-    abstract protected function getManagerRegistry(): ManagerRegistry;
+    /**
+     * Gets class metadata for the given resource.
+     */
+    abstract protected function getClassMetadata(string $resourceClass): ClassMetadata;
 
     /**
      * Determines whether the given property is mapped.
@@ -124,16 +126,5 @@ trait PropertyHelperTrait
         }
 
         return $metadata;
-    }
-
-    /**
-     * Gets class metadata for the given resource.
-     */
-    protected function getClassMetadata(string $resourceClass): ClassMetadata
-    {
-        return $this
-            ->getManagerRegistry()
-            ->getManagerForClass($resourceClass)
-            ->getClassMetadata($resourceClass);
     }
 }

--- a/src/Doctrine/Odm/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactory.php
+++ b/src/Doctrine/Odm/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactory.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Doctrine\Odm\Metadata\Resource;
 
 use ApiPlatform\Doctrine\Odm\State\CollectionProvider;
 use ApiPlatform\Doctrine\Odm\State\ItemProvider;
+use ApiPlatform\Doctrine\Odm\State\Options;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\DeleteOperationInterface;
@@ -44,7 +45,12 @@ final class DoctrineMongoDbOdmResourceCollectionMetadataFactory implements Resou
             if ($operations) {
                 /** @var Operation $operation */
                 foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
-                    if (!$this->managerRegistry->getManagerForClass($operation->getClass()) instanceof DocumentManager) {
+                    $documentClass = $operation->getClass();
+                    if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getDocumentClass()) {
+                        $documentClass = $options->getDocumentClass();
+                    }
+
+                    if (!$this->managerRegistry->getManagerForClass($documentClass) instanceof DocumentManager) {
                         continue;
                     }
 

--- a/src/Doctrine/Odm/PropertyHelperTrait.php
+++ b/src/Doctrine/Odm/PropertyHelperTrait.php
@@ -17,6 +17,7 @@ use ApiPlatform\Exception\InvalidArgumentException;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MongoDbOdmClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
@@ -26,6 +27,8 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  */
 trait PropertyHelperTrait
 {
+    abstract protected function getManagerRegistry(): ManagerRegistry;
+
     /**
      * Splits the given property into parts.
      */
@@ -34,7 +37,18 @@ trait PropertyHelperTrait
     /**
      * Gets class metadata for the given resource.
      */
-    abstract protected function getClassMetadata(string $resourceClass): ClassMetadata;
+    protected function getClassMetadata(string $resourceClass): ClassMetadata
+    {
+        $manager = $this
+            ->getManagerRegistry()
+            ->getManagerForClass($resourceClass);
+
+        if ($manager) {
+            return $manager->getClassMetadata($resourceClass);
+        }
+
+        return new MongoDbOdmClassMetadata($resourceClass);
+    }
 
     /**
      * Adds the necessary lookups for a nested property.

--- a/src/Doctrine/Odm/State/CollectionProvider.php
+++ b/src/Doctrine/Odm/State/CollectionProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\State\ProviderInterface;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
 
 /**
  * Collection state provider using the Doctrine ODM.
@@ -33,37 +34,46 @@ final class CollectionProvider implements ProviderInterface
     /**
      * @param AggregationCollectionExtensionInterface[] $collectionExtensions
      */
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [])
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [], ContainerInterface $handleLinksLocator = null)
     {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->handleLinksLocator = $handleLinksLocator;
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable
     {
-        $resourceClass = $operation->getClass();
-        /** @var DocumentManager $manager */
-        $manager = $this->managerRegistry->getManagerForClass($resourceClass);
+        $documentClass = $operation->getClass();
+        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getDocumentClass()) {
+            $documentClass = $options->getDocumentClass();
+        }
 
-        $repository = $manager->getRepository($resourceClass);
+        /** @var DocumentManager $manager */
+        $manager = $this->managerRegistry->getManagerForClass($documentClass);
+
+        $repository = $manager->getRepository($documentClass);
         if (!$repository instanceof DocumentRepository) {
-            throw new RuntimeException(sprintf('The repository for "%s" must be an instance of "%s".', $resourceClass, DocumentRepository::class));
+            throw new RuntimeException(sprintf('The repository for "%s" must be an instance of "%s".', $documentClass, DocumentRepository::class));
         }
 
         $aggregationBuilder = $repository->createAggregationBuilder();
 
-        $this->handleLinks($aggregationBuilder, $uriVariables, $context, $resourceClass, $operation);
+        if ($handleLinks = $this->getLinksHandler($operation)) {
+            $handleLinks($aggregationBuilder, $uriVariables, ['documentClass' => $documentClass, 'operation' => $operation] + $context);
+        } else {
+            $this->handleLinks($aggregationBuilder, $uriVariables, $context, $documentClass, $operation);
+        }
 
         foreach ($this->collectionExtensions as $extension) {
-            $extension->applyToCollection($aggregationBuilder, $resourceClass, $operation, $context);
+            $extension->applyToCollection($aggregationBuilder, $documentClass, $operation, $context);
 
-            if ($extension instanceof AggregationResultCollectionExtensionInterface && $extension->supportsResult($resourceClass, $operation, $context)) {
-                return $extension->getResult($aggregationBuilder, $resourceClass, $operation, $context);
+            if ($extension instanceof AggregationResultCollectionExtensionInterface && $extension->supportsResult($documentClass, $operation, $context)) {
+                return $extension->getResult($aggregationBuilder, $documentClass, $operation, $context);
             }
         }
 
         $attribute = $operation->getExtraProperties()['doctrine_mongodb'] ?? [];
         $executeOptions = $attribute['execute_options'] ?? [];
 
-        return $aggregationBuilder->hydrate($resourceClass)->execute($executeOptions);
+        return $aggregationBuilder->hydrate($documentClass)->execute($executeOptions);
     }
 }

--- a/src/Doctrine/Odm/State/ItemProvider.php
+++ b/src/Doctrine/Odm/State/ItemProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\State\ProviderInterface;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
 
 /**
  * Item state provider using the Doctrine ODM.
@@ -36,41 +37,50 @@ final class ItemProvider implements ProviderInterface
     /**
      * @param AggregationItemExtensionInterface[] $itemExtensions
      */
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $itemExtensions = [])
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $itemExtensions = [], ContainerInterface $handleLinksLocator = null)
     {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->handleLinksLocator = $handleLinksLocator;
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object
     {
-        $resourceClass = $operation->getClass();
+        $documentClass = $operation->getClass();
+        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getDocumentClass()) {
+            $documentClass = $options->getDocumentClass();
+        }
+
         /** @var DocumentManager $manager */
-        $manager = $this->managerRegistry->getManagerForClass($resourceClass);
+        $manager = $this->managerRegistry->getManagerForClass($documentClass);
 
         $fetchData = $context['fetch_data'] ?? true;
         if (!$fetchData) {
-            return $manager->getReference($resourceClass, reset($uriVariables));
+            return $manager->getReference($documentClass, reset($uriVariables));
         }
 
-        $repository = $manager->getRepository($resourceClass);
+        $repository = $manager->getRepository($documentClass);
         if (!$repository instanceof DocumentRepository) {
-            throw new RuntimeException(sprintf('The repository for "%s" must be an instance of "%s".', $resourceClass, DocumentRepository::class));
+            throw new RuntimeException(sprintf('The repository for "%s" must be an instance of "%s".', $documentClass, DocumentRepository::class));
         }
 
         $aggregationBuilder = $repository->createAggregationBuilder();
 
-        $this->handleLinks($aggregationBuilder, $uriVariables, $context, $resourceClass, $operation);
+        if ($handleLinks = $this->getLinksHandler($operation)) {
+            $handleLinks($aggregationBuilder, $uriVariables, ['documentClass' => $documentClass, 'operation' => $operation] + $context);
+        } else {
+            $this->handleLinks($aggregationBuilder, $uriVariables, $context, $documentClass, $operation);
+        }
 
         foreach ($this->itemExtensions as $extension) {
-            $extension->applyToItem($aggregationBuilder, $resourceClass, $uriVariables, $operation, $context);
+            $extension->applyToItem($aggregationBuilder, $documentClass, $uriVariables, $operation, $context);
 
-            if ($extension instanceof AggregationResultItemExtensionInterface && $extension->supportsResult($resourceClass, $operation, $context)) {
-                return $extension->getResult($aggregationBuilder, $resourceClass, $operation, $context);
+            if ($extension instanceof AggregationResultItemExtensionInterface && $extension->supportsResult($documentClass, $operation, $context)) {
+                return $extension->getResult($aggregationBuilder, $documentClass, $operation, $context);
             }
         }
 
         $executeOptions = $operation->getExtraProperties()['doctrine_mongodb']['execute_options'] ?? [];
 
-        return $aggregationBuilder->hydrate($resourceClass)->execute($executeOptions)->current() ?: null;
+        return $aggregationBuilder->hydrate($documentClass)->execute($executeOptions)->current() ?: null;
     }
 }

--- a/src/Doctrine/Odm/State/LinksHandlerInterface.php
+++ b/src/Doctrine/Odm/State/LinksHandlerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Odm\State;
+
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+
+/**
+ * @experimental
+ */
+interface LinksHandlerInterface
+{
+    /**
+     * Handle Doctrine ORM links.
+     *
+     * @see ApiPlatform\Doctrine\Odm\State\LinksHandlerTrait
+     *
+     * @param array<string, mixed>                                                  $uriVariables
+     * @param array{entityClass: string, operation: Operation}&array<string, mixed> $context
+     */
+    public function handleLinks(Builder $aggregationBuilder, array $uriVariables, array $context): void;
+}

--- a/src/Doctrine/Odm/State/Options.php
+++ b/src/Doctrine/Odm/State/Options.php
@@ -11,32 +11,32 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Doctrine\Orm\State;
+namespace ApiPlatform\Doctrine\Odm\State;
 
 use ApiPlatform\State\OptionsInterface;
 
 class Options implements OptionsInterface
 {
     /**
-     * @param string|callable $handleLinks experimental callable, typed mixed as we may want a service name in the future
+     * @param mixed $handleLinks experimental callable, typed mixed as we may want a service name in the future
      *
-     * @see \ApiPlatform\Doctrine\Orm\State\LinksHandlerInterface
+     * @see \ApiPlatform\Doctrine\Odm\State\LinksHandlerInterface
      */
     public function __construct(
-        protected ?string $entityClass = null,
+        protected ?string $documentClass = null,
         protected mixed $handleLinks = null,
     ) {
     }
 
-    public function getEntityClass(): ?string
+    public function getDocumentClass(): ?string
     {
-        return $this->entityClass;
+        return $this->documentClass;
     }
 
-    public function withEntityClass(?string $entityClass): self
+    public function withDocumentClass(?string $documentClass): self
     {
         $self = clone $this;
-        $self->entityClass = $entityClass;
+        $self->documentClass = $documentClass;
 
         return $self;
     }

--- a/src/Doctrine/Orm/PropertyHelperTrait.php
+++ b/src/Doctrine/Orm/PropertyHelperTrait.php
@@ -16,7 +16,10 @@ namespace ApiPlatform\Doctrine\Orm;
 use ApiPlatform\Doctrine\Orm\Util\QueryBuilderHelper;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Exception\InvalidArgumentException;
+use Doctrine\ORM\Mapping\ClassMetadata as ClassMetadataInfo;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Helper trait regarding a property in an entity using the resource metadata.
@@ -26,10 +29,28 @@ use Doctrine\ORM\QueryBuilder;
  */
 trait PropertyHelperTrait
 {
+    abstract protected function getManagerRegistry(): ManagerRegistry;
+
     /**
      * Splits the given property into parts.
      */
     abstract protected function splitPropertyParts(string $property, string $resourceClass): array;
+
+    /**
+     * Gets class metadata for the given resource.
+     */
+    protected function getClassMetadata(string $resourceClass): ClassMetadata
+    {
+        $manager = $this
+            ->getManagerRegistry()
+            ->getManagerForClass($resourceClass);
+
+        if ($manager) {
+            return $manager->getClassMetadata($resourceClass);
+        }
+
+        return new ClassMetadataInfo($resourceClass);
+    }
 
     /**
      * Adds the necessary joins for a nested property.

--- a/src/Doctrine/Orm/State/CollectionProvider.php
+++ b/src/Doctrine/Orm/State/CollectionProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\State\ProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
 
 /**
  * Collection state provider using the Doctrine ORM.
@@ -36,9 +37,10 @@ final class CollectionProvider implements ProviderInterface
     /**
      * @param QueryCollectionExtensionInterface[] $collectionExtensions
      */
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [])
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [], ContainerInterface $handleLinksLocator = null)
     {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->handleLinksLocator = $handleLinksLocator;
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable
@@ -59,7 +61,11 @@ final class CollectionProvider implements ProviderInterface
         $queryBuilder = $repository->createQueryBuilder('o');
         $queryNameGenerator = new QueryNameGenerator();
 
-        $this->handleLinks($queryBuilder, $uriVariables, $queryNameGenerator, $context, $entityClass, $operation);
+        if ($handleLinks = $this->getLinksHandler($operation)) {
+            $handleLinks($queryBuilder, $uriVariables, $queryNameGenerator, ['entityClass' => $entityClass, 'operation' => $operation] + $context);
+        } else {
+            $this->handleLinks($queryBuilder, $uriVariables, $queryNameGenerator, $context, $entityClass, $operation);
+        }
 
         foreach ($this->collectionExtensions as $extension) {
             $extension->applyToCollection($queryBuilder, $queryNameGenerator, $entityClass, $operation, $context);

--- a/src/Doctrine/Orm/State/LinksHandlerInterface.php
+++ b/src/Doctrine/Orm/State/LinksHandlerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Orm\State;
+
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @experimental
+ */
+interface LinksHandlerInterface
+{
+    /**
+     * Handle Doctrine ORM links.
+     *
+     * @see ApiPlatform\Doctrine\Orm\State\LinksHandlerTrait
+     *
+     * @param array<string, mixed>                                                  $uriVariables
+     * @param array{entityClass: string, operation: Operation}&array<string, mixed> $context
+     */
+    public function handleLinks(QueryBuilder $queryBuilder, array $uriVariables, QueryNameGeneratorInterface $queryNameGenerator, array $context): void;
+}

--- a/src/Doctrine/Orm/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Orm/State/LinksHandlerTrait.php
@@ -20,6 +20,9 @@ use ApiPlatform\Metadata\Operation;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\QueryBuilder;
 
+/**
+ * @internal
+ */
 trait LinksHandlerTrait
 {
     use CommonLinksHandlerTrait;

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\Type;
 
+use ApiPlatform\Doctrine\Odm\State\Options as ODMOptions;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\GraphQl\Resolver\Factory\ResolverFactory;
 use ApiPlatform\GraphQl\Resolver\Factory\ResolverFactoryInterface;
@@ -425,8 +426,14 @@ final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumIn
             }
 
             $entityClass = $resourceClass;
-            if (($options = $resourceOperation->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
-                $entityClass = $options->getEntityClass();
+            if ($options = $resourceOperation->getStateOptions()) {
+                if ($options instanceof Options && $options->getEntityClass()) {
+                    $entityClass = $options->getEntityClass();
+                }
+
+                if ($options instanceof ODMOptions && $options->getDocumentClass()) {
+                    $entityClass = $options->getDocumentClass();
+                }
             }
 
             foreach ($this->filterLocator->get($filterId)->getDescription($entityClass) as $key => $value) {

--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Hydra\Serializer;
 
 use ApiPlatform\Api\FilterLocatorTrait;
+use ApiPlatform\Doctrine\Odm\State\Options as ODMOptions;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\FilterInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -111,8 +112,14 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
             }
         }
 
-        if (($options = $operation?->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
-            $resourceClass = $options->getEntityClass();
+        if ($options = $operation->getStateOptions()) {
+            if ($options instanceof Options && $options->getEntityClass()) {
+                $resourceClass = $options->getEntityClass();
+            }
+
+            if ($options instanceof ODMOptions && $options->getDocumentClass()) {
+                $resourceClass = $options->getDocumentClass();
+            }
         }
 
         if ($currentFilters) {

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\OpenApi\Factory;
 
+use ApiPlatform\Doctrine\Odm\State\Options as DoctrineODMOptions;
 use ApiPlatform\Doctrine\Orm\State\Options as DoctrineOptions;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
@@ -561,8 +562,14 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
             $filter = $this->filterLocator->get($filterId);
             $entityClass = $operation->getClass();
-            if (($options = $operation->getStateOptions()) && $options instanceof DoctrineOptions && $options->getEntityClass()) {
-                $entityClass = $options->getEntityClass();
+            if ($options = $operation->getStateOptions()) {
+                if ($options instanceof DoctrineOptions && $options->getEntityClass()) {
+                    $entityClass = $options->getEntityClass();
+                }
+
+                if ($options instanceof DoctrineODMOptions && $options->getDocumentClass()) {
+                    $entityClass = $options->getDocumentClass();
+                }
             }
 
             foreach ($filter->getDescription($entityClass) as $name => $data) {

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -17,11 +17,13 @@ use ApiPlatform\ApiResource\Error;
 use ApiPlatform\Doctrine\Odm\Extension\AggregationCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Odm\Extension\AggregationItemExtensionInterface;
 use ApiPlatform\Doctrine\Odm\Filter\AbstractFilter as DoctrineMongoDbOdmAbstractFilter;
+use ApiPlatform\Doctrine\Odm\State\LinksHandlerInterface as OdmLinksHandlerInterface;
 use ApiPlatform\Doctrine\Orm\Extension\EagerLoadingExtension;
 use ApiPlatform\Doctrine\Orm\Extension\FilterEagerLoadingExtension;
 use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface as DoctrineQueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter as DoctrineOrmAbstractFilter;
+use ApiPlatform\Doctrine\Orm\State\LinksHandlerInterface as OrmLinksHandlerInterface;
 use ApiPlatform\Elasticsearch\Extension\RequestBodySearchCollectionExtensionInterface;
 use ApiPlatform\GraphQl\Error\ErrorHandlerInterface;
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
@@ -616,6 +618,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             ->addTag('api_platform.doctrine.orm.query_extension.collection');
         $container->registerForAutoconfiguration(DoctrineOrmAbstractFilter::class);
 
+        $container->registerForAutoconfiguration(OrmLinksHandlerInterface::class)
+            ->addTag('api_platform.doctrine.orm.links_handler');
+
         $loader->load('doctrine_orm.xml');
 
         if ($this->isConfigEnabled($container, $config['eager_loading'])) {
@@ -640,6 +645,8 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             ->addTag('api_platform.doctrine_mongodb.odm.aggregation_extension.collection');
         $container->registerForAutoconfiguration(DoctrineMongoDbOdmAbstractFilter::class)
             ->setBindings(['$managerRegistry' => new Reference('doctrine_mongodb')]);
+        $container->registerForAutoconfiguration(OdmLinksHandlerInterface::class)
+            ->addTag('api_platform.doctrine.odm.links_handler');
 
         $loader->load('doctrine_mongodb_odm.xml');
     }

--- a/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
@@ -128,6 +128,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine_mongodb" />
             <argument type="tagged" tag="api_platform.doctrine_mongodb.odm.aggregation_extension.collection" />
+            <argument type="tagged_locator" tag="api_platform.doctrine.odm.links_handler" index-by="key" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Odm\State\CollectionProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine_mongodb.odm.state.collection_provider" />
@@ -138,6 +139,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine_mongodb" />
             <argument type="tagged" tag="api_platform.doctrine_mongodb.odm.aggregation_extension.item" />
+            <argument type="tagged_locator" tag="api_platform.doctrine.odm.links_handler" index-by="key" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Odm\State\ItemProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine_mongodb.odm.state.item_provider" />

--- a/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -130,6 +130,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine" />
             <argument type="tagged" tag="api_platform.doctrine.orm.query_extension.collection" />
+            <argument type="tagged_locator" tag="api_platform.doctrine.orm.links_handler" index-by="key" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Orm\State\CollectionProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine.orm.state.collection_provider" />
@@ -140,6 +141,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine" />
             <argument type="tagged" tag="api_platform.doctrine.orm.query_extension.item" />
+            <argument type="tagged_locator" tag="api_platform.doctrine.orm.links_handler" index-by="key" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Orm\State\ItemProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine.orm.state.item_provider" />

--- a/src/Symfony/EventListener/QueryParameterValidateListener.php
+++ b/src/Symfony/EventListener/QueryParameterValidateListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\EventListener;
 
 use ApiPlatform\Api\QueryParameterValidator\QueryParameterValidator;
+use ApiPlatform\Doctrine\Odm\State\Options as ODMOptions;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -64,8 +65,14 @@ final class QueryParameterValidateListener
 
         $class = $attributes['resource_class'];
 
-        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
-            $class = $options->getEntityClass();
+        if ($options = $operation->getStateOptions()) {
+            if ($options instanceof Options && $options->getEntityClass()) {
+                $class = $options->getEntityClass();
+            }
+
+            if ($options instanceof ODMOptions && $options->getDocumentClass()) {
+                $class = $options->getDocumentClass();
+            }
         }
 
         $this->queryParameterValidator->validateFilters($class, $operation->getFilters() ?? [], $queryParameters);

--- a/src/Symfony/EventListener/SerializeListener.php
+++ b/src/Symfony/EventListener/SerializeListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Symfony\EventListener;
 
+use ApiPlatform\Doctrine\Odm\State\Options as ODMOptions;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Exception\RuntimeException;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -126,7 +127,10 @@ final class SerializeListener
         $resourcesToPush = new ResourceList();
         $context['resources_to_push'] = &$resourcesToPush;
         $context[AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY][] = 'resources_to_push';
-        if (($options = $operation?->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
+        if (($options = $operation?->getStateOptions()) && (
+            ($options instanceof Options && $options->getEntityClass())
+            || ($options instanceof ODMOptions && $options->getDocumentClass())
+        )) {
             $context['force_resource_class'] = $operation->getClass();
         }
 

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -62,6 +62,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\FourthLevel as FourthLevelDoc
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Greeting as GreetingDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\InitializeInput as InitializeInputDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\IriOnlyDummy as IriOnlyDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\LinkHandledDummy as LinkHandledDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MaxDepthDummy as MaxDepthDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsDummy as MultiRelationsDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsRelatedDummy as MultiRelationsRelatedDummyDocument;
@@ -84,6 +85,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelatedSecuredDummy as Relate
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelatedToDummyFriend as RelatedToDummyFriendDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\RelationEmbedder as RelationEmbedderDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\SecuredDummy as SecuredDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\SeparatedEntity as SeparatedEntityDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\SoMany as SoManyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Taxon as TaxonDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\ThirdLevel as ThirdLevelDocument;
@@ -147,6 +149,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\IriOnlyDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5722\Event;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5722\ItemLog;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5735\Group;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\LinkHandledDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsRelatedDummy;
@@ -2055,7 +2058,7 @@ final class DoctrineContext implements Context
     public function thereAreSeparatedEntities(int $nb): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
-            $entity = new SeparatedEntity();
+            $entity = $this->buildSeparatedEntity();
             $entity->value = (string) $i;
             $this->manager->persist($entity);
         }
@@ -2199,6 +2202,18 @@ final class DoctrineContext implements Context
             $this->manager->persist($log);
         }
 
+        $this->manager->flush();
+    }
+
+    /**
+     * @Given there are a few link handled dummies
+     */
+    public function thereAreAFewLinkHandledDummies(): void
+    {
+        $this->manager->persist($this->buildLinkHandledDummy('foo'));
+        $this->manager->persist($this->buildLinkHandledDummy('bar'));
+        $this->manager->persist($this->buildLinkHandledDummy('baz'));
+        $this->manager->persist($this->buildLinkHandledDummy('foz'));
         $this->manager->flush();
     }
 
@@ -2545,5 +2560,15 @@ final class DoctrineContext implements Context
     private function buildVideoGame(): VideoGame|VideoGameDocument
     {
         return $this->isOrm() ? new VideoGame() : new VideoGameDocument();
+    }
+
+    private function buildSeparatedEntity(): SeparatedEntity|SeparatedEntityDocument
+    {
+        return $this->isOrm() ? new SeparatedEntity() : new SeparatedEntityDocument();
+    }
+
+    private function buildLinkHandledDummy(string $slug): LinkHandledDummy|LinkHandledDummyDocument
+    {
+        return $this->isOrm() ? new LinkHandledDummy($slug) : new LinkHandledDummyDocument($slug);
     }
 }

--- a/tests/Fixtures/TestBundle/ApiResource/ResourceWithSeparatedDocument.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ResourceWithSeparatedDocument.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Odm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Odm\State\Options as ODMOptions;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\SeparatedEntity;
+
+#[ApiResource(shortName: 'SeparatedDocument', stateOptions: new ODMOptions(documentClass: SeparatedEntity::class))]
+class ResourceWithSeparatedDocument
+{
+    public string $id;
+    #[ApiFilter(OrderFilter::class)]
+    public string $value;
+}

--- a/tests/Fixtures/TestBundle/Document/LinkHandledDummy.php
+++ b/tests/Fixtures/TestBundle/Document/LinkHandledDummy.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\State\ODMLinkHandledDummyLinksHandler as LinkHandledDummyLinksHandler;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document]
+#[ApiResource(
+    operations: [
+        new Get(), new GetCollection(),
+    ],
+    stateOptions: new Options(handleLinks: LinkHandledDummyLinksHandler::class)
+)]
+class LinkHandledDummy
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\Field()]
+    private string $slug;
+
+    public function __construct(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/SeparatedEntity.php
+++ b/tests/Fixtures/TestBundle/Document/SeparatedEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document]
+class SeparatedEntity
+{
+    #[ODM\Field]
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    public ?int $id = null;
+    #[ODM\Field]
+    public string $value;
+}

--- a/tests/Fixtures/TestBundle/Entity/LinkHandledDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/LinkHandledDummy.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\State\LinkHandledDummyLinksHandler;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ApiResource(
+    operations: [
+        new Get(), new GetCollection(),
+    ],
+    stateOptions: new Options(handleLinks: LinkHandledDummyLinksHandler::class)
+)]
+class LinkHandledDummy
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column()]
+    private string $slug;
+
+    public function __construct(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Fixtures/TestBundle/State/LinkHandledDummyLinksHandler.php
+++ b/tests/Fixtures/TestBundle/State/LinkHandledDummyLinksHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
+
+use ApiPlatform\Doctrine\Orm\State\LinksHandlerInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class LinkHandledDummyLinksHandler implements LinksHandlerInterface
+{
+    public function handleLinks(QueryBuilder $queryBuilder, array $uriVariables, QueryNameGeneratorInterface $queryNameGenerator, array $context): void
+    {
+        $queryBuilder->andWhere($queryBuilder->getRootAliases()[0].'.slug = :slug')->setParameter('slug', 'foo');
+    }
+}

--- a/tests/Fixtures/TestBundle/State/ODMLinkHandledDummyLinksHandler.php
+++ b/tests/Fixtures/TestBundle/State/ODMLinkHandledDummyLinksHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
+
+use ApiPlatform\Doctrine\Odm\State\LinksHandlerInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+
+class ODMLinkHandledDummyLinksHandler implements LinksHandlerInterface
+{
+    public function handleLinks(Builder $aggregationBuilder, array $uriVariables, array $context): void
+    {
+        $aggregationBuilder->match()->field('slug')->equals('foo');
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -439,3 +439,11 @@ services:
     ApiPlatform\Tests\Fixtures\TestBundle\State\Issue5452\LibraryItemProvider:
         tags:
             - { name: 'api_platform.state_provider' }
+
+    ApiPlatform\Tests\Fixtures\TestBundle\State\LinkHandledDummyLinksHandler:
+        tags:
+            - {name: 'api_platform.doctrine.orm.links_handler'}
+
+    ApiPlatform\Tests\Fixtures\TestBundle\State\ODMLinkHandledDummyLinksHandler:
+        tags:
+            - {name: 'api_platform.doctrine.odm.links_handler'}


### PR DESCRIPTION
First, this patch allows `stateOptions: entityClass` to work with Doctrine ODM (I'll move this to another patch though).

Then, it provides a way to hook into our providers to change how links are provided to Doctrine. This really help with improving performances, it is quite complicated let me try to explain.

## The Problem

Say you have `/company/les-tilleuls/employees/soyuka`. API Platform tries to handle your links, and the algorithm tries to cover all the cases so it'd probably do something like this:

```sql
SELECT * FROM Employee e
INNER JOIN Company c ON e.company_id = c.id
WHERE c.id = 'les-tilleuls' and e.id = 'soyuka'
```

First it's not that simple as we work with doctrine, relations between multiple tables and different nature (toMany, toOne) are sometimes really tricky and API Platform does things like this:

```sql
SELECT * FROM Employee e
WHERE e.id IN (
    SELECT c.employee_id FROM Company c
    WHERE c.id = 'les-tilleuls'
)
```

Depending on the nature of the relation it can be over-complicated and probably also bad in term of query performances.

A solution to this is to say that, depending on business rules, we decide to use:

```
SELECT * FROM Employee e
WHERE e.company = 'les-tilleuls' and e.id = 'soyuka'
```

## DX

Today you'd have to write a custom provider. Thing is, people love our filters and our pagination handling. Despite trying my best to work on that extensibility, for now, the best is to "copy paste API Platform code" (and keep our copyright thanks <3).

[URI Variables](https://github.com/api-platform/core/blob/main/docs/adr/0003-uri-variables.md) came with this huge refactoring and re-visiting data retrieval on subresources. This lead to a quite natural extension point where all our logic resides:

https://github.com/api-platform/core/blob/92a81f024541054b9322e7457b75c721261e14e0/src/Doctrine/Odm/State/ItemProvider.php#L62

https://github.com/api-platform/core/blob/92a81f024541054b9322e7457b75c721261e14e0/src/Doctrine/Orm/State/ItemProvider.php#L67

While discussing with @divine, we thought it'd be a good idea to be able to change that part in the User-land.

## Current implementation

Maybe this needs re-visiting, maybe that we need a new interface, but it'd need an ORM-specific signature... We already happen to have `ApiPlatfirm\State\Option` for this?

```php
use ApiPlatform\Doctrine\Orm\State;
use Doctrine\ORM\QueryBuilder;
use ApiPlatform\Doctrine\Orm\Util\QueryNameGenerator;
use ApiPlatform\Metadata\Operation;

#[ApiResource(uriTemplate: '/company/{company}/employees/{employee}' stateOptions: new Options(handleLinks: [Employee::class, 'handleLinks']))]
#[ORM\Entity]
final class Employee {
    public string $id;
    public string $employee;

    static function handleLinks(QueryBuilder $queryBuilder, array $identifiers, QueryNameGenerator $queryNameGenerator, array $context, string $entityClass, Operation $operation) {
        $alias = $queryBuilder->getRootAliases()[0];
        $queryBuilder->andWhere("$alias.id = :id");
        $queryBuilder->setParameter('id', $identifiers['employee']);
    }
}
```

You really have all you need in that signature, but we could also move some of them in the `$context` (entityClass and operation).

Let me know your thoughts.
