### PR TITLE
fix(serializer) Restore the use of placeholders named differently than `id`

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -513,9 +513,12 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $collectionKeyType = $type->getCollectionKeyTypes()[0] ?? null;
         $collectionKeyBuiltinType = $collectionKeyType?->getBuiltinType();
         $childContext = $this->createChildContext(['resource_class' => $className] + $context, $attribute, $format);
-        unset($childContext['uri_variables']);
-        if ($this->resourceMetadataCollectionFactory) {
-            $childContext['operation'] = $this->resourceMetadataCollectionFactory->create($className)->getOperation();
+        $lastUriVariable = \array_key_exists('uri_variables', $childContext) ? array_key_last($childContext['uri_variables']) : null;
+        if ('id' === $lastUriVariable) {
+            unset($childContext['uri_variables']);
+            if ($this->resourceMetadataCollectionFactory) {
+                $childContext['operation'] = $this->resourceMetadataCollectionFactory->create($className)->getOperation();
+            }
         }
 
         $values = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Tickets       | Closes #5736
| License       | MIT

Restore the use of placeholders named differently than `id`.

See #5736 for more details.

- [ ] Verify why `ItemNormalizerTest::testDenormalizeGuessingUriVariables()` din't intercepted the breaking change introduced with #5604 (I need help here, please)