### PR TITLE
fix: Add missing deprecated elasticsearch related interfaces/classes

### DIFF
--- a/src/deprecated_interfaces.php
+++ b/src/deprecated_interfaces.php
@@ -38,6 +38,8 @@ return [
 
     // Bridge\Elasticsearch => Elasticsearch
     ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface::class => ApiPlatform\Elasticsearch\Metadata\Document\Factory\DocumentMetadataFactoryInterface::class,
+    ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\FilterInterface::class => ApiPlatform\Elasticsearch\Filter\FilterInterface::class,
+    ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\ConstantScoreFilterInterface::class => ApiPlatform\Elasticsearch\Filter\ConstantScoreFilterInterface::class,
 
     // Bridge\Symfony\Validator
     ApiPlatform\Core\Bridge\Symfony\Validator\ValidationGroupsGeneratorInterface::class => ApiPlatform\Symfony\Validator\ValidationGroupsGeneratorInterface::class,
@@ -75,6 +77,7 @@ return [
     ApiPlatform\Core\Validator\ValidatorInterface::class => ApiPlatform\Validator\ValidatorInterface::class,
 
     // API:
+    ApiPlatform\Core\Api\FilterInterface::class => ApiPlatform\Api\FilterInterface::class,
     ApiPlatform\Core\Api\ResourceClassResolverInterface::class => ApiPlatform\Api\ResourceClassResolverInterface::class,
     ApiPlatform\Core\Api\UrlGeneratorInterface::class => ApiPlatform\Api\UrlGeneratorInterface::class,
 

--- a/src/deprecation.php
+++ b/src/deprecation.php
@@ -444,6 +444,8 @@ $deprecatedClassesWithoutAliases = [
     ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Extension\ConstantScoreFilterExtension::class => ApiPlatform\Elasticsearch\Extension\ConstantScoreFilterExtension::class,
     ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Extension\SortExtension::class => ApiPlatform\Elasticsearch\Extension\SortExtension::class,
     ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Extension\SortFilterExtension::class => ApiPlatform\Elasticsearch\Extension\SortFilterExtension::class,
+
+    ApiPlatform\Core\Bridge\Elasticsearch\Serializer\ItemNormalizer::class => ApiPlatform\Elasticsearch\Serializer\ItemNormalizer::class,
 ];
 
 spl_autoload_register(function ($className) use ($deprecatedInterfaces, $deprecatedClassesWithoutAliases, $deprecatedClassesWithAliases) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see below -->
| License       | MIT


Added a few missing deprecations that needs to be fixed when upgrading from the old metadata system.

