### PR TITLE
feat(testing): Improve ApiTestAssertionsTrait::assertJsonEquals

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -74,7 +74,7 @@ trait ApiTestAssertionsTrait
             throw new \InvalidArgumentException('$json must be array or string (JSON array or JSON object)');
         }
 
-        static::assertEqualsCanonicalizing($json, self::getHttpResponse()->toArray(false), $message);
+        static::assertEquals($json, self::getHttpResponse()->toArray(false), $message);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | main
| Tickets       | Closes #5751, closes #5751
| License       | MIT

Improve ApiTestAssertionsTrait::assertJsonEquals by replacing `assertEqualsCanonicalizing` with `assertEquals`.