### PR TITLE
chore(HttpCache): outsource cache tag collection into normalizer events

### DIFF
--- a/src/HttpCache/EventListener/NormalizerListener.php
+++ b/src/HttpCache/EventListener/NormalizerListener.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache\EventListener;
+
+use ApiPlatform\Serializer\NormalizeItemEvent;
+
+/**
+ * Collects cache tags during normalization.
+ *
+ * @author Urban Suppiger <urban@suppiger.net>
+ */
+class NormalizerListener
+{
+    public function onPreNormalizeItem(NormalizeItemEvent $event): void
+    {
+        $this->addResourceToContext($event);
+    }
+
+    public function onNormalizeRelation(NormalizeItemEvent $event): void
+    {
+        $this->addResourceToContext($event);
+    }
+
+    public function onJsonApiNormalizeRelation(NormalizeItemEvent $event): void
+    {
+        $this->addResourceToContext($event);
+    }
+
+    private function addResourceToContext(NormalizeItemEvent $event): void
+    {
+        if (isset($event->context['resources'])) {
+            $event->context['resources'][$event->iri] = $event->iri;
+        }
+    }
+}

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -26,6 +26,7 @@ use ApiPlatform\Metadata\Util\ClassInfoTrait;
 use ApiPlatform\Serializer\AbstractItemNormalizer;
 use ApiPlatform\Serializer\ContextTrait;
 use ApiPlatform\Symfony\Security\ResourceAccessCheckerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -45,9 +46,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
     public const FORMAT = 'jsonld';
 
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, private readonly ContextBuilderInterface $contextBuilder, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], ResourceAccessCheckerInterface $resourceAccessChecker = null)
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, private readonly ContextBuilderInterface $contextBuilder, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], ResourceAccessCheckerInterface $resourceAccessChecker = null, protected ?EventDispatcher $eventDispatcher = null)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataCollectionFactory, $resourceAccessChecker);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataCollectionFactory, $resourceAccessChecker, $eventDispatcher);
     }
 
     /**

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -24,6 +24,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Symfony\Security\ResourceAccessCheckerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -38,9 +39,9 @@ class ItemNormalizer extends AbstractItemNormalizer
 {
     private readonly LoggerInterface $logger;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, LoggerInterface $logger = null, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null, array $defaultContext = [])
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, LoggerInterface $logger = null, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null, array $defaultContext = [], protected ?EventDispatcher $eventDispatcher = null)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataFactory, $resourceAccessChecker);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataFactory, $resourceAccessChecker, $eventDispatcher);
 
         $this->logger = $logger ?: new NullLogger();
     }

--- a/src/Serializer/NormalizeAttributeEvent.php
+++ b/src/Serializer/NormalizeAttributeEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event class for normalizer events (normalize attributes).
+ *
+ * @author Urban Suppiger <urban@suppiger.net>
+ */
+class NormalizeAttributeEvent extends Event
+{
+    public const NORMALIZE_ATTRIBUTE = 'api_platform.normalizer.normalize_attribute';
+
+    public function __construct(
+        public mixed $object,
+        public ?string $format = null,
+        public array $context = [],
+        public ?string $iri = null,
+        public array|string|int|float|bool|\ArrayObject|null $data = null,
+        public ?string $attribute = null,
+        public ?ApiProperty $propertyMetadata = null,
+        public ?Type $type = null,
+        public array $childContext = [],
+    ) {
+    }
+}

--- a/src/Serializer/NormalizeItemEvent.php
+++ b/src/Serializer/NormalizeItemEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event class for normalizer events (normalize items).
+ *
+ * @author Urban Suppiger <urban@suppiger.net>
+ */
+class NormalizeItemEvent extends Event
+{
+    public const NORMALIZE_ITEM_PRE = 'api_platform.normalizer.normalize_item.pre';
+    public const NORMALIZE_ITEM_POST = 'api_platform.normalizer.normalize_item.post';
+    public const NORMALIZE_RELATION = 'api_platform.normalizer.normalize_relation';
+    public const JSONAPI_NORMALIZE_RELATION = 'api_platform.jsonapi.normalizer.normalize_relation';
+
+    public function __construct(
+        public mixed $object,
+        public ?string $format = null,
+        public array $context = [],
+        public ?string $iri = null,
+        public array|string|int|float|bool|\ArrayObject|null $data = null
+    ) {
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -57,6 +57,8 @@
             <argument>null</argument>
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" on-invalid="ignore" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="ignore" />
+            <argument type="collection" />
+            <argument type="service" id="event_dispatcher" on-invalid="ignore" />
 
             <!-- Run before serializer.normalizer.json_serializable -->
             <tag name="serializer.normalizer" priority="-895" />

--- a/src/Symfony/Bundle/Resources/config/http_cache_purger.xml
+++ b/src/Symfony/Bundle/Resources/config/http_cache_purger.xml
@@ -25,5 +25,12 @@
             <argument type="service" id="api_platform.http_cache.purger" on-invalid="null" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-2" />
         </service>
+
+        <service id="api_platform.http_cache.listener.normalizer.collect_tags" class="ApiPlatform\HttpCache\EventListener\NormalizerListener">
+            <tag name="kernel.event_listener" event="api_platform.normalizer.normalize_item.pre" method="onPreNormalizeItem" />
+            <tag name="kernel.event_listener" event="api_platform.normalizer.normalize_relation" method="onNormalizeRelation" />
+            <tag name="kernel.event_listener" event="api_platform.jsonapi.normalizer.normalize_relation" method="onJsonApiNormalizeRelation" />
+        </service>
+
     </services>
 </container>

--- a/src/Symfony/Bundle/Resources/config/jsonapi.xml
+++ b/src/Symfony/Bundle/Resources/config/jsonapi.xml
@@ -43,6 +43,7 @@
             <argument type="collection" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="ignore" />
+            <argument type="service" id="event_dispatcher" on-invalid="ignore" />
 
             <!-- Run before serializer.normalizer.json_serializable -->
             <tag name="serializer.normalizer" priority="-890" />

--- a/src/Symfony/Bundle/Resources/config/jsonld.xml
+++ b/src/Symfony/Bundle/Resources/config/jsonld.xml
@@ -29,6 +29,7 @@
             <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
             <argument type="collection" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="ignore" />
+            <argument type="service" id="event_dispatcher" on-invalid="ignore" />
 
             <!-- Run before serializer.normalizer.json_serializable -->
             <tag name="serializer.normalizer" priority="-890" />

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -80,6 +80,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
 
         $this->assertTrue($normalizer->supportsNormalization($dummy));
@@ -151,6 +152,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -212,6 +214,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -266,6 +269,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -320,6 +324,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -383,6 +388,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -447,6 +453,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -507,6 +514,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -578,6 +586,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -644,6 +653,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -702,6 +712,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -763,7 +774,7 @@ class AbstractItemNormalizerTest extends TestCase
         // $serializerProphecy->willImplement(DenormalizerInterface::class);
         // $serializerProphecy->denormalize($data, DummyForAdditionalFieldsInput::class, 'json', $cleanedContextWithObjectToPopulate)->willReturn($dummyInputDto);
         //
-        // $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), null, null, null, [], null, null) extends AbstractItemNormalizer {
+        // $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), null, null, null, [], null, null, null) extends AbstractItemNormalizer {
         // };
         // $normalizer->setSerializer($serializerProphecy->reveal());
         //
@@ -821,6 +832,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -874,6 +886,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -923,6 +936,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -966,6 +980,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1004,6 +1019,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1048,6 +1064,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1118,6 +1135,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1156,6 +1174,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1234,6 +1253,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1305,6 +1325,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1345,6 +1366,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1389,6 +1411,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR outsources the collection of cache tags for HTTP cache into individual events triggered from the normalizers instead of hardcoding into the the normalizers. This allows users to override or extend the cache tag logic with their own implementation.

This is related to https://github.com/api-platform/core/pull/5650, where I brought up the idea:

> Would it makes sense to outsource the actual calculation of the cache tags into seperate event listeners instead of hard-baking it into AbstractItemNormalizer? This would it make easier for users to extend or overwrite the cache tag generation with their own logic.

The same events could later be extended for other purposes where we need to trigger side effects during normalization (e.g. to collect push resources). And of course can be used by users for other user specific business logic.

Should this be documented somewhere? And if so, where and how?
