### PR TITLE
fix: use name_converter in Doctrine LinksHandler if defined

### DIFF
--- a/features/graphql/collection.feature
+++ b/features/graphql/collection.feature
@@ -1,6 +1,38 @@
 Feature: GraphQL collection support
 
   @createSchema
+  Scenario: Retrieve a collection with converted entities
+    Given there is a Foo named Alice with a Bar and a collection of Bars
+    When I send the following GraphQL request:
+    """
+    {
+      issue5723Foos {
+        edges {
+          node {
+            bar_converted {
+              id
+              name
+            }
+            bars_converted {
+              edges {
+                node {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.issue5723Foos.edges[0].node.bars_converted.edges[0].node.name" should not be null
+    And the JSON node "data.issue5723Foos.edges[0].node.bar_converted.name" should not be null
+
+  @createSchema
   Scenario: Retrieve a collection through a GraphQL query
     Given there are 4 dummy objects with relatedDummy and its thirdLevel
     When I send the following GraphQL request:

--- a/src/Doctrine/Common/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Common/State/LinksHandlerTrait.php
@@ -21,10 +21,12 @@ use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 trait LinksHandlerTrait
 {
     private ?ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory;
+    private ?NameConverterInterface $nameConverter;
 
     /**
      * @return Link[]
@@ -41,7 +43,8 @@ trait LinksHandlerTrait
         $linkProperty = $context['linkProperty'] ?? null;
 
         foreach ($links as $link) {
-            if ($linkClass === $link->getFromClass() && $linkProperty === $link->getFromProperty()) {
+            $testedProperty = $this->nameConverter ? $this->nameConverter->normalize($link->getFromProperty()) : $link->getFromProperty();
+            if ($linkClass === $link->getFromClass() && $linkProperty === $testedProperty) {
                 $newLink = $link;
                 break;
             }
@@ -75,7 +78,8 @@ trait LinksHandlerTrait
         }
 
         foreach ($this->getOperationLinks($linkedOperation ?? null) as $link) {
-            if ($resourceClass === $link->getToClass() && $linkProperty === $link->getFromProperty()) {
+            $testedProperty = $this->nameConverter ? $this->nameConverter->normalize($link->getFromProperty()) : $link->getFromProperty();
+            if ($resourceClass === $link->getToClass() && $linkProperty === $testedProperty) {
                 $newLink = $link;
                 break;
             }

--- a/src/Doctrine/Common/State/PersistProcessor.php
+++ b/src/Doctrine/Common/State/PersistProcessor.php
@@ -21,14 +21,16 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager as DoctrineObjectManager;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 final class PersistProcessor implements ProcessorInterface
 {
     use ClassInfoTrait;
     use LinksHandlerTrait;
 
-    public function __construct(private readonly ManagerRegistry $managerRegistry)
+    public function __construct(private readonly ManagerRegistry $managerRegistry, NameConverterInterface $nameConverter = null)
     {
+        $this->nameConverter = $nameConverter;
     }
 
     /**

--- a/src/Doctrine/Odm/State/CollectionProvider.php
+++ b/src/Doctrine/Odm/State/CollectionProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\State\ProviderInterface;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Collection state provider using the Doctrine ODM.
@@ -33,9 +34,10 @@ final class CollectionProvider implements ProviderInterface
     /**
      * @param AggregationCollectionExtensionInterface[] $collectionExtensions
      */
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [])
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [], NameConverterInterface $nameConverter = null)
     {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->nameConverter = $nameConverter;
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable

--- a/src/Doctrine/Odm/State/ItemProvider.php
+++ b/src/Doctrine/Odm/State/ItemProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\State\ProviderInterface;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Item state provider using the Doctrine ODM.
@@ -36,9 +37,10 @@ final class ItemProvider implements ProviderInterface
     /**
      * @param AggregationItemExtensionInterface[] $itemExtensions
      */
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $itemExtensions = [])
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $itemExtensions = [], NameConverterInterface $nameConverter = null)
     {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->nameConverter = $nameConverter;
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object

--- a/src/Doctrine/Orm/State/CollectionProvider.php
+++ b/src/Doctrine/Orm/State/CollectionProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\State\ProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Collection state provider using the Doctrine ORM.
@@ -36,9 +37,10 @@ final class CollectionProvider implements ProviderInterface
     /**
      * @param QueryCollectionExtensionInterface[] $collectionExtensions
      */
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [])
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $collectionExtensions = [], NameConverterInterface $nameConverter = null)
     {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->nameConverter = $nameConverter;
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable

--- a/src/Doctrine/Orm/State/ItemProvider.php
+++ b/src/Doctrine/Orm/State/ItemProvider.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\State\ProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Item state provider using the Doctrine ORM.
@@ -36,9 +37,10 @@ final class ItemProvider implements ProviderInterface
     /**
      * @param QueryItemExtensionInterface[] $itemExtensions
      */
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $itemExtensions = [])
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ManagerRegistry $managerRegistry, private readonly iterable $itemExtensions = [], NameConverterInterface $nameConverter = null)
     {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->nameConverter = $nameConverter;
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object

--- a/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
@@ -27,6 +27,7 @@
 
         <service id="api_platform.doctrine_mongodb.odm.state.persist_processor" class="ApiPlatform\Doctrine\Common\State\PersistProcessor">
             <argument type="service" id="doctrine_mongodb" />
+            <argument key="$nameConverter" type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="api_platform.state_processor" priority="-100" key="api_platform.doctrine_mongodb.odm.state.persist_processor" />
             <tag name="api_platform.state_processor" priority="-100" key="ApiPlatform\Doctrine\Common\State\PersistProcessor" />
@@ -128,6 +129,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine_mongodb" />
             <argument type="tagged" tag="api_platform.doctrine_mongodb.odm.aggregation_extension.collection" />
+            <argument key="$nameConverter" type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Odm\State\CollectionProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine_mongodb.odm.state.collection_provider" />
@@ -138,6 +140,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine_mongodb" />
             <argument type="tagged" tag="api_platform.doctrine_mongodb.odm.aggregation_extension.item" />
+            <argument key="$nameConverter" type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Odm\State\ItemProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine_mongodb.odm.state.item_provider" />

--- a/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -19,6 +19,7 @@
 
         <service id="api_platform.doctrine.orm.state.persist_processor" class="ApiPlatform\Doctrine\Common\State\PersistProcessor">
             <argument type="service" id="doctrine" />
+            <argument key="$nameConverter" type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="api_platform.state_processor" priority="-100" key="api_platform.doctrine.orm.state.persist_processor" />
             <tag name="api_platform.state_processor" priority="-100" key="ApiPlatform\Doctrine\Common\State\PersistProcessor" />
@@ -130,6 +131,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine" />
             <argument type="tagged" tag="api_platform.doctrine.orm.query_extension.collection" />
+            <argument key="$nameConverter" type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Orm\State\CollectionProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine.orm.state.collection_provider" />
@@ -140,6 +142,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="doctrine" />
             <argument type="tagged" tag="api_platform.doctrine.orm.query_extension.item" />
+            <argument key="$nameConverter" type="service" id="api_platform.name_converter" on-invalid="ignore" />
 
             <tag name="api_platform.state_provider" priority="-100" key="ApiPlatform\Doctrine\Orm\State\ItemProvider" />
             <tag name="api_platform.state_provider" priority="-100" key="api_platform.doctrine.orm.state.item_provider" />

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -62,6 +62,8 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\FourthLevel as FourthLevelDoc
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Greeting as GreetingDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\InitializeInput as InitializeInputDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\IriOnlyDummy as IriOnlyDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue5723\Issue5723Bar as Issue5723BarDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue5723\Issue5723Foo as Issue5723FooDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MaxDepthDummy as MaxDepthDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsDummy as MultiRelationsDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsRelatedDummy as MultiRelationsRelatedDummyDocument;
@@ -144,6 +146,8 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Greeting;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\InitializeInput;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\InternalUser;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\IriOnlyDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5723\Issue5723Bar;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5723\Issue5723Foo;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsRelatedDummy;
@@ -1745,6 +1749,32 @@ final class DoctrineContext implements Context
         $this->manager->persist($person);
         $this->manager->persist($greeting);
 
+        $this->manager->flush();
+        $this->manager->clear();
+    }
+
+    /**
+     * @Given there is a Foo named :name with a Bar and a collection of Bars
+     */
+    public function thereIsAFooWithABarAndACollectionOfBars(string $name): void
+    {
+        if ($this->isOrm()) {
+            $foo = new Issue5723Foo();
+            $bar = new Issue5723Bar();
+            $bar2 = new Issue5723Bar();
+        } else {
+            $foo = new Issue5723FooDocument();
+            $bar = new Issue5723BarDocument();
+            $bar2 = new Issue5723BarDocument();
+        }
+        $foo->name = $name;
+        $bar->fooConverted = $foo;
+        $bar->name = 'bar';
+        $bar2->name = 'bar2';
+        $foo->barConverted = $bar2;
+        $this->manager->persist($foo);
+        $this->manager->persist($bar);
+        $this->manager->persist($bar2);
         $this->manager->flush();
         $this->manager->clear();
     }

--- a/tests/Fixtures/TestBundle/Document/Issue5723/Issue5723Bar.php
+++ b/tests/Fixtures/TestBundle/Document/Issue5723/Issue5723Bar.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue5723;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[ODM\Document]
+class Issue5723Bar
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    #[ODM\Field(type: 'string')]
+    public string $name;
+
+    #[ODM\ReferenceOne(nullable: true, storeAs: 'id', targetDocument: Issue5723Foo::class, inversedBy: 'barsConverted')]
+    public Issue5723Foo|null $fooConverted = null;
+}

--- a/tests/Fixtures/TestBundle/Document/Issue5723/Issue5723Foo.php
+++ b/tests/Fixtures/TestBundle/Document/Issue5723/Issue5723Foo.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue5723;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[ODM\Document]
+class Issue5723Foo
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    #[ODM\Field(type: 'string')]
+    public string $name;
+
+    #[ODM\ReferenceMany(targetDocument: Issue5723Bar::class, mappedBy: 'fooConverted')]
+    public Collection|iterable|null $barsConverted = null;
+
+    #[ODM\ReferenceOne(nullable: true, storeAs: 'id', targetDocument: Issue5723Bar::class)]
+    public Issue5723Bar|null $barConverted = null;
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue5723/Issue5723Bar.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue5723/Issue5723Bar.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5723;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[ORM\Entity]
+class Issue5723Bar
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    #[ORM\Column(type: 'string')]
+    public string $name;
+
+    #[ORM\ManyToOne(targetEntity: Issue5723Foo::class, inversedBy: 'barsConverted')]
+    public Issue5723Foo|null $fooConverted = null;
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue5723/Issue5723Foo.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue5723/Issue5723Foo.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5723;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[ORM\Entity]
+class Issue5723Foo
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    #[ORM\Column(type: 'string')]
+    public string $name;
+
+    #[ORM\OneToMany(mappedBy: 'fooConverted', targetEntity: Issue5723Bar::class)]
+    public Collection|iterable|null $barsConverted = null;
+
+    #[ORM\OneToOne(targetEntity: Issue5723Bar::class)]
+    public Issue5723Bar|null $barConverted = null;
+}

--- a/tests/Fixtures/TestBundle/Serializer/NameConverter/CustomConverter.php
+++ b/tests/Fixtures/TestBundle/Serializer/NameConverter/CustomConverter.php
@@ -23,11 +23,11 @@ class CustomConverter extends CamelCaseToSnakeCaseNameConverter
 {
     public function normalize(string $propertyName): string
     {
-        return 'nameConverted' === $propertyName ? parent::normalize($propertyName) : $propertyName;
+        return str_ends_with($propertyName, 'Converted') ? parent::normalize($propertyName) : $propertyName;
     }
 
     public function denormalize(string $propertyName): string
     {
-        return 'name_converted' === $propertyName ? parent::denormalize($propertyName) : $propertyName;
+        return str_ends_with($propertyName, '_converted') ? parent::denormalize($propertyName) : $propertyName;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Closes #5723 
| License       | MIT
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Use `api_platform.name_converter` service in `LinksHandlerTrait` to match the correct link.

Needs tests but I don't really understand the testing policy, I could use some help.