### PR TITLE
chore(serializer): outsource cache tag collection into separate service

### DIFF
--- a/src/HttpCache/TagCollector.php
+++ b/src/HttpCache/TagCollector.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Collects cache tags during normalization.
+ *
+ * @author Urban Suppiger <urban@suppiger.net>
+ */
+class TagCollector implements TagCollectorInterface
+{
+    public function collectTagsFromNormalize(mixed $object, string $format = null, array $context = [], string $iri = null): void
+    {
+        $this->addResourceToContext($context, $iri);
+    }
+
+    public function collectTagsFromNormalizeRelation(mixed $object, string $format = null, array $context = [], string $iri = null): void
+    {
+        $this->addResourceToContext($context, $iri);
+    }
+
+    public function collectTagsFromGetAttribute(mixed $object, string $format = null, array $context = [], string $iri = null, string $attribute = null, ApiProperty $propertyMetadata = null, Type $type = null, array $childContext = []): void
+    {
+    }
+
+    private function addResourceToContext(array $context, ?string $iri): void
+    {
+        if (isset($context['resources']) && isset($iri)) {
+            $context['resources'][$iri] = $iri;
+        }
+    }
+}

--- a/src/HttpCache/TagCollectorInterface.php
+++ b/src/HttpCache/TagCollectorInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\HttpCache;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Interface for collecting cache tags during normalization.
+ *
+ * @author Urban Suppiger <urban@suppiger.net>
+ */
+interface TagCollectorInterface
+{
+    public function collectTagsFromNormalize(mixed $object, string $format = null, array $context = [], string $iri = null): void;
+
+    public function collectTagsFromNormalizeRelation(mixed $object, string $format = null, array $context = [], string $iri = null): void;
+
+    public function collectTagsFromGetAttribute(mixed $object, string $format = null, array $context = [], string $iri = null, string $attribute = null, ApiProperty $propertyMetadata = null, Type $type = null, array $childContext = []): void;
+}

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -17,6 +17,7 @@ use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Exception\ItemNotFoundException;
+use ApiPlatform\HttpCache\TagCollectorInterface;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -52,9 +53,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
     private array $componentsCache = [];
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null)
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null, protected ?TagCollectorInterface $tagCollector = null)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataCollectionFactory, $resourceAccessChecker);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataCollectionFactory, $resourceAccessChecker, $tagCollector);
     }
 
     /**
@@ -223,8 +224,8 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $iri = $this->iriConverter->getIriFromResource($relatedObject);
             $context['iri'] = $iri;
 
-            if (isset($context['resources'])) {
-                $context['resources'][$iri] = $iri;
+            if ($this->tagCollector) {
+                $this->tagCollector->collectTagsFromNormalizeRelation($relatedObject, $format, $context, $iri);
             }
         }
 

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\JsonLd\Serializer;
 use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\HttpCache\TagCollectorInterface;
 use ApiPlatform\JsonLd\AnonymousContextBuilderInterface;
 use ApiPlatform\JsonLd\ContextBuilderInterface;
 use ApiPlatform\Metadata\HttpOperation;
@@ -45,9 +46,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
     public const FORMAT = 'jsonld';
 
-    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, private readonly ContextBuilderInterface $contextBuilder, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], ResourceAccessCheckerInterface $resourceAccessChecker = null)
+    public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, private readonly ContextBuilderInterface $contextBuilder, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], ResourceAccessCheckerInterface $resourceAccessChecker = null, protected ?TagCollectorInterface $tagCollector = null)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataCollectionFactory, $resourceAccessChecker);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataCollectionFactory, $resourceAccessChecker, $tagCollector);
     }
 
     /**

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -17,6 +17,7 @@ use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Exception\InvalidArgumentException;
+use ApiPlatform\HttpCache\TagCollectorInterface;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -38,9 +39,9 @@ class ItemNormalizer extends AbstractItemNormalizer
 {
     private readonly LoggerInterface $logger;
 
-    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, LoggerInterface $logger = null, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null, array $defaultContext = [])
+    public function __construct(PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface $iriConverter, ResourceClassResolverInterface $resourceClassResolver, PropertyAccessorInterface $propertyAccessor = null, NameConverterInterface $nameConverter = null, ClassMetadataFactoryInterface $classMetadataFactory = null, LoggerInterface $logger = null, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null, ResourceAccessCheckerInterface $resourceAccessChecker = null, array $defaultContext = [], protected ?TagCollectorInterface $tagCollector = null)
     {
-        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataFactory, $resourceAccessChecker);
+        parent::__construct($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, $nameConverter, $classMetadataFactory, $defaultContext, $resourceMetadataFactory, $resourceAccessChecker, $tagCollector);
 
         $this->logger = $logger ?: new NullLogger();
     }

--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -57,6 +57,8 @@
             <argument>null</argument>
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" on-invalid="ignore" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="ignore" />
+            <argument type="collection" />
+            <argument type="service" id="api_platform.http_cache.tag_collector" on-invalid="ignore" />
 
             <!-- Run before serializer.normalizer.json_serializable -->
             <tag name="serializer.normalizer" priority="-895" />

--- a/src/Symfony/Bundle/Resources/config/http_cache_purger.xml
+++ b/src/Symfony/Bundle/Resources/config/http_cache_purger.xml
@@ -25,5 +25,8 @@
             <argument type="service" id="api_platform.http_cache.purger" on-invalid="null" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-2" />
         </service>
+
+        <service id="api_platform.http_cache.tag_collector" class="ApiPlatform\HttpCache\TagCollector" />
+
     </services>
 </container>

--- a/src/Symfony/Bundle/Resources/config/jsonapi.xml
+++ b/src/Symfony/Bundle/Resources/config/jsonapi.xml
@@ -43,6 +43,7 @@
             <argument type="collection" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="ignore" />
+            <argument type="service" id="api_platform.http_cache.tag_collector" on-invalid="ignore" />
 
             <!-- Run before serializer.normalizer.json_serializable -->
             <tag name="serializer.normalizer" priority="-890" />

--- a/src/Symfony/Bundle/Resources/config/jsonld.xml
+++ b/src/Symfony/Bundle/Resources/config/jsonld.xml
@@ -29,6 +29,7 @@
             <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
             <argument type="collection" />
             <argument type="service" id="api_platform.security.resource_access_checker" on-invalid="ignore" />
+            <argument type="service" id="api_platform.http_cache.tag_collector" on-invalid="ignore" />
 
             <!-- Run before serializer.normalizer.json_serializable -->
             <tag name="serializer.normalizer" priority="-890" />

--- a/tests/Serializer/AbstractItemNormalizerTest.php
+++ b/tests/Serializer/AbstractItemNormalizerTest.php
@@ -80,6 +80,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
 
         $this->assertTrue($normalizer->supportsNormalization($dummy));
@@ -151,6 +152,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -212,6 +214,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -266,6 +269,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -320,6 +324,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -383,6 +388,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -447,6 +453,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -507,6 +514,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             $resourceAccessChecker->reveal(),
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -578,6 +586,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -644,6 +653,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -702,6 +712,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -763,7 +774,7 @@ class AbstractItemNormalizerTest extends TestCase
         // $serializerProphecy->willImplement(DenormalizerInterface::class);
         // $serializerProphecy->denormalize($data, DummyForAdditionalFieldsInput::class, 'json', $cleanedContextWithObjectToPopulate)->willReturn($dummyInputDto);
         //
-        // $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), null, null, null, [], null, null) extends AbstractItemNormalizer {
+        // $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), null, null, null, [], null, null, null) extends AbstractItemNormalizer {
         // };
         // $normalizer->setSerializer($serializerProphecy->reveal());
         //
@@ -821,6 +832,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -874,6 +886,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -923,6 +936,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -966,6 +980,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1004,6 +1019,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1048,6 +1064,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1118,6 +1135,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1156,6 +1174,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1234,6 +1253,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1305,6 +1325,7 @@ class AbstractItemNormalizerTest extends TestCase
             [],
             null,
             null,
+            null,
         ]);
         $normalizer->setSerializer($serializerProphecy->reveal());
 
@@ -1345,6 +1366,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);
@@ -1389,6 +1411,7 @@ class AbstractItemNormalizerTest extends TestCase
             null,
             null,
             [],
+            null,
             null,
             null,
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Supersedes #5753 
| License       | MIT
| Doc PR        | 

Alternative implementation of #5753 but using a service instead of events
