### PR TITLE
BUG: Error 500 on request with 'empty' Accept headers, e.g. 'Accept: 0' or 'Accept: '

### DIFF
--- a/src/Symfony/EventListener/AddFormatListener.php
+++ b/src/Symfony/EventListener/AddFormatListener.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Symfony\EventListener;
 use ApiPlatform\Api\FormatMatcher;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Util\OperationRequestInitiatorTrait;
+use Exception;
 use Negotiation\Negotiator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -73,8 +74,15 @@ final class AddFormatListener
         // First, try to guess the format from the Accept header
         /** @var string|null $accept */
         $accept = $request->headers->get('Accept');
-        if (!empty($accept)) {
-            if (null === $mediaType = $this->negotiator->getBest($accept, $mimeTypes)) {
+
+        if (null !== $accept) {
+            try {
+                $mediaType = $this->negotiator->getBest($accept, $mimeTypes);
+            } catch (Exception) {
+                throw $this->getNotAcceptableHttpException($accept, $flattenedMimeTypes);
+            }
+
+            if (null === $mediaType) {
                 throw $this->getNotAcceptableHttpException($accept, $flattenedMimeTypes);
             }
 

--- a/src/Symfony/EventListener/AddFormatListener.php
+++ b/src/Symfony/EventListener/AddFormatListener.php
@@ -73,7 +73,7 @@ final class AddFormatListener
         // First, try to guess the format from the Accept header
         /** @var string|null $accept */
         $accept = $request->headers->get('Accept');
-        if (null !== $accept) {
+        if (!empty($accept)) {
             if (null === $mediaType = $this->negotiator->getBest($accept, $mimeTypes)) {
                 throw $this->getNotAcceptableHttpException($accept, $flattenedMimeTypes);
             }

--- a/tests/Symfony/EventListener/AddFormatListenerTest.php
+++ b/tests/Symfony/EventListener/AddFormatListenerTest.php
@@ -268,6 +268,9 @@ class AddFormatListenerTest extends TestCase
 
     public function testZeroAcceptHeader(): void
     {
+        $this->expectException(NotAcceptableHttpException::class);
+        $this->expectExceptionMessage('Requested format "0" is not supported. Supported MIME types are "application/octet-stream", "application/json"');
+
         $request = new Request([], [], ['_api_resource_class' => 'Foo', '_api_operation_name' => 'get']);
         $request->headers->set('Accept', '0');
 
@@ -288,7 +291,6 @@ class AddFormatListenerTest extends TestCase
         $listener = new AddFormatListener(new Negotiator(), $resourceMetadataFactoryProphecy->reveal());
         $listener->onKernelRequest($event);
 
-        $this->assertSame('binary', $request->getRequestFormat());
     }
 
     public function testAcceptHeaderTakePrecedenceOverRequestFormat(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | stable/latest 2.x/3.x
| Tickets       | 
| License       | MIT
| Doc PR        | 
<!--

On request with empty ('0', ' ', etc.) header framework response with status code 500. Because \Negotiation\AbstractNegotiator:23 check empty header value as `!$header` but in the Symfony/EventListener/AddFormatListener.php:81 as `$accept !== null`.

I changed  `$accept !== null` to `!empty($accept)`.

Fixed destination branch to 3.1 see https://github.com/api-platform/core/pull/5616

