### PR TITLE
fix(serializer): correct supported types for elasticsearch item normalizer decorator

### DIFF
--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -111,7 +111,7 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
             ];
         }
 
-        return DocumentNormalizer::FORMAT === $format ? $this->decorated->getSupportedTypes($format) : [];
+        return DocumentNormalizer::FORMAT !== $format ? $this->decorated->getSupportedTypes($format) : [];
     }
 
     /**

--- a/tests/Elasticsearch/Serializer/ItemNormalizerTest.php
+++ b/tests/Elasticsearch/Serializer/ItemNormalizerTest.php
@@ -166,7 +166,7 @@ final class ItemNormalizerTest extends TestCase
             }
         });
 
-        $this->assertEmpty($this->itemNormalizer->getSupportedTypes('json'));
-        $this->assertSame(['*' => true], $this->itemNormalizer->getSupportedTypes($this->itemNormalizer::FORMAT));
+        $this->assertEmpty($this->itemNormalizer->getSupportedTypes($this->itemNormalizer::FORMAT));
+        $this->assertSame(['*' => true], $this->itemNormalizer->getSupportedTypes('json'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | -
| License       | MIT
| Doc PR        | -

I have issue using DTO input (https://api-platform.com/docs/core/dto/#implementing-a-write-operation-with-an-input-different-from-the-resource). The state processor doesn't receive the input class as argument. There is a problem with the deserialization process.

This pull request fixes my issue.

With elasticsearch support enabled, the normalizer `api_platform.elasticsearch.normalizer.item` is registered, it decorates the default item normalizer `api_platform.serializer.normalizer.item`. 

I guess that this `ApiPlatform\Elasticsearch\Serializer\ItemNormalizer` class intend to prevent calling the decorated service when using `elasticsearch` format.

Unfortunately, recent patch on the `getSupportedTypes` method break this.

