### PR TITLE
Fixes undefined property error in CollectionNormalizer.php, line 46

### DIFF
--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -43,7 +43,7 @@ final class CollectionNormalizer extends AbstractCollectionNormalizer
     {
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
 
-        if ($this->resourceMetadataCollectionFactory) {
+        if ($resourceMetadataCollectionFactory) {
             trigger_deprecation('api-platform/core', '3.0', sprintf('Injecting "%s" within "%s" is not needed anymore and this dependency will be removed in 4.0.', ResourceMetadataCollectionFactoryInterface::class, self::class));
         }
 


### PR DESCRIPTION
This fixes a bug introduced by the removal of "private" keyword in 3.1.15 here: https://github.com/api-platform/core/compare/v3.1.14...v3.1.15#diff-865ce957323cd00c97d744721bce982a833cc16edba4d141f0d841277295a02eL41-L48