### PR TITLE
Update ItemNormalizer decorator for ElasticSearch

### DIFF
--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -111,7 +111,7 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
             ];
         }
 
-        return DocumentNormalizer::FORMAT === $format ? $this->decorated->getSupportedTypes($format) : [];
+        return DocumentNormalizer::FORMAT !== $format ? $this->decorated->getSupportedTypes($format) : [];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| License       | MIT

Fixing a bug where the ElasticSearch decoration of the ItermNormalizer is returning back a wrong value for the `getSupportedTypes` method.  With the current code, and using the "json" format instead of the "ld+json", the ItemNormalizer will not be called properly when using the ElasticSearch layer on top of API Platform.