### PR TITLE
perf: reset local cache to prevent memory leak if long running http server is used

### DIFF
--- a/src/Api/CachedIdentifiersExtractor.php
+++ b/src/Api/CachedIdentifiersExtractor.php
@@ -18,13 +18,14 @@ use Psr\Cache\CacheException;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * {@inheritdoc}
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-final class CachedIdentifiersExtractor implements IdentifiersExtractorInterface
+final class CachedIdentifiersExtractor implements IdentifiersExtractorInterface, ResetInterface
 {
     use ResourceClassInfoTrait;
 
@@ -103,6 +104,16 @@ final class CachedIdentifiersExtractor implements IdentifiersExtractorInterface
         }
 
         return $identifiers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        unset($this->localCache, $this->localResourceCache);
+        $this->localCache = [];
+        $this->localResourceCache = [];
     }
 
     private function getKeys($item, callable $retriever): array

--- a/src/Bridge/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
+++ b/src/Bridge/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException;
 use ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata;
 use Psr\Cache\CacheException;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches document metadata.
@@ -25,7 +26,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
-final class CachedDocumentMetadataFactory implements DocumentMetadataFactoryInterface
+final class CachedDocumentMetadataFactory implements DocumentMetadataFactoryInterface, ResetInterface
 {
     private const CACHE_KEY_PREFIX = 'index_metadata';
 
@@ -37,6 +38,15 @@ final class CachedDocumentMetadataFactory implements DocumentMetadataFactoryInte
     {
         $this->cacheItemPool = $cacheItemPool;
         $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        unset($this->localCache);
+        $this->localCache = [];
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/api.xml
@@ -27,6 +27,7 @@
         <service id="api_platform.route_name_resolver.cached" class="ApiPlatform\Core\Bridge\Symfony\Routing\CachedRouteNameResolver" decorates="api_platform.route_name_resolver" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.route_name_resolver" />
             <argument type="service" id="api_platform.route_name_resolver.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="api_platform.route_loader" class="ApiPlatform\Core\Bridge\Symfony\Routing\ApiLoader" public="false">
@@ -267,6 +268,7 @@
             <argument type="service" id="api_platform.identifiers_extractor.cached.inner" />
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="api_platform.resource_class_resolver" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
         <service id="ApiPlatform\Core\Api\IdentifiersExtractorInterface" alias="api_platform.identifiers_extractor.cached" />
 
@@ -297,6 +299,7 @@
         <service id="api_platform.subresource_operation_factory.cached" class="ApiPlatform\Core\Operation\Factory\CachedSubresourceOperationFactory" decorates="api_platform.subresource_operation_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.subresource_operation_factory" />
             <argument type="service" id="api_platform.subresource_operation_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <!-- Cache -->

--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -37,6 +37,7 @@
         <service id="api_platform.elasticsearch.metadata.document.metadata_factory.cached" class="ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\CachedDocumentMetadataFactory" decorates="api_platform.elasticsearch.metadata.document.metadata_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.elasticsearch.cache.metadata.document" />
             <argument type="service" id="api_platform.elasticsearch.metadata.document.metadata_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="api_platform.elasticsearch.identifier_extractor" class="ApiPlatform\Core\Bridge\Elasticsearch\Api\IdentifierExtractor" public="false">

--- a/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/metadata/metadata.xml
@@ -10,6 +10,7 @@
         <service id="api_platform.metadata.resource.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceNameCollectionFactory" decorates="api_platform.metadata.resource.name_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.resource" />
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
         <service id="ApiPlatform\Core\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface" alias="api_platform.metadata.resource.name_collection_factory" />
 
@@ -36,6 +37,7 @@
         <service id="api_platform.metadata.resource.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Resource\Factory\CachedResourceMetadataFactory" decorates="api_platform.metadata.resource.metadata_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.resource" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface" alias="api_platform.metadata.resource.metadata_factory" />
@@ -52,6 +54,7 @@
         <service id="api_platform.metadata.property.name_collection_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.property" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <!-- Property metadata -->
@@ -72,6 +75,7 @@
         <service id="api_platform.metadata.property.metadata_factory.cached" class="ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.property" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="api_platform.metadata.property.metadata_factory.default_property" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="30" class="ApiPlatform\Core\Metadata\Property\Factory\DefaultPropertyMetadataFactory" public="false">

--- a/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
+++ b/src/Bridge/Symfony/Routing/CachedRouteNameResolver.php
@@ -15,13 +15,14 @@ namespace ApiPlatform\Core\Bridge\Symfony\Routing;
 
 use ApiPlatform\Core\Cache\CachedTrait;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * {@inheritdoc}
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedRouteNameResolver implements RouteNameResolverInterface
+final class CachedRouteNameResolver implements RouteNameResolverInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Cache/CachedTrait.php
+++ b/src/Cache/CachedTrait.php
@@ -25,6 +25,12 @@ trait CachedTrait
     private $cacheItemPool;
     private $localCache = [];
 
+    public function reset()
+    {
+        unset($this->localCache);
+        $this->localCache = [];
+    }
+
     private function getCached(string $cacheKey, callable $getValue)
     {
         if (\array_key_exists($cacheKey, $this->localCache)) {

--- a/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Core\Metadata\Property\Factory;
 use ApiPlatform\Core\Cache\CachedTrait;
 use ApiPlatform\Core\Metadata\Property\PropertyMetadata;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches property metadata.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInterface
+final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Core\Metadata\Property\Factory;
 use ApiPlatform\Core\Cache\CachedTrait;
 use ApiPlatform\Core\Metadata\Property\PropertyNameCollection;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches property name collection.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedPropertyNameCollectionFactory implements PropertyNameCollectionFactoryInterface
+final class CachedPropertyNameCollectionFactory implements PropertyNameCollectionFactoryInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Metadata/Resource/Factory/CachedResourceMetadataFactory.php
+++ b/src/Metadata/Resource/Factory/CachedResourceMetadataFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Core\Metadata\Resource\Factory;
 use ApiPlatform\Core\Cache\CachedTrait;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches resource metadata.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedResourceMetadataFactory implements ResourceMetadataFactoryInterface
+final class CachedResourceMetadataFactory implements ResourceMetadataFactoryInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Core\Metadata\Resource\Factory;
 use ApiPlatform\Core\Cache\CachedTrait;
 use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches resource name collection.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
+final class CachedResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Operation/Factory/CachedSubresourceOperationFactory.php
+++ b/src/Operation/Factory/CachedSubresourceOperationFactory.php
@@ -15,11 +15,12 @@ namespace ApiPlatform\Core\Operation\Factory;
 
 use ApiPlatform\Core\Cache\CachedTrait;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @internal
  */
-final class CachedSubresourceOperationFactory implements SubresourceOperationFactoryInterface
+final class CachedSubresourceOperationFactory implements SubresourceOperationFactoryInterface, ResetInterface
 {
     use CachedTrait;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

Recently started using a RoadRunner as a web server and noticed a small memory leak. 
Once started digging, found out that api-platform has several services where array attributes are used as a cache storages. Unfortunately they are never cleared between requests, resulting to not freeing memory.
With this PR I have implemented symfony's services resetter interface, which is called after each handled request, to clear up these arrays.
Targeting main branch as it looks like a new feature although I;m not sure.. Let me know how such change should be prepared and I will correct my PR