### PR TITLE
perf: reset local cache to prevent memory leak if long running http server is used

### DIFF
--- a/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyMetadataFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Metadata\Property\Factory;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Util\CachedTrait;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches property metadata.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInterface
+final class CachedPropertyMetadataFactory implements PropertyMetadataFactoryInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Metadata\Property\Factory;
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Metadata\Util\CachedTrait;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches property name collection.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedPropertyNameCollectionFactory implements PropertyNameCollectionFactoryInterface
+final class CachedPropertyNameCollectionFactory implements PropertyNameCollectionFactoryInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Metadata/Resource/Factory/CachedResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/CachedResourceMetadataCollectionFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Metadata\Resource\Factory;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use Psr\Cache\CacheException;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches resource metadata.
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-final class CachedResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+final class CachedResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface, ResetInterface
 {
     public const CACHE_KEY_PREFIX = 'resource_metadata_collection_';
     private array $localCache = [];
@@ -62,5 +63,13 @@ final class CachedResourceMetadataCollectionFactory implements ResourceMetadataC
         $this->cacheItemPool->save($cacheItem);
 
         return $resourceMetadataCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(): void
+    {
+        $this->localCache = [];
     }
 }

--- a/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/CachedResourceNameCollectionFactory.php
@@ -16,13 +16,14 @@ namespace ApiPlatform\Metadata\Resource\Factory;
 use ApiPlatform\Metadata\Resource\ResourceNameCollection;
 use ApiPlatform\Metadata\Util\CachedTrait;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Caches resource name collection.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class CachedResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
+final class CachedResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface, ResetInterface
 {
     use CachedTrait;
 

--- a/src/Metadata/Util/CachedTrait.php
+++ b/src/Metadata/Util/CachedTrait.php
@@ -24,6 +24,11 @@ trait CachedTrait
     private CacheItemPoolInterface $cacheItemPool;
     private array $localCache = [];
 
+    public function reset(): void
+    {
+        $this->localCache = [];
+    }
+
     private function getCached(string $cacheKey, callable $getValue): mixed
     {
         if (\array_key_exists($cacheKey, $this->localCache)) {

--- a/src/Symfony/Bundle/Resources/config/metadata/property.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/property.xml
@@ -26,6 +26,7 @@
         <service id="api_platform.metadata.property.metadata_factory.cached" class="ApiPlatform\Metadata\Property\Factory\CachedPropertyMetadataFactory" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.property" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="api_platform.metadata.property.metadata_factory.default_property" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="30" class="ApiPlatform\Metadata\Property\Factory\DefaultPropertyMetadataFactory" public="false">

--- a/src/Symfony/Bundle/Resources/config/metadata/property_name.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/property_name.xml
@@ -17,6 +17,7 @@
         <service id="api_platform.metadata.property.name_collection_factory.cached" class="ApiPlatform\Metadata\Property\Factory\CachedPropertyNameCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.property" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="api_platform.metadata.property.name_collection_factory.xml" class="ApiPlatform\Metadata\Property\Factory\ExtractorPropertyNameCollectionFactory" decorates="api_platform.metadata.property.name_collection_factory" public="false">

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -71,6 +71,7 @@
         <service id="api_platform.metadata.resource.metadata_collection_factory.cached" class="ApiPlatform\Metadata\Resource\Factory\CachedResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.resource_collection" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="api_platform.cache.metadata.resource_collection" parent="cache.system" public="false">

--- a/src/Symfony/Bundle/Resources/config/metadata/resource_name.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource_name.xml
@@ -14,6 +14,7 @@
         <service id="api_platform.metadata.resource.name_collection_factory.cached" class="ApiPlatform\Metadata\Resource\Factory\CachedResourceNameCollectionFactory" decorates="api_platform.metadata.resource.name_collection_factory" decoration-priority="-10" public="false">
             <argument type="service" id="api_platform.cache.metadata.resource" />
             <argument type="service" id="api_platform.metadata.resource.name_collection_factory.cached.inner" />
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <!-- XML is the default -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

Recently started using a RoadRunner as a web server and noticed a small memory leak. 
Once started digging, found out that api-platform has several services where array attributes are used as a cache storages. Unfortunately they are never cleared between requests, resulting to not freeing memory.
With this PR I have implemented symfony's services resetter interface, which is called after each handled request, to clear up these arrays.
Targeting main branch as it looks like a new feature although I;m not sure.. Let me know how such change should be prepared and I will correct my PR

P.S. already opened a similar PR in symfony repository: https://github.com/symfony/symfony/pull/51528