### PR TITLE
fix(doctrine): fix BC break about final filters

### DIFF
--- a/src/Doctrine/Odm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Odm/Filter/BooleanFilter.php
@@ -30,8 +30,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @final
  */
-final class BooleanFilter extends AbstractFilter
+class BooleanFilter extends AbstractFilter
 {
     use BooleanFilterTrait;
 

--- a/src/Doctrine/Odm/Filter/DateFilter.php
+++ b/src/Doctrine/Odm/Filter/DateFilter.php
@@ -26,8 +26,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @final
  */
-final class DateFilter extends AbstractFilter implements DateFilterInterface
+class DateFilter extends AbstractFilter implements DateFilterInterface
 {
     use DateFilterTrait;
 

--- a/src/Doctrine/Odm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Odm/Filter/ExistsFilter.php
@@ -34,8 +34,10 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @final
  */
-final class ExistsFilter extends AbstractFilter implements ExistsFilterInterface
+class ExistsFilter extends AbstractFilter implements ExistsFilterInterface
 {
     use ExistsFilterTrait;
 

--- a/src/Doctrine/Odm/Filter/NumericFilter.php
+++ b/src/Doctrine/Odm/Filter/NumericFilter.php
@@ -29,8 +29,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @final
  */
-final class NumericFilter extends AbstractFilter
+class NumericFilter extends AbstractFilter
 {
     use NumericFilterTrait;
 

--- a/src/Doctrine/Odm/Filter/OrderFilter.php
+++ b/src/Doctrine/Odm/Filter/OrderFilter.php
@@ -34,8 +34,10 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @final
  */
-final class OrderFilter extends AbstractFilter implements OrderFilterInterface
+class OrderFilter extends AbstractFilter implements OrderFilterInterface
 {
     use OrderFilterTrait;
 

--- a/src/Doctrine/Odm/Filter/RangeFilter.php
+++ b/src/Doctrine/Odm/Filter/RangeFilter.php
@@ -23,8 +23,10 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @final
  */
-final class RangeFilter extends AbstractFilter implements RangeFilterInterface
+class RangeFilter extends AbstractFilter implements RangeFilterInterface
 {
     use RangeFilterTrait;
 

--- a/src/Doctrine/Odm/Filter/SearchFilter.php
+++ b/src/Doctrine/Odm/Filter/SearchFilter.php
@@ -34,8 +34,10 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @final
  */
-final class SearchFilter extends AbstractFilter implements SearchFilterInterface
+class SearchFilter extends AbstractFilter implements SearchFilterInterface
 {
     use SearchFilterTrait;
 

--- a/src/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Orm/Filter/BooleanFilter.php
@@ -31,8 +31,10 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @final
  */
-final class BooleanFilter extends AbstractFilter
+class BooleanFilter extends AbstractFilter
 {
     use BooleanFilterTrait;
 

--- a/src/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Doctrine/Orm/Filter/DateFilter.php
@@ -28,8 +28,10 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class DateFilter extends AbstractFilter implements DateFilterInterface
+class DateFilter extends AbstractFilter implements DateFilterInterface
 {
     use DateFilterTrait;
 

--- a/src/Doctrine/Orm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Orm/Filter/ExistsFilter.php
@@ -36,8 +36,10 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * Interpretation: filter products which have a brand
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @final
  */
-final class ExistsFilter extends AbstractFilter implements ExistsFilterInterface
+class ExistsFilter extends AbstractFilter implements ExistsFilterInterface
 {
     use ExistsFilterTrait;
 

--- a/src/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Doctrine/Orm/Filter/NumericFilter.php
@@ -30,8 +30,10 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @final
  */
-final class NumericFilter extends AbstractFilter
+class NumericFilter extends AbstractFilter
 {
     use NumericFilterTrait;
 

--- a/src/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Doctrine/Orm/Filter/OrderFilter.php
@@ -35,8 +35,10 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class OrderFilter extends AbstractFilter implements OrderFilterInterface
+class OrderFilter extends AbstractFilter implements OrderFilterInterface
 {
     use OrderFilterTrait;
 

--- a/src/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Doctrine/Orm/Filter/RangeFilter.php
@@ -24,8 +24,10 @@ use Doctrine\ORM\QueryBuilder;
  * Filters the collection by range.
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
+ *
+ * @final
  */
-final class RangeFilter extends AbstractFilter implements RangeFilterInterface
+class RangeFilter extends AbstractFilter implements RangeFilterInterface
 {
     use RangeFilterTrait;
 

--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -33,8 +33,10 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * Filter the collection by given properties.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final
  */
-final class SearchFilter extends AbstractFilter implements SearchFilterInterface
+class SearchFilter extends AbstractFilter implements SearchFilterInterface
 {
     use SearchFilterTrait;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

### Description

Doctrine filters weren't final in 2.6 but were moved to `final` in 2.7, which is a BC break. This blocks developers to update to 2.7 in case they're extending API Platform Doctrine filters.

If developers cannot update to 2.7, they can't migrate to 3.x.

### Solution

Mark those filters as `@final` in 2.7.

**Note: there is no need to backport this fix on 3.0 as those filters are already `final`.**