### PR TITLE
fix: profiler can not serialize closure

### DIFF
--- a/src/Symfony/Bundle/Resources/config/legacy/events.xml
+++ b/src/Symfony/Bundle/Resources/config/legacy/events.xml
@@ -61,7 +61,7 @@
             <argument type="service" id="api_platform.serializer" />
             <argument>%api_platform.error_formats%</argument>
             <argument>%api_platform.exception_to_status%</argument>
-            <argument type="service" id="api_platform.listener.exception" />
+            <argument type="service" id="api_platform.listener.exception" on-invalid="null" />
 
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>

--- a/src/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -24,7 +24,9 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Handles validation errors.
- * todo remove this class.
+ * TODO: remove this class.
+ *
+ * @deprecated
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -39,9 +41,8 @@ final class ValidationExceptionListener
      */
     public function onKernelException(ExceptionEvent $event): void
     {
+        // API Platform 3.2 handles every exception through the exception listener so we just skip this one
         if ($this->exceptionListener) {
-            $this->exceptionListener->onKernelException($event);
-
             return;
         }
 


### PR DESCRIPTION
When an exception occurs the profiler can not serialize a closure. We're using a static function instead.  