### PR TITLE
[HTTP] Add canonical_uri_template

### DIFF
--- a/src/Symfony/Bundle/Resources/config/state.xml
+++ b/src/Symfony/Bundle/Resources/config/state.xml
@@ -37,6 +37,7 @@
         <service id="api_platform.state_processor.respond" class="ApiPlatform\State\Processor\RespondProcessor">
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.metadata.operation.metadata_factory" />
         </service>
         <service id="api_platform.state_processor.main" alias="api_platform.state_processor.respond" />
 

--- a/tests/State/RespondProcessorTest.php
+++ b/tests/State/RespondProcessorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\State;
+
+use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
+use ApiPlatform\State\Processor\RespondProcessor;
+use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Employee;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RespondProcessorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testRedirectToOperation(): void
+    {
+        $canonicalUriTemplateRedirectingOperation = new Get(
+            status: 302,
+            extraProperties: [
+                'canonical_uri_template' => '/canonical',
+            ]
+        );
+
+        $alternateRedirectingResourceOperation = new Get(
+            status: 308,
+            extraProperties: [
+                'is_alternate_resource_metadata' => true,
+            ]
+        );
+
+        $alternateResourceOperation = new Get(
+            extraProperties: [
+                'is_alternate_resource_metadata' => true,
+            ]
+        );
+
+        $operationMetadataFactory = $this->prophesize(OperationMetadataFactoryInterface::class);
+        $operationMetadataFactory
+            ->create('/canonical', Argument::type('array'))
+            ->shouldBeCalledOnce()
+            ->willReturn(new Get(uriTemplate: '/canonical'));
+
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver
+            ->isResourceClass(Employee::class)
+            ->willReturn(true);
+
+        $iriConverter = $this->prophesize(IriConverterInterface::class);
+        $iriConverter
+            ->getIriFromResource(Argument::cetera())
+            ->will(static function (array $args): ?string {
+                return ($args[2] ?? null)?->getUriTemplate() ?? '/default';
+            });
+
+        /** @var ProcessorInterface<Response> $respondProcessor */
+        $respondProcessor = new RespondProcessor($iriConverter->reveal(), $resourceClassResolver->reveal(), $operationMetadataFactory->reveal());
+
+        $response = $respondProcessor->process('content', $canonicalUriTemplateRedirectingOperation, context: [
+            'request' => new Request(),
+            'original_data' => new Employee(),
+        ]);
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/canonical', $response->headers->get('Location'));
+
+        $response = $respondProcessor->process('content', $alternateRedirectingResourceOperation, context: [
+            'request' => new Request(),
+            'original_data' => new Employee(),
+        ]);
+
+        $this->assertSame(308, $response->getStatusCode());
+        $this->assertSame('/default', $response->headers->get('Location'));
+
+        $response = $respondProcessor->process('content', $alternateResourceOperation, context: [
+            'request' => new Request(),
+            'original_data' => new Employee(),
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertNull($response->headers->get('Location'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | TODO


Add `canonical_uri_template` extra property to be able to specify the URI template of the canonical resource.
Plus, widen the allowed status code for the alternate redirect to 3xx.