### PR TITLE
fix: fix Mercure assertions to public to allow Mercure Hub reset

### DIFF
--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -24,6 +24,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlResolverPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -55,6 +56,7 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new GraphQlResolverPass());
         $container->addCompilerPass(new MetadataAwareNameConverterPass());
         $container->addCompilerPass(new TestClientPass());
+        $container->addCompilerPass(new TestMercureHubPass());
         $container->addCompilerPass(new AuthenticatorManagerPass());
     }
 }

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/TestMercureHubPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/TestMercureHubPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Mercure\Debug\TraceableHub;
+
+/**
+ * Decorate each Mercure Hub with TraceableHub for test purpose.
+ * Prevents enabling debug mode on tests for Mercure assertions.
+ */
+final class TestMercureHubPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        // Only enable this if class exists and "framework.test" is enabled
+        if (!class_exists(TraceableHub::class) || !$container->has('test.service_container')) {
+            return;
+        }
+
+        foreach ($container->findTaggedServiceIds('mercure.hub', true) as $serviceId => $attributes) {
+            $container->register("test.api_platform.mercure.hub.$serviceId", TraceableHub::class)
+                ->setDecoratedService($serviceId)
+                ->addArgument(new Reference("test.api_platform.mercure.hub.$serviceId.inner"))
+                ->addArgument(new Reference('debug.stopwatch'));
+        }
+    }
+}

--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -164,6 +164,26 @@ trait ApiTestAssertionsTrait
         static::assertSame($retry, $update->getRetry(), $message);
     }
 
+    public static function getMercureRegistry(): HubRegistry
+    {
+        $container = static::getContainer();
+        if ($container->has(HubRegistry::class)) {
+            return $container->get(HubRegistry::class);
+        }
+
+        static::fail('A client must have Mercure enabled to make update assertions. Did you forget to require symfony/mercure?');
+    }
+
+    public static function getMercureHub(string $name = null): TraceableHub
+    {
+        $hub = self::getMercureRegistry()->getHub($name);
+        if (!$hub instanceof TraceableHub) {
+            static::fail('You must enabled the profiler to make Mercure update assertions.');
+        }
+
+        return $hub;
+    }
+
     private static function getHttpClient(Client $newClient = null): ?Client
     {
         static $client;
@@ -213,25 +233,5 @@ trait ApiTestAssertionsTrait
         }
 
         return $resourceMetadataFactoryCollection;
-    }
-
-    private static function getMercureRegistry(): HubRegistry
-    {
-        $container = static::getContainer();
-        if ($container->has(HubRegistry::class)) {
-            return $container->get(HubRegistry::class);
-        }
-
-        static::fail('A client must have Mercure enabled to make update assertions. Did you forget to require symfony/mercure?');
-    }
-
-    private static function getMercureHub(string $name = null): TraceableHub
-    {
-        $hub = self::getMercureRegistry()->getHub($name);
-        if (!$hub instanceof TraceableHub) {
-            static::fail('You must enabled the profiler to make Mercure update assertions.');
-        }
-
-        return $hub;
     }
 }

--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -178,7 +178,7 @@ trait ApiTestAssertionsTrait
     {
         $hub = self::getMercureRegistry()->getHub($name);
         if (!$hub instanceof TraceableHub) {
-            static::fail('You must enabled the profiler to make Mercure update assertions.');
+            static::fail('You must enable "framework.test" to make Mercure update assertions.');
         }
 
         return $hub;

--- a/tests/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -25,6 +25,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlResolverPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -51,6 +52,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(GraphQlResolverPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(MetadataAwareNameConverterPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(TestClientPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(TestMercureHubPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(AuthenticatorManagerPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
 
         $bundle = new ApiPlatformBundle();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | N/A
| License       | MIT
| Doc PR        | **TODO**

Creating fixtures on functional tests may send Mercure Update objects. Before executing the test calls, the developer should be able to reset the Mercure Hub:

```php
public function testAsAdminUserICanUpdateABook(): void
{
    FooFactory::createOne();
    self::getMercureHub()->reset();    // <== this line resets the Mercure Hub

    $this->client->request(...);
    self::assertCount(1, self::getMercureMessages());
}
```

- [x] fix Mercure assertions to public to allow Mercure Hub reset
- [x] decorate Mercure Hub for test performance