### PR TITLE
docs(subresource): Parser is losing the closing structure on new line

### DIFF
--- a/docs/guides/subresource.php
+++ b/docs/guides/subresource.php
@@ -90,8 +90,7 @@ namespace DoctrineMigrations {
         public function up(Schema $schema): void
         {
             $this->addSql('CREATE TABLE company (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(255) NOT NULL);');
-            $this->addSql('CREATE TABLE employee (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, company_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, CONSTRAINT FK_COMPANY FOREIGN KEY (company_id) REFERENCES company (id) NOT DEFERRABLE INITIALLY IMMEDIATE);
-');
+            $this->addSql('CREATE TABLE employee (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, company_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, CONSTRAINT FK_COMPANY FOREIGN KEY (company_id) REFERENCES company (id) NOT DEFERRABLE INITIALLY IMMEDIATE);');
             $this->addSql('CREATE INDEX FK_COMPANY ON employee (company_id)');
         }
     }


### PR DESCRIPTION
First of all, thanks @soyuka for your amazing work with the wasm integration and the new guide :heart_eyes: 

It seems that the parser is losing the closing of the string. I guess it's because on a new line, so I hope this will fix it !

![image](https://github.com/api-platform/core/assets/2320425/a3478489-8c96-4b2b-adb9-5565f4a079cc)
