### PR TITLE
feat(symfony): add `getOperation` Expression Language function on Mercure topics

### DIFF
--- a/features/mercure/publish.feature
+++ b/features/mercure/publish.feature
@@ -31,3 +31,30 @@ Feature: Mercure publish support
         "name": "Hello World!"
     }
     """
+
+  Scenario: Checks that Mercure Updates are dispatched following topics configured with expression language
+    Given I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    When I send a "POST" request to "/mercure_with_topics_and_get_operations" with body:
+    """
+    {
+      "name": "Hello World!"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    Then 1 Mercure update should have been sent
+    And the Mercure update should have topics:
+      | http://example.com/mercure_with_topics_and_get_operations/1                 |
+      | http://example.com/custom_resource/mercure_with_topics_and_get_operations/1 |
+    And the Mercure update should have data:
+    """
+    {
+        "@context": "/contexts/MercureWithTopicsAndGetOperation",
+        "@id": "/mercure_with_topics_and_get_operations/1",
+        "@type": "MercureWithTopicsAndGetOperation",
+        "id": 1,
+        "name": "Hello World!"
+    }
+    """

--- a/src/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -22,6 +22,7 @@ use ApiPlatform\GraphQl\Subscription\MercureSubscriptionIriGeneratorInterface as
 use ApiPlatform\GraphQl\Subscription\SubscriptionManagerInterface as GraphQlSubscriptionManagerInterface;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\IriConverterInterface;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
@@ -84,7 +85,10 @@ final class PublishMercureUpdatesListener
             $this->expressionLanguage->addFunction($rawurlencode);
 
             $this->expressionLanguage->addFunction(
-                new ExpressionFunction('iri', static fn (string $apiResource, int $referenceType = UrlGeneratorInterface::ABS_URL): string => sprintf('iri(%s, %d)', $apiResource, $referenceType), static fn (array $arguments, $apiResource, int $referenceType = UrlGeneratorInterface::ABS_URL): string => $iriConverter->getIriFromResource($apiResource, $referenceType))
+                new ExpressionFunction('getOperation', static fn (string $apiResource, string $name): string => sprintf('getOperation(%s, %s)', $apiResource, $name), static fn (array $arguments, $apiResource, string $name): Operation => $resourceMetadataFactory->create($resourceClassResolver->getResourceClass($apiResource))->getOperation($name))
+            );
+            $this->expressionLanguage->addFunction(
+                new ExpressionFunction('iri', static fn (string $apiResource, int $referenceType = UrlGeneratorInterface::ABS_URL, ?string $operation = null): string => sprintf('iri(%s, %d, %s)', $apiResource, $referenceType, $operation), static fn (array $arguments, $apiResource, int $referenceType = UrlGeneratorInterface::ABS_URL, $operation = null): string => $iriConverter->getIriFromResource($apiResource, $referenceType, $operation))
             );
         }
 

--- a/tests/Fixtures/TestBundle/Document/MercureWithTopicsAndGetOperation.php
+++ b/tests/Fixtures/TestBundle/Document/MercureWithTopicsAndGetOperation.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource(
+    operations: [
+        new Get(uriTemplate: '/mercure_with_topics_and_get_operations/{id}{._format}'),
+        new Post(uriTemplate: '/mercure_with_topics_and_get_operations{._format}'),
+        new Get(uriTemplate: '/custom_resource/mercure_with_topics_and_get_operations/{id}{._format}'),
+    ],
+    mercure: [
+        'topics' => [
+            '@=iri(object)',
+            '@=iri(object, '.UrlGeneratorInterface::ABS_URL.', getOperation(object, "/custom_resource/mercure_with_topics_and_get_operations/{id}{._format}"))',
+        ],
+    ]
+)]
+#[ODM\Document]
+class MercureWithTopicsAndGetOperation
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    public $id;
+    #[ODM\Field(type: 'string')]
+    public $name;
+}

--- a/tests/Fixtures/TestBundle/Entity/MercureWithTopicsAndGetOperation.php
+++ b/tests/Fixtures/TestBundle/Entity/MercureWithTopicsAndGetOperation.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(
+    operations: [
+        new Get(uriTemplate: '/mercure_with_topics_and_get_operations/{id}{._format}'),
+        new Post(uriTemplate: '/mercure_with_topics_and_get_operations{._format}'),
+        new Get(uriTemplate: '/custom_resource/mercure_with_topics_and_get_operations/{id}{._format}'),
+    ],
+    mercure: [
+        'topics' => [
+            '@=iri(object)',
+            '@=iri(object, '.UrlGeneratorInterface::ABS_URL.', getOperation(object, "/custom_resource/mercure_with_topics_and_get_operations/{id}{._format}"))',
+        ],
+    ]
+)]
+#[ORM\Entity]
+class MercureWithTopicsAndGetOperation
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public $id;
+    #[ORM\Column]
+    public $name;
+}

--- a/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -245,8 +245,7 @@ JSON;
      */
     public function testGetMercureMessages(): void
     {
-        // debug mode is required to get Mercure TraceableHub
-        $this->recreateSchema(['debug' => true, 'environment' => 'mercure']);
+        $this->recreateSchema(['environment' => 'mercure']);
 
         self::createClient()->request('POST', '/direct_mercures', [
             'headers' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | N/A
| License       | MIT
| Doc PR        | **TODO**

### Description

When using Mercure on a resource, it's possible to specify multiple topics using Symfony Expression Language:
```php
#[ApiResource(
    mercure: [
        'topics' => [
            '@=iri(object)',
            '@=iri(object.getOwner()) ~ "/?topic=" ~ escape(iri(object))',
            '@=iri(object, '.UrlGeneratorInterface::ABS_PATH.')', // you can also change the reference type
            'https://example.com/books/1',
        ],
    ],
)]
```
(source: https://api-platform.com/docs/core/mercure/#dispatching-restrictive-updates-security-mode)

But the `iri` Expression Language function does not allow to send the second argument of [IriConverter::getIriFromResource](https://github.com/api-platform/core/blob/main/src/Metadata/IriConverterInterface.php) (`$operation`), which will just retrieve the first `Get` operation detected on the resource. While using multiple operations, it should be possible to specify which operation to use to generate the IRI.

### Proposition

Considering the following resource with multiple operations:
```php
#[ApiResource(
    operations: [
        new Get(uriTemplate: '/foos/{id}{._format}'),
        new Get(uriTemplate: '/foos/bars/{id}{._format}'),
        new Post(uriTemplate: '/foos{._format}'),
    ]
)]
```

On `POST /foos` request, I want to send a Mercure Update to both `Get` operations identified by their _uriTemplate_.

Introducing `getOperation` Expression Language function (currently only) available on Mercure `topics` feature:
```php
#[ApiResource(
    // ...
    mercure: [
        'topics' => [
            '@=iri(object)',
            '@=iri(object, '.UrlGeneratorInterface::ABS_URL.', getOperation(object, "/foos/bars/{id}{._format}"))'
        ],
    ]
)]
```

> Note: the `object` variable is required as `getOperation` first argument to retrieve the resource class. It's also possible to refer to a class name directly (e.g.: using DTO):
```
'@=iri(object, '.UrlGeneratorInterface::ABS_URL.', getOperation('.OutputDto::class.', "/a/custom/dtos/{id}{._format}"))'
```