### PR TITLE
fix(serializer): allow usage of genId property for collection

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -665,6 +665,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if ($type && 'array' === $type->getBuiltinType()) {
             $childContext = $this->createChildContext($context, $attribute, $format);
+            $childContext['output']['gen_id'] = $propertyMetadata->getGenId() ?? true;
 
             return $this->serializer->normalize($attributeValue, $format, $childContext);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Closes #5745
| License       | MIT

Allow usage of `#[ApiProperty(genId: false)` on collection. Currently the property is ignored resulting in unwanted skolem identifiers generation.
