### PR TITLE
fix(openapi): dump security properties scheme as object

### DIFF
--- a/tests/Fixtures/TestBundle/Entity/Issue5625/Currency.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue5625/Currency.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5625;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\OpenApi\Model\Operation;
+
+/**
+ * Currency.
+ */
+#[ApiResource(operations: [
+    new Get(uriTemplate: '/get_security_1', openapi: new Operation(security: [['JWT' => ['CURRENCY_READ']]])),
+])]
+class Currency
+{
+    public $id;
+    public $name;
+}

--- a/tests/Symfony/Bundle/Command/OpenApiCommandTest.php
+++ b/tests/Symfony/Bundle/Command/OpenApiCommandTest.php
@@ -41,7 +41,6 @@ class OpenApiCommandTest extends KernelTestCase
         $application = new Application(static::$kernel);
         $application->setCatchExceptions(false);
         $application->setAutoExit(false);
-
         $this->tester = new ApplicationTester($application);
 
         $this->handleDeprecations();
@@ -59,6 +58,7 @@ class OpenApiCommandTest extends KernelTestCase
         $this->tester->run(['command' => 'api:openapi:export', '--yaml' => true]);
 
         $result = $this->tester->getDisplay();
+
         $this->assertYaml($result);
         $operationId = 'api_dummy_cars_get_collection';
 
@@ -95,6 +95,14 @@ YAML;
   version: 0.0.0
 YAML;
 
+        $this->assertStringContainsString(str_replace(\PHP_EOL, "\n", $expected), $result);
+
+        $expected = <<<YAML
+      security:
+        -
+          JWT:
+            - CURRENCY_READ
+YAML;
         $this->assertStringContainsString(str_replace(\PHP_EOL, "\n", $expected), $result);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | #5625
| License       | MIT

Cf. https://swagger.io/docs/specification/authentication/#security