### PR TITLE
fix: only generate jsonld docs when docs disabled

### DIFF
--- a/src/Symfony/Bundle/Resources/config/routing/docs_jsonld.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/docs_jsonld.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="api_doc" path="/docs.jsonld">
+        <default key="_controller">api_platform.action.documentation</default>
+        <default key="_format">jsonld</default>
+        <default key="_api_respond">true</default>
+    </route>
+
+</routes>

--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -133,6 +133,8 @@ final class ApiLoader extends Loader
 
         if ($this->docsEnabled) {
             $routeCollection->addCollection($this->fileLoader->load('docs.xml'));
+        } else {
+            $routeCollection->addCollection($this->fileLoader->load('docs_jsonld.xml'));
         }
 
         if ($this->graphqlEnabled) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Closes #5528 
| License       | MIT

Only generate jsonld docs when docs disabled to avoid routing error when request to /contexts.