### PR TITLE
fix(serializer): Remove ItemNormalizer wrong return type

### DIFF
--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -84,7 +84,7 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array
+    public function normalize($object, $format = null, array $context = [])
     {
         return $this->decorated->normalize($object, $format, $context);
     }

--- a/tests/Elasticsearch/Serializer/ItemNormalizerTest.php
+++ b/tests/Elasticsearch/Serializer/ItemNormalizerTest.php
@@ -83,6 +83,13 @@ final class ItemNormalizerTest extends TestCase
         self::assertSame(['foo'], $this->itemNormalizer->normalize($object, 'json', ['groups' => 'foo']));
     }
 
+    public function testNormalizeToString(): void
+    {
+        $this->normalizerProphecy->normalize($object = (object) ['foo'], 'json', ['groups' => 'foo'])->willReturn('/foo/iri')->shouldBeCalledOnce();
+
+        self::assertSame('/foo/iri', $this->itemNormalizer->normalize($object, 'json', ['groups' => 'foo']));
+    }
+
     public function testSupportsNormalization(): void
     {
         $this->normalizerProphecy->supportsNormalization($object = (object) ['foo'], 'json')->willReturn(true)->shouldBeCalledOnce();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | #5620 
| License       | MIT

Hello,

I'm sorry I want to propose a fix for 2.7 🙈 , I found out `ApiPlatform\Elasticsearch\Serializer\ItemNormalizer` is defining an `array` return type, while the decorated service really doesn't return just array.

It is already fixed in 3.0 and 3.1, but I think it is still quite a big issue for 2.7 because this service was introduced as a decorator of `api_platform.serializer.normalizer.item` in https://github.com/api-platform/core/pull/3981 and the return type was added in https://github.com/api-platform/core/pull/4526 , so it basically kicks in everytime as soon as elastic is enabled (and BC flag is off), and then throws a type error when returning anything else than an array (e.g. an iri).