### PR TITLE
feat: add webhook - openapi

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -70,6 +70,7 @@ Feature: Documentation support
     And the OpenAPI class "UuidIdentifierDummy" exists
     And the OpenAPI class "ThirdLevel" exists
     And the OpenAPI class "DummyCar" exists
+    And the OpenAPI class "DummyWebhook" exists
     And the OpenAPI class "ParentDummy" doesn't exist
     And the OpenAPI class "UnknownDummy" doesn't exist
     And the OpenAPI path "/relation_embedders/{id}/custom" exists
@@ -114,6 +115,10 @@ Feature: Documentation support
 
     And the JSON node "paths./dummy_cars.get.parameters[8].name" should be equal to "foobar[]"
     And the JSON node "paths./dummy_cars.get.parameters[8].description" should be equal to "Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: foobar[]={propertyName}&foobar[]={anotherPropertyName}&foobar[{nestedPropertyParent}][]={nestedProperty}"
+
+    # Webhook
+    And the JSON node "webhooks.webhook[0].get.description" should be equal to "Something else here for example"
+    And the JSON node "webhooks.webhook[1].post.description" should be equal to "Hi! it's me, I'm the problem, it's me"
 
     # Subcollection - check filter on subResource
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[0].name" should be equal to "id"

--- a/src/Metadata/Delete.php
+++ b/src/Metadata/Delete.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -44,7 +45,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?array $paginationViaCursor = null,
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = null,
+        bool|OpenApiOperation|Webhook|null $openapi = null,
         ?array $exceptionToStatus = null,
         ?bool $queryParameterValidationEnabled = null,
         ?array $links = null,

--- a/src/Metadata/Error.php
+++ b/src/Metadata/Error.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -44,7 +45,7 @@ final class Error extends HttpOperation
         ?array $paginationViaCursor = null,
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = null,
+        bool|OpenApiOperation|Webhook|null $openapi = null,
         ?array $exceptionToStatus = null,
         ?bool $queryParameterValidationEnabled = null,
         ?array $links = null,

--- a/src/Metadata/Get.php
+++ b/src/Metadata/Get.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -44,7 +45,7 @@ final class Get extends HttpOperation
         ?array $paginationViaCursor = null,
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = null,
+        bool|OpenApiOperation|Webhook|null $openapi = null,
         ?array $exceptionToStatus = null,
         ?bool $queryParameterValidationEnabled = null,
         ?array $links = null,

--- a/src/Metadata/GetCollection.php
+++ b/src/Metadata/GetCollection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -44,7 +45,7 @@ final class GetCollection extends HttpOperation implements CollectionOperationIn
         ?array $paginationViaCursor = null,
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = null,
+        bool|OpenApiOperation|Webhook|null $openapi = null,
         ?array $exceptionToStatus = null,
         ?bool $queryParameterValidationEnabled = null,
         ?array $links = null,

--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 use Symfony\Component\WebLink\Link as WebLink;
@@ -150,7 +151,7 @@ class HttpOperation extends Operation
         protected ?array $paginationViaCursor = null,
         protected ?array $hydraContext = null,
         protected ?array $openapiContext = null, // TODO Remove in 4.0
-        protected bool|OpenApiOperation|null $openapi = null,
+        protected bool|OpenApiOperation|Webhook|null $openapi = null,
         protected ?array $exceptionToStatus = null,
         protected ?bool $queryParameterValidationEnabled = null,
         protected ?array $links = null,
@@ -578,12 +579,12 @@ class HttpOperation extends Operation
         return $self;
     }
 
-    public function getOpenapi(): bool|OpenApiOperation|null
+    public function getOpenapi(): bool|OpenApiOperation|Webhook|null
     {
         return $this->openapi;
     }
 
-    public function withOpenapi(bool|OpenApiOperation $openapi): self
+    public function withOpenapi(bool|OpenApiOperation|Webhook $openapi): self
     {
         $self = clone $this;
         $self->openapi = $openapi;

--- a/src/Metadata/NotExposed.php
+++ b/src/Metadata/NotExposed.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -56,7 +57,7 @@ final class NotExposed extends HttpOperation
 
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = false,
+        bool|OpenApiOperation|Webhook|null $openapi = false,
         ?array $exceptionToStatus = null,
 
         ?bool $queryParameterValidationEnabled = null,

--- a/src/Metadata/Patch.php
+++ b/src/Metadata/Patch.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -44,7 +45,7 @@ final class Patch extends HttpOperation
         ?array $paginationViaCursor = null,
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = null,
+        bool|OpenApiOperation|Webhook|null $openapi = null,
         ?array $exceptionToStatus = null,
         ?bool $queryParameterValidationEnabled = null,
         ?array $links = null,

--- a/src/Metadata/Post.php
+++ b/src/Metadata/Post.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -44,7 +45,7 @@ final class Post extends HttpOperation
         ?array $paginationViaCursor = null,
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = null,
+        bool|OpenApiOperation|Webhook|null $openapi = null,
         ?array $exceptionToStatus = null,
         ?bool $queryParameterValidationEnabled = null,
         ?array $links = null,

--- a/src/Metadata/Put.php
+++ b/src/Metadata/Put.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+use ApiPlatform\OpenApi\Attributes\Webhook;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\State\OptionsInterface;
 
@@ -44,7 +45,7 @@ final class Put extends HttpOperation
         ?array $paginationViaCursor = null,
         ?array $hydraContext = null,
         ?array $openapiContext = null,
-        bool|OpenApiOperation|null $openapi = null,
+        bool|OpenApiOperation|Webhook|null $openapi = null,
         ?array $exceptionToStatus = null,
         ?bool $queryParameterValidationEnabled = null,
         ?array $links = null,

--- a/src/OpenApi/Attributes/Webhook.php
+++ b/src/OpenApi/Attributes/Webhook.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\OpenApi\Attributes;
+
+use ApiPlatform\OpenApi\Model\PathItem;
+
+class Webhook
+{
+    public function __construct(
+        protected string $name,
+        protected ?PathItem $pathItem = null,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function withName(string $name): self
+    {
+        $self = clone $this;
+        $self->name = $name;
+
+        return $self;
+    }
+
+    public function getPathItem(): ?PathItem
+    {
+        return $this->pathItem;
+    }
+
+    public function withPathItem(PathItem $pathItem): self
+    {
+        $self = clone $this;
+        $self->pathItem = $pathItem;
+
+        return $self;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyWebhook.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyWebhook.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Attributes\Webhook;
+use ApiPlatform\OpenApi\Model\Operation;
+use ApiPlatform\OpenApi\Model\PathItem;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(operations: [new Get(openapi: new Webhook(
+    name: 'webhook',
+    pathItem: new PathItem(
+        get: new Operation(
+            summary: 'Something else here',
+            description: 'Something else here for example',
+        ),
+    )
+)), new Post(openapi: new Webhook(
+    name: 'webhook',
+    pathItem: new PathItem(
+        post: new Operation(
+            summary: 'Something else here',
+            description: 'Hi! it\'s me, I\'m the problem, it\'s me',
+        ),
+    )
+)),
+])]
+#[ORM\Entity]
+class DummyWebhook
+{
+    /**
+     * @var int|null The id
+     */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private $id;
+
+}

--- a/tests/Fixtures/TestBundle/Entity/DummyWebhook.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyWebhook.php
@@ -49,5 +49,4 @@ class DummyWebhook
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     private $id;
-
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | 


Possible to configure a webhook via an attribute:

`
#[ApiResource(operations: [

    new Post(openapi: new Webhook(name: 'a cute name')
    )),
    new Get(openapi: new Webhook(
        name: 'a cute name',
        pathItem: new PathItem(
            get: new Operation(
                summary: 'Something else here',
                description: 'Something else here for example',
            ),
        )
    )),
]
)]`
and generate documentation