### PR TITLE
fix: error traces without arguments

### DIFF
--- a/src/ApiResource/Error.php
+++ b/src/ApiResource/Error.php
@@ -61,26 +61,33 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
         private readonly string $title,
         private readonly string $detail,
         #[ApiProperty(identifier: true)] private int $status,
-        private readonly array $originalTrace,
+        array $originalTrace = null,
         private ?string $instance = null,
         private string $type = 'about:blank',
         private array $headers = []
     ) {
         parent::__construct();
+
+        if (!$originalTrace) {
+            return;
+        }
+
+        $this->originalTrace = [];
+        foreach ($originalTrace as $i => $t) {
+            unset($t['args']); // we don't want arguments in our JSON traces, especially with xdebug
+            $this->originalTrace[$i] = $t;
+        }
     }
+
+    #[SerializedName('trace')]
+    #[Groups(['trace'])]
+    public ?array $originalTrace = null;
 
     #[SerializedName('hydra:title')]
     #[Groups(['jsonld', 'legacy_jsonld'])]
     public function getHydraTitle(): string
     {
         return $this->title;
-    }
-
-    #[SerializedName('trace')]
-    #[Groups(['trace'])]
-    public function getOriginalTrace(): array
-    {
-        return $this->originalTrace;
     }
 
     #[SerializedName('hydra:description')]

--- a/src/Symfony/EventListener/ErrorListener.php
+++ b/src/Symfony/EventListener/ErrorListener.php
@@ -67,7 +67,13 @@ final class ErrorListener extends SymfonyErrorListener
     protected function duplicateRequest(\Throwable $exception, Request $request): Request
     {
         $dup = parent::duplicateRequest($exception, $request);
+
         $apiOperation = $this->initializeOperation($request);
+
+        if ($this->debug) {
+            $this->logger?->error('An exception occured, transforming to an Error resource.', ['exception' => $exception, 'operation' => $apiOperation]);
+        }
+
         $format = $this->getRequestFormat($request, $this->errorFormats, false);
 
         if ($this->resourceMetadataCollectionFactory) {


### PR DESCRIPTION
When using xdebug, traces may have arguments, that themselves would go through our normalizers. This isn't needed so we prevent it from happening inside our resources.
I also added a log entry in debug mode to warn that API Platform sends an HTTP Exception.

fixes #5845