### PR TITLE
 fix(jsonschema): restore type factory usage 

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,7 +26,7 @@ parameters:
 		- src/Symfony/Bundle/DependencyInjection/Configuration.php
 		# Templates for Maker
 		- src/Symfony/Maker/Resources/skeleton
-		- src/*/vendor
+		- **vendor**
 	earlyTerminatingMethodCalls:
 		PHPUnit\Framework\Constraint\Constraint:
 			- fail

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -23,6 +23,8 @@ use Symfony\Component\Uid\Uuid;
 /**
  * {@inheritdoc}
  *
+ * @deprecated since 3.3 https://github.com/api-platform/core/pull/5470
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 final class TypeFactory implements TypeFactoryInterface
@@ -46,6 +48,11 @@ final class TypeFactory implements TypeFactoryInterface
      */
     public function getType(Type $type, string $format = 'json', bool $readableLink = null, array $serializerContext = null, Schema $schema = null): array
     {
+        if ('jsonschema' === $format) {
+            return [];
+        }
+
+        // TODO: OpenApiFactory uses this to compute filter types
         if ($type->isCollection()) {
             $keyType = $type->getCollectionKeyTypes()[0] ?? null;
             $subType = ($type->getCollectionValueTypes()[0] ?? null) ?? new Type($type->getBuiltinType(), false, $type->getClassName(), false);

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -573,7 +573,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             }
 
             foreach ($filter->getDescription($entityClass) as $name => $data) {
-                $schema = $data['schema'] ?? (\in_array($data['type'], Type::$builtinTypes, true) ? $this->jsonSchemaTypeFactory->getType(new Type($data['type'], false, null, $data['is_collection'] ?? false)) : ['type' => 'string']);
+                $schema = $data['schema'] ?? (\in_array($data['type'], Type::$builtinTypes, true) ? $this->jsonSchemaTypeFactory->getType(new Type($data['type'], false, null, $data['is_collection'] ?? false), 'openapi') : ['type' => 'string']);
 
                 $parameters[] = new Parameter(
                     $name,

--- a/src/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Symfony/Bundle/Resources/config/json_schema.xml
@@ -16,7 +16,7 @@
         <service id="ApiPlatform\JsonSchema\TypeFactoryInterface" alias="api_platform.json_schema.type_factory" />
 
         <service id="api_platform.json_schema.schema_factory" class="ApiPlatform\JsonSchema\SchemaFactory">
-            <argument>null</argument>
+            <argument type="service" id="api_platform.json_schema.type_factory" on-invalid="ignore"></argument>
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />

--- a/tests/Fixtures/TestBundle/ApiResource/Issue5896/Foo.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue5896/Foo.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5896;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+
+#[Get]
+class Foo
+{
+    #[ApiProperty(readable: false, writable: false, identifier: true)]
+    public ?int $id = null;
+    public ?LocalDate $expiration;
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue5896/LocalDate.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue5896/LocalDate.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5896;
+
+class LocalDate
+{
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue5896/TypeFactoryDecorator.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue5896/TypeFactoryDecorator.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5896;
+
+use ApiPlatform\JsonSchema\Schema;
+use ApiPlatform\JsonSchema\TypeFactoryInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class TypeFactoryDecorator implements TypeFactoryInterface
+{
+    public function __construct(
+        private readonly TypeFactoryInterface $decorated,
+    ) {
+    }
+
+    public function getType(Type $type, string $format = 'json', bool $readableLink = null, array $serializerContext = null, Schema $schema = null): array
+    {
+        if (is_a($type->getClassName(), LocalDate::class, true)) {
+            return [
+                'type' => 'string',
+                'format' => 'date',
+            ];
+        }
+
+        return $this->decorated->getType($type, $format, $readableLink, $serializerContext, $schema);
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -457,3 +457,8 @@ services:
     ApiPlatform\Tests\Fixtures\TestBundle\State\ODMLinkHandledDummyLinksHandler:
         tags:
             - {name: 'api_platform.doctrine.odm.links_handler'}
+
+    ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5896\TypeFactoryDecorator:
+      decorates: 'api_platform.json_schema.type_factory'
+      arguments:
+        $decorated: '@.inner'

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -124,4 +124,18 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
             '$ref' => '#/definitions/TestEntity.jsonld-write',
         ]);
     }
+
+    /**
+     * TODO: add deprecation (TypeFactory will be deprecated in api platform 3.3).
+     *
+     * @group legacy
+     */
+    public function testArraySchemaWithTypeFactory(): void
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5896\Foo', '--type' => 'output']);
+        $result = $this->tester->getDisplay();
+        $json = json_decode($result, associative: true);
+
+        $this->assertEquals($json['definitions']['Foo.jsonld']['properties']['expiration'], ['type' => 'string', 'format' => 'date']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | fixes #5896
| License       | MIT

We wrongly assumed in #5470 that the TypeFactory would be `@internal` which it is not. We moved the logic related to type computation to our Schema PropertyMetadataFactory so that the schema could get cached. 

This patch restores the TypeFactory behavior.

I think that we should postpone the deprecation of the TypeFactory to 3.3 and provide a way to configure this on non-resources (see #5896) for example:

```php
#[JsonSchema(['type' => 'string', 'format' => 'date'])
class LocalDate {}
```

Overriding the property metadata factory is also an option but requires more code user land.
