### PR TITLE
[typo] fix misnamed, so unused, variable in UriVariablesResolverTrait

### DIFF
--- a/src/State/UriVariablesResolverTrait.php
+++ b/src/State/UriVariablesResolverTrait.php
@@ -52,14 +52,14 @@ trait UriVariablesResolverTrait
 
                 foreach ($currentIdentifiers as $key => $value) {
                     $identifiers[$key] = $value;
-                    $uriVariableMap[$key] = $uriVariableDefinition;
+                    $uriVariablesMap[$key] = $uriVariableDefinition;
                 }
 
                 continue;
             }
 
             $identifiers[$parameterName] = $parameters[$parameterName];
-            $uriVariableMap[$parameterName] = $uriVariableDefinition;
+            $uriVariablesMap[$parameterName] = $uriVariableDefinition;
         }
 
         if ($this->uriVariablesConverter) {


### PR DESCRIPTION
I suspect this has no impact since everywhere using $context['uri_variables_map'] falls back on $operation->getUriVariables() anyway.

| Q             | A
| ------------- | ---
| Branch?       | 3.1 (or 3.0 if still getting bugfixes) <!-- see below -->
| Tickets       | New issue <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
