### PR TITLE
feat(Serializer): update MissingConstructorArgumentsException message

### DIFF
--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -155,7 +155,7 @@ Feature: Value object as ApiResource
           "pattern": "^An error occurred$"
         },
         "hydra:description": {
-          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires parameter \"drivers\" to be present.$"
+          "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\\$drivers\".$"
         }
       },
       "required": [

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -295,6 +295,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $constructorParameters = $constructor->getParameters();
 
             $params = [];
+            $missingConstructorArguments = [];
             foreach ($constructorParameters as $constructorParameter) {
                 $paramName = $constructorParameter->name;
                 $key = $this->nameConverter ? $this->nameConverter->normalize($paramName, $class, $format, $context) : $paramName;
@@ -329,12 +330,16 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                     $params[] = $constructorParameter->getDefaultValue();
                 } else {
                     if (!isset($context['not_normalizable_value_exceptions'])) {
-                        throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires parameter "%s" to be present.', $class, $constructorParameter->name), 0, null, [$constructorParameter->name]);
+                        $missingConstructorArguments[] = $constructorParameter->name;
                     }
 
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(sprintf('Failed to create object because the class misses the "%s" property.', $constructorParameter->name), $data, ['unknown'], $context['deserialization_path'] ?? null, true);
                     $context['not_normalizable_value_exceptions'][] = $exception;
                 }
+            }
+
+            if ($missingConstructorArguments) {
+                throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires the following parameters to be present : "$%s".', $class, implode('", "$', $missingConstructorArguments)), 0, null, $missingConstructorArguments, $class);
             }
 
             if (\count($context['not_normalizable_value_exceptions'] ?? []) > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Accidentally have closed https://github.com/api-platform/core/pull/5649 PR
This is its copy.

Have found that if validation attributes are specified on DTOs or if the `Valid()` constraint is used on not api-resource property (just an entity in example) then Symfony's [AbstractNormalizer](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php) is used and it has a bit different `MissingConstructorArgumentsException` [exception message that also contains the list of missed arguments](https://github.com/symfony/symfony/blob/9b2ac59e8a373e983157f9a57de8ae951cc1a3ba/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php#L414).
But in ApiPlatform this exception has another [message and it contains only the first one of missed arguments in it](https://github.com/api-platform/core/blob/4ef0ef856ced658ac942fd6a2c6f7c5c563078d1/src/Serializer/AbstractItemNormalizer.php#L312).
This way someone, who relies on this message, in example, to convert it to something like validation error in the response, will get different messages.
So I want to suggest to make this message and its parameters consistent with Symfony's one.

The example of the new message:
```
Cannot create an instance of "App\Entity\Book" from serialized data because its constructor requires the following parameters to be present : "$author", "$name".
```