### PR TITLE
fix(doctrine): OrderFilter should use a left join on nullable fields

### DIFF
--- a/src/Doctrine/Odm/Extension/OrderExtension.php
+++ b/src/Doctrine/Odm/Extension/OrderExtension.php
@@ -64,7 +64,7 @@ final class OrderExtension implements AggregationCollectionExtensionInterface
                 }
 
                 if ($this->isPropertyNested($field, $resourceClass)) {
-                    [$field] = $this->addLookupsForNestedProperty($field, $aggregationBuilder, $resourceClass);
+                    [$field] = $this->addLookupsForNestedProperty($field, $aggregationBuilder, $resourceClass, true);
                 }
                 $aggregationBuilder->sort(
                     $context['mongodb_odm_sort_fields'] = ($context['mongodb_odm_sort_fields'] ?? []) + [$field => $order]

--- a/src/Doctrine/Odm/Filter/OrderFilter.php
+++ b/src/Doctrine/Odm/Filter/OrderFilter.php
@@ -253,7 +253,7 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface
         $matchField = $property;
 
         if ($this->isPropertyNested($property, $resourceClass)) {
-            [$matchField] = $this->addLookupsForNestedProperty($property, $aggregationBuilder, $resourceClass);
+            [$matchField] = $this->addLookupsForNestedProperty($property, $aggregationBuilder, $resourceClass, true);
         }
 
         $aggregationBuilder->sort(

--- a/src/Doctrine/Odm/PropertyHelperTrait.php
+++ b/src/Doctrine/Odm/PropertyHelperTrait.php
@@ -60,7 +60,7 @@ trait PropertyHelperTrait
      *               the second element is the $field name
      *               the third element is the $associations array
      */
-    protected function addLookupsForNestedProperty(string $property, Builder $aggregationBuilder, string $resourceClass): array
+    protected function addLookupsForNestedProperty(string $property, Builder $aggregationBuilder, string $resourceClass, bool $preserveNullAndEmptyArrays = false): array
     {
         $propertyParts = $this->splitPropertyParts($property, $resourceClass);
         $alias = '';
@@ -98,7 +98,8 @@ trait PropertyHelperTrait
                     ->localField($isOwningSide ? $localField : '_id')
                     ->foreignField($isOwningSide ? '_id' : $referenceMapping['mappedBy'])
                     ->alias($alias);
-                $aggregationBuilder->unwind("\$$alias");
+                $aggregationBuilder->unwind("\$$alias")
+                    ->preserveNullAndEmptyArrays($preserveNullAndEmptyArrays);
 
                 // association.property => association_lkup.property
                 $property = substr_replace($property, $propertyAlias, strpos($property, (string) $association), \strlen((string) $association));

--- a/tests/Doctrine/Common/Filter/OrderFilterTestTrait.php
+++ b/tests/Doctrine/Common/Filter/OrderFilterTestTrait.php
@@ -325,6 +325,14 @@ trait OrderFilterTestTrait
                     ],
                 ],
             ],
+            'nullable field in relation will be a LEFT JOIN' => [
+                [
+                    'relatedDummy.name' => null,
+                ],
+                [
+                    'order' => ['relatedDummy.name' => 'ASC'],
+                ],
+            ],
         ];
     }
 }

--- a/tests/Doctrine/Odm/Extension/OrderExtensionTest.php
+++ b/tests/Doctrine/Odm/Extension/OrderExtensionTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\Dummy;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Lookup;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Unwind;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
@@ -128,7 +129,9 @@ class OrderExtensionTest extends TestCase
         $lookupProphecy->foreignField('_id')->shouldBeCalled()->willReturn($lookupProphecy);
         $lookupProphecy->alias('author_lkup')->shouldBeCalled();
         $aggregationBuilderProphecy->lookup(Dummy::class)->shouldBeCalled()->willReturn($lookupProphecy->reveal());
-        $aggregationBuilderProphecy->unwind('$author_lkup')->shouldBeCalled();
+        $unwindProphecy = $this->prophesize(Unwind::class);
+        $unwindProphecy->preserveNullAndEmptyArrays(true)->shouldBeCalled();
+        $aggregationBuilderProphecy->unwind('$author_lkup')->shouldBeCalled()->willReturn($unwindProphecy->reveal());
         $aggregationBuilderProphecy->getStage(0)->willThrow(new \OutOfRangeException('message'));
         $aggregationBuilderProphecy->sort(['author_lkup.name' => 'ASC'])->shouldBeCalled();
 

--- a/tests/Doctrine/Odm/Filter/OrderFilterTest.php
+++ b/tests/Doctrine/Odm/Filter/OrderFilterTest.php
@@ -343,7 +343,10 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                         [
-                            '$unwind' => '$relatedDummy_lkup',
+                            '$unwind' => [
+                                'path' => '$relatedDummy_lkup',
+                                'preserveNullAndEmptyArrays' => true,
+                            ],
                         ],
                         [
                             '$sort' => [
@@ -514,7 +517,10 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                             ],
                         ],
                         [
-                            '$unwind' => '$relatedDummy_lkup',
+                            '$unwind' => [
+                                'path' => '$relatedDummy_lkup',
+                                'preserveNullAndEmptyArrays' => true,
+                            ],
                         ],
                         [
                             '$sort' => [
@@ -545,6 +551,30 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                     ],
                     $orderFilterFactory,
                     EmbeddedDummy::class,
+                ],
+                'nullable field in relation will be a LEFT JOIN' => [
+                    [
+                        [
+                            '$lookup' => [
+                                'from' => 'RelatedDummy',
+                                'localField' => 'relatedDummy',
+                                'foreignField' => '_id',
+                                'as' => 'relatedDummy_lkup',
+                            ],
+                        ],
+                        [
+                            '$unwind' => [
+                                'path' => '$relatedDummy_lkup',
+                                'preserveNullAndEmptyArrays' => true,
+                            ],
+                        ],
+                        [
+                            '$sort' => [
+                                'relatedDummy_lkup.name' => 1,
+                            ],
+                        ],
+                    ],
+                    $orderFilterFactory,
                 ],
             ]
         );

--- a/tests/Doctrine/Orm/Filter/OrderFilterTest.php
+++ b/tests/Doctrine/Orm/Filter/OrderFilterTest.php
@@ -414,6 +414,11 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                     $orderFilterFactory,
                     EmbeddedDummy::class,
                 ],
+                'nullable field in relation will be a LEFT JOIN' => [
+                    sprintf('SELECT o FROM %s o LEFT JOIN o.relatedDummy relatedDummy_a1 ORDER BY relatedDummy_a1.name ASC', Dummy::class),
+                    null,
+                    $orderFilterFactory,
+                ],
             ]
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | Closes #5877
| License       | MIT

Doctrine ODM OrderFilter omitted the relation, if used on a field which is null
