### PR TITLE
fix(graphql): item resolver inheritance error 

### DIFF
--- a/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
@@ -106,7 +106,7 @@ final class ItemResolverFactory implements ResolverFactoryInterface
             return $itemClass;
         }
 
-        if ($resourceClass !== $itemClass) {
+        if ($resourceClass !== $itemClass && !$item instanceof $resourceClass) {
             throw new \UnexpectedValueException(sprintf($errorMessage, (new \ReflectionClass($resourceClass))->getShortName(), (new \ReflectionClass($itemClass))->getShortName()));
         }
 

--- a/src/GraphQl/Tests/Fixtures/ApiResource/ChildFoo.php
+++ b/src/GraphQl/Tests/Fixtures/ApiResource/ChildFoo.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\GraphQl\Tests\Fixtures\ApiResource;
+
+class ChildFoo extends ParentFoo
+{
+}

--- a/src/GraphQl/Tests/Fixtures/ApiResource/ParentFoo.php
+++ b/src/GraphQl/Tests/Fixtures/ApiResource/ParentFoo.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\GraphQl\Tests\Fixtures\ApiResource;
+
+class ParentFoo
+{
+}

--- a/src/GraphQl/Tests/Resolver/Factory/ItemResolverFactoryTest.php
+++ b/src/GraphQl/Tests/Resolver/Factory/ItemResolverFactoryTest.php
@@ -18,7 +18,9 @@ use ApiPlatform\GraphQl\Resolver\Stage\ReadStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SecurityPostDenormalizeStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SecurityStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SerializeStageInterface;
+use ApiPlatform\GraphQl\Tests\Fixtures\ApiResource\ChildFoo;
 use ApiPlatform\GraphQl\Tests\Fixtures\ApiResource\Dummy;
+use ApiPlatform\GraphQl\Tests\Fixtures\ApiResource\ParentFoo;
 use ApiPlatform\Metadata\GraphQl\Query;
 use GraphQL\Type\Definition\ResolveInfo;
 use PHPUnit\Framework\TestCase;
@@ -242,6 +244,24 @@ class ItemResolverFactoryTest extends TestCase
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Custom query resolver "query_resolver_id" has to return an item of class stdClass but returned an item of class Dummy.');
+
+        ($this->itemResolverFactory)($resourceClass, $rootClass, $operation)($source, $args, null, $info);
+    }
+
+    public function testResolveInheritedClass(): void
+    {
+        $resourceClass = ParentFoo::class;
+        $rootClass = $resourceClass;
+        $operationName = 'custom_query';
+        $operation = (new Query())->withName($operationName);
+        $source = ['source'];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $info->fieldName = 'field';
+        $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => false, 'is_mutation' => false, 'is_subscription' => false];
+
+        $readStageItem = new ChildFoo();
+        $this->readStageProphecy->__invoke($resourceClass, $rootClass, $operation, $resolverContext)->shouldBeCalled()->willReturn($readStageItem);
 
         ($this->itemResolverFactory)($resourceClass, $rootClass, $operation)($source, $args, null, $info);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       |https://github.com/api-platform/core/issues/5750
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Please read https://github.com/api-platform/core/issues/5750 to understand and reproduce.

This is the exception I came across while performing a query:
![Screenshot 2023-08-15 144506](https://github.com/api-platform/core/assets/47795200/7cd5f5df-98f7-45af-abc2-59952f04c2c3)
