### PR TITLE
perf(http_cache): don't load every value for a non-resource collection

### DIFF
--- a/src/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -124,6 +124,11 @@ final class PurgeHttpCacheListener
     {
         $associationMappings = $em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
         foreach (array_keys($associationMappings) as $property) {
+            if (
+                \array_key_exists('targetEntity', $associationMappings[$property])
+                && !$this->resourceClassResolver->isResourceClass($associationMappings[$property]['targetEntity'])) {
+                return;
+            }
             if ($this->propertyAccessor->isReadable($entity, $property)) {
                 $this->addTagsFor($this->propertyAccessor->getValue($entity, $property));
             }

--- a/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -201,13 +201,16 @@ class PurgeHttpCacheListenerTest extends TestCase
         // @phpstan-ignore-next-line
         $dummyClassMetadata->associationMappings = [
             'notAResource' => [],
+            'collectionOfNotAResource' => ['targetEntity' => NotAResource::class],
         ];
         $emProphecy->getClassMetadata(ContainNonResource::class)->willReturn($dummyClassMetadata);
         $eventArgs = new OnFlushEventArgs($emProphecy->reveal());
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->isReadable(Argument::type(ContainNonResource::class), 'notAResource')->willReturn(true);
+        $propertyAccessorProphecy->isReadable(Argument::type(ContainNonResource::class), 'collectionOfNotAResource')->shouldNotBeCalled();
         $propertyAccessorProphecy->getValue(Argument::type(ContainNonResource::class), 'notAResource')->shouldBeCalled()->willReturn($nonResource);
+        $propertyAccessorProphecy->getValue(Argument::type(ContainNonResource::class), 'collectionOfNotAResource')->shouldNotBeCalled();
 
         $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal());
         $listener->onFlush($eventArgs);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1 <!-- see below -->
| Tickets       | -  <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        |  -  <!-- required for new features -->


**Description**
When a entity has relation to non-resource collection and is flushed, the `PurgeHttpCacheListener` loads each value and checks if it is a resource. This can be a problem with large collections over 10k, it can cause a out-of-memory exception. 

**Solution**
We can check whether the collection contains an entity that is a resource or not before loading each value by checking the class form `$associationMappings[$property]['targetEntity']`