### PR TITLE
ci: fix 2.7 behat tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,12 +252,12 @@ jobs:
           composer remove --dev --no-interaction --no-progress --no-update --ansi \
             doctrine/mongodb-odm \
             doctrine/mongodb-odm-bundle
-      - name: Update project dependencies
-        run: composer update --no-interaction --no-progress --ansi
       # https://github.com/doctrine/dbal/issues/5570
       - name: Fix Doctrine dependencies
         if: (startsWith(matrix.php, '7.1') || startsWith(matrix.php, '7.2') || startsWith(matrix.php, '7.3'))
         run: composer require "doctrine/orm:<2.13" -W --dev --no-interaction --no-progress --ansi
+      - name: Update project dependencies
+        run: composer update --no-interaction --no-progress --ansi
       - name: Require Symfony components
         if: (!startsWith(matrix.php, '7.1'))
         run: composer require symfony/uid --dev --no-interaction --no-progress --ansi

--- a/features/hal/max_depth.feature
+++ b/features/hal/max_depth.feature
@@ -19,79 +19,33 @@ Feature: Max depth handling
     Then the response status code should be 201
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/hal+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "_links": {
-        "self": {
-          "href": "/max_depth_eager_dummies/1"
-        },
-        "child": {
-          "href": "/max_depth_eager_dummies/2"
-        }
-      },
-      "_embedded": {
-        "child": {
-          "_links": {
-            "self": {
-              "href": "/max_depth_eager_dummies/2"
-            }
-          },
-          "id": 2,
-          "name": "level 2"
-        }
-      },
-      "id": 1,
-      "name": "level 1"
-    }
-    """
+    Then the JSON node "_embedded" should exist
+    Then the JSON node "_embedded.child" should exist
+    Then the JSON node "_embedded.child._embedded" should not exist
 
-  Scenario: Add a 2nd level of descendants
+  Scenario: Create a resource with 2 levels of descendants
     When I add "Accept" header equal to "application/hal+json"
     And I add "Content-Type" header equal to "application/json"
-    And I send a "PUT" request to "max_depth_eager_dummies/1" with body:
+    And I send a "POST" request to "/max_depth_eager_dummies" with body:
     """
     {
-      "id": "/max_depth_eager_dummies/1",
+      "name": "level 1",
       "child": {
-        "id": "/max_depth_eager_dummies/2",
+        "name": "level 2",
         "child": {
           "name": "level 3"
         }
       }
     }
     """
-    And the response status code should be 200
+    And the response status code should be 201
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/hal+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "_links": {
-        "self": {
-          "href": "/max_depth_eager_dummies/1"
-        },
-        "child": {
-          "href": "/max_depth_eager_dummies/2"
-        }
-      },
-      "_embedded": {
-        "child": {
-          "_links": {
-            "self": {
-              "href": "/max_depth_eager_dummies/2"
-            }
-          },
-          "id": 2,
-          "name": "level 2"
-        }
-      },
-      "id": 1,
-      "name": "level 1"
-    }
-    """
+    Then the JSON node "_embedded" should exist
+    Then the JSON node "_embedded.child" should exist
+    Then the JSON node "_embedded.child._embedded" should not exist
 
-  Scenario: Add a 2nd level of descendants when eager fetching is disabled
+  Scenario: Create a resource with 1 levels of descendants then add a 2nd level of descendants when eager fetching is disabled
     Given there is a max depth dummy with 1 level of descendants
     When I add "Accept" header equal to "application/hal+json"
     And I add "Content-Type" header equal to "application/json"
@@ -110,29 +64,6 @@ Feature: Max depth handling
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/hal+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "_links": {
-        "self": {
-          "href": "/max_depth_dummies/1"
-        },
-        "child": {
-          "href": "/max_depth_dummies/2"
-        }
-      },
-      "_embedded": {
-        "child": {
-          "_links": {
-            "self": {
-              "href": "/max_depth_dummies/2"
-            }
-          },
-          "id": 2,
-          "name": "level 2"
-        }
-      },
-      "id": 1,
-      "name": "level 1"
-    }
-    """
+    Then the JSON node "_embedded" should exist
+    Then the JSON node "_embedded.child" should exist
+    Then the JSON node "_embedded.child._embedded" should not exist

--- a/features/jsonld/max_depth.feature
+++ b/features/jsonld/max_depth.feature
@@ -18,54 +18,26 @@ Feature: Max depth handling
     Then the response status code should be 201
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/MaxDepthEagerDummy",
-      "@id": "/max_depth_eager_dummies/1",
-      "@type": "MaxDepthEagerDummy",
-      "id": 1,
-      "name": "level 1",
-      "child": {
-        "@id": "/max_depth_eager_dummies/2",
-        "@type": "MaxDepthEagerDummy",
-        "id": 2,
-        "name": "level 2"
-      }
-    }
-    """
+    Then the JSON node "child" should exist
+    Then the JSON node "child.name" should be equal to "level 2"
 
   Scenario: Add a 2nd level of descendants
     When I add "Content-Type" header equal to "application/ld+json"
-    And I send a "PUT" request to "max_depth_eager_dummies/1" with body:
+    And I send a "POST" request to "/max_depth_eager_dummies" with body:
     """
     {
-      "@id": "/max_depth_eager_dummies/1",
+      "name": "level 1",
       "child": {
-        "@id": "/max_depth_eager_dummies/2",
+        "name": "level 2",
         "child": {
           "name": "level 3"
         }
       }
     }
     """
-    And the response status code should be 200
+    And the response status code should be 201
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the JSON should be equal to:
-    """
-    {
-      "@context": "/contexts/MaxDepthEagerDummy",
-      "@id": "/max_depth_eager_dummies/1",
-      "@type": "MaxDepthEagerDummy",
-      "id": 1,
-      "name": "level 1",
-      "child": {
-        "@id": "/max_depth_eager_dummies/2",
-        "@type": "MaxDepthEagerDummy",
-        "id": 2,
-        "name": "level 2"
-      }
-    }
-    """
-
+    Then the JSON node "child" should exist
+    Then the JSON node "child.name" should be equal to "level 2"
+    Then the JSON node "child.child" should not exist

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -31,7 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(graphql={"item_query", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
+ * @ApiResource(graphql={"item_query", "collection_query", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
  *
  * @ORM\Entity
  *

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -31,7 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(graphql={"item_query", "collection_query", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
+ * @ApiResource(graphql={"item_query", "collection_query", "create", "update_subscription", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
  *
  * @ORM\Entity
  *

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -31,7 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(graphql={"item_query", "collection_query", "create", "update_subscription", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
+ * @ApiResource(graphql={"item_query", "collection_query", "create", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}}, mercure=true)
  *
  * @ORM\Entity
  *

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -31,7 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @ApiResource(graphql={"item_query", "collection_query", "create", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}}, mercure=true)
+ * @ApiResource(graphql={"item_query", "collection_query", "create", "update"={"normalization_context"={"groups"={"chicago", "fakemanytomany"}}, "denormalization_context"={"groups"={"friends"}}}}, iri="https://schema.org/Product", attributes={"normalization_context"={"groups"={"friends"}}, "filters"={"related_dummy.friends", "related_dummy.complex_sub_query"}})
  *
  * @ORM\Entity
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | none
| License       | MIT

# Reasons for changes :
## Composer
Use the same composer dependencies changes in behat and phpunit
## HAL
Don't rely on insertion https://github.com/api-platform/core/pull/5709
## JsonLD
Don't rely on insertion https://github.com/api-platform/core/pull/5709
## GraphQL
Add some missing operations


# Need help
## Mercure 

The Mercure update sent is made with json+ld instead of simple json so it fails to match format.
features/graphql/subscription.feature:187
```
"{"@context":"\/contexts\/DummyMercure","@id":"\/dummy_mercures\/1","@type":"DummyMercure","id":1,"name":"Dummy Mercure #1 updated","description":"Description","relatedDummy":"\/related_dummies\/1"}"
"{"dummyMercure":{"id":1,"name":"Dummy Mercure #1 updated","relatedDummy":{"name":"RelatedDummy #1"}}}"
```

## Subresource
features/main/subresource.feature:476
On PHP 8.*, value of `offers` and `relatedProducts` keys from DummyProduct are empty.

features/main/subresource.feature:401
On PHP 8.*, hydra:member is empty instead of containing a DummyOffer