### PR TITLE
GraphQL: Support Enum collections

### DIFF
--- a/features/graphql/mutation.feature
+++ b/features/graphql/mutation.feature
@@ -505,6 +505,31 @@ Feature: GraphQL mutation support
     And the JSON node "data.createPerson.person.name" should be equal to "Mob"
     And the JSON node "data.createPerson.person.genderType" should be equal to "FEMALE"
 
+  @!mongodb
+  Scenario: Create an item with an enum collection
+    When I send the following GraphQL request:
+    """
+    mutation {
+      createPerson(input: {name: "Harry", academicGrades: [BACHELOR, MASTER]}) {
+        person {
+          id
+          name
+          genderType
+          academicGrades
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "data.createPerson.person.id" should be equal to "/people/2"
+    And the JSON node "data.createPerson.person.name" should be equal to "Harry"
+    And the JSON node "data.createPerson.person.genderType" should be equal to "MALE"
+    And the JSON node "data.createPerson.person.academicGrades" should have 2 elements
+    And the JSON node "data.createPerson.person.academicGrades[0]" should be equal to "BACHELOR"
+    And the JSON node "data.createPerson.person.academicGrades[1]" should be equal to "MASTER"
+
   Scenario: Create an item with an enum as a resource
     When I send the following GraphQL request:
     """

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -46,6 +46,10 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
                 return null;
             }
 
+            if (is_a($resourceClass, \BackedEnum::class, true) && $source && \array_key_exists($info->fieldName, $source)) {
+                return $source[$info->fieldName];
+            }
+
             $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
             $collection = ($this->readStage)($resourceClass, $rootClass, $operation, $resolverContext);

--- a/src/GraphQl/Tests/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/src/GraphQl/Tests/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\GraphQl\Resolver\Stage\ReadStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SecurityPostDenormalizeStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SecurityStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SerializeStageInterface;
+use ApiPlatform\GraphQl\Tests\Fixtures\Enum\GenderTypeEnum;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use GraphQL\Type\Definition\ResolveInfo;
 use PHPUnit\Framework\TestCase;
@@ -91,6 +92,20 @@ class CollectionResolverFactoryTest extends TestCase
         $this->serializeStageProphecy->__invoke($readStageCollection, $resourceClass, $operation, $resolverContext)->shouldBeCalled()->willReturn($serializeStageData);
 
         $this->assertSame($serializeStageData, ($this->collectionResolverFactory)($resourceClass, $rootClass, $operation)($source, $args, null, $info));
+    }
+
+    public function testResolveEnumFieldFromSource(): void
+    {
+        $resourceClass = GenderTypeEnum::class;
+        $rootClass = 'rootClass';
+        $operationName = 'collection_query';
+        $operation = (new QueryCollection())->withName($operationName);
+        $source = ['genders' => [GenderTypeEnum::MALE, GenderTypeEnum::FEMALE]];
+        $args = ['args'];
+        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $info->fieldName = 'genders';
+
+        $this->assertSame([GenderTypeEnum::MALE, GenderTypeEnum::FEMALE], ($this->collectionResolverFactory)($resourceClass, $rootClass, $operation)($source, $args, null, $info));
     }
 
     public function testResolveFieldNotInSource(): void

--- a/src/GraphQl/Tests/Type/TypeBuilderTest.php
+++ b/src/GraphQl/Tests/Type/TypeBuilderTest.php
@@ -568,15 +568,15 @@ class TypeBuilderTest extends TestCase
     {
         $enumClass = GamePlayMode::class;
         $enumName = 'GamePlayMode';
-        $enumDescription = 'GamePlayModeEnum description';
+        $enumDescription = 'GamePlayMode description';
         /** @var Operation $operation */
         $operation = (new Operation())
             ->withClass($enumClass)
             ->withShortName($enumName)
-            ->withDescription('GamePlayModeEnum description');
+            ->withDescription('GamePlayMode description');
 
-        $this->typesContainerProphecy->has('GamePlayModeEnum')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('GamePlayModeEnum', Argument::type(EnumType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('GamePlayMode')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('GamePlayMode', Argument::type(EnumType::class))->shouldBeCalled();
         $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
         $enumValues = [
             GamePlayMode::CO_OP->name => ['value' => GamePlayMode::CO_OP->value],
@@ -587,7 +587,7 @@ class TypeBuilderTest extends TestCase
         $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->willReturn($fieldsBuilderProphecy->reveal());
 
         self::assertEquals(new EnumType([
-            'name' => 'GamePlayModeEnum',
+            'name' => 'GamePlayMode',
             'description' => $enumDescription,
             'values' => $enumValues,
         ]), $this->typeBuilder->getEnumType($operation));

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -243,6 +243,11 @@ final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumIn
         return $fields;
     }
 
+    private function isEnumClass(string $resourceClass): bool
+    {
+        return is_a($resourceClass, \BackedEnum::class, true);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -331,7 +336,7 @@ final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumIn
             $args = [];
 
             if (!$input && !$rootOperation instanceof Mutation && !$rootOperation instanceof Subscription && !$isStandardGraphqlType && $isCollectionType) {
-                if ($this->pagination->isGraphQlEnabled($resourceOperation)) {
+                if (!$this->isEnumClass($resourceClass) && $this->pagination->isGraphQlEnabled($resourceOperation)) {
                     $args = $this->getGraphQlPaginationArgs($resourceOperation);
                 }
 
@@ -544,7 +549,7 @@ final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumIn
         }
 
         if ($this->typeBuilder->isCollection($type)) {
-            if (!$input && $this->pagination->isGraphQlEnabled($resourceOperation)) {
+            if (!$input && !$this->isEnumClass($resourceClass) && $this->pagination->isGraphQlEnabled($resourceOperation)) {
                 // Deprecated path, to remove in API Platform 4.
                 if ($this->typeBuilder instanceof TypeBuilderInterface) {
                     return $this->typeBuilder->getResourcePaginatedCollectionType($graphqlType, $resourceClass, $resourceOperation);

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -245,9 +245,6 @@ final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterfac
     public function getEnumType(Operation $operation): GraphQLType
     {
         $enumName = $operation->getShortName();
-        if (!str_ends_with($enumName, 'Enum')) {
-            $enumName = sprintf('%sEnum', $enumName);
-        }
 
         if ($this->typesContainer->has($enumName)) {
             return $this->typesContainer->get($enumName);

--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -70,28 +70,7 @@ final class TypeConverter implements TypeConverterInterface
                     return GraphQLType::string();
                 }
 
-                $resourceType = $this->getResourceType($type, $input, $rootOperation, $rootResource, $property, $depth);
-
-                if (!$resourceType && is_a($type->getClassName(), \BackedEnum::class, true)) {
-                    // Remove the condition in API Platform 4.
-                    if ($this->typeBuilder instanceof TypeBuilderEnumInterface) {
-                        $operation = null;
-                        try {
-                            $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($type->getClassName());
-                            $operation = $resourceMetadataCollection->getOperation();
-                        } catch (ResourceClassNotFoundException|OperationNotFoundException) {
-                        }
-                        /** @var Query $enumOperation */
-                        $enumOperation = (new Query())
-                            ->withClass($type->getClassName())
-                            ->withShortName($operation?->getShortName() ?? (new \ReflectionClass($type->getClassName()))->getShortName())
-                            ->withDescription($operation?->getDescription());
-
-                        return $this->typeBuilder->getEnumType($enumOperation);
-                    }
-                }
-
-                return $resourceType;
+                return $this->getResourceType($type, $input, $rootOperation, $rootResource, $property, $depth);
             default:
                 return null;
         }
@@ -149,6 +128,25 @@ final class TypeConverter implements TypeConverterInterface
         }
 
         if (!$hasGraphQl) {
+            if (is_a($resourceClass, \BackedEnum::class, true)) {
+                // Remove the condition in API Platform 4.
+                if ($this->typeBuilder instanceof TypeBuilderEnumInterface) {
+                    $operation = null;
+                    try {
+                        $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
+                        $operation = $resourceMetadataCollection->getOperation();
+                    } catch (ResourceClassNotFoundException|OperationNotFoundException) {
+                    }
+                    /** @var Query $enumOperation */
+                    $enumOperation = (new Query())
+                        ->withClass($resourceClass)
+                        ->withShortName($operation?->getShortName() ?? (new \ReflectionClass($resourceClass))->getShortName())
+                        ->withDescription($operation?->getDescription());
+
+                    return $this->typeBuilder->getEnumType($enumOperation);
+                }
+            }
+
             return null;
         }
 

--- a/tests/Fixtures/TestBundle/Entity/Person.php
+++ b/tests/Fixtures/TestBundle/Entity/Person.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\AcademicGrade;
 use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -41,6 +42,11 @@ class Person
     #[ORM\Column(type: 'string')]
     #[Groups(['people.pets'])]
     public string $name;
+
+    /** @var array<AcademicGrade> */
+    #[ORM\Column(nullable: true)]
+    #[Groups(['people.pets'])]
+    public array $academicGrades = [];
 
     #[ORM\OneToMany(targetEntity: PersonToPet::class, mappedBy: 'person')]
     #[Groups(['people.pets'])]

--- a/tests/Fixtures/TestBundle/Enum/AcademicGrade.php
+++ b/tests/Fixtures/TestBundle/Enum/AcademicGrade.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Enum;
+
+/**
+ * An enumeration of academic grades.
+ */
+enum AcademicGrade: string
+{
+    case BACHELOR = 'BACHELOR';
+
+    case MASTER = 'MASTER';
+
+    case DOCTOR = 'DOCTOR';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

We have a resource with an array property. The content of this array are enum values. This information can be provided with a doc block. Unfortunatelly on the GraphQL API this was visible as an `iterable`. With the changes in this PR it will be a proper "array of enum", same like i.e. "array of string".

The Behat tests should give you an insight into the details.