### PR TITLE
fix(openapi): api_entrypoint should use "docs_formats" config

### DIFF
--- a/features/hydra/docs.feature
+++ b/features/hydra/docs.feature
@@ -4,6 +4,7 @@ Feature: Documentation support
   I need to know Hydra specifications of objects I send and receive
 
   Scenario: Checks that the Link pointing to the Hydra documentation is set
+    When I add "Accept" header equal to "application/ld+json"
     Given I send a "GET" request to "/"
     Then the header "Link" should be equal to '<http://example.com/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
 

--- a/features/mercure/discover.feature
+++ b/features/mercure/discover.feature
@@ -9,5 +9,6 @@ Feature: Mercure discovery support
     Then the header "Link" should contain '<https://demo.mercure.rocks>; rel="mercure"'
 
   Scenario: Checks that the Mercure Link is not added on endpoints where updates are not dispatched
+    When I add "Accept" header equal to "application/ld+json"
     Given I send a "GET" request to "/"
     Then the header "Link" should not contain '<https://demo.mercure.rocks/hub>; rel="mercure"'

--- a/src/Symfony/EventListener/AddFormatListener.php
+++ b/src/Symfony/EventListener/AddFormatListener.php
@@ -65,7 +65,7 @@ final class AddFormatListener
             return;
         }
 
-        $formats = $operation?->getOutputFormats() ?? (in_array($request->attributes->get('_route'), ['api_doc', 'api_entrypoint']) ? $this->docsFormats : $this->formats);
+        $formats = $operation?->getOutputFormats() ?? (\in_array($request->attributes->get('_route'), ['api_doc', 'api_entrypoint'], true) ? $this->docsFormats : $this->formats);
 
         $this->addRequestFormats($request, $formats);
 

--- a/src/Symfony/EventListener/AddFormatListener.php
+++ b/src/Symfony/EventListener/AddFormatListener.php
@@ -65,7 +65,7 @@ final class AddFormatListener
             return;
         }
 
-        $formats = $operation?->getOutputFormats() ?? ('api_doc' === $request->attributes->get('_route') ? $this->docsFormats : $this->formats);
+        $formats = $operation?->getOutputFormats() ?? (in_array($request->attributes->get('_route'), ['api_doc', 'api_entrypoint']) ? $this->docsFormats : $this->formats);
 
         $this->addRequestFormats($request, $formats);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | Addresses https://github.com/api-platform/core/issues/5845#issuecomment-1748641671
| License       | MIT
| Doc PR        | N/A

I still have a slightly obscure issue where the api_entrypoint is returning a 406 error in some cases (at least when I load the page with curl with "Accept: text/html" headers).  Essentially, its using the formats rather than docs_formats config for that url, and my formats list doesn't include text/html as an option.

There's a test for this currently, I think, but it already passes because the test API has text/html in the config file for both formats and doc_formats, which masks that it's picking the wrong option.  I'm not sure if there's a way to modify the config on a single Behat test?
