### PR TITLE
fix(jsonSchema): fix recursive documentation when using a dto entity wrapper

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -319,3 +319,26 @@ Feature: Documentation support
       "nullable":true
     }
     """
+
+  @!mongodb
+  Scenario: Retrieve the OpenAPI documentation for Entity Dto Wrappers
+    Given I send a "GET" request to "/docs.json"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+    And the OpenAPI class "WrappedResponseEntity-read" exists
+    And the "id" property exists for the OpenAPI class "WrappedResponseEntity-read"
+    And the "id" property for the OpenAPI class "WrappedResponseEntity-read" should be equal to:
+    """
+    {
+      "type": "string"
+    }
+    """
+    And the OpenAPI class "WrappedResponseEntity.CustomOutputEntityWrapperDto-read" exists
+    And the "data" property exists for the OpenAPI class "WrappedResponseEntity.CustomOutputEntityWrapperDto-read"
+    And the "data" property for the OpenAPI class "WrappedResponseEntity.CustomOutputEntityWrapperDto-read" should be equal to:
+    """
+    {
+      "$ref": "#\/components\/schemas\/WrappedResponseEntity-read"
+    }
+    """

--- a/tests/Fixtures/TestBundle/Dto/CustomOutputEntityWrapperDto.php
+++ b/tests/Fixtures/TestBundle/Dto/CustomOutputEntityWrapperDto.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Dto;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\WrappedResponseEntity;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class CustomOutputEntityWrapperDto
+{
+    /** @var WrappedResponseEntity */
+    #[Groups(['read'])]
+    public $data;
+}

--- a/tests/Fixtures/TestBundle/Entity/WrappedResponseEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/WrappedResponseEntity.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\CustomOutputEntityWrapperDto;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(operations: [new Get(normalizationContext: ['groups' => ['read']], output: CustomOutputEntityWrapperDto::class
+)])]
+#[ORM\Entity]
+class WrappedResponseEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid')]
+    #[Groups(['read'])]
+    public $id;
+}


### PR DESCRIPTION
…wrapper

| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Closes #https://github.com/api-platform/core/issues/5626
| License       | MIT

This fixes ar regression introduced in https://github.com/api-platform/core/pull/5469 that caused a recursive openapi schema definition to be generated when using a DTO wrapper as the ApiResource response.
See: https://api-platform.com/docs/core/dto/#implementing-a-read-operation-with-an-output-different-from-the-resource
Ex
```
class CustomOutputEntityWrapperDto
{
    /** @var WrappedResponseEntity */
    #[Groups(['read'])]
    public $data;
}
```

```
#[ApiResource(operations: [new Get(normalizationContext: ['groups' => ['read']], output: CustomOutputEntityWrapperDto::class
)])]
#[ORM\Entity]
class WrappedResponseEntity
{
    #[ORM\Id]
    #[ORM\Column(type: 'guid')]
    #[Groups(['read'])]
    public $id;
}
```
