### PR TITLE
fix(openapi): Invalid type specification

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -238,7 +238,8 @@ Feature: Documentation support
                                         "type": "string"
                                     },
                                     "property": {
-                                        "type": ["string", "null"]
+                                        "type": "string",
+                                        "nullable": true
                                     },
                                     "required": {
                                         "type": "boolean"

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -92,12 +92,12 @@ final class SchemaFactory implements SchemaFactoryInterface
             unset($schema['items']);
 
             switch ($schema->getVersion()) {
-                // JSON Schema + OpenAPI 3.1
                 case Schema::VERSION_OPENAPI:
+                    $nullableStringDefinition = ['type' => 'string', 'nullable' => true];
+                    break;
                 case Schema::VERSION_JSON_SCHEMA:
                     $nullableStringDefinition = ['type' => ['string', 'null']];
                     break;
-                    // Swagger
                 default:
                     $nullableStringDefinition = ['type' => 'string'];
                     break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | https://github.com/api-platform/core/issues/5975
| License       | MIT

Slight rollback to 3.1 logic for generating OpenApi spec on Hydra.
