### PR TITLE
Bugfix/exclusive properties dont allow booleans for open api 3.1

### DIFF
--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
@@ -31,8 +31,7 @@ final class PropertySchemaGreaterThanRestriction implements PropertySchemaRestri
     public function create(Constraint $constraint, ApiProperty $propertyMetadata): array
     {
         return [
-            'minimum' => $constraint->value,
-            'exclusiveMinimum' => true,
+            'exclusiveMinimum' => $constraint->value,
         ];
     }
 

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
@@ -31,8 +31,7 @@ final class PropertySchemaLessThanRestriction implements PropertySchemaRestricti
     public function create(Constraint $constraint, ApiProperty $propertyMetadata): array
     {
         return [
-            'maximum' => $constraint->value,
-            'exclusiveMaximum' => true,
+            'exclusiveMaximum' => $constraint->value,
         ];
     }
 

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestrictionTest.php
@@ -58,8 +58,7 @@ final class PropertySchemaGreaterThanRestrictionTest extends TestCase
     public function testCreate(): void
     {
         self::assertEquals([
-            'minimum' => 10,
-            'exclusiveMinimum' => true,
+            'exclusiveMinimum' => 10,
         ], $this->propertySchemaGreaterThanRestriction->create(new GreaterThan(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)])));
     }
 }

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestrictionTest.php
@@ -58,8 +58,7 @@ final class PropertySchemaLessThanRestrictionTest extends TestCase
     public function testCreate(): void
     {
         self::assertEquals([
-            'maximum' => 10,
-            'exclusiveMaximum' => true,
+            'exclusiveMaximum' => 10,
         ], $this->propertySchemaLessThanRestriction->create(new LessThan(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)])));
     }
 }

--- a/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -675,7 +675,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]),
             'property' => 'greaterThanMe',
-            'expectedSchema' => ['minimum' => 10, 'exclusiveMinimum' => true],
+            'expectedSchema' => ['exclusiveMinimum' => 10],
         ];
 
         yield [
@@ -687,7 +687,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]),
             'property' => 'lessThanMe',
-            'expectedSchema' => ['maximum' => 99, 'exclusiveMaximum' => true],
+            'expectedSchema' => ['exclusiveMaximum' => 99],
         ];
 
         yield [
@@ -699,7 +699,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]),
             'property' => 'positive',
-            'expectedSchema' => ['minimum' => 0, 'exclusiveMinimum' => true],
+            'expectedSchema' => ['exclusiveMinimum' => 0],
         ];
 
         yield [
@@ -711,7 +711,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_INT)]),
             'property' => 'negative',
-            'expectedSchema' => ['maximum' => 0, 'exclusiveMaximum' => true],
+            'expectedSchema' => ['exclusiveMaximum' => 0],
         ];
 
         yield [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| License       | MIT

The generated open api spec is currently invalid for open api 3.1. 
exclusiveMinimum and exclusiveMaximum are still used as boolean, while properties minimum and exclusiveMinimum are merged into one property exclusiveMinimum. 

See https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

The only problem I see now, is that users can configure their open api version. 
But I don't know how I can toggle the logic between 3.0 and 3.1.
Any help is appreciated. Thx!
