### PR TITLE
feat(metadata): introduce api resource dto annotation

### DIFF
--- a/features/authorization/deny.feature
+++ b/features/authorization/deny.feature
@@ -217,3 +217,69 @@ Feature: Authorization checking
     And I send a "GET" request to "/secured_dummies"
     Then the response status code should be 200
     And the response should contain "ownerOnlyProperty"
+
+  Scenario: A standard user can create a resource and can not write secured property
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send a "POST" request to "/secured_dummies_with_input_dto" with body:
+    """
+    {
+        "title": "Title",
+        "description": "Description",
+        "adminOnlyProperty": "foo"
+    }
+    """
+    Then the response status code should be 201
+    And the response should contain "adminOnlyProperty"
+    And the JSON node "adminOnlyProperty" should be null
+
+  Scenario: A standard user can update only not secured properties
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic ZHVuZ2xhczprZXZpbg=="
+    And I send a "PUT" request to "/secured_dummies_with_input_dto/1" with body:
+    """
+    {
+        "title": "NewTitle",
+        "description": "NewDescription",
+        "adminOnlyProperty": "foo"
+    }
+    """
+    Then the response status code should be 200
+    And the JSON node "adminOnlyProperty" should be null
+    And the JSON node "title" should be equal to the string "NewTitle"
+    And the JSON node "description" should be equal to the string "NewDescription"
+
+  Scenario: An admin can create a resource and can write secured property
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send a "POST" request to "/secured_dummies_with_input_dto" with body:
+    """
+    {
+        "title": "Title",
+        "description": "Description",
+        "adminOnlyProperty": "foo"
+    }
+    """
+    Then the response status code should be 201
+    And the response should contain "adminOnlyProperty"
+    And the JSON node "adminOnlyProperty" should be equal to the string "foo"
+
+  Scenario: An admin can update secured properties
+    When I add "Accept" header equal to "application/ld+json"
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Authorization" header equal to "Basic YWRtaW46a2l0dGVu"
+    And I send a "PUT" request to "/secured_dummies_with_input_dto/2" with body:
+    """
+    {
+        "title": "NewTitle",
+        "description": "NewDescription",
+        "adminOnlyProperty": "NewAdminOnlyProperty"
+    }
+    """
+    Then the response status code should be 200
+    And the JSON node "adminOnlyProperty" should be equal to the string "NewAdminOnlyProperty"
+    And the JSON node "title" should be equal to the string "NewTitle"
+    And the JSON node "description" should be equal to the string "NewDescription"

--- a/src/Metadata/ApiResourceDto.php
+++ b/src/Metadata/ApiResourceDto.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ApiResourceDto
+{
+}

--- a/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Resource\Factory;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\ApiResourceDto;
 use ApiPlatform\Metadata\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\Metadata\HttpOperation;
@@ -85,6 +86,14 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
         $hasApiResource = false;
 
         foreach ($attributes as $attribute) {
+            if (is_a($attribute->getName(), ApiResourceDto::class, true)) {
+                $hasApiResource = true;
+                $resource = $this->getResourceWithDefaults($resourceClass, $shortName, new ApiResource())
+                    ->withOperations(new Operations());
+                $resources[++$index] = $resource;
+                continue;
+            }
+
             if (is_a($attribute->getName(), ApiResource::class, true)) {
                 $hasApiResource = true;
                 $resource = $this->getResourceWithDefaults($resourceClass, $shortName, $attribute->newInstance());
@@ -172,7 +181,7 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
     private function hasResourceAttributes(\ReflectionClass $reflectionClass): bool
     {
         foreach ($reflectionClass->getAttributes() as $attribute) {
-            if (is_a($attribute->getName(), ApiResource::class, true) || is_subclass_of($attribute->getName(), HttpOperation::class) || is_subclass_of($attribute->getName(), GraphQlOperation::class)) {
+            if (is_a($attribute->getName(), ApiResource::class, true) || is_a($attribute->getName(), ApiResourceDto::class, true) || is_subclass_of($attribute->getName(), HttpOperation::class) || is_subclass_of($attribute->getName(), GraphQlOperation::class)) {
                 return true;
             }
         }

--- a/src/Metadata/Resource/Factory/AttributesResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/AttributesResourceNameCollectionFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Resource\Factory;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\ApiResourceDto;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Resource\ResourceNameCollection;
@@ -58,6 +59,10 @@ final class AttributesResourceNameCollectionFactory implements ResourceNameColle
     private function isResource(\ReflectionClass $reflectionClass): bool
     {
         if ($reflectionClass->getAttributes(ApiResource::class, \ReflectionAttribute::IS_INSTANCEOF)) {
+            return true;
+        }
+
+        if ($reflectionClass->getAttributes(ApiResourceDto::class, \ReflectionAttribute::IS_INSTANCEOF)) {
             return true;
         }
 

--- a/tests/Fixtures/TestBundle/Dto/SecuredDummyInputDto.php
+++ b/tests/Fixtures/TestBundle/Dto/SecuredDummyInputDto.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Dto;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResourceDto;
+
+#[ApiResourceDto]
+class SecuredDummyInputDto
+{
+    /**
+     * @var string
+     */
+    public $title;
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var string|null
+     */
+    #[ApiProperty(security: "is_granted('ROLE_ADMIN')")]
+    public $adminOnlyProperty;
+}

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummyWithInputDto.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummyWithInputDto.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\SecuredDummyInputDto;
+use ApiPlatform\Tests\Fixtures\TestBundle\State\SecuredDummyDtoInputProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Resource with input DTO and secured properties.
+ */
+#[ApiResource(
+    operations: [
+        new Get(uriTemplate: 'secured_dummies_with_input_dto/{id}'),
+        new GetCollection(uriTemplate: 'secured_dummies_with_input_dto'),
+        new Post(uriTemplate: 'secured_dummies_with_input_dto'),
+        new Put(uriTemplate: 'secured_dummies_with_input_dto/{id}'),
+    ],
+    input: SecuredDummyInputDto::class,
+    processor: SecuredDummyDtoInputProcessor::class)
+]
+#[ORM\Entity]
+class SecuredDummyWithInputDto
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    /**
+     * @var string The title
+     */
+    #[ORM\Column]
+    #[Assert\NotBlank]
+    private string $title;
+
+    /**
+     * @var string The description
+     */
+    #[ORM\Column]
+    private string $description = '';
+
+    #[ORM\Column(nullable: true)]
+    private ?string $adminOnlyProperty = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getAdminOnlyProperty(): ?string
+    {
+        return $this->adminOnlyProperty;
+    }
+
+    public function setAdminOnlyProperty(?string $adminOnlyProperty): void
+    {
+        $this->adminOnlyProperty = $adminOnlyProperty;
+    }
+}

--- a/tests/Fixtures/TestBundle/State/SecuredDummyDtoInputProcessor.php
+++ b/tests/Fixtures/TestBundle/State/SecuredDummyDtoInputProcessor.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\SecuredDummyInputDto;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\SecuredDummyWithInputDto;
+use Doctrine\ORM\EntityManager;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class SecuredDummyDtoInputProcessor implements ProcessorInterface
+{
+    public function __construct(private readonly ManagerRegistry $registry)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param SecuredDummyInputDto|mixed $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        if (!$data instanceof SecuredDummyInputDto) {
+            throw new \RuntimeException('Data is not an SecuredDummyInputDto');
+        }
+
+        /** @var EntityManager */
+        $manager = $this->registry->getManagerForClass($operation->getClass());
+        /** @var SecuredDummyWithInputDto $entity */
+        $entity = new ($operation->getClass())();
+
+        if (isset($context['previous_data'])) {
+            /** @var SecuredDummyWithInputDto $entity */
+            $entity = $manager->getReference($operation->getClass(), $context['previous_data']->getId());
+        }
+
+        $entity->setTitle($data->title);
+        $entity->setDescription($data->description);
+
+        if (isset($data->adminOnlyProperty)) {
+            $entity->setAdminOnlyProperty($data->adminOnlyProperty);
+        }
+
+        $manager->persist($entity);
+        $manager->flush();
+
+        return $entity;
+    }
+}

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -242,7 +242,10 @@ class AppKernel extends Kernel
 
         $c->prependExtensionConfig('api_platform', [
             'mapping' => [
-                'paths' => ['%kernel.project_dir%/../TestBundle/Resources/config/api_resources'],
+                'paths' => [
+                    '%kernel.project_dir%/../TestBundle/Resources/config/api_resources',
+                    '%kernel.project_dir%/../TestBundle/Dto',
+                ],
             ],
             'graphql' => [
                 'graphql_playground' => false,

--- a/tests/Fixtures/app/config/config_doctrine.yml
+++ b/tests/Fixtures/app/config/config_doctrine.yml
@@ -112,6 +112,12 @@ services:
             $decorated: '@ApiPlatform\Doctrine\Common\State\PersistProcessor'
         tags:
             - name: 'api_platform.state_processor'
+              
+    ApiPlatform\Tests\Fixtures\TestBundle\State\SecuredDummyDtoInputProcessor:
+        arguments:
+            $registry: '@doctrine'
+        tags:
+            - name: 'api_platform.state_processor'
 
     ApiPlatform\Tests\Fixtures\TestBundle\State\EntityClassAndCustomProviderResourceProvider:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\State\EntityClassAndCustomProviderResourceProvider'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT
| Doc PR        | will be added if maintainers approve this approach

This PR is the second variation of https://github.com/api-platform/core/pull/5982

I've noticed that the current API platform lacks security functionality for attributes in input DTOs. Although it's possible in ApiResource to check if an attribute is accessible for the current user, like this:

```php
    #[ApiProperty(security: "is_granted('ROLE_ADMIN')")]
    public $adminOnlyProperty;
```

Unfortunately, this functionality is not available for input DTOs.

After @soyuka https://github.com/api-platform/core/pull/5982#issuecomment-1822777342 that we can consider input/output DTO as ApiResources I decided to introduce a special attribute for DTO to avoid confusion and clearly distinguish between DTO and ApiResource.
