### PR TITLE
Fix/missing eager joins

### DIFF
--- a/features/json/relation.feature
+++ b/features/json/relation.feature
@@ -25,7 +25,8 @@ Feature: JSON relations support
       "badFourthLevel": null,
       "id": 1,
       "level": 3,
-      "test": true
+      "test": true,
+      "relatedDummies": []
     }
     """
 

--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -483,6 +483,18 @@ Feature: JSON API Inclusion of Related Resources
                             "type": "FourthLevel",
                             "id": "/fourth_levels/1"
                         }
+                    },
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/1"
+                            },
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/2"
+                            }
+                        ]
                     }
                 }
             },
@@ -581,6 +593,16 @@ Feature: JSON API Inclusion of Related Resources
                     "_id": 1,
                     "level": 3,
                     "test": true
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/1"
+                            }
+                        ]
+                    }
                 }
             },
             {
@@ -618,6 +640,16 @@ Feature: JSON API Inclusion of Related Resources
                     "_id": 2,
                     "level": 3,
                     "test": true
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/2"
+                            }
+                        ]
+                    }
                 }
             },
             {
@@ -655,6 +687,16 @@ Feature: JSON API Inclusion of Related Resources
                     "_id": 3,
                     "level": 3,
                     "test": true
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/3"
+                            }
+                        ]
+                    }
                 }
             }
         ]
@@ -802,6 +844,24 @@ Feature: JSON API Inclusion of Related Resources
                     "_id": 1,
                     "level": 3,
                     "test": true
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/1"
+                            },
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/2"
+                            },
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/3"
+                            }
+                        ]
+                    }
                 }
             },
             {
@@ -1286,6 +1346,16 @@ Feature: JSON API Inclusion of Related Resources
                     "_id": 1,
                     "level": 3,
                     "test": true
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/1"
+                            }
+                        ]
+                    }
                 }
             },
             {
@@ -1323,6 +1393,16 @@ Feature: JSON API Inclusion of Related Resources
                     "_id": 2,
                     "level": 3,
                     "test": true
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/2"
+                            }
+                        ]
+                    }
                 }
             },
             {
@@ -1360,6 +1440,16 @@ Feature: JSON API Inclusion of Related Resources
                     "_id": 3,
                     "level": 3,
                     "test": true
+                },
+                "relationships": {
+                    "relatedDummies": {
+                        "data": [
+                            {
+                                "type": "RelatedDummy",
+                                "id": "/related_dummies/3"
+                            }
+                        ]
+                    }
                 }
             }
         ]

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -23,7 +23,8 @@ Feature: Relations support
       "badFourthLevel": null,
       "id": 1,
       "level": 3,
-      "test": true
+      "test": true,
+      "relatedDummies": []
     }
     """
 

--- a/features/main/sub_resource.feature
+++ b/features/main/sub_resource.feature
@@ -376,7 +376,11 @@ Feature: Sub-resource support
       "badFourthLevel": null,
       "id": 1,
       "level": 3,
-      "test": true
+      "test": true,
+      "relatedDummies": [
+            "/related_dummies/1",
+            "/related_dummies/2"
+      ]
     }
     """
 

--- a/src/Doctrine/Orm/Extension/EagerLoadingExtension.php
+++ b/src/Doctrine/Orm/Extension/EagerLoadingExtension.php
@@ -168,6 +168,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
             if (
                 null !== $parentAssociation
                 && isset($mapping['inversedBy'])
+                && $mapping['sourceEntity'] === $mapping['targetEntity']
                 && $mapping['inversedBy'] === $parentAssociation
                 && $mapping['type'] & ClassMetadata::TO_ONE
             ) {

--- a/tests/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
+++ b/tests/Doctrine/Orm/Extension/EagerLoadingExtensionTest.php
@@ -29,6 +29,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ConcreteDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\EmbeddableDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ThirdLevel;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\UnknownDummy;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -140,6 +141,7 @@ class EagerLoadingExtensionTest extends TestCase
         $propertyNameCollectionFactoryProphecy->create(RelatedDummy::class)->willReturn($relatedNameCollection)->shouldBeCalled();
         $propertyNameCollectionFactoryProphecy->create(EmbeddableDummy::class)->willReturn($relatedEmbedableCollection)->shouldBeCalled();
         $propertyNameCollectionFactoryProphecy->create(UnknownDummy::class)->willReturn(new PropertyNameCollection(['id']))->shouldBeCalled();
+        $propertyNameCollectionFactoryProphecy->create(ThirdLevel::class)->willReturn(new PropertyNameCollection(['id']))->shouldBeCalled();
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $relationPropertyMetadata = new ApiProperty();
@@ -151,6 +153,7 @@ class EagerLoadingExtensionTest extends TestCase
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy4', $callContext)->willReturn($relationPropertyMetadata)->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummy5', $callContext)->willReturn($relationPropertyMetadata)->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'singleInheritanceRelation', $callContext)->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(Dummy::class, 'relatedDummies', $callContext)->willReturn($relationPropertyMetadata)->shouldBeCalled();
 
         $idPropertyMetadata = new ApiProperty();
         $idPropertyMetadata = $idPropertyMetadata->withIdentifier(true);
@@ -169,7 +172,9 @@ class EagerLoadingExtensionTest extends TestCase
         $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notindatabase', $callContext)->willReturn($notInDatabasePropertyMetadata)->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'notreadable', $callContext)->willReturn($notReadablePropertyMetadata)->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'relation', $callContext)->willReturn($relationPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(RelatedDummy::class, 'thirdLevel', $callContext)->willReturn($relationPropertyMetadata)->shouldBeCalled();
         $propertyMetadataFactoryProphecy->create(UnknownDummy::class, 'id', $callContext)->willReturn($idPropertyMetadata)->shouldBeCalled();
+        $propertyMetadataFactoryProphecy->create(ThirdLevel::class, 'id', $callContext)->willReturn($idPropertyMetadata)->shouldBeCalled();
 
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
 
@@ -181,6 +186,7 @@ class EagerLoadingExtensionTest extends TestCase
             'relatedDummy4' => ['fetch' => ClassMetadataInfo::FETCH_EAGER, 'targetEntity' => UnknownDummy::class],
             'relatedDummy5' => ['fetch' => ClassMetadataInfo::FETCH_LAZY, 'targetEntity' => UnknownDummy::class],
             'singleInheritanceRelation' => ['fetch' => ClassMetadataInfo::FETCH_EAGER, 'targetEntity' => AbstractDummy::class],
+            'relatedDummies' => ['fetch' => ClassMetadataInfo::FETCH_EAGER, 'targetEntity' => RelatedDummy::class],
         ];
 
         $relatedClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
@@ -194,6 +200,7 @@ class EagerLoadingExtensionTest extends TestCase
 
         $relatedClassMetadataProphecy->associationMappings = [
             'relation' => ['fetch' => ClassMetadataInfo::FETCH_EAGER, 'joinColumns' => [['nullable' => false]], 'targetEntity' => UnknownDummy::class],
+            'thirdLevel' => ['fetch' => ClassMetadataInfo::FETCH_EAGER, 'targetEntity' => ThirdLevel::class, 'sourceEntity' => RelatedDummy::class, 'inversedBy' => 'relatedDummies', 'type' => ClassMetadata::TO_ONE],
         ];
 
         $relatedClassMetadataProphecy->embeddedClasses = ['embeddedDummy' => ['class' => EmbeddableDummy::class]];
@@ -204,26 +211,38 @@ class EagerLoadingExtensionTest extends TestCase
         $unknownClassMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $unknownClassMetadataProphecy->associationMappings = [];
 
+        $thirdLevelMetadataProphecy = $this->prophesize(ClassMetadata::class);
+        $thirdLevelMetadataProphecy->associationMappings = [];
+
         $emProphecy = $this->prophesize(EntityManager::class);
         $emProphecy->getClassMetadata(Dummy::class)->shouldBeCalled()->willReturn($classMetadataProphecy->reveal());
         $emProphecy->getClassMetadata(RelatedDummy::class)->shouldBeCalled()->willReturn($relatedClassMetadataProphecy->reveal());
         $emProphecy->getClassMetadata(AbstractDummy::class)->shouldBeCalled()->willReturn($singleInheritanceClassMetadataProphecy->reveal());
         $emProphecy->getClassMetadata(UnknownDummy::class)->shouldBeCalled()->willReturn($unknownClassMetadataProphecy->reveal());
+        $emProphecy->getClassMetadata(ThirdLevel::class)->shouldBeCalled()->willReturn($thirdLevelMetadataProphecy->reveal());
 
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
         $queryBuilderProphecy->getEntityManager()->willReturn($emProphecy);
         $queryBuilderProphecy->leftJoin('o.relatedDummy', 'relatedDummy_a1')->shouldBeCalledTimes(1);
         $queryBuilderProphecy->leftJoin('relatedDummy_a1.relation', 'relation_a2')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'relatedDummy2_a3')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->leftJoin('o.relatedDummy3', 'relatedDummy3_a4')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->leftJoin('o.relatedDummy4', 'relatedDummy4_a5')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->leftJoin('o.singleInheritanceRelation', 'singleInheritanceRelation_a6')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->leftJoin('relatedDummy_a1.thirdLevel', 'thirdLevel_a3')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->innerJoin('o.relatedDummy2', 'relatedDummy2_a4')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->leftJoin('o.relatedDummy3', 'relatedDummy3_a5')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->leftJoin('o.relatedDummy4', 'relatedDummy4_a6')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->leftJoin('o.singleInheritanceRelation', 'singleInheritanceRelation_a7')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->leftJoin('o.relatedDummies', 'relatedDummies_a8')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->leftJoin('relatedDummies_a8.relation', 'relation_a9')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->leftJoin('relatedDummies_a8.thirdLevel', 'thirdLevel_a10')->shouldBeCalledTimes(1);
         $queryBuilderProphecy->addSelect('partial relatedDummy_a1.{id,name,embeddedDummy.name}')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('partial thirdLevel_a3.{id}')->shouldBeCalledTimes(1);
         $queryBuilderProphecy->addSelect('partial relation_a2.{id}')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->addSelect('partial relatedDummy2_a3.{id}')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->addSelect('partial relatedDummy3_a4.{id}')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->addSelect('partial relatedDummy4_a5.{id}')->shouldBeCalledTimes(1);
-        $queryBuilderProphecy->addSelect('singleInheritanceRelation_a6')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('partial relatedDummy2_a4.{id}')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('partial relatedDummy3_a5.{id}')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('partial relatedDummy4_a6.{id}')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('singleInheritanceRelation_a7')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('partial relatedDummies_a8.{id,name,embeddedDummy.name}')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('partial relation_a9.{id}')->shouldBeCalledTimes(1);
+        $queryBuilderProphecy->addSelect('partial thirdLevel_a10.{id}')->shouldBeCalledTimes(1);
         $queryBuilderProphecy->getDQLPart('join')->willReturn([]);
         $queryBuilderProphecy->getDQLPart('select')->willReturn([]);
 

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -86,7 +86,7 @@ class RelatedDummy extends ParentDummy implements \Stringable
     #[ApiFilter(filterClass: DateFilter::class)]
     public $dummyDate;
 
-    #[ORM\ManyToOne(targetEntity: ThirdLevel::class, cascade: ['persist'])]
+    #[ORM\ManyToOne(targetEntity: ThirdLevel::class, cascade: ['persist'], inversedBy: 'relatedDummies')]
     #[Groups(['barcelona', 'chicago', 'friends'])]
     public ?ThirdLevel $thirdLevel = null;
 

--- a/tests/Fixtures/TestBundle/Entity/ThirdLevel.php
+++ b/tests/Fixtures/TestBundle/Entity/ThirdLevel.php
@@ -16,6 +16,8 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Link;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -50,6 +52,14 @@ class ThirdLevel
     public ?FourthLevel $fourthLevel = null;
     #[ORM\ManyToOne(targetEntity: FourthLevel::class, cascade: ['persist'])]
     public $badFourthLevel;
+
+    #[ORM\OneToMany(mappedBy: 'thirdLevel', targetEntity: RelatedDummy::class)]
+    public Collection|iterable $relatedDummies;
+
+    public function __construct()
+    {
+        $this->relatedDummies = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Closes #5847 
| License       | MIT


Following https://github.com/api-platform/core/pull/5992

In some cases, the EagerLoadingExtension misses some joins it should normally load eagerly. This happens when a *ToOne relationship shares the same inversedBy name than in the parent class. This PR aims to solve this problem and correctly eager join all to-one relationships than should be eager joined.