### PR TITLE
feat(symfony): Add `$buildDir` to `CachePoolClearerCacheWarmer::warmUp()`

### DIFF
--- a/src/Symfony/Bundle/CacheWarmer/CachePoolClearerCacheWarmer.php
+++ b/src/Symfony/Bundle/CacheWarmer/CachePoolClearerCacheWarmer.php
@@ -34,7 +34,7 @@ final class CachePoolClearerCacheWarmer implements CacheWarmerInterface
      *
      * @return string[]
      */
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         foreach ($this->pools as $pool) {
             if ($this->poolClearer->hasPool($pool)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #6004 partially
| License       | MIT
| Doc PR        | n/a

Symfony 7 adds a new parameter `$buildDir` to
`WarmableInterface::warmUp()`, so that the method signature of
`CachePoolClearerCacheWarmer::warmUp()` needs to be updated.