### PR TITLE
fix: remove link to ApiDocumentation when doc is disabled

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -516,6 +516,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         if (!$config['enable_docs']) {
             $container->removeDefinition('api_platform.hydra.listener.response.add_link_header');
+            $container->removeDefinition('api_platform.hydra.processor.link');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | /
| License       | MIT
| Doc PR        | 

The `HydraLinkProcessor` injects links to ApiDocumentation in the response header even when the doc is disabled.

This PR remove the service (like it was the case with the legacy `AddLinkHeaderListener`) when the doc is not enabled.