### PR TITLE
feat(pagination): provide a way to manually disable distinct on count

### DIFF
--- a/src/Doctrine/Orm/Extension/PaginationExtension.php
+++ b/src/Doctrine/Orm/Extension/PaginationExtension.php
@@ -80,6 +80,10 @@ final class PaginationExtension implements QueryResultCollectionExtensionInterfa
             $query->setHint(CountWalker::HINT_DISTINCT, false);
         }
 
+        if (null !== $distinctCount = $operation?->getDistinctCount()) {
+            $query->setHint(CountWalker::HINT_DISTINCT, $distinctCount);
+        }
+
         $doctrineOrmPaginator = new DoctrineOrmPaginator($query, $this->shouldDoctrinePaginatorFetchJoinCollection($queryBuilder, $operation, $context));
         $doctrineOrmPaginator->setUseOutputWalkers($this->shouldDoctrinePaginatorUseOutputWalkers($queryBuilder, $operation, $context));
 

--- a/src/Metadata/GetCollection.php
+++ b/src/Metadata/GetCollection.php
@@ -94,6 +94,7 @@ final class GetCollection extends HttpOperation implements CollectionOperationIn
         OptionsInterface $stateOptions = null,
         array $extraProperties = [],
         private ?string $itemUriTemplate = null,
+        private ?bool $distinctCount = null,
     ) {
         parent::__construct(
             uriTemplate: $uriTemplate,
@@ -174,6 +175,11 @@ final class GetCollection extends HttpOperation implements CollectionOperationIn
     public function getItemUriTemplate(): ?string
     {
         return $this->itemUriTemplate;
+    }
+
+    public function getDistinctCount(): ?bool
+    {
+        return $this->distinctCount;
     }
 
     public function withItemUriTemplate(string $itemUriTemplate): self


### PR DESCRIPTION
Using DISTINCT in a COUNT has a major impact on performance. This change pushes the existing fix forward by delegating the responsibility to disable the DISTINCT presence to the developers.

For instance, it is possible to safely remove the DISTINCT from a query that joins a "to one" association.

The existing optimization still exists for most cases.

| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | 
| License       | MIT
| Doc PR        | to write (depending on the output of the discussion)

TODO:
 - [ ] write doc (api-platform/docs)
 - [ ] Update CHANGELOG.md
 - [ ] Discuss alternatives


I'm not a big fan of this solution, given the amount of properties that already exist on the `Operation` class (including its inheritance tree).

An alternative would be to change the current detection behavior (which is only based on the number of aliases in the query), to take into account the type of the associations ("to one" association are ok, DISTINCT should be discardable). I could use the `QueryChecker::hasJoinedToManyAssociation` for instance.

Any suggestions on how to proceed are very welcome,
Thanks.