### PR TITLE
fix(symfony): use Type constraint violation code instead of exception code

### DIFF
--- a/src/Symfony/EventListener/DeserializeListener.php
+++ b/src/Symfony/EventListener/DeserializeListener.php
@@ -111,7 +111,7 @@ final class DeserializeListener
                 if ($exception->canUseMessageForUser()) {
                     $parameters['hint'] = $exception->getMessage();
                 }
-                $violations->add(new ConstraintViolation($this->translator->trans($message, ['{{ type }}' => implode('|', $exception->getExpectedTypes() ?? [])], 'validators'), $message, $parameters, null, $exception->getPath(), null, null, (string) $exception->getCode()));
+                $violations->add(new ConstraintViolation($this->translator->trans($message, ['{{ type }}' => implode('|', $exception->getExpectedTypes() ?? [])], 'validators'), $message, $parameters, null, $exception->getPath(), null, null, Type::INVALID_TYPE_ERROR));
             }
             if (0 !== \count($violations)) {
                 throw new ValidationException($violations);

--- a/tests/Symfony/EventListener/DeserializeListenerTest.php
+++ b/tests/Symfony/EventListener/DeserializeListenerTest.php
@@ -366,7 +366,7 @@ class DeserializeListenerTest extends TestCase
             $this->assertSame($violation->getPropertyPath(), 'foo');
             $this->assertNull($violation->getInvalidValue());
             $this->assertNull($violation->getPlural());
-            $this->assertSame($violation->getCode(), '0');
+            $this->assertSame($violation->getCode(), 'ba785a8c-82cb-4283-967c-3cf342181b40');
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

I've a custom ConstraintViolationListNormalizer which adds error name to the payload from the constraint error code, but given that listener uses NotNormalizableValueException code which is always 0, getting error name fails, so this sets the correct code
