### PR TITLE
GraphQL: Nested Collections

### DIFF
--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -22,7 +22,7 @@ Feature: GraphQL query support
 
   @createSchema
   Scenario: Retrieve an item with different relations to the same resource
-    Given there are 2 multiRelationsDummy objects having each a manyToOneRelation, 2 manyToManyRelations and 3 oneToManyRelations
+    Given there are 2 multiRelationsDummy objects having each a manyToOneRelation, 2 manyToManyRelations, 3 oneToManyRelations and 4 embeddedRelations
     When I send the following GraphQL request:
     """
     {
@@ -49,6 +49,16 @@ Feature: GraphQL query support
             }
           }
         }
+        nestedCollection {
+          name
+        }
+        nestedPaginatedCollection {
+          edges{
+            node {
+              name
+            }
+          }
+        }
       }
     }
     """
@@ -67,6 +77,15 @@ Feature: GraphQL query support
     And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges[1].node.id" should not be null
     And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges[0].node.name" should match "#RelatedOneToManyDummy(1|3)2#"
     And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges[2].node.name" should match "#RelatedOneToManyDummy(1|3)2#"
+    And the JSON node "data.multiRelationsDummy.nestedCollection[0].name" should be equal to "NestedDummy1"
+    And the JSON node "data.multiRelationsDummy.nestedCollection[1].name" should be equal to "NestedDummy2"
+    And the JSON node "data.multiRelationsDummy.nestedCollection[2].name" should be equal to "NestedDummy3"
+    And the JSON node "data.multiRelationsDummy.nestedCollection[3].name" should be equal to "NestedDummy4"
+    And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges" should have 4 element
+    And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges[0].node.name" should be equal to "NestedPaginatedDummy1"
+    And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges[1].node.name" should be equal to "NestedPaginatedDummy2"
+    And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges[2].node.name" should be equal to "NestedPaginatedDummy3"
+    And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges[3].node.name" should be equal to "NestedPaginatedDummy4"
 
   @createSchema @!mongodb
   Scenario: Retrieve an item with child relation to the same resource

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -19,7 +19,9 @@ use ApiPlatform\GraphQl\Resolver\Stage\SecurityPostDenormalizeStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SecurityStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SerializeStageInterface;
 use ApiPlatform\Metadata\GraphQl\Operation;
+use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\Util\CloneTrait;
+use ApiPlatform\State\Pagination\ArrayPaginator;
 use GraphQL\Type\Definition\ResolveInfo;
 use Psr\Container\ContainerInterface;
 
@@ -51,6 +53,10 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
             }
 
             $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
+
+            if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && !$operation->getProvider() && $source && \array_key_exists($info->fieldName, $source)) {
+                return ($this->serializeStage)(new ArrayPaginator($source[$info->fieldName], 0, \count($source[$info->fieldName])), $resourceClass, $operation, $resolverContext);
+            }
 
             $collection = ($this->readStage)($resourceClass, $rootClass, $operation, $resolverContext);
             if (!is_iterable($collection)) {

--- a/src/GraphQl/Resolver/Factory/ResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ResolverFactory.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\GraphQl\Resolver\Factory;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\State\Pagination\ArrayPaginator;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\State\ProviderInterface;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -33,6 +34,11 @@ class ResolverFactory implements ResolverFactoryInterface
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operation) {
             // Data already fetched and normalized (field or nested resource)
             if ($body = $source[$info->fieldName] ?? null) {
+                // special treatment for nested resources without a resolver/provider
+                if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && !$operation->getProvider()) {
+                    return $this->resolve($source, $args, $info, $rootClass, $operation, new ArrayPaginator($body, 0, \count($body)));
+                }
+
                 return $body;
             }
 
@@ -45,23 +51,28 @@ class ResolverFactory implements ResolverFactoryInterface
                 return null;
             }
 
-            // Handles relay nodes
-            $operation ??= new Query();
-
-            $graphQlContext = [];
-            $context = ['source' => $source, 'args' => $args, 'info' => $info, 'root_class' => $rootClass, 'graphql_context' => &$graphQlContext];
-
-            if (null === $operation->canValidate()) {
-                $operation = $operation->withValidate($operation instanceof Mutation);
-            }
-
-            $body = $this->provider->provide($operation, [], $context);
-
-            if (null === $operation->canWrite()) {
-                $operation = $operation->withWrite($operation instanceof Mutation && null !== $body);
-            }
-
-            return $this->processor->process($body, $operation, [], $context);
+            return $this->resolve($source, $args, $info, $rootClass, $operation, null);
         };
+    }
+
+    private function resolve(?array $source, array $args, ResolveInfo $info, string $rootClass = null, Operation $operation = null, mixed $body)
+    {
+        // Handles relay nodes
+        $operation ??= new Query();
+
+        $graphQlContext = [];
+        $context = ['source' => $source, 'args' => $args, 'info' => $info, 'root_class' => $rootClass, 'graphql_context' => &$graphQlContext];
+
+        if (null === $operation->canValidate()) {
+            $operation = $operation->withValidate($operation instanceof Mutation);
+        }
+
+        $body ??= $this->provider->provide($operation, [], $context);
+
+        if (null === $operation->canWrite()) {
+            $operation = $operation->withWrite($operation instanceof Mutation && null !== $body);
+        }
+
+        return $this->processor->process($body, $operation, [], $context);
     }
 }

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\GraphQl\Serializer;
 
 use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\IdentifiersExtractorInterface;
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -110,6 +111,14 @@ final class ItemNormalizer extends BaseItemNormalizer
      */
     protected function normalizeCollectionOfRelations(ApiProperty $propertyMetadata, iterable $attributeValue, string $resourceClass, ?string $format, array $context): array
     {
+        if ($this->resourceMetadataCollectionFactory) {
+            // check for nested collection
+            $operation = $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation(forceCollection: true, forceGraphQl: true);
+            if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && !$operation->getProvider()) {
+                return [...$attributeValue];
+            }
+        }
+
         // to-many are handled directly by the GraphQL resolver
         return [];
     }

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -111,12 +111,10 @@ final class ItemNormalizer extends BaseItemNormalizer
      */
     protected function normalizeCollectionOfRelations(ApiProperty $propertyMetadata, iterable $attributeValue, string $resourceClass, ?string $format, array $context): array
     {
-        if ($this->resourceMetadataCollectionFactory) {
-            // check for nested collection
-            $operation = $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation(forceCollection: true, forceGraphQl: true);
-            if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && !$operation->getProvider()) {
-                return [...$attributeValue];
-            }
+        // check for nested collection
+        $operation = $this?->resourceMetadataCollectionFactory->create($resourceClass)->getOperation(forceCollection: true, forceGraphQl: true);
+        if ($operation && $operation instanceof Query && $operation->getNested() && !$operation->getResolver() && !$operation->getProvider()) {
+            return [...$attributeValue];
         }
 
         // to-many are handled directly by the GraphQL resolver

--- a/src/GraphQl/Tests/Resolver/Factory/ResolverFactoryTest.php
+++ b/src/GraphQl/Tests/Resolver/Factory/ResolverFactoryTest.php
@@ -45,7 +45,7 @@ class ResolverFactoryTest extends TestCase
         $this->assertEquals($resolverFactory->__invoke($resourceClass, $rootClass, $operation)(['test' => null], [], [], $resolveInfo), $returnValue);
     }
 
-    public function graphQlQueries(): array
+    public static function graphQlQueries(): array
     {
         return [
             ['Dummy', 'Dummy', new Query()],

--- a/src/GraphQl/Tests/State/Processor/NormalizeProcessorTest.php
+++ b/src/GraphQl/Tests/State/Processor/NormalizeProcessorTest.php
@@ -41,7 +41,7 @@ class NormalizeProcessorTest extends TestCase
         $processor->process($body, $operation, [], $context);
     }
 
-    public function processItems(): array
+    public static function processItems(): array
     {
         return [
             [new \stdClass(), new Query(class: 'foo')],
@@ -68,7 +68,7 @@ class NormalizeProcessorTest extends TestCase
         $processor->process($body, $operation, [], $context);
     }
 
-    public function processCollection(): array
+    public static function processCollection(): array
     {
         return [
             [new ArrayPaginator([new \stdClass()], 0, 1), new QueryCollection(class: 'foo')],

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -66,6 +66,8 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\IriOnlyDummy as IriOnlyDummyD
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\LinkHandledDummy as LinkHandledDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MaxDepthDummy as MaxDepthDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsDummy as MultiRelationsDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsNested as MultiRelationsNestedDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsNestedPaginated as MultiRelationsNestedPaginatedDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsRelatedDummy as MultiRelationsRelatedDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MusicGroup as MusicGroupDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\NetworkPathDummy as NetworkPathDummyDocument;
@@ -157,6 +159,8 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5735\Group;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\LinkHandledDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsNested;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsNestedPaginated;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsRelatedDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MusicGroup;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\NetworkPathDummy;
@@ -801,9 +805,9 @@ final class DoctrineContext implements Context
     }
 
     /**
-     * @Given there are :nb multiRelationsDummy objects having each a manyToOneRelation, :nbmtmr manyToManyRelations and :nbotmr oneToManyRelations
+     * @Given there are :nb multiRelationsDummy objects having each a manyToOneRelation, :nbmtmr manyToManyRelations, :nbotmr oneToManyRelations and :nber embeddedRelations
      */
-    public function thereAreMultiRelationsDummyObjectsHavingEachAManyToOneRelationManyToManyRelationsAndOneToManyRelations(int $nb, int $nbmtmr, int $nbotmr): void
+    public function thereAreMultiRelationsDummyObjectsHavingEachAManyToOneRelationManyToManyRelationsOneToManyRelationsAndEmbeddedRelations(int $nb, int $nbmtmr, int $nbotmr, int $nber): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $relatedDummy = $this->buildMultiRelationsRelatedDummy();
@@ -829,6 +833,22 @@ final class DoctrineContext implements Context
 
                 $dummy->addOneToManyRelation($oneToManyItem);
             }
+
+            $nested = new ArrayCollection();
+            for ($j = 1; $j <= $nber; ++$j) {
+                $embeddedItem = $this->buildMultiRelationsNested();
+                $embeddedItem->name = 'NestedDummy'.$j;
+                $nested->add($embeddedItem);
+            }
+            $dummy->setNestedCollection($nested);
+
+            $nestedPaginated = new ArrayCollection();
+            for ($j = 1; $j <= $nber; ++$j) {
+                $embeddedItem = $this->buildMultiRelationsNestedPaginated();
+                $embeddedItem->name = 'NestedPaginatedDummy'.$j;
+                $nestedPaginated->add($embeddedItem);
+            }
+            $dummy->setNestedPaginatedCollection($nestedPaginated);
 
             $this->manager->persist($relatedDummy);
             $this->manager->persist($dummy);
@@ -2597,6 +2617,16 @@ final class DoctrineContext implements Context
     private function buildMultiRelationsRelatedDummy(): MultiRelationsRelatedDummy|MultiRelationsRelatedDummyDocument
     {
         return $this->isOrm() ? new MultiRelationsRelatedDummy() : new MultiRelationsRelatedDummyDocument();
+    }
+
+    private function buildMultiRelationsNested(): MultiRelationsNested|MultiRelationsNestedDocument
+    {
+        return $this->isOrm() ? new MultiRelationsNested() : new MultiRelationsNestedDocument();
+    }
+
+    private function buildMultiRelationsNestedPaginated(): MultiRelationsNestedPaginated|MultiRelationsNestedPaginatedDocument
+    {
+        return $this->isOrm() ? new MultiRelationsNestedPaginated() : new MultiRelationsNestedPaginatedDocument();
     }
 
     private function buildMusicGroup(): MusicGroup|MusicGroupDocument

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsDummy.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsDummy.php
@@ -46,10 +46,20 @@ class MultiRelationsDummy
     #[ODM\ReferenceMany(targetDocument: MultiRelationsRelatedDummy::class, mappedBy: 'oneToManyRelation', storeAs: 'id')]
     public Collection $oneToManyRelations;
 
+    /** @var array<MultiRelationsNested> */
+    #[ODM\EmbedMany]
+    private array $nestedCollection;
+
+    /** @var array<MultiRelationsNestedPaginated> */
+    #[ODM\EmbedMany]
+    private array $nestedPaginatedCollection;
+
     public function __construct()
     {
         $this->manyToManyRelations = new ArrayCollection();
         $this->oneToManyRelations = new ArrayCollection();
+        $this->nestedCollection = [];
+        $this->nestedPaginatedCollection = [];
     }
 
     public function getId(): ?int
@@ -75,5 +85,29 @@ class MultiRelationsDummy
     public function addOneToManyRelation(MultiRelationsRelatedDummy $relatedMultiUsedDummy): void
     {
         $this->oneToManyRelations->add($relatedMultiUsedDummy);
+    }
+
+    public function getNestedCollection(): Collection
+    {
+        return new ArrayCollection($this->nestedCollection);
+    }
+
+    public function setNestedCollection(Collection $nestedCollection): self
+    {
+        $this->nestedCollection = $nestedCollection->toArray();
+
+        return $this;
+    }
+
+    public function getNestedPaginatedCollection(): Collection
+    {
+        return new ArrayCollection($this->nestedPaginatedCollection);
+    }
+
+    public function setNestedPaginatedCollection(Collection $nestedPaginatedCollection): self
+    {
+        $this->nestedPaginatedCollection = $nestedPaginatedCollection->toArray();
+
+        return $this;
     }
 }

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsNested.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsNested.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+
+#[ApiResource(graphQlOperations: [new QueryCollection(paginationEnabled: false, nested: true)])]
+class MultiRelationsNested
+{
+    public ?string $name;
+}

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsNestedPaginated.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsNestedPaginated.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+
+#[ApiResource(graphQlOperations: [new QueryCollection(nested: true)])]
+class MultiRelationsNestedPaginated
+{
+    public ?string $name;
+}

--- a/tests/Fixtures/TestBundle/Entity/MultiRelationsDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/MultiRelationsDummy.php
@@ -48,10 +48,20 @@ class MultiRelationsDummy
     #[ORM\OneToMany(targetEntity: MultiRelationsRelatedDummy::class, mappedBy: 'oneToManyRelation')]
     public Collection $oneToManyRelations;
 
+    /** @var array<MultiRelationsNested> */
+    #[ORM\Column(type: 'json')]
+    private array $nestedCollection;
+
+    /** @var array<MultiRelationsNestedPaginated> */
+    #[ORM\Column(type: 'json')]
+    private array $nestedPaginatedCollection;
+
     public function __construct()
     {
         $this->manyToManyRelations = new ArrayCollection();
         $this->oneToManyRelations = new ArrayCollection();
+        $this->nestedCollection = [];
+        $this->nestedPaginatedCollection = [];
     }
 
     public function getId(): ?int
@@ -77,5 +87,29 @@ class MultiRelationsDummy
     public function addOneToManyRelation(MultiRelationsRelatedDummy $relatedMultiUsedDummy): void
     {
         $this->oneToManyRelations->add($relatedMultiUsedDummy);
+    }
+
+    public function getNestedCollection(): Collection
+    {
+        return new ArrayCollection($this->nestedCollection);
+    }
+
+    public function setNestedCollection(Collection $nestedCollection): self
+    {
+        $this->nestedCollection = $nestedCollection->toArray();
+
+        return $this;
+    }
+
+    public function getNestedPaginatedCollection(): Collection
+    {
+        return new ArrayCollection($this->nestedPaginatedCollection);
+    }
+
+    public function setNestedPaginatedCollection(Collection $nestedPaginatedCollection): self
+    {
+        $this->nestedPaginatedCollection = $nestedPaginatedCollection->toArray();
+
+        return $this;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/MultiRelationsNested.php
+++ b/tests/Fixtures/TestBundle/Entity/MultiRelationsNested.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+
+#[ApiResource(graphQlOperations: [new QueryCollection(paginationEnabled: false, nested: true)])]
+class MultiRelationsNested
+{
+    public ?string $name;
+}

--- a/tests/Fixtures/TestBundle/Entity/MultiRelationsNestedPaginated.php
+++ b/tests/Fixtures/TestBundle/Entity/MultiRelationsNestedPaginated.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+
+#[ApiResource(graphQlOperations: [new QueryCollection(nested: true)])]
+class MultiRelationsNestedPaginated
+{
+    public ?string $name;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

We sometimes use JSON arrays to persist a collection of Value Objects which are not an entity. So this collection should be treated like a property of the parent entity. On the GraphQL queries fetching this collection was not an easy task. We had to create some special resolvers which try to fetch the ID of the parent entity out of the `$context`, load it and determine the collection from there.

So I decided to spend this PR that utilizes the `nested` property of the `ApiProperty` and uses the collection already loaded with the entity when no own resolver is given. I added a Behat test that covers that new scenario.