### PR TITLE
feat: enable Swagger UI deep linking

### DIFF
--- a/src/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -45,6 +45,7 @@ window.onload = function() {
         spec: data.spec,
         dom_id: '#swagger-ui',
         validatorUrl: null,
+        deepLinking: true,
         oauth2RedirectUrl: data.oauth.redirectUrl,
         presets: [
             SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#1857

I suggest enabling `deepLinking` as a default feature in Swagger UI. This functionality greatly enhances API documentation. WDYT?

With this feature, you can link to specific operations within your API documentation. For example https://petstore.swagger.io/#/user/createUsersWithListInput