### PR TITLE
fix(symfony): do not use metadata when merging schema constraints in Collection constraint

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -82,6 +82,7 @@ return (new PhpCsFixer\Config())
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => [
             'allow_mixed' => false,
+            'allow_unused_params' => true,
         ],
         'no_unset_cast' => true,
         'no_unset_on_property' => true,

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
@@ -52,8 +52,7 @@ final class PropertySchemaChoiceRestriction implements PropertySchemaRestriction
 
         $restriction['type'] = 'array';
 
-        $builtInTypes = $propertyMetadata->getBuiltinTypes() ?? [];
-        $types = array_unique(array_map(fn (Type $type) => Type::BUILTIN_TYPE_STRING === $type->getBuiltinType() ? 'string' : 'number', $builtInTypes));
+        $types = array_values(array_unique(array_map(fn (mixed $choice) => \is_string($choice) ? 'string' : 'number', $choices)));
 
         if ($count = \count($types)) {
             if (1 === $count) {
@@ -80,6 +79,9 @@ final class PropertySchemaChoiceRestriction implements PropertySchemaRestriction
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
         $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
+            $types = [Type::BUILTIN_TYPE_STRING];
+        }
 
         return $constraint instanceof Choice && \count($types) && array_intersect($types, [Type::BUILTIN_TYPE_STRING, Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT]);
     }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
@@ -69,19 +69,19 @@ final class PropertySchemaCollectionRestriction implements PropertySchemaRestric
         return $constraint instanceof Collection;
     }
 
-    private function mergeConstraintRestrictions(Required|Optional $constraint, ApiProperty $propertyMetadata): array
+    private function mergeConstraintRestrictions(Required|Optional $constraint, ApiProperty $propertyMetadata): array|\ArrayObject
     {
         $propertyRestrictions = [];
         $nestedConstraints = $constraint->constraints;
 
         foreach ($nestedConstraints as $nestedConstraint) {
             foreach ($this->restrictionsMetadata as $restrictionMetadata) {
-                if ($restrictionMetadata->supports($nestedConstraint, $propertyMetadata) && !empty($nestedConstraintRestriction = $restrictionMetadata->create($nestedConstraint, $propertyMetadata))) {
+                if ($restrictionMetadata->supports($nestedConstraint, $propertyMetadata->withExtraProperties(($propertyMetadata->getExtraProperties() ?? []) + ['nested_schema' => true])) && !empty($nestedConstraintRestriction = $restrictionMetadata->create($nestedConstraint, $propertyMetadata))) {
                     $propertyRestrictions[] = $nestedConstraintRestriction;
                 }
             }
         }
 
-        return array_merge([], ...$propertyRestrictions);
+        return array_merge([], ...$propertyRestrictions) ?: new \ArrayObject();
     }
 }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestriction.php
@@ -41,6 +41,9 @@ final class PropertySchemaGreaterThanOrEqualRestriction implements PropertySchem
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
         $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
+            $types = [Type::BUILTIN_TYPE_INT];
+        }
 
         return $constraint instanceof GreaterThanOrEqual && is_numeric($constraint->value) && \count($types) && array_intersect($types, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT]);
     }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
@@ -41,6 +41,9 @@ final class PropertySchemaGreaterThanRestriction implements PropertySchemaRestri
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
         $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
+            $types = [Type::BUILTIN_TYPE_INT];
+        }
 
         return $constraint instanceof GreaterThan && is_numeric($constraint->value) && \count($types) && array_intersect($types, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT]);
     }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLengthRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLengthRestriction.php
@@ -51,6 +51,9 @@ class PropertySchemaLengthRestriction implements PropertySchemaRestrictionMetada
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
         $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
+            $types = [Type::BUILTIN_TYPE_STRING];
+        }
 
         return $constraint instanceof Length && \count($types) && \in_array(Type::BUILTIN_TYPE_STRING, $types, true);
     }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestriction.php
@@ -41,6 +41,9 @@ final class PropertySchemaLessThanOrEqualRestriction implements PropertySchemaRe
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
         $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
+            $types = [Type::BUILTIN_TYPE_INT];
+        }
 
         return $constraint instanceof LessThanOrEqual && is_numeric($constraint->value) && \count($types) && array_intersect($types, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT]);
     }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
@@ -41,6 +41,9 @@ final class PropertySchemaLessThanRestriction implements PropertySchemaRestricti
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
         $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
+            $types = [Type::BUILTIN_TYPE_INT];
+        }
 
         return $constraint instanceof LessThan && is_numeric($constraint->value) && \count($types) && array_intersect($types, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT]);
     }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
@@ -49,6 +49,9 @@ final class PropertySchemaRangeRestriction implements PropertySchemaRestrictionM
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
         $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
+            $types = [Type::BUILTIN_TYPE_INT];
+        }
 
         return $constraint instanceof Range && \count($types) && array_intersect($types, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT]);
     }

--- a/tests/Fixtures/DummyCollectionValidatedEntity.php
+++ b/tests/Fixtures/DummyCollectionValidatedEntity.php
@@ -37,6 +37,7 @@ class DummyCollectionValidatedEntity
             ]),
             'age' => new Assert\Optional([
                 new Assert\Type(type: 'int'),
+                new Assert\GreaterThan(0),
             ]),
             'social' => new Assert\Collection(
                 fields: [

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestrictionTest.php
@@ -96,22 +96,22 @@ final class PropertySchemaChoiceRestrictionTest extends TestCase
             new Type(Type::BUILTIN_TYPE_STRING),
             new Type(Type::BUILTIN_TYPE_INT),
             new Type(Type::BUILTIN_TYPE_FLOAT),
-        ]), ['type' => 'array', 'items' => ['type' => ['string', 'number'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2]]]];
+        ]), ['type' => 'array', 'items' => ['type' => ['number', 'string'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2]]]];
         yield 'multi string/int/float choice min with union types' => [new Choice(['choices' => [1, 2, 'a', 'b', 1.1, 2.2], 'multiple' => true, 'min' => 2]), (new ApiProperty())->withBuiltinTypes([
             new Type(Type::BUILTIN_TYPE_STRING),
             new Type(Type::BUILTIN_TYPE_INT),
             new Type(Type::BUILTIN_TYPE_FLOAT),
-        ]), ['type' => 'array', 'items' => ['type' => ['string', 'number'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2]], 'minItems' => 2]];
+        ]), ['type' => 'array', 'items' => ['type' => ['number', 'string'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2]], 'minItems' => 2]];
         yield 'multi string/int/float choice max with union types' => [new Choice(['choices' => [1, 2, 'a', 'b', 1.1, 2.2, 3.3, 4.4], 'multiple' => true, 'max' => 4]), (new ApiProperty())->withBuiltinTypes([
             new Type(Type::BUILTIN_TYPE_STRING),
             new Type(Type::BUILTIN_TYPE_INT),
             new Type(Type::BUILTIN_TYPE_FLOAT),
-        ]), ['type' => 'array', 'items' => ['type' => ['string', 'number'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2, 3.3, 4.4]], 'maxItems' => 4]];
+        ]), ['type' => 'array', 'items' => ['type' => ['number', 'string'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2, 3.3, 4.4]], 'maxItems' => 4]];
         yield 'multi string/int/float choice min/max with union types' => [new Choice(['choices' => [1, 2, 'a', 'b', 1.1, 2.2, 3.3, 4.4], 'multiple' => true, 'min' => 2, 'max' => 4]), (new ApiProperty())->withBuiltinTypes([
             new Type(Type::BUILTIN_TYPE_STRING),
             new Type(Type::BUILTIN_TYPE_INT),
             new Type(Type::BUILTIN_TYPE_FLOAT),
-        ]), ['type' => 'array', 'items' => ['type' => ['string', 'number'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2, 3.3, 4.4]], 'minItems' => 2, 'maxItems' => 4]];
+        ]), ['type' => 'array', 'items' => ['type' => ['number', 'string'], 'enum' => [1, 2, 'a', 'b', 1.1, 2.2, 3.3, 4.4]], 'minItems' => 2, 'maxItems' => 4]];
 
         yield 'single choice callback' => [new Choice(['callback' => ChoiceCallback::getChoices(...)]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)]), ['enum' => ['a', 'b', 'c', 'd']]];
         yield 'multi choice callback' => [new Choice(['callback' => ChoiceCallback::getChoices(...), 'multiple' => true]), (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_STRING)]), ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ['a', 'b', 'c', 'd']]]];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Symfony\Validator\Metadata\Property\Restriction;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaCollectionRestriction;
 use ApiPlatform\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaFormat;
+use ApiPlatform\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaGreaterThanRestriction;
 use ApiPlatform\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaLengthRestriction;
 use ApiPlatform\Symfony\Validator\Metadata\Property\Restriction\PropertySchemaRegexRestriction;
 use PHPUnit\Framework\TestCase;
@@ -23,6 +24,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -44,6 +46,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
     protected function setUp(): void
     {
         $this->propertySchemaCollectionRestriction = new PropertySchemaCollectionRestriction([
+            new PropertySchemaGreaterThanRestriction(),
             new PropertySchemaLengthRestriction(),
             new PropertySchemaRegexRestriction(),
             new PropertySchemaFormat(),
@@ -71,7 +74,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
      */
     public function testCreate(Constraint $constraint, ApiProperty $propertyMetadata, array $expectedResult): void
     {
-        self::assertSame($expectedResult, $this->propertySchemaCollectionRestriction->create($constraint, $propertyMetadata));
+        self::assertEquals($expectedResult, $this->propertySchemaCollectionRestriction->create($constraint, $propertyMetadata));
     }
 
     public static function createProvider(): \Generator
@@ -93,6 +96,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
             ]),
             'age' => new Optional([
                 new Type(['type' => 'int']),
+                new GreaterThan(0),
             ]),
             'social' => new Collection([
                 'fields' => [
@@ -101,11 +105,11 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
             ]),
         ];
         $properties = [
-            'name' => [],
-            'email' => ['format' => 'email'],
+            'name' => new \ArrayObject(),
+            'email' => ['minLength' => 2, 'maxLength' => 255, 'format' => 'email'],
             'phone' => ['pattern' => '^([+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
-            'age' => [],
-            'social' => ['type' => 'object', 'properties' => ['githubUsername' => []], 'additionalProperties' => false, 'required' => ['githubUsername']],
+            'age' => ['exclusiveMinimum' => 0],
+            'social' => ['type' => 'object', 'properties' => ['githubUsername' => new \ArrayObject()], 'additionalProperties' => false, 'required' => ['githubUsername']],
         ];
         $required = ['name', 'email', 'social'];
 

--- a/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -589,18 +589,22 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
             (new ApiProperty())->withBuiltinTypes([new Type(Type::BUILTIN_TYPE_ARRAY)])
         )->shouldBeCalled();
 
+        $greaterThanRestriction = new PropertySchemaGreaterThanRestriction();
         $lengthRestriction = new PropertySchemaLengthRestriction();
         $regexRestriction = new PropertySchemaRegexRestriction();
         $formatRestriction = new PropertySchemaFormat();
         $restrictionsMetadata = [
+            $greaterThanRestriction,
             $lengthRestriction,
             $regexRestriction,
             $formatRestriction,
             new PropertySchemaCollectionRestriction([
+                $greaterThanRestriction,
                 $lengthRestriction,
                 $regexRestriction,
                 $formatRestriction,
                 new PropertySchemaCollectionRestriction([
+                    $greaterThanRestriction,
                     $lengthRestriction,
                     $regexRestriction,
                     $formatRestriction,
@@ -619,14 +623,16 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals([
             'type' => 'object',
             'properties' => [
-                'name' => [],
-                'email' => ['format' => 'email'],
+                'name' => new \ArrayObject(),
+                'email' => ['format' => 'email', 'minLength' => 2, 'maxLength' => 255],
                 'phone' => ['pattern' => '^([+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
-                'age' => [],
+                'age' => [
+                    'exclusiveMinimum' => 0,
+                ],
                 'social' => [
                     'type' => 'object',
                     'properties' => [
-                        'githubUsername' => [],
+                        'githubUsername' => new \ArrayObject(),
                     ],
                     'additionalProperties' => false,
                     'required' => ['githubUsername'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | Closes #5414, closes #5413
| License       | MIT
| Doc PR        | N/A

Supersedes https://github.com/api-platform/core/pull/5505.