### PR TITLE
Hotfix/fix attribute filter parsing

### DIFF
--- a/docs/src/DependencyInjection/Compiler/AttributeFilterPass.php
+++ b/docs/src/DependencyInjection/Compiler/AttributeFilterPass.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Playground\DependencyInjection\Compiler;
 
-use ApiPlatform\Util\AttributeFilterExtractorTrait;
+use ApiPlatform\Metadata\Util\AttributeFilterExtractorTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/AttributeFilterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/AttributeFilterPass.php
@@ -15,7 +15,7 @@ namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
 
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\Util\ReflectionClassRecursiveIterator;
-use ApiPlatform\Util\AttributeFilterExtractorTrait;
+use ApiPlatform\Metadata\Util\AttributeFilterExtractorTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/AttributeFilterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/AttributeFilterPass.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
 
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\Util\ReflectionClassRecursiveIterator;
 use ApiPlatform\Metadata\Util\AttributeFilterExtractorTrait;
+use ApiPlatform\Metadata\Util\ReflectionClassRecursiveIterator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | Closes #6023 
| License       | MIT
| Doc PR        | 

Branch: 
- the stable/latest 3.2 for bug fixes

I don't know what kind of test I can add for this case.
Do I have to find a unit test, checking that AttributeFilterPass::generateFilterId() returns the same than FiltersResourceMetadataCollectionFactory::generateFilterId() in the edge case evoqued in the issue (ReflectionClass with a namespace containing consecutive uppercase) ; 
Or do I have to do something like an integration test, creating a fake Resource in the 'Fixtures' directory (somethink like  ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6023\ConsecutiveUPPERCASE with a custom filter and check that the global 'process' method register it in ServiceLocator under the correct name  (something like 'annotated_.api_platform_tests_fixtures_test_bundle_entity_issue6023_consecutive_uppercase_my_filter') ? 


Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
