### PR TITLE
fix: Remove comparator conflict in 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,6 @@
         "doctrine/mongodb-odm": "<2.4",
         "doctrine/persistence": "<1.3",
         "symfony/var-exporter": "<6.1.1",
-        "sebastian/comparator": ">=5.0",
         "phpunit/phpunit": "<9.5",
         "phpspec/prophecy": "<1.15",
         "elasticsearch/elasticsearch": ">=8.0,<8.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | /
| License       | MIT
| Doc PR        | /


This conflict prevents people from installing 3.2.8

Same commit than cbc803cab81bc6acbe74c4db4eba63bc8539aa16 for 3.2 branch
