### PR TITLE
fix(symfony): use Type constraint violation code instead of exception code

### DIFF
--- a/features/main/validation.feature
+++ b/features/main/validation.feature
@@ -102,39 +102,39 @@ Feature: Using validations groups
         {
           "propertyPath": "",
           "message": "This value should be of type unknown.",
-          "code": "0",
+          "code": "ba785a8c-82cb-4283-967c-3cf342181b40",
           "hint": "Failed to create object because the class misses the \"baz\" property."
         },
         {
           "propertyPath": "qux",
           "message": "This value should be of type string.",
-          "code": "0"
+          "code": "ba785a8c-82cb-4283-967c-3cf342181b40"
         },
         {
           "propertyPath": "foo",
           "message": "This value should be of type bool.",
-          "code": "0"
+          "code": "ba785a8c-82cb-4283-967c-3cf342181b40"
         },
         {
           "propertyPath": "bar",
           "message": "This value should be of type int.",
-          "code": "0"
+          "code": "ba785a8c-82cb-4283-967c-3cf342181b40"
         },
         {
           "propertyPath": "uuid",
           "message": "This value should be of type uuid.",
-          "code": "0",
+          "code": "ba785a8c-82cb-4283-967c-3cf342181b40",
           "hint": "Invalid UUID string: y"
         },
         {
           "propertyPath": "relatedDummy",
           "message": "This value should be of type array|string.",
-          "code": "0"
+          "code": "ba785a8c-82cb-4283-967c-3cf342181b40"
         },
         {
           "propertyPath": "relatedDummies",
           "message": "This value should be of type array.",
-          "code": "0"
+          "code": "ba785a8c-82cb-4283-967c-3cf342181b40"
         }
       ]
     }

--- a/src/Symfony/EventListener/DeserializeListener.php
+++ b/src/Symfony/EventListener/DeserializeListener.php
@@ -111,7 +111,7 @@ final class DeserializeListener
                 if ($exception->canUseMessageForUser()) {
                     $parameters['hint'] = $exception->getMessage();
                 }
-                $violations->add(new ConstraintViolation($this->translator->trans($message, ['{{ type }}' => implode('|', $exception->getExpectedTypes() ?? [])], 'validators'), $message, $parameters, null, $exception->getPath(), null, null, (string) $exception->getCode()));
+                $violations->add(new ConstraintViolation($this->translator->trans($message, ['{{ type }}' => implode('|', $exception->getExpectedTypes() ?? [])], 'validators'), $message, $parameters, null, $exception->getPath(), null, null, Type::INVALID_TYPE_ERROR));
             }
             if (0 !== \count($violations)) {
                 throw new ValidationException($violations);

--- a/tests/Symfony/EventListener/DeserializeListenerTest.php
+++ b/tests/Symfony/EventListener/DeserializeListenerTest.php
@@ -366,7 +366,7 @@ class DeserializeListenerTest extends TestCase
             $this->assertSame($violation->getPropertyPath(), 'foo');
             $this->assertNull($violation->getInvalidValue());
             $this->assertNull($violation->getPlural());
-            $this->assertSame($violation->getCode(), '0');
+            $this->assertSame($violation->getCode(), 'ba785a8c-82cb-4283-967c-3cf342181b40');
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Replaces #6037
