### PR TITLE
fix(graphql): remove count query if paginationInfo is not requested

### DIFF
--- a/src/GraphQl/Resolver/Stage/SerializeStage.php
+++ b/src/GraphQl/Resolver/Stage/SerializeStage.php
@@ -88,7 +88,7 @@ final class SerializeStage implements SerializeStageInterface
             } else {
                 $data = 'cursor' === $this->pagination->getGraphQlPaginationType($operation) ?
                     $this->serializeCursorBasedPaginatedCollection($itemOrCollection, $normalizationContext, $context) :
-                    $this->serializePageBasedPaginatedCollection($itemOrCollection, $normalizationContext);
+                    $this->serializePageBasedPaginatedCollection($itemOrCollection, $normalizationContext, $context);
             }
         }
 
@@ -117,53 +117,61 @@ final class SerializeStage implements SerializeStageInterface
             throw new \LogicException(sprintf('Collection returned by the collection data provider must implement %s or %s.', PaginatorInterface::class, PartialPaginatorInterface::class));
         }
 
+        $selection = $context['info']->getFieldSelection(1);
+
         $offset = 0;
         $totalItems = 1; // For partial pagination, always consider there is at least one item.
-        $nbPageItems = $collection->count();
-        if (isset($args['after'])) {
-            $after = base64_decode($args['after'], true);
-            if (false === $after || '' === $args['after']) {
-                throw new \UnexpectedValueException('' === $args['after'] ? 'Empty cursor is invalid' : sprintf('Cursor %s is invalid', $args['after']));
-            }
-            $offset = 1 + (int) $after;
-        }
-
-        if ($collection instanceof PaginatorInterface) {
-            $totalItems = $collection->getTotalItems();
-
-            if (isset($args['before'])) {
-                $before = base64_decode($args['before'], true);
-                if (false === $before || '' === $args['before']) {
-                    throw new \UnexpectedValueException('' === $args['before'] ? 'Empty cursor is invalid' : sprintf('Cursor %s is invalid', $args['before']));
+        $data = ['edges' => []];
+        if (isset($selection['pageInfo']) || isset($selection['totalCount']) || isset($selection['edges']['cursor'])) {
+            $nbPageItems = $collection->count();
+            if (isset($args['after'])) {
+                $after = base64_decode($args['after'], true);
+                if (false === $after || '' === $args['after']) {
+                    throw new \UnexpectedValueException('' === $args['after'] ? 'Empty cursor is invalid' : sprintf('Cursor %s is invalid', $args['after']));
                 }
-                $offset = (int) $before - $nbPageItems;
+                $offset = 1 + (int) $after;
             }
-            if (isset($args['last']) && !isset($args['before'])) {
-                $offset = $totalItems - $args['last'];
+
+            if ($collection instanceof PaginatorInterface && (isset($selection['pageInfo']) || isset($selection['totalCount']))) {
+                $totalItems = $collection->getTotalItems();
+                if (isset($args['before'])) {
+                    $before = base64_decode($args['before'], true);
+                    if (false === $before || '' === $args['before']) {
+                        throw new \UnexpectedValueException('' === $args['before'] ? 'Empty cursor is invalid' : sprintf('Cursor %s is invalid', $args['before']));
+                    }
+                    $offset = (int) $before - $nbPageItems;
+                }
+                if (isset($args['last']) && !isset($args['before'])) {
+                    $offset = $totalItems - $args['last'];
+                }
             }
-        }
 
-        $offset = 0 > $offset ? 0 : $offset;
+            $offset = max(0, $offset);
 
-        $data = $this->getDefaultCursorBasedPaginatedData();
-        if ($totalItems > 0) {
-            $data['pageInfo']['startCursor'] = base64_encode((string) $offset);
-            $end = $offset + $nbPageItems - 1;
-            $data['pageInfo']['endCursor'] = base64_encode((string) ($end >= 0 ? $end : 0));
-            $data['pageInfo']['hasPreviousPage'] = $offset > 0;
-            if ($collection instanceof PaginatorInterface) {
-                $data['totalCount'] = $totalItems;
-                $itemsPerPage = $collection->getItemsPerPage();
-                $data['pageInfo']['hasNextPage'] = (float) ($itemsPerPage > 0 ? $offset % $itemsPerPage : $offset) + $itemsPerPage * $collection->getCurrentPage() < $totalItems;
+            $data = $this->getDefaultCursorBasedPaginatedData();
+            if ((isset($selection['pageInfo']) || isset($selection['totalCount'])) && $totalItems > 0) {
+                isset($selection['pageInfo']['startCursor']) && $data['pageInfo']['startCursor'] = base64_encode((string) $offset);
+                $end = $offset + $nbPageItems - 1;
+                isset($selection['pageInfo']['endCursor']) && $data['pageInfo']['endCursor'] = base64_encode((string) max($end, 0));
+                isset($selection['pageInfo']['hasPreviousPage']) && $data['pageInfo']['hasPreviousPage'] = $offset > 0;
+                if ($collection instanceof PaginatorInterface) {
+                    isset($selection['totalCount']) && $data['totalCount'] = $totalItems;
+
+                    $itemsPerPage = $collection->getItemsPerPage();
+                    isset($selection['pageInfo']['hasNextPage']) && $data['pageInfo']['hasNextPage'] = (float) ($itemsPerPage > 0 ? $offset % $itemsPerPage : $offset) + $itemsPerPage * $collection->getCurrentPage() < $totalItems;
+                }
             }
         }
 
         $index = 0;
         foreach ($collection as $object) {
-            $data['edges'][$index] = [
+            $edge = [
                 'node' => $this->normalizer->normalize($object, ItemNormalizer::FORMAT, $normalizationContext),
-                'cursor' => base64_encode((string) ($index + $offset)),
             ];
+            if (isset($selection['edges']['cursor'])) {
+                $edge['cursor'] = base64_encode((string) ($index + $offset));
+            }
+            $data['edges'][$index] = $edge;
             ++$index;
         }
 
@@ -173,16 +181,32 @@ final class SerializeStage implements SerializeStageInterface
     /**
      * @throws \LogicException
      */
-    private function serializePageBasedPaginatedCollection(iterable $collection, array $normalizationContext): array
+    private function serializePageBasedPaginatedCollection(iterable $collection, array $normalizationContext, array $context): array
     {
-        if (!($collection instanceof PaginatorInterface)) {
-            throw new \LogicException(sprintf('Collection returned by the collection data provider must implement %s.', PaginatorInterface::class));
-        }
+        $data = ['collection' => []];
 
-        $data = $this->getDefaultPageBasedPaginatedData();
-        $data['paginationInfo']['totalCount'] = $collection->getTotalItems();
-        $data['paginationInfo']['lastPage'] = $collection->getLastPage();
-        $data['paginationInfo']['itemsPerPage'] = $collection->getItemsPerPage();
+        $selection = $context['info']->getFieldSelection(1);
+        if (isset($selection['paginationInfo'])) {
+            $data['paginationInfo'] = [];
+            if (isset($selection['paginationInfo']['itemsPerPage'])) {
+                if (!($collection instanceof PartialPaginatorInterface)) {
+                    throw new \LogicException(sprintf('Collection returned by the collection data provider must implement %s to return itemsPerPage field.', PartialPaginatorInterface::class));
+                }
+                $data['paginationInfo']['itemsPerPage'] = $collection->getItemsPerPage();
+            }
+            if (isset($selection['paginationInfo']['totalCount'])) {
+                if (!($collection instanceof PaginatorInterface)) {
+                    throw new \LogicException(sprintf('Collection returned by the collection data provider must implement %s to return totalCount field.', PaginatorInterface::class));
+                }
+                $data['paginationInfo']['totalCount'] = $collection->getTotalItems();
+            }
+            if (isset($selection['paginationInfo']['lastPage'])) {
+                if (!($collection instanceof PaginatorInterface)) {
+                    throw new \LogicException(sprintf('Collection returned by the collection data provider must implement %s to return lastPage field.', PaginatorInterface::class));
+                }
+                $data['paginationInfo']['lastPage'] = $collection->getLastPage();
+            }
+        }
 
         foreach ($collection as $object) {
             $data['collection'][] = $this->normalizer->normalize($object, ItemNormalizer::FORMAT, $normalizationContext);

--- a/src/GraphQl/Tests/Resolver/Factory/CollectionResolverFactoryTest.php
+++ b/src/GraphQl/Tests/Resolver/Factory/CollectionResolverFactoryTest.php
@@ -68,7 +68,9 @@ class CollectionResolverFactoryTest extends TestCase
         $operation = (new QueryCollection())->withName($operationName);
         $source = ['testField' => 0];
         $args = ['args'];
-        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $infoProphecy->getFieldSelection()->willReturn(['testField' => true]);
+        $info = $infoProphecy->reveal();
         $info->fieldName = 'testField';
         $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
@@ -101,7 +103,9 @@ class CollectionResolverFactoryTest extends TestCase
         $operation = (new QueryCollection())->withName($operationName);
         $source = ['source'];
         $args = ['args'];
-        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $infoProphecy->getFieldSelection()->willReturn(['testField' => true]);
+        $info = $infoProphecy->reveal();
         $info->fieldName = 'testField';
         $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
@@ -132,7 +136,9 @@ class CollectionResolverFactoryTest extends TestCase
         $operation = (new QueryCollection())->withName($operationName);
         $source = null;
         $args = ['args'];
-        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $infoProphecy->getFieldSelection()->willReturn([]);
+        $info = $infoProphecy->reveal();
         $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageCollection = [new \stdClass()];
@@ -164,7 +170,9 @@ class CollectionResolverFactoryTest extends TestCase
         $operation = (new QueryCollection())->withName($operationName);
         $source = ['source'];
         $args = ['args'];
-        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $infoProphecy->getFieldSelection()->willReturn([]);
+        $info = $infoProphecy->reveal();
 
         $this->assertNull(($this->collectionResolverFactory)($resourceClass, $rootClass, $operation)($source, $args, null, $info));
     }
@@ -177,7 +185,9 @@ class CollectionResolverFactoryTest extends TestCase
         $operation = (new QueryCollection())->withName($operationName);
         $source = ['source'];
         $args = ['args'];
-        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $infoProphecy->getFieldSelection()->willReturn([]);
+        $info = $infoProphecy->reveal();
 
         $this->assertNull(($this->collectionResolverFactory)($resourceClass, $rootClass, $operation)($source, $args, null, $info));
     }
@@ -190,7 +200,9 @@ class CollectionResolverFactoryTest extends TestCase
         $operation = (new QueryCollection())->withName($operationName);
         $source = null;
         $args = ['args'];
-        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $infoProphecy->getFieldSelection()->willReturn([]);
+        $info = $infoProphecy->reveal();
         $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageCollection = new \stdClass();
@@ -210,7 +222,9 @@ class CollectionResolverFactoryTest extends TestCase
         $operation = (new QueryCollection())->withResolver('query_resolver_id')->withName($operationName);
         $source = null;
         $args = ['args'];
-        $info = $this->prophesize(ResolveInfo::class)->reveal();
+        $infoProphecy = $this->prophesize(ResolveInfo::class);
+        $infoProphecy->getFieldSelection()->willReturn([]);
+        $info = $infoProphecy->reveal();
         $resolverContext = ['source' => $source, 'args' => $args, 'info' => $info, 'is_collection' => true, 'is_mutation' => false, 'is_subscription' => false];
 
         $readStageCollection = [new \stdClass()];

--- a/src/GraphQl/Tests/State/Processor/NormalizeProcessorTest.php
+++ b/src/GraphQl/Tests/State/Processor/NormalizeProcessorTest.php
@@ -21,11 +21,27 @@ use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Subscription;
 use ApiPlatform\State\Pagination\ArrayPaginator;
 use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\PartialPaginatorInterface;
+use GraphQL\Type\Definition\ResolveInfo;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class NormalizeProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
+    private ObjectProphecy $resolveInfoProphecy;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->resolveInfoProphecy = $this->prophesize(ResolveInfo::class);
+    }
+
     /**
      * @dataProvider processItems
      */
@@ -53,25 +69,65 @@ class NormalizeProcessorTest extends TestCase
     /**
      * @dataProvider processCollection
      */
-    public function testProcessCollection($body, $operation): void
+    public function testProcessCollection($collection, $operation, $args, ?array $expectedResult, array $getFieldSelection, string $expectedExceptionClass = null, string $expectedExceptionMessage = null): void
     {
-        $context = ['args' => []];
+        $this->resolveInfoProphecy->getFieldSelection(1)->willReturn($getFieldSelection);
+        $context = ['args' => $args, 'info' => $this->resolveInfoProphecy->reveal()];
         $serializerContext = ['resource_class' => $operation->getClass()];
-        $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer = $this->prophesize(NormalizerInterface::class);
+
         $serializerContextBuilder = $this->createMock(SerializerContextBuilderInterface::class);
         $serializerContextBuilder->expects($this->once())->method('create')->with($operation->getClass(), $operation, $context, normalization: true)->willReturn($serializerContext);
-        foreach ($body as $v) {
-            $normalizer->expects($this->once())->method('normalize')->with($v, 'graphql', $serializerContext);
+        foreach ($collection as $v) {
+            $normalizer->normalize($v, 'graphql', $serializerContext)->willReturn(['normalized_item'])->shouldBeCalledOnce();
         }
 
-        $processor = new NormalizeProcessor($normalizer, $serializerContextBuilder, new Pagination());
-        $processor->process($body, $operation, [], $context);
+        if ($expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $processor = new NormalizeProcessor($normalizer->reveal(), $serializerContextBuilder, new Pagination());
+        $result = $processor->process(\is_callable($collection) ? $collection($this) : $collection, $operation, [], $context);
+        $this->assertSame($expectedResult, $result);
     }
 
-    public function processCollection(): array
+    public function processCollection(): iterable
     {
-        return [
-            [new ArrayPaginator([new \stdClass()], 0, 1), new QueryCollection(class: 'foo')],
-        ];
+        $partialPaginatorFactory = function (self $that): PartialPaginatorInterface {
+            $partialPaginatorProphecy = $that->prophesize(PartialPaginatorInterface::class);
+            $partialPaginatorProphecy->count()->willReturn(2);
+            $partialPaginatorProphecy->valid()->willReturn(false);
+            $partialPaginatorProphecy->getItemsPerPage()->willReturn(2.0);
+            $partialPaginatorProphecy->rewind();
+
+            return $partialPaginatorProphecy->reveal();
+        };
+
+        yield 'cursor - not paginator' => [[], new QueryCollection(class: 'foo'), [], null, [], \LogicException::class, 'Collection returned by the collection data provider must implement ApiPlatform\State\Pagination\PaginatorInterface or ApiPlatform\State\Pagination\PartialPaginatorInterface.'];
+        yield 'cursor - empty paginator' => [new ArrayPaginator([], 0, 0), new QueryCollection(class: 'foo'), [], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => null, 'endCursor' => null, 'hasNextPage' => false, 'hasPreviousPage' => false]], ['totalCount' => true, 'edges' => ['cursor' => true], 'pageInfo' => ['startCursor' => true, 'endCursor' => true, 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+        yield 'cursor - paginator' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 0, 2), new QueryCollection(class: 'foo'), [],  ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MA=='], ['node' => ['normalized_item'], 'cursor' => 'MQ==']], 'pageInfo' => ['startCursor' => 'MA==', 'endCursor' => 'MQ==', 'hasNextPage' => true, 'hasPreviousPage' => false]], ['totalCount' => true, 'edges' => ['cursor' => true], 'pageInfo' => ['startCursor' => true, 'endCursor' => true, 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+        yield 'cursor - paginator with after cursor' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 1, 2), new QueryCollection(class: 'foo'), ['after' => 'MA=='], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ=='], ['node' => ['normalized_item'], 'cursor' => 'Mg==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]], ['totalCount' => true, 'edges' => ['cursor' => true], 'pageInfo' => ['startCursor' => true, 'endCursor' => true, 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+        yield 'cursor - paginator with bad after cursor' => [new ArrayPaginator([], 0, 0), new QueryCollection(class: 'foo'), ['after' => '-'], null, ['edges' => ['cursor' => []]], \UnexpectedValueException::class, 'Cursor - is invalid'];
+        yield 'cursor - paginator with empty after cursor' => [new ArrayPaginator([], 0, 0), new QueryCollection(class: 'foo'), ['after' => ''], null, ['edges' => ['cursor' => []]], \UnexpectedValueException::class, 'Empty cursor is invalid'];
+        yield 'cursor - paginator with before cursor' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 1, 1), new QueryCollection(class: 'foo'), ['before' => 'Mg=='], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'MQ==', 'hasNextPage' => true, 'hasPreviousPage' => true]], ['totalCount' => true, 'edges' => ['cursor' => true], 'pageInfo' => ['startCursor' => true, 'endCursor' => true, 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+        yield 'cursor - paginator with bad before cursor' => [new ArrayPaginator([], 0, 0), new QueryCollection(class: 'foo'), ['before' => '-'], null, ['pageInfo' => ['endCursor' => true]], \UnexpectedValueException::class, 'Cursor - is invalid'];
+        yield 'cursor - paginator with empty before cursor' => [new ArrayPaginator([], 0, 0), new QueryCollection(class: 'foo'), ['before' => ''], null, ['pageInfo' => ['endCursor' => true]], \UnexpectedValueException::class, 'Empty cursor is invalid'];
+        yield 'cursor - paginator with last' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 1, 2), new QueryCollection(class: 'foo'), ['last' => 2], ['totalCount' => 3., 'edges' => [['node' => ['normalized_item'], 'cursor' => 'MQ=='], ['node' => ['normalized_item'], 'cursor' => 'Mg==']], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]], ['totalCount' => true, 'edges' => ['cursor' => true], 'pageInfo' => ['startCursor' => true, 'endCursor' => true, 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+        yield 'cursor - partial paginator' => [$partialPaginatorFactory, new QueryCollection(class: 'foo'), [], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => 'MA==', 'endCursor' => 'MQ==', 'hasNextPage' => false, 'hasPreviousPage' => false]], ['totalCount' => true, 'edges' => ['cursor' => true], 'pageInfo' => ['startCursor' => true, 'endCursor' => true, 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+        yield 'cursor - partial paginator with after cursor' => [$partialPaginatorFactory, new QueryCollection(class: 'foo'), ['after' => 'MA=='], ['totalCount' => 0., 'edges' => [], 'pageInfo' => ['startCursor' => 'MQ==', 'endCursor' => 'Mg==', 'hasNextPage' => false, 'hasPreviousPage' => true]], ['totalCount' => true, 'edges' => ['cursor' => true], 'pageInfo' => ['startCursor' => true, 'endCursor' => true, 'hasNextPage' => true, 'hasPreviousPage' => true]]];
+
+        yield 'page - not paginator, itemsPerPage requested' => [[], (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], [], ['paginationInfo' => ['itemsPerPage' => true]], \LogicException::class, 'Collection returned by the collection data provider must implement ApiPlatform\State\Pagination\PartialPaginatorInterface to return itemsPerPage field.'];
+        yield 'page - not paginator, lastPage requested' => [[], (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], [], ['paginationInfo' => ['lastPage' => true]], \LogicException::class, 'Collection returned by the collection data provider must implement ApiPlatform\State\Pagination\PaginatorInterface to return lastPage field.'];
+        yield 'page - not paginator, totalCount requested' => [[], (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], [], ['paginationInfo' => ['totalCount' => true]], \LogicException::class, 'Collection returned by the collection data provider must implement ApiPlatform\State\Pagination\PaginatorInterface to return totalCount field.'];
+        yield 'page - empty paginator - itemsPerPage requested' => [new ArrayPaginator([], 0, 0), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [], 'paginationInfo' => ['itemsPerPage' => .0]], ['paginationInfo' => ['itemsPerPage' => true]]];
+        yield 'page - empty paginator - lastPage requested' => [new ArrayPaginator([], 0, 0), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [], 'paginationInfo' => ['lastPage' => 1.0]], ['paginationInfo' => ['lastPage' => true]]];
+        yield 'page - empty paginator - totalCount requested' => [new ArrayPaginator([], 0, 0), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [], 'paginationInfo' => ['totalCount' => .0]], ['paginationInfo' => ['totalCount' => true]]];
+        yield 'page - paginator page 1 - itemsPerPage requested' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 0, 2), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [['normalized_item'], ['normalized_item']], 'paginationInfo' => ['itemsPerPage' => 2.0]], ['paginationInfo' => ['itemsPerPage' => true]]];
+        yield 'page - paginator page 1 - lastPage requested' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 0, 2), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [['normalized_item'], ['normalized_item']], 'paginationInfo' => ['lastPage' => 2.0]], ['paginationInfo' => ['lastPage' => true]]];
+        yield 'page - paginator page 1 - totalCount requested' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 0, 2), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [['normalized_item'], ['normalized_item']], 'paginationInfo' => ['totalCount' => 3.0]], ['paginationInfo' => ['totalCount' => true]]];
+        yield 'page - paginator with page - itemsPerPage requested' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 2, 2), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [['normalized_item']], 'paginationInfo' => ['itemsPerPage' => 2.0]], ['paginationInfo' => ['itemsPerPage' => true]]];
+        yield 'page - paginator with page - lastPage requested' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 2, 2), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [['normalized_item']], 'paginationInfo' => ['lastPage' => 2.0]], ['paginationInfo' => ['lastPage' => true]]];
+        yield 'page - paginator with page - totalCount requested' => [new ArrayPaginator([(object) ['test' => 'a'], (object) ['test' => 'b'], (object) ['test' => 'c']], 2, 2), (new QueryCollection(class: 'foo'))->withPaginationType('page'), [], ['collection' => [['normalized_item']], 'paginationInfo' => ['totalCount' => 3.0]], ['paginationInfo' => ['totalCount' => true]]];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | current stable version branch for bug fixes
| License       | MIT

This pull request is a draft to fix a bug discovered on the current graphql implementation.

If the following request is sent:

```
{
  nameMetricFirstnameDepartmentOccurrences {
    collection {
      geoEntityDepartment {
        label
      }
    }
  }
}
```
The current implementation executes the count query on the database, to populate `paginationInfo` in the result until this information is dropped by the method `ReferenceExecutor::collectAndExecuteSubFields`.
I would expect the count query to be executed only if the `paginationInfo` is requested, like with the following request:

```
{
  nameMetricFirstnameDepartmentOccurrences {
    paginationInfo {
      itemsPerPage
      lastPage
      totalCount
    }
    collection {
      geoEntityDepartment {
        label
      }
    }
  }
}
```

I'm not quite sure that this is the best way to implement that fix, I open this pull request to start the discussion. There is probably some other implementations I should look at (like cursor based pagination, perhaps the NormalizeProcessor) and add some tests. In the meantime what do you think of this approach ?

Thanks,