### PR TITLE
fix: operation cache key without operation name

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -580,7 +580,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             $options['serializer_groups'] = (array) $context[self::GROUPS];
         }
 
-        $operationCacheKey = ($context['resource_class'] ?? '').($context['operation_name'] ?? '').($context['api_normalize'] ?? '');
+        $operationCacheKey = ($context['resource_class'] ?? '').($context['operation_name'] ?? $context['root_operation_name'] ?? '').($context['api_normalize'] ?? '');
         if ($operationCacheKey && isset($this->localFactoryOptionsCache[$operationCacheKey])) {
             return $options + $this->localFactoryOptionsCache[$operationCacheKey];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Closes https://github.com/api-platform/core/issues/6024
| License       | MIT

Following https://github.com/api-platform/core/pull/5663 , the `$operationCacheKey` generated in \ApiPlatform\Serializer\AbstractItemNormalizer::getFactoryOptions() does not include an operation_name when working on a relation context (e.g. denormalizing a child resource). This leads to `$operationCacheKey` equals to `$context['resource_class']` which is too generic and leads, at its turn, to buggy situations. For instance when manually denormalizing an object of the same class that `$context['resource_class']` but in a complete other context.

More information can be found in https://github.com/api-platform/core/issues/6024
