### PR TITLE
fix: In PHP, requests without content-type will result in an empty content-type, not null

### DIFF
--- a/src/State/Provider/ContentNegotiationProvider.php
+++ b/src/State/Provider/ContentNegotiationProvider.php
@@ -97,7 +97,8 @@ final class ContentNegotiationProvider implements ProviderInterface
      */
     private function getInputFormat(HttpOperation $operation, Request $request): ?string
     {
-        if (null === ($contentType = $request->headers->get('CONTENT_TYPE'))) {
+        $contentType = $request->headers->get('CONTENT_TYPE');
+        if (null === $contentType || '' === $contentType) {
             return null;
         }
 

--- a/src/State/Provider/DeserializeProvider.php
+++ b/src/State/Provider/DeserializeProvider.php
@@ -56,7 +56,7 @@ final class DeserializeProvider implements ProviderInterface
         }
 
         $contentType = $request->headers->get('CONTENT_TYPE');
-        if (null === $contentType) {
+        if (null === $contentType || '' === $contentType) {
             throw new UnsupportedMediaTypeHttpException('The "Content-Type" header must exist.');
         }
 

--- a/src/Symfony/EventListener/DeserializeListener.php
+++ b/src/Symfony/EventListener/DeserializeListener.php
@@ -132,7 +132,7 @@ final class DeserializeListener
     {
         /** @var ?string $contentType */
         $contentType = $request->headers->get('CONTENT_TYPE');
-        if (null === $contentType) {
+        if (null === $contentType || '' === $contentType) {
             throw new UnsupportedMediaTypeHttpException('The "Content-Type" header must exist.');
         }
 

--- a/tests/State/Provider/ContentNegotiationProviderTest.php
+++ b/tests/State/Provider/ContentNegotiationProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\State\Provider;
+
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\Provider\ContentNegotiationProvider;
+use ApiPlatform\State\ProviderInterface;
+use Negotiation\Negotiator;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContentNegotiationProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testRequestWithEmptyContentType(): void
+    {
+        $expectedResult = new \stdClass();
+
+        $decorated = $this->prophesize(ProviderInterface::class);
+        $decorated->provide(Argument::cetera())->willReturn($expectedResult);
+
+        $negotiator = new Negotiator();
+        $formats = ['jsonld' => ['application/ld+json']];
+        $errorFormats = ['jsonld' => ['application/ld+json']];
+
+        $provider = new ContentNegotiationProvider($decorated->reveal(), $negotiator, $formats, $errorFormats);
+
+        // in Symfony (at least up to 7.0.2, 6.4.2, 6.3.11, 5.4.34), a request
+        // without a content-type and content-length header will result in the
+        // variables set to an empty string, not null
+
+        $request = new Request(
+            server: [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/',
+                'CONTENT_TYPE' => '',
+                'CONTENT_LENGTH' => '',
+            ],
+            content: ''
+        );
+
+        $operation = new Post();
+        $context = ['request' => $request];
+
+        $result = $provider->provide($operation, [], $context);
+
+        $this->assertSame($expectedResult, $result);
+    }
+}

--- a/tests/State/Provider/DeserializeProviderTest.php
+++ b/tests/State/Provider/DeserializeProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\State\Provider;
+
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Serializer\SerializerContextBuilderInterface;
+use ApiPlatform\State\Provider\DeserializeProvider;
+use ApiPlatform\State\ProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class DeserializeProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testRequestWithEmptyContentType(): void
+    {
+        $expectedResult = new \stdClass();
+
+        $decorated = $this->prophesize(ProviderInterface::class);
+        $decorated->provide(Argument::cetera())->willReturn($expectedResult);
+
+        $serializer = $this->prophesize(SerializerInterface::class);
+        $serializerContextBuilder = $this->prophesize(SerializerContextBuilderInterface::class);
+
+        $provider = new DeserializeProvider($decorated->reveal(), $serializer->reveal(), $serializerContextBuilder->reveal());
+
+        // in Symfony (at least up to 7.0.2, 6.4.2, 6.3.11, 5.4.34), a request
+        // without a content-type and content-length header will result in the
+        // variables set to an empty string, not null
+
+        $request = new Request(
+            server: [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/',
+                'CONTENT_TYPE' => '',
+                'CONTENT_LENGTH' => '',
+            ],
+            content: ''
+        );
+
+        $operation = new Post(deserialize: true);
+        $context = ['request' => $request];
+
+        $this->expectException(UnsupportedMediaTypeHttpException::class);
+        $result = $provider->provide($operation, [], $context);
+    }
+}

--- a/tests/Symfony/EventListener/DeserializeListenerTest.php
+++ b/tests/Symfony/EventListener/DeserializeListenerTest.php
@@ -28,6 +28,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -368,5 +369,57 @@ class DeserializeListenerTest extends TestCase
             $this->assertNull($violation->getPlural());
             $this->assertSame($violation->getCode(), 'ba785a8c-82cb-4283-967c-3cf342181b40');
         }
+    }
+
+    public function testRequestWithEmptyContentType(): void
+    {
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->deserialize(Argument::cetera())->shouldNotBeCalled();
+
+        $serializerContextBuilderProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
+        $serializerContextBuilderProphecy->createFromRequest(Argument::cetera())->willReturn([]);
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Argument::cetera())->willReturn(new ResourceMetadataCollection(Dummy::class, [
+            new ApiResource(operations: [
+                'post' => new Post(inputFormats: self::FORMATS),
+            ]),
+        ]))->shouldBeCalled();
+
+        $listener = new DeserializeListener(
+            $serializerProphecy->reveal(),
+            $serializerContextBuilderProphecy->reveal(),
+            $resourceMetadataFactoryProphecy->reveal()
+        );
+
+        // in Symfony (at least up to 7.0.2, 6.4.2, 6.3.11, 5.4.34), a request
+        // without a content-type and content-length header will result in the
+        // variables set to an empty string, not null
+
+        $request = new Request(
+            server: [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/',
+                'CONTENT_TYPE' => '',
+                'CONTENT_LENGTH' => '',
+            ],
+            attributes: [
+                '_api_resource_class' => Dummy::class,
+                '_api_operation_name' => 'post',
+                '_api_receive' => true,
+            ],
+            content: ''
+        );
+
+        $event = new RequestEvent(
+            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            $request,
+            \defined(HttpKernelInterface::class.'::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST,
+        );
+
+        $this->expectException(UnsupportedMediaTypeHttpException::class);
+        $this->expectExceptionMessage('The "Content-Type" header must exist.');
+
+        $listener->onKernelRequest($event);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | 
| License       | MIT
| Doc PR        | 

In PHP, requests without content-type will result in an empty string, not null. This PR modifies several checks for empty content-type in the codebase. They failed because they previously check for a null value, not an empty string.

Also related: https://github.com/symfony/symfony/pull/53380