### PR TITLE
GraphQL: Errors with nullish ManyToOne-Relation when using new ResolverFactory

### DIFF
--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -22,7 +22,7 @@ Feature: GraphQL query support
 
   @createSchema
   Scenario: Retrieve an item with different relations to the same resource
-    Given there are 2 multiRelationsDummy objects having each a manyToOneRelation, 2 manyToManyRelations, 3 oneToManyRelations and 4 embeddedRelations
+    Given there are 2 multiRelationsDummy objects having each 1 manyToOneRelation, 2 manyToManyRelations, 3 oneToManyRelations and 4 embeddedRelations
     When I send the following GraphQL request:
     """
     {
@@ -30,6 +30,10 @@ Feature: GraphQL query support
         id
         name
         manyToOneRelation {
+          id
+          name
+        }
+        manyToOneResolveRelation {
           id
           name
         }
@@ -70,7 +74,7 @@ Feature: GraphQL query support
 
   @createSchema
   Scenario: Retrieve embedded collections
-    Given there are 2 multiRelationsDummy objects having each a manyToOneRelation, 2 manyToManyRelations, 3 oneToManyRelations and 4 embeddedRelations
+    Given there are 2 multiRelationsDummy objects having each 1 manyToOneRelation, 2 manyToManyRelations, 3 oneToManyRelations and 4 embeddedRelations
     When I send the following GraphQL request:
     """
     {
@@ -113,10 +117,13 @@ Feature: GraphQL query support
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "errors" should not exist
     And the JSON node "data.multiRelationsDummy.id" should be equal to "/multi_relations_dummies/2"
     And the JSON node "data.multiRelationsDummy.name" should be equal to "Dummy #2"
     And the JSON node "data.multiRelationsDummy.manyToOneRelation.id" should not be null
     And the JSON node "data.multiRelationsDummy.manyToOneRelation.name" should be equal to "RelatedManyToOneDummy #2"
+    And the JSON node "data.multiRelationsDummy.manyToOneResolveRelation.id" should not be null
+    And the JSON node "data.multiRelationsDummy.manyToOneResolveRelation.name" should be equal to "RelatedManyToOneResolveDummy #2"
     And the JSON node "data.multiRelationsDummy.manyToManyRelations.edges" should have 2 element
     And the JSON node "data.multiRelationsDummy.manyToManyRelations.edges[1].node.id" should not be null
     And the JSON node "data.multiRelationsDummy.manyToManyRelations.edges[0].node.name" should match "#RelatedManyToManyDummy(1|2)2#"
@@ -134,6 +141,65 @@ Feature: GraphQL query support
     And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges[1].node.name" should be equal to "NestedPaginatedDummy2"
     And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges[2].node.name" should be equal to "NestedPaginatedDummy3"
     And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges[3].node.name" should be equal to "NestedPaginatedDummy4"
+
+  @createSchema
+  Scenario: Retrieve an item with different relations (all unset)
+    Given there are 2 multiRelationsDummy objects having each 0 manyToOneRelation, 0 manyToManyRelations, 0 oneToManyRelations and 0 embeddedRelations
+    When I send the following GraphQL request:
+    """
+    {
+      multiRelationsDummy(id: "/multi_relations_dummies/2") {
+        id
+        name
+        manyToOneRelation {
+          id
+          name
+        }
+        manyToOneResolveRelation {
+          id
+          name
+        }
+        manyToManyRelations {
+          edges{
+            node {
+             id
+              name
+            }
+          }
+        }
+        oneToManyRelations {
+          edges{
+            node {
+              id
+              name
+            }
+          }
+        }
+        nestedCollection {
+          name
+        }
+        nestedPaginatedCollection {
+          edges{
+            node {
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "errors" should not exist
+    And the JSON node "data.multiRelationsDummy.id" should be equal to "/multi_relations_dummies/2"
+    And the JSON node "data.multiRelationsDummy.name" should be equal to "Dummy #2"
+    And the JSON node "data.multiRelationsDummy.manyToOneRelation" should be null
+    And the JSON node "data.multiRelationsDummy.manyToOneResolveRelation" should be null
+    And the JSON node "data.multiRelationsDummy.manyToManyRelations.edges" should have 0 element
+    And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges" should have 0 element
+    And the JSON node "data.multiRelationsDummy.nestedCollection" should have 0 element
+    And the JSON node "data.multiRelationsDummy.nestedPaginatedCollection.edges" should have 0 element
 
   @createSchema @!mongodb
   Scenario: Retrieve an item with child relation to the same resource

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -85,6 +85,10 @@ Feature: GraphQL query support
           id
           name
         }
+        manyToOneResolveRelation {
+          id
+          name
+        }
         manyToManyRelations {
           edges{
             node {

--- a/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/CollectionResolverFactory.php
@@ -20,6 +20,7 @@ use ApiPlatform\GraphQl\Resolver\Stage\SecurityStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SerializeStageInterface;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use ApiPlatform\State\Pagination\ArrayPaginator;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -40,7 +41,7 @@ final class CollectionResolverFactory implements ResolverFactoryInterface
     {
     }
 
-    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null): callable
+    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null, ?PropertyMetadataFactoryInterface $propertyMetadataFactory = null): callable
     {
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operation): ?array {
             // If authorization has failed for a relation field (e.g. via ApiProperty security), the field is not present in the source: null can be returned directly to ensure the collection isn't in the response.

--- a/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemMutationResolverFactory.php
@@ -24,6 +24,7 @@ use ApiPlatform\GraphQl\Resolver\Stage\ValidateStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\WriteStageInterface;
 use ApiPlatform\Metadata\DeleteOperationInterface;
 use ApiPlatform\Metadata\GraphQl\Operation;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -44,7 +45,7 @@ final class ItemMutationResolverFactory implements ResolverFactoryInterface
     {
     }
 
-    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null): callable
+    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null, ?PropertyMetadataFactoryInterface $propertyMetadataFactory = null): callable
     {
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operation): ?array {
             if (null === $resourceClass || null === $operation) {

--- a/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemResolverFactory.php
@@ -20,6 +20,7 @@ use ApiPlatform\GraphQl\Resolver\Stage\SecurityStageInterface;
 use ApiPlatform\GraphQl\Resolver\Stage\SerializeStageInterface;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -41,7 +42,7 @@ final class ItemResolverFactory implements ResolverFactoryInterface
     {
     }
 
-    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null): callable
+    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null, ?PropertyMetadataFactoryInterface $propertyMetadataFactory = null): callable
     {
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operation) {
             // Data already fetched and normalized (field or nested resource)

--- a/src/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ItemSubscriptionResolverFactory.php
@@ -19,6 +19,7 @@ use ApiPlatform\GraphQl\Resolver\Stage\SerializeStageInterface;
 use ApiPlatform\GraphQl\Subscription\MercureSubscriptionIriGeneratorInterface;
 use ApiPlatform\GraphQl\Subscription\SubscriptionManagerInterface;
 use ApiPlatform\Metadata\GraphQl\Operation;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -37,7 +38,7 @@ final class ItemSubscriptionResolverFactory implements ResolverFactoryInterface
     {
     }
 
-    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null): callable
+    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null, ?PropertyMetadataFactoryInterface $propertyMetadataFactory = null): callable
     {
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operation): ?array {
             if (null === $resourceClass || null === $operation) {

--- a/src/GraphQl/Resolver/Factory/ResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ResolverFactory.php
@@ -17,6 +17,7 @@ use ApiPlatform\GraphQl\State\Provider\NoopProvider;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\State\Pagination\ArrayPaginator;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\State\ProviderInterface;
@@ -26,25 +27,35 @@ class ResolverFactory implements ResolverFactoryInterface
 {
     public function __construct(
         private readonly ProviderInterface $provider,
-        private readonly ProcessorInterface $processor
+        private readonly ProcessorInterface $processor,
+        private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory
     ) {
     }
 
     public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null): callable
     {
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operation) {
-            // Data already fetched and normalized (field or nested resource)
-            if ($body = $source[$info->fieldName] ?? null) {
+            if (\array_key_exists($info->fieldName, $source ?? [])) {
+                $body = $source[$info->fieldName];
+
                 // special treatment for nested resources without a resolver/provider
                 if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && (!$operation->getProvider() || NoopProvider::class === $operation->getProvider())) {
-                    return $this->resolve($source, $args, $info, $rootClass, $operation, new ArrayPaginator($body, 0, \count($body)));
+                    return \is_array($body) ? $this->resolve(
+                        $source,
+                        $args,
+                        $info,
+                        $rootClass,
+                        $operation,
+                        new ArrayPaginator($body, 0, \count($body))
+                    ) : $body;
                 }
 
-                return $body;
-            }
-
-            if (null === $resourceClass && \array_key_exists($info->fieldName, $source ?? [])) {
-                return $body;
+                $propertyMetadata = $rootClass ? $this->propertyMetadataFactory->create($rootClass, $info->fieldName) : null;
+                $propertySchemaType = $propertyMetadata?->getSchema()['type'] ?? null;
+                // Data already fetched and normalized (field or nested resource)
+                if ($body || null === $resourceClass || 'array' !== $propertySchemaType) {
+                    return $body;
+                }
             }
 
             // If authorization has failed for a relation field (e.g. via ApiProperty security), the field is not present in the source: null can be returned directly to ensure the collection isn't in the response.

--- a/src/GraphQl/Resolver/Factory/ResolverFactoryInterface.php
+++ b/src/GraphQl/Resolver/Factory/ResolverFactoryInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\GraphQl\Resolver\Factory;
 
 use ApiPlatform\Metadata\GraphQl\Operation;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 
 /**
  * Builds a GraphQL resolver.
@@ -22,5 +23,5 @@ use ApiPlatform\Metadata\GraphQl\Operation;
  */
 interface ResolverFactoryInterface
 {
-    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null): callable;
+    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null, ?PropertyMetadataFactoryInterface $propertyMetadataFactory = null): callable;
 }

--- a/src/GraphQl/Tests/Resolver/Factory/ResolverFactoryTest.php
+++ b/src/GraphQl/Tests/Resolver/Factory/ResolverFactoryTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace ApiPlatform\GraphQl\Tests\Resolver\Factory;
 
 use ApiPlatform\GraphQl\Resolver\Factory\ResolverFactory;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\State\ProviderInterface;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -38,10 +40,12 @@ class ResolverFactoryTest extends TestCase
         $provider->expects($this->once())->method('provide')->with($providedOperation ?: $operation, [], $context)->willReturn($body);
         $processor = $this->createMock(ProcessorInterface::class);
         $processor->expects($this->once())->method('process')->with($body, $processedOperation ?: $operation, [], $context)->willReturn($returnValue);
+        $propertyMetadataFactory = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->expects($this->once())->method('create')->with($rootClass, 'test')->willReturn(new ApiProperty(schema: ['type' => 'array']));
         $resolveInfo = $this->createMock(ResolveInfo::class);
         $resolveInfo->fieldName = 'test';
 
-        $resolverFactory = new ResolverFactory($provider, $processor);
+        $resolverFactory = new ResolverFactory($provider, $processor, $propertyMetadataFactory);
         $this->assertEquals($resolverFactory->__invoke($resourceClass, $rootClass, $operation)(['test' => null], [], [], $resolveInfo), $returnValue);
     }
 

--- a/src/GraphQl/Tests/Resolver/Factory/ResolverFactoryTest.php
+++ b/src/GraphQl/Tests/Resolver/Factory/ResolverFactoryTest.php
@@ -45,8 +45,8 @@ class ResolverFactoryTest extends TestCase
         $resolveInfo = $this->createMock(ResolveInfo::class);
         $resolveInfo->fieldName = 'test';
 
-        $resolverFactory = new ResolverFactory($provider, $processor, $propertyMetadataFactory);
-        $this->assertEquals($resolverFactory->__invoke($resourceClass, $rootClass, $operation)(['test' => null], [], [], $resolveInfo), $returnValue);
+        $resolverFactory = new ResolverFactory($provider, $processor);
+        $this->assertEquals($resolverFactory->__invoke($resourceClass, $rootClass, $operation, $propertyMetadataFactory)(['test' => null], [], [], $resolveInfo), $returnValue);
     }
 
     public static function graphQlQueries(): array

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -458,7 +458,7 @@ final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumIn
                 if ($isStandardGraphqlType || $input) {
                     $resolve = null;
                 } else {
-                    $resolve = ($this->itemResolverFactory)($resourceClass, $rootResource, $resourceOperation);
+                    $resolve = ($this->itemResolverFactory)($resourceClass, $rootResource, $resourceOperation, $this->propertyMetadataFactory);
                 }
             } else {
                 if ($isStandardGraphqlType || $input) {

--- a/src/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Symfony/Bundle/Resources/config/graphql.xml
@@ -190,6 +190,7 @@
         <service id="api_platform.graphql.resolver.factory.item" class="ApiPlatform\GraphQl\Resolver\Factory\ResolverFactory" public="false">
             <argument type="service" id="api_platform.graphql.state_provider" />
             <argument type="service" id="api_platform.graphql.state_processor" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
         </service>
 
         <!-- Resolver Stages -->

--- a/src/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Symfony/Bundle/Resources/config/graphql.xml
@@ -190,7 +190,6 @@
         <service id="api_platform.graphql.resolver.factory.item" class="ApiPlatform\GraphQl\Resolver\Factory\ResolverFactory" public="false">
             <argument type="service" id="api_platform.graphql.state_provider" />
             <argument type="service" id="api_platform.graphql.state_processor" />
-            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
         </service>
 
         <!-- Resolver Stages -->

--- a/src/Symfony/GraphQl/Resolver/Factory/DataCollectorResolverFactory.php
+++ b/src/Symfony/GraphQl/Resolver/Factory/DataCollectorResolverFactory.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Symfony\GraphQl\Resolver\Factory;
 
 use ApiPlatform\GraphQl\Resolver\Factory\ResolverFactoryInterface;
 use ApiPlatform\Metadata\GraphQl\Operation;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use GraphQL\Type\Definition\ResolveInfo;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -24,7 +25,7 @@ final class DataCollectorResolverFactory implements ResolverFactoryInterface
     {
     }
 
-    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null): callable
+    public function __invoke(?string $resourceClass = null, ?string $rootClass = null, ?Operation $operation = null, ?PropertyMetadataFactoryInterface $propertyMetadataFactory = null): callable
     {
         return function (?array $source, array $args, $context, ResolveInfo $info) use ($resourceClass, $rootClass, $operation) {
             if ($this->requestStack && null !== $request = $this->requestStack->getCurrentRequest()) {

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -69,6 +69,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsDummy as MultiR
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsNested as MultiRelationsNestedDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsNestedPaginated as MultiRelationsNestedPaginatedDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsRelatedDummy as MultiRelationsRelatedDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsResolveDummy as MultiRelationsResolveDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\MusicGroup as MusicGroupDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\NetworkPathDummy as NetworkPathDummyDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\NetworkPathRelationDummy as NetworkPathRelationDummyDocument;
@@ -165,6 +166,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsNested;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsNestedPaginated;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsRelatedDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsResolveDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MusicGroup;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\NetworkPathDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\NetworkPathRelationDummy;
@@ -809,17 +811,24 @@ final class DoctrineContext implements Context
     }
 
     /**
-     * @Given there are :nb multiRelationsDummy objects having each a manyToOneRelation, :nbmtmr manyToManyRelations, :nbotmr oneToManyRelations and :nber embeddedRelations
+     * @Given there are :nb multiRelationsDummy objects having each :nbmtor manyToOneRelation, :nbmtmr manyToManyRelations, :nbotmr oneToManyRelations and :nber embeddedRelations
      */
-    public function thereAreMultiRelationsDummyObjectsHavingEachAManyToOneRelationManyToManyRelationsOneToManyRelationsAndEmbeddedRelations(int $nb, int $nbmtmr, int $nbotmr, int $nber): void
+    public function thereAreMultiRelationsDummyObjectsHavingEachAManyToOneRelationManyToManyRelationsOneToManyRelationsAndEmbeddedRelations(int $nb, int $nbmtor, int $nbmtmr, int $nbotmr, int $nber): void
     {
         for ($i = 1; $i <= $nb; ++$i) {
             $relatedDummy = $this->buildMultiRelationsRelatedDummy();
             $relatedDummy->name = 'RelatedManyToOneDummy #'.$i;
 
+            $resolveDummy = $this->buildMultiRelationsResolveDummy();
+            $resolveDummy->name = 'RelatedManyToOneResolveDummy #'.$i;
+
             $dummy = $this->buildMultiRelationsDummy();
             $dummy->name = 'Dummy #'.$i;
-            $dummy->setManyToOneRelation($relatedDummy);
+
+            if ($nbmtor) {
+                $dummy->setManyToOneRelation($relatedDummy);
+                $dummy->setManyToOneResolveRelation($resolveDummy);
+            }
 
             for ($j = 1; $j <= $nbmtmr; ++$j) {
                 $manyToManyItem = $this->buildMultiRelationsRelatedDummy();
@@ -855,6 +864,7 @@ final class DoctrineContext implements Context
             $dummy->setNestedPaginatedCollection($nestedPaginated);
 
             $this->manager->persist($relatedDummy);
+            $this->manager->persist($resolveDummy);
             $this->manager->persist($dummy);
         }
         $this->manager->flush();
@@ -2656,6 +2666,11 @@ final class DoctrineContext implements Context
     private function buildMultiRelationsRelatedDummy(): MultiRelationsRelatedDummy|MultiRelationsRelatedDummyDocument
     {
         return $this->isOrm() ? new MultiRelationsRelatedDummy() : new MultiRelationsRelatedDummyDocument();
+    }
+
+    private function buildMultiRelationsResolveDummy(): MultiRelationsResolveDummy|MultiRelationsResolveDummyDocument
+    {
+        return $this->isOrm() ? new MultiRelationsResolveDummy() : new MultiRelationsResolveDummyDocument();
     }
 
     private function buildMultiRelationsNested(): MultiRelationsNested|MultiRelationsNestedDocument

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsDummy.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsDummy.php
@@ -38,6 +38,9 @@ class MultiRelationsDummy
     #[ODM\ReferenceOne(targetDocument: MultiRelationsRelatedDummy::class, storeAs: 'id', nullable: true)]
     public ?MultiRelationsRelatedDummy $manyToOneRelation = null;
 
+    #[ODM\ReferenceOne(targetDocument: MultiRelationsResolveDummy::class, storeAs: 'id', nullable: true)]
+    public ?MultiRelationsResolveDummy $manyToOneResolveRelation = null;
+
     /** @var Collection<int, MultiRelationsRelatedDummy> */
     #[ODM\ReferenceMany(targetDocument: MultiRelationsRelatedDummy::class, storeAs: 'id', nullable: true)]
     public Collection $manyToManyRelations;
@@ -75,6 +78,18 @@ class MultiRelationsDummy
     public function setManyToOneRelation(?MultiRelationsRelatedDummy $relatedMultiUsedDummy): void
     {
         $this->manyToOneRelation = $relatedMultiUsedDummy;
+    }
+
+    public function getManyToOneResolveRelation(): ?MultiRelationsResolveDummy
+    {
+        return $this->manyToOneResolveRelation;
+    }
+
+    public function setManyToOneResolveRelation(?MultiRelationsResolveDummy $manyToOneResolveRelation): self
+    {
+        $this->manyToOneResolveRelation = $manyToOneResolveRelation;
+
+        return $this;
     }
 
     public function addManyToManyRelation(MultiRelationsRelatedDummy $relatedMultiUsedDummy): void

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsResolveDummy.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsResolveDummy.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Dummy used in different kind of relations in the same resource.
+ *
+ * @author Thomas Helmrich <thomas@gigabit.de>
+ */
+#[ApiResource(graphQlOperations: [new Query(resolver: 'app.graphql.query_resolver.multi_relations_custom_item', read: false), new QueryCollection(resolver: 'app.graphql.query_resolver.multi_relations_collection', read: false)])]
+#[ODM\Document]
+class MultiRelationsResolveDummy
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\Field(type: 'string', nullable: true)]
+    public ?string $name;
+
+    #[ODM\ReferenceOne(targetDocument: MultiRelationsDummy::class, inversedBy: 'oneToManyResolveRelations', nullable: true, storeAs: 'id')]
+    private ?MultiRelationsDummy $oneToManyResolveRelation;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOneToManyResolveRelation(): ?MultiRelationsDummy
+    {
+        return $this->oneToManyResolveRelation;
+    }
+
+    public function setOneToManyResolveRelation(?MultiRelationsDummy $oneToManyResolveRelation): void
+    {
+        $this->oneToManyResolveRelation = $oneToManyResolveRelation;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/MultiRelationsDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/MultiRelationsDummy.php
@@ -40,6 +40,9 @@ class MultiRelationsDummy
     #[ORM\ManyToOne(targetEntity: MultiRelationsRelatedDummy::class)]
     public ?MultiRelationsRelatedDummy $manyToOneRelation = null;
 
+    #[ORM\ManyToOne(targetEntity: MultiRelationsResolveDummy::class)]
+    public ?MultiRelationsResolveDummy $manyToOneResolveRelation = null;
+
     /** @var Collection<int, MultiRelationsRelatedDummy> */
     #[ORM\ManyToMany(targetEntity: MultiRelationsRelatedDummy::class)]
     public Collection $manyToManyRelations;
@@ -77,6 +80,18 @@ class MultiRelationsDummy
     public function setManyToOneRelation(?MultiRelationsRelatedDummy $relatedMultiUsedDummy): void
     {
         $this->manyToOneRelation = $relatedMultiUsedDummy;
+    }
+
+    public function getManyToOneResolveRelation(): ?MultiRelationsResolveDummy
+    {
+        return $this->manyToOneResolveRelation;
+    }
+
+    public function setManyToOneResolveRelation(?MultiRelationsResolveDummy $manyToOneResolveRelation): self
+    {
+        $this->manyToOneResolveRelation = $manyToOneResolveRelation;
+
+        return $this;
     }
 
     public function addManyToManyRelation(MultiRelationsRelatedDummy $relatedMultiUsedDummy): void

--- a/tests/Fixtures/TestBundle/Entity/MultiRelationsResolveDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/MultiRelationsResolveDummy.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Dummy used in different kind of relations in the same resource.
+ *
+ * @author Thomas Helmrich <thomas@gigabit.de>
+ */
+#[ApiResource(graphQlOperations: [new Query(resolver: 'app.graphql.query_resolver.multi_relations_custom_item', read: false), new QueryCollection(resolver: 'app.graphql.query_resolver.multi_relations_collection', read: false)])]
+#[ORM\Entity]
+class MultiRelationsResolveDummy
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column(nullable: true)]
+    public ?string $name;
+
+    #[ORM\ManyToOne(targetEntity: MultiRelationsDummy::class, inversedBy: 'oneToManyResolveRelations')]
+    private ?MultiRelationsDummy $oneToManyResolveRelation = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOneToManyResolveRelation(): ?MultiRelationsDummy
+    {
+        return $this->oneToManyResolveRelation;
+    }
+
+    public function setOneToManyResolveRelation(?MultiRelationsDummy $oneToManyResolveRelation): void
+    {
+        $this->oneToManyResolveRelation = $oneToManyResolveRelation;
+    }
+}

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNotRetrievedItemResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/DummyCustomQueryNotRetrievedItemResolver.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\QueryItemResolverInterface;
-use ApiPlatform\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
 
 /**
@@ -24,7 +23,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyCustomQuery;
  */
 class DummyCustomQueryNotRetrievedItemResolver implements QueryItemResolverInterface
 {
-    public function __invoke(?object $item, array $context): DummyCustomQuery|DummyCustomQueryDocument
+    public function __invoke(?object $item, array $context): DummyCustomQuery
     {
         if (null === $item) {
             $item = new DummyCustomQuery();

--- a/tests/Fixtures/TestBundle/GraphQl/Resolver/MultiRelationsResolveQueryItemResolver.php
+++ b/tests/Fixtures/TestBundle/GraphQl/Resolver/MultiRelationsResolveQueryItemResolver.php
@@ -14,25 +14,18 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\QueryItemResolverInterface;
-use ApiPlatform\Tests\Fixtures\TestBundle\Document\DummyCustomQuery as DummyCustomQueryDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\MultiRelationsResolveDummy as MultiRelationsResolveDummyDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MultiRelationsResolveDummy;
 
 /**
  * Resolver for dummy item custom query.
  *
  * @author Lukas Lücke <lukas@luecke.me>
  */
-class DummyCustomQueryNotRetrievedItemDocumentResolver implements QueryItemResolverInterface
+class MultiRelationsResolveQueryItemResolver implements QueryItemResolverInterface
 {
-    public function __invoke(?object $item, array $context): DummyCustomQueryDocument
+    public function __invoke(?object $item, array $context): MultiRelationsResolveDummy|MultiRelationsResolveDummyDocument
     {
-        if (null === $item) {
-            $item = new DummyCustomQueryDocument();
-            $item->id = 0;
-            $item->message = 'Success (not retrieved)!';
-
-            return $item;
-        }
-
-        return $item;
+        return $context['source']['manyToOneResolveRelation'];
     }
 }

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -301,6 +301,11 @@ services:
         tags:
             - name: 'api_platform.graphql.resolver'
 
+    app.graphql.query_resolver.multi_relations_custom_item:
+        class: 'ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver\MultiRelationsResolveQueryItemResolver'
+        tags:
+            - { name: 'api_platform.graphql.resolver' }
+
     app.graphql.mutation_resolver.upload_media_object:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver\UploadMediaObjectResolver'
         tags:

--- a/tests/Fixtures/app/config/config_mongodb.yml
+++ b/tests/Fixtures/app/config/config_mongodb.yml
@@ -110,6 +110,11 @@ services:
         tags:
             - name: 'api_platform.graphql.resolver'
 
+    app.graphql.query_resolver.multi_relations_custom_item_document:
+        class: 'ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver\MultiRelationsResolveQueryItemResolver'
+        tags:
+            - { name: 'api_platform.graphql.resolver' }
+
     app.graphql.mutation_resolver.dummy_custom_only_persist_document:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver\SumOnlyPersistDocumentMutationResolver'
         public: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #6083 <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | -

This PR introduces a new the test case especially for properties and Many-To-One-Relations being `null`. It fixes the issues relevant for 3.2 and additionally provides a fix for the nested collection feature which was recently introduced on the main branch. There is another PR https://github.com/api-platform/core/pull/6092 that contains only the fixes relevant for 3.2.