### PR TITLE
Add support for MongoDB ODM Bundle v5 with Symfony 7.0 full compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "doctrine/dbal": "^3.4.0",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
         "doctrine/mongodb-odm": "^2.2",
+        "doctrine/mongodb-odm-bundle": "^4.0 || ^5.0",
         "doctrine/orm": "^2.14",
         "elasticsearch/elasticsearch": "^7.11.0",
         "friends-of-behat/mink-browserkit-driver": "^1.3.1",

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -41,7 +41,7 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
         self::bootKernel();
 
         $this->manager = DoctrineMongoDbOdmTestCase::createTestDocumentManager();
-        $this->managerRegistry = self::$kernel->getContainer()->get('doctrine_mongodb'); // @phpstan-ignore-line
+        $this->managerRegistry = self::$kernel->getContainer()->get('doctrine_mongodb');
         $this->repository = $this->manager->getRepository($this->resourceClass);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

[DoctrineMongoDBBundle v5](https://github.com/doctrine/DoctrineMongoDBBundle/releases/tag/5.0.0-RC1) provides full compatibility with Symfony 7, removing the last deprecation that make the build fail.

(I'm checking compatibility with libraries like API platform before tagging a the stable version)