### PR TITLE
fix(graphql): Embedded nullable relations graphql

### DIFF
--- a/features/graphql/schema.feature
+++ b/features/graphql/schema.feature
@@ -98,3 +98,16 @@ Feature: GraphQL schema-related features
       clientMutationId: String
     }
     """
+    And the command output should contain:
+    """
+    "Updates a OptionalRequiredDummy."
+    input updateOptionalRequiredDummyInput {
+      id: ID!
+      thirdLevel: updateThirdLevelNestedInput
+      thirdLevelRequired: updateThirdLevelNestedInput!
+
+      "Get relatedToDummyFriend."
+      relatedToDummyFriend: [updateRelatedToDummyFriendNestedInput]
+      clientMutationId: String
+    }
+    """

--- a/src/GraphQl/Tests/Type/FieldsBuilderTest.php
+++ b/src/GraphQl/Tests/Type/FieldsBuilderTest.php
@@ -16,8 +16,8 @@ namespace ApiPlatform\GraphQl\Tests\Type;
 use ApiPlatform\GraphQl\Resolver\Factory\ResolverFactoryInterface;
 use ApiPlatform\GraphQl\Tests\Fixtures\Enum\GenderTypeEnum;
 use ApiPlatform\GraphQl\Tests\Fixtures\Serializer\NameConverter\CustomConverter;
+use ApiPlatform\GraphQl\Type\ContextAwareTypeBuilderInterface;
 use ApiPlatform\GraphQl\Type\FieldsBuilder;
-use ApiPlatform\GraphQl\Type\TypeBuilderEnumInterface;
 use ApiPlatform\GraphQl\Type\TypeConverterInterface;
 use ApiPlatform\GraphQl\Type\TypesContainerInterface;
 use ApiPlatform\Metadata\ApiProperty;
@@ -79,7 +79,7 @@ class FieldsBuilderTest extends TestCase
         $this->propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $this->resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $this->typesContainerProphecy = $this->prophesize(TypesContainerInterface::class);
-        $this->typeBuilderProphecy = $this->prophesize(TypeBuilderEnumInterface::class);
+        $this->typeBuilderProphecy = $this->prophesize(ContextAwareTypeBuilderInterface::class);
         $this->typeConverterProphecy = $this->prophesize(TypeConverterInterface::class);
         $this->itemResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);
         $this->collectionResolverFactoryProphecy = $this->prophesize(ResolverFactoryInterface::class);

--- a/src/GraphQl/Tests/Type/TypeBuilderTest.php
+++ b/src/GraphQl/Tests/Type/TypeBuilderTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\GraphQl\Tests\Fixtures\Enum\GamePlayMode;
 use ApiPlatform\GraphQl\Type\FieldsBuilderEnumInterface;
 use ApiPlatform\GraphQl\Type\TypeBuilder;
 use ApiPlatform\GraphQl\Type\TypesContainerInterface;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation;
@@ -83,9 +84,9 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Query())->withShortName('shortName')->withDescription('description');
+        $operation = (new Query())->withShortName('shortName')->withDescription('description')->withClass('resourceClass');
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadataCollection, $operation, false);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadataCollection, $operation, null, ['input' => false]);
         $this->assertSame('shortName', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -111,7 +112,7 @@ class TypeBuilderTest extends TestCase
         /** @var Operation $operation */
         $operation = (new Query())->withShortName('shortName')->withDescription('description')->withOutput(['class' => 'outputClass']);
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadataCollection, $operation, false);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadataCollection, $operation, null, ['input' => false]);
         $this->assertSame('shortName', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -139,7 +140,7 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, false);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => false]);
         $this->assertSame($shortName, $resourceObjectType->name);
     }
 
@@ -171,14 +172,14 @@ class TypeBuilderTest extends TestCase
     {
         $resourceMetadata = new ResourceMetadataCollection('resourceClass', []);
         $this->typesContainerProphecy->has('customShortNameInput')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('customShortNameInput', Argument::type(NonNull::class))->shouldBeCalled();
+        $this->typesContainerProphecy->set('customShortNameInput', Argument::type(InputObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Mutation())->withName('custom')->withShortName('shortName')->withDescription('description');
+        $operation = (new Mutation())->withName('custom')->withShortName('shortName')->withDescription('description')->withClass('resourceClass');
         /** @var NonNull $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, true);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => true]);
         /** @var InputObjectType $wrappedType */
         $wrappedType = $resourceObjectType->getWrappedType();
         $this->assertInstanceOf(InputObjectType::class, $wrappedType);
@@ -196,14 +197,14 @@ class TypeBuilderTest extends TestCase
     {
         $resourceMetadata = new ResourceMetadataCollection('resourceClass', []);
         $this->typesContainerProphecy->has('customShortNameNestedInput')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('customShortNameNestedInput', Argument::type(NonNull::class))->shouldBeCalled();
+        $this->typesContainerProphecy->set('customShortNameNestedInput', Argument::type(InputObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Mutation())->withName('custom')->withShortName('shortName')->withDescription('description');
+        $operation = (new Mutation())->withName('custom')->withShortName('shortName')->withDescription('description')->withClass('resourceClass');
         /** @var NonNull $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, true, false, 1);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => true, 'wrapped' => false, 'depth' => 1]);
         /** @var InputObjectType $wrappedType */
         $wrappedType = $resourceObjectType->getWrappedType();
         $this->assertInstanceOf(InputObjectType::class, $wrappedType);
@@ -217,18 +218,48 @@ class TypeBuilderTest extends TestCase
         $wrappedType->config['fields']();
     }
 
-    public function testGetResourceObjectTypeCustomMutationInputArgs(): void
+    public function testGetResourceObjectTypeNestedInputNullable(): void
     {
         $resourceMetadata = new ResourceMetadataCollection('resourceClass', []);
-        $this->typesContainerProphecy->has('customShortNameInput')->shouldBeCalled()->willReturn(false);
-        $this->typesContainerProphecy->set('customShortNameInput', Argument::type(NonNull::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('customShortNameNullableNestedInput')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('customShortNameNullableNestedInput', Argument::type(InputObjectType::class))->shouldBeCalled();
         $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Mutation())->withArgs([])->withName('custom')->withShortName('shortName')->withDescription('description');
+        $operation = (new Mutation())->withName('custom')->withShortName('shortNameNullable')->withDescription('description nullable')->withClass('resourceClass');
+        /** @var ApiProperty $propertyMetadata */
+        $propertyMetadata = (new ApiProperty())->withRequired(false);
+        /** @var InputObjectType $resourceObjectType */
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, $propertyMetadata, [
+            'input' => true,
+            'wrapped' => false,
+            'depth' => 1,
+        ]);
+
+        $this->assertInstanceOf(InputObjectType::class, $resourceObjectType);
+        $this->assertSame('customShortNameNullableNestedInput', $resourceObjectType->name);
+        $this->assertSame('description nullable', $resourceObjectType->description);
+        $this->assertArrayHasKey('fields', $resourceObjectType->config);
+
+        $fieldsBuilderProphecy = $this->prophesize(FieldsBuilderEnumInterface::class);
+        $fieldsBuilderProphecy->getResourceObjectTypeFields('resourceClass', $operation, true, 1, null)->shouldBeCalled();
+        $this->fieldsBuilderLocatorProphecy->get('api_platform.graphql.fields_builder')->shouldBeCalled()->willReturn($fieldsBuilderProphecy->reveal());
+        $resourceObjectType->config['fields']();
+    }
+
+    public function testGetResourceObjectTypeCustomMutationInputArgs(): void
+    {
+        $resourceMetadata = new ResourceMetadataCollection('resourceClass', []);
+        $this->typesContainerProphecy->has('customShortNameInput')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('customShortNameInput', Argument::type(InputObjectType::class))->shouldBeCalled();
+        $this->typesContainerProphecy->has('Node')->shouldBeCalled()->willReturn(false);
+        $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
+
+        /** @var Operation $operation */
+        $operation = (new Mutation())->withArgs([])->withName('custom')->withShortName('shortName')->withDescription('description')->withClass('resourceClass');
         /** @var NonNull $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, true);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => true]);
         /** @var InputObjectType $wrappedType */
         $wrappedType = $resourceObjectType->getWrappedType();
         $this->assertInstanceOf(InputObjectType::class, $wrappedType);
@@ -257,9 +288,9 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description');
+        $operation = (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description')->withClass('resourceClass');
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, false);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => false]);
         $this->assertSame('createShortNamePayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -280,8 +311,8 @@ class TypeBuilderTest extends TestCase
     public function testGetResourceObjectTypeMutationWrappedType(): void
     {
         $resourceMetadata = new ResourceMetadataCollection('resourceClass', [(new ApiResource())->withGraphQlOperations([
-            'item_query' => (new Query())->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['item_query']]),
-            'create' => (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['create']]),
+            'item_query' => (new Query())->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['item_query']])->withClass('resourceClass'),
+            'create' => (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['create']])->withClass('resourceClass'),
         ])]);
         $this->typesContainerProphecy->has('createShortNamePayload')->shouldBeCalled()->willReturn(false);
         $this->typesContainerProphecy->set('createShortNamePayload', Argument::type(ObjectType::class))->shouldBeCalled();
@@ -289,9 +320,9 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['create']]);
+        $operation = (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['create']])->withClass('resourceClass');
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, false);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => false]);
         $this->assertSame('createShortNamePayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -331,9 +362,9 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description');
+        $operation = (new Mutation())->withName('create')->withShortName('shortName')->withDescription('description')->withClass('resourceClass');
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, false, false, 1);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => false, 'wrapped' => false, 'depth' => 1]);
         $this->assertSame('createShortNameNestedPayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -359,9 +390,9 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withMercure(true);
+        $operation = (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withMercure(true)->withClass('resourceClass');
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, false);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => false]);
         $this->assertSame('updateShortNameSubscriptionPayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -384,8 +415,8 @@ class TypeBuilderTest extends TestCase
     public function testGetResourceObjectTypeSubscriptionWrappedType(): void
     {
         $resourceMetadata = new ResourceMetadataCollection('resourceClass', [(new ApiResource())->withGraphQlOperations([
-            'item_query' => (new Query())->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['item_query']]),
-            'update' => (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['update']]),
+            'item_query' => (new Query())->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['item_query']])->withClass('resourceClass'),
+            'update' => (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['update']])->withClass('resourceClass'),
         ])]);
         $this->typesContainerProphecy->has('updateShortNameSubscriptionPayload')->shouldBeCalled()->willReturn(false);
         $this->typesContainerProphecy->set('updateShortNameSubscriptionPayload', Argument::type(ObjectType::class))->shouldBeCalled();
@@ -393,9 +424,9 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['update']]);
+        $operation = (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withNormalizationContext(['groups' => ['update']])->withClass('resourceClass');
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, false);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => false]);
         $this->assertSame('updateShortNameSubscriptionPayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);
@@ -436,9 +467,9 @@ class TypeBuilderTest extends TestCase
         $this->typesContainerProphecy->set('Node', Argument::type(InterfaceType::class))->shouldBeCalled();
 
         /** @var Operation $operation */
-        $operation = (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withMercure(true);
+        $operation = (new Subscription())->withName('update')->withShortName('shortName')->withDescription('description')->withMercure(true)->withClass('resourceClass');
         /** @var ObjectType $resourceObjectType */
-        $resourceObjectType = $this->typeBuilder->getResourceObjectType('resourceClass', $resourceMetadata, $operation, false, false, 1);
+        $resourceObjectType = $this->typeBuilder->getResourceObjectType($resourceMetadata, $operation, null, ['input' => false, 'wrapped' => false, 'depth' => 1]);
         $this->assertSame('updateShortNameSubscriptionNestedPayload', $resourceObjectType->name);
         $this->assertSame('description', $resourceObjectType->description);
         $this->assertSame($this->defaultFieldResolver, $resourceObjectType->resolveFieldFn);

--- a/src/GraphQl/Type/ContextAwareTypeBuilderInterface.php
+++ b/src/GraphQl/Type/ContextAwareTypeBuilderInterface.php
@@ -23,18 +23,18 @@ use Symfony\Component\PropertyInfo\Type;
 /**
  * Interface implemented to build a GraphQL type.
  *
- * @author Alan Poulain <contact@alanpoulain.eu>
- *
- * @deprecated Since API Platform 3.3. Use @see ContextAwareTypeBuilderInterface instead.
+ * @author Antoine Bluchet <soyuka@gmail.com>
  */
-interface TypeBuilderEnumInterface
+interface ContextAwareTypeBuilderInterface
 {
     /**
      * Gets the object type of the given resource.
      *
+     * @param array<string, mixed>&array{input?: bool, wrapped?: bool, depth?: int} $context
+     *
      * @return GraphQLType the object type, possibly wrapped by NonNull
      */
-    public function getResourceObjectType(?string $resourceClass, ResourceMetadataCollection $resourceMetadataCollection, Operation $operation, bool $input, bool $wrapped = false, int $depth = 0, ?ApiProperty $propertyMetadata = null): GraphQLType;
+    public function getResourceObjectType(ResourceMetadataCollection $resourceMetadataCollection, Operation $operation, ?ApiProperty $propertyMetadata = null, array $context = []): GraphQLType;
 
     /**
      * Get the interface type of a node.

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -47,12 +47,15 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  */
 final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumInterface
 {
-    private readonly TypeBuilderEnumInterface|TypeBuilderInterface $typeBuilder;
+    private readonly ContextAwareTypeBuilderInterface|TypeBuilderEnumInterface|TypeBuilderInterface $typeBuilder;
 
-    public function __construct(private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ResourceClassResolverInterface $resourceClassResolver, private readonly TypesContainerInterface $typesContainer, TypeBuilderEnumInterface|TypeBuilderInterface $typeBuilder, private readonly TypeConverterInterface $typeConverter, private readonly ResolverFactoryInterface $itemResolverFactory, private readonly ?ResolverFactoryInterface $collectionResolverFactory, private readonly ?ResolverFactoryInterface $itemMutationResolverFactory, private readonly ?ResolverFactoryInterface $itemSubscriptionResolverFactory, private readonly ContainerInterface $filterLocator, private readonly Pagination $pagination, private readonly ?NameConverterInterface $nameConverter, private readonly string $nestingSeparator)
+    public function __construct(private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ResourceClassResolverInterface $resourceClassResolver, private readonly TypesContainerInterface $typesContainer, ContextAwareTypeBuilderInterface|TypeBuilderEnumInterface|TypeBuilderInterface $typeBuilder, private readonly TypeConverterInterface $typeConverter, private readonly ResolverFactoryInterface $itemResolverFactory, private readonly ?ResolverFactoryInterface $collectionResolverFactory, private readonly ?ResolverFactoryInterface $itemMutationResolverFactory, private readonly ?ResolverFactoryInterface $itemSubscriptionResolverFactory, private readonly ContainerInterface $filterLocator, private readonly Pagination $pagination, private readonly ?NameConverterInterface $nameConverter, private readonly string $nestingSeparator)
     {
         if ($typeBuilder instanceof TypeBuilderInterface) {
             @trigger_error(sprintf('$typeBuilder argument of FieldsBuilder implementing "%s" is deprecated since API Platform 3.1. It has to implement "%s" instead.', TypeBuilderInterface::class, TypeBuilderEnumInterface::class), \E_USER_DEPRECATED);
+        }
+        if ($typeBuilder instanceof TypeBuilderEnumInterface) {
+            @trigger_error(sprintf('$typeBuilder argument of TypeConverter implementing "%s" is deprecated since API Platform 3.3. It has to implement "%s" instead.', TypeBuilderEnumInterface::class, ContextAwareTypeBuilderInterface::class), \E_USER_DEPRECATED);
         }
         $this->typeBuilder = $typeBuilder;
     }

--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\GraphQl\Type;
 
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Exception\OperationNotFoundException;
 use ApiPlatform\Metadata\GraphQl\Mutation;
@@ -36,7 +37,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterface
+final class TypeBuilder implements ContextAwareTypeBuilderInterface
 {
     private $defaultFieldResolver;
 
@@ -48,10 +49,13 @@ final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterfac
     /**
      * {@inheritdoc}
      */
-    public function getResourceObjectType(?string $resourceClass, ResourceMetadataCollection $resourceMetadataCollection, Operation $operation, bool $input, bool $wrapped = false, int $depth = 0): GraphQLType
+    public function getResourceObjectType(ResourceMetadataCollection $resourceMetadataCollection, Operation $operation, ?ApiProperty $propertyMetadata = null, array $context = []): GraphQLType
     {
         $shortName = $operation->getShortName();
         $operationName = $operation->getName();
+        $input = $context['input'];
+        $depth = $context['depth'] ?? 0;
+        $wrapped = $context['wrapped'] ?? false;
 
         if ($operation instanceof Mutation) {
             $shortName = $operationName.ucfirst($shortName);
@@ -84,80 +88,21 @@ final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterfac
             $shortName .= 'Data';
         }
 
-        if ($this->typesContainer->has($shortName)) {
-            $resourceObjectType = $this->typesContainer->get($shortName);
-            if (!($resourceObjectType instanceof ObjectType || $resourceObjectType instanceof NonNull)) {
-                throw new \LogicException(sprintf('Expected GraphQL type "%s" to be %s.', $shortName, implode('|', [ObjectType::class, NonNull::class])));
-            }
-
-            return $resourceObjectType;
+        $resourceObjectType = null;
+        if (!$this->typesContainer->has($shortName)) {
+            $resourceObjectType = $this->getResourceObjectTypeConfiguration($shortName, $resourceMetadataCollection, $operation, $context);
+            $this->typesContainer->set($shortName, $resourceObjectType);
         }
 
-        $ioMetadata = $input ? $operation->getInput() : $operation->getOutput();
-        if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
-            $resourceClass = $ioMetadata['class'];
+        $resourceObjectType = $resourceObjectType ?? $this->typesContainer->get($shortName);
+        if (!($resourceObjectType instanceof ObjectType || $resourceObjectType instanceof NonNull || $resourceObjectType instanceof InputObjectType)) {
+            throw new \LogicException(sprintf('Expected GraphQL type "%s" to be %s.', $shortName, implode('|', [ObjectType::class, NonNull::class, InputObjectType::class])));
         }
 
-        $wrapData = !$wrapped && ($operation instanceof Mutation || $operation instanceof Subscription) && !$input && $depth < 1;
-
-        $configuration = [
-            'name' => $shortName,
-            'description' => $operation->getDescription(),
-            'resolveField' => $this->defaultFieldResolver,
-            'fields' => function () use ($resourceClass, $operation, $operationName, $resourceMetadataCollection, $input, $wrapData, $depth, $ioMetadata) {
-                if ($wrapData) {
-                    $queryNormalizationContext = $this->getQueryOperation($resourceMetadataCollection)?->getNormalizationContext() ?? [];
-
-                    try {
-                        $mutationNormalizationContext = $operation instanceof Mutation || $operation instanceof Subscription ? ($resourceMetadataCollection->getOperation($operationName)->getNormalizationContext() ?? []) : [];
-                    } catch (OperationNotFoundException) {
-                        $mutationNormalizationContext = [];
-                    }
-                    // Use a new type for the wrapped object only if there is a specific normalization context for the mutation or the subscription.
-                    // If not, use the query type in order to ensure the client cache could be used.
-                    $useWrappedType = $queryNormalizationContext !== $mutationNormalizationContext;
-
-                    $wrappedOperationName = $operationName;
-
-                    if (!$useWrappedType) {
-                        $wrappedOperationName = $operation instanceof Query ? $operationName : 'item_query';
-                    }
-
-                    $wrappedOperation = $resourceMetadataCollection->getOperation($wrappedOperationName);
-
-                    $fields = [
-                        lcfirst($wrappedOperation->getShortName()) => $this->getResourceObjectType($resourceClass, $resourceMetadataCollection, $wrappedOperation instanceof Operation ? $wrappedOperation : null, $input, true, $depth),
-                    ];
-
-                    if ($operation instanceof Subscription) {
-                        $fields['clientSubscriptionId'] = GraphQLType::string();
-                        if ($operation->getMercure()) {
-                            $fields['mercureUrl'] = GraphQLType::string();
-                        }
-
-                        return $fields;
-                    }
-
-                    return $fields + ['clientMutationId' => GraphQLType::string()];
-                }
-
-                $fieldsBuilder = $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder');
-                $fields = $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $operation, $input, $depth, $ioMetadata);
-
-                if ($input && $operation instanceof Mutation && null !== $mutationArgs = $operation->getArgs()) {
-                    return $fieldsBuilder->resolveResourceArgs($mutationArgs, $operation) + ['clientMutationId' => $fields['clientMutationId']];
-                }
-                if ($input && $operation instanceof Mutation && null !== $extraMutationArgs = $operation->getExtraArgs()) {
-                    return $fields + $fieldsBuilder->resolveResourceArgs($extraMutationArgs, $operation);
-                }
-
-                return $fields;
-            },
-            'interfaces' => $wrapData ? [] : [$this->getNodeInterface()],
-        ];
-
-        $resourceObjectType = $input ? GraphQLType::nonNull(new InputObjectType($configuration)) : new ObjectType($configuration);
-        $this->typesContainer->set($shortName, $resourceObjectType);
+        $required = $propertyMetadata?->isRequired() ?? true;
+        if ($required && $input) {
+            $resourceObjectType = GraphQLType::nonNull($resourceObjectType);
+        }
 
         return $resourceObjectType;
     }
@@ -355,5 +300,83 @@ final class TypeBuilder implements TypeBuilderInterface, TypeBuilderEnumInterfac
         }
 
         return null;
+    }
+
+    private function getResourceObjectTypeConfiguration(string $shortName, ResourceMetadataCollection $resourceMetadataCollection, Operation $operation, array $context = []): InputObjectType|ObjectType
+    {
+        $operationName = $operation->getName();
+        $resourceClass = $operation->getClass();
+        $input = $context['input'];
+        $depth = $context['depth'] ?? 0;
+        $wrapped = $context['wrapped'] ?? false;
+
+        $ioMetadata = $input ? $operation->getInput() : $operation->getOutput();
+        if (null !== $ioMetadata && \array_key_exists('class', $ioMetadata) && null !== $ioMetadata['class']) {
+            $resourceClass = $ioMetadata['class'];
+        }
+
+        $wrapData = !$wrapped && ($operation instanceof Mutation || $operation instanceof Subscription) && !$input && $depth < 1;
+
+        $configuration = [
+            'name' => $shortName,
+            'description' => $operation->getDescription(),
+            'resolveField' => $this->defaultFieldResolver,
+            'fields' => function () use ($resourceClass, $operation, $operationName, $resourceMetadataCollection, $input, $wrapData, $depth, $ioMetadata) {
+                if ($wrapData) {
+                    $queryNormalizationContext = $this->getQueryOperation($resourceMetadataCollection)?->getNormalizationContext() ?? [];
+
+                    try {
+                        $mutationNormalizationContext = $operation instanceof Mutation || $operation instanceof Subscription ? ($resourceMetadataCollection->getOperation($operationName)->getNormalizationContext() ?? []) : [];
+                    } catch (OperationNotFoundException) {
+                        $mutationNormalizationContext = [];
+                    }
+                    // Use a new type for the wrapped object only if there is a specific normalization context for the mutation or the subscription.
+                    // If not, use the query type in order to ensure the client cache could be used.
+                    $useWrappedType = $queryNormalizationContext !== $mutationNormalizationContext;
+
+                    $wrappedOperationName = $operationName;
+
+                    if (!$useWrappedType) {
+                        $wrappedOperationName = $operation instanceof Query ? $operationName : 'item_query';
+                    }
+
+                    $wrappedOperation = $resourceMetadataCollection->getOperation($wrappedOperationName);
+
+                    $fields = [
+                        lcfirst($wrappedOperation->getShortName()) => $this->getResourceObjectType($resourceMetadataCollection, $wrappedOperation instanceof Operation ? $wrappedOperation : null, null, [
+                            'input' => $input,
+                            'wrapped' => true,
+                            'depth' => $depth,
+                        ]),
+                    ];
+
+                    if ($operation instanceof Subscription) {
+                        $fields['clientSubscriptionId'] = GraphQLType::string();
+                        if ($operation->getMercure()) {
+                            $fields['mercureUrl'] = GraphQLType::string();
+                        }
+
+                        return $fields;
+                    }
+
+                    return $fields + ['clientMutationId' => GraphQLType::string()];
+                }
+
+                $fieldsBuilder = $this->fieldsBuilderLocator->get('api_platform.graphql.fields_builder');
+                $fields = $fieldsBuilder->getResourceObjectTypeFields($resourceClass, $operation, $input, $depth, $ioMetadata);
+
+                if ($input && $operation instanceof Mutation && null !== $mutationArgs = $operation->getArgs()) {
+                    return $fieldsBuilder->resolveResourceArgs($mutationArgs, $operation) + ['clientMutationId' => $fields['clientMutationId']];
+                }
+                if ($input && $operation instanceof Mutation && null !== $extraMutationArgs = $operation->getExtraArgs()) {
+                    return $fields + $fieldsBuilder->resolveResourceArgs($extraMutationArgs, $operation);
+                }
+
+                return $fields;
+            },
+            'interfaces' => $wrapData ? [] : [$this->getNodeInterface()],
+        ];
+
+        return $input ? new InputObjectType($configuration) : new ObjectType($configuration);
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/OptionalRequiredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/OptionalRequiredDummy.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * OptionalRequiredDummy. Used to test GraphQL Schema generation for nullable embedded relations.
+ */
+#[ApiResource(
+    graphQlOperations: [
+        new Query(name: 'item_query'),
+        new Mutation(name: 'update', normalizationContext: ['groups' => ['chicago', 'fakemanytomany']], denormalizationContext: ['groups' => ['friends']]),
+    ],
+)]
+#[ORM\Entity]
+class OptionalRequiredDummy
+{
+    #[ApiProperty(writable: false)]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[Groups(['chicago', 'friends'])]
+    private $id;
+
+    #[ORM\ManyToOne(targetEntity: ThirdLevel::class, cascade: ['persist'], inversedBy: 'relatedDummies')]
+    #[Groups(['barcelona', 'chicago', 'friends'])]
+    public ?ThirdLevel $thirdLevel = null;
+
+    #[ORM\ManyToOne(targetEntity: ThirdLevel::class, cascade: ['persist'])]
+    #[ORM\JoinColumn(nullable: false)]
+    #[ApiProperty(required: true)]
+    #[Groups(['barcelona', 'chicago', 'friends'])]
+    public ThirdLevel $thirdLevelRequired;
+
+    #[ORM\OneToMany(targetEntity: RelatedToDummyFriend::class, cascade: ['persist'], mappedBy: 'relatedDummy')]
+    #[Groups(['fakemanytomany', 'friends'])]
+    public Collection|iterable $relatedToDummyFriend;
+
+    public function __construct()
+    {
+        $this->relatedToDummyFriend = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getThirdLevel(): ?ThirdLevel
+    {
+        return $this->thirdLevel;
+    }
+
+    public function setThirdLevel(?ThirdLevel $thirdLevel = null): void
+    {
+        $this->thirdLevel = $thirdLevel;
+    }
+
+    public function getThirdLevelRequired(): ThirdLevel
+    {
+        return $this->thirdLevelRequired;
+    }
+
+    public function setThirdLevelRequired(ThirdLevel $thirdLevelRequired): void
+    {
+        $this->thirdLevelRequired = $thirdLevelRequired;
+    }
+
+    /**
+     * Get relatedToDummyFriend.
+     */
+    public function getRelatedToDummyFriend(): Collection|iterable
+    {
+        return $this->relatedToDummyFriend;
+    }
+
+    /**
+     * Set relatedToDummyFriend.
+     *
+     * @param RelatedToDummyFriend $relatedToDummyFriend the value to set
+     */
+    public function addRelatedToDummyFriend(RelatedToDummyFriend $relatedToDummyFriend): void
+    {
+        $this->relatedToDummyFriend->add($relatedToDummyFriend);
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->getId();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `main`
| Tickets       | https://github.com/api-platform/api-platform/issues/2562
| License       | MIT

We have a number of cases where we support creating new entities through a relationship with a 'parent' entity. This works fine, but the prop is always marked as 'required' in the GraphQL types that are being generated. This PR addresses this issue and will look for `#[ApiProperty(required: false)]` or `#[ORM\JoinColumn(nullable: true)]` to mark the input as non-required in the GraphQL type. 