### PR TITLE
fix: better generics support for State\ProcessorInterface

### DIFF
--- a/src/HttpCache/State/AddHeadersProcessor.php
+++ b/src/HttpCache/State/AddHeadersProcessor.php
@@ -18,10 +18,16 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ */
 final class AddHeadersProcessor implements ProcessorInterface
 {
     /**
-     * @param ProcessorInterface<Response>|ProcessorInterface<mixed> $decorated
+     * @param ProcessorInterface<T1, T2> $decorated
      */
     public function __construct(private readonly ProcessorInterface $decorated, private readonly bool $etag = false, private readonly ?int $maxAge = null, private readonly ?int $sharedMaxAge = null, private readonly ?array $vary = null, private readonly ?bool $public = null, private readonly ?int $staleWhileRevalidate = null, private readonly ?int $staleIfError = null)
     {

--- a/src/Hydra/State/HydraLinkProcessor.php
+++ b/src/Hydra/State/HydraLinkProcessor.php
@@ -22,12 +22,18 @@ use ApiPlatform\State\Util\CorsTrait;
 use Symfony\Component\WebLink\GenericLinkProvider;
 use Symfony\Component\WebLink\Link;
 
+/**
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ */
 final class HydraLinkProcessor implements ProcessorInterface
 {
     use CorsTrait;
 
     /**
-     * @param ProcessorInterface<mixed> $decorated
+     * @param ProcessorInterface<T1, T2> $decorated
      */
     public function __construct(private readonly ProcessorInterface $decorated, private readonly UrlGeneratorInterface $urlGenerator)
     {

--- a/src/State/CallableProcessor.php
+++ b/src/State/CallableProcessor.php
@@ -17,6 +17,12 @@ use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Operation;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ */
 final class CallableProcessor implements ProcessorInterface
 {
     public function __construct(private readonly ?ContainerInterface $locator = null)
@@ -40,7 +46,7 @@ final class CallableProcessor implements ProcessorInterface
             throw new RuntimeException(sprintf('Processor "%s" not found on operation "%s"', $processor, $operation->getName()));
         }
 
-        /** @var ProcessorInterface $processorInstance */
+        /** @var ProcessorInterface<T1, T2> $processorInstance */
         $processorInstance = $this->locator->get($processor);
 
         return $processorInstance->process($data, $operation, $uriVariables, $context);

--- a/src/State/Processor/AddLinkHeaderProcessor.php
+++ b/src/State/Processor/AddLinkHeaderProcessor.php
@@ -18,8 +18,17 @@ use ApiPlatform\State\ProcessorInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 
+/**
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ */
 final class AddLinkHeaderProcessor implements ProcessorInterface
 {
+    /**
+     * @param ProcessorInterface<T1, T2> $decorated
+     */
     public function __construct(private readonly ProcessorInterface $decorated, private readonly ?HttpHeaderSerializer $serializer = new HttpHeaderSerializer())
     {
     }

--- a/src/State/Processor/RespondProcessor.php
+++ b/src/State/Processor/RespondProcessor.php
@@ -24,6 +24,7 @@ use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use ApiPlatform\State\ProcessorInterface;
+use DateTimeInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface as SymfonyHttpExceptionInterface;
 
@@ -74,7 +75,7 @@ final class RespondProcessor implements ProcessorInterface
         $status = $operation->getStatus();
 
         if ($sunset = $operation->getSunset()) {
-            $headers['Sunset'] = (new \DateTimeImmutable($sunset))->format(\DateTime::RFC1123);
+            $headers['Sunset'] = (new \DateTimeImmutable($sunset))->format(DateTimeInterface::RFC1123);
         }
 
         if ($acceptPatch = $operation->getAcceptPatch()) {

--- a/src/State/Processor/RespondProcessor.php
+++ b/src/State/Processor/RespondProcessor.php
@@ -24,7 +24,6 @@ use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use ApiPlatform\State\ProcessorInterface;
-use DateTimeInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface as SymfonyHttpExceptionInterface;
 
@@ -75,7 +74,7 @@ final class RespondProcessor implements ProcessorInterface
         $status = $operation->getStatus();
 
         if ($sunset = $operation->getSunset()) {
-            $headers['Sunset'] = (new \DateTimeImmutable($sunset))->format(DateTimeInterface::RFC1123);
+            $headers['Sunset'] = (new \DateTimeImmutable($sunset))->format(\DateTimeInterface::RFC1123);
         }
 
         if ($acceptPatch = $operation->getAcceptPatch()) {

--- a/src/State/Processor/SerializeProcessor.php
+++ b/src/State/Processor/SerializeProcessor.php
@@ -26,10 +26,18 @@ use Symfony\Component\WebLink\Link;
 /**
  * Serializes data.
  *
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 final class SerializeProcessor implements ProcessorInterface
 {
+    /**
+     * @param ProcessorInterface<T1, T2> $processor
+     */
     public function __construct(private readonly ProcessorInterface $processor, private readonly SerializerInterface $serializer, private readonly SerializerContextBuilderInterface $serializerContextBuilder)
     {
     }

--- a/src/State/Processor/WriteProcessor.php
+++ b/src/State/Processor/WriteProcessor.php
@@ -21,6 +21,11 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Bridges persistence and the API system.
  *
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
@@ -28,6 +33,10 @@ final class WriteProcessor implements ProcessorInterface
 {
     use ClassInfoTrait;
 
+    /**
+     * @param ProcessorInterface<T1, T2> $processor
+     * @param ProcessorInterface<T1, T2> $callableProcessor
+     */
     public function __construct(private readonly ProcessorInterface $processor, private readonly ProcessorInterface $callableProcessor)
     {
     }

--- a/src/State/ProcessorInterface.php
+++ b/src/State/ProcessorInterface.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\State;
 
 use ApiPlatform\Metadata\Operation;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Process data: send an email, persist to storage, add to queue etc.
+ * Processes data: sends an email, persists to storage, adds to queue etc.
  *
- * @template T
+ * @template T1 of object
+ * @template T2 of object
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
@@ -27,11 +29,11 @@ interface ProcessorInterface
     /**
      * Handles the state.
      *
-     * @param T                                                                                                                                                      $data
-     * @param array<string, mixed>                                                                                                                                   $uriVariables
-     * @param array<string, mixed>&array{request?: \Symfony\Component\HttpFoundation\Request, previous_data?: mixed, resource_class?: string, original_data?: mixed} $context
+     * @param T1                                                                                                                   $data
+     * @param array<string, mixed>                                                                                                 $uriVariables
+     * @param array<string, mixed>&array{request?: Request, previous_data?: mixed, resource_class?: string, original_data?: mixed} $context
      *
-     * @return T
+     * @return T2
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []);
 }

--- a/src/State/ProcessorInterface.php
+++ b/src/State/ProcessorInterface.php
@@ -25,8 +25,9 @@ use ApiPlatform\Metadata\Operation;
 interface ProcessorInterface
 {
     /**
-     * Handle the state.
+     * Handles the state.
      *
+     * @param T                                                                                                                                                      $data
      * @param array<string, mixed>                                                                                                                                   $uriVariables
      * @param array<string, mixed>&array{request?: \Symfony\Component\HttpFoundation\Request, previous_data?: mixed, resource_class?: string, original_data?: mixed} $context
      *

--- a/src/State/ProcessorInterface.php
+++ b/src/State/ProcessorInterface.php
@@ -19,8 +19,8 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Processes data: sends an email, persists to storage, adds to queue etc.
  *
- * @template T1 of object
- * @template T2 of object
+ * @template T1
+ * @template T2
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */

--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\State;
 
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\PartialPaginatorInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Retrieves data from a persistence layer.
@@ -27,10 +29,10 @@ interface ProviderInterface
     /**
      * Provides data.
      *
-     * @param array<string, mixed>                                                                                     $uriVariables
-     * @param array<string, mixed>|array{request?: \Symfony\Component\HttpFoundation\Request, resource_class?: string} $context
+     * @param array<string, mixed>                                                   $uriVariables
+     * @param array<string, mixed>|array{request?: Request, resource_class?: string} $context
      *
-     * @return T|Pagination\PartialPaginatorInterface<T>|iterable<T>|null
+     * @return T|PartialPaginatorInterface<T>|iterable<T>|null
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null;
 }

--- a/src/Symfony/State/MercureLinkProcessor.php
+++ b/src/Symfony/State/MercureLinkProcessor.php
@@ -17,10 +17,16 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Symfony\Component\Mercure\Discovery;
 
+/**
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ */
 final class MercureLinkProcessor implements ProcessorInterface
 {
     /**
-     * @param ProcessorInterface<mixed> $decorated
+     * @param ProcessorInterface<T1, T2> $decorated
      */
     public function __construct(private readonly ProcessorInterface $decorated, private readonly Discovery $discovery)
     {

--- a/tests/State/RespondProcessorTest.php
+++ b/tests/State/RespondProcessorTest.php
@@ -71,7 +71,7 @@ class RespondProcessorTest extends TestCase
                 return ($args[2] ?? null)?->getUriTemplate() ?? '/default';
             });
 
-        /** @var ProcessorInterface<Response> $respondProcessor */
+        /** @var ProcessorInterface<string, Response> $respondProcessor */
         $respondProcessor = new RespondProcessor($iriConverter->reveal(), $resourceClassResolver->reveal(), $operationMetadataFactory->reveal());
 
         $response = $respondProcessor->process('content', $canonicalUriTemplateRedirectingOperation, context: [
@@ -103,7 +103,7 @@ class RespondProcessorTest extends TestCase
     {
         $operation = new Get();
 
-        /** @var ProcessorInterface<Response> $respondProcessor */
+        /** @var ProcessorInterface<string, Response> $respondProcessor */
         $respondProcessor = new RespondProcessor();
         $req = new Request();
         $req->attributes->set('exception', new TooManyRequestsHttpException(32));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

In a next PR, the maker command could also be improved to take the name of the provided entity class as an optional parameter.