### PR TITLE
Exclude IRI from serializer's cache key to avoid cache explosion

### DIFF
--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -94,6 +94,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
         $context = $this->initContext($resourceClass, $context);
         $iri = $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_PATH, $context['operation'] ?? null, $context);
         $context['iri'] = $iri;
+        $context = $this->excludeIriFromCacheKey($context);
         $context['api_normalize'] = true;
 
         if (!isset($context['cache_key'])) {

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -150,6 +150,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         $context['api_normalize'] = true;
         $iri = $context['iri'] ??= $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_URL, $context['operation'] ?? null, $context);
+        $context = $this->excludeIriFromCacheKey($context);
 
         /*
          * When true, converts the normalized data array of a resource into an

--- a/src/Serializer/ContextTrait.php
+++ b/src/Serializer/ContextTrait.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Serializer;
 
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+
+
 /**
  * Creates and manipulates the Serializer context.
  *
@@ -29,5 +32,23 @@ trait ContextTrait
             'api_sub_level' => true,
             'resource_class' => $resourceClass,
         ]);
+    }
+
+    /**
+     * Exclude 'iri' from serializer cache key. Not doing this results in a cache explosion
+     * when iterating big result sets because a unique iri generates unique cache keys in
+     * Symfony Serializer's AbstractObjectNormalizer::getCacheKey()
+     */
+    private function excludeIriFromCacheKey(array $context): array
+    {
+        if (empty($context[AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY])) {
+            $context[AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY] = ['iri'];
+        } else {
+            if (!in_array('iri', $context[AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY])) {
+                $context[AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY][] = 'iri';
+            }
+        }
+
+        return $context;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Exclude IRI from serializer's cache key. Having this unique identifier in $context results in private array caches explosion when iterating big result sets and normalizing items (batch processing jobs or exports). 

Trying to serialize with provided $context['cache_key'] would work but this line https://github.com/symfony/symfony/blob/34915f6e16f04537eb18d9d2c303ec375e63cc4b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L708 results in normalized child contexts ignoring the provided 'cache_key' and generating unique cache keys because the IRI is part of the hash.

No tests were added because I'm not really sure how to test for this. The affected cache behavior is in Symfony not here.