### PR TITLE
fix: return null instead of exception for GraphQL Query operation

### DIFF
--- a/src/GraphQl/State/Provider/ReadProvider.php
+++ b/src/GraphQl/State/Provider/ReadProvider.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\State\Provider;
 
-use ApiPlatform\Exception\ItemNotFoundException;
+use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\GraphQl\Resolver\Util\IdentifierTrait;
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
 use ApiPlatform\GraphQl\Serializer\SerializerContextBuilderInterface;
@@ -69,10 +69,6 @@ final class ReadProvider implements ProviderInterface
                 $item = null;
             }
 
-            if ($operation instanceof Query && null === $item) {
-                return $item;
-            }
-
             if ($operation instanceof Subscription || $operation instanceof Mutation) {
                 if (null === $item) {
                     throw new NotFoundHttpException(sprintf('Item "%s" not found.', $args['input']['id']));
@@ -83,7 +79,7 @@ final class ReadProvider implements ProviderInterface
                 }
             }
 
-            if (!\is_object($item)) {
+            if (null !== $item && !\is_object($item)) {
                 throw new \LogicException('Item from read provider should be a nullable object.');
             }
 

--- a/src/GraphQl/State/Provider/ReadProvider.php
+++ b/src/GraphQl/State/Provider/ReadProvider.php
@@ -21,6 +21,7 @@ use ApiPlatform\GraphQl\Util\ArrayTrait;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
+use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Subscription;
 use ApiPlatform\Metadata\IriConverterInterface;
@@ -66,6 +67,10 @@ final class ReadProvider implements ProviderInterface
                 $item = $this->iriConverter->getResourceFromIri($identifier, $context);
             } catch (ItemNotFoundException) {
                 $item = null;
+            }
+
+            if ($operation instanceof Query && null === $item) {
+                return $item;
             }
 
             if ($operation instanceof Subscription || $operation instanceof Mutation) {

--- a/src/GraphQl/State/Provider/ReadProvider.php
+++ b/src/GraphQl/State/Provider/ReadProvider.php
@@ -13,15 +13,14 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\State\Provider;
 
-use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\GraphQl\Resolver\Util\IdentifierTrait;
 use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
 use ApiPlatform\GraphQl\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\GraphQl\Util\ArrayTrait;
 use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
-use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Subscription;
 use ApiPlatform\Metadata\IriConverterInterface;
@@ -79,7 +78,11 @@ final class ReadProvider implements ProviderInterface
                 }
             }
 
-            if (null !== $item && !\is_object($item)) {
+            if (null === $item) {
+                return $item;
+            }
+
+            if (!\is_object($item)) {
                 throw new \LogicException('Item from read provider should be a nullable object.');
             }
 

--- a/src/GraphQl/Tests/State/Provider/ReadProviderTest.php
+++ b/src/GraphQl/Tests/State/Provider/ReadProviderTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\Tests\State\Provider;
 
-use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\GraphQl\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\GraphQl\State\Provider\ReadProvider;
+use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\IriConverterInterface;

--- a/src/GraphQl/Tests/State/Provider/ReadProviderTest.php
+++ b/src/GraphQl/Tests/State/Provider/ReadProviderTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\Tests\State\Provider;
 
-use ApiPlatform\Exception\ItemNotFoundException;
+use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\GraphQl\Serializer\SerializerContextBuilderInterface;
 use ApiPlatform\GraphQl\State\Provider\ReadProvider;
 use ApiPlatform\Metadata\GraphQl\Query;
@@ -44,10 +44,6 @@ class ReadProviderTest extends TestCase
      */
     public function testProvideNotExistedResource(): void
     {
-        if (!class_exists('\ApiPlatform\Exception\ItemNotFoundException')) {
-            class_alias('\ApiPlatform\Metadata\Exception\ItemNotFoundException', '\ApiPlatform\Exception\ItemNotFoundException');
-        }
-
         $context = ['args' => ['id' => '/dummy/1']];
         $operation = new Query(class: 'dummy');
         $decorated = $this->createMock(ProviderInterface::class);

--- a/src/GraphQl/Tests/State/Provider/ReadProviderTest.php
+++ b/src/GraphQl/Tests/State/Provider/ReadProviderTest.php
@@ -39,10 +39,15 @@ class ReadProviderTest extends TestCase
 
     /**
      * Tests that provider returns null if resource is not found.
+     *
      * @see https://github.com/api-platform/core/issues/6072
      */
     public function testProvideNotExistedResource(): void
     {
+        if (!class_exists('\ApiPlatform\Exception\ItemNotFoundException')) {
+            class_alias('\ApiPlatform\Metadata\Exception\ItemNotFoundException', '\ApiPlatform\Exception\ItemNotFoundException');
+        }
+
         $context = ['args' => ['id' => '/dummy/1']];
         $operation = new Query(class: 'dummy');
         $decorated = $this->createMock(ProviderInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `3.2`
| Tickets       | Closes api-platform/core#6072
| License       | MIT
| Doc PR        | -

After upgrading to 3.2 we noticed a new error `Item from read provider should be a nullable object.` in our projects, when request single resource via GraphQL Query if such resource does not exists with provided id, see api-platform/core#6072.