### PR TITLE
Don't check for the security on null obj on graphql

### DIFF
--- a/src/Symfony/Security/State/AccessCheckerProvider.php
+++ b/src/Symfony/Security/State/AccessCheckerProvider.php
@@ -73,6 +73,10 @@ final class AccessCheckerProvider implements ProviderInterface
                 'object' => $body,
                 'previous_object' => $context['graphql_context']['previous_object'] ?? null,
             ];
+
+            if (null === $resourceAccessCheckerContext['object'] && null === $resourceAccessCheckerContext['previous_object']) {
+                return null;
+            }
         }
 
         if (!$this->resourceAccessChecker->isGranted($operation->getClass(), $isGranted, $resourceAccessCheckerContext)) {

--- a/tests/Symfony/Security/State/AccessCheckerProviderTest.php
+++ b/tests/Symfony/Security/State/AccessCheckerProviderTest.php
@@ -89,4 +89,16 @@ class AccessCheckerProviderTest extends TestCase
         $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker);
         $accessChecker->provide($operation, [], []);
     }
+
+    public function testCheckAccessOnNullObjectWithGraphQl(): void
+    {
+        $operation = new Query(class: 'foo', security: 'hi', securityMessage: 'hello');
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->method('provide')->willReturn(null);
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->expects($this->never())->method('isGranted');
+        $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker);
+        $result = $accessChecker->provide($operation, [], []);
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
Hi,

I have an security issue with GraphQl endpoint

example graphql query:
```
{
  intent(id: "/api/intents/30") {
    mainEconomicActivity {
      isMainActivity
    }
  }
}
```
problem here is that when `intent.mainEconomicActivity` is `null` api-platform still tries to run the security check which is causing the request to fail with, but when it is not null then the code is working properly.
I enabled both RestAPI and GraphQl in my project and the problem exists only with GraphQl.

the error:
```
      "extensions": {
        "debugMessage": "Unable to call method \"getIntent\" of non-object \"object\".",
        "file": "/var/www/api/vendor/symfony/expression-language/Node/GetAttrNode.php",
        "line": 111,
        "trace": [
          {
            "file": "/var/www/api/vendor/symfony/expression-language/Node/GetAttrNode.php",
```

Resources:
```php
<?php
namespace App\Entity;

use ApiPlatform\Metadata\ApiProperty;
use ApiPlatform\Metadata\ApiResource;
use ApiPlatform\Metadata\Get;
use ApiPlatform\Metadata\GetCollection;
use ApiPlatform\Metadata\GraphQl\Query;
use ApiPlatform\Metadata\GraphQl\QueryCollection;
use Doctrine\Common\Collections\ArrayCollection;
use Doctrine\Common\Collections\Collection;
use Doctrine\DBAL\Types\Types;
use Doctrine\ORM\Mapping as ORM;
use Gedmo\Mapping\Annotation\Blameable;
use Symfony\Component\Serializer\Annotation\Groups;

#[ApiResource(
    operations: [
        new Get(security: "object.getUserId() == user.getUserIdentifier()"),
        new GetCollection(),
    ],
    normalizationContext: ['skip_null_values' => false, 'groups' => ['intent:read']],
    graphQlOperations: [
        new Query(security: "object.getUserId() == user?.getUserIdentifier()"),
        new QueryCollection(),
    ],
)]
#[ORM\Entity]
#[ORM\Index(columns: ['user_id'])]
class Intent
{
    #[ORM\Id]
    #[ORM\Column(type: Types::INTEGER)]
    #[ORM\GeneratedValue]
    #[Groups(['intent:read'])]
    private ?int $id = null;

    #[ORM\Column]
    #[Blameable(on: 'create')]
    #[Groups(['intent:read'])]
    private string|null $userId = null;

    /**
     * @var Collection<IntentEconomicActivity>
     */
    #[ORM\OneToMany(mappedBy: 'intent', targetEntity: IntentEconomicActivity::class, cascade: ['persist', 'remove'])]
    #[Groups(['intent:read'])]
    private Collection $economicActivities;

    public function __construct()  {
        $this->economicActivities = new ArrayCollection();
    }
    public function getId(): ?int {
        return $this->id;
    }
    public function getUserId(): ?string  {
        return $this->userId;
    }

    // this is the property dynamic property that I am trying to access
     #[Groups(['intent:read'])]
    public function getMainEconomicActivity(): ?IntentEconomicActivity
    {
        $mainActivities = $this->economicActivities->filter(fn(IntentEconomicActivity $item) => $item->getIsMainActivity());
        return $mainActivities[0] ?? null;
    }
}
```

```php
<?php
namespace App\Entity;

use ApiPlatform\Metadata\ApiResource;
use ApiPlatform\Metadata\Get;
use ApiPlatform\Metadata\GraphQl\Query;
use ApiPlatform\Metadata\Link;
use Doctrine\DBAL\Types\Types;
use Doctrine\ORM\Mapping as ORM;
use Symfony\Component\Serializer\Annotation\Groups;

#[ApiResource(
    uriTemplate: '/intents/{intentId}/intent_economic_activities/{id}',
    operations: [
        new Get(security: "object.getIntent().getUserId() == user.getUserIdentifier()"),
    ],
    uriVariables: [
        'intentId' => new Link(toProperty: 'intent', fromClass: Intent::class),
        'id'       => new Link(fromClass: IntentEconomicActivity::class),
    ],
    normalizationContext: ['skip_null_values' => false, 'groups' => ['intent:read']],
    graphQlOperations: [
       // this expression is almost the same as for restAPI
       // as mentioned in the error "object.getIntent()" this check is failing because object is null. 
       // it also works if I change expression to "null === object || object.getIntent().getUserId() == user?.getUserIdentifier()"
       // but I prefer when it is the same expression as in RestAPI
        new Query(security: "object.getIntent().getUserId() == user?.getUserIdentifier()"),
    ],
)]
#[ORM\Entity]
#[ORM\UniqueConstraint(columns: ['intent_id', 'economic_activity_code'])]
class IntentEconomicActivity
{
    #[ORM\Id]
    #[ORM\Column(type: Types::INTEGER)]
    #[ORM\GeneratedValue]
    #[Groups(['intent:read'])]
    private ?int $id = null;

    #[ORM\ManyToOne(targetEntity: Intent::class, inversedBy: 'economicActivities')]
    #[ORM\JoinColumn(nullable: false)]
    #[Groups(['intent:read'])]
    private Intent $intent;

    #[ORM\Column(type: Types::BOOLEAN)]
    #[Groups(['intent:read'])]
    private bool $isMainActivity = false;

    public function getId(): ?int  {
        return $this->id;
    }

    public function getIntent(): Intent  {
        return $this->intent;
    }

    public function getIsMainActivity(): bool  {
        return $this->isMainActivity;
    }
}
```