### PR TITLE
ci: make subtree split fail if any command fails

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
       - name: 'Install splitsh'
-        run: | 
+        run: |
           curl -L https://github.com/splitsh/lite/releases/download/v1.0.1/lite_linux_amd64.tar.gz > lite_linux_amd64.tar.gz
           tar -zxpf lite_linux_amd64.tar.gz
           chmod +x splitsh-lite
           echo "$(pwd)" >> $GITHUB_PATH
       - name: 'Split to manyrepo'
-        run: find src -maxdepth 3 -name composer.json -print0 | xargs -I '{}' -n 1 -0 bash subtree.sh {} ${{ github.ref }}
+        run: bash subtree.sh ${{ github.ref }}

--- a/subtree.sh
+++ b/subtree.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 
+set -e # Exit immediately if a command exits with a non-zero status.
 set -x
 
-# Subtree split on tag this script gets called using find:
-# find src -maxdepth 2 -name composer.json -print0 | xargs -I '{}' -n 1 -0 bash subtree.sh {} refs/tags/3.1.5
-# find src -maxdepth 2 -name composer.json -print0 | xargs -I '{}' -n 1 -0 bash subtree.sh {} refs/heads/3.1
-# See the subtree workflow
-package=$(jq -r .name $1)
-directory=$(dirname $1)
-repository="https://github.com/$package"
-git remote add $package $repository
-sha=$(splitsh-lite --prefix=$directory)
-git push $package $sha:$2
+GITHUB_REF="$1"
+
+if [[ -z "${GITHUB_REF}" ]]; then
+    echo "Usage: $0 GITHUB_REF"
+    exit 129
+fi
+
+while IFS= read -r -d '' file
+do
+
+  package=$(jq -r .name "${file}")
+  directory=$(dirname "${file}")
+  repository="https://github.com/${package}"
+
+  git remote add "${package}" "${repository}"
+  sha=$(splitsh-lite --prefix="${directory}")
+  git push "${package}" "${sha}:${GITHUB_REF}"
+
+done < <(find src -maxdepth 3 -name composer.json -not -path '*/vendor/*' -print0)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The current CI does not fail if the subtree split fails. This breaks individual package 
installation when these errors occurs.

This pull-request aims to be less permissive by failing on any errors
