### PR TITLE
fix(elasticsearch): return type for ItemNormalizer

### DIFF
--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -88,7 +88,7 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): ArrayObject|array|string|int|float|bool|null
+    public function normalize(mixed $object, string $format = null, array $context = []): \ArrayObject|array|string|int|float|bool|null
     {
         return $this->decorated->normalize($object, $format, $context);
     }

--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -88,7 +88,7 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    public function normalize(mixed $object, string $format = null, array $context = []): mixed
     {
         return $this->decorated->normalize($object, $format, $context);
     }

--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -88,7 +88,7 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): mixed
+    public function normalize(mixed $object, string $format = null, array $context = []): ArrayObject|array|string|int|float|bool|null
     {
         return $this->decorated->normalize($object, $format, $context);
     }

--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -88,7 +88,7 @@ final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): \ArrayObject|array|string|int|float|bool|null
+    public function normalize(mixed $object, ?string $format = null, array $context = []): \ArrayObject|array|string|int|float|bool|null
     {
         return $this->decorated->normalize($object, $format, $context);
     }

--- a/src/Elasticsearch/Tests/Serializer/ItemNormalizerTest.php
+++ b/src/Elasticsearch/Tests/Serializer/ItemNormalizerTest.php
@@ -91,6 +91,15 @@ final class ItemNormalizerTest extends TestCase
         self::assertEquals(['foo'], $this->itemNormalizer->normalize($object, 'json', ['groups' => 'foo']));
     }
 
+    public function testNormalizeIntoIri(): void
+    {
+        $iri = '/foobar/1234';
+        $item = new \stdClass();
+        $this->normalizerProphecy->normalize($item, 'json', ['groups' => 'foo'])->willReturn($iri)->shouldBeCalledOnce();
+
+        self::assertEquals($iri, $this->itemNormalizer->normalize($item, 'json', ['groups' => 'foo']));
+    }
+
     public function testSupportsNormalization(): void
     {
         $this->normalizerProphecy->supportsNormalization($object = (object) ['foo'], 'json')->willReturn(true)->shouldBeCalledOnce();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2

Decorated normalizer has return type `array|ArrayObject|bool|float|int|null|string \ArrayObject`, and I had issues in test where the returned value was string (item uri)