### PR TITLE
fix(doctrine): fix error when identifier is not 'id'

### DIFF
--- a/src/Doctrine/Orm/State/ItemProvider.php
+++ b/src/Doctrine/Orm/State/ItemProvider.php
@@ -56,7 +56,7 @@ final class ItemProvider implements ProviderInterface
         $fetchData = $context['fetch_data'] ?? true;
         if (!$fetchData && \array_key_exists('id', $uriVariables)) {
             // todo : if uriVariables don't contain the id, this fails. This should behave like it does in the following code
-            return $manager->getReference($entityClass, $uriVariables);
+            return $manager->getReference($entityClass, $uriVariables['id']);
         }
 
         $repository = $manager->getRepository($entityClass);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2

When your entity identifier is not named id, your `uriVariables` (if not customized) will contains something like `["id" =>"THE_CODE"]`, but Doctine will throw if you send an array as it expect something like  `["nameOfIdentifer" =>"THE_CODE"]`

By using the identifier directly, we let doctrine figure out the rest