### PR TITLE
feat: Paginators for Doctrine Collection & Selectable

### DIFF
--- a/src/Doctrine/Common/CollectionPaginator.php
+++ b/src/Doctrine/Common/CollectionPaginator.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common;
+
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use Doctrine\Common\Collections\ReadableCollection;
+
+/**
+ * @template T of object
+ *
+ * @implements PaginatorInterface<T>
+ * @implements \IteratorAggregate<T>
+ */
+final class CollectionPaginator implements \IteratorAggregate, PaginatorInterface
+{
+    /**
+     * @var array<array-key,T>
+     */
+    private readonly array $items;
+    private readonly float $totalItems;
+
+    /**
+     * @param ReadableCollection<array-key,T> $collection
+     */
+    public function __construct(
+        readonly ReadableCollection $collection,
+        private readonly float $currentPage,
+        private readonly float $itemsPerPage
+    ) {
+        $this->items = $collection->slice((int) (($currentPage - 1) * $itemsPerPage), $itemsPerPage > 0 ? (int) $itemsPerPage : null);
+        $this->totalItems = $collection->count();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentPage(): float
+    {
+        return $this->currentPage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastPage(): float
+    {
+        if (0. >= $this->itemsPerPage) {
+            return 1.;
+        }
+
+        return max(ceil($this->totalItems / $this->itemsPerPage) ?: 1., 1.);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItemsPerPage(): float
+    {
+        return $this->itemsPerPage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTotalItems(): float
+    {
+        return $this->totalItems;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int
+    {
+        return \count($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return \Traversable<T>
+     */
+    public function getIterator(): \Traversable
+    {
+        yield from $this->items;
+    }
+}

--- a/src/Doctrine/Common/SelectablePaginator.php
+++ b/src/Doctrine/Common/SelectablePaginator.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common;
+
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\ReadableCollection;
+use Doctrine\Common\Collections\Selectable;
+
+/**
+ * @template T of object
+ *
+ * @implements PaginatorInterface<T>
+ * @implements \IteratorAggregate<T>
+ */
+final class SelectablePaginator implements \IteratorAggregate, PaginatorInterface
+{
+    /**
+     * @var ReadableCollection<array-key,T>
+     */
+    private readonly ReadableCollection $slicedCollection;
+    private readonly float $totalItems;
+
+    /**
+     * @param Selectable<array-key,T> $selectable
+     */
+    public function __construct(
+        readonly Selectable $selectable,
+        private readonly float $currentPage,
+        private readonly float $itemsPerPage
+    ) {
+        $this->totalItems = $this->selectable instanceof \Countable ? $this->selectable->count() : $this->selectable->matching(Criteria::create())->count();
+
+        $criteria = Criteria::create()
+            ->setFirstResult((int) (($currentPage - 1) * $itemsPerPage))
+            ->setMaxResults($itemsPerPage > 0 ? (int) $itemsPerPage : null);
+
+        $this->slicedCollection = $selectable->matching($criteria);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentPage(): float
+    {
+        return $this->currentPage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastPage(): float
+    {
+        if (0. >= $this->itemsPerPage) {
+            return 1.;
+        }
+
+        return max(ceil($this->totalItems / $this->itemsPerPage) ?: 1., 1.);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItemsPerPage(): float
+    {
+        return $this->itemsPerPage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTotalItems(): float
+    {
+        return $this->totalItems;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int
+    {
+        return $this->slicedCollection->count();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return \Traversable<T>
+     */
+    public function getIterator(): \Traversable
+    {
+        return $this->slicedCollection->getIterator();
+    }
+}

--- a/src/Doctrine/Common/SelectablePartialPaginator.php
+++ b/src/Doctrine/Common/SelectablePartialPaginator.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common;
+
+use ApiPlatform\State\Pagination\PartialPaginatorInterface;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\ReadableCollection;
+use Doctrine\Common\Collections\Selectable;
+
+/**
+ * @template T of object
+ *
+ * @implements PartialPaginatorInterface<T>
+ * @implements \IteratorAggregate<T>
+ */
+final class SelectablePartialPaginator implements \IteratorAggregate, PartialPaginatorInterface
+{
+    /**
+     * @var ReadableCollection<array-key,T>
+     */
+    private readonly ReadableCollection $slicedCollection;
+
+    /**
+     * @param Selectable<array-key,T> $selectable
+     */
+    public function __construct(
+        readonly Selectable $selectable,
+        private readonly float $currentPage,
+        private readonly float $itemsPerPage
+    ) {
+        $criteria = Criteria::create()
+            ->setFirstResult((int) (($currentPage - 1) * $itemsPerPage))
+            ->setMaxResults((int) $itemsPerPage);
+
+        $this->slicedCollection = $selectable->matching($criteria);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentPage(): float
+    {
+        return $this->currentPage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItemsPerPage(): float
+    {
+        return $this->itemsPerPage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int
+    {
+        return $this->slicedCollection->count();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return \Traversable<T>
+     */
+    public function getIterator(): \Traversable
+    {
+        return $this->slicedCollection->getIterator();
+    }
+}

--- a/src/Doctrine/Common/Tests/CollectionPaginatorTest.php
+++ b/src/Doctrine/Common/Tests/CollectionPaginatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests;
+
+use ApiPlatform\Doctrine\Common\CollectionPaginator;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+
+class CollectionPaginatorTest extends TestCase
+{
+    /**
+     * @dataProvider initializeProvider
+     */
+    public function testInitialize($results, $currentPage, $itemsPerPage, $totalItems, $lastPage, $currentItems): void
+    {
+        $results = new ArrayCollection($results);
+        $paginator = new CollectionPaginator($results, $currentPage, $itemsPerPage);
+
+        $this->assertSame((float) $currentPage, $paginator->getCurrentPage());
+        $this->assertSame((float) $itemsPerPage, $paginator->getItemsPerPage());
+        $this->assertSame((float) $totalItems, $paginator->getTotalItems());
+        $this->assertCount($currentItems, $paginator);
+        $this->assertSame((float) $lastPage, $paginator->getLastPage());
+    }
+
+    public static function initializeProvider(): array
+    {
+        return [
+            'First of three pages of 3 items each' => [[0, 1, 2, 3, 4, 5, 6], 1, 3, 7, 3, 3],
+            'Second of two pages of 3 items for the first page and 2 for the second' => [[0, 1, 2, 3, 4], 2, 3, 5, 2, 2],
+            'Empty results' => [[], 1, 2, 0, 1, 0],
+            '0 items per page' => [[0, 1, 2, 3], 1, 0, 4, 1, 4],
+            'Total items less than items per page' => [[0, 1, 2], 1, 4, 3, 1, 3],
+        ];
+    }
+}

--- a/src/Doctrine/Common/Tests/SelectablePaginatorTest.php
+++ b/src/Doctrine/Common/Tests/SelectablePaginatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests;
+
+use ApiPlatform\Doctrine\Common\SelectablePaginator;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+
+class SelectablePaginatorTest extends TestCase
+{
+    /**
+     * @dataProvider initializeProvider
+     */
+    public function testInitialize($results, $currentPage, $itemsPerPage, $totalItems, $lastPage, $currentItems): void
+    {
+        $results = new ArrayCollection($results);
+        $paginator = new SelectablePaginator($results, $currentPage, $itemsPerPage);
+
+        $this->assertSame((float) $currentPage, $paginator->getCurrentPage());
+        $this->assertSame((float) $itemsPerPage, $paginator->getItemsPerPage());
+        $this->assertSame((float) $totalItems, $paginator->getTotalItems());
+        $this->assertCount($currentItems, $paginator);
+        $this->assertSame((float) $lastPage, $paginator->getLastPage());
+    }
+
+    public static function initializeProvider(): array
+    {
+        return [
+            'First of three pages of 3 items each' => [[0, 1, 2, 3, 4, 5, 6], 1, 3, 7, 3, 3],
+            'Second of two pages of 3 items for the first page and 2 for the second' => [[0, 1, 2, 3, 4], 2, 3, 5, 2, 2],
+            'Empty results' => [[], 1, 2, 0, 1, 0],
+            '0 items per page' => [[0, 1, 2, 3], 1, 0, 4, 1, 4],
+            'Total items less than items per page' => [[0, 1, 2], 1, 4, 3, 1, 3],
+        ];
+    }
+}

--- a/src/Doctrine/Common/Tests/SelectablePartialPaginatorTest.php
+++ b/src/Doctrine/Common/Tests/SelectablePartialPaginatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests;
+
+use ApiPlatform\Doctrine\Common\SelectablePartialPaginator;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+
+class SelectablePartialPaginatorTest extends TestCase
+{
+    /**
+     * @dataProvider initializeProvider
+     */
+    public function testInitialize($results, $currentPage, $itemsPerPage, $currentItems): void
+    {
+        $results = new ArrayCollection($results);
+        $paginator = new SelectablePartialPaginator($results, $currentPage, $itemsPerPage);
+
+        $this->assertSame((float) $currentPage, $paginator->getCurrentPage());
+        $this->assertSame((float) $itemsPerPage, $paginator->getItemsPerPage());
+        $this->assertCount($currentItems, $paginator);
+    }
+
+    public static function initializeProvider(): array
+    {
+        return [
+            'First of three pages of 3 items each' => [[0, 1, 2, 3, 4, 5, 6], 1, 3, 3],
+            'Second of two pages of 3 items for the first page and 2 for the second' => [[0, 1, 2, 3, 4], 2, 3, 2],
+            'Empty results' => [[], 1, 2, 0],
+            '0 items per page' => [[0, 1, 2, 3], 1, 0, 4],
+            'Total items less than items per page' => [[0, 1, 2], 1, 4, 3],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/1895

Adds three paginators for Doctrine Collection & Selectable.

Some use cases:

```php
use ApiPlatform\Doctrine\Common\SelectablePaginator;
use ApiPlatform\Doctrine\Common\CollectionPaginator;

/** @var BookRepository $repository */
$bookPaginator = new SelectablePaginator($repository, $currentPage, $itemsPerPage);

/** @var Book $book */
/** @var Collection<array-key,Chapter> */
$chapters = $book->getChapters();
$chapterPaginator = new CollectionPaginator($chapters, $currentPage, $itemsPerPage);
```
