### PR TITLE
fix(hydra): remove dependency from ApiPlatform/Api dependency

### DIFF
--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -162,7 +162,7 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
     /**
      * Gets a filter with a backward compatibility.
      */
-    private function getFilter(string $filterId): FilterInterface|null
+    private function getFilter(string $filterId): LegacyFilterInterface|FilterInterface|null
     {
         if ($this->filterLocator && $this->filterLocator->has($filterId)) {
             return $this->filterLocator->get($filterId);

--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Hydra\Serializer;
 
+use ApiPlatform\Api\FilterInterface as LegacyFilterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface as LegacyResourceClassResolverInterface;
 use ApiPlatform\Doctrine\Odm\State\Options as ODMOptions;
 use ApiPlatform\Doctrine\Orm\State\Options;
-use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\FilterInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
@@ -36,12 +36,14 @@ use Symfony\Component\Serializer\Serializer;
  */
 final class CollectionFiltersNormalizer implements NormalizerInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
 {
+    private ?ContainerInterface $filterLocator = null;
+
     /**
      * @param ContainerInterface $filterLocator The new filter locator or the deprecated filter collection
      */
     public function __construct(private readonly NormalizerInterface $collectionNormalizer, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly LegacyResourceClassResolverInterface|ResourceClassResolverInterface $resourceClassResolver, ContainerInterface $filterLocator)
     {
-        $this->setFilterLocator($filterLocator);
+        $this->filterLocator = $filterLocator;
     }
 
     /**
@@ -155,20 +157,6 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
         }
 
         return ['@type' => 'hydra:IriTemplate', 'hydra:template' => sprintf('%s{?%s}', $parts['path'], implode(',', $variables)), 'hydra:variableRepresentation' => 'BasicRepresentation', 'hydra:mapping' => $mapping];
-    }
-
-    private ?ContainerInterface $filterLocator = null;
-
-    /**
-     * Sets a filter locator with a backward compatibility.
-     */
-    private function setFilterLocator(?ContainerInterface $filterLocator, bool $allowNull = false): void
-    {
-        if ($filterLocator instanceof ContainerInterface || (null === $filterLocator && $allowNull)) {
-            $this->filterLocator = $filterLocator;
-        } else {
-            throw new InvalidArgumentException(sprintf('The "$filterLocator" argument is expected to be an implementation of the "%s" interface%s.', ContainerInterface::class, $allowNull ? ' or null' : ''));
-        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This PR purpose is to resolve issue with the splitted version.

`ApiPlatform/Api` is not exported in any components, the `FilterLocatorTrait` cannot be loaded.

This is a quick & dirty workaround that solves the 3.3.0-alpha.1 issue but I think we must find abetter way to solve and provide the filters.

We could describle a FilterRegistryInterface in `ApiPlatform/Metadata` and inject it in the variouscomponents that relies on this feature (Hydra, ParameterValidator) the symfony component could fill an implementation of this registry and inject it.



<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
