### PR TITLE
fix: use short name when generating parameter description

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -265,7 +265,14 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     continue;
                 }
 
-                $parameter = new Parameter($parameterName, 'path', (new \ReflectionClass($uriVariable->getFromClass()))->getShortName().' identifier', true, false, false, ['type' => 'string']);
+                $fromClass = $this->resourceMetadataFactory->create($uriVariable->getFromClass());
+                $shortName = $fromClass->getOperation()->getShortName();
+
+                if (!$shortName) {
+                    $shortName = (new \ReflectionClass($uriVariable->getFromClass()))->getShortName();
+                }
+
+                $parameter = new Parameter($parameterName, 'path', $shortName.' identifier', true, false, false, ['type' => 'string']);
                 if ($this->hasParameter($openapiOperation, $parameter)) {
                     continue;
                 }

--- a/src/OpenApi/Tests/Fixtures/DummyWithDifferentShortName.php
+++ b/src/OpenApi/Tests/Fixtures/DummyWithDifferentShortName.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\OpenApi\Tests\Fixtures;
+
+use ApiPlatform\Metadata\ApiResource;
+
+/**
+ * Dummy with a different short name.
+ *
+ * @author Priyadi Iman Nurcahyo <priyadi@rekalogika.com>
+ */
+#[ApiResource(shortName: 'DummyShortName')]
+class DummyWithDifferentShortName
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | 
| License       | MIT
| Doc PR        | 

OpenApiFactory previously only uses class name when generating parameter description, and did not respect the `shortName` parameter. This PR fixes the problem.