### PR TITLE
fix: Use normalisation context when none is provided in tests

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -119,6 +119,8 @@ trait ApiTestAssertionsTrait
             $operation = $operationName ? (new GetCollection())->withName($operationName) : new GetCollection();
         }
 
+        $serializationContext = $serializationContext ?? $operation->getNormalizationContext();
+
         $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null, ($serializationContext ?? []) + [BackwardCompatibleSchemaFactory::SCHEMA_DRAFT4_VERSION => true]);
 
         static::assertMatchesJsonSchema($schema->getArrayCopy());
@@ -133,6 +135,8 @@ trait ApiTestAssertionsTrait
         } else {
             $operation = $operationName ? (new Get())->withName($operationName) : new Get();
         }
+
+        $serializationContext = $serializationContext ?? $operation->getNormalizationContext();
 
         $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null, ($serializationContext ?? []) + [BackwardCompatibleSchemaFactory::SCHEMA_DRAFT4_VERSION => true]);
 

--- a/tests/Fixtures/TestBundle/Entity/Issue6146/Issue6146Child.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue6146/Issue6146Child.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6146;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ApiResource(
+    operations: [
+        new Get(uriTemplate: 'issue-6146-childs/{id}'),
+        new GetCollection(uriTemplate: 'issue-6146-childs'),
+    ],
+    normalizationContext: ['groups' => ['testgroup']],
+)]
+#[ORM\Entity]
+class Issue6146Child
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Issue6146Parent::class, inversedBy: 'childs')]
+    #[ORM\JoinColumn(nullable: false)]
+    private Issue6146Parent $parent;
+
+    #[ORM\Column(type: 'string')]
+    #[Groups(['testgroup'])]
+    private string $foo = 'testtest';
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function setParent(Issue6146Parent $parent): self
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    public function getParent(): Issue6146Parent
+    {
+        return $this->parent;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue6146/Issue6146Parent.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue6146/Issue6146Parent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6146;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ApiResource(
+    operations: [
+        new Get(uriTemplate: 'issue-6146-parents/{id}'),
+        new GetCollection(uriTemplate: 'issue-6146-parents'),
+    ],
+    normalizationContext: ['groups' => ['testgroup']],
+)]
+#[ORM\Entity]
+class Issue6146Parent
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\OneToMany(mappedBy: 'parent', targetEntity: Issue6146Child::class)]
+    #[Groups(['testgroup'])]
+    private Collection $childs;
+
+    public function __construct()
+    {
+        $this->childs = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function addChild(Issue6146Child $child): void
+    {
+        $this->childs->add($child);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes https://github.com/api-platform/core/issues/6146
| License       | MIT
| Doc PR        | 

In https://github.com/api-platform/core/pull/6098 the behavious was changed in the test trait.
Before when you didn't provide a serialization context, the SerializationFactory would initialize it to the normalization context of the operation.
With this change the normalization context is an empty array instead so we loose the normalization context.

Solution: use the normalization context of the operation if the serialization context is null.