### PR TITLE
fix(openapi): skip requestBody if input is false

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -353,7 +353,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
                 $input = $operation->getInput();
 
-                if (!(false === $input || (\is_array($input) && $input['class'] === null))) {
+                if (!(false === $input || (\is_array($input) && null === $input['class']))) {
                     $operationInputSchemas = [];
                     foreach ($requestMimeTypes as $operationFormat) {
                         $operationInputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_INPUT, $operation, $schema, null, $forceSchemaCollection);

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -353,7 +353,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
                 $input = $operation->getInput();
 
-                if (!(false === $input || (\is_array($input) && $input['class'] ?? null === null))) {
+                if (!(false === $input || (\is_array($input) && $input['class'] === null))) {
                     $operationInputSchemas = [];
                     foreach ($requestMimeTypes as $operationFormat) {
                         $operationInputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_INPUT, $operation, $schema, null, $forceSchemaCollection);

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -353,7 +353,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
                 $input = $operation->getInput();
 
-                if (!($input === false || (is_array($input) && $input['class'] ?? null === null))) {
+                if (!(false === $input || (\is_array($input) && $input['class'] ?? null === null))) {
                     $operationInputSchemas = [];
                     foreach ($requestMimeTypes as $operationFormat) {
                         $operationInputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_INPUT, $operation, $schema, null, $forceSchemaCollection);

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -239,6 +239,7 @@ class OpenApiFactoryTest extends TestCase
                     ),
                 ],
             )),
+            'postDummyItemWithoutInput' => (new Post())->withUriTemplate('/dummyitem/noinput')->withOperation($baseOperation)->withInput(false),
         ])
         );
 
@@ -927,5 +928,28 @@ class OpenApiFactoryTest extends TestCase
                 ]),
             ]
         ), $dummyItemPath->getGet());
+
+        $emptyRequestBodyPath = $paths->getPath('/dummyitem/noinput');
+        $this->assertEquals(new Operation(
+            'postDummyItemWithoutInput',
+            ['Dummy'],
+            [
+                '201' => new Response(
+                    'Dummy resource created',
+                    new \ArrayObject([
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                    ]),
+                    null,
+                    new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
+                ),
+                '400' => new Response('Invalid input'),
+                '422' => new Response('Unprocessable entity'),
+            ],
+            'Creates a Dummy resource.',
+            'Creates a Dummy resource.',
+            null,
+            [],
+            null
+        ), $emptyRequestBodyPath->getPost());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | 
| License       | MIT
| Doc PR        | 

If the operation has `input: false`, then `OpenApiFactory` should skip adding the `requestBody` for that operation.