### PR TITLE
fix(graphql): nested collection for mongo

### DIFF
--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -68,7 +68,6 @@ Feature: GraphQL query support
     And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges[0].node.name" should match "#RelatedOneToManyDummy(1|3)2#"
     And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges[2].node.name" should match "#RelatedOneToManyDummy(1|3)2#"
 
-  @createSchema @!mongodb
   Scenario: Retrieve embedded collections
     Given there are 2 multiRelationsDummy objects having each a manyToOneRelation, 2 manyToManyRelations, 3 oneToManyRelations and 4 embeddedRelations
     When I send the following GraphQL request:

--- a/features/graphql/query.feature
+++ b/features/graphql/query.feature
@@ -68,6 +68,7 @@ Feature: GraphQL query support
     And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges[0].node.name" should match "#RelatedOneToManyDummy(1|3)2#"
     And the JSON node "data.multiRelationsDummy.oneToManyRelations.edges[2].node.name" should match "#RelatedOneToManyDummy(1|3)2#"
 
+  @createSchema
   Scenario: Retrieve embedded collections
     Given there are 2 multiRelationsDummy objects having each a manyToOneRelation, 2 manyToManyRelations, 3 oneToManyRelations and 4 embeddedRelations
     When I send the following GraphQL request:

--- a/src/GraphQl/Resolver/Factory/ResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ResolverFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\Resolver\Factory;
 
+use ApiPlatform\GraphQl\State\Provider\NoopProvider;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
@@ -35,7 +36,7 @@ class ResolverFactory implements ResolverFactoryInterface
             // Data already fetched and normalized (field or nested resource)
             if ($body = $source[$info->fieldName] ?? null) {
                 // special treatment for nested resources without a resolver/provider
-                if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && (!$operation->getProvider() || $operation->getProvider() === $resourceClass)) {
+                if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && (!$operation->getProvider() || NoopProvider::class === $operation->getProvider())) {
                     return $this->resolve($source, $args, $info, $rootClass, $operation, new ArrayPaginator($body, 0, \count($body)));
                 }
 

--- a/src/GraphQl/Resolver/Factory/ResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ResolverFactory.php
@@ -35,7 +35,7 @@ class ResolverFactory implements ResolverFactoryInterface
             // Data already fetched and normalized (field or nested resource)
             if ($body = $source[$info->fieldName] ?? null) {
                 // special treatment for nested resources without a resolver/provider
-                if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && !$operation->getProvider()) {
+                if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && (!$operation->getProvider() || $operation->getProvider() === $resourceClass)) {
                     return $this->resolve($source, $args, $info, $rootClass, $operation, new ArrayPaginator($body, 0, \count($body)));
                 }
 

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -113,7 +113,7 @@ final class ItemNormalizer extends BaseItemNormalizer
     {
         // check for nested collection
         $operation = $this->resourceMetadataCollectionFactory?->create($resourceClass)->getOperation(forceCollection: true, forceGraphQl: true);
-        if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && !$operation->getProvider()) {
+        if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && (!$operation->getProvider() || $operation->getProvider() === $resourceClass)) {
             return [...$attributeValue];
         }
 

--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\GraphQl\Serializer;
 
+use ApiPlatform\GraphQl\State\Provider\NoopProvider;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\IdentifiersExtractorInterface;
@@ -113,7 +114,7 @@ final class ItemNormalizer extends BaseItemNormalizer
     {
         // check for nested collection
         $operation = $this->resourceMetadataCollectionFactory?->create($resourceClass)->getOperation(forceCollection: true, forceGraphQl: true);
-        if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && (!$operation->getProvider() || $operation->getProvider() === $resourceClass)) {
+        if ($operation instanceof Query && $operation->getNested() && !$operation->getResolver() && (!$operation->getProvider() || NoopProvider::class === $operation->getProvider())) {
             return [...$attributeValue];
         }
 

--- a/src/GraphQl/State/Provider/NoopProvider.php
+++ b/src/GraphQl/State/Provider/NoopProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\GraphQl\State\Provider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+/**
+ * No-op Provider for GraphQl.
+ */
+final class NoopProvider implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsDummy.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsDummy.php
@@ -89,7 +89,7 @@ class MultiRelationsDummy
 
     public function getNestedCollection(): Collection
     {
-        return $this->nestedCollection;
+        return $this->nestedCollection->map(fn ($entry) => ['name' => $entry->name]);
     }
 
     public function setNestedCollection(Collection $nestedCollection): self
@@ -101,7 +101,7 @@ class MultiRelationsDummy
 
     public function getNestedPaginatedCollection(): Collection
     {
-        return $this->nestedPaginatedCollection;
+        return $this->nestedPaginatedCollection->map(fn ($entry) => ['name' => $entry->name]);
     }
 
     public function setNestedPaginatedCollection(Collection $nestedPaginatedCollection): self

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsNested.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsNested.php
@@ -17,7 +17,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-#[ApiResource(graphQlOperations: [new QueryCollection(paginationEnabled: false, nested: true)])]
+#[ApiResource(graphQlOperations: [new QueryCollection(paginationEnabled: false, provider: self::class, nested: true)])]
 #[ODM\EmbeddedDocument]
 class MultiRelationsNested
 {

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsNested.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsNested.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
+use ApiPlatform\GraphQl\State\Provider\NoopProvider;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-#[ApiResource(graphQlOperations: [new QueryCollection(paginationEnabled: false, provider: self::class, nested: true)])]
+#[ApiResource(graphQlOperations: [new QueryCollection(paginationEnabled: false, provider: NoopProvider::class, nested: true)])]
 #[ODM\EmbeddedDocument]
 class MultiRelationsNested
 {

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsNestedPaginated.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsNestedPaginated.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
+use ApiPlatform\GraphQl\State\Provider\NoopProvider;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-#[ApiResource(graphQlOperations: [new QueryCollection(provider: self::class, nested: true)])]
+#[ApiResource(graphQlOperations: [new QueryCollection(provider: NoopProvider::class, nested: true)])]
 #[ODM\EmbeddedDocument]
 class MultiRelationsNestedPaginated
 {

--- a/tests/Fixtures/TestBundle/Document/MultiRelationsNestedPaginated.php
+++ b/tests/Fixtures/TestBundle/Document/MultiRelationsNestedPaginated.php
@@ -17,7 +17,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-#[ApiResource(graphQlOperations: [new QueryCollection(nested: true)])]
+#[ApiResource(graphQlOperations: [new QueryCollection(provider: self::class, nested: true)])]
 #[ODM\EmbeddedDocument]
 class MultiRelationsNestedPaginated
 {

--- a/tests/Fixtures/TestBundle/Document/SoMany.php
+++ b/tests/Fixtures/TestBundle/Document/SoMany.php
@@ -29,4 +29,7 @@ class SoMany
     public $id;
     #[ODM\Field(nullable: true)]
     public $content;
+
+    #[ODM\ReferenceOne(targetDocument: FooDummy::class, storeAs: 'id', nullable: true)]
+    public ?FooDummy $fooDummy;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #6107 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

https://github.com/api-platform/core/pull/6038 was introduced but we had mongodb tests disabled. Though the new scenario has been disabled temporarily for mongo. I activated it again and updated the mongo test fixtures to represent the same case as the ORM ones do. 