### PR TITLE
fix(serializer): allow POST for `api_allow_update`

### DIFF
--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -95,7 +95,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
 
         if (!$normalization) {
             if (!isset($context['api_allow_update'])) {
-                $context['api_allow_update'] = \in_array($method = $request->getMethod(), ['PUT', 'PATCH'], true);
+                $context['api_allow_update'] = \in_array($method = $request->getMethod(), ['PUT', 'PATCH', 'POST'], true);
 
                 if ($context['api_allow_update'] && 'PATCH' === $method) {
                     $context['deep_object_to_populate'] ??= true;

--- a/src/Serializer/Tests/SerializerContextBuilderTest.php
+++ b/src/Serializer/Tests/SerializerContextBuilderTest.php
@@ -82,7 +82,7 @@ class SerializerContextBuilderTest extends TestCase
 
         $request = Request::create('/foos', 'POST');
         $request->attributes->replace(['_api_resource_class' => 'Foo', '_api_operation_name' => 'post', '_api_format' => 'xml', '_api_mime_type' => 'text/xml']);
-        $expected = ['bar' => 'baz', 'operation_name' => 'post',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => false, 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'iri_only' => false, 'skip_null_values' => true, 'operation' => $this->operation->withName('post'), 'exclude_from_cache_key' => ['root_operation', 'operation']];
+        $expected = ['bar' => 'baz', 'operation_name' => 'post',  'resource_class' => 'Foo', 'request_uri' => '/foos', 'api_allow_update' => true, 'uri' => 'http://localhost/foos', 'output' => null, 'input' => null, 'iri_only' => false, 'skip_null_values' => true, 'operation' => $this->operation->withName('post'), 'exclude_from_cache_key' => ['root_operation', 'operation']];
         $this->assertEquals($expected, $this->builder->createFromRequest($request, false));
 
         $request = Request::create('/foos', 'PUT');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | 
| License       | MIT
| Doc PR        | 

The documentation says:

> It is also possible to embed a relation in PUT, PATCH and **POST** requests. To enable that feature, set the serialization groups the same way as normalization
>
> ...

But the code currently only allow PUT and PATCH. This PR fixes the problem.