### PR TITLE
Allow IRI to be pre-configured in context when serializing in HAL or JsonApi format

### DIFF
--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -66,9 +66,8 @@ final class ItemNormalizer extends AbstractItemNormalizer
         }
 
         $context = $this->initContext($resourceClass, $context);
-        $iri = $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_PATH, $context['operation'] ?? null, $context);
 
-        $context['iri'] = $iri;
+        $iri = $context['iri'] ??= $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_PATH, $context['operation'] ?? null, $context);
         $context['object'] = $object;
         $context['format'] = $format;
         $context['api_normalize'] = true;

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -93,8 +93,8 @@ final class ItemNormalizer extends AbstractItemNormalizer
         }
 
         $context = $this->initContext($resourceClass, $context);
-        $iri = $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_PATH, $context['operation'] ?? null, $context);
-        $context['iri'] = $iri;
+
+        $iri = $context['iri'] ??= $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_PATH, $context['operation'] ?? null, $context);
         $context['object'] = $object;
         $context['format'] = $format;
         $context['api_normalize'] = true;


### PR DESCRIPTION
The AbstractItemNormalizer allows for the pre-configuration of the IRI within the context. It is proposed that this feature be extended to both the HAL and JsonApi normalizers for consistency and flexibility.

Example usage:


```php
#[ApiResource(
    operations: [
        new Get(),
        new Post(
            uriTemplate: '/search/parse-query',
            controller: SearchController::class.'::parseQuery',
            normalizationContext: ['groups' => ['api:read'], 'iri' => 'not-existing'],
            write: false,
        ),
        new Post(
            uriTemplate: '/search/parse-url',
            controller: SearchController::class.'::parseUrl',
            normalizationContext: ['groups' => ['api:read'], 'iri' => 'not-existing'],
            input: SearchParseUrlDto::class,
            validate: false,
            write: false,
        ),
    ],
    normalizationContext: ['groups' => ['api:read']],
    denormalizationContext: ['groups' => ['api:write']],
)]
class Search { ... }
```

This modification addresses the issue where POST requests that accept HAL data and target the parse-query and parse-url methods (which return a Search object) might trigger an IRI-related error. This is because the returned Search object does not actually exist in the database.