### PR TITLE
Fix class alias without class name

### DIFF
--- a/src/Api/Entrypoint.php
+++ b/src/Api/Entrypoint.php
@@ -35,6 +35,6 @@ final class Entrypoint
     }
 }
 
-if (!class_exists()) {
+if (!class_exists(\ApiPlatform\Core\Api\Entrypoint::class)) {
     class_alias(Entrypoint::class, \ApiPlatform\Core\Api\Entrypoint::class);
 }

--- a/src/Api/QueryParameterValidator/Validator/Enum.php
+++ b/src/Api/QueryParameterValidator/Validator/Enum.php
@@ -34,6 +34,6 @@ final class Enum implements ValidatorInterface
     }
 }
 
-if (!class_exists()) {
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Enum::class)) {
     class_alias(Enum::class, \ApiPlatform\Core\Filter\Validator\Enum::class);
 }

--- a/src/Api/QueryParameterValidator/Validator/Length.php
+++ b/src/Api/QueryParameterValidator/Validator/Length.php
@@ -39,6 +39,6 @@ final class Length implements ValidatorInterface
     }
 }
 
-if (!class_exists()) {
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Length::class)) {
     class_alias(Length::class, \ApiPlatform\Core\Filter\Validator\Length::class);
 }

--- a/src/Api/QueryParameterValidator/Validator/MultipleOf.php
+++ b/src/Api/QueryParameterValidator/Validator/MultipleOf.php
@@ -34,6 +34,6 @@ final class MultipleOf implements ValidatorInterface
     }
 }
 
-if (!class_exists()) {
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\MultipleOf::class)) {
     class_alias(MultipleOf::class, \ApiPlatform\Core\Filter\Validator\MultipleOf::class);
 }

--- a/src/Api/QueryParameterValidator/Validator/Pattern.php
+++ b/src/Api/QueryParameterValidator/Validator/Pattern.php
@@ -34,6 +34,6 @@ final class Pattern implements ValidatorInterface
     }
 }
 
-if (!class_exists()) {
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Pattern::class)) {
     class_alias(Pattern::class, \ApiPlatform\Core\Filter\Validator\Pattern::class);
 }

--- a/src/Api/QueryParameterValidator/Validator/Required.php
+++ b/src/Api/QueryParameterValidator/Validator/Required.php
@@ -98,6 +98,6 @@ final class Required implements ValidatorInterface
     }
 }
 
-if (!class_exists()) {
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Required::class)) {
     class_alias(Required::class, \ApiPlatform\Core\Filter\Validator\Required::class);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | Fixes errors from https://github.com/api-platform/core/pull/6217
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

This PR fixes 6 usages of `class_alias()` without argument