### PR TITLE
fix(serializer): json non-resource intermittent class (HAL & JSON:API)

### DIFF
--- a/features/issues/5926.feature
+++ b/features/issues/5926.feature
@@ -10,3 +10,27 @@ Feature: Issue 5926
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json; charset=utf-8"
+
+  @!mongodb
+  Scenario: Create and retrieve a JSON:API WriteResource
+    When I add "Accept" header equal to "application/vnd.api+json"
+    And I send a "GET" request to "/test_issue5926s/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/vnd.api+json; charset=utf-8"
+
+  @!mongodb
+  Scenario: Create and retrieve a LD+JSON WriteResource
+    When I add "Accept" header equal to "application/ld+json"
+    And I send a "GET" request to "/test_issue5926s/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+
+  @!mongodb
+  Scenario: Create and retrieve a HAL WriteResource
+    When I add "Accept" header equal to "application/hal+json"
+    And I send a "GET" request to "/test_issue5926s/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/hal+json; charset=utf-8"

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -61,8 +61,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
             return parent::normalize($object, $format, $context);
         }
 
-        if ($this->resourceClassResolver->isResourceClass($resourceClass)) {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null);
+        $previousResourceClass = $context['resource_class'] ?? null;
+        if ($this->resourceClassResolver->isResourceClass($resourceClass) && (null === $previousResourceClass || $this->resourceClassResolver->isResourceClass($previousResourceClass))) {
+            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $previousResourceClass);
         }
 
         $context = $this->initContext($resourceClass, $context);

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -83,8 +83,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
             return parent::normalize($object, $format, $context);
         }
 
-        if ($this->resourceClassResolver->isResourceClass($resourceClass)) {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $context['resource_class'] ?? null);
+        $previousResourceClass = $context['resource_class'] ?? null;
+        if ($this->resourceClassResolver->isResourceClass($resourceClass) && (null === $previousResourceClass || $this->resourceClassResolver->isResourceClass($previousResourceClass))) {
+            $resourceClass = $this->resourceClassResolver->getResourceClass($object, $previousResourceClass);
         }
 
         if (($operation = $context['operation'] ?? null) && method_exists($operation, 'getItemUriTemplate')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |3.2
| Tickets       | #5926
| License       | MIT

This is meant as a follow up to #5937, as both the JSON:API & HAL serializers need the context check (c.f. #5937) in the `normalize()` method.

For reference here, without the code change the Behat test will fail with a 400 response that contains a "No resource class found […]" exception emitted from the `ResourceClassResolver`.