### PR TITLE
fix(jsonschema): generation of non-LD+JSON distinct schema formats

### DIFF
--- a/src/Hal/JsonSchema/SchemaFactory.php
+++ b/src/Hal/JsonSchema/SchemaFactory.php
@@ -46,7 +46,6 @@ final class SchemaFactory implements SchemaFactoryInterface
 
     public function __construct(private readonly SchemaFactoryInterface $schemaFactory)
     {
-        $this->addDistinctFormat('jsonhal');
         if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
             $this->schemaFactory->setSchemaFactory($this);
         }
@@ -125,12 +124,5 @@ final class SchemaFactory implements SchemaFactoryInterface
         }
 
         return $schema;
-    }
-
-    public function addDistinctFormat(string $format): void
-    {
-        if (method_exists($this->schemaFactory, 'addDistinctFormat')) {
-            $this->schemaFactory->addDistinctFormat($format);
-        }
     }
 }

--- a/src/Hal/JsonSchema/SchemaFactory.php
+++ b/src/Hal/JsonSchema/SchemaFactory.php
@@ -78,8 +78,12 @@ final class SchemaFactory implements SchemaFactoryInterface
             $schema['type'] = 'object';
             $schema['properties'] = [
                 '_embedded' => [
-                    'type' => 'array',
-                    'items' => $items,
+                    'properties' => [
+                        'items' => [
+                            'type' => 'array',
+                            'items' => $items,
+                        ],
+                    ],
                 ],
                 'totalItems' => [
                     'type' => 'integer',

--- a/src/Hal/JsonSchema/SchemaFactory.php
+++ b/src/Hal/JsonSchema/SchemaFactory.php
@@ -78,11 +78,17 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             $schema['type'] = 'object';
             $schema['properties'] = [
                 '_embedded' => [
-                    'properties' => [
-                        'items' => [
-                            'type' => 'array',
-                            'items' => $items,
+                    'anyOf' => [
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'item' => [
+                                    'type' => 'array',
+                                    'items' => $items,
+                                ],
+                            ],
                         ],
+                        ['type' => 'object'],
                     ],
                 ],
                 'totalItems' => [

--- a/src/Hal/JsonSchema/SchemaFactory.php
+++ b/src/Hal/JsonSchema/SchemaFactory.php
@@ -24,7 +24,7 @@ use ApiPlatform\Metadata\Operation;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Jachim Coudenys <jachimcoudenys@gmail.com>
  */
-final class SchemaFactory implements SchemaFactoryInterface
+final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     private const HREF_PROP = [
         'href' => [
@@ -128,5 +128,12 @@ final class SchemaFactory implements SchemaFactoryInterface
         }
 
         return $schema;
+    }
+
+    public function setSchemaFactory(SchemaFactoryInterface $schemaFactory): void
+    {
+        if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
+            $this->schemaFactory->setSchemaFactory($schemaFactory);
+        }
     }
 }

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Hydra\JsonSchema;
 
 use ApiPlatform\JsonLd\ContextBuilder;
 use ApiPlatform\JsonSchema\Schema;
-use ApiPlatform\JsonSchema\SchemaFactory as BaseSchemaFactory;
 use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\Metadata\Operation;
@@ -60,7 +59,6 @@ final class SchemaFactory implements SchemaFactoryInterface
 
     public function __construct(private readonly SchemaFactoryInterface $schemaFactory)
     {
-        $this->addDistinctFormat('jsonld');
         if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
             $this->schemaFactory->setSchemaFactory($this);
         }
@@ -182,12 +180,5 @@ final class SchemaFactory implements SchemaFactoryInterface
         }
 
         return $schema;
-    }
-
-    public function addDistinctFormat(string $format): void
-    {
-        if ($this->schemaFactory instanceof BaseSchemaFactory) {
-            $this->schemaFactory->addDistinctFormat($format);
-        }
     }
 }

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -24,7 +24,7 @@ use ApiPlatform\Metadata\Operation;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class SchemaFactory implements SchemaFactoryInterface
+final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     private const BASE_PROP = [
         'readOnly' => true,
@@ -180,5 +180,12 @@ final class SchemaFactory implements SchemaFactoryInterface
         }
 
         return $schema;
+    }
+
+    public function setSchemaFactory(SchemaFactoryInterface $schemaFactory): void
+    {
+        if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
+            $this->schemaFactory->setSchemaFactory($schemaFactory);
+        }
     }
 }

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -36,14 +36,13 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     use ResourceClassInfoTrait;
-    private array $distinctFormats = [];
     private ?TypeFactoryInterface $typeFactory = null;
     private ?SchemaFactoryInterface $schemaFactory = null;
     // Edge case where the related resource is not readable (for example: NotExposed) but we have groups to read the whole related object
     public const FORCE_SUBSCHEMA = '_api_subschema_force_readable_link';
     public const OPENAPI_DEFINITION_NAME = 'openapi_definition_name';
 
-    public function __construct(?TypeFactoryInterface $typeFactory, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory, private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, private readonly ?NameConverterInterface $nameConverter = null, ?ResourceClassResolverInterface $resourceClassResolver = null)
+    public function __construct(?TypeFactoryInterface $typeFactory, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory, private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, private readonly ?NameConverterInterface $nameConverter = null, ?ResourceClassResolverInterface $resourceClassResolver = null, private readonly ?array $distinctFormats = null)
     {
         if ($typeFactory) {
             $this->typeFactory = $typeFactory;
@@ -51,16 +50,6 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
 
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         $this->resourceClassResolver = $resourceClassResolver;
-    }
-
-    /**
-     * When added to the list, the given format will lead to the creation of a new definition.
-     *
-     * @internal
-     */
-    public function addDistinctFormat(string $format): void
-    {
-        $this->distinctFormats[$format] = true;
     }
 
     /**
@@ -267,7 +256,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             $prefix .= '.'.$shortName;
         }
 
-        if (isset($this->distinctFormats[$format])) {
+        if ('json' !== $format && ($this->distinctFormats[$format] ?? false)) {
             // JSON is the default, and so isn't included in the definition name
             $prefix .= '.'.$format;
         }

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -120,6 +120,16 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $patchFormats = $this->getFormats($config['patch_formats']);
         $errorFormats = $this->getFormats($config['error_formats']);
         $docsFormats = $this->getFormats($config['docs_formats']);
+        $jsonSchemaFormats = $config['jsonschema_formats'];
+
+        if (!$jsonSchemaFormats) {
+            foreach (array_keys($formats) as $f) {
+                // Distinct JSON-based formats must have names that start with 'json'
+                if (str_starts_with($f, 'json')) {
+                    $jsonSchemaFormats[$f] = true;
+                }
+            }
+        }
 
         if (!isset($errorFormats['json'])) {
             $errorFormats['json'] = ['application/problem+json', 'application/json'];
@@ -144,7 +154,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $docsFormats['jsonopenapi'] = ['application/vnd.openapi+json'];
         }
 
-        $this->registerCommonConfiguration($container, $config, $loader, $formats, $patchFormats, $errorFormats, $docsFormats);
+        $this->registerCommonConfiguration($container, $config, $loader, $formats, $patchFormats, $errorFormats, $docsFormats, $jsonSchemaFormats);
         $this->registerMetadataConfiguration($container, $config, $loader);
         $this->registerOAuthConfiguration($container, $config);
         $this->registerOpenApiConfiguration($container, $config, $loader);
@@ -185,7 +195,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerInflectorConfiguration($config);
     }
 
-    private function registerCommonConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader, array $formats, array $patchFormats, array $errorFormats, array $docsFormats): void
+    private function registerCommonConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader, array $formats, array $patchFormats, array $errorFormats, array $docsFormats, array $jsonSchemaFormats): void
     {
         $loader->load('symfony/events.xml');
         $loader->load('symfony/controller.xml');
@@ -218,6 +228,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.patch_formats', $patchFormats);
         $container->setParameter('api_platform.error_formats', $errorFormats);
         $container->setParameter('api_platform.docs_formats', $docsFormats);
+        $container->setParameter('api_platform.jsonschema_formats', $jsonSchemaFormats);
         $container->setParameter('api_platform.eager_loading.enabled', $this->isConfigEnabled($container, $config['eager_loading']));
         $container->setParameter('api_platform.eager_loading.max_joins', $config['eager_loading']['max_joins']);
         $container->setParameter('api_platform.eager_loading.fetch_partial', $config['eager_loading']['fetch_partial']);

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -174,6 +174,14 @@ final class Configuration implements ConfigurationInterface
             'jsonproblem' => ['mime_types' => ['application/problem+json']],
             'json' => ['mime_types' => ['application/problem+json', 'application/json']],
         ]);
+        $rootNode
+            ->children()
+                ->arrayNode('jsonschema_formats')
+                    ->scalarPrototype()->end()
+                    ->defaultValue([])
+                    ->info('The JSON formats to compute the JSON Schemas for.')
+                ->end()
+            ->end();
 
         $this->addDefaultsSection($rootNode);
 

--- a/src/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Symfony/Bundle/Resources/config/json_schema.xml
@@ -22,6 +22,7 @@
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
             <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument on-invalid="ignore">%api_platform.jsonschema_formats%</argument>
         </service>
         <service id="ApiPlatform\JsonSchema\SchemaFactoryInterface" alias="api_platform.json_schema.schema_factory" />
 

--- a/tests/Hal/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hal/JsonSchema/SchemaFactoryTest.php
@@ -53,7 +53,10 @@ class SchemaFactoryTest extends TestCase
             null,
             $resourceMetadataFactory->reveal(),
             $propertyNameCollectionFactory->reveal(),
-            $propertyMetadataFactory->reveal()
+            $propertyMetadataFactory->reveal(),
+            null,
+            null,
+            ['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true],
         );
 
         $hydraSchemaFactory = new HydraSchemaFactory($baseSchemaFactory);

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -54,7 +54,10 @@ class SchemaFactoryTest extends TestCase
             null,
             $resourceMetadataFactoryCollection->reveal(),
             $propertyNameCollectionFactory->reveal(),
-            $propertyMetadataFactory->reveal()
+            $propertyMetadataFactory->reveal(),
+            null,
+            null,
+            ['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true],
         );
 
         $this->schemaFactory = new SchemaFactory($baseSchemaFactory);

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -98,6 +98,7 @@ class ConfigurationTest extends TestCase
                 'jsonld' => ['mime_types' => ['application/ld+json']],
                 'json' => ['mime_types' => ['application/problem+json', 'application/json']],
             ],
+            'jsonschema_formats' => [],
             'exception_to_status' => [
                 ExceptionInterface::class => Response::HTTP_BAD_REQUEST,
                 InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | Closes #6228
| License       | MIT

I've not figured out a good way to CI test this, so guidance will be gratefully appreciated.

To reproduce the base issue, apply the following to the `3.2` branch and run `vendor/bin/simple-phpunit --filter JsonSchemaGenerateCommandTest::testSubSchemaJsonLd`

```diff
diff --git a/src/Hydra/JsonSchema/SchemaFactory.php b/src/Hydra/JsonSchema/SchemaFactory.php
index b04ba616b8..43478de74d 100644
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -186,7 +186,7 @@ public function buildSchema(string $className, string $format = 'jsonld', string
 
     public function addDistinctFormat(string $format): void
     {
-        if ($this->schemaFactory instanceof BaseSchemaFactory) {
+        if (method_exists($this->schemaFactory, 'addDistinctFormat')) {
             $this->schemaFactory->addDistinctFormat($format);
         }
     }
diff --git a/src/JsonApi/JsonSchema/SchemaFactory.php b/src/JsonApi/JsonSchema/SchemaFactory.php
new file mode 100644
index 0000000000..b9747c281d
--- /dev/null
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -0,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApiPlatform\JsonApi\JsonSchema;
+
+use ApiPlatform\JsonSchema\Schema;
+use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
+use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Metadata\Operation;
+
+final class SchemaFactory implements SchemaFactoryInterface
+{
+    public function __construct(private SchemaFactoryInterface $schemaFactory)
+    {
+        $this->addDistinctFormat('jsonapi');
+        if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
+            $this->schemaFactory->setSchemaFactory($this);
+        }
+    }
+
+    public function buildSchema(string $className, string $format = 'jsonapi', string $type = Schema::TYPE_OUTPUT, ?Operation $operation = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
+    {
+        $schema = $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
+
+        if ('jsonapi' !== $format) {
+            return $schema;
+        }
+
+        // Do schema updates here …
+
+        return $schema;
+    }
+
+    public function addDistinctFormat(string $format): void
+    {
+        if (method_exists($this->schemaFactory, 'addDistinctFormat')) {
+            $this->schemaFactory->addDistinctFormat($format);
+        }
+    }
+}
diff --git a/src/Symfony/Bundle/Resources/config/jsonapi.xml b/src/Symfony/Bundle/Resources/config/jsonapi.xml
index 0a84066acc..98f1b08bc6 100644
--- a/src/Symfony/Bundle/Resources/config/jsonapi.xml
+++ b/src/Symfony/Bundle/Resources/config/jsonapi.xml
@@ -5,6 +5,10 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="api_platform.jsonapi.json_schema.schema_factory" class="ApiPlatform\JsonApi\JsonSchema\SchemaFactory" decorates="api_platform.json_schema.schema_factory">
+            <argument type="service" id="api_platform.jsonapi.json_schema.schema_factory.inner" />
+        </service>
+
         <service id="api_platform.jsonapi.encoder" class="ApiPlatform\Serializer\JsonEncoder" public="false">
             <argument>jsonapi</argument>
 
```