### PR TITLE
feat(hydra): read hydra:property from ApiProperty::jsonLdContext

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -498,22 +498,22 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
             $iri = "#$shortName/$propertyName";
         }
 
-        $propertyData = [
+        $propertyData = ($propertyMetadata->getJsonldContext()['hydra:property'] ?? []) + [
             '@id' => $iri,
             '@type' => false === $propertyMetadata->isReadableLink() ? 'hydra:Link' : 'rdf:Property',
             'rdfs:label' => $propertyName,
             'domain' => $prefixedShortName,
         ];
 
-        if ($propertyMetadata->getDeprecationReason()) {
+        if (!isset($propertyData['owl:deprecated']) && $propertyMetadata->getDeprecationReason()) {
             $propertyData['owl:deprecated'] = true;
         }
 
-        if ($this->isSingleRelation($propertyMetadata)) {
+        if (!isset($propertyData['owl:maxCardinality']) && $this->isSingleRelation($propertyMetadata)) {
             $propertyData['owl:maxCardinality'] = 1;
         }
 
-        if (null !== $range = $this->getRange($propertyMetadata)) {
+        if (!isset($propertyData['range']) && null !== $range = $this->getRange($propertyMetadata)) {
             $propertyData['range'] = $range;
         }
 


### PR DESCRIPTION
Allows to add informations to the `hydra:property` documentation: 

```php
class Dummy {
    #[ApiProperty(jsonLdContext: ['hydra:property' => ['rdfs:label' => 'change this value', 'owl:maxCardinality' => 5]]);
    public array $foo;
}
```

Previously only `@type` was read from `getIris`, this brings more flexibility.