### PR TITLE
additional_allowed_attributes

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -420,7 +420,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $options = $this->getFactoryOptions($context);
         $propertyNames = $this->propertyNameCollectionFactory->create($resourceClass, $options);
 
-        $allowedAttributes = [];
+        $allowedAttributes = $context['additional_allowed_attributes'] ?? [];
         foreach ($propertyNames as $propertyName) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $propertyName, $options);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes https://github.com/api-platform/core/issues/6225
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Tested it on my project and it works and solves my use case and the id case from https://api-platform.com/docs/core/serialization/#denormalization. But then tried to add to test tests/JsonLd/Serializer/ItemNormalizerTest.php something like:
```php
        $context = [
            'allow_extra_attributes' => false,
            'additional_allowed_attributes' => ['@type', 'extra'],
        ];
        $data = [
            // '@context' => '/contexts/Dummy',
            // '@id' => '/dummies/1988',
            '@type' => 'Dummy',
            'name' => 'hello',
            'extra' => 'hello',
        ];
        $normalizer->denormalize($data, Dummy::class, context: $context);
``` 
But the test fails not sure why. I probably set the test wrong?