### PR TITLE
feat(openapi): Allow per-endpoint OpenApi request formats to add allowed Content-Types.

### DIFF
--- a/src/State/Provider/ContentNegotiationProvider.php
+++ b/src/State/Provider/ContentNegotiationProvider.php
@@ -103,7 +103,7 @@ final class ContentNegotiationProvider implements ProviderInterface
         }
 
         /** @var string $contentType */
-        $formats = $operation->getInputFormats() ?? [];
+        $formats = array_merge($operation->getInputFormats() ?? [], $this->getOpenApiRequestBodyFormats($operation));
         if ($format = $this->getMimeTypeFormat($contentType, $formats)) {
             return $format;
         }
@@ -120,5 +120,20 @@ final class ContentNegotiationProvider implements ProviderInterface
         }
 
         return null;
+    }
+
+    private function getOpenApiRequestBodyFormats(HttpOperation $operation): array
+    {
+        if ($openApi = $operation->getOpenapi()) {
+            if ($openApi->getRequestBody()) {
+                foreach ($openApi->getRequestBody()->getContent() as $mimeType => $format) {
+                    // get the shortname as the mimetype after the slash
+                    $shortName = substr($mimeType, strpos($mimeType, '/') + 1);
+                    $openApiInputFormats[$shortName] = [$mimeType];
+                }
+            }
+        }
+
+        return $openApiInputFormats ?? [];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main (only affects 3.3.0)
| Tickets       | Closes #6141 (may also relate to #6210, which I can't reproduce - it's currently working on 3.2.x for me...)
| License       | MIT
| Doc PR        | I'm happy to update the docs if we need it for this change

I suspect this is non-idiomatic and suboptimal, so I'll leave it as a draft, but would you be willing to accept something like this?

OpenAPI allows endpoint-specific definition of Content-Type:
https://spec.openapis.org/oas/latest.html#special-considerations-for-multipart-content

The UI in API-P displays this correctly - offering a different list of input formats for that one endpoint - and API-P 3.2.x works with this (because it's not rigorously checking input formats in `ApiPlatform\Symfony\EventListener\AddFormatListener`, as far as I can see).

3.3.0 updates AddFormatListener, checks input formats and fails when using one not defined in the global formats list.  In my case, enabling `multipart/form-data` on every endpoint so that I can use it on 2 or 3 endpoints is the wrong solution - it makes the UI show an invalid format on every endpoint (and probably allows API-P to try to process data in the wrong input format too - which will potentially fail further down the line).

This patch pulls the list of formats out of the openapi definition on the request and adds that to the list of accepted formats.  It would probably be more correct to ONLY accept these formats, in place of the global list, but that's breaking some existing tests, so this is a compromise for now.

I think there's a case for separating input and output format definitions (see #5944), but that's a different discussion. 

I haven't added any tests because I think I'd need to stop the tests running with all the formats enabled by default - and I'm not sure how to change that for a single test.  I'm happy to add some if you can give me a pointer how to changes that, just for my tests?


Ultimately, if this isn't acceptable, I'll just patch my own version of 3.3 - the current behaviour is an upgrade-blocker for me.
