### PR TITLE
[JsonSchema] Only build schemas which can be serialized / deserialied

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -80,6 +80,14 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             return $schema;
         }
 
+        if ('input' === $type && !($operation?->canDeserialize() ?? true)) {
+            return $schema;
+        }
+
+        if ('output' === $type && !($operation?->canSerialize() ?? true)) {
+            return $schema;
+        }
+
         $validationGroups = $operation ? $this->getValidationGroups($operation) : [];
         $version = $schema->getVersion();
         $method = $operation instanceof HttpOperation ? $operation->getMethod() : 'GET';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | None
| License       | MIT
| Doc PR        | None

Hello,

This PR is a first step for a discussion about a bugfix.

Given the following ApiResource:

```php
#[ApiResource(operations: [new Delete()])]
class MyResource
{
}
```

If I generate the OpenAPI documentation using `php bin/console api:openapi:export`, the `ApiPlatform\OpenApi\Factory\OpenApiFactory` will generate a doc including the components "MyResource" whereas no operation references it (request / response -> no content). 

Futhermore, it exposes all `MyResource` properties which should stay internal as it is not part of our API.

I would expect that the `OpenApiFactory` only builds schemas that operation can deserialize / serialize and this is what this PR does.

Now, to fix my OpenAPI doc, I can just do the following:

```php
#[ApiResource(operations: [new Delete(
    deserialize: false,
    serialize: false,
)])]
class MyResource
{
}
```

WDYT ?
