### PR TITLE
fix: class_alias with preloading

### DIFF
--- a/src/Action/EntrypointAction.php
+++ b/src/Action/EntrypointAction.php
@@ -36,4 +36,6 @@ final class EntrypointAction
     }
 }
 
-class_alias(EntrypointAction::class, \ApiPlatform\Core\Action\EntrypointAction::class);
+if (!class_exists(\ApiPlatform\Core\Action\EntrypointAction::class, false)) {
+    class_alias(EntrypointAction::class, \ApiPlatform\Core\Action\EntrypointAction::class);
+}

--- a/src/Action/ExceptionAction.php
+++ b/src/Action/ExceptionAction.php
@@ -122,4 +122,6 @@ final class ExceptionAction
     }
 }
 
-class_alias(ExceptionAction::class, \ApiPlatform\Core\Action\ExceptionAction::class);
+if (!class_exists(\ApiPlatform\Core\Action\ExceptionAction::class, false)) {
+    class_alias(ExceptionAction::class, \ApiPlatform\Core\Action\ExceptionAction::class);
+}

--- a/src/Action/NotFoundAction.php
+++ b/src/Action/NotFoundAction.php
@@ -26,4 +26,6 @@ final class NotFoundAction
     }
 }
 
-class_alias(NotFoundAction::class, \ApiPlatform\Core\Action\NotFoundAction::class);
+if (!class_exists(\ApiPlatform\Core\Action\NotFoundAction::class, false)) {
+    class_alias(NotFoundAction::class, \ApiPlatform\Core\Action\NotFoundAction::class);
+}

--- a/src/Action/PlaceholderAction.php
+++ b/src/Action/PlaceholderAction.php
@@ -31,4 +31,6 @@ final class PlaceholderAction
     }
 }
 
-class_alias(PlaceholderAction::class, \ApiPlatform\Core\Action\PlaceholderAction::class);
+if (!class_exists(\ApiPlatform\Core\Action\PlaceholderAction::class, false)) {
+    class_alias(PlaceholderAction::class, \ApiPlatform\Core\Action\PlaceholderAction::class);
+}

--- a/src/Api/Entrypoint.php
+++ b/src/Api/Entrypoint.php
@@ -35,4 +35,6 @@ final class Entrypoint
     }
 }
 
-class_alias(Entrypoint::class, \ApiPlatform\Core\Api\Entrypoint::class);
+if (!class_exists(\ApiPlatform\Core\Api\Entrypoint::class, false)) {
+    class_alias(Entrypoint::class, \ApiPlatform\Core\Api\Entrypoint::class);
+}

--- a/src/Api/FormatMatcher.php
+++ b/src/Api/FormatMatcher.php
@@ -63,4 +63,6 @@ final class FormatMatcher
     }
 }
 
-class_alias(FormatMatcher::class, \ApiPlatform\Core\Api\FormatMatcher::class);
+if (!class_exists(\ApiPlatform\Core\Api\FormatMatcher::class, false)) {
+    class_alias(FormatMatcher::class, \ApiPlatform\Core\Api\FormatMatcher::class);
+}

--- a/src/Api/QueryParameterValidator/QueryParameterValidator.php
+++ b/src/Api/QueryParameterValidator/QueryParameterValidator.php
@@ -65,4 +65,6 @@ class QueryParameterValidator
     }
 }
 
-class_alias(QueryParameterValidator::class, \ApiPlatform\Core\Filter\QueryParameterValidator::class);
+if (!class_exists(\ApiPlatform\Core\Filter\QueryParameterValidator::class, false)) {
+    class_alias(QueryParameterValidator::class, \ApiPlatform\Core\Filter\QueryParameterValidator::class);
+}

--- a/src/Api/QueryParameterValidator/Validator/ArrayItems.php
+++ b/src/Api/QueryParameterValidator/Validator/ArrayItems.php
@@ -82,4 +82,6 @@ final class ArrayItems implements ValidatorInterface
     }
 }
 
-class_alias(ArrayItems::class, \ApiPlatform\Core\Filter\Validator\ArrayItems::class);
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\ArrayItems::class, false)) {
+    class_alias(ArrayItems::class, \ApiPlatform\Core\Filter\Validator\ArrayItems::class);
+}

--- a/src/Api/QueryParameterValidator/Validator/Bounds.php
+++ b/src/Api/QueryParameterValidator/Validator/Bounds.php
@@ -47,4 +47,6 @@ final class Bounds implements ValidatorInterface
     }
 }
 
-class_alias(Bounds::class, \ApiPlatform\Core\Filter\Validator\Bounds::class);
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Bounds::class, false)) {
+    class_alias(Bounds::class, \ApiPlatform\Core\Filter\Validator\Bounds::class);
+}

--- a/src/Api/QueryParameterValidator/Validator/Enum.php
+++ b/src/Api/QueryParameterValidator/Validator/Enum.php
@@ -34,4 +34,6 @@ final class Enum implements ValidatorInterface
     }
 }
 
-class_alias(Enum::class, \ApiPlatform\Core\Filter\Validator\Enum::class);
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Enum::class, false)) {
+    class_alias(Enum::class, \ApiPlatform\Core\Filter\Validator\Enum::class);
+}

--- a/src/Api/QueryParameterValidator/Validator/Length.php
+++ b/src/Api/QueryParameterValidator/Validator/Length.php
@@ -39,4 +39,6 @@ final class Length implements ValidatorInterface
     }
 }
 
-class_alias(Length::class, \ApiPlatform\Core\Filter\Validator\Length::class);
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Length::class, false)) {
+    class_alias(Length::class, \ApiPlatform\Core\Filter\Validator\Length::class);
+}

--- a/src/Api/QueryParameterValidator/Validator/MultipleOf.php
+++ b/src/Api/QueryParameterValidator/Validator/MultipleOf.php
@@ -34,4 +34,6 @@ final class MultipleOf implements ValidatorInterface
     }
 }
 
-class_alias(MultipleOf::class, \ApiPlatform\Core\Filter\Validator\MultipleOf::class);
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\MultipleOf::class, false)) {
+    class_alias(MultipleOf::class, \ApiPlatform\Core\Filter\Validator\MultipleOf::class);
+}

--- a/src/Api/QueryParameterValidator/Validator/Pattern.php
+++ b/src/Api/QueryParameterValidator/Validator/Pattern.php
@@ -34,4 +34,6 @@ final class Pattern implements ValidatorInterface
     }
 }
 
-class_alias(Pattern::class, \ApiPlatform\Core\Filter\Validator\Pattern::class);
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Pattern::class, false)) {
+    class_alias(Pattern::class, \ApiPlatform\Core\Filter\Validator\Pattern::class);
+}

--- a/src/Api/QueryParameterValidator/Validator/Required.php
+++ b/src/Api/QueryParameterValidator/Validator/Required.php
@@ -98,4 +98,6 @@ final class Required implements ValidatorInterface
     }
 }
 
-class_alias(Required::class, \ApiPlatform\Core\Filter\Validator\Required::class);
+if (!class_exists(\ApiPlatform\Core\Filter\Validator\Required::class, false)) {
+    class_alias(Required::class, \ApiPlatform\Core\Filter\Validator\Required::class);
+}

--- a/src/Api/ResourceClassResolver.php
+++ b/src/Api/ResourceClassResolver.php
@@ -102,4 +102,6 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
     }
 }
 
-class_alias(ResourceClassResolver::class, \ApiPlatform\Core\Api\ResourceClassResolver::class);
+if (!class_exists(\ApiPlatform\Core\Api\ResourceClassResolver::class, false)) {
+    class_alias(ResourceClassResolver::class, \ApiPlatform\Core\Api\ResourceClassResolver::class);
+}

--- a/src/Core/Bridge/Symfony/Bundle/Test/Constraint/ArraySubset.php
+++ b/src/Core/Bridge/Symfony/Bundle/Test/Constraint/ArraySubset.php
@@ -17,7 +17,7 @@ use PHPUnit\Runner\Version;
 use PHPUnit\SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\ComparisonFailure as LegacyComparisonFailure;
 
-if (!class_exists(ComparisonFailure::class)) {
+if (!class_exists(ComparisonFailure::class, false)) {
     class_alias(LegacyComparisonFailure::class, 'PHPUnit\SebastianBergmann\Comparator\ComparisonFailure');
 }
 

--- a/src/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -176,4 +176,6 @@ final class PurgeHttpCacheListener
     }
 }
 
-class_alias(PurgeHttpCacheListener::class, \ApiPlatform\Core\Bridge\Doctrine\EventListener\PurgeHttpCacheListener::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\EventListener\PurgeHttpCacheListener::class, false)) {
+    class_alias(PurgeHttpCacheListener::class, \ApiPlatform\Core\Bridge\Doctrine\EventListener\PurgeHttpCacheListener::class);
+}

--- a/src/Doctrine/EventListener/WriteListener.php
+++ b/src/Doctrine/EventListener/WriteListener.php
@@ -83,4 +83,6 @@ final class WriteListener
     }
 }
 
-class_alias(WriteListener::class, \ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener::class, false)) {
+    class_alias(WriteListener::class, \ApiPlatform\Core\Bridge\Doctrine\EventListener\WriteListener::class);
+}

--- a/src/Doctrine/Odm/Paginator.php
+++ b/src/Doctrine/Odm/Paginator.php
@@ -165,4 +165,6 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
     }
 }
 
-class_alias(Paginator::class, \ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Paginator::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Paginator::class, false)) {
+    class_alias(Paginator::class, \ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Paginator::class);
+}

--- a/src/Doctrine/Odm/PropertyInfo/DoctrineExtractor.php
+++ b/src/Doctrine/Odm/PropertyInfo/DoctrineExtractor.php
@@ -172,4 +172,6 @@ final class DoctrineExtractor implements PropertyListExtractorInterface, Propert
     }
 }
 
-class_alias(DoctrineExtractor::class, \ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\PropertyInfo\DoctrineExtractor::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\PropertyInfo\DoctrineExtractor::class, false)) {
+    class_alias(DoctrineExtractor::class, \ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\PropertyInfo\DoctrineExtractor::class);
+}

--- a/src/Doctrine/Orm/AbstractPaginator.php
+++ b/src/Doctrine/Orm/AbstractPaginator.php
@@ -66,4 +66,6 @@ abstract class AbstractPaginator implements \IteratorAggregate, PartialPaginator
     }
 }
 
-class_alias(AbstractPaginator::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\AbstractPaginator::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\Orm\AbstractPaginator::class, false)) {
+    class_alias(AbstractPaginator::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\AbstractPaginator::class);
+}

--- a/src/Doctrine/Orm/Paginator.php
+++ b/src/Doctrine/Orm/Paginator.php
@@ -48,4 +48,6 @@ final class Paginator extends AbstractPaginator implements PaginatorInterface, Q
     }
 }
 
-class_alias(Paginator::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator::class, false)) {
+    class_alias(Paginator::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator::class);
+}

--- a/src/Doctrine/Orm/Util/QueryBuilderHelper.php
+++ b/src/Doctrine/Orm/Util/QueryBuilderHelper.php
@@ -219,4 +219,6 @@ final class QueryBuilderHelper
     }
 }
 
-class_alias(QueryBuilderHelper::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryBuilderHelper::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryBuilderHelper::class, false)) {
+    class_alias(QueryBuilderHelper::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryBuilderHelper::class);
+}

--- a/src/Doctrine/Orm/Util/QueryNameGenerator.php
+++ b/src/Doctrine/Orm/Util/QueryNameGenerator.php
@@ -36,4 +36,6 @@ final class QueryNameGenerator implements QueryNameGeneratorInterface
     }
 }
 
-class_alias(QueryNameGenerator::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator::class, false)) {
+    class_alias(QueryNameGenerator::class, \ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator::class);
+}

--- a/src/Documentation/Action/DocumentationAction.php
+++ b/src/Documentation/Action/DocumentationAction.php
@@ -95,4 +95,6 @@ final class DocumentationAction
     }
 }
 
-class_alias(DocumentationAction::class, \ApiPlatform\Core\Documentation\Action\DocumentationAction::class);
+if (!class_exists(\ApiPlatform\Core\Documentation\Action\DocumentationAction::class, false)) {
+    class_alias(DocumentationAction::class, \ApiPlatform\Core\Documentation\Action\DocumentationAction::class);
+}

--- a/src/Documentation/Documentation.php
+++ b/src/Documentation/Documentation.php
@@ -76,4 +76,6 @@ final class Documentation implements DocumentationInterface
     }
 }
 
-class_alias(Documentation::class, \ApiPlatform\Core\Documentation\Documentation::class);
+if (!class_exists(\ApiPlatform\Core\Documentation\Documentation::class, false)) {
+    class_alias(Documentation::class, \ApiPlatform\Core\Documentation\Documentation::class);
+}

--- a/src/Elasticsearch/Exception/IndexNotFoundException.php
+++ b/src/Elasticsearch/Exception/IndexNotFoundException.php
@@ -26,4 +26,6 @@ final class IndexNotFoundException extends \Exception implements ExceptionInterf
 {
 }
 
-class_alias(IndexNotFoundException::class, \ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException::class, false)) {
+    class_alias(IndexNotFoundException::class, \ApiPlatform\Core\Bridge\Elasticsearch\Exception\IndexNotFoundException::class);
+}

--- a/src/Elasticsearch/Exception/NonUniqueIdentifierException.php
+++ b/src/Elasticsearch/Exception/NonUniqueIdentifierException.php
@@ -26,4 +26,6 @@ final class NonUniqueIdentifierException extends \Exception implements Exception
 {
 }
 
-class_alias(NonUniqueIdentifierException::class, \ApiPlatform\Core\Bridge\Elasticsearch\Exception\NonUniqueIdentifierException::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Exception\NonUniqueIdentifierException::class, false)) {
+    class_alias(NonUniqueIdentifierException::class, \ApiPlatform\Core\Bridge\Elasticsearch\Exception\NonUniqueIdentifierException::class);
+}

--- a/src/Elasticsearch/Metadata/Document/DocumentMetadata.php
+++ b/src/Elasticsearch/Metadata/Document/DocumentMetadata.php
@@ -74,4 +74,6 @@ final class DocumentMetadata
     }
 }
 
-class_alias(DocumentMetadata::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata::class, false)) {
+    class_alias(DocumentMetadata::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\DocumentMetadata::class);
+}

--- a/src/Elasticsearch/Metadata/Document/Factory/AttributeDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/AttributeDocumentMetadataFactory.php
@@ -86,4 +86,6 @@ final class AttributeDocumentMetadataFactory implements DocumentMetadataFactoryI
     }
 }
 
-class_alias(AttributeDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\AttributeDocumentMetadataFactory::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\AttributeDocumentMetadataFactory::class, false)) {
+    class_alias(AttributeDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\AttributeDocumentMetadataFactory::class);
+}

--- a/src/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/CachedDocumentMetadataFactory.php
@@ -76,4 +76,6 @@ final class CachedDocumentMetadataFactory implements DocumentMetadataFactoryInte
     }
 }
 
-class_alias(CachedDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\CachedDocumentMetadataFactory::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\CachedDocumentMetadataFactory::class, false)) {
+    class_alias(CachedDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\CachedDocumentMetadataFactory::class);
+}

--- a/src/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/CatDocumentMetadataFactory.php
@@ -102,4 +102,6 @@ final class CatDocumentMetadataFactory implements DocumentMetadataFactoryInterfa
     }
 }
 
-class_alias(CatDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\CatDocumentMetadataFactory::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\CatDocumentMetadataFactory::class, false)) {
+    class_alias(CatDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\CatDocumentMetadataFactory::class);
+}

--- a/src/Elasticsearch/Metadata/Document/Factory/ConfiguredDocumentMetadataFactory.php
+++ b/src/Elasticsearch/Metadata/Document/Factory/ConfiguredDocumentMetadataFactory.php
@@ -67,4 +67,6 @@ final class ConfiguredDocumentMetadataFactory implements DocumentMetadataFactory
     }
 }
 
-class_alias(ConfiguredDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\ConfiguredDocumentMetadataFactory::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\ConfiguredDocumentMetadataFactory::class, false)) {
+    class_alias(ConfiguredDocumentMetadataFactory::class, \ApiPlatform\Core\Bridge\Elasticsearch\Metadata\Document\Factory\ConfiguredDocumentMetadataFactory::class);
+}

--- a/src/Elasticsearch/Paginator.php
+++ b/src/Elasticsearch/Paginator.php
@@ -111,4 +111,6 @@ final class Paginator implements \IteratorAggregate, PaginatorInterface
     }
 }
 
-class_alias(Paginator::class, \ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Paginator::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Paginator::class, false)) {
+    class_alias(Paginator::class, \ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Paginator::class);
+}

--- a/src/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
+++ b/src/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
@@ -55,4 +55,6 @@ final class InnerFieldsNameConverter implements AdvancedNameConverterInterface
     }
 }
 
-class_alias(InnerFieldsNameConverter::class, \ApiPlatform\Core\Bridge\Elasticsearch\Serializer\NameConverter\InnerFieldsNameConverter::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Serializer\NameConverter\InnerFieldsNameConverter::class, false)) {
+    class_alias(InnerFieldsNameConverter::class, \ApiPlatform\Core\Bridge\Elasticsearch\Serializer\NameConverter\InnerFieldsNameConverter::class);
+}

--- a/src/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -105,4 +105,6 @@ trait FieldDatatypeTrait
     }
 }
 
-class_alias(FieldDatatypeTrait::class, \ApiPlatform\Core\Bridge\Elasticsearch\Util\FieldDatatypeTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Bridge\Elasticsearch\Util\FieldDatatypeTrait::class, false)) {
+    class_alias(FieldDatatypeTrait::class, \ApiPlatform\Core\Bridge\Elasticsearch\Util\FieldDatatypeTrait::class);
+}

--- a/src/Exception/DeserializationException.php
+++ b/src/Exception/DeserializationException.php
@@ -25,4 +25,6 @@ class DeserializationException extends \Exception implements ExceptionInterface,
 {
 }
 
-class_alias(DeserializationException::class, \ApiPlatform\Core\Exception\DeserializationException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\DeserializationException::class, false)) {
+    class_alias(DeserializationException::class, \ApiPlatform\Core\Exception\DeserializationException::class);
+}

--- a/src/Exception/FilterValidationException.php
+++ b/src/Exception/FilterValidationException.php
@@ -35,4 +35,6 @@ final class FilterValidationException extends \Exception implements ExceptionInt
     }
 }
 
-class_alias(FilterValidationException::class, \ApiPlatform\Core\Exception\FilterValidationException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\FilterValidationException::class, false)) {
+    class_alias(FilterValidationException::class, \ApiPlatform\Core\Exception\FilterValidationException::class);
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -22,4 +22,6 @@ class InvalidArgumentException extends \InvalidArgumentException implements Exce
 {
 }
 
-class_alias(InvalidArgumentException::class, \ApiPlatform\Core\Exception\InvalidArgumentException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\InvalidArgumentException::class, false)) {
+    class_alias(InvalidArgumentException::class, \ApiPlatform\Core\Exception\InvalidArgumentException::class);
+}

--- a/src/Exception/InvalidIdentifierException.php
+++ b/src/Exception/InvalidIdentifierException.php
@@ -22,4 +22,6 @@ final class InvalidIdentifierException extends \Exception implements ExceptionIn
 {
 }
 
-class_alias(InvalidIdentifierException::class, \ApiPlatform\Core\Exception\InvalidIdentifierException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\InvalidIdentifierException::class, false)) {
+    class_alias(InvalidIdentifierException::class, \ApiPlatform\Core\Exception\InvalidIdentifierException::class);
+}

--- a/src/Exception/InvalidResourceException.php
+++ b/src/Exception/InvalidResourceException.php
@@ -22,4 +22,6 @@ class InvalidResourceException extends \Exception implements ExceptionInterface
 {
 }
 
-class_alias(InvalidResourceException::class, \ApiPlatform\Core\Exception\InvalidResourceException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\InvalidResourceException::class, false)) {
+    class_alias(InvalidResourceException::class, \ApiPlatform\Core\Exception\InvalidResourceException::class);
+}

--- a/src/Exception/InvalidValueException.php
+++ b/src/Exception/InvalidValueException.php
@@ -17,4 +17,6 @@ class InvalidValueException extends InvalidArgumentException
 {
 }
 
-class_alias(InvalidValueException::class, \ApiPlatform\Core\Exception\InvalidValueException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\InvalidValueException::class, false)) {
+    class_alias(InvalidValueException::class, \ApiPlatform\Core\Exception\InvalidValueException::class);
+}

--- a/src/Exception/ItemNotFoundException.php
+++ b/src/Exception/ItemNotFoundException.php
@@ -22,4 +22,6 @@ class ItemNotFoundException extends InvalidArgumentException
 {
 }
 
-class_alias(ItemNotFoundException::class, \ApiPlatform\Core\Exception\ItemNotFoundException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\ItemNotFoundException::class, false)) {
+    class_alias(ItemNotFoundException::class, \ApiPlatform\Core\Exception\ItemNotFoundException::class);
+}

--- a/src/Exception/PropertyNotFoundException.php
+++ b/src/Exception/PropertyNotFoundException.php
@@ -22,4 +22,6 @@ class PropertyNotFoundException extends \Exception implements ExceptionInterface
 {
 }
 
-class_alias(PropertyNotFoundException::class, \ApiPlatform\Core\Exception\PropertyNotFoundException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\PropertyNotFoundException::class, false)) {
+    class_alias(PropertyNotFoundException::class, \ApiPlatform\Core\Exception\PropertyNotFoundException::class);
+}

--- a/src/Exception/ResourceClassNotFoundException.php
+++ b/src/Exception/ResourceClassNotFoundException.php
@@ -22,4 +22,6 @@ class ResourceClassNotFoundException extends \Exception implements ExceptionInte
 {
 }
 
-class_alias(ResourceClassNotFoundException::class, \ApiPlatform\Core\Exception\ResourceClassNotFoundException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\ResourceClassNotFoundException::class, false)) {
+    class_alias(ResourceClassNotFoundException::class, \ApiPlatform\Core\Exception\ResourceClassNotFoundException::class);
+}

--- a/src/Exception/ResourceClassNotSupportedException.php
+++ b/src/Exception/ResourceClassNotSupportedException.php
@@ -22,4 +22,6 @@ class ResourceClassNotSupportedException extends \Exception implements Exception
 {
 }
 
-class_alias(ResourceClassNotSupportedException::class, \ApiPlatform\Core\Exception\ResourceClassNotSupportedException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\ResourceClassNotSupportedException::class, false)) {
+    class_alias(ResourceClassNotSupportedException::class, \ApiPlatform\Core\Exception\ResourceClassNotSupportedException::class);
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -22,4 +22,6 @@ class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }
 
-class_alias(RuntimeException::class, \ApiPlatform\Core\Exception\RuntimeException::class);
+if (!class_exists(\ApiPlatform\Core\Exception\RuntimeException::class, false)) {
+    class_alias(RuntimeException::class, \ApiPlatform\Core\Exception\RuntimeException::class);
+}

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -227,4 +227,6 @@ final class EntrypointAction
     }
 }
 
-class_alias(EntrypointAction::class, \ApiPlatform\Core\GraphQl\Action\EntrypointAction::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Action\EntrypointAction::class, false)) {
+    class_alias(EntrypointAction::class, \ApiPlatform\Core\GraphQl\Action\EntrypointAction::class);
+}

--- a/src/GraphQl/Action/GraphQlPlaygroundAction.php
+++ b/src/GraphQl/Action/GraphQlPlaygroundAction.php
@@ -55,4 +55,6 @@ final class GraphQlPlaygroundAction
     }
 }
 
-class_alias(GraphQlPlaygroundAction::class, \ApiPlatform\Core\GraphQl\Action\GraphQlPlaygroundAction::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Action\GraphQlPlaygroundAction::class, false)) {
+    class_alias(GraphQlPlaygroundAction::class, \ApiPlatform\Core\GraphQl\Action\GraphQlPlaygroundAction::class);
+}

--- a/src/GraphQl/Action/GraphiQlAction.php
+++ b/src/GraphQl/Action/GraphiQlAction.php
@@ -55,4 +55,6 @@ final class GraphiQlAction
     }
 }
 
-class_alias(GraphiQlAction::class, \ApiPlatform\Core\GraphQl\Action\GraphiQlAction::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Action\GraphiQlAction::class, false)) {
+    class_alias(GraphiQlAction::class, \ApiPlatform\Core\GraphQl\Action\GraphiQlAction::class);
+}

--- a/src/GraphQl/Error/ErrorHandler.php
+++ b/src/GraphQl/Error/ErrorHandler.php
@@ -26,4 +26,6 @@ final class ErrorHandler implements ErrorHandlerInterface
     }
 }
 
-class_alias(ErrorHandler::class, \ApiPlatform\Core\GraphQl\Error\ErrorHandler::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Error\ErrorHandler::class, false)) {
+    class_alias(ErrorHandler::class, \ApiPlatform\Core\GraphQl\Error\ErrorHandler::class);
+}

--- a/src/GraphQl/Executor.php
+++ b/src/GraphQl/Executor.php
@@ -30,4 +30,6 @@ final class Executor implements ExecutorInterface
     }
 }
 
-class_alias(Executor::class, \ApiPlatform\Core\GraphQl\Executor::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Executor::class, false)) {
+    class_alias(Executor::class, \ApiPlatform\Core\GraphQl\Executor::class);
+}

--- a/src/GraphQl/Resolver/Util/IdentifierTrait.php
+++ b/src/GraphQl/Resolver/Util/IdentifierTrait.php
@@ -34,4 +34,6 @@ trait IdentifierTrait
     }
 }
 
-class_alias(IdentifierTrait::class, \ApiPlatform\Core\GraphQl\Resolver\Util\IdentifierTrait::class);
+if (!trait_exists(\ApiPlatform\Core\GraphQl\Resolver\Util\IdentifierTrait::class, false)) {
+    class_alias(IdentifierTrait::class, \ApiPlatform\Core\GraphQl\Resolver\Util\IdentifierTrait::class);
+}

--- a/src/GraphQl/Type/Definition/IterableType.php
+++ b/src/GraphQl/Type/Definition/IterableType.php
@@ -133,4 +133,6 @@ final class IterableType extends ScalarType implements TypeInterface
     }
 }
 
-class_alias(IterableType::class, \ApiPlatform\Core\GraphQl\Type\Definition\IterableType::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Type\Definition\IterableType::class, false)) {
+    class_alias(IterableType::class, \ApiPlatform\Core\GraphQl\Type\Definition\IterableType::class);
+}

--- a/src/GraphQl/Type/Definition/UploadType.php
+++ b/src/GraphQl/Type/Definition/UploadType.php
@@ -74,4 +74,6 @@ final class UploadType extends ScalarType implements TypeInterface
     }
 }
 
-class_alias(UploadType::class, \ApiPlatform\Core\GraphQl\Type\Definition\UploadType::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Type\Definition\UploadType::class, false)) {
+    class_alias(UploadType::class, \ApiPlatform\Core\GraphQl\Type\Definition\UploadType::class);
+}

--- a/src/GraphQl/Type/TypeNotFoundException.php
+++ b/src/GraphQl/Type/TypeNotFoundException.php
@@ -40,4 +40,6 @@ final class TypeNotFoundException extends \InvalidArgumentException implements N
     }
 }
 
-class_alias(TypeNotFoundException::class, \ApiPlatform\Core\GraphQl\Type\TypeNotFoundException::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Type\TypeNotFoundException::class, false)) {
+    class_alias(TypeNotFoundException::class, \ApiPlatform\Core\GraphQl\Type\TypeNotFoundException::class);
+}

--- a/src/GraphQl/Type/TypesContainer.php
+++ b/src/GraphQl/Type/TypesContainer.php
@@ -49,4 +49,6 @@ final class TypesContainer implements TypesContainerInterface
     }
 }
 
-class_alias(TypesContainer::class, \ApiPlatform\Core\GraphQl\Type\TypesContainer::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Type\TypesContainer::class, false)) {
+    class_alias(TypesContainer::class, \ApiPlatform\Core\GraphQl\Type\TypesContainer::class);
+}

--- a/src/GraphQl/Type/TypesFactory.php
+++ b/src/GraphQl/Type/TypesFactory.php
@@ -49,4 +49,6 @@ final class TypesFactory implements TypesFactoryInterface
     }
 }
 
-class_alias(TypesFactory::class, \ApiPlatform\Core\GraphQl\Type\TypesFactory::class);
+if (!class_exists(\ApiPlatform\Core\GraphQl\Type\TypesFactory::class, false)) {
+    class_alias(TypesFactory::class, \ApiPlatform\Core\GraphQl\Type\TypesFactory::class);
+}

--- a/src/Hal/Serializer/CollectionNormalizer.php
+++ b/src/Hal/Serializer/CollectionNormalizer.php
@@ -101,4 +101,6 @@ final class CollectionNormalizer extends AbstractCollectionNormalizer
     }
 }
 
-class_alias(CollectionNormalizer::class, \ApiPlatform\Core\Hal\Serializer\CollectionNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hal\Serializer\CollectionNormalizer::class, false)) {
+    class_alias(CollectionNormalizer::class, \ApiPlatform\Core\Hal\Serializer\CollectionNormalizer::class);
+}

--- a/src/Hal/Serializer/EntrypointNormalizer.php
+++ b/src/Hal/Serializer/EntrypointNormalizer.php
@@ -110,4 +110,6 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
     }
 }
 
-class_alias(EntrypointNormalizer::class, \ApiPlatform\Core\Hal\Serializer\EntrypointNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hal\Serializer\EntrypointNormalizer::class, false)) {
+    class_alias(EntrypointNormalizer::class, \ApiPlatform\Core\Hal\Serializer\EntrypointNormalizer::class);
+}

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -271,4 +271,6 @@ final class ItemNormalizer extends AbstractItemNormalizer
     }
 }
 
-class_alias(ItemNormalizer::class, \ApiPlatform\Core\Hal\Serializer\ItemNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hal\Serializer\ItemNormalizer::class, false)) {
+    class_alias(ItemNormalizer::class, \ApiPlatform\Core\Hal\Serializer\ItemNormalizer::class);
+}

--- a/src/Hal/Serializer/ObjectNormalizer.php
+++ b/src/Hal/Serializer/ObjectNormalizer.php
@@ -100,4 +100,6 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
     }
 }
 
-class_alias(ObjectNormalizer::class, \ApiPlatform\Core\Hal\Serializer\ObjectNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hal\Serializer\ObjectNormalizer::class, false)) {
+    class_alias(ObjectNormalizer::class, \ApiPlatform\Core\Hal\Serializer\ObjectNormalizer::class);
+}

--- a/src/HttpCache/EventListener/AddHeadersListener.php
+++ b/src/HttpCache/EventListener/AddHeadersListener.php
@@ -114,4 +114,6 @@ final class AddHeadersListener
     }
 }
 
-class_alias(AddHeadersListener::class, \ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener::class);
+if (!class_exists(\ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener::class, false)) {
+    class_alias(AddHeadersListener::class, \ApiPlatform\Core\HttpCache\EventListener\AddHeadersListener::class);
+}

--- a/src/HttpCache/EventListener/AddTagsListener.php
+++ b/src/HttpCache/EventListener/AddTagsListener.php
@@ -107,4 +107,6 @@ final class AddTagsListener
     }
 }
 
-class_alias(AddTagsListener::class, \ApiPlatform\Core\HttpCache\EventListener\AddTagsListener::class);
+if (!class_exists(\ApiPlatform\Core\HttpCache\EventListener\AddTagsListener::class, false)) {
+    class_alias(AddTagsListener::class, \ApiPlatform\Core\HttpCache\EventListener\AddTagsListener::class);
+}

--- a/src/HttpCache/VarnishPurger.php
+++ b/src/HttpCache/VarnishPurger.php
@@ -132,4 +132,6 @@ final class VarnishPurger implements PurgerInterface
     }
 }
 
-class_alias(VarnishPurger::class, \ApiPlatform\Core\HttpCache\VarnishPurger::class);
+if (!class_exists(\ApiPlatform\Core\HttpCache\VarnishPurger::class, false)) {
+    class_alias(VarnishPurger::class, \ApiPlatform\Core\HttpCache\VarnishPurger::class);
+}

--- a/src/HttpCache/VarnishXKeyPurger.php
+++ b/src/HttpCache/VarnishXKeyPurger.php
@@ -105,4 +105,6 @@ final class VarnishXKeyPurger implements PurgerInterface
     }
 }
 
-class_alias(VarnishXKeyPurger::class, \ApiPlatform\Core\HttpCache\VarnishXKeyPurger::class);
+if (!class_exists(\ApiPlatform\Core\HttpCache\VarnishXKeyPurger::class, false)) {
+    class_alias(VarnishXKeyPurger::class, \ApiPlatform\Core\HttpCache\VarnishXKeyPurger::class);
+}

--- a/src/Hydra/EventListener/AddLinkHeaderListener.php
+++ b/src/Hydra/EventListener/AddLinkHeaderListener.php
@@ -59,4 +59,6 @@ final class AddLinkHeaderListener
     }
 }
 
-class_alias(AddLinkHeaderListener::class, \ApiPlatform\Core\Hydra\EventListener\AddLinkHeaderListener::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\EventListener\AddLinkHeaderListener::class, false)) {
+    class_alias(AddLinkHeaderListener::class, \ApiPlatform\Core\Hydra\EventListener\AddLinkHeaderListener::class);
+}

--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -138,4 +138,6 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
     }
 }
 
-class_alias(CollectionFiltersNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\CollectionFiltersNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\Serializer\CollectionFiltersNormalizer::class, false)) {
+    class_alias(CollectionFiltersNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\CollectionFiltersNormalizer::class);
+}

--- a/src/Hydra/Serializer/CollectionNormalizer.php
+++ b/src/Hydra/Serializer/CollectionNormalizer.php
@@ -136,4 +136,6 @@ final class CollectionNormalizer implements NormalizerInterface, NormalizerAware
     }
 }
 
-class_alias(CollectionNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\CollectionNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\Serializer\CollectionNormalizer::class, false)) {
+    class_alias(CollectionNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\CollectionNormalizer::class);
+}

--- a/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Hydra/Serializer/ConstraintViolationListNormalizer.php
@@ -54,4 +54,6 @@ final class ConstraintViolationListNormalizer extends AbstractConstraintViolatio
     }
 }
 
-class_alias(ConstraintViolationListNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\ConstraintViolationListNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\Serializer\ConstraintViolationListNormalizer::class, false)) {
+    class_alias(ConstraintViolationListNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\ConstraintViolationListNormalizer::class);
+}

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -723,4 +723,6 @@ final class DocumentationNormalizer implements NormalizerInterface, CacheableSup
     }
 }
 
-class_alias(DocumentationNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\DocumentationNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\Serializer\DocumentationNormalizer::class, false)) {
+    class_alias(DocumentationNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\DocumentationNormalizer::class);
+}

--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -115,4 +115,6 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
     }
 }
 
-class_alias(EntrypointNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\EntrypointNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\Serializer\EntrypointNormalizer::class, false)) {
+    class_alias(EntrypointNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\EntrypointNormalizer::class);
+}

--- a/src/Hydra/Serializer/ErrorNormalizer.php
+++ b/src/Hydra/Serializer/ErrorNormalizer.php
@@ -76,4 +76,6 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
     }
 }
 
-class_alias(ErrorNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\ErrorNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\Serializer\ErrorNormalizer::class, false)) {
+    class_alias(ErrorNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\ErrorNormalizer::class);
+}

--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -187,4 +187,6 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Norm
     }
 }
 
-class_alias(PartialCollectionViewNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\PartialCollectionViewNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Hydra\Serializer\PartialCollectionViewNormalizer::class, false)) {
+    class_alias(PartialCollectionViewNormalizer::class, \ApiPlatform\Core\Hydra\Serializer\PartialCollectionViewNormalizer::class);
+}

--- a/src/JsonApi/Serializer/CollectionNormalizer.php
+++ b/src/JsonApi/Serializer/CollectionNormalizer.php
@@ -113,4 +113,6 @@ final class CollectionNormalizer extends AbstractCollectionNormalizer
     }
 }
 
-class_alias(CollectionNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\CollectionNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\Serializer\CollectionNormalizer::class, false)) {
+    class_alias(CollectionNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\CollectionNormalizer::class);
+}

--- a/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
@@ -105,4 +105,6 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface, Ca
     }
 }
 
-class_alias(ConstraintViolationListNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ConstraintViolationListNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\Serializer\ConstraintViolationListNormalizer::class, false)) {
+    class_alias(ConstraintViolationListNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ConstraintViolationListNormalizer::class);
+}

--- a/src/JsonApi/Serializer/EntrypointNormalizer.php
+++ b/src/JsonApi/Serializer/EntrypointNormalizer.php
@@ -116,4 +116,6 @@ final class EntrypointNormalizer implements NormalizerInterface, CacheableSuppor
     }
 }
 
-class_alias(EntrypointNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\EntrypointNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\Serializer\EntrypointNormalizer::class, false)) {
+    class_alias(EntrypointNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\EntrypointNormalizer::class);
+}

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -76,4 +76,6 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
     }
 }
 
-class_alias(ErrorNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ErrorNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\Serializer\ErrorNormalizer::class, false)) {
+    class_alias(ErrorNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ErrorNormalizer::class);
+}

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -458,4 +458,6 @@ final class ItemNormalizer extends AbstractItemNormalizer
     }
 }
 
-class_alias(ItemNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ItemNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\Serializer\ItemNormalizer::class, false)) {
+    class_alias(ItemNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ItemNormalizer::class);
+}

--- a/src/JsonApi/Serializer/ObjectNormalizer.php
+++ b/src/JsonApi/Serializer/ObjectNormalizer.php
@@ -123,4 +123,6 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
     }
 }
 
-class_alias(ObjectNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ObjectNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\Serializer\ObjectNormalizer::class, false)) {
+    class_alias(ObjectNormalizer::class, \ApiPlatform\Core\JsonApi\Serializer\ObjectNormalizer::class);
+}

--- a/src/JsonApi/Serializer/ReservedAttributeNameConverter.php
+++ b/src/JsonApi/Serializer/ReservedAttributeNameConverter.php
@@ -65,4 +65,6 @@ final class ReservedAttributeNameConverter implements AdvancedNameConverterInter
     }
 }
 
-class_alias(ReservedAttributeNameConverter::class, \ApiPlatform\Core\JsonApi\Serializer\ReservedAttributeNameConverter::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\Serializer\ReservedAttributeNameConverter::class, false)) {
+    class_alias(ReservedAttributeNameConverter::class, \ApiPlatform\Core\JsonApi\Serializer\ReservedAttributeNameConverter::class);
+}

--- a/src/JsonLd/Action/ContextAction.php
+++ b/src/JsonLd/Action/ContextAction.php
@@ -88,4 +88,6 @@ final class ContextAction
     }
 }
 
-class_alias(ContextAction::class, \ApiPlatform\Core\JsonLd\Action\ContextAction::class);
+if (!class_exists(\ApiPlatform\Core\JsonLd\Action\ContextAction::class, false)) {
+    class_alias(ContextAction::class, \ApiPlatform\Core\JsonLd\Action\ContextAction::class);
+}

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -262,4 +262,6 @@ final class ContextBuilder implements AnonymousContextBuilderInterface
     }
 }
 
-class_alias(ContextBuilder::class, \ApiPlatform\Core\JsonLd\ContextBuilder::class);
+if (!class_exists(\ApiPlatform\Core\JsonLd\ContextBuilder::class, false)) {
+    class_alias(ContextBuilder::class, \ApiPlatform\Core\JsonLd\ContextBuilder::class);
+}

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -159,4 +159,6 @@ final class ItemNormalizer extends AbstractItemNormalizer
     }
 }
 
-class_alias(ItemNormalizer::class, \ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer::class, false)) {
+    class_alias(ItemNormalizer::class, \ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer::class);
+}

--- a/src/JsonLd/Serializer/JsonLdContextTrait.php
+++ b/src/JsonLd/Serializer/JsonLdContextTrait.php
@@ -60,4 +60,6 @@ trait JsonLdContextTrait
     }
 }
 
-class_alias(JsonLdContextTrait::class, \ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait::class);
+if (!trait_exists(\ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait::class, false)) {
+    class_alias(JsonLdContextTrait::class, \ApiPlatform\Core\JsonLd\Serializer\JsonLdContextTrait::class);
+}

--- a/src/JsonLd/Serializer/ObjectNormalizer.php
+++ b/src/JsonLd/Serializer/ObjectNormalizer.php
@@ -99,4 +99,6 @@ final class ObjectNormalizer implements NormalizerInterface, CacheableSupportsMe
     }
 }
 
-class_alias(ObjectNormalizer::class, \ApiPlatform\Core\JsonLd\Serializer\ObjectNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\JsonLd\Serializer\ObjectNormalizer::class, false)) {
+    class_alias(ObjectNormalizer::class, \ApiPlatform\Core\JsonLd\Serializer\ObjectNormalizer::class);
+}

--- a/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
+++ b/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
@@ -122,4 +122,6 @@ final class JsonSchemaGenerateCommand extends Command
     }
 }
 
-class_alias(JsonSchemaGenerateCommand::class, \ApiPlatform\Core\JsonSchema\Command\JsonSchemaGenerateCommand::class);
+if (!class_exists(\ApiPlatform\Core\JsonSchema\Command\JsonSchemaGenerateCommand::class, false)) {
+    class_alias(JsonSchemaGenerateCommand::class, \ApiPlatform\Core\JsonSchema\Command\JsonSchemaGenerateCommand::class);
+}

--- a/src/JsonSchema/Schema.php
+++ b/src/JsonSchema/Schema.php
@@ -130,4 +130,6 @@ final class Schema extends \ArrayObject
     }
 }
 
-class_alias(Schema::class, \ApiPlatform\Core\JsonSchema\Schema::class);
+if (!class_exists(\ApiPlatform\Core\JsonSchema\Schema::class, false)) {
+    class_alias(Schema::class, \ApiPlatform\Core\JsonSchema\Schema::class);
+}

--- a/src/JsonSchema/TypeFactory.php
+++ b/src/JsonSchema/TypeFactory.php
@@ -193,4 +193,6 @@ final class TypeFactory implements TypeFactoryInterface
     }
 }
 
-class_alias(TypeFactory::class, \ApiPlatform\Core\JsonSchema\TypeFactory::class);
+if (!class_exists(\ApiPlatform\Core\JsonSchema\TypeFactory::class, false)) {
+    class_alias(TypeFactory::class, \ApiPlatform\Core\JsonSchema\TypeFactory::class);
+}

--- a/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/CachedPropertyNameCollectionFactory.php
@@ -46,4 +46,6 @@ final class CachedPropertyNameCollectionFactory implements PropertyNameCollectio
     }
 }
 
-class_alias(CachedPropertyNameCollectionFactory::class, \ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory::class);
+if (!class_exists(\ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory::class, false)) {
+    class_alias(CachedPropertyNameCollectionFactory::class, \ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyNameCollectionFactory::class);
+}

--- a/src/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyNameCollectionFactory.php
@@ -74,4 +74,6 @@ final class ExtractorPropertyNameCollectionFactory implements PropertyNameCollec
     }
 }
 
-class_alias(ExtractorPropertyNameCollectionFactory::class, \ApiPlatform\Core\Metadata\Property\Factory\ExtractorPropertyNameCollectionFactory::class);
+if (!class_exists(\ApiPlatform\Core\Metadata\Property\Factory\ExtractorPropertyNameCollectionFactory::class, false)) {
+    class_alias(ExtractorPropertyNameCollectionFactory::class, \ApiPlatform\Core\Metadata\Property\Factory\ExtractorPropertyNameCollectionFactory::class);
+}

--- a/src/Metadata/Property/Factory/PropertyInfoPropertyNameCollectionFactory.php
+++ b/src/Metadata/Property/Factory/PropertyInfoPropertyNameCollectionFactory.php
@@ -40,4 +40,6 @@ final class PropertyInfoPropertyNameCollectionFactory implements PropertyNameCol
     }
 }
 
-class_alias(PropertyInfoPropertyNameCollectionFactory::class, \ApiPlatform\Core\Bridge\Symfony\PropertyInfo\Metadata\Property\PropertyInfoPropertyNameCollectionFactory::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\PropertyInfo\Metadata\Property\PropertyInfoPropertyNameCollectionFactory::class, false)) {
+    class_alias(PropertyInfoPropertyNameCollectionFactory::class, \ApiPlatform\Core\Bridge\Symfony\PropertyInfo\Metadata\Property\PropertyInfoPropertyNameCollectionFactory::class);
+}

--- a/src/Metadata/Property/PropertyNameCollection.php
+++ b/src/Metadata/Property/PropertyNameCollection.php
@@ -46,4 +46,6 @@ final class PropertyNameCollection implements \IteratorAggregate, \Countable
     }
 }
 
-class_alias(PropertyNameCollection::class, \ApiPlatform\Core\Metadata\Property\PropertyNameCollection::class);
+if (!class_exists(\ApiPlatform\Core\Metadata\Property\PropertyNameCollection::class, false)) {
+    class_alias(PropertyNameCollection::class, \ApiPlatform\Core\Metadata\Property\PropertyNameCollection::class);
+}

--- a/src/OpenApi/Model/Components.php
+++ b/src/OpenApi/Model/Components.php
@@ -177,4 +177,6 @@ final class Components
     }
 }
 
-class_alias(Components::class, \ApiPlatform\Core\OpenApi\Model\Components::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Components::class, false)) {
+    class_alias(Components::class, \ApiPlatform\Core\OpenApi\Model\Components::class);
+}

--- a/src/OpenApi/Model/Contact.php
+++ b/src/OpenApi/Model/Contact.php
@@ -68,4 +68,6 @@ final class Contact
     }
 }
 
-class_alias(Contact::class, \ApiPlatform\Core\OpenApi\Model\Contact::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Contact::class, false)) {
+    class_alias(Contact::class, \ApiPlatform\Core\OpenApi\Model\Contact::class);
+}

--- a/src/OpenApi/Model/Encoding.php
+++ b/src/OpenApi/Model/Encoding.php
@@ -108,4 +108,6 @@ final class Encoding
     }
 }
 
-class_alias(Encoding::class, \ApiPlatform\Core\OpenApi\Model\Encoding::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Encoding::class, false)) {
+    class_alias(Encoding::class, \ApiPlatform\Core\OpenApi\Model\Encoding::class);
+}

--- a/src/OpenApi/Model/ExtensionTrait.php
+++ b/src/OpenApi/Model/ExtensionTrait.php
@@ -35,4 +35,6 @@ trait ExtensionTrait
     }
 }
 
-class_alias(ExtensionTrait::class, \ApiPlatform\Core\OpenApi\Model\ExtensionTrait::class);
+if (!trait_exists(\ApiPlatform\Core\OpenApi\Model\ExtensionTrait::class, false)) {
+    class_alias(ExtensionTrait::class, \ApiPlatform\Core\OpenApi\Model\ExtensionTrait::class);
+}

--- a/src/OpenApi/Model/ExternalDocumentation.php
+++ b/src/OpenApi/Model/ExternalDocumentation.php
@@ -53,4 +53,6 @@ final class ExternalDocumentation
     }
 }
 
-class_alias(ExternalDocumentation::class, \ApiPlatform\Core\OpenApi\Model\ExternalDocumentation::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\ExternalDocumentation::class, false)) {
+    class_alias(ExternalDocumentation::class, \ApiPlatform\Core\OpenApi\Model\ExternalDocumentation::class);
+}

--- a/src/OpenApi/Model/Info.php
+++ b/src/OpenApi/Model/Info.php
@@ -128,4 +128,6 @@ final class Info
     }
 }
 
-class_alias(Info::class, \ApiPlatform\Core\OpenApi\Model\Info::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Info::class, false)) {
+    class_alias(Info::class, \ApiPlatform\Core\OpenApi\Model\Info::class);
+}

--- a/src/OpenApi/Model/License.php
+++ b/src/OpenApi/Model/License.php
@@ -68,4 +68,6 @@ final class License
     }
 }
 
-class_alias(License::class, \ApiPlatform\Core\OpenApi\Model\License::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\License::class, false)) {
+    class_alias(License::class, \ApiPlatform\Core\OpenApi\Model\License::class);
+}

--- a/src/OpenApi/Model/Link.php
+++ b/src/OpenApi/Model/Link.php
@@ -98,4 +98,6 @@ final class Link
     }
 }
 
-class_alias(Link::class, \ApiPlatform\Core\OpenApi\Model\Link::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Link::class, false)) {
+    class_alias(Link::class, \ApiPlatform\Core\OpenApi\Model\Link::class);
+}

--- a/src/OpenApi/Model/MediaType.php
+++ b/src/OpenApi/Model/MediaType.php
@@ -83,4 +83,6 @@ final class MediaType
     }
 }
 
-class_alias(MediaType::class, \ApiPlatform\Core\OpenApi\Model\MediaType::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\MediaType::class, false)) {
+    class_alias(MediaType::class, \ApiPlatform\Core\OpenApi\Model\MediaType::class);
+}

--- a/src/OpenApi/Model/OAuthFlow.php
+++ b/src/OpenApi/Model/OAuthFlow.php
@@ -83,4 +83,6 @@ final class OAuthFlow
     }
 }
 
-class_alias(OAuthFlow::class, \ApiPlatform\Core\OpenApi\Model\OAuthFlow::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\OAuthFlow::class, false)) {
+    class_alias(OAuthFlow::class, \ApiPlatform\Core\OpenApi\Model\OAuthFlow::class);
+}

--- a/src/OpenApi/Model/OAuthFlows.php
+++ b/src/OpenApi/Model/OAuthFlows.php
@@ -83,4 +83,6 @@ final class OAuthFlows
     }
 }
 
-class_alias(OAuthFlows::class, \ApiPlatform\Core\OpenApi\Model\OAuthFlows::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\OAuthFlows::class, false)) {
+    class_alias(OAuthFlows::class, \ApiPlatform\Core\OpenApi\Model\OAuthFlows::class);
+}

--- a/src/OpenApi/Model/Operation.php
+++ b/src/OpenApi/Model/Operation.php
@@ -211,4 +211,6 @@ final class Operation
     }
 }
 
-class_alias(Operation::class, \ApiPlatform\Core\OpenApi\Model\Operation::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Operation::class, false)) {
+    class_alias(Operation::class, \ApiPlatform\Core\OpenApi\Model\Operation::class);
+}

--- a/src/OpenApi/Model/Parameter.php
+++ b/src/OpenApi/Model/Parameter.php
@@ -243,4 +243,6 @@ final class Parameter
     }
 }
 
-class_alias(Parameter::class, \ApiPlatform\Core\OpenApi\Model\Parameter::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Parameter::class, false)) {
+    class_alias(Parameter::class, \ApiPlatform\Core\OpenApi\Model\Parameter::class);
+}

--- a/src/OpenApi/Model/PathItem.php
+++ b/src/OpenApi/Model/PathItem.php
@@ -219,4 +219,6 @@ final class PathItem
     }
 }
 
-class_alias(PathItem::class, \ApiPlatform\Core\OpenApi\Model\PathItem::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\PathItem::class, false)) {
+    class_alias(PathItem::class, \ApiPlatform\Core\OpenApi\Model\PathItem::class);
+}

--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -35,4 +35,6 @@ final class Paths
     }
 }
 
-class_alias(Paths::class, \ApiPlatform\Core\OpenApi\Model\Paths::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Paths::class, false)) {
+    class_alias(Paths::class, \ApiPlatform\Core\OpenApi\Model\Paths::class);
+}

--- a/src/OpenApi/Model/RequestBody.php
+++ b/src/OpenApi/Model/RequestBody.php
@@ -68,4 +68,6 @@ final class RequestBody
     }
 }
 
-class_alias(RequestBody::class, \ApiPlatform\Core\OpenApi\Model\RequestBody::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\RequestBody::class, false)) {
+    class_alias(RequestBody::class, \ApiPlatform\Core\OpenApi\Model\RequestBody::class);
+}

--- a/src/OpenApi/Model/Response.php
+++ b/src/OpenApi/Model/Response.php
@@ -83,4 +83,6 @@ final class Response
     }
 }
 
-class_alias(Response::class, \ApiPlatform\Core\OpenApi\Model\Response::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Response::class, false)) {
+    class_alias(Response::class, \ApiPlatform\Core\OpenApi\Model\Response::class);
+}

--- a/src/OpenApi/Model/Schema.php
+++ b/src/OpenApi/Model/Schema.php
@@ -170,4 +170,6 @@ final class Schema extends \ArrayObject
     }
 }
 
-class_alias(Schema::class, \ApiPlatform\Core\OpenApi\Model\Schema::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Schema::class, false)) {
+    class_alias(Schema::class, \ApiPlatform\Core\OpenApi\Model\Schema::class);
+}

--- a/src/OpenApi/Model/SecurityScheme.php
+++ b/src/OpenApi/Model/SecurityScheme.php
@@ -143,4 +143,6 @@ final class SecurityScheme
     }
 }
 
-class_alias(SecurityScheme::class, \ApiPlatform\Core\OpenApi\Model\SecurityScheme::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\SecurityScheme::class, false)) {
+    class_alias(SecurityScheme::class, \ApiPlatform\Core\OpenApi\Model\SecurityScheme::class);
+}

--- a/src/OpenApi/Model/Server.php
+++ b/src/OpenApi/Model/Server.php
@@ -68,4 +68,6 @@ final class Server
     }
 }
 
-class_alias(Server::class, \ApiPlatform\Core\OpenApi\Model\Server::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Model\Server::class, false)) {
+    class_alias(Server::class, \ApiPlatform\Core\OpenApi\Model\Server::class);
+}

--- a/src/OpenApi/OpenApi.php
+++ b/src/OpenApi/OpenApi.php
@@ -175,4 +175,6 @@ final class OpenApi implements DocumentationInterface
     }
 }
 
-class_alias(OpenApi::class, \ApiPlatform\Core\OpenApi\OpenApi::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\OpenApi::class, false)) {
+    class_alias(OpenApi::class, \ApiPlatform\Core\OpenApi\OpenApi::class);
+}

--- a/src/OpenApi/Options.php
+++ b/src/OpenApi/Options.php
@@ -140,4 +140,6 @@ final class Options
     }
 }
 
-class_alias(Options::class, \ApiPlatform\Core\OpenApi\Options::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Options::class, false)) {
+    class_alias(Options::class, \ApiPlatform\Core\OpenApi\Options::class);
+}

--- a/src/OpenApi/Serializer/ApiGatewayNormalizer.php
+++ b/src/OpenApi/Serializer/ApiGatewayNormalizer.php
@@ -144,4 +144,6 @@ final class ApiGatewayNormalizer implements NormalizerInterface, CacheableSuppor
     }
 }
 
-class_alias(ApiGatewayNormalizer::class, \ApiPlatform\Core\Swagger\Serializer\ApiGatewayNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Swagger\Serializer\ApiGatewayNormalizer::class, false)) {
+    class_alias(ApiGatewayNormalizer::class, \ApiPlatform\Core\Swagger\Serializer\ApiGatewayNormalizer::class);
+}

--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -79,4 +79,6 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
     }
 }
 
-class_alias(OpenApiNormalizer::class, \ApiPlatform\Core\OpenApi\Serializer\OpenApiNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\OpenApi\Serializer\OpenApiNormalizer::class, false)) {
+    class_alias(OpenApiNormalizer::class, \ApiPlatform\Core\OpenApi\Serializer\OpenApiNormalizer::class);
+}

--- a/src/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Operation/DashPathSegmentNameGenerator.php
@@ -33,4 +33,6 @@ final class DashPathSegmentNameGenerator implements PathSegmentNameGeneratorInte
     }
 }
 
-class_alias(DashPathSegmentNameGenerator::class, \ApiPlatform\Core\Operation\DashPathSegmentNameGenerator::class);
+if (!class_exists(\ApiPlatform\Core\Operation\DashPathSegmentNameGenerator::class, false)) {
+    class_alias(DashPathSegmentNameGenerator::class, \ApiPlatform\Core\Operation\DashPathSegmentNameGenerator::class);
+}

--- a/src/Operation/UnderscorePathSegmentNameGenerator.php
+++ b/src/Operation/UnderscorePathSegmentNameGenerator.php
@@ -30,4 +30,6 @@ final class UnderscorePathSegmentNameGenerator implements PathSegmentNameGenerat
     }
 }
 
-class_alias(UnderscorePathSegmentNameGenerator::class, \ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator::class);
+if (!class_exists(\ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator::class, false)) {
+    class_alias(UnderscorePathSegmentNameGenerator::class, \ApiPlatform\Core\Operation\UnderscorePathSegmentNameGenerator::class);
+}

--- a/src/PathResolver/CustomOperationPathResolver.php
+++ b/src/PathResolver/CustomOperationPathResolver.php
@@ -43,4 +43,6 @@ final class CustomOperationPathResolver implements OperationPathResolverInterfac
     }
 }
 
-class_alias(CustomOperationPathResolver::class, \ApiPlatform\Core\PathResolver\CustomOperationPathResolver::class);
+if (!class_exists(\ApiPlatform\Core\PathResolver\CustomOperationPathResolver::class, false)) {
+    class_alias(CustomOperationPathResolver::class, \ApiPlatform\Core\PathResolver\CustomOperationPathResolver::class);
+}

--- a/src/PathResolver/OperationPathResolver.php
+++ b/src/PathResolver/OperationPathResolver.php
@@ -62,4 +62,6 @@ final class OperationPathResolver implements OperationPathResolverInterface
     }
 }
 
-class_alias(OperationPathResolver::class, \ApiPlatform\Core\PathResolver\OperationPathResolver::class);
+if (!class_exists(\ApiPlatform\Core\PathResolver\OperationPathResolver::class, false)) {
+    class_alias(OperationPathResolver::class, \ApiPlatform\Core\PathResolver\OperationPathResolver::class);
+}

--- a/src/Problem/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/Problem/Serializer/ConstraintViolationListNormalizer.php
@@ -54,4 +54,6 @@ final class ConstraintViolationListNormalizer extends AbstractConstraintViolatio
     }
 }
 
-class_alias(ConstraintViolationListNormalizer::class, \ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer::class, false)) {
+    class_alias(ConstraintViolationListNormalizer::class, \ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer::class);
+}

--- a/src/Problem/Serializer/ErrorNormalizer.php
+++ b/src/Problem/Serializer/ErrorNormalizer.php
@@ -70,4 +70,6 @@ final class ErrorNormalizer implements NormalizerInterface, CacheableSupportsMet
     }
 }
 
-class_alias(ErrorNormalizer::class, \ApiPlatform\Core\Problem\Serializer\ErrorNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Problem\Serializer\ErrorNormalizer::class, false)) {
+    class_alias(ErrorNormalizer::class, \ApiPlatform\Core\Problem\Serializer\ErrorNormalizer::class);
+}

--- a/src/Problem/Serializer/ErrorNormalizerTrait.php
+++ b/src/Problem/Serializer/ErrorNormalizerTrait.php
@@ -54,4 +54,6 @@ trait ErrorNormalizerTrait
     }
 }
 
-class_alias(ErrorNormalizerTrait::class, \ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait::class, false)) {
+    class_alias(ErrorNormalizerTrait::class, \ApiPlatform\Core\Problem\Serializer\ErrorNormalizerTrait::class);
+}

--- a/src/RamseyUuid/Serializer/UuidDenormalizer.php
+++ b/src/RamseyUuid/Serializer/UuidDenormalizer.php
@@ -40,4 +40,6 @@ final class UuidDenormalizer implements DenormalizerInterface
     }
 }
 
-class_alias(UuidDenormalizer::class, \ApiPlatform\Core\Bridge\RamseyUuid\Serializer\UuidDenormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\RamseyUuid\Serializer\UuidDenormalizer::class, false)) {
+    class_alias(UuidDenormalizer::class, \ApiPlatform\Core\Bridge\RamseyUuid\Serializer\UuidDenormalizer::class);
+}

--- a/src/Serializer/AbstractCollectionNormalizer.php
+++ b/src/Serializer/AbstractCollectionNormalizer.php
@@ -147,4 +147,6 @@ abstract class AbstractCollectionNormalizer implements NormalizerInterface, Norm
     abstract protected function getItemsData($object, string $format = null, array $context = []): array;
 }
 
-class_alias(AbstractCollectionNormalizer::class, \ApiPlatform\Core\Serializer\AbstractCollectionNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\AbstractCollectionNormalizer::class, false)) {
+    class_alias(AbstractCollectionNormalizer::class, \ApiPlatform\Core\Serializer\AbstractCollectionNormalizer::class);
+}

--- a/src/Serializer/AbstractConstraintViolationListNormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListNormalizer.php
@@ -80,4 +80,6 @@ abstract class AbstractConstraintViolationListNormalizer implements NormalizerIn
     }
 }
 
-class_alias(AbstractConstraintViolationListNormalizer::class, \ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer::class, false)) {
+    class_alias(AbstractConstraintViolationListNormalizer::class, \ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer::class);
+}

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -1071,4 +1071,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     }
 }
 
-class_alias(AbstractItemNormalizer::class, \ApiPlatform\Core\Serializer\AbstractItemNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\AbstractItemNormalizer::class, false)) {
+    class_alias(AbstractItemNormalizer::class, \ApiPlatform\Core\Serializer\AbstractItemNormalizer::class);
+}

--- a/src/Serializer/CacheKeyTrait.php
+++ b/src/Serializer/CacheKeyTrait.php
@@ -45,4 +45,6 @@ trait CacheKeyTrait
     }
 }
 
-class_alias(CacheKeyTrait::class, \ApiPlatform\Core\Serializer\CacheKeyTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Serializer\CacheKeyTrait::class, false)) {
+    class_alias(CacheKeyTrait::class, \ApiPlatform\Core\Serializer\CacheKeyTrait::class);
+}

--- a/src/Serializer/ContextTrait.php
+++ b/src/Serializer/ContextTrait.php
@@ -32,4 +32,6 @@ trait ContextTrait
     }
 }
 
-class_alias(ContextTrait::class, \ApiPlatform\Core\Serializer\ContextTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Serializer\ContextTrait::class, false)) {
+    class_alias(ContextTrait::class, \ApiPlatform\Core\Serializer\ContextTrait::class);
+}

--- a/src/Serializer/Filter/GroupFilter.php
+++ b/src/Serializer/Filter/GroupFilter.php
@@ -70,4 +70,6 @@ final class GroupFilter implements FilterInterface
     }
 }
 
-class_alias(GroupFilter::class, \ApiPlatform\Core\Serializer\Filter\GroupFilter::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\Filter\GroupFilter::class, false)) {
+    class_alias(GroupFilter::class, \ApiPlatform\Core\Serializer\Filter\GroupFilter::class);
+}

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -163,4 +163,6 @@ final class PropertyFilter implements FilterInterface
     }
 }
 
-class_alias(PropertyFilter::class, \ApiPlatform\Core\Serializer\Filter\PropertyFilter::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\Filter\PropertyFilter::class, false)) {
+    class_alias(PropertyFilter::class, \ApiPlatform\Core\Serializer\Filter\PropertyFilter::class);
+}

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -105,4 +105,6 @@ class ItemNormalizer extends AbstractItemNormalizer
     }
 }
 
-class_alias(ItemNormalizer::class, \ApiPlatform\Core\Serializer\ItemNormalizer::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\ItemNormalizer::class, false)) {
+    class_alias(ItemNormalizer::class, \ApiPlatform\Core\Serializer\ItemNormalizer::class);
+}

--- a/src/Serializer/JsonEncoder.php
+++ b/src/Serializer/JsonEncoder.php
@@ -73,4 +73,6 @@ final class JsonEncoder implements EncoderInterface, DecoderInterface
     }
 }
 
-class_alias(JsonEncoder::class, \ApiPlatform\Core\Serializer\JsonEncoder::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\JsonEncoder::class, false)) {
+    class_alias(JsonEncoder::class, \ApiPlatform\Core\Serializer\JsonEncoder::class);
+}

--- a/src/Serializer/Mapping/Factory/ClassMetadataFactory.php
+++ b/src/Serializer/Mapping/Factory/ClassMetadataFactory.php
@@ -39,4 +39,6 @@ final class ClassMetadataFactory implements ClassMetadataFactoryInterface
     }
 }
 
-class_alias(ClassMetadataFactory::class, \ApiPlatform\Core\Serializer\Mapping\Factory\ClassMetadataFactory::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\Mapping\Factory\ClassMetadataFactory::class, false)) {
+    class_alias(ClassMetadataFactory::class, \ApiPlatform\Core\Serializer\Mapping\Factory\ClassMetadataFactory::class);
+}

--- a/src/Serializer/ResourceList.php
+++ b/src/Serializer/ResourceList.php
@@ -20,4 +20,6 @@ class ResourceList extends \ArrayObject
 {
 }
 
-class_alias(ResourceList::class, \ApiPlatform\Core\Serializer\ResourceList::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\ResourceList::class, false)) {
+    class_alias(ResourceList::class, \ApiPlatform\Core\Serializer\ResourceList::class);
+}

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -200,4 +200,6 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
     }
 }
 
-class_alias(SerializerContextBuilder::class, \ApiPlatform\Core\Serializer\SerializerContextBuilder::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\SerializerContextBuilder::class, false)) {
+    class_alias(SerializerContextBuilder::class, \ApiPlatform\Core\Serializer\SerializerContextBuilder::class);
+}

--- a/src/Serializer/SerializerFilterContextBuilder.php
+++ b/src/Serializer/SerializerFilterContextBuilder.php
@@ -71,4 +71,6 @@ final class SerializerFilterContextBuilder implements SerializerContextBuilderIn
     }
 }
 
-class_alias(SerializerFilterContextBuilder::class, \ApiPlatform\Core\Serializer\SerializerFilterContextBuilder::class);
+if (!class_exists(\ApiPlatform\Core\Serializer\SerializerFilterContextBuilder::class, false)) {
+    class_alias(SerializerFilterContextBuilder::class, \ApiPlatform\Core\Serializer\SerializerFilterContextBuilder::class);
+}

--- a/src/State/Pagination/ArrayPaginator.php
+++ b/src/State/Pagination/ArrayPaginator.php
@@ -76,4 +76,6 @@ final class ArrayPaginator implements \IteratorAggregate, PaginatorInterface
     }
 }
 
-class_alias(ArrayPaginator::class, \ApiPlatform\Core\DataProvider\ArrayPaginator::class);
+if (!class_exists(\ApiPlatform\Core\DataProvider\ArrayPaginator::class, false)) {
+    class_alias(ArrayPaginator::class, \ApiPlatform\Core\DataProvider\ArrayPaginator::class);
+}

--- a/src/State/Pagination/PaginationOptions.php
+++ b/src/State/Pagination/PaginationOptions.php
@@ -103,4 +103,6 @@ final class PaginationOptions
     }
 }
 
-class_alias(PaginationOptions::class, \ApiPlatform\Core\DataProvider\PaginationOptions::class);
+if (!class_exists(\ApiPlatform\Core\DataProvider\PaginationOptions::class, false)) {
+    class_alias(PaginationOptions::class, \ApiPlatform\Core\DataProvider\PaginationOptions::class);
+}

--- a/src/State/Pagination/TraversablePaginator.php
+++ b/src/State/Pagination/TraversablePaginator.php
@@ -71,4 +71,6 @@ final class TraversablePaginator implements \IteratorAggregate, PaginatorInterfa
     }
 }
 
-class_alias(TraversablePaginator::class, \ApiPlatform\Core\DataProvider\TraversablePaginator::class);
+if (!class_exists(\ApiPlatform\Core\DataProvider\TraversablePaginator::class, false)) {
+    class_alias(TraversablePaginator::class, \ApiPlatform\Core\DataProvider\TraversablePaginator::class);
+}

--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -56,4 +56,6 @@ final class ApiPlatformBundle extends Bundle
     }
 }
 
-class_alias(ApiPlatformBundle::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle::class, false)) {
+    class_alias(ApiPlatformBundle::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle::class);
+}

--- a/src/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
+++ b/src/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
@@ -77,4 +77,6 @@ final class PayloadArgumentResolver implements ArgumentValueResolverInterface
     }
 }
 
-class_alias(PayloadArgumentResolver::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\ArgumentResolver\PayloadArgumentResolver::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\ArgumentResolver\PayloadArgumentResolver::class, false)) {
+    class_alias(PayloadArgumentResolver::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\ArgumentResolver\PayloadArgumentResolver::class);
+}

--- a/src/Symfony/Bundle/CacheWarmer/CachePoolClearerCacheWarmer.php
+++ b/src/Symfony/Bundle/CacheWarmer/CachePoolClearerCacheWarmer.php
@@ -55,4 +55,6 @@ final class CachePoolClearerCacheWarmer implements CacheWarmerInterface
     }
 }
 
-class_alias(CachePoolClearerCacheWarmer::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\CacheWarmer\CachePoolClearerCacheWarmer::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\CacheWarmer\CachePoolClearerCacheWarmer::class, false)) {
+    class_alias(CachePoolClearerCacheWarmer::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\CacheWarmer\CachePoolClearerCacheWarmer::class);
+}

--- a/src/Symfony/Bundle/Command/GraphQlExportCommand.php
+++ b/src/Symfony/Bundle/Command/GraphQlExportCommand.php
@@ -79,4 +79,6 @@ class GraphQlExportCommand extends Command
     }
 }
 
-class_alias(GraphQlExportCommand::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Command\GraphQlExportCommand::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\Command\GraphQlExportCommand::class, false)) {
+    class_alias(GraphQlExportCommand::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Command\GraphQlExportCommand::class);
+}

--- a/src/Symfony/Bundle/Command/OpenApiCommand.php
+++ b/src/Symfony/Bundle/Command/OpenApiCommand.php
@@ -94,4 +94,6 @@ final class OpenApiCommand extends Command
     }
 }
 
-class_alias(OpenApiCommand::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Command\OpenApiCommand::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\Command\OpenApiCommand::class, false)) {
+    class_alias(OpenApiCommand::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Command\OpenApiCommand::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -1002,4 +1002,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     }
 }
 
-class_alias(ApiPlatformExtension::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension::class, false)) {
+    class_alias(ApiPlatformExtension::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPass.php
@@ -98,4 +98,6 @@ final class AnnotationFilterPass implements CompilerPassInterface
     }
 }
 
-class_alias(AnnotationFilterPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass::class, false)) {
+    class_alias(AnnotationFilterPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/AuthenticatorManagerPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/AuthenticatorManagerPass.php
@@ -33,4 +33,6 @@ final class AuthenticatorManagerPass implements CompilerPassInterface
     }
 }
 
-class_alias(AuthenticatorManagerPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass::class, false)) {
+    class_alias(AuthenticatorManagerPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AuthenticatorManagerPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -59,4 +59,6 @@ final class DataProviderPass implements CompilerPassInterface
     }
 }
 
-class_alias(DataProviderPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass::class, false)) {
+    class_alias(DataProviderPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DataProviderPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/DeprecateMercurePublisherPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/DeprecateMercurePublisherPass.php
@@ -42,4 +42,6 @@ final class DeprecateMercurePublisherPass implements CompilerPassInterface
     }
 }
 
-class_alias(DeprecateMercurePublisherPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DeprecateMercurePublisherPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DeprecateMercurePublisherPass::class, false)) {
+    class_alias(DeprecateMercurePublisherPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DeprecateMercurePublisherPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/ElasticsearchClientPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/ElasticsearchClientPass.php
@@ -53,4 +53,6 @@ final class ElasticsearchClientPass implements CompilerPassInterface
     }
 }
 
-class_alias(ElasticsearchClientPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass::class, false)) {
+    class_alias(ElasticsearchClientPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\ElasticsearchClientPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/FilterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/FilterPass.php
@@ -48,4 +48,6 @@ final class FilterPass implements CompilerPassInterface
     }
 }
 
-class_alias(FilterPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass::class, false)) {
+    class_alias(FilterPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\FilterPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/GraphQlMutationResolverPass.php
@@ -43,4 +43,6 @@ final class GraphQlMutationResolverPass implements CompilerPassInterface
     }
 }
 
-class_alias(GraphQlMutationResolverPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlMutationResolverPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlMutationResolverPass::class, false)) {
+    class_alias(GraphQlMutationResolverPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlMutationResolverPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/GraphQlQueryResolverPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/GraphQlQueryResolverPass.php
@@ -43,4 +43,6 @@ final class GraphQlQueryResolverPass implements CompilerPassInterface
     }
 }
 
-class_alias(GraphQlQueryResolverPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolverPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolverPass::class, false)) {
+    class_alias(GraphQlQueryResolverPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolverPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/GraphQlTypePass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/GraphQlTypePass.php
@@ -44,4 +44,6 @@ final class GraphQlTypePass implements CompilerPassInterface
     }
 }
 
-class_alias(GraphQlTypePass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass::class, false)) {
+    class_alias(GraphQlTypePass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
@@ -52,4 +52,6 @@ final class MetadataAwareNameConverterPass implements CompilerPassInterface
     }
 }
 
-class_alias(MetadataAwareNameConverterPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass::class, false)) {
+    class_alias(MetadataAwareNameConverterPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/TestClientPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/TestClientPass.php
@@ -42,4 +42,6 @@ final class TestClientPass implements CompilerPassInterface
     }
 }
 
-class_alias(TestClientPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass::class, false)) {
+    class_alias(TestClientPass::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass::class);
+}

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -678,4 +678,6 @@ final class Configuration implements ConfigurationInterface
     }
 }
 
-class_alias(Configuration::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Configuration::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Configuration::class, false)) {
+    class_alias(Configuration::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Configuration::class);
+}

--- a/src/Symfony/Bundle/EventListener/SwaggerUiListener.php
+++ b/src/Symfony/Bundle/EventListener/SwaggerUiListener.php
@@ -34,4 +34,6 @@ final class SwaggerUiListener
     }
 }
 
-class_alias(SwaggerUiListener::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\EventListener\SwaggerUiListener::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\EventListener\SwaggerUiListener::class, false)) {
+    class_alias(SwaggerUiListener::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\EventListener\SwaggerUiListener::class);
+}

--- a/src/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
+++ b/src/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
@@ -136,4 +136,6 @@ final class SwaggerUiAction
     }
 }
 
-class_alias(SwaggerUiAction::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiAction::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiAction::class, false)) {
+    class_alias(SwaggerUiAction::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiAction::class);
+}

--- a/src/Symfony/Bundle/SwaggerUi/SwaggerUiContext.php
+++ b/src/Symfony/Bundle/SwaggerUi/SwaggerUiContext.php
@@ -77,4 +77,6 @@ final class SwaggerUiContext
     }
 }
 
-class_alias(SwaggerUiContext::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiContext::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiContext::class, false)) {
+    class_alias(SwaggerUiContext::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\SwaggerUi\SwaggerUiContext::class);
+}

--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -208,4 +208,6 @@ trait ApiTestAssertionsTrait
     }
 }
 
-class_alias(ApiTestAssertionsTrait::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestAssertionsTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestAssertionsTrait::class, false)) {
+    class_alias(ApiTestAssertionsTrait::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestAssertionsTrait::class);
+}

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -101,4 +101,6 @@ abstract class ApiTestCase extends KernelTestCase
     }
 }
 
-class_alias(ApiTestCase::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase::class, false)) {
+    class_alias(ApiTestCase::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase::class);
+}

--- a/src/Symfony/Bundle/Test/Client.php
+++ b/src/Symfony/Bundle/Test/Client.php
@@ -249,4 +249,6 @@ final class Client implements HttpClientInterface
     }
 }
 
-class_alias(Client::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Client::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Client::class, false)) {
+    class_alias(Client::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Client::class);
+}

--- a/src/Symfony/Bundle/Test/Constraint/ArraySubset.php
+++ b/src/Symfony/Bundle/Test/Constraint/ArraySubset.php
@@ -17,7 +17,7 @@ use PHPUnit\Runner\Version;
 use PHPUnit\SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\ComparisonFailure as LegacyComparisonFailure;
 
-if (!class_exists(ComparisonFailure::class) && class_exists(LegacyComparisonFailure::class)) {
+if (!class_exists(ComparisonFailure::class) && class_exists(LegacyComparisonFailure::class, false)) {
     class_alias(LegacyComparisonFailure::class, 'PHPUnit\SebastianBergmann\Comparator\ComparisonFailure');
 }
 

--- a/src/Symfony/Bundle/Test/Constraint/ArraySubset.php
+++ b/src/Symfony/Bundle/Test/Constraint/ArraySubset.php
@@ -17,7 +17,7 @@ use PHPUnit\Runner\Version;
 use PHPUnit\SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\ComparisonFailure as LegacyComparisonFailure;
 
-if (!class_exists(ComparisonFailure::class) && class_exists(LegacyComparisonFailure::class, false)) {
+if (!class_exists(ComparisonFailure::class) && class_exists(LegacyComparisonFailure::class)) {
     class_alias(LegacyComparisonFailure::class, 'PHPUnit\SebastianBergmann\Comparator\ComparisonFailure');
 }
 

--- a/src/Symfony/Bundle/Test/Response.php
+++ b/src/Symfony/Bundle/Test/Response.php
@@ -169,4 +169,6 @@ final class Response implements ResponseInterface
     }
 }
 
-class_alias(Response::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Response::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Response::class, false)) {
+    class_alias(Response::class, \ApiPlatform\Core\Bridge\Symfony\Bundle\Test\Response::class);
+}

--- a/src/Symfony/EventListener/AddFormatListener.php
+++ b/src/Symfony/EventListener/AddFormatListener.php
@@ -189,4 +189,6 @@ final class AddFormatListener
     }
 }
 
-class_alias(AddFormatListener::class, \ApiPlatform\Core\EventListener\AddFormatListener::class);
+if (!class_exists(\ApiPlatform\Core\EventListener\AddFormatListener::class, false)) {
+    class_alias(AddFormatListener::class, \ApiPlatform\Core\EventListener\AddFormatListener::class);
+}

--- a/src/Symfony/EventListener/AddLinkHeaderListener.php
+++ b/src/Symfony/EventListener/AddLinkHeaderListener.php
@@ -104,4 +104,6 @@ final class AddLinkHeaderListener
     }
 }
 
-class_alias(AddLinkHeaderListener::class, \ApiPlatform\Core\Mercure\EventListener\AddLinkHeaderListener::class);
+if (!class_exists(\ApiPlatform\Core\Mercure\EventListener\AddLinkHeaderListener::class, false)) {
+    class_alias(AddLinkHeaderListener::class, \ApiPlatform\Core\Mercure\EventListener\AddLinkHeaderListener::class);
+}

--- a/src/Symfony/EventListener/DenyAccessListener.php
+++ b/src/Symfony/EventListener/DenyAccessListener.php
@@ -156,4 +156,6 @@ final class DenyAccessListener
     }
 }
 
-class_alias(DenyAccessListener::class, \ApiPlatform\Core\Security\EventListener\DenyAccessListener::class);
+if (!class_exists(\ApiPlatform\Core\Security\EventListener\DenyAccessListener::class, false)) {
+    class_alias(DenyAccessListener::class, \ApiPlatform\Core\Security\EventListener\DenyAccessListener::class);
+}

--- a/src/Symfony/EventListener/DeserializeListener.php
+++ b/src/Symfony/EventListener/DeserializeListener.php
@@ -170,4 +170,6 @@ final class DeserializeListener
     }
 }
 
-class_alias(DeserializeListener::class, \ApiPlatform\Core\EventListener\DeserializeListener::class);
+if (!class_exists(\ApiPlatform\Core\EventListener\DeserializeListener::class, false)) {
+    class_alias(DeserializeListener::class, \ApiPlatform\Core\EventListener\DeserializeListener::class);
+}

--- a/src/Symfony/EventListener/EventPriorities.php
+++ b/src/Symfony/EventListener/EventPriorities.php
@@ -37,4 +37,6 @@ final class EventPriorities
     public const POST_RESPOND = 0;
 }
 
-class_alias(EventPriorities::class, \ApiPlatform\Core\EventListener\EventPriorities::class);
+if (!class_exists(\ApiPlatform\Core\EventListener\EventPriorities::class, false)) {
+    class_alias(EventPriorities::class, \ApiPlatform\Core\EventListener\EventPriorities::class);
+}

--- a/src/Symfony/EventListener/ExceptionListener.php
+++ b/src/Symfony/EventListener/ExceptionListener.php
@@ -55,4 +55,6 @@ final class ExceptionListener
     }
 }
 
-class_alias(ExceptionListener::class, \ApiPlatform\Core\EventListener\ExceptionListener::class);
+if (!class_exists(\ApiPlatform\Core\EventListener\ExceptionListener::class, false)) {
+    class_alias(ExceptionListener::class, \ApiPlatform\Core\EventListener\ExceptionListener::class);
+}

--- a/src/Symfony/EventListener/JsonApi/TransformFieldsetsParametersListener.php
+++ b/src/Symfony/EventListener/JsonApi/TransformFieldsetsParametersListener.php
@@ -89,4 +89,6 @@ final class TransformFieldsetsParametersListener
     }
 }
 
-class_alias(TransformFieldsetsParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformFieldsetsParametersListener::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\EventListener\TransformFieldsetsParametersListener::class, false)) {
+    class_alias(TransformFieldsetsParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformFieldsetsParametersListener::class);
+}

--- a/src/Symfony/EventListener/JsonApi/TransformFilteringParametersListener.php
+++ b/src/Symfony/EventListener/JsonApi/TransformFilteringParametersListener.php
@@ -42,4 +42,6 @@ final class TransformFilteringParametersListener
     }
 }
 
-class_alias(TransformFilteringParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformFilteringParametersListener::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\EventListener\TransformFilteringParametersListener::class, false)) {
+    class_alias(TransformFilteringParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformFilteringParametersListener::class);
+}

--- a/src/Symfony/EventListener/JsonApi/TransformPaginationParametersListener.php
+++ b/src/Symfony/EventListener/JsonApi/TransformPaginationParametersListener.php
@@ -44,4 +44,6 @@ final class TransformPaginationParametersListener
     }
 }
 
-class_alias(TransformPaginationParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformPaginationParametersListener::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\EventListener\TransformPaginationParametersListener::class, false)) {
+    class_alias(TransformPaginationParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformPaginationParametersListener::class);
+}

--- a/src/Symfony/EventListener/JsonApi/TransformSortingParametersListener.php
+++ b/src/Symfony/EventListener/JsonApi/TransformSortingParametersListener.php
@@ -64,4 +64,6 @@ final class TransformSortingParametersListener
     }
 }
 
-class_alias(TransformSortingParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformSortingParametersListener::class);
+if (!class_exists(\ApiPlatform\Core\JsonApi\EventListener\TransformSortingParametersListener::class, false)) {
+    class_alias(TransformSortingParametersListener::class, \ApiPlatform\Core\JsonApi\EventListener\TransformSortingParametersListener::class);
+}

--- a/src/Symfony/EventListener/QueryParameterValidateListener.php
+++ b/src/Symfony/EventListener/QueryParameterValidateListener.php
@@ -101,4 +101,6 @@ final class QueryParameterValidateListener
     }
 }
 
-class_alias(QueryParameterValidateListener::class, \ApiPlatform\Core\EventListener\QueryParameterValidateListener::class);
+if (!class_exists(\ApiPlatform\Core\EventListener\QueryParameterValidateListener::class, false)) {
+    class_alias(QueryParameterValidateListener::class, \ApiPlatform\Core\EventListener\QueryParameterValidateListener::class);
+}

--- a/src/Symfony/EventListener/RespondListener.php
+++ b/src/Symfony/EventListener/RespondListener.php
@@ -157,4 +157,6 @@ final class RespondListener
     }
 }
 
-class_alias(RespondListener::class, \ApiPlatform\Core\EventListener\RespondListener::class);
+if (!class_exists(\ApiPlatform\Core\EventListener\RespondListener::class, false)) {
+    class_alias(RespondListener::class, \ApiPlatform\Core\EventListener\RespondListener::class);
+}

--- a/src/Symfony/EventListener/SerializeListener.php
+++ b/src/Symfony/EventListener/SerializeListener.php
@@ -153,4 +153,6 @@ final class SerializeListener
     }
 }
 
-class_alias(SerializeListener::class, \ApiPlatform\Core\EventListener\SerializeListener::class);
+if (!class_exists(\ApiPlatform\Core\EventListener\SerializeListener::class, false)) {
+    class_alias(SerializeListener::class, \ApiPlatform\Core\EventListener\SerializeListener::class);
+}

--- a/src/Symfony/EventListener/ValidateListener.php
+++ b/src/Symfony/EventListener/ValidateListener.php
@@ -98,4 +98,6 @@ final class ValidateListener
     }
 }
 
-class_alias(ValidateListener::class, \ApiPlatform\Core\Validator\EventListener\ValidateListener::class);
+if (!class_exists(\ApiPlatform\Core\Validator\EventListener\ValidateListener::class, false)) {
+    class_alias(ValidateListener::class, \ApiPlatform\Core\Validator\EventListener\ValidateListener::class);
+}

--- a/src/Symfony/Messenger/ContextStamp.php
+++ b/src/Symfony/Messenger/ContextStamp.php
@@ -38,4 +38,6 @@ final class ContextStamp implements StampInterface
     }
 }
 
-class_alias(ContextStamp::class, \ApiPlatform\Core\Bridge\Symfony\Messenger\ContextStamp::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Messenger\ContextStamp::class, false)) {
+    class_alias(ContextStamp::class, \ApiPlatform\Core\Bridge\Symfony\Messenger\ContextStamp::class);
+}

--- a/src/Symfony/Messenger/DispatchTrait.php
+++ b/src/Symfony/Messenger/DispatchTrait.php
@@ -54,4 +54,6 @@ trait DispatchTrait
     }
 }
 
-class_alias(DispatchTrait::class, \ApiPlatform\Core\Bridge\Symfony\Messenger\DispatchTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Bridge\Symfony\Messenger\DispatchTrait::class, false)) {
+    class_alias(DispatchTrait::class, \ApiPlatform\Core\Bridge\Symfony\Messenger\DispatchTrait::class);
+}

--- a/src/Symfony/Messenger/RemoveStamp.php
+++ b/src/Symfony/Messenger/RemoveStamp.php
@@ -24,4 +24,6 @@ final class RemoveStamp implements StampInterface
 {
 }
 
-class_alias(RemoveStamp::class, \ApiPlatform\Core\Bridge\Symfony\Messenger\RemoveStamp::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Messenger\RemoveStamp::class, false)) {
+    class_alias(RemoveStamp::class, \ApiPlatform\Core\Bridge\Symfony\Messenger\RemoveStamp::class);
+}

--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -346,4 +346,6 @@ final class ApiLoader extends Loader
     }
 }
 
-class_alias(ApiLoader::class, \ApiPlatform\Core\Bridge\Symfony\Routing\ApiLoader::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Routing\ApiLoader::class, false)) {
+    class_alias(ApiLoader::class, \ApiPlatform\Core\Bridge\Symfony\Routing\ApiLoader::class);
+}

--- a/src/Symfony/Routing/Router.php
+++ b/src/Symfony/Routing/Router.php
@@ -93,4 +93,6 @@ final class Router implements RouterInterface, UrlGeneratorInterface
     }
 }
 
-class_alias(Router::class, \ApiPlatform\Core\Bridge\Symfony\Routing\Router::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Routing\Router::class, false)) {
+    class_alias(Router::class, \ApiPlatform\Core\Bridge\Symfony\Routing\Router::class);
+}

--- a/src/Symfony/Security/Core/Authorization/ExpressionLanguageProvider.php
+++ b/src/Symfony/Security/Core/Authorization/ExpressionLanguageProvider.php
@@ -35,4 +35,6 @@ final class ExpressionLanguageProvider implements ExpressionFunctionProviderInte
     }
 }
 
-class_alias(ExpressionLanguageProvider::class, \ApiPlatform\Core\Security\Core\Authorization\ExpressionLanguageProvider::class);
+if (!class_exists(\ApiPlatform\Core\Security\Core\Authorization\ExpressionLanguageProvider::class, false)) {
+    class_alias(ExpressionLanguageProvider::class, \ApiPlatform\Core\Security\Core\Authorization\ExpressionLanguageProvider::class);
+}

--- a/src/Symfony/Security/ExpressionLanguage.php
+++ b/src/Symfony/Security/ExpressionLanguage.php
@@ -45,4 +45,6 @@ class ExpressionLanguage extends BaseExpressionLanguage
     }
 }
 
-class_alias(ExpressionLanguage::class, \ApiPlatform\Core\Security\ExpressionLanguage::class);
+if (!class_exists(\ApiPlatform\Core\Security\ExpressionLanguage::class, false)) {
+    class_alias(ExpressionLanguage::class, \ApiPlatform\Core\Security\ExpressionLanguage::class);
+}

--- a/src/Symfony/Security/ResourceAccessChecker.php
+++ b/src/Symfony/Security/ResourceAccessChecker.php
@@ -113,4 +113,6 @@ final class ResourceAccessChecker implements ResourceAccessCheckerInterface
     }
 }
 
-class_alias(ResourceAccessChecker::class, \ApiPlatform\Core\Security\ResourceAccessChecker::class);
+if (!class_exists(\ApiPlatform\Core\Security\ResourceAccessChecker::class, false)) {
+    class_alias(ResourceAccessChecker::class, \ApiPlatform\Core\Security\ResourceAccessChecker::class);
+}

--- a/src/Symfony/Validator/EventListener/ValidationExceptionListener.php
+++ b/src/Symfony/Validator/EventListener/ValidationExceptionListener.php
@@ -72,4 +72,6 @@ final class ValidationExceptionListener
     }
 }
 
-class_alias(ValidationExceptionListener::class, \ApiPlatform\Core\Bridge\Symfony\Validator\EventListener\ValidationExceptionListener::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Validator\EventListener\ValidationExceptionListener::class, false)) {
+    class_alias(ValidationExceptionListener::class, \ApiPlatform\Core\Bridge\Symfony\Validator\EventListener\ValidationExceptionListener::class);
+}

--- a/src/Symfony/Validator/Exception/ValidationException.php
+++ b/src/Symfony/Validator/Exception/ValidationException.php
@@ -55,4 +55,6 @@ final class ValidationException extends BaseValidationException implements Const
     }
 }
 
-class_alias(ValidationException::class, \ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException::class, false)) {
+    class_alias(ValidationException::class, \ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException::class);
+}

--- a/src/Symfony/Validator/Validator.php
+++ b/src/Symfony/Validator/Validator.php
@@ -68,4 +68,6 @@ class Validator implements ValidatorInterface
     }
 }
 
-class_alias(Validator::class, \ApiPlatform\Core\Bridge\Symfony\Validator\Validator::class);
+if (!class_exists(\ApiPlatform\Core\Bridge\Symfony\Validator\Validator::class, false)) {
+    class_alias(Validator::class, \ApiPlatform\Core\Bridge\Symfony\Validator\Validator::class);
+}

--- a/src/Test/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmFilterTestCase.php
@@ -104,4 +104,6 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
     abstract public function provideApplyTestData(): array;
 }
 
-class_alias(DoctrineMongoDbOdmFilterTestCase::class, \ApiPlatform\Core\Test\DoctrineMongoDbOdmFilterTestCase::class);
+if (!class_exists(\ApiPlatform\Core\Test\DoctrineMongoDbOdmFilterTestCase::class, false)) {
+    class_alias(DoctrineMongoDbOdmFilterTestCase::class, \ApiPlatform\Core\Test\DoctrineMongoDbOdmFilterTestCase::class);
+}

--- a/src/Test/DoctrineMongoDbOdmSetup.php
+++ b/src/Test/DoctrineMongoDbOdmSetup.php
@@ -120,4 +120,6 @@ class DoctrineMongoDbOdmSetup
     }
 }
 
-class_alias(DoctrineMongoDbOdmSetup::class, \ApiPlatform\Core\Test\DoctrineMongoDbOdmSetup::class);
+if (!class_exists(\ApiPlatform\Core\Test\DoctrineMongoDbOdmSetup::class, false)) {
+    class_alias(DoctrineMongoDbOdmSetup::class, \ApiPlatform\Core\Test\DoctrineMongoDbOdmSetup::class);
+}

--- a/src/Test/DoctrineMongoDbOdmTestCase.php
+++ b/src/Test/DoctrineMongoDbOdmTestCase.php
@@ -49,4 +49,6 @@ class DoctrineMongoDbOdmTestCase extends TestCase
     }
 }
 
-class_alias(DoctrineMongoDbOdmTestCase::class, \ApiPlatform\Core\Test\DoctrineMongoDbOdmTestCase::class);
+if (!class_exists(\ApiPlatform\Core\Test\DoctrineMongoDbOdmTestCase::class, false)) {
+    class_alias(DoctrineMongoDbOdmTestCase::class, \ApiPlatform\Core\Test\DoctrineMongoDbOdmTestCase::class);
+}

--- a/src/Util/AnnotationFilterExtractorTrait.php
+++ b/src/Util/AnnotationFilterExtractorTrait.php
@@ -156,4 +156,6 @@ trait AnnotationFilterExtractorTrait
     }
 }
 
-class_alias(AnnotationFilterExtractorTrait::class, \ApiPlatform\Core\Util\AnnotationFilterExtractorTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\AnnotationFilterExtractorTrait::class, false)) {
+    class_alias(AnnotationFilterExtractorTrait::class, \ApiPlatform\Core\Util\AnnotationFilterExtractorTrait::class);
+}

--- a/src/Util/ArrayTrait.php
+++ b/src/Util/ArrayTrait.php
@@ -41,4 +41,6 @@ trait ArrayTrait
     }
 }
 
-class_alias(ArrayTrait::class, \ApiPlatform\Core\Util\ArrayTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\ArrayTrait::class, false)) {
+    class_alias(ArrayTrait::class, \ApiPlatform\Core\Util\ArrayTrait::class);
+}

--- a/src/Util/AttributesExtractor.php
+++ b/src/Util/AttributesExtractor.php
@@ -95,4 +95,6 @@ final class AttributesExtractor
     }
 }
 
-class_alias(AttributesExtractor::class, \ApiPlatform\Core\Util\AttributesExtractor::class);
+if (!class_exists(\ApiPlatform\Core\Util\AttributesExtractor::class, false)) {
+    class_alias(AttributesExtractor::class, \ApiPlatform\Core\Util\AttributesExtractor::class);
+}

--- a/src/Util/CachedTrait.php
+++ b/src/Util/CachedTrait.php
@@ -50,4 +50,6 @@ trait CachedTrait
     }
 }
 
-class_alias(CachedTrait::class, \ApiPlatform\Core\Cache\CachedTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Cache\CachedTrait::class, false)) {
+    class_alias(CachedTrait::class, \ApiPlatform\Core\Cache\CachedTrait::class);
+}

--- a/src/Util/ClassInfoTrait.php
+++ b/src/Util/ClassInfoTrait.php
@@ -60,4 +60,6 @@ trait ClassInfoTrait
     }
 }
 
-class_alias(ClassInfoTrait::class, \ApiPlatform\Core\Util\ClassInfoTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\ClassInfoTrait::class, false)) {
+    class_alias(ClassInfoTrait::class, \ApiPlatform\Core\Util\ClassInfoTrait::class);
+}

--- a/src/Util/ClientTrait.php
+++ b/src/Util/ClientTrait.php
@@ -25,4 +25,6 @@ if (\PHP_VERSION_ID >= 80000) {
     }
 }
 
-class_alias(ClientTrait::class, \ApiPlatform\Core\Util\ClientTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\ClientTrait::class, false)) {
+    class_alias(ClientTrait::class, \ApiPlatform\Core\Util\ClientTrait::class);
+}

--- a/src/Util/CloneTrait.php
+++ b/src/Util/CloneTrait.php
@@ -36,4 +36,6 @@ trait CloneTrait
     }
 }
 
-class_alias(CloneTrait::class, \ApiPlatform\Core\Util\CloneTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\CloneTrait::class, false)) {
+    class_alias(CloneTrait::class, \ApiPlatform\Core\Util\CloneTrait::class);
+}

--- a/src/Util/CorsTrait.php
+++ b/src/Util/CorsTrait.php
@@ -32,4 +32,6 @@ trait CorsTrait
     }
 }
 
-class_alias(CorsTrait::class, \ApiPlatform\Core\Util\CorsTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\CorsTrait::class, false)) {
+    class_alias(CorsTrait::class, \ApiPlatform\Core\Util\CorsTrait::class);
+}

--- a/src/Util/ErrorFormatGuesser.php
+++ b/src/Util/ErrorFormatGuesser.php
@@ -54,4 +54,6 @@ final class ErrorFormatGuesser
     }
 }
 
-class_alias(ErrorFormatGuesser::class, \ApiPlatform\Core\Util\ErrorFormatGuesser::class);
+if (!class_exists(\ApiPlatform\Core\Util\ErrorFormatGuesser::class, false)) {
+    class_alias(ErrorFormatGuesser::class, \ApiPlatform\Core\Util\ErrorFormatGuesser::class);
+}

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -54,4 +54,6 @@ final class Inflector
     }
 }
 
-class_alias(Inflector::class, \ApiPlatform\Core\Util\Inflector::class);
+if (!class_exists(\ApiPlatform\Core\Util\Inflector::class, false)) {
+    class_alias(Inflector::class, \ApiPlatform\Core\Util\Inflector::class);
+}

--- a/src/Util/IriHelper.php
+++ b/src/Util/IriHelper.php
@@ -111,4 +111,6 @@ final class IriHelper
     }
 }
 
-class_alias(IriHelper::class, \ApiPlatform\Core\Util\IriHelper::class);
+if (!class_exists(\ApiPlatform\Core\Util\IriHelper::class, false)) {
+    class_alias(IriHelper::class, \ApiPlatform\Core\Util\IriHelper::class);
+}

--- a/src/Util/Reflection.php
+++ b/src/Util/Reflection.php
@@ -40,4 +40,6 @@ final class Reflection
     }
 }
 
-class_alias(Reflection::class, \ApiPlatform\Core\Util\Reflection::class);
+if (!class_exists(\ApiPlatform\Core\Util\Reflection::class, false)) {
+    class_alias(Reflection::class, \ApiPlatform\Core\Util\Reflection::class);
+}

--- a/src/Util/ReflectionClassRecursiveIterator.php
+++ b/src/Util/ReflectionClassRecursiveIterator.php
@@ -71,4 +71,6 @@ final class ReflectionClassRecursiveIterator
     }
 }
 
-class_alias(ReflectionClassRecursiveIterator::class, \ApiPlatform\Core\Util\ReflectionClassRecursiveIterator::class);
+if (!class_exists(\ApiPlatform\Core\Util\ReflectionClassRecursiveIterator::class, false)) {
+    class_alias(ReflectionClassRecursiveIterator::class, \ApiPlatform\Core\Util\ReflectionClassRecursiveIterator::class);
+}

--- a/src/Util/RequestAttributesExtractor.php
+++ b/src/Util/RequestAttributesExtractor.php
@@ -36,4 +36,6 @@ final class RequestAttributesExtractor
     }
 }
 
-class_alias(RequestAttributesExtractor::class, \ApiPlatform\Core\Util\RequestAttributesExtractor::class);
+if (!class_exists(\ApiPlatform\Core\Util\RequestAttributesExtractor::class, false)) {
+    class_alias(RequestAttributesExtractor::class, \ApiPlatform\Core\Util\RequestAttributesExtractor::class);
+}

--- a/src/Util/RequestParser.php
+++ b/src/Util/RequestParser.php
@@ -93,4 +93,6 @@ final class RequestParser
     }
 }
 
-class_alias(RequestParser::class, \ApiPlatform\Core\Util\RequestParser::class);
+if (!class_exists(\ApiPlatform\Core\Util\RequestParser::class, false)) {
+    class_alias(RequestParser::class, \ApiPlatform\Core\Util\RequestParser::class);
+}

--- a/src/Util/ResourceClassInfoTrait.php
+++ b/src/Util/ResourceClassInfoTrait.php
@@ -84,4 +84,6 @@ trait ResourceClassInfoTrait
     }
 }
 
-class_alias(ResourceClassInfoTrait::class, \ApiPlatform\Core\Util\ResourceClassInfoTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\ResourceClassInfoTrait::class, false)) {
+    class_alias(ResourceClassInfoTrait::class, \ApiPlatform\Core\Util\ResourceClassInfoTrait::class);
+}

--- a/src/Util/ResponseTrait.php
+++ b/src/Util/ResponseTrait.php
@@ -25,4 +25,6 @@ if (\PHP_VERSION_ID < 80000) {
     }
 }
 
-class_alias(ResponseTrait::class, \ApiPlatform\Core\Util\ResponseTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\ResponseTrait::class, false)) {
+    class_alias(ResponseTrait::class, \ApiPlatform\Core\Util\ResponseTrait::class);
+}

--- a/src/Util/SortTrait.php
+++ b/src/Util/SortTrait.php
@@ -34,4 +34,6 @@ trait SortTrait
     }
 }
 
-class_alias(SortTrait::class, \ApiPlatform\Core\Util\SortTrait::class);
+if (!trait_exists(\ApiPlatform\Core\Util\SortTrait::class, false)) {
+    class_alias(SortTrait::class, \ApiPlatform\Core\Util\SortTrait::class);
+}

--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -24,4 +24,6 @@ class ValidationException extends RuntimeException
 {
 }
 
-class_alias(ValidationException::class, \ApiPlatform\Core\Validator\Exception\ValidationException::class);
+if (!class_exists(\ApiPlatform\Core\Validator\Exception\ValidationException::class, false)) {
+    class_alias(ValidationException::class, \ApiPlatform\Core\Validator\Exception\ValidationException::class);
+}

--- a/src/deprecation.php
+++ b/src/deprecation.php
@@ -12,10 +12,10 @@
 declare(strict_types=1);
 
 // Must be declared first!
-if (!interface_exists(ApiPlatform\Core\Api\FilterInterface::class)) {
+if (!interface_exists(ApiPlatform\Core\Api\FilterInterface::class, false)) {
     class_alias(ApiPlatform\Api\FilterInterface::class, ApiPlatform\Core\Api\FilterInterface::class);
 }
-if (!interface_exists(ApiPlatform\Core\Api\ResourceClassResolverInterface::class)) {
+if (!interface_exists(ApiPlatform\Core\Api\ResourceClassResolverInterface::class, false)) {
     class_alias(ApiPlatform\Api\ResourceClassResolverInterface::class, ApiPlatform\Core\Api\ResourceClassResolverInterface::class);
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Tickets       | Closes similar issue to https://github.com/api-platform/core/pull/5523/files
| License       | MIT
| Doc PR        | N/A

https://github.com/api-platform/core/blob/2.7/src/Symfony/Validator/EventListener/ValidationExceptionListener.php suffers from the same issue as https://github.com/api-platform/core/pull/5523/files

=> This PR wraps all calls to `class_alias()` in an if condition to check first if the alias already exists

This is important to us because we want to upgrade first to 2.7 before moving forward to 3.0: we cannot do it right now because preloading breaks with 2.7

This PR follows up on https://github.com/api-platform/core/pull/6217 which was a disaster. This new version has been tested internally within my company and we plan to release it on week 15 (April 8th, 2024)
