### PR TITLE
fix(messenger): context not serializable when session

### DIFF
--- a/src/Symfony/Messenger/ContextStamp.php
+++ b/src/Symfony/Messenger/ContextStamp.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Symfony\Messenger;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
@@ -22,8 +23,15 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
  */
 final class ContextStamp implements StampInterface
 {
-    public function __construct(private readonly array $context = [])
+    private readonly array $context;
+
+    public function __construct(array $context = [])
     {
+        if (($request = ($context['request'] ?? null)) && $request instanceof Request && $request->hasSession()) {
+            unset($context['request']);
+        }
+
+        $this->context = $context;
     }
 
     /**

--- a/tests/Symfony/Messenger/ContextStampTest.php
+++ b/tests/Symfony/Messenger/ContextStampTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Tests\Symfony\Messenger;
 
 use ApiPlatform\Symfony\Messenger\ContextStamp;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
@@ -31,5 +32,17 @@ class ContextStampTest extends TestCase
     {
         $contextStamp = new ContextStamp();
         $this->assertIsArray($contextStamp->getContext());
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testSerializable(): void
+    {
+        $request = new Request();
+        $request->setSessionFactory(fn () => 'session');
+
+        $stamp = new ContextStamp(['request' => $request]);
+        serialize($stamp);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Tickets       | Closes https://github.com/api-platform/api-platform/issues/2611
| License       | MIT

In some case, a "Serialization of 'Closure' is not allowed" Exception is thrown when using Messenger. This is due to the fact that the `$context` array is passed to the Envelope via the ContextStamp and that `$context['request']` is set with a not serializable Request object.

Symfony does not guarantee that a Request is serializable so the best solution would be to completely unset `$context['request']` in the ContextStamp. However this would be a breaking change. So, I'm proposing an alternative solution by unsetting `$context['request']` only when the Request object has a session as it seems to be the identified buggy case.
