### PR TITLE
feat: BackedEnum resources

### DIFF
--- a/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
@@ -59,15 +59,11 @@ final class AttributePropertyMetadataFactory implements PropertyMetadataFactoryI
             return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
         }
 
-        if ($reflectionEnum) {
-            if ($reflectionEnum->hasCase($property)) {
-                $reflectionCase = $reflectionEnum->getCase($property);
-                if ($attributes = $reflectionCase->getAttributes(ApiProperty::class)) {
-                    return $this->createMetadata($attributes[0]->newInstance(), $parentPropertyMetadata);
-                }
+        if ($reflectionEnum && $reflectionEnum->hasCase($property)) {
+            $reflectionCase = $reflectionEnum->getCase($property);
+            if ($attributes = $reflectionCase->getAttributes(ApiProperty::class)) {
+                return $this->createMetadata($attributes[0]->newInstance(), $parentPropertyMetadata);
             }
-
-            return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
         }
 
         if ($reflectionClass->hasProperty($property)) {
@@ -79,11 +75,11 @@ final class AttributePropertyMetadataFactory implements PropertyMetadataFactoryI
 
         foreach (array_merge(Reflection::ACCESSOR_PREFIXES, Reflection::MUTATOR_PREFIXES) as $prefix) {
             $methodName = $prefix.ucfirst($property);
-            if (!$reflectionClass->hasMethod($methodName)) {
+            if (!$reflectionClass->hasMethod($methodName) && !$reflectionEnum?->hasMethod($methodName)) {
                 continue;
             }
 
-            $reflectionMethod = $reflectionClass->getMethod($methodName);
+            $reflectionMethod = $reflectionClass->hasMethod($methodName) ? $reflectionClass->getMethod($methodName) : $reflectionEnum?->getMethod($methodName);
             if (!$reflectionMethod->isPublic()) {
                 continue;
             }

--- a/src/Metadata/Resource/Factory/BackedEnumResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/BackedEnumResourceMetadataCollectionFactory.php
@@ -24,6 +24,7 @@ use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 final class BackedEnumResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {
     public const PROVIDER = 'api_platform.state_provider.backed_enum';
+
     public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $decorated)
     {
     }

--- a/src/Metadata/Resource/Factory/BackedEnumResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/BackedEnumResourceMetadataCollectionFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+
+/**
+ * Triggers resource deprecations.
+ *
+ * @internal
+ */
+final class BackedEnumResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public const PROVIDER = 'api_platform.state_provider.backed_enum';
+    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $decorated)
+    {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+        if (!is_a($resourceClass, \BackedEnum::class, true)) {
+            return $resourceMetadataCollection;
+        }
+
+        foreach ($resourceMetadataCollection as $i => $resourceMetadata) {
+            $newOperations = [];
+            foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
+                $newOperations[$operationName] = $operation;
+
+                if (null !== $operation->getProvider()) {
+                    continue;
+                }
+
+                $newOperations[$operationName] = $operation->withProvider(self::PROVIDER);
+            }
+
+            $newGraphQlOperations = [];
+            foreach ($resourceMetadata->getGraphQlOperations() as $operationName => $operation) {
+                $newGraphQlOperations[$operationName] = $operation;
+
+                if (null !== $operation->getProvider()) {
+                    continue;
+                }
+
+                $newGraphQlOperations[$operationName] = $operation->withProvider(self::PROVIDER);
+            }
+
+            $resourceMetadataCollection[$i] = $resourceMetadata->withOperations(new Operations($newOperations))->withGraphQlOperations($newGraphQlOperations);
+        }
+
+        return $resourceMetadataCollection;
+    }
+}

--- a/src/Metadata/Resource/Factory/LinkFactory.php
+++ b/src/Metadata/Resource/Factory/LinkFactory.php
@@ -59,6 +59,9 @@ final class LinkFactory implements LinkFactoryInterface, PropertyLinkFactoryInte
 
         $link = (new Link())->withFromClass($resourceClass)->withIdentifiers($identifiers);
         $parameterName = $identifiers[0];
+        if ('value' === $parameterName && enum_exists($resourceClass)) {
+            $parameterName = 'id';
+        }
 
         if (1 < \count($identifiers)) {
             $parameterName = 'id';
@@ -153,6 +156,10 @@ final class LinkFactory implements LinkFactoryInterface, PropertyLinkFactoryInte
 
         if ($hasIdProperty && !$identifiers) {
             return ['id'];
+        }
+
+        if (!$hasIdProperty && !$identifiers && enum_exists($resourceClass)) {
+            return ['value'];
         }
 
         return $identifiers;

--- a/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -88,6 +88,10 @@ trait OperationDefaultsTrait
 
     private function getDefaultHttpOperations($resource): iterable
     {
+        if (enum_exists($resource->getClass())) {
+            return new Operations([new GetCollection(paginationEnabled: false), new Get()]);
+        }
+
         if (($defaultOperations = $this->defaults['operations'] ?? null) && null === $resource->getOperations()) {
             $operations = [];
 
@@ -108,8 +112,9 @@ trait OperationDefaultsTrait
 
     private function addDefaultGraphQlOperations(ApiResource $resource): ApiResource
     {
+        $operations = enum_exists($resource->getClass()) ? [new QueryCollection(paginationEnabled: false), new Query()] : [new QueryCollection(), new Query(), (new Mutation())->withName('update'), (new DeleteMutation())->withName('delete'), (new Mutation())->withName('create')];
         $graphQlOperations = [];
-        foreach ([new QueryCollection(), new Query(), (new Mutation())->withName('update'), (new DeleteMutation())->withName('delete'), (new Mutation())->withName('create')] as $operation) {
+        foreach ($operations as $operation) {
             [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
             $graphQlOperations[$key] = $operation;
         }

--- a/src/State/Provider/BackedEnumProvider.php
+++ b/src/State/Provider/BackedEnumProvider.php
@@ -14,21 +14,18 @@ declare(strict_types=1);
 namespace ApiPlatform\State\Provider;
 
 use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final class BackedEnumProvider implements ProviderInterface
 {
-    public function __construct(private ProviderInterface $decorated)
-    {
-    }
-
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         $resourceClass = $operation->getClass();
         if (!$resourceClass || !is_a($resourceClass, \BackedEnum::class, true)) {
-            return $this->decorated->provide($operation, $uriVariables, $context);
+            throw new RuntimeException('This resource is not an enum');
         }
 
         if ($operation instanceof CollectionOperationInterface) {

--- a/src/State/Provider/BackedEnumProvider.php
+++ b/src/State/Provider/BackedEnumProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Provider;
+
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class BackedEnumProvider implements ProviderInterface
+{
+    public function __construct(private ProviderInterface $decorated)
+    {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        $resourceClass = $operation->getClass();
+        if (!$resourceClass || !is_a($resourceClass, \BackedEnum::class, true)) {
+            return $this->decorated->provide($operation, $uriVariables, $context);
+        }
+
+        if ($operation instanceof CollectionOperationInterface) {
+            return $resourceClass::cases();
+        }
+
+        $id = $uriVariables['id'] ?? null;
+        if (null === $id) {
+            throw new NotFoundHttpException('Not Found');
+        }
+
+        if ($enum = $this->resolveEnum($resourceClass, $id)) {
+            return $enum;
+        }
+
+        throw new NotFoundHttpException('Not Found');
+    }
+
+    /**
+     * @param class-string $resourceClass
+     */
+    private function resolveEnum(string $resourceClass, string|int $id): ?\BackedEnum
+    {
+        $reflectEnum = new \ReflectionEnum($resourceClass);
+        $type = (string) $reflectEnum->getBackingType();
+
+        if ('int' === $type) {
+            if (!is_numeric($id)) {
+                return null;
+            }
+            $enum = $resourceClass::tryFrom((int) $id);
+        } else {
+            $enum = $resourceClass::tryFrom($id);
+        }
+
+        // @deprecated enums will be indexable only by value in 4.0
+        $enum ??= array_reduce($resourceClass::cases(), static fn ($c, \BackedEnum $case) => $id === $case->name ? $case : $c, null);
+
+        return $enum;
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Symfony/Bundle/Resources/config/graphql.xml
@@ -146,10 +146,6 @@
         <service id="api_platform.graphql.state_provider" alias="api_platform.state_provider.locator" />
         <service id="api_platform.graphql.state_processor" alias="api_platform.graphql.state_processor.normalize" />
 
-        <service id="api_platform.graphql.state_provider.backed_enum" class="ApiPlatform\State\Provider\BackedEnumProvider" decorates="api_platform.graphql.state_provider" decoration-priority="450">
-            <argument type="service" id="api_platform.graphql.state_provider.backed_enum.inner" />
-        </service>
-
         <service id="api_platform.graphql.state_provider.read" class="ApiPlatform\GraphQl\State\Provider\ReadProvider" decorates="api_platform.graphql.state_provider" decoration-priority="500">
             <argument type="service" id="api_platform.graphql.state_provider.read.inner" />
             <argument type="service" id="api_platform.symfony.iri_converter" />

--- a/src/Symfony/Bundle/Resources/config/graphql.xml
+++ b/src/Symfony/Bundle/Resources/config/graphql.xml
@@ -146,6 +146,10 @@
         <service id="api_platform.graphql.state_provider" alias="api_platform.state_provider.locator" />
         <service id="api_platform.graphql.state_processor" alias="api_platform.graphql.state_processor.normalize" />
 
+        <service id="api_platform.graphql.state_provider.backed_enum" class="ApiPlatform\State\Provider\BackedEnumProvider" decorates="api_platform.graphql.state_provider" decoration-priority="450">
+            <argument type="service" id="api_platform.graphql.state_provider.backed_enum.inner" />
+        </service>
+
         <service id="api_platform.graphql.state_provider.read" class="ApiPlatform\GraphQl\State\Provider\ReadProvider" decorates="api_platform.graphql.state_provider" decoration-priority="500">
             <argument type="service" id="api_platform.graphql.state_provider.read.inner" />
             <argument type="service" id="api_platform.symfony.iri_converter" />

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -29,6 +29,10 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.not_exposed_operation.inner" />
         </service>
 
+        <service id="api_platform.metadata.resource.metadata_collection_factory.backed_enum" class="ApiPlatform\Metadata\Resource\Factory\BackedEnumResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="500" public="false">
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.backed_enum.inner" />
+        </service>
+
         <service id="api_platform.metadata.resource.metadata_collection_factory.uri_template" class="ApiPlatform\Metadata\Resource\Factory\UriTemplateResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="500" public="false">
             <argument type="service" id="api_platform.metadata.resource.link_factory" />
             <argument type="service" id="api_platform.path_segment_name_generator" />

--- a/src/Symfony/Bundle/Resources/config/state/provider.xml
+++ b/src/Symfony/Bundle/Resources/config/state/provider.xml
@@ -25,6 +25,10 @@
             <argument type="service" id="translator" on-invalid="null" />
         </service>
 
+        <service id="api_platform.state_provider.backed_enum" class="ApiPlatform\State\Provider\BackedEnumProvider" decorates="api_platform.state_provider.main" decoration-priority="300">
+            <argument type="service" id="api_platform.state_provider.backed_enum.inner" />
+        </service>
+
         <service id="api_platform.error_listener" class="ApiPlatform\Symfony\EventListener\ErrorListener">
             <argument key="$controller">api_platform.symfony.main_controller</argument>
             <argument key="$logger" type="service" id="logger" on-invalid="null" />

--- a/src/Symfony/Bundle/Resources/config/state/provider.xml
+++ b/src/Symfony/Bundle/Resources/config/state/provider.xml
@@ -25,8 +25,9 @@
             <argument type="service" id="translator" on-invalid="null" />
         </service>
 
-        <service id="api_platform.state_provider.backed_enum" class="ApiPlatform\State\Provider\BackedEnumProvider" decorates="api_platform.state_provider.main" decoration-priority="300">
-            <argument type="service" id="api_platform.state_provider.backed_enum.inner" />
+        <service id="api_platform.state_provider.backed_enum" class="ApiPlatform\State\Provider\BackedEnumProvider">
+            <tag name="api_platform.state_provider" key="ApiPlatform\State\Provider\BackedEnumProvidevr" />
+            <tag name="api_platform.state_provider" key="api_platform.state_provider.backed_enum" />
         </service>
 
         <service id="api_platform.error_listener" class="ApiPlatform\Symfony\EventListener\ErrorListener">

--- a/tests/Fixtures/TestBundle/ApiResource/BackedEnumIntegerResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/BackedEnumIntegerResource.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource]
+enum BackedEnumIntegerResource: int
+{
+    case Yes = 1;
+    case No = 2;
+    case Maybe = 3;
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Yes => 'We say yes',
+            self::No => 'Computer says no',
+            self::Maybe => 'Let me think about it',
+        };
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/BackedEnumStringResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/BackedEnumStringResource.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource]
+enum BackedEnumStringResource: string
+{
+    case Yes = 'yes';
+    case No = 'no';
+    case Maybe = 'maybe';
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Yes => 'We say yes',
+            self::No => 'Computer says no',
+            self::Maybe => 'Let me think about it',
+        };
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6264/Availability.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6264/Availability.php
@@ -17,18 +17,16 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\GraphQl\Query;
-use ApiPlatform\Metadata\GraphQl\QueryCollection;
 
 #[ApiResource(
     normalizationContext: ['groups' => ['get']],
-        operations: [
-            new GetCollection(provider: Availability::class.'::getCases'),
-            new Get(provider: Availability::class.'::getCase')
-        ],
-        graphQlOperations: [
-            new Query(),
-            new QueryCollection(),
-        ]
+    operations: [
+        new GetCollection(provider: Availability::class.'::getCases'),
+        new Get(provider: Availability::class.'::getCase'),
+    ],
+    graphQlOperations: [
+        new Query(provider: Availability::class.'getCase'),
+    ]
 )]
 enum Availability: int
 {

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6264/Availability.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6264/Availability.php
@@ -16,10 +16,20 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6264;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 
-#[ApiResource(normalizationContext: ['groups' => ['get']])]
-#[GetCollection(provider: Availability::class.'::getCases')]
-#[Get(provider: Availability::class.'::getCase')]
+#[ApiResource(
+    normalizationContext: ['groups' => ['get']],
+        operations: [
+            new GetCollection(provider: Availability::class.'::getCases'),
+            new Get(provider: Availability::class.'::getCase')
+        ],
+        graphQlOperations: [
+            new Query(),
+            new QueryCollection(),
+        ]
+)]
 enum Availability: int
 {
     use BackedEnumTrait;

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6264/AvailabilityStatus.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6264/AvailabilityStatus.php
@@ -22,7 +22,7 @@ use ApiPlatform\Metadata\GetCollection;
 #[Get(provider: AvailabilityStatus::class.'::getCase')]
 enum AvailabilityStatus: string
 {
-    use BackedEnumTrait;
+    use BackedEnumStringTrait;
 
     case Pending = 'pending';
     case Reviewed = 'reviewed';

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6264/BackedEnumStringTrait.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6264/BackedEnumStringTrait.php
@@ -16,20 +16,20 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6264;
 use ApiPlatform\Metadata\Operation;
 use Symfony\Component\Serializer\Attribute\Groups;
 
-trait BackedEnumTrait
+trait BackedEnumStringTrait
 {
     public static function values(): array
     {
         return array_map(static fn (\BackedEnum $feature) => $feature->value, self::cases());
     }
 
-    public function getId(): int
+    public function getId(): string
     {
         return $this->value;
     }
 
     #[Groups(['get'])]
-    public function getValue(): int
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6317/Issue6317.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6317/Issue6317.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6317;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource]
+enum Issue6317: int
+{
+    case First = 1;
+    case Second = 2;
+
+    #[ApiProperty(identifier: true, example: 'An example of an ID')]
+    public function getId(): int
+    {
+        return $this->value;
+    }
+
+    #[ApiProperty(jsonSchemaContext: ['example' => '/lisa/mary'])]
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    #[ApiProperty(jsonldContext: ['example' => '24'])]
+    public function getOrdinal(): string
+    {
+        return 1 === $this->value ? '1st' : '2nd';
+    }
+
+    #[ApiProperty(openapiContext: ['example' => '42'])]
+    public function getCardinal(): int
+    {
+        return $this->value;
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/ResourceWithEnumProperty.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ResourceWithEnumProperty.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
+
+#[ApiResource()]
+#[Get(
+    provider: self::class.'::providerItem',
+)]
+#[GetCollection(
+    provider: self::class.'::providerCollection',
+)]
+class ResourceWithEnumProperty
+{
+    public int $id = 1;
+
+    public ?BackedEnumIntegerResource $intEnum = null;
+
+    /** @var BackedEnumStringResource[] */
+    public array $stringEnum = [];
+
+    public ?GenderTypeEnum $gender = null;
+
+    /** @var GenderTypeEnum[] */
+    public array $genders = [];
+
+    public static function providerItem(Operation $operation, array $uriVariables): self
+    {
+        $self = new self();
+        $self->intEnum = BackedEnumIntegerResource::Yes;
+        $self->stringEnum = [BackedEnumStringResource::Maybe, BackedEnumStringResource::No];
+        $self->gender = GenderTypeEnum::FEMALE;
+        $self->genders = [GenderTypeEnum::FEMALE, GenderTypeEnum::MALE];
+
+        return $self;
+    }
+
+    public static function providerCollection(Operation $operation, array $uriVariables): array
+    {
+        return [self::providerItem($operation, $uriVariables)];
+    }
+}

--- a/tests/Functional/BackedEnumResourceTest.php
+++ b/tests/Functional/BackedEnumResourceTest.php
@@ -471,75 +471,81 @@ final class BackedEnumResourceTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-//     public static function providerEnumItemsGraphQl(): iterable
-//     {
-//         // Integer cases
-//         $query = <<<'GRAPHQL'
-// query GetAvailability($identifier: ID!) {
-//     availability(id: $identifier) {
-//         value
-//     }
-// }
-// GRAPHQL;
-//         foreach (Availability::cases() as $case) {
-//             yield [$query, ['identifier' => '/availabilities/'.$case->value], ['data' => ['availability' => ['value' => $case->value]]]];
-//         }
-//
-//         // String cases
-//         $query = <<<'GRAPHQL'
-// query GetAvailabilityStatus($identifier: ID!) {
-//     availabilityStatus(id: $identifier) {
-//         value
-//     }
-// }
-// GRAPHQL;
-//         foreach (AvailabilityStatus::cases() as $case) {
-//             yield [$query, ['identifier' => '/availability_statuses/'.$case->value], ['data' => ['availability_status' => ['value' => $case->value]]]];
-//         }
-//     }
-//
-//     /**
-//      * @dataProvider providerEnumItemsGraphQl
-//      *
-//      * @group legacy
-//      */
-//     public function testItemGraphql(string $query, array $variables, array $expected): void
-//     {
-//         $options = (new HttpOptions())
-//             ->setJson(['query' => $query, 'variables' => $variables])
-//             ->setHeaders(['Content-Type' => 'application/json']);
-//         self::createClient()->request('POST', '/graphql', $options->toArray());
-//
-//         $this->assertResponseIsSuccessful();
-//         $this->assertJsonEquals($expected);
-//     }
-//
-//     public function testCollectionGraphQl(): void
-//     {
-//         $query = <<<'GRAPHQL'
-// query {
-//   backedEnumIntegerResources {
-//     value
-//   }
-// }
-// GRAPHQL;
-//         $options = (new HttpOptions())
-//             ->setJson(['query' => $query, 'variables' => []])
-//             ->setHeaders(['Content-Type' => 'application/json']);
-//         self::createClient()->request('POST', '/graphql', $options->toArray());
-//
-//         $this->assertResponseIsSuccessful();
-//         $this->assertJsonEquals([
-//             'data' => [
-//                 'backedEnumIntegerResources' => [
-//                     ['value' => 1],
-//                     ['value' => 2],
-//                     ['value' => 3],
-//                 ],
-//             ],
-//         ]);
-//     }
+    public static function providerEnumItemsGraphQl(): iterable
+    {
+        // Integer cases
+        $query = <<<'GRAPHQL'
+query GetAvailability($identifier: ID!) {
+    availability(id: $identifier) {
+        value
+    }
+}
+GRAPHQL;
+        foreach (Availability::cases() as $case) {
+            yield [$query, ['identifier' => '/availabilities/'.$case->value], ['data' => ['availability' => ['value' => $case->value]]]];
+        }
 
+        // String cases
+        $query = <<<'GRAPHQL'
+query GetAvailabilityStatus($identifier: ID!) {
+    availabilityStatus(id: $identifier) {
+        value
+    }
+}
+GRAPHQL;
+        foreach (AvailabilityStatus::cases() as $case) {
+            yield [$query, ['identifier' => '/availability_statuses/'.$case->value], ['data' => ['availabilityStatus' => ['value' => $case->value]]]];
+        }
+    }
+
+    /**
+     * @dataProvider providerEnumItemsGraphQl
+     *
+     * @group legacy
+     */
+    public function testItemGraphql(string $query, array $variables, array $expected): void
+    {
+        $options = (new HttpOptions())
+            ->setJson(['query' => $query, 'variables' => $variables])
+            ->setHeaders(['Content-Type' => 'application/json']);
+        self::createClient()->request('POST', '/graphql', $options->toArray());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals($expected);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCollectionGraphQl(): void
+    {
+        $query = <<<'GRAPHQL'
+query {
+  backedEnumIntegerResources {
+    value
+  }
+}
+GRAPHQL;
+        $options = (new HttpOptions())
+            ->setJson(['query' => $query, 'variables' => []])
+            ->setHeaders(['Content-Type' => 'application/json']);
+        self::createClient()->request('POST', '/graphql', $options->toArray());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            'data' => [
+                'backedEnumIntegerResources' => [
+                    ['value' => 1],
+                    ['value' => 2],
+                    ['value' => 3],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @group legacy
+     */
     public function testItemGraphQlInteger(): void
     {
         $query = <<<'GRAPHQL'
@@ -559,7 +565,9 @@ GRAPHQL;
         $this->assertResponseIsSuccessful();
         $this->assertJsonEquals([
             'data' => [
-                'status' => [
+                'backedEnumIntegerResource' => [
+                    'description' => 'We say yes',
+                    'name' => 'Yes',
                     'value' => 1,
                 ],
             ],

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -269,4 +269,22 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $this->assertArrayHasKey('kingdom', $properties['attributes']['properties']);
         $this->assertArrayHasKey('phylum', $properties['attributes']['properties']);
     }
+
+    /**
+     * Test issue #6317.
+     */
+    public function testBackedEnumExamplesAreNotLost(): void
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6317\Issue6317', '--type' => 'output', '--format' => 'jsonld']);
+        $result = $this->tester->getDisplay();
+        $json = json_decode($result, associative: true);
+        $properties = $json['definitions']['Issue6317.jsonld']['properties'];
+
+        $this->assertArrayHasKey('example', $properties['id']);
+        $this->assertArrayHasKey('example', $properties['name']);
+        // jsonldContext
+        $this->assertArrayNotHasKey('example', $properties['ordinal']);
+        // openapiContext
+        $this->assertArrayNotHasKey('example', $properties['cardinal']);
+    }
 }

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -287,4 +287,49 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         // openapiContext
         $this->assertArrayNotHasKey('example', $properties['cardinal']);
     }
+
+    public function testResourceWithEnumPropertiesSchema(): void
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ResourceWithEnumProperty', '--type' => 'output', '--format' => 'jsonld']);
+        $result = $this->tester->getDisplay();
+        $json = json_decode($result, associative: true);
+        $properties = $json['definitions']['ResourceWithEnumProperty.jsonld']['properties'];
+
+        $this->assertSame(
+            [
+                'type' => ['string', 'null'],
+                'format' => 'iri-reference',
+                'example' => 'https://example.com/',
+            ],
+            $properties['intEnum']
+        );
+        $this->assertSame(
+            [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                    'format' => 'iri-reference',
+                    'example' => 'https://example.com/',
+                ],
+            ],
+            $properties['stringEnum']
+        );
+        $this->assertSame(
+            [
+                'type' => ['string', 'null'],
+                'enum' => ['male', 'female', null],
+            ],
+            $properties['gender']
+        );
+        $this->assertSame(
+            [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                    'enum' => ['male', 'female'],
+                ],
+            ],
+            $properties['genders']
+        );
+    }
 }

--- a/tests/State/Provider/BackedEnumProviderTest.php
+++ b/tests/State/Provider/BackedEnumProviderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\State\Provider;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Provider\BackedEnumProvider;
+use ApiPlatform\State\ProviderInterface;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\BackedEnumIntegerResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\BackedEnumStringResource;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class BackedEnumProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public static function provideCollection(): iterable
+    {
+        yield 'Integer case enum' => [BackedEnumIntegerResource::class, BackedEnumIntegerResource::cases()];
+        yield 'String case enum' => [BackedEnumStringResource::class, BackedEnumStringResource::cases()];
+    }
+
+    /** @dataProvider provideCollection */
+    public function testProvideCollection(string $class, array $expected): void
+    {
+        $operation = new GetCollection(class: $class);
+
+        $this->testProvide($expected, $operation);
+    }
+
+    public static function provideItem(): iterable
+    {
+        yield 'Integer case enum' => [BackedEnumIntegerResource::class, 1, BackedEnumIntegerResource::Yes];
+        yield 'String case enum' => [BackedEnumStringResource::class, 'yes', BackedEnumStringResource::Yes];
+    }
+
+    /** @dataProvider provideItem */
+    public function testProvideItem(string $class, string|int $id, \BackedEnum $expected): void
+    {
+        $operation = new Get(class: $class);
+
+        $this->testProvide($expected, $operation, ['id' => $id]);
+    }
+
+    private function testProvide($expected, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $decorated = $this->prophesize(ProviderInterface::class);
+        $decorated->provide(Argument::any())->shouldNotBeCalled();
+        $provider = new BackedEnumProvider($decorated->reveal());
+
+        $this->assertSame($expected, $provider->provide($operation, $uriVariables, $context));
+    }
+}

--- a/tests/State/Provider/BackedEnumProviderTest.php
+++ b/tests/State/Provider/BackedEnumProviderTest.php
@@ -60,7 +60,7 @@ final class BackedEnumProviderTest extends TestCase
     {
         $decorated = $this->prophesize(ProviderInterface::class);
         $decorated->provide(Argument::any())->shouldNotBeCalled();
-        $provider = new BackedEnumProvider($decorated->reveal());
+        $provider = new BackedEnumProvider();
 
         $this->assertSame($expected, $provider->provide($operation, $uriVariables, $context));
     }

--- a/tests/Symfony/Bundle/Command/OpenApiCommandTest.php
+++ b/tests/Symfony/Bundle/Command/OpenApiCommandTest.php
@@ -117,6 +117,28 @@ YAML;
         @unlink($tmpFile);
     }
 
+    /**
+     * Test issue #6317.
+     */
+    public function testBackedEnumExamplesAreNotLost(): void
+    {
+        $this->tester->run(['command' => 'api:openapi:export']);
+        $result = $this->tester->getDisplay();
+        $json = json_decode($result, true, 512, \JSON_THROW_ON_ERROR);
+
+        $assertExample = function (array $properties, string $id): void {
+            $this->assertArrayHasKey('example', $properties[$id]);          // default
+            $this->assertArrayHasKey('example', $properties['cardinal']);   // openapiContext
+            $this->assertArrayNotHasKey('example', $properties['name']);    // jsonSchemaContext
+            $this->assertArrayNotHasKey('example', $properties['ordinal']); // jsonldContext
+        };
+
+        $assertExample($json['components']['schemas']['Issue6317']['properties'], 'id');
+        $assertExample($json['components']['schemas']['Issue6317.jsonld']['properties'], 'id');
+        $assertExample($json['components']['schemas']['Issue6317.jsonapi']['properties']['data']['properties']['attributes']['properties'], '_id');
+        $assertExample($json['components']['schemas']['Issue6317.jsonhal']['properties'], 'id');
+    }
+
     private function assertYaml(string $data): void
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #6298, closes #6317
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Intended for 3.4, so now it is just for review. 

Depends on #6288 as I want to refactor `BackedEnumPlainResourceTest` test methods into those classes.

- Add a provider for `BackedEnum`s
- Identifier is `value` by default, and implementing `function getId()`, etc, works too
- Resource operations will default to only `Get` & `GetCollection` unless otherwise configured 

```php
#[ApiResource]
enum Status: int
{
    case DRAFT = 0;
    case PUBLISHED = 1;
}
```

`GET /statuses`
```json
[
  {
    "name": "DRAFT",
    "value": 0
  },
  {
    "name": "PUBLISHED",
    "value": 1
  }
]
```

`GET /statuses/1`
```json
{
  "name": "PUBLISHED",
  "value": 1
}
```
