### PR TITLE
fix(serializer): uriTemplate wrong cache usage in hal format

### DIFF
--- a/features/hal/collection_uri_template.feature
+++ b/features/hal/collection_uri_template.feature
@@ -36,9 +36,23 @@ Feature: Exposing a property being a collection of resources
               "_links": {
                 "self": {
                   "href": "/property_collection_iri_only_relations/1"
+                },
+                "children": {
+                  "href": "/property_collection_iri_only_relations/1/children"
                 }
               },
-              "name": "asb"
+              "name": "asb1"
+            },
+            {
+              "_links": {
+                "self": {
+                    "href": "/property_collection_iri_only_relations/2"
+                },
+                "children": {
+                  "href": "/property_collection_iri_only_relations/2/children"
+                }
+              },
+              "name": "asb2"
             }
           ],
           "iterableIri": [
@@ -46,6 +60,9 @@ Feature: Exposing a property being a collection of resources
               "_links": {
                 "self": {
                   "href": "/property_collection_iri_only_relations/9999"
+                },
+                "children": {
+                  "href": "/property_collection_iri_only_relations/9999/children"
                 }
               },
               "name": "Michel"

--- a/features/jsonapi/collection_uri_template.feature
+++ b/features/jsonapi/collection_uri_template.feature
@@ -33,6 +33,10 @@ Feature: Exposing a property being a collection of resources
                 {
                   "type": "PropertyCollectionIriOnlyRelation",
                   "id": "/property_collection_iri_only_relations/1"
+                },
+                {
+                  "type": "PropertyCollectionIriOnlyRelation",
+                  "id": "/property_collection_iri_only_relations/2"
                 }
               ]
             },

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -184,6 +184,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
                     $relation['iri'] = $this->iriConverter->getIriFromResource($object, UrlGeneratorInterface::ABS_PATH, $operation, $childContext);
                     $relation['operation'] = $operation;
+                    $cacheKey = null;
                 }
 
                 if ($propertyMetadata->isReadableLink()) {
@@ -200,7 +201,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             }
         }
 
-        if (false !== $context['cache_key']) {
+        if ($cacheKey && false !== $context['cache_key']) {
             $this->componentsCache[$cacheKey] = $components;
         }
 

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -1993,18 +1993,23 @@ final class DoctrineContext implements Context
      */
     public function thereAreResourcesWithPropertyUriTemplates(): void
     {
-        $propertyCollectionIriOnlyRelation = $this->isOrm() ? new PropertyCollectionIriOnlyRelation() : new PropertyCollectionIriOnlyRelationDocument();
-        $propertyCollectionIriOnlyRelation->name = 'asb';
+        $propertyCollectionIriOnlyRelation1 = $this->isOrm() ? new PropertyCollectionIriOnlyRelation() : new PropertyCollectionIriOnlyRelationDocument();
+        $propertyCollectionIriOnlyRelation1->name = 'asb1';
+
+        $propertyCollectionIriOnlyRelation2 = $this->isOrm() ? new PropertyCollectionIriOnlyRelation() : new PropertyCollectionIriOnlyRelationDocument();
+        $propertyCollectionIriOnlyRelation2->name = 'asb2';
 
         $propertyToOneRelation = $this->isOrm() ? new PropertyUriTemplateOneToOneRelation() : new PropertyUriTemplateOneToOneRelationDocument();
         $propertyToOneRelation->name = 'xarguš';
 
         $propertyCollectionIriOnly = $this->isOrm() ? new PropertyCollectionIriOnly() : new PropertyCollectionIriOnlyDocument();
-        $propertyCollectionIriOnly->addPropertyCollectionIriOnlyRelation($propertyCollectionIriOnlyRelation);
+        $propertyCollectionIriOnly->addPropertyCollectionIriOnlyRelation($propertyCollectionIriOnlyRelation1);
+        $propertyCollectionIriOnly->addPropertyCollectionIriOnlyRelation($propertyCollectionIriOnlyRelation2);
         $propertyCollectionIriOnly->setToOneRelation($propertyToOneRelation);
 
         $this->manager->persist($propertyCollectionIriOnly);
-        $this->manager->persist($propertyCollectionIriOnlyRelation);
+        $this->manager->persist($propertyCollectionIriOnlyRelation1);
+        $this->manager->persist($propertyCollectionIriOnlyRelation2);
         $this->manager->persist($propertyToOneRelation);
         $this->manager->flush();
     }

--- a/tests/Fixtures/TestBundle/Document/PropertyCollectionIriOnlyRelation.php
+++ b/tests/Fixtures/TestBundle/Document/PropertyCollectionIriOnlyRelation.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Post;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -42,6 +45,16 @@ class PropertyCollectionIriOnlyRelation
     #[ODM\ReferenceOne(targetDocument: PropertyCollectionIriOnly::class)]
     private ?PropertyCollectionIriOnly $propertyCollectionIriOnly = null;
 
+    #[ODM\ReferenceMany(targetDocument: PropertyCollectionIriOnlyRelationSecondLevel::class)]
+    #[ApiProperty(uriTemplate: '/property_collection_iri_only_relations/{parentId}/children')]
+    #[Groups('read')]
+    private Collection $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
     public function getId(): ?int
     {
         return $this->id ?? 9999;
@@ -55,5 +68,35 @@ class PropertyCollectionIriOnlyRelation
     public function setPropertyCollectionIriOnly(?PropertyCollectionIriOnly $propertyCollectionIriOnly): void
     {
         $this->propertyCollectionIriOnly = $propertyCollectionIriOnly;
+    }
+
+    /**
+     * @return Collection<int, PropertyCollectionIriOnlyRelationSecondLevel>
+     */
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+
+    public function addChild(PropertyCollectionIriOnlyRelationSecondLevel $child): self
+    {
+        if (!$this->children->contains($child)) {
+            $this->children->add($child);
+            $child->setParent($this);
+        }
+
+        return $this;
+    }
+
+    public function removeChild(PropertyCollectionIriOnlyRelationSecondLevel $child): self
+    {
+        if ($this->children->removeElement($child)) {
+            // set the owning side to null (unless already changed)
+            if ($child->getParent() === $this) {
+                $child->setParent(null);
+            }
+        }
+
+        return $this;
     }
 }

--- a/tests/Fixtures/TestBundle/Document/PropertyCollectionIriOnlyRelationSecondLevel.php
+++ b/tests/Fixtures/TestBundle/Document/PropertyCollectionIriOnlyRelationSecondLevel.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[
+    Post,
+    GetCollection(uriTemplate: '/property-collection-relation-second-levels'),
+    GetCollection(
+        uriTemplate: '/property_collection_iri_only_relations/{parentId}/children',
+        uriVariables: [
+            'parentId' => new Link(toProperty: 'parent', fromClass: PropertyCollectionIriOnlyRelation::class),
+        ]
+    )
+]
+#[ODM\Document]
+class PropertyCollectionIriOnlyRelationSecondLevel
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\ReferenceOne(targetDocument: PropertyCollectionIriOnlyRelation::class)]
+    private ?PropertyCollectionIriOnlyRelation $parent = null;
+
+    public function getId(): ?int
+    {
+        return $this->id ?? 9999;
+    }
+
+    public function getParent(): ?PropertyCollectionIriOnlyRelation
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?PropertyCollectionIriOnlyRelation $parent): void
+    {
+        $this->parent = $parent;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/PropertyCollectionIriOnlyRelation.php
+++ b/tests/Fixtures/TestBundle/Entity/PropertyCollectionIriOnlyRelation.php
@@ -13,16 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Serializer\Annotation\Groups;
-use ORM\OneToMany;
-use Doctrine\ORM\Mapping as ORM;
-use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\ArrayCollection;
-use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Link;
-use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 #[
     Post,

--- a/tests/Fixtures/TestBundle/Entity/PropertyCollectionIriOnlyRelation.php
+++ b/tests/Fixtures/TestBundle/Entity/PropertyCollectionIriOnlyRelation.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Metadata\GetCollection;
-use ApiPlatform\Metadata\Link;
-use ApiPlatform\Metadata\Post;
-use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Serializer\Annotation\Groups;
+use ORM\OneToMany;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\ApiProperty;
 
 #[
     Post,
@@ -49,6 +53,16 @@ class PropertyCollectionIriOnlyRelation
     #[ORM\ManyToOne(inversedBy: 'propertyCollectionIriOnlyRelation')]
     private ?PropertyCollectionIriOnly $propertyCollectionIriOnly = null;
 
+    #[ORM\OneToMany(mappedBy: 'parent', targetEntity: PropertyCollectionIriOnlyRelationSecondLevel::class)]
+    #[ApiProperty(uriTemplate: '/property_collection_iri_only_relations/{parentId}/children')]
+    #[Groups('read')]
+    private Collection $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
     public function getId(): ?int
     {
         return $this->id ?? 9999;
@@ -62,5 +76,35 @@ class PropertyCollectionIriOnlyRelation
     public function setPropertyCollectionIriOnly(?PropertyCollectionIriOnly $propertyCollectionIriOnly): void
     {
         $this->propertyCollectionIriOnly = $propertyCollectionIriOnly;
+    }
+
+    /**
+     * @return Collection<int, PropertyCollectionIriOnlyRelationSecondLevel>
+     */
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+
+    public function addChild(PropertyCollectionIriOnlyRelationSecondLevel $child): self
+    {
+        if (!$this->children->contains($child)) {
+            $this->children->add($child);
+            $child->setParent($this);
+        }
+
+        return $this;
+    }
+
+    public function removeChild(PropertyCollectionIriOnlyRelationSecondLevel $child): self
+    {
+        if ($this->children->removeElement($child)) {
+            // set the owning side to null (unless already changed)
+            if ($child->getParent() === $this) {
+                $child->setParent(null);
+            }
+        }
+
+        return $this;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/PropertyCollectionIriOnlyRelationSecondLevel.php
+++ b/tests/Fixtures/TestBundle/Entity/PropertyCollectionIriOnlyRelationSecondLevel.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use Doctrine\ORM\Mapping as ORM;
+
+#[
+    Post,
+    GetCollection(uriTemplate: '/property-collection-relation-second-levels'),
+    GetCollection(
+        uriTemplate: '/property_collection_iri_only_relations/{parentId}/children',
+        uriVariables: [
+            'parentId' => new Link(toProperty: 'parent', fromClass: PropertyCollectionIriOnlyRelation::class),
+        ]
+    )
+]
+#[ORM\Entity]
+class PropertyCollectionIriOnlyRelationSecondLevel
+{
+    /**
+     * The entity ID.
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'children')]
+    private ?PropertyCollectionIriOnlyRelation $parent = null;
+
+    public function getId(): ?int
+    {
+        return $this->id ?? 9999;
+    }
+
+    public function getParent(): ?PropertyCollectionIriOnlyRelation
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?PropertyCollectionIriOnlyRelation $parent): void
+    {
+        $this->parent = $parent;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR fixes a bug introduced with https://github.com/api-platform/core/pull/5675.

For embedded subresources using the new uriTemplate property, components cache is wrongly populated and used for different entities, hence ending in wrong IRIs used in the response.


### Response of features/hal/collection_uri_template.feature before fixing
Note that the IRI-link of the children subresource in the 2nd relation "asb2" is wrongly `"/property_collection_iri_only_relations/1/children"` instead of `"/property_collection_iri_only_relations/2/children"`.

```json
      {
        "_links": {
          "self": {
            "href": "/property_collection_iri_onlies/1"
          },
          "propertyCollectionIriOnlyRelation": {
            "href": "/property-collection-relations"
          },
          "iterableIri": {
            "href": "/parent/1/another-collection-operations"
          },
          "toOneRelation": {
            "href": "/parent/1/property-uri-template/one-to-ones/1"
          }
        },
        "_embedded": {
          "propertyCollectionIriOnlyRelation": [
            {
              "_links": {
                "self": {
                  "href": "/property_collection_iri_only_relations/1"
                },
                "children": {
                  "href": "/property_collection_iri_only_relations/1/children"
                }
              },
              "name": "asb1"
            },
            {
              "_links": {
                "self": {
                    "href": "/property_collection_iri_only_relations/2"
                },
                "children": {
                  "href": "/property_collection_iri_only_relations/1/children"
                }
              },
              "name": "asb2"
            }
          ],
          "iterableIri": [
            {
              "_links": {
                "self": {
                  "href": "/property_collection_iri_only_relations/9999"
                },
                "children": {
                  "href": "/property_collection_iri_only_relations/9999/children"
                }
              },
              "name": "Michel"
            }
          ],
          "toOneRelation": {
            "_links": {
              "self": {
                "href": "/parent/1/property-uri-template/one-to-ones/1"
              }
            },
            "name": "xarguš"
          }
        }
      }
```

### Response of features/hal/collection_uri_template.feature after fixing
```json
      {
        "_links": {
          "self": {
            "href": "/property_collection_iri_onlies/1"
          },
          "propertyCollectionIriOnlyRelation": {
            "href": "/property-collection-relations"
          },
          "iterableIri": {
            "href": "/parent/1/another-collection-operations"
          },
          "toOneRelation": {
            "href": "/parent/1/property-uri-template/one-to-ones/1"
          }
        },
        "_embedded": {
          "propertyCollectionIriOnlyRelation": [
            {
              "_links": {
                "self": {
                  "href": "/property_collection_iri_only_relations/1"
                },
                "children": {
                  "href": "/property_collection_iri_only_relations/1/children"
                }
              },
              "name": "asb1"
            },
            {
              "_links": {
                "self": {
                    "href": "/property_collection_iri_only_relations/2"
                },
                "children": {
                  "href": "/property_collection_iri_only_relations/2/children"
                }
              },
              "name": "asb2"
            }
          ],
          "iterableIri": [
            {
              "_links": {
                "self": {
                  "href": "/property_collection_iri_only_relations/9999"
                },
                "children": {
                  "href": "/property_collection_iri_only_relations/9999/children"
                }
              },
              "name": "Michel"
            }
          ],
          "toOneRelation": {
            "_links": {
              "self": {
                "href": "/parent/1/property-uri-template/one-to-ones/1"
              }
            },
            "name": "xarguš"
          }
        }
      }
```
