### PR TITLE
fix(graphql): check inheritance in ResolverProvider

### DIFF
--- a/src/GraphQl/State/Provider/ResolverProvider.php
+++ b/src/GraphQl/State/Provider/ResolverProvider.php
@@ -69,7 +69,7 @@ final class ResolverProvider implements ProviderInterface
             return $itemClass;
         }
 
-        if ($resourceClass !== $itemClass) {
+        if ($resourceClass !== $itemClass && !$item instanceof $resourceClass) {
             throw new \UnexpectedValueException(sprintf($errorMessage, (new \ReflectionClass($resourceClass))->getShortName(), (new \ReflectionClass($itemClass))->getShortName()));
         }
 

--- a/src/GraphQl/Tests/State/Provider/ResolverProviderTest.php
+++ b/src/GraphQl/Tests/State/Provider/ResolverProviderTest.php
@@ -15,6 +15,9 @@ namespace ApiPlatform\GraphQl\Tests\State\Provider;
 
 use ApiPlatform\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\GraphQl\State\Provider\ResolverProvider;
+use ApiPlatform\GraphQl\Tests\Fixtures\ApiResource\ChildFoo;
+use ApiPlatform\GraphQl\Tests\Fixtures\ApiResource\ParentFoo;
+use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\State\ProviderInterface;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +29,20 @@ class ResolverProviderTest extends TestCase
     {
         $res = new \stdClass();
         $operation = new QueryCollection(class: 'dummy', resolver: 'foo');
+        $context = [];
+        $decorated = $this->createMock(ProviderInterface::class);
+        $resolverMock = $this->createMock(QueryItemResolverInterface::class);
+        $resolverMock->expects($this->once())->method('__invoke')->willReturn($res);
+        $resolverLocator = $this->createMock(ContainerInterface::class);
+        $resolverLocator->expects($this->once())->method('get')->with('foo')->willReturn($resolverMock);
+        $provider = new ResolverProvider($decorated, $resolverLocator);
+        $this->assertEquals($res, $provider->provide($operation, [], $context));
+    }
+
+    public function testProvideInheritedClass(): void
+    {
+        $res = new ChildFoo();
+        $operation = new Query(class: ParentFoo::class, resolver: 'foo');
         $context = [];
         $decorated = $this->createMock(ProviderInterface::class);
         $resolverMock = $this->createMock(QueryItemResolverInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 3.2
| Tickets       | -
| License       | MIT
| Doc PR        | -

With the new `ResolverProvider` some cases with inheritance are broken in our project. It was not a big deal to find out that `ItemResolverFactory` also checked if the resolver provided a subclass of the `resourceClass`. So I added this also to the `ResolverProvider` and everything works like a charm. I am not sure if it should also be extended in `ReadProvider` - there is similar code, but I had no problem with that. Thx for your advice.
