### PR TITLE
fix(jsonapi): add support for pagination array parameter name

### DIFF
--- a/src/JsonApi/State/JsonApiProvider.php
+++ b/src/JsonApi/State/JsonApiProvider.php
@@ -60,7 +60,7 @@ final class JsonApiProvider implements ProviderInterface
             $filterParameter
             && \is_array($filterParameter)
         ) {
-            $filters = array_merge($filterParameter, $filters);
+            $filters = array_merge(['page' => $filterParameter], $filterParameter, $filters);
         }
 
         $pageParameter = $queryParameters['page'] ?? null;

--- a/src/JsonApi/State/JsonApiProvider.php
+++ b/src/JsonApi/State/JsonApiProvider.php
@@ -60,14 +60,15 @@ final class JsonApiProvider implements ProviderInterface
             $filterParameter
             && \is_array($filterParameter)
         ) {
-            $filters = array_merge(['page' => $filterParameter], $filterParameter, $filters);
+            $filters = array_merge($filterParameter, $filters);
         }
 
         $pageParameter = $queryParameters['page'] ?? null;
         if (
             \is_array($pageParameter)
         ) {
-            $filters = array_merge($pageParameter, $filters);
+            // To not break existing integration, put page array in _page
+            $filters = array_merge(['_page' => $pageParameter], $pageParameter, $filters);
         }
 
         [$included, $properties] = $this->transformFieldsetsParameters($queryParameters, $operation->getShortName() ?? '');

--- a/src/State/Pagination/Pagination.php
+++ b/src/State/Pagination/Pagination.php
@@ -222,16 +222,16 @@ final class Pagination
     /**
      * Extract pagination parameter
      * page[page] => $contextFilters['page'] with default configuration page_parameter_name: page
-     * page[number] => $contextFilters['_page'][number] with configuration page_parameter_name: page[number]
+     * page[number] => $contextFilters['_page'][number] with configuration page_parameter_name: page[number].
      */
     private function extractParameter(array $contextFilters, string $parameterName)
     {
         preg_match_all("/[\w-]+/", $parameterName, $matches);
         foreach ($matches[0] as $i => $key) {
-            if ($i === 0 && $key === 'page' && count($matches[0]) > 1) {
+            if (0 === $i && 'page' === $key && \count($matches[0]) > 1) {
                 $key = '_page';
             }
-            if (\is_array($contextFilters) === false) {
+            if (false === \is_array($contextFilters)) {
                 return $contextFilters;
             }
             if (!\array_key_exists($key, $contextFilters)) {

--- a/src/State/Pagination/Pagination.php
+++ b/src/State/Pagination/Pagination.php
@@ -224,7 +224,7 @@ final class Pagination
      * page[page] => $contextFilters['page'] with default configuration page_parameter_name: page
      * page[number] => $contextFilters['_page'][number] with configuration page_parameter_name: page[number].
      */
-    private function extractParameter(array $contextFilters, string $parameterName)
+    private function extractParameter(array $contextFilters, string $parameterName): mixed
     {
         preg_match_all("/[\w-]+/", $parameterName, $matches);
         foreach ($matches[0] as $i => $key) {
@@ -246,7 +246,7 @@ final class Pagination
     /**
      * Gets the given pagination parameter name from the given context.
      */
-    private function getParameterFromContext(array $context, string $parameterName, mixed $default = null)
+    private function getParameterFromContext(array $context, string $parameterName, mixed $default = null): mixed
     {
         $filters = $context['filters'] ?? [];
         $filterValue = $this->extractParameter($filters, $parameterName);

--- a/src/State/Pagination/Pagination.php
+++ b/src/State/Pagination/Pagination.php
@@ -219,13 +219,28 @@ final class Pagination
         return $operation?->getPaginationEnabled() ?? $enabled;
     }
 
+    private function extractParameter(array $contextFilters, string $parameterName)
+    {
+        \preg_match_all("/[\w-]+/", $parameterName, $matches);
+
+        foreach($matches[0] as $key){
+            if (!\array_key_exists($key, $contextFilters)) {
+                return null;
+            }
+            $contextFilters = $contextFilters[$key];
+        }
+
+        return $contextFilters;
+    }
+
     /**
      * Gets the given pagination parameter name from the given context.
      */
     private function getParameterFromContext(array $context, string $parameterName, mixed $default = null)
     {
         $filters = $context['filters'] ?? [];
+        $filterValue = $this->extractParameter($filters, $parameterName);
 
-        return \array_key_exists($parameterName, $filters) ? $filters[$parameterName] : $default;
+        return $filterValue ?? $default;
     }
 }

--- a/src/State/Pagination/Pagination.php
+++ b/src/State/Pagination/Pagination.php
@@ -219,11 +219,21 @@ final class Pagination
         return $operation?->getPaginationEnabled() ?? $enabled;
     }
 
+    /**
+     * Extract pagination parameter
+     * page[page] => $contextFilters['page'] with default configuration page_parameter_name: page
+     * page[number] => $contextFilters['_page'][number] with configuration page_parameter_name: page[number]
+     */
     private function extractParameter(array $contextFilters, string $parameterName)
     {
-        \preg_match_all("/[\w-]+/", $parameterName, $matches);
-
-        foreach($matches[0] as $key){
+        preg_match_all("/[\w-]+/", $parameterName, $matches);
+        foreach ($matches[0] as $i => $key) {
+            if ($i === 0 && $key === 'page' && count($matches[0]) > 1) {
+                $key = '_page';
+            }
+            if (\is_array($contextFilters) === false) {
+                return $contextFilters;
+            }
             if (!\array_key_exists($key, $contextFilters)) {
                 return null;
             }

--- a/src/State/Tests/PaginationTest.php
+++ b/src/State/Tests/PaginationTest.php
@@ -19,6 +19,7 @@ class PaginationTest extends TestCase
         $this->assertSame(0, $paginationInfo[1]);
         $this->assertSame(30, $paginationInfo[2]);
     }
+
     public function testPaginationGetPaginationWithPageParameterNameAsArrayAndDefaultContext(): void
     {
         $operation = new GetCollection(name: 'hello', provider: 'provider');
@@ -28,6 +29,7 @@ class PaginationTest extends TestCase
         $this->assertSame(0, $paginationInfo[1]);
         $this->assertSame(30, $paginationInfo[2]);
     }
+
     public function testPaginationGetPaginationWithPageParametersAsArrayAndCustomContext(): void
     {
         $operation = new GetCollection(paginationClientItemsPerPage: true, name: 'hello', provider: 'provider');

--- a/src/State/Tests/PaginationTest.php
+++ b/src/State/Tests/PaginationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Tests;
+
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\State\Pagination\Pagination;
+use PHPUnit\Framework\TestCase;
+
+class PaginationTest extends TestCase
+{
+    public function testPaginationGetPaginationWithDefaultOptionsAndDefaultContext(): void
+    {
+        $operation = new GetCollection(name: 'hello', provider: 'provider');
+        $pagination = new Pagination();
+        $paginationInfo = $pagination->getPagination($operation);
+        $this->assertSame(1, $paginationInfo[0]);
+        $this->assertSame(0, $paginationInfo[1]);
+        $this->assertSame(30, $paginationInfo[2]);
+    }
+    public function testPaginationGetPaginationWithPageParameterNameAsArrayAndDefaultContext(): void
+    {
+        $operation = new GetCollection(name: 'hello', provider: 'provider');
+        $pagination = new Pagination(['page_parameter_name' => 'page[number]']);
+        $paginationInfo = $pagination->getPagination($operation);
+        $this->assertSame(1, $paginationInfo[0]);
+        $this->assertSame(0, $paginationInfo[1]);
+        $this->assertSame(30, $paginationInfo[2]);
+    }
+    public function testPaginationGetPaginationWithPageParametersAsArrayAndCustomContext(): void
+    {
+        $operation = new GetCollection(paginationClientItemsPerPage: true, name: 'hello', provider: 'provider');
+        $pagination = new Pagination([
+            'page_parameter_name' => 'page[number]',
+            'items_per_page_parameter_name' => 'page[size]',
+        ]);
+        $paginationInfo = $pagination->getPagination(
+            $operation,
+            [
+                'filters' => [
+                    'number' => 2,
+                    'size' => 10,
+                    '_page' => [
+                        'number' => 2,
+                        'size' => 10,
+                    ],
+                ],
+            ],
+        );
+        $this->assertSame(2, $paginationInfo[0]);
+        $this->assertSame(10, $paginationInfo[1]);
+        $this->assertSame(10, $paginationInfo[2]);
+    }
+}

--- a/src/State/Tests/PaginationTest.php
+++ b/src/State/Tests/PaginationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace ApiPlatform\State\Tests;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | 
| License       | MIT
| Doc PR        | 

This bugfix is related to the jsonapi spec & the handling of pagination parameters in the pagination service.
Following the JSON:API specification around pagination => https://jsonapi.org/format/#fetching-pagination
When i setup api_platform.yaml with
```
api_platform:
    collection:
        pagination:
            page_parameter_name: page[number]
            items_per_page_parameter_name: page[size]
```
And use ApiPlatform\State\Pagination\Pagination in a custom provider, we can't retrieve the `page[number]` & `page[size]` in `$context['filters']`.

Thanks to @GregoireHebert for the help.

In addition this fix that let us specify array in pagination parameter names will fix the generated documentation.