### PR TITLE
fix(symfony)!: context stamp not serializable because of request object

### DIFF
--- a/src/Symfony/Messenger/ContextStamp.php
+++ b/src/Symfony/Messenger/ContextStamp.php
@@ -27,7 +27,8 @@ final class ContextStamp implements StampInterface
 
     public function __construct(array $context = [])
     {
-        if (($request = ($context['request'] ?? null)) && $request instanceof Request && $request->hasSession()) {
+        /* Symfony does not guarantee that the Request object is serializable */
+        if (($request = ($context['request'] ?? null)) && $request instanceof Request) {
             unset($context['request']);
         }
 

--- a/tests/Symfony/Messenger/ContextStampTest.php
+++ b/tests/Symfony/Messenger/ContextStampTest.php
@@ -34,15 +34,11 @@ class ContextStampTest extends TestCase
         $this->assertIsArray($contextStamp->getContext());
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testSerializable(): void
+    public function testRequestIsUnset(): void
     {
         $request = new Request();
-        $request->setSessionFactory(function (): void {}); // @phpstan-ignore-line
-
         $stamp = new ContextStamp(['request' => $request]);
-        serialize($stamp);
+
+        self::assertArrayNotHasKey('request', $stamp->getContext());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes https://github.com/api-platform/api-platform/issues/2611
| License       | MIT

Following https://github.com/api-platform/core/pull/6302, here is the PR to completely remove request object from `$context` in the `ContextStamp`. Symfony does not guarantee that the Request object is serializable.

As specified in the commit description, this is a breaking change.


