### PR TITLE
fix(metadata): allow extracting routeName from XML config

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -404,6 +404,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
                 'queryParameterValidate' => $this->phpize($operation, 'queryParameterValidate', 'bool'),
                 'priority' => $this->phpize($operation, 'priority', 'integer'),
                 'name' => $this->phpize($operation, 'name', 'string'),
+                'routeName' => $this->phpize($operation, 'routeName', 'string'),
             ]);
         }
 

--- a/src/Metadata/Extractor/schema/resources.xsd
+++ b/src/Metadata/Extractor/schema/resources.xsd
@@ -48,6 +48,7 @@
         <xsd:attribute type="xsd:positiveInteger" name="priority"/>
         <xsd:attribute type="xsd:string" name="name"/>
         <xsd:attribute type="xsd:string" name="itemUriTemplate"/>
+        <xsd:attribute type="xsd:string" name="routeName"/>
     </xsd:complexType>
 
     <xsd:complexType name="graphQlOperations">

--- a/src/Metadata/Tests/Extractor/XmlExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/XmlExtractorTest.php
@@ -273,6 +273,7 @@ class XmlExtractorTest extends TestCase
                             'itemUriTemplate' => null,
                             'stateOptions' => null,
                             'links' => null,
+                            'routeName' => 'custom_route_name',
                         ],
                         [
                             'name' => null,
@@ -373,6 +374,7 @@ class XmlExtractorTest extends TestCase
                             'provider' => null,
                             'stateOptions' => null,
                             'links' => null,
+                            'routeName' => null,
                         ],
                     ],
                     'graphQlOperations' => null,

--- a/src/Metadata/Tests/Extractor/xml/valid.xml
+++ b/src/Metadata/Tests/Extractor/xml/valid.xml
@@ -95,7 +95,7 @@
         </exceptionToStatus>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" name="custom_operation_name"/>
+            <operation class="ApiPlatform\Metadata\GetCollection" name="custom_operation_name" routeName="custom_route_name"/>
             <operation class="ApiPlatform\Metadata\Get" uriTemplate="/users/{userId}/comments/{id}{._format}">
                 <uriVariables>
                     <uriVariable parameterName="userId" fromClass="ApiPlatform\Metadata\Tests\Fixtures\ApiResource\User" fromProperty="author"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | Closes #6031 
| License       | MIT
| Doc PR        |


Allow using `routeName` Operation property when configuring resources with XML