### PR TITLE
feat(jsonschema): make JSON-LD specific properties required

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -153,7 +153,7 @@ Feature: Documentation support
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 6 elements
 
     # Subcollection - check schema
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany.output"
 
     # Deprecations
     And the JSON node "paths./dummies.get.deprecated" should be false
@@ -165,8 +165,8 @@ Feature: Documentation support
     And the JSON node "paths./deprecated_resources/{id}.patch.deprecated" should be true
 
     # Formats
-    And the OpenAPI class "Dummy.jsonld" exists
-    And the "@id" property exists for the OpenAPI class "Dummy.jsonld"
+    And the OpenAPI class "Dummy.jsonld.output" exists
+    And the "@id" property exists for the OpenAPI class "Dummy.jsonld.output"
     And the JSON node "paths./dummies.get.responses.200.content.application/ld+json" should be equal to:
     """
     {
@@ -176,7 +176,7 @@ Feature: Documentation support
                 "hydra:member": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/components/schemas/Dummy.jsonld"
+                        "$ref": "#/components/schemas/Dummy.jsonld.output"
                     }
                 },
                 "hydra:totalItems": {

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -95,11 +95,17 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         $definitions = $schema->getDefinitions();
         if ($key = $schema->getRootDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);
+            foreach (array_keys(self::BASE_ROOT_PROPS) as $property) {
+                $definitions[$key]['required'] = array_unique([...($definitions[$key]['required'] ?? []), $property]);
+            }
 
             return $schema;
         }
         if ($key = $schema->getItemsDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
+            foreach (array_keys(self::BASE_PROPS) as $property) {
+                $definitions[$key]['required'] = array_unique([...($definitions[$key]['required'] ?? []), $property]);
+            }
         }
 
         if (($schema['type'] ?? '') === 'array') {

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -27,7 +27,6 @@ use ApiPlatform\Metadata\Operation;
 final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     private const BASE_PROP = [
-        'readOnly' => true,
         'type' => 'string',
     ];
     private const BASE_PROPS = [
@@ -36,7 +35,6 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
     ];
     private const BASE_ROOT_PROPS = [
         '@context' => [
-            'readOnly' => true,
             'oneOf' => [
                 ['type' => 'string'],
                 [
@@ -87,17 +85,15 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             }
         }
 
-        if ('input' === $type) {
-            return $schema;
-        }
-
         $definitions = $schema->getDefinitions();
         if ($key = $schema->getRootDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);
-            foreach (array_keys(self::BASE_ROOT_PROPS) as $property) {
-                $definitions[$key]['required'] ??= [];
-                if (!\in_array($property, $definitions[$key]['required'], true)) {
-                    $definitions[$key]['required'][] = $property;
+            if (Schema::TYPE_OUTPUT === $type) {
+                foreach (array_keys(self::BASE_ROOT_PROPS) as $property) {
+                    $definitions[$key]['required'] ??= [];
+                    if (!\in_array($property, $definitions[$key]['required'], true)) {
+                        $definitions[$key]['required'][] = $property;
+                    }
                 }
             }
 
@@ -105,10 +101,12 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         }
         if ($key = $schema->getItemsDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
-            foreach (array_keys(self::BASE_PROPS) as $property) {
-                $definitions[$key]['required'] ??= [];
-                if (!\in_array($property, $definitions[$key]['required'], true)) {
-                    $definitions[$key]['required'][] = $property;
+            if (Schema::TYPE_OUTPUT === $type) {
+                foreach (array_keys(self::BASE_PROPS) as $property) {
+                    $definitions[$key]['required'] ??= [];
+                    if (!\in_array($property, $definitions[$key]['required'], true)) {
+                        $definitions[$key]['required'][] = $property;
+                    }
                 }
             }
         }

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -95,7 +95,10 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         if ($key = $schema->getRootDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);
             foreach (array_keys(self::BASE_ROOT_PROPS) as $property) {
-                $definitions[$key]['required'] = array_unique([...($definitions[$key]['required'] ?? []), $property]);
+                $definitions[$key]['required'] ??= [];
+                if (!\in_array($property, $definitions[$key]['required'], true)) {
+                    $definitions[$key]['required'][] = $property;
+                }
             }
 
             return $schema;
@@ -103,7 +106,10 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         if ($key = $schema->getItemsDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
             foreach (array_keys(self::BASE_PROPS) as $property) {
-                $definitions[$key]['required'] = array_unique([...($definitions[$key]['required'] ?? []), $property]);
+                $definitions[$key]['required'] ??= [];
+                if (!\in_array($property, $definitions[$key]['required'], true)) {
+                    $definitions[$key]['required'][] = $property;
+                }
             }
         }
 

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -74,6 +74,20 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             return $schema;
         }
 
+        if (($key = $schema->getRootDefinitionKey() ?? $schema->getItemsDefinitionKey()) !== null) {
+            $postfix = '.'.$type;
+            $typedKey = $key.$postfix;
+            $definitions = $schema->getDefinitions();
+            $definitions[$typedKey] = $definitions[$key];
+            unset($definitions[$key]);
+
+            if (($schema['type'] ?? '') === 'array') {
+                $schema['items']['$ref'] .= $postfix;
+            } else {
+                $schema['$ref'] .= $postfix;
+            }
+        }
+
         if ('input' === $type) {
             return $schema;
         }

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -76,9 +76,8 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
 
         if (($key = $schema->getRootDefinitionKey() ?? $schema->getItemsDefinitionKey()) !== null) {
             $postfix = '.'.$type;
-            $typedKey = $key.$postfix;
             $definitions = $schema->getDefinitions();
-            $definitions[$typedKey] = $definitions[$key];
+            $definitions[$key.$postfix] = $definitions[$key];
             unset($definitions[$key]);
 
             if (($schema['type'] ?? '') === 'array') {

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -188,9 +188,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]['required']));
         $requiredProperties = $resultSchema['definitions'][$rootDefinitionKey]['required'];
         $this->assertContains('@context', $requiredProperties);
@@ -201,9 +199,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $itemsDefinitionKey = array_key_first($definitions->getArrayCopy());
 
-        // @noRector
         $this->assertTrue(isset($definitions[$itemsDefinitionKey]));
-        // @noRector
         $this->assertTrue(isset($definitions[$itemsDefinitionKey]['required']));
         $requiredProperties = $resultSchema['definitions'][$itemsDefinitionKey]['required'];
         $this->assertNotContains('@context', $requiredProperties);
@@ -214,9 +210,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $itemsDefinitionKey = array_key_first($definitions->getArrayCopy());
 
-        // @noRector
         $this->assertTrue(isset($definitions[$itemsDefinitionKey]));
-        // @noRector
         $this->assertFalse(isset($definitions[$itemsDefinitionKey]['required']));
     }
 }

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -181,4 +181,42 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('hydra:previous', $resultSchema['properties']['hydra:view']['properties']);
         $this->assertArrayHasKey('hydra:next', $resultSchema['properties']['hydra:view']['properties']);
     }
+
+    public function testRequiredBasePropertiesBuildSchema(): void
+    {
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class);
+        $definitions = $resultSchema->getDefinitions();
+        $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
+
+        // @noRector
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]));
+        // @noRector
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]['required']));
+        $requiredProperties = $resultSchema['definitions'][$rootDefinitionKey]['required'];
+        $this->assertContains('@context', $requiredProperties);
+        $this->assertContains('@id', $requiredProperties);
+        $this->assertContains('@type', $requiredProperties);
+
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection());
+        $definitions = $resultSchema->getDefinitions();
+        $itemsDefinitionKey = array_key_first($definitions->getArrayCopy());
+
+        // @noRector
+        $this->assertTrue(isset($definitions[$itemsDefinitionKey]));
+        // @noRector
+        $this->assertTrue(isset($definitions[$itemsDefinitionKey]['required']));
+        $requiredProperties = $resultSchema['definitions'][$itemsDefinitionKey]['required'];
+        $this->assertNotContains('@context', $requiredProperties);
+        $this->assertContains('@id', $requiredProperties);
+        $this->assertContains('@type', $requiredProperties);
+
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_INPUT, new Post());
+        $definitions = $resultSchema->getDefinitions();
+        $itemsDefinitionKey = array_key_first($definitions->getArrayCopy());
+
+        // @noRector
+        $this->assertTrue(isset($definitions[$itemsDefinitionKey]));
+        // @noRector
+        $this->assertFalse(isset($definitions[$itemsDefinitionKey]['required']));
+    }
 }

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -101,7 +101,6 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('@context', $properties);
         $this->assertEquals(
             [
-                'readOnly' => true,
                 'oneOf' => [
                     ['type' => 'string'],
                     [

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -76,9 +76,9 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--operation' => '_api_/dummies{._format}_post', '--format' => 'jsonld', '--type' => 'input']);
         $result = $this->tester->getDisplay();
 
-        $this->assertStringNotContainsString('@id', $result);
-        $this->assertStringNotContainsString('@context', $result);
-        $this->assertStringNotContainsString('@type', $result);
+        $this->assertStringContainsString('@id', $result);
+        $this->assertStringContainsString('@context', $result);
+        $this->assertStringContainsString('@type', $result);
     }
 
     /**

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -103,24 +103,24 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['tests'], [
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['tests'], [
             'type' => 'string',
             'foo' => 'bar',
         ]);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['nonResourceTests'], [
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['nonResourceTests'], [
             'type' => 'array',
             'items' => [
-                '$ref' => '#/definitions/NonResourceTestEntity.jsonld-write',
+                '$ref' => '#/definitions/NonResourceTestEntity.jsonld-write.input',
             ],
         ]);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['description'], [
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['description'], [
             'maxLength' => 255,
         ]);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['type'], [
-            '$ref' => '#/definitions/TestEntity.jsonld-write',
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['type'], [
+            '$ref' => '#/definitions/TestEntity.jsonld-write.input',
         ]);
     }
 
@@ -130,14 +130,14 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['Nest.jsonld']['properties']['owner']['anyOf'], [
-            ['$ref' => '#/definitions/Wren.jsonld'],
-            ['$ref' => '#/definitions/Robin.jsonld'],
+        $this->assertEquals($json['definitions']['Nest.jsonld.output']['properties']['owner']['anyOf'], [
+            ['$ref' => '#/definitions/Wren.jsonld.output'],
+            ['$ref' => '#/definitions/Robin.jsonld.output'],
             ['type' => 'null'],
         ]);
 
-        $this->assertArrayHasKey('Wren.jsonld', $json['definitions']);
-        $this->assertArrayHasKey('Robin.jsonld', $json['definitions']);
+        $this->assertArrayHasKey('Wren.jsonld.output', $json['definitions']);
+        $this->assertArrayHasKey('Robin.jsonld.output', $json['definitions']);
     }
 
     public function testArraySchemaWithMultipleUnionTypesJsonApi(): void
@@ -183,7 +183,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['Foo.jsonld']['properties']['expiration'], ['type' => 'string', 'format' => 'date']);
+        $this->assertEquals($json['definitions']['Foo.jsonld.output']['properties']['expiration'], ['type' => 'string', 'format' => 'date']);
     }
 
     /**
@@ -195,7 +195,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['SaveProduct.jsonld']['properties']['codes']['items']['$ref'], '#/definitions/ProductCode.jsonld');
+        $this->assertEquals($json['definitions']['SaveProduct.jsonld.input']['properties']['codes']['items']['$ref'], '#/definitions/ProductCode.jsonld.input');
     }
 
     /**
@@ -207,8 +207,8 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals('#/definitions/DummyFriend', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld']['properties']['itemDto']['$ref']);
-        $this->assertEquals('#/definitions/DummyDate', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld']['properties']['collectionDto']['items']['$ref']);
+        $this->assertEquals('#/definitions/DummyFriend', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld.output']['properties']['itemDto']['$ref']);
+        $this->assertEquals('#/definitions/DummyDate', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld.output']['properties']['collectionDto']['items']['$ref']);
     }
 
     /**
@@ -220,7 +220,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertArrayHasKey('@id', $json['definitions']['ThirdLevel.jsonld-friends']['properties']);
+        $this->assertArrayHasKey('@id', $json['definitions']['ThirdLevel.jsonld-friends.output']['properties']);
     }
 
     public function testJsonApiIncludesSchema(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR modifies SchemaFactory for JSON-LD to output JSON-LD specific properties such as `@context` `@id` `@type` as REQUIRED.

Below is a simple example.

```php
#[ORM\Entity(repositoryClass: TodoRepository::class)]
#[ApiResource]
class Todo
{
    #[ORM\Id]
    #[ORM\GeneratedValue]
    #[ORM\Column]
    private ?int $id = null;

    #[ORM\Column(length: 255)]
    #[Assert\NotBlank]
    #[Assert\Length(max: 255)]
    private ?string $title = null;

    #[ORM\Column(type: Types::TEXT, nullable: true)]
    private ?string $description = null;

    #[ORM\Column]
    #[Assert\NotNull]
    private ?bool $done = null;
```

Currently, the following schema is generated for the above API resource.

![image](https://github.com/api-platform/core/assets/4360663/c4a5b129-11c1-4d48-9fdb-787bd05824b4)

JSON-LD specific properties such as `@context` `@id` `@type` **should be output as required in the OpenAPI document**. However, since the above schema is **shared by both the request body and response body**, if we set these properties to required, they will also be required in the request body.

In the first place, [even though `ApiPlatform\Hydra\JsonSchema\SchemaFactory` does not add JSON-LD specific properties in the `input` context]((https://github.com/api-platform/core/blob/e867d07f59b82d5f1bdca69e096ddf452dd7efc8/src/Hydra/JsonSchema/SchemaFactory.php#L77-L79)), the schemas for input and output are **generated with the same key**, so in the OpenAPI document, properties such as `@context` `@id` `@type` are output even in POST/PUT/PATCH operations. This is the fundamental problem.

> See:
> * https://github.com/api-platform/core/blob/e867d07f59b82d5f1bdca69e096ddf452dd7efc8/src/OpenApi/Factory/OpenApiFactory.php#L258-L260
> * https://github.com/api-platform/core/blob/e867d07f59b82d5f1bdca69e096ddf452dd7efc8/src/OpenApi/Factory/OpenApiFactory.php#L402-L404

Therefore, in this PR, I first modified the schemas for input and output to be generated with different keys, so that JSON-LD specific properties would not be output during POST/PUT/PATCH operations.

And I made sure to always output JSON-LD specific properties such as `@context` `@id` `@type` as required (if those properties exist).

This ensures that JSON-LD specific properties are not required in the request body, and those properties are marked as required in the response body.

![image](https://github.com/api-platform/core/assets/4360663/86f2dcd9-0df1-4b13-b850-7a025e9f1e97)
![image](https://github.com/api-platform/core/assets/4360663/1c08b5db-77cb-478a-ae31-bbbe04581c57)

This has the advantage that the type information of API clients automatically generated by [OpenAPI TypeScript](https://openapi-ts.pages.dev/) etc. will be more precise.

```diff
  export interface operations {
      api_todos_post: {
          requestBody: {
-             "application/ld+json": components["schemas"]["Todo.jsonld"];
+             "application/ld+json": components["schemas"]["Todo.jsonld.input"];
          };
          responses: {
              201: {
                  content: {
-                     "application/ld+json": compoennts["schemas"]["Todo.jsonld"];
+                     "application/ld+json": compoennts["schemas"]["Todo.jsonld.output"];
                  };
              };
          };
      };
  };
  
  export interface components {
      schemas: {
+         "Todo.jsonld.input": {
+             readonly id?: number;
+             title: string;
+             description?: string | null;
+             done: boolean;
+         };
-         "Todo.jsonld": {
+         "Todo.jsonld.output": {
-             readonly "@context"?: string | {
+             readonly "@context": string | {
                  "@vocab": string;
                  /** @enum {string} */
                  hydra: "http://www.w3.org/ns/hydra/core#";
                  [key: string]: unknown;
              };
-             readonly "@id"?: string;
+             readonly "@id": string;
-             readonly "@type"?: string;
+             readonly "@type": string;
              readonly id?: number;
              title: string;
              description?: string | null;
              done: boolean;
          };
      };
  };
```
