### PR TITLE
feat(openapi): allow optional request body content

### DIFF
--- a/src/OpenApi/Model/RequestBody.php
+++ b/src/OpenApi/Model/RequestBody.php
@@ -17,16 +17,16 @@ final class RequestBody
 {
     use ExtensionTrait;
 
-    public function __construct(private string $description = '', private ?\ArrayObject $content = null, private bool $required = false)
+    public function __construct(private ?string $description = null, private ?\ArrayObject $content = null, private bool $required = false)
     {
     }
 
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    public function getContent(): \ArrayObject
+    public function getContent(): ?\ArrayObject
     {
         return $this->content;
     }

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -175,11 +175,11 @@ class OpenApiFactoryTest extends TestCase
             'filteredDummyCollection' => (new GetCollection())->withUriTemplate('/filtered')->withFilters(['f1', 'f2', 'f3', 'f4', 'f5'])->withOperation($baseOperation),
             // Paginated
             'paginatedDummyCollection' => (new GetCollection())->withUriTemplate('/paginated')
-                                           ->withPaginationClientEnabled(true)
-                                           ->withPaginationClientItemsPerPage(true)
-                                           ->withPaginationItemsPerPage(20)
-                                       ->withPaginationMaximumItemsPerPage(80)
-                                               ->withOperation($baseOperation),
+                ->withPaginationClientEnabled(true)
+                ->withPaginationClientItemsPerPage(true)
+                ->withPaginationItemsPerPage(20)
+                ->withPaginationMaximumItemsPerPage(80)
+                ->withOperation($baseOperation),
             'postDummyCollectionWithRequestBody' => (new Post())->withUriTemplate('/dummiesRequestBody')->withOperation($baseOperation)->withOpenapi(new OpenApiOperation(
                 requestBody: new RequestBody(
                     description: 'List of Ids',
@@ -200,6 +200,11 @@ class OpenApiFactoryTest extends TestCase
                             ],
                         ],
                     ]),
+                ),
+            )),
+            'postDummyCollectionWithRequestBodyWithoutContent' => (new Post())->withUriTemplate('/dummiesRequestBodyWithoutContent')->withOperation($baseOperation)->withOpenapi(new OpenApiOperation(
+                requestBody: new RequestBody(
+                    description: 'Extended description for the new Dummy resource',
                 ),
             )),
             'putDummyItemWithResponse' => (new Put())->withUriTemplate('/dummyitems/{id}')->withOperation($baseOperation)->withOpenapi(new OpenApiOperation(
@@ -866,6 +871,36 @@ class OpenApiFactoryTest extends TestCase
                             ],
                         ],
                     ],
+                ]),
+                false
+            ),
+            deprecated: false,
+        ), $requestBodyPath->getPost());
+
+        $requestBodyPath = $paths->getPath('/dummiesRequestBodyWithoutContent');
+        $this->assertEquals(new Operation(
+            'postDummyCollectionWithRequestBodyWithoutContent',
+            ['Dummy'],
+            [
+                '201' => new Response(
+                    'Dummy resource created',
+                    new \ArrayObject([
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                    ]),
+                    null,
+                    new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
+                ),
+                '400' => new Response('Invalid input'),
+                '422' => new Response('Unprocessable entity'),
+            ],
+            'Creates a Dummy resource.',
+            'Creates a Dummy resource.',
+            null,
+            [],
+            new RequestBody(
+                'Extended description for the new Dummy resource',
+                new \ArrayObject([
+                    'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy']))),
                 ]),
                 false
             ),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main <!-- see below -->
| Tickets       | Closes #2680 <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | _already existing ([see doc](https://api-platform.com/docs/guides/extend-openapi-documentation/#:~:text=When%20a%20field%20is%20not%20specified%20API%20Platform%20will%20add%20the%20missing%20informations.))_ 

Allow to generate a default request content or description if not defined in the extension of OpenApi using `Model\RequestBody`.

For example, on a `POST /greetings/test` operation on a `Greeting` entity with a `id` and a `name`, the following:
```php
#[ApiResource(
    mercure: true,
    operations: [
        new Post(
            uriTemplate: '/greetings/test',
            openapi: new Operation(
                requestBody: new RequestBody(
                    description: 'Extended description',
                ),
            ),
        ),
    ],
)]
```

Will generate the following OpenApi, with the default generated content:
![image](https://github.com/api-platform/core/assets/1794571/537bb7f4-46b2-438f-86d7-312a7014cd7f)
