### PR TITLE
fix(validation): ValidationException causes TypeError exception when called with $code=null

### DIFF
--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -81,7 +81,7 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
         }
 
         trigger_deprecation('api_platform/core', '3.3', sprintf('The "%s" exception will have a "%s" first argument in 4.x.', self::class, ConstraintViolationListInterface::class));
-        parent::__construct($message ?: $this->__toString(), $code, $previous);
+        parent::__construct($message ?: $this->__toString(), $code ?? 0, $previous);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | 
| License       | MIT
| Doc PR        | 

After update to 3.3.3, `ValidationException` called in custom validators code may cause issued.

For example: If you previously used `ValidationException` with only 1st string argument, after migration to 3.3.3 backward backward compatibility is broken.

```
Failed asserting that exception of type "TypeError" matches expected exception
"ApiPlatform\Validator\Exception\ValidationException". Message was: "Exception::__construct(): Argument #2 ($code) must be of type int, null given" at
/app/vendor/api-platform/core/src/Validator/Exception/ValidationException.php:84
```

