### PR TITLE
fix(symfony): make `WriteListener` compatible with `MainController`

### DIFF
--- a/src/Symfony/EventListener/WriteListener.php
+++ b/src/Symfony/EventListener/WriteListener.php
@@ -110,6 +110,7 @@ final class WriteListener
                 'uri_variables' => $uriVariables,
                 'resource_class' => $operation->getClass(),
                 'previous_data' => false === $operation->canRead() ? null : $request->attributes->get('previous_data'),
+                'data' => false === $operation->canRead() ? null : $request->attributes->get('data'),
             ]);
 
             if ($data) {


### PR DESCRIPTION
While "data" is set in the context in the `MainController`, this was not the case with the `WriteListener`.

I noticed this after updating from v3.2.14 to v3.3.3. Although I had set `event_listeners_backward_compatibility_layer` to `false`, the Symfony events were used again instead of the `MainController`. I had to set `use_symfony_listeners` to `false` so that I could restore the behavior of v3.2.14.

Shouldn't `use_symfony_listeners` be `false` if `event_listeners_backward_compatibility_layer` is also set to `false`?

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | 
| License       | MIT
| Doc PR        | 
