### PR TITLE
feat(jsonschema): make all required properties optional in PATCH operation with 'json' format

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -18,6 +18,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -33,6 +34,9 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     use ResourceMetadataTrait;
+
+    private const PATCH_SCHEMA_POSTFIX = '.patch';
+
     private ?TypeFactoryInterface $typeFactory = null;
     private ?SchemaFactoryInterface $schemaFactory = null;
     // Edge case where the related resource is not readable (for example: NotExposed) but we have groups to read the whole related object
@@ -88,6 +92,12 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             return $schema;
         }
 
+        $isJsonMergePatch = 'json' === $format && $operation instanceof Patch && Schema::TYPE_INPUT === $type;
+
+        if ($isJsonMergePatch) {
+            $definitionName .= self::PATCH_SCHEMA_POSTFIX;
+        }
+
         if (!isset($schema['$ref']) && !isset($schema['type'])) {
             $ref = Schema::VERSION_OPENAPI === $version ? '#/components/schemas/'.$definitionName : '#/definitions/'.$definitionName;
             if ($forceCollection || ('POST' !== $method && $operation instanceof CollectionOperationInterface)) {
@@ -136,7 +146,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             }
 
             $normalizedPropertyName = $this->nameConverter ? $this->nameConverter->normalize($propertyName, $inputOrOutputClass, $format, $serializerContext) : $propertyName;
-            if ($propertyMetadata->isRequired()) {
+            if ($propertyMetadata->isRequired() && !$isJsonMergePatch) {
                 $definition['required'][] = $normalizedPropertyName;
             }
 


### PR DESCRIPTION
> [!NOTE]
> Is this a bug? If so, we can close this PR and go to #6394.

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In the schema for the request body of `application/merge-patch+json` PATCH operation, all required properties should be output as optional.

> See here: https://datatracker.ietf.org/doc/html/rfc7386#section-3

This PR fixes the SchemaFactory for the `'json'` format to output required properties as optional only for input context of PATCH operations.

For example, for the following entity, the output of the OpenAPI document will change as follows:

```php
#[ORM\Entity(repositoryClass: TodoRepository::class)]
#[ApiResource]
class Todo
{
    #[ORM\Id]
    #[ORM\GeneratedValue]
    #[ORM\Column]
    private ?int $id = null;

    #[ORM\Column(length: 255)]
    #[Assert\NotBlank]
    #[Assert\Length(max: 255)]
    private ?string $title = null;

    #[ORM\Column(type: Types::TEXT, nullable: true)]
    private ?string $description = null;

    #[ORM\Column]
    #[Assert\NotNull]
    private ?bool $done = null;
```

| | Before | After |
| --- | --- | --- |
| **PATCH Operation** | ![image](https://github.com/api-platform/core/assets/4360663/699ffa26-142f-4a12-9973-de9cb3e39628) | ![image](https://github.com/api-platform/core/assets/4360663/765f0b44-ca88-478a-b999-b72e5a291c8f) |
| **Schemas** | ![image](https://github.com/api-platform/core/assets/4360663/6641c6a6-4d5e-409c-9618-758754b7ae14) | ![](https://github.com/api-platform/core/assets/4360663/60638a26-d869-45cf-ad12-7791f40a9d0c) |