### PR TITLE
fix(state) handle empty request in read provider

### DIFF
--- a/src/State/Provider/ReadProvider.php
+++ b/src/State/Provider/ReadProvider.php
@@ -54,7 +54,7 @@ final class ReadProvider implements ProviderInterface
             return null;
         }
 
-        if (null === $filters = $request?->attributes->get('_api_filters')) {
+        if (null === ($filters = $request?->attributes->get('_api_filters')) && $request) {
             $queryString = RequestParser::getQueryString($request);
             $filters = $queryString ? RequestParser::parseRequestParams($queryString) : null;
         }

--- a/src/State/Tests/ReadProviderTest.php
+++ b/src/State/Tests/ReadProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Tests;
+
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Serializer\SerializerContextBuilderInterface;
+use ApiPlatform\State\Provider\ReadProvider;
+use ApiPlatform\State\ProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class ReadProviderTest extends TestCase
+{
+    public function testWithoutRequest(): void
+    {
+        $operation = new GetCollection(read: true);
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->method('provide')->willReturn(['ok']);
+        $serializerContextBuilder = $this->createMock(SerializerContextBuilderInterface::class);
+
+        $readProvider = new ReadProvider($provider, $serializerContextBuilder);
+        $this->assertEquals($readProvider->provide($operation), ['ok']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | #6404
| License       | MIT
| Doc PR        | N/A

Hello, this PR let ReadProvider handle nullable request because `RequestParser::getQueryString($request)` expects a request object to work.

We had this bug when using provider in CLI during async export of a GetCollection operation