### PR TITLE
docs: remove unnecessary  comments

### DIFF
--- a/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
+++ b/src/JsonSchema/Command/JsonSchemaGenerateCommand.php
@@ -31,7 +31,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class JsonSchemaGenerateCommand extends Command
 {
-    // @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector
     private array $formats;
 
     public function __construct(private readonly SchemaFactoryInterface $schemaFactory, array $formats)

--- a/src/JsonSchema/Tests/SchemaFactoryTest.php
+++ b/src/JsonSchema/Tests/SchemaFactoryTest.php
@@ -91,7 +91,6 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(NotAResource::class))->getShortName(), $rootDefinitionKey);
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
@@ -168,7 +167,6 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(NotAResourceWithUnionIntersectTypes::class))->getShortName(), $rootDefinitionKey);
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
@@ -252,7 +250,6 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(OverriddenOperationDummy::class))->getShortName().'-'.$serializerGroup, $rootDefinitionKey);
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]);
         $this->assertSame('object', $definitions[$rootDefinitionKey]['type']);
@@ -311,7 +308,6 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
 
         $this->assertSame((new \ReflectionClass(NotAResource::class))->getShortName(), $rootDefinitionKey);
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
         $this->assertArrayHasKey('properties', $definitions[$rootDefinitionKey]);
         $this->assertArrayHasKey('foo', $definitions[$rootDefinitionKey]['properties']);

--- a/src/JsonSchema/Tests/SchemaTest.php
+++ b/src/JsonSchema/Tests/SchemaTest.php
@@ -73,12 +73,10 @@ class SchemaTest extends TestCase
         if (Schema::VERSION_OPENAPI === $version) {
             $this->assertArrayHasKey('schemas', $schema['components']);
         } else {
-            // @noRector
             $this->assertTrue(isset($schema['definitions']));
         }
 
         $definitions = $schema->getDefinitions();
-        // @noRector
         $this->assertTrue(isset($definitions['foo']));
 
         $this->assertArrayNotHasKey('definitions', $schema->getArrayCopy(false));

--- a/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -95,7 +95,6 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
                             priority: 4,
                             status: 301,
                             provider: AttributeResourceProvider::class,
-                            // @noRector \Rector\Php81\Rector\Array_\FirstClassCallableRector
                             processor: [AttributeResourceProcessor::class, 'process']
                         ),
                         '_api_/dummy/{dummyId}/attribute_resources/{identifier}{._format}_patch' => new Patch(
@@ -106,14 +105,12 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
                             priority: 5,
                             status: 301,
                             provider: AttributeResourceProvider::class,
-                            // @noRector \Rector\Php81\Rector\Array_\FirstClassCallableRector
                             processor: [AttributeResourceProcessor::class, 'process']
                         ),
                     ],
                     inputFormats: ['json' => ['application/merge-patch+json']],
                     status: 301,
                     provider: AttributeResourceProvider::class,
-                    // @noRector \Rector\Php81\Rector\Array_\FirstClassCallableRector
                     processor: [AttributeResourceProcessor::class, 'process']
                 ),
             ]),

--- a/src/Serializer/AbstractCollectionNormalizer.php
+++ b/src/Serializer/AbstractCollectionNormalizer.php
@@ -40,7 +40,6 @@ abstract class AbstractCollectionNormalizer implements NormalizerInterface, Norm
     /**
      * This constant must be overridden in the child class.
      */
-    // @noRector \Rector\Php81\Rector\ClassConst\FinalizePublicClassConstantRector
     public const FORMAT = 'to-override';
 
     public function __construct(protected ResourceClassResolverInterface|LegacyResourceClassResolverInterface $resourceClassResolver, protected string $pageParameterName, protected ?ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null)

--- a/src/Serializer/JsonEncoder.php
+++ b/src/Serializer/JsonEncoder.php
@@ -26,7 +26,6 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder as BaseJsonEncoder;
  */
 final class JsonEncoder implements EncoderInterface, DecoderInterface
 {
-    // @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector
     public function __construct(private readonly string $format, private ?BaseJsonEncoder $jsonEncoder = null)
     {
         if (null !== $this->jsonEncoder) {

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/ElasticsearchClientPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/ElasticsearchClientPass.php
@@ -57,10 +57,8 @@ final class ElasticsearchClientPass implements CompilerPassInterface
         $clientDefinition = $container->getDefinition('api_platform.elasticsearch.client');
 
         if (!$clientConfiguration) {
-            // @noRector \Rector\Php81\Rector\Array_\FirstClassCallableRector
             $clientDefinition->setFactory([$builderName, 'build']);
         } else {
-            // @noRector \Rector\Php81\Rector\Array_\FirstClassCallableRector
             $clientDefinition->setFactory([$builderName, 'fromConfig']);
             $clientDefinition->setArguments([$clientConfiguration]);
         }

--- a/tests/Behat/DoctrineContext.php
+++ b/tests/Behat/DoctrineContext.php
@@ -224,11 +224,8 @@ use Symfony\Component\Uid\Uuid as SymfonyUuid;
  */
 final class DoctrineContext implements Context
 {
-    // @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector
     private ObjectManager $manager;
-    // @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector
     private ?SchemaTool $schemaTool;
-    // @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector
     private ?SchemaManager $schemaManager;
 
     /**

--- a/tests/Fixtures/TestBundle/Entity/Content.php
+++ b/tests/Fixtures/TestBundle/Entity/Content.php
@@ -37,7 +37,6 @@ class Content implements \JsonSerializable
     #[ORM\OrderBy(['id' => 'ASC'])]
     private Collection|iterable $fields;
     #[ORM\Column(type: 'string')]
-    // @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector
     private string $status = ContentStatus::DRAFT;
 
     public function __construct()

--- a/tests/Hal/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hal/JsonSchema/SchemaFactoryTest.php
@@ -87,9 +87,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]['properties']));
         $properties = $resultSchema['definitions'][$rootDefinitionKey]['properties'];
         $this->assertArrayHasKey('_links', $properties);
@@ -118,7 +116,6 @@ class SchemaFactoryTest extends TestCase
         $definitionName = 'Dummy.jsonhal';
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']));
         $this->assertArrayHasKey('_embedded', $resultSchema['properties']);
         $this->assertArrayHasKey('totalItems', $resultSchema['properties']);
@@ -130,7 +127,6 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonhal', Schema::TYPE_OUTPUT, null, null, null, true);
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']));
         $this->assertArrayHasKey('_embedded', $resultSchema['properties']);
         $this->assertArrayHasKey('totalItems', $resultSchema['properties']);

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -86,9 +86,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]['properties']));
         $properties = $resultSchema['definitions'][$rootDefinitionKey]['properties'];
         $this->assertArrayHasKey('@context', $properties);
@@ -125,9 +123,7 @@ class SchemaFactoryTest extends TestCase
         $definitionName = 'Dummy.jsonld';
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']));
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']['hydra:member']));
         $this->assertArrayHasKey('hydra:totalItems', $resultSchema['properties']);
         $this->assertArrayHasKey('hydra:view', $resultSchema['properties']);
@@ -140,9 +136,7 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, null, null, true);
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']));
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']['hydra:member']));
         $this->assertArrayHasKey('hydra:totalItems', $resultSchema['properties']);
         $this->assertArrayHasKey('hydra:view', $resultSchema['properties']);
@@ -158,9 +152,7 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection());
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']));
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']['hydra:view']));
         $this->assertArrayHasKey('properties', $resultSchema['properties']['hydra:view']);
         $this->assertArrayHasKey('hydra:first', $resultSchema['properties']['hydra:view']['properties']);

--- a/tests/JsonApi/JsonSchema/SchemaFactoryTest.php
+++ b/tests/JsonApi/JsonSchema/SchemaFactoryTest.php
@@ -98,9 +98,7 @@ class SchemaFactoryTest extends TestCase
         $definitions = $resultSchema->getDefinitions();
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
-        // @noRector
         $this->assertTrue(isset($definitions[$rootDefinitionKey]['properties']));
         $properties = $resultSchema['definitions'][$rootDefinitionKey]['properties'];
         $this->assertArrayHasKey('data', $properties);
@@ -135,7 +133,6 @@ class SchemaFactoryTest extends TestCase
         $definitionName = 'Dummy.jsonapi';
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']));
         $this->assertArrayHasKey('links', $resultSchema['properties']);
         $this->assertArrayHasKey('self', $resultSchema['properties']['links']['properties']);
@@ -163,7 +160,6 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonapi', Schema::TYPE_OUTPUT, forceCollection: true);
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        // @noRector
         $this->assertTrue(isset($resultSchema['properties']));
         $this->assertArrayHasKey('links', $resultSchema['properties']);
         $this->assertArrayHasKey('self', $resultSchema['properties']['links']['properties']);

--- a/tests/Symfony/Bundle/DependencyInjection/Compiler/ElasticsearchClientPassTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/Compiler/ElasticsearchClientPassTest.php
@@ -56,7 +56,6 @@ class ElasticsearchClientPassTest extends TestCase
         }
 
         $clientDefinitionProphecy = $this->prophesize(Definition::class);
-        // @noRector \Rector\Php81\Rector\Array_\FirstClassCallableRector
         $clientDefinitionProphecy->setFactory([$clientBuilder, 'fromConfig'])->willReturn($clientDefinitionProphecy->reveal())->shouldBeCalled();
         $clientDefinitionProphecy->setArguments(
             Argument::allOf(
@@ -79,7 +78,6 @@ class ElasticsearchClientPassTest extends TestCase
         $clientBuilder = class_exists(\Elasticsearch\ClientBuilder::class) ? \Elasticsearch\ClientBuilder::class : \Elastic\Elasticsearch\ClientBuilder::class;
 
         $clientDefinitionProphecy = $this->prophesize(Definition::class);
-        // @noRector \Rector\Php81\Rector\Array_\FirstClassCallableRector
         $clientDefinitionProphecy->setFactory([$clientBuilder, 'build'])->willReturn($clientDefinitionProphecy->reveal())->shouldBeCalled();
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

[This commit](https://github.com/api-platform/core/pull/4851/commits/0ad3439f4d4c91c0586abb14ab6d9c14d6c38ddf) added many `@noRector` comments, but it is strange that the `@noRector` comments remain even though `rector.php` itself was removed in [this commit](https://github.com/api-platform/core/commit/b158de0eb0875310a0daa8bce0d641be64812e5b). This PR removes those unnecessary `@noRector` comments.

Regards.