### PR TITLE
Typo fix in delete-operation-with-validation guide

### DIFF
--- a/docs/guides/delete-operation-with-validation.php
+++ b/docs/guides/delete-operation-with-validation.php
@@ -15,7 +15,7 @@ namespace App\Validator {
     #[\Attribute]
     class AssertCanDelete extends Constraint
     {
-        public string $message = 'For whatever reason we denied removeal of this data.';
+        public string $message = 'For whatever reason we denied removal of this data.';
         public string $mode = 'strict';
 
         public function getTargets(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | stable
| License       | MIT

Fixing a typo in constraint message.