### PR TITLE
fix(metadata): wrong schema generated if openapicontext set on array

### DIFF
--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -100,9 +100,10 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             $propertySchema['example'] = $propertySchema['default'];
         }
 
-        // never override the following keys if at least one is already set
+        // never override the following keys if at least one is already set or if there's a custom openapi context
         if ([] === $types
             || ($propertySchema['type'] ?? $propertySchema['$ref'] ?? $propertySchema['anyOf'] ?? $propertySchema['allOf'] ?? $propertySchema['oneOf'] ?? false)
+            || ($propertyMetadata->getOpenapiContext() ?? false)
         ) {
             return $propertyMetadata->withSchema($propertySchema);
         }

--- a/src/JsonSchema/Tests/Fixtures/DummyWithCustomOpenApiContext.php
+++ b/src/JsonSchema/Tests/Fixtures/DummyWithCustomOpenApiContext.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\JsonSchema\Tests\Fixtures;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#[ApiResource]
+class DummyWithCustomOpenApiContext
+{
+    #[ApiProperty(openapiContext: ['type' => 'object', 'properties' => ['alpha' => ['type' => 'integer']]])]
+    public $acme;
+}

--- a/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
+++ b/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\JsonSchema\Tests\Metadata\Property\Factory;
 
 use ApiPlatform\JsonSchema\Metadata\Property\Factory\SchemaPropertyMetadataFactory;
+use ApiPlatform\JsonSchema\Tests\Fixtures\DummyWithCustomOpenApiContext;
 use ApiPlatform\JsonSchema\Tests\Fixtures\DummyWithEnum;
 use ApiPlatform\JsonSchema\Tests\Fixtures\Enum\IntEnumAsIdentifier;
 use ApiPlatform\Metadata\ApiProperty;
@@ -33,5 +34,19 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
         $schemaPropertyMetadataFactory = new SchemaPropertyMetadataFactory($resourceClassResolver, $decorated);
         $apiProperty = $schemaPropertyMetadataFactory->create(DummyWithEnum::class, 'intEnumAsIdentifier');
         $this->assertEquals(['type' => ['integer', 'null'], 'enum' => [1, 2, null]], $apiProperty->getSchema());
+    }
+
+    public function testWithCustomOpenApiContext(): void
+    {
+        $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
+        $apiProperty = new ApiProperty(
+            builtinTypes: [new Type(builtinType: 'object', nullable: true, class: IntEnumAsIdentifier::class)],
+            openapiContext: ['type' => 'object', 'properties' => ['alpha' => ['type' => 'integer']]],
+        );
+        $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $decorated->expects($this->once())->method('create')->with(DummyWithCustomOpenApiContext::class, 'acme')->willReturn($apiProperty);
+        $schemaPropertyMetadataFactory = new SchemaPropertyMetadataFactory($resourceClassResolver, $decorated);
+        $apiProperty = $schemaPropertyMetadataFactory->create(DummyWithCustomOpenApiContext::class, 'acme');
+        $this->assertEquals([], $apiProperty->getSchema());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | Closes https://github.com/api-platform/core/issues/6391
| License       | MIT
| Doc PR        | none

On a calculated field that returns an array, if we add a ApiProperty to change the type into object, the generated OpenAPI does generate a `"type": "object"` but there is also an extra `"items": {"type": "string"}`.

<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
