### PR TITLE
feat(doctrine): check property security during search filter

### DIFF
--- a/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -177,6 +177,8 @@
         <service id="api_platform.doctrine.orm.search_filter" class="ApiPlatform\Doctrine\Orm\Filter\SearchFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
             <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.security.resource_access_checker" />
             <argument type="service" id="api_platform.property_accessor" />
             <argument type="service" id="logger" on-invalid="ignore" />
             <argument key="$identifiersExtractor" type="service" id="api_platform.identifiers_extractor" on-invalid="ignore" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

**TODO**
- [ ] tests
- [ ] add a parameter (where ?) to enable this feature (BC)
- [ ] manage security for nested properties
- [ ] reproduce code in ODM

`SearchFilter` should check property security before adding where condition to the query. In other words : a user should not be able to filter resources by a property he is not allowed to see.

**Use case**
Considering a `Student` resource with following properties :
- `name`
- `anonymizationCode`

Users with «corrector» role don't see `name` property.
A `SearchFilter` can be applied on `name`.

As a corrector I can try to find which student matches each anonymization code by trying : 
`GET /api/students?name=John+Doe`
