### PR TITLE
feat(state): add security to parameters

### DIFF
--- a/src/Metadata/Link.php
+++ b/src/Metadata/Link.php
@@ -27,8 +27,8 @@ final class Link extends Parameter
         private ?array $identifiers = null,
         private ?bool $compositeIdentifier = null,
         private ?string $expandedValue = null,
-        private ?string $security = null,
-        private ?string $securityMessage = null,
+        ?string $security = null,
+        ?string $securityMessage = null,
         private ?string $securityObjectName = null,
 
         ?string $key = null,
@@ -55,6 +55,8 @@ final class Link extends Parameter
             property: $property,
             description: $description,
             required: $required,
+            security: $security,
+            securityMessage: $securityMessage,
             extraProperties: $extraProperties
         );
     }
@@ -166,27 +168,6 @@ final class Link extends Parameter
     public function getSecurity(): ?string
     {
         return $this->security;
-    }
-
-    public function getSecurityMessage(): ?string
-    {
-        return $this->securityMessage;
-    }
-
-    public function withSecurity(?string $security): self
-    {
-        $self = clone $this;
-        $self->security = $security;
-
-        return $self;
-    }
-
-    public function withSecurityMessage(?string $securityMessage): self
-    {
-        $self = clone $this;
-        $self->securityMessage = $securityMessage;
-
-        return $self;
     }
 
     public function getSecurityObjectName(): ?string

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -40,6 +40,8 @@ abstract class Parameter
         protected ?bool $required = null,
         protected ?int $priority = null,
         protected Constraint|array|null $constraints = null,
+        protected string|\Stringable|null $security = null,
+        protected ?string $securityMessage = null,
         protected ?array $extraProperties = [],
     ) {
     }
@@ -98,6 +100,16 @@ abstract class Parameter
     public function getConstraints(): Constraint|array|null
     {
         return $this->constraints;
+    }
+
+    public function getSecurity(): string|\Stringable|null
+    {
+        return $this->security;
+    }
+
+    public function getSecurityMessage(): ?string
+    {
+        return $this->securityMessage;
     }
 
     /**
@@ -193,6 +205,22 @@ abstract class Parameter
     {
         $self = clone $this;
         $self->constraints = $constraints;
+
+        return $self;
+    }
+
+    public function withSecurity(string|\Stringable|null $security): self
+    {
+        $self = clone $this;
+        $self->security = $security;
+
+        return $self;
+    }
+
+    public function withSecurityMessage(?string $securityMessage): self
+    {
+        $self = clone $this;
+        $self->securityMessage = $securityMessage;
 
         return $self;
     }

--- a/src/State/Provider/SecurityParameterProvider.php
+++ b/src/State/Provider/SecurityParameterProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Provider;
+
+use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\ResourceAccessCheckerInterface;
+use ApiPlatform\State\ProviderInterface;
+use ApiPlatform\State\Util\ParameterParserTrait;
+use ApiPlatform\Symfony\Security\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Loops over parameters to check parameter security.
+ * Throws an exception if security is not granted.
+ */
+final class SecurityParameterProvider implements ProviderInterface
+{
+    use ParameterParserTrait;
+
+    public function __construct(private readonly ?ProviderInterface $decorated = null, private readonly ?ResourceAccessCheckerInterface $resourceAccessChecker = null)
+    {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if (!($request = $context['request']) instanceof Request) {
+            return $this->decorated->provide($operation, $uriVariables, $context);
+        }
+
+        /** @var Operation $apiOperation */
+        $apiOperation = $request->attributes->get('_api_operation');
+
+        foreach ($apiOperation->getParameters() ?? [] as $parameter) {
+            if (null === $security = $parameter->getSecurity()) {
+                continue;
+            }
+
+            $key = $this->getParameterFlattenKey($parameter->getKey(), $this->extractParameterValues($parameter, $request, $context));
+            $apiValues = $parameter->getExtraProperties()['_api_values'] ?? [];
+            if (!isset($apiValues[$key])) {
+                continue;
+            }
+            $value = $apiValues[$key];
+
+            if (!$this->resourceAccessChecker->isGranted($context['resource_class'], $security, [$key => $value])) {
+                throw $operation instanceof GraphQlOperation ? new AccessDeniedHttpException($parameter->getSecurityMessage() ?? 'Access Denied.') : new AccessDeniedException($parameter->getSecurityMessage() ?? 'Access Denied.');
+            }
+        }
+
+        return $this->decorated->provide($operation, $uriVariables, $context);
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/state/provider.xml
+++ b/src/Symfony/Bundle/Resources/config/state/provider.xml
@@ -48,5 +48,10 @@
             <argument type="service" id="api_platform.state_provider.parameter.inner" />
             <argument type="tagged_locator" tag="api_platform.parameter_provider" index-by="key" />
         </service>
+
+        <service id="api_platform.state_provider.security_parameter" class="ApiPlatform\State\Provider\SecurityParameterProvider" decorates="api_platform.state_provider.main" decoration-priority="200">
+            <argument type="service" id="api_platform.state_provider.security_parameter.inner" />
+            <argument type="service" id="api_platform.security.resource_access_checker" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/Resources/config/state/state.xml
+++ b/src/Symfony/Bundle/Resources/config/state/state.xml
@@ -54,7 +54,6 @@
             <tag name="api_platform.state_provider" key="api_platform.state_provider.object" />
         </service>
         <service id="ApiPlatform\State\ObjectProvider" alias="api_platform.state_provider.object" />
-
         <service id="ApiPlatform\State\SerializerContextBuilderInterface" alias="api_platform.serializer.context_builder" />
     </services>
 </container>

--- a/tests/Fixtures/TestBundle/ApiResource/WithSecurityParameter.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WithSecurityParameter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\HeaderParameter;
+use ApiPlatform\Metadata\QueryParameter;
+
+#[GetCollection(
+    uriTemplate: 'with_security_parameters_collection{._format}',
+    parameters: [
+        'name' => new QueryParameter(security: 'is_granted("ROLE_ADMIN")'),
+        'auth' => new HeaderParameter(security: '"secured" == auth[0]'),
+        'secret' => new QueryParameter(security: '"secured" == secret')
+    ],
+    provider: [self::class, 'collectionProvider'],
+)]
+class WithSecurityParameter
+{
+    public static function collectionProvider()
+    {
+        return [new self()];
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/WithSecurityParameter.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WithSecurityParameter.php
@@ -22,7 +22,7 @@ use ApiPlatform\Metadata\QueryParameter;
     parameters: [
         'name' => new QueryParameter(security: 'is_granted("ROLE_ADMIN")'),
         'auth' => new HeaderParameter(security: '"secured" == auth[0]'),
-        'secret' => new QueryParameter(security: '"secured" == secret')
+        'secret' => new QueryParameter(security: '"secured" == secret'),
     ],
     provider: [self::class, 'collectionProvider'],
 )]

--- a/tests/Functional/Parameters/SecurityTests.php
+++ b/tests/Functional/Parameters/SecurityTests.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+class SecurityTests extends ApiTestCase
+{
+    public function dataUserAuthorization(): iterable
+    {
+        yield [['ROLE_ADMIN'], Response::HTTP_OK];
+        yield [['ROLE_USER'], Response::HTTP_FORBIDDEN];
+    }
+
+    /** @dataProvider dataUserAuthorization */
+    public function testUserAuthorization(array $roles, int $expectedStatusCode): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new InMemoryUser('emmanuel', 'password', $roles));
+
+        $client->request('GET', 'with_security_parameters_collection?name=foo');
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public function testNoValueParameter(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new InMemoryUser('emmanuel', 'password', ['ROLE_ADMIN']));
+
+        $client->request('GET', 'with_security_parameters_collection?name');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function dataSecurityValues(): iterable
+    {
+        yield ['secured', Response::HTTP_OK];
+        yield ['not_the_expected_parameter_value', Response::HTTP_UNAUTHORIZED];
+    }
+
+    /** @dataProvider dataSecurityValues */
+    public function testSecurityHeaderValues(string $parameterValue, int $expectedStatusCode): void
+    {
+        self::createClient()->request('GET', 'with_security_parameters_collection', [
+            'headers' => [
+                'auth' => $parameterValue,
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    /** @dataProvider dataSecurityValues */
+    public function testSecurityQueryValues(string $parameterValue, int $expectedStatusCode): void
+    {
+        self::createClient()->request('GET', sprintf('with_security_parameters_collection?secret=%s', $parameterValue));
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

This PR adds a security property to `Parameter`, and the corresponding state provider to manage it.

**TODO**
- [x] should I move `securityMessage` and `securityObject` from `Link` to `Parameter` ?
- [x] set the correct value for `SecurityProvider` decoration priority
- [x] should I move `security` property after `extraProperties` in `Parameter` constructor to avoid BC break ?
- [x] tests
- [ ] docs PR
