### PR TITLE
fix(openapi): Yaml openapi export should have numeric keys as string

### DIFF
--- a/src/OpenApi/Command/OpenApiCommand.php
+++ b/src/OpenApi/Command/OpenApiCommand.php
@@ -57,7 +57,7 @@ final class OpenApiCommand extends Command
             'spec_version' => $input->getOption('spec-version'),
         ]);
         $content = $input->getOption('yaml')
-            ? Yaml::dump($data, 10, 2, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK)
+            ? Yaml::dump($data, 10, 2, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_NUMERIC_KEY_AS_STRING)
             : (json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES) ?: '');
 
         $filename = $input->getOption('output');


### PR DESCRIPTION
###  Description

The OpenAPI specification mandates that all keys in the Responses Object be strings, as outlined here: https://github.com/OAI/OpenAPI-Specification/blob/157a4c81ae537ef793b2bee368bc00d88b461de8/versions/3.0.2.md#patterned-fields-1.

This requirement includes values like '200', which PHP typecasts to integers. Therefore, Yaml should also adhere to this rule.
