### PR TITLE
fix(symfony): check method for readonly routes

### DIFF
--- a/src/Symfony/Bundle/Resources/config/routing/api.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/api.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_entrypoint" path="/{index}.{_format}">
+    <route id="api_entrypoint" path="/{index}.{_format}" methods="GET|HEAD">
         <default key="_controller">api_platform.action.entrypoint</default>
         <default key="_format" />
         <default key="_api_respond">true</default>

--- a/src/Symfony/Bundle/Resources/config/routing/docs.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/docs.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_doc" path="/docs.{_format}">
+    <route id="api_doc" path="/docs.{_format}" methods="GET|HEAD">
         <default key="_controller">api_platform.action.documentation</default>
         <default key="_format" />
         <default key="_api_respond">true</default>

--- a/src/Symfony/Bundle/Resources/config/routing/errors.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/errors.xml
@@ -5,14 +5,14 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_errors" path="/errors/{status}">
+    <route id="api_errors" path="/errors/{status}" methods="GET|HEAD">
         <default key="_controller">api_platform.action.not_exposed</default>
         <default key="status">500</default>
 
         <requirement key="status">\d+</requirement>
     </route>
 
-    <route id="api_validation_errors" path="/validation_errors/{id}">
+    <route id="api_validation_errors" path="/validation_errors/{id}" methods="GET|HEAD">
         <default key="_controller">api_platform.action.not_exposed</default>
     </route>
 </routes>

--- a/src/Symfony/Bundle/Resources/config/routing/genid.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/genid.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_genid" path="/.well-known/genid/{id}">
+    <route id="api_genid" path="/.well-known/genid/{id}" methods="GET|HEAD">
         <default key="_controller">api_platform.action.not_exposed</default>
         <default key="_api_respond">true</default>
     </route>

--- a/src/Symfony/Bundle/Resources/config/routing/graphql/graphiql.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/graphql/graphiql.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_graphql_graphiql" path="/graphql/graphiql">
+    <route id="api_graphql_graphiql" path="/graphql/graphiql" methods="GET|HEAD">
         <default key="_controller">api_platform.graphql.action.graphiql</default>
     </route>
 

--- a/src/Symfony/Bundle/Resources/config/routing/graphql/graphql_playground.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/graphql/graphql_playground.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_graphql_graphql_playground" path="/graphql/graphql_playground">
+    <route id="api_graphql_graphql_playground" path="/graphql/graphql_playground" methods="GET|HEAD">
         <default key="_controller">api_platform.graphql.action.graphql_playground</default>
     </route>
 

--- a/src/Symfony/Bundle/Resources/config/routing/jsonld.xml
+++ b/src/Symfony/Bundle/Resources/config/routing/jsonld.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_jsonld_context" path="/contexts/{shortName}.{_format}">
+    <route id="api_jsonld_context" path="/contexts/{shortName}.{_format}" methods="GET|HEAD">
         <default key="_controller">api_platform.jsonld.action.context</default>
         <default key="_format">jsonld</default>
         <default key="_api_respond">true</default>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

To prevent weird behaviors like this:

```console
$ curl -vk -X DELETE https://localhost                       392ms  Mer 26 jui 19:14:01 2024
snip
< HTTP/2 204
snip
```