### PR TITLE
fix(jsonld): allow @id, @context and @type on denormalization 2

### DIFF
--- a/features/main/standard_put.feature
+++ b/features/main/standard_put.feature
@@ -66,6 +66,20 @@ Feature: Spec-compliant PUT support
     """
     Then the response status code should be 400
 
+  Scenario: Fails to create a new resource when the JSON-LD @id doesn't match the URI
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/standard_puts/7" with body:
+    """
+    {
+      "@id": "/standard_puts/6",
+      "@context": "/contexts/StandardPut",
+      "@type": "StandardPut",
+      "foo": "a",
+      "bar": "b"
+    }
+    """
+    Then the response status code should be 400
+
   Scenario: Replace an existing resource
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/standard_puts/5" with body:

--- a/features/main/standard_put.feature
+++ b/features/main/standard_put.feature
@@ -52,6 +52,20 @@ Feature: Spec-compliant PUT support
     }
     """
 
+  Scenario: Fails to create a new resource with the wrong JSON-LD @id
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/standard_puts/7" with body:
+    """
+    {
+      "@id": "/dummies/6",
+      "@context": "/contexts/StandardPut",
+      "@type": "StandardPut",
+      "foo": "a",
+      "bar": "b"
+    }
+    """
+    Then the response status code should be 400
+
   Scenario: Replace an existing resource
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/standard_puts/5" with body:

--- a/features/main/standard_put.feature
+++ b/features/main/standard_put.feature
@@ -26,7 +26,7 @@ Feature: Spec-compliant PUT support
     }
     """
 
-  Scenario: Create a new resource with json-ld attributes
+  Scenario: Create a new resource with JSON-LD attributes
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/standard_puts/6" with body:
     """

--- a/features/main/standard_put.feature
+++ b/features/main/standard_put.feature
@@ -26,6 +26,32 @@ Feature: Spec-compliant PUT support
     }
     """
 
+  Scenario: Create a new resource with json-ld attributes
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I send a "PUT" request to "/standard_puts/6" with body:
+    """
+    {
+      "@id": "/standard_puts/6",
+      "@context": "/contexts/StandardPut",
+      "@type": "StandardPut",
+      "foo": "a",
+      "bar": "b"
+    }
+    """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/StandardPut",
+      "@id": "/standard_puts/6",
+      "@type": "StandardPut",
+      "id": 6,
+      "foo": "a",
+      "bar": "b"
+    }
+    """
+
   Scenario: Replace an existing resource
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "PUT" request to "/standard_puts/5" with body:

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -49,7 +49,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
     use JsonLdContextTrait;
 
     public const FORMAT = 'jsonld';
-    public const JSONLD_KEYWORDS = [
+    private const JSONLD_KEYWORDS = [
         '@context',
         '@direction',
         '@graph',

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -49,6 +49,29 @@ final class ItemNormalizer extends AbstractItemNormalizer
     use JsonLdContextTrait;
 
     public const FORMAT = 'jsonld';
+    public const JSONLD_KEYWORDS = [
+        '@context',
+        '@direction',
+        '@graph',
+        '@id',
+        '@import',
+        '@included',
+        '@index',
+        '@json',
+        '@language',
+        '@list',
+        '@nest',
+        '@none',
+        '@prefix',
+        '@propagate',
+        '@protected',
+        '@reverse',
+        '@set',
+        '@type',
+        '@value',
+        '@version',
+        '@vocab',
+    ];
 
     public function __construct(ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, PropertyMetadataFactoryInterface $propertyMetadataFactory, IriConverterInterface|LegacyIriConverterInterface $iriConverter, ResourceClassResolverInterface|LegacyResourceClassResolverInterface $resourceClassResolver, private readonly ContextBuilderInterface $contextBuilder, ?PropertyAccessorInterface $propertyAccessor = null, ?NameConverterInterface $nameConverter = null, ?ClassMetadataFactoryInterface $classMetadataFactory = null, array $defaultContext = [], ?ResourceAccessCheckerInterface $resourceAccessChecker = null, protected ?TagCollectorInterface $tagCollector = null)
     {
@@ -151,7 +174,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             }
 
             try {
-                $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getResourceFromIri($data['@id'], $context + ['fetch_data' => true]);
+                $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getResourceFromIri($data['@id'], $context + ['fetch_data' => true], $context['operation'] ?? null);
             } catch (ItemNotFoundException $e) {
                 $operation = $context['operation'] ?? null;
                 if (!($operation instanceof Put && ($operation->getExtraProperties()['standard_put'] ?? false))) {
@@ -167,7 +190,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
     {
         $allowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
         if (\is_array($allowedAttributes) && ($context['api_denormalize'] ?? false)) {
-            $allowedAttributes = array_merge($allowedAttributes, ['@id', '@type', '@context']);
+            $allowedAttributes = array_merge($allowedAttributes, self::JSONLD_KEYWORDS);
         }
 
         return $allowedAttributes;

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -78,6 +78,10 @@ final class IriConverter implements IriConverterInterface
             throw new InvalidArgumentException(sprintf('No resource associated to "%s".', $iri));
         }
 
+        if ($operation && $operation->getClass() !== $parameters['_api_resource_class']) {
+            throw new InvalidArgumentException(sprintf('The iri "%s" does not reference the correct resource.', $iri));
+        }
+
         $operation = $parameters['_api_operation'] = $this->resourceMetadataCollectionFactory->create($parameters['_api_resource_class'])->getOperation($parameters['_api_operation_name']);
 
         if ($operation instanceof CollectionOperationInterface) {

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -78,7 +78,13 @@ final class IriConverter implements IriConverterInterface
             throw new InvalidArgumentException(sprintf('No resource associated to "%s".', $iri));
         }
 
-        if ($operation && $operation->getClass() !== $parameters['_api_resource_class']) {
+        foreach ($context['uri_variables'] ?? [] as $key => $value) {
+            if (!isset($parameters[$key]) || $parameters[$key] !== (string) $value) {
+                throw new InvalidArgumentException(sprintf('The iri "%s" does not reference the correct resource.', $iri));
+            }
+        }
+
+        if ($operation && !is_a($parameters['_api_resource_class'], $operation->getClass(), true)) {
             throw new InvalidArgumentException(sprintf('The iri "%s" does not reference the correct resource.', $iri));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3  <!-- see below -->
| Tickets       | Closes https://github.com/api-platform/core/issues/6225 <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | Feature already documented

Allaw `@id`, `@type`, `@context` with JsonLd. With this it's possible to use the `@id` as [described in the documentation ](https://api-platform.com/docs/core/serialization/#denormalization) while using `allow_extra_attributes: false`.
More info in https://github.com/api-platform/core/pull/6402.