### PR TITLE
feat: deprecate query parameter validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1333,3 +1333,52 @@ jobs:
           name: openapi-docs-php${{ matrix.php }}
           path: build/out/openapi
         continue-on-error: true
+
+  behat_legacy_query_parameter_validator:
+    name: Behat query parameter validator (PHP ${{ matrix.php }})
+    env:
+      QUERY_PARAMETER_VALIDATOR: 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: pecl, composer
+          extensions: intl, bcmath, curl, openssl, mbstring, pdo_sqlite
+          coverage: pcov
+          ini-values: memory_limit=-1
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Update project dependencies
+        run: composer update --no-interaction --no-progress --ansi
+      - name: Install PHPUnit
+        run: vendor/bin/simple-phpunit --version
+      - name: Clear test app cache
+        run: tests/Fixtures/app/console cache:clear --ansi
+      - name: Run Behat tests (PHP 8)
+        run: |
+          mkdir -p build/logs/behat
+          vendor/bin/behat --out=std --format=progress --format=junit --out=build/logs/behat/junit --tags=query_parameter_validator
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: behat-logs-php${{ matrix.php }}
+          path: build/logs/behat
+        continue-on-error: true

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -16,7 +16,7 @@ default:
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
-        tags: '~@postgres&&~@mongodb&&~@elasticsearch&&~@controller&&~@mercure'
+        tags: '~@postgres&&~@mongodb&&~@elasticsearch&&~@controller&&~@mercure&&~@query_parameter_validator'
   extensions:
     'FriendsOfBehat\SymfonyExtension':
       bootstrap: 'tests/Fixtures/app/bootstrap.php'
@@ -52,7 +52,7 @@ postgres:
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
-        tags: '~@sqlite&&~@mongodb&&~@elasticsearch&&~@controller&&~@mercure'
+        tags: '~@sqlite&&~@mongodb&&~@elasticsearch&&~@controller&&~@mercure&&~@query_parameter_validator'
 
 mongodb:
   suites:
@@ -73,7 +73,7 @@ mongodb:
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
-        tags: '~@sqlite&&~@elasticsearch&&~@!mongodb&&~@mercure&&~@controller'
+        tags: '~@sqlite&&~@elasticsearch&&~@!mongodb&&~@mercure&&~@controller&&~@query_parameter_validator'
 
 mercure:
   suites:
@@ -109,7 +109,7 @@ elasticsearch:
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
-        tags: '@elasticsearch&&~@mercure'
+        tags: '@elasticsearch&&~@mercure&&~@query_parameter_validator'
 
 default-coverage:
   suites:
@@ -203,7 +203,7 @@ legacy:
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
-        tags: '~@postgres&&~@mongodb&&~@elasticsearch&&~@link_security&&~@use_listener'
+        tags: '~@postgres&&~@mongodb&&~@elasticsearch&&~@link_security&&~@use_listener&&~@query_parameter_validator'
   extensions:
     'FriendsOfBehat\SymfonyExtension':
       bootstrap: 'tests/Fixtures/app/bootstrap.php'
@@ -238,7 +238,7 @@ symfony_listeners:
         - 'Behat\MinkExtension\Context\MinkContext'
         - 'behatch:context:rest'
       filters:
-        tags: '~@postgres&&~@mongodb&&~@elasticsearch&&~@mercure'
+        tags: '~@postgres&&~@mongodb&&~@elasticsearch&&~@mercure&&~@query_parameter_validator'
   extensions:
     'FriendsOfBehat\SymfonyExtension':
       bootstrap: 'tests/Fixtures/app/bootstrap.php'

--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -10,13 +10,13 @@ Feature: Validate filters based upon filter description
 
   Scenario: Required filter that does not allow empty value should throw an error if empty
     When I am on "/filter_validators?required=&required-allow-empty=&arrayRequired[foo]="
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "required" does not allow empty value'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'required: This value should not be blank.'
 
   Scenario: Required filter should throw an error if not set
     When I am on "/filter_validators"
-    Then the response status code should be 400
-    And the JSON node "detail" should match '/^Query parameter "required" is required\nQuery parameter "required-allow-empty" is required$/'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'required: This value should not be blank.\nrequired-allow-empty: The parameter "required-allow-empty" is required.'
 
   Scenario: Required filter should not throw an error if set
     When I am on "/array_filter_validators?arrayRequired[]=foo&indexedArrayRequired[foo]=foo"
@@ -24,76 +24,64 @@ Feature: Validate filters based upon filter description
 
   Scenario: Required filter should throw an error if not set
     When I am on "/array_filter_validators"
-    Then the response status code should be 400
-    And the JSON node "detail" should match '/^Query parameter "arrayRequired\[\]" is required\nQuery parameter "indexedArrayRequired\[foo\]" is required$/'
-
-    When I am on "/array_filter_validators?arrayRequired=foo&indexedArrayRequired[foo]=foo"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "arrayRequired[]" is required'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'arrayRequired: This value should not be blank.\nindexedArrayRequired: This value should not be blank.'
 
     When I am on "/array_filter_validators?arrayRequired[foo]=foo"
-    Then the response status code should be 400
-    And the JSON node "detail" should match '/^Query parameter "arrayRequired\[\]" is required\nQuery parameter "indexedArrayRequired\[foo\]" is required$/'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'indexedArrayRequired: This value should not be blank.'
 
     When I am on "/array_filter_validators?arrayRequired[]=foo"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "indexedArrayRequired[foo]" is required'
-
-    When I am on "/array_filter_validators?arrayRequired[]=foo&indexedArrayRequired[bar]=bar"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "indexedArrayRequired[foo]" is required'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'indexedArrayRequired: This value should not be blank.'
 
   Scenario: Test filter bounds: maximum
     When I am on "/filter_validators?required=foo&required-allow-empty&maximum=10"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&maximum=11"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "maximum" must be less than or equal to 10'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'maximum: This value should be less than or equal to 10.'
 
   Scenario: Test filter bounds: exclusiveMaximum
     When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMaximum=9"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMaximum=10"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "exclusiveMaximum" must be less than 10'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'maximum: This value should be less than 10.'
 
   Scenario: Test filter bounds: minimum
     When I am on "/filter_validators?required=foo&required-allow-empty&minimum=5"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&minimum=0"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "minimum" must be greater than or equal to 5'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'minimum: This value should be greater than or equal to 5.'
 
   Scenario: Test filter bounds: exclusiveMinimum
     When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=6"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=5"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "exclusiveMinimum" must be greater than 5'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'exclusiveMinimum: This value should be greater than 5.'
 
   Scenario: Test filter bounds: max length
     When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3=123"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3=1234"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "max-length-3" length must be lower than or equal to 3'
-
-  Scenario: Do not throw an error if value is not an array
-    When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3[]=12345"
-    Then the response status code should be 200
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'max-length-3: This value is too long. It should have 3 characters or less.'
 
   Scenario: Test filter bounds: min length
     When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=123"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=12"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "min-length-3" length must be greater than or equal to 3'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'min-length-3: This value is too short. It should have 3 characters or more.'
 
   Scenario: Test filter pattern
     When I am on "/filter_validators?required=foo&required-allow-empty&pattern=pattern"
@@ -101,70 +89,21 @@ Feature: Validate filters based upon filter description
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&pattern=not-pattern"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "pattern" must match pattern /^(pattern|nrettap)$/'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'pattern: This value is not valid.'
 
   Scenario: Test filter enum
     When I am on "/filter_validators?required=foo&required-allow-empty&enum=in-enum"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&enum=not-in-enum"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "enum" must be one of "in-enum, mune-ni"'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'enum: The value you selected is not a valid choice.'
 
   Scenario: Test filter multipleOf
     When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=4"
     Then the response status code should be 200
 
     When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=3"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "multiple-of" must multiple of 2'
-
-  Scenario: Test filter array items csv format minItems
-    When I am on "/filter_validators?required=foo&required-allow-empty&csv-min-2=a,b"
-    Then the response status code should be 200
-
-    When I am on "/filter_validators?required=foo&required-allow-empty&csv-min-2=a"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "csv-min-2" must contain more than 2 values'
-
-  Scenario: Test filter array items csv format maxItems
-    When I am on "/filter_validators?required=foo&required-allow-empty&csv-max-3=a,b,c"
-    Then the response status code should be 200
-
-    When I am on "/filter_validators?required=foo&required-allow-empty&csv-max-3=a,b,c,d"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "csv-max-3" must contain less than 3 values'
-
-  Scenario: Test filter array items tsv format minItems
-    When I am on "/filter_validators?required=foo&required-allow-empty&tsv-min-2=a\tb"
-    Then the response status code should be 200
-
-    When I am on "/filter_validators?required=foo&required-allow-empty&tsv-min-2=a,b"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "tsv-min-2" must contain more than 2 values'
-
-  Scenario: Test filter array items pipes format minItems
-    When I am on "/filter_validators?required=foo&required-allow-empty&pipes-min-2=a|b"
-    Then the response status code should be 200
-
-    When I am on "/filter_validators?required=foo&required-allow-empty&pipes-min-2=a,b"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "pipes-min-2" must contain more than 2 values'
-
-  Scenario: Test filter array items ssv format minItems
-    When I am on "/filter_validators?required=foo&required-allow-empty&ssv-min-2=a b"
-    Then the response status code should be 200
-
-    When I am on "/filter_validators?required=foo&required-allow-empty&ssv-min-2=a,b"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "ssv-min-2" must contain more than 2 values'
-
-  @dropSchema
-  Scenario: Test filter array items unique items
-    When I am on "/filter_validators?required=foo&required-allow-empty&csv-uniques=a,b"
-    Then the response status code should be 200
-
-    When I am on "/filter_validators?required=foo&required-allow-empty&csv-uniques=a,a"
-    Then the response status code should be 400
-    And the JSON node "detail" should be equal to 'Query parameter "csv-uniques" must contain unique values'
+    Then the response status code should be 422
+    And the JSON node "detail" should be equal to 'multiple-of: This value should be a multiple of 2.'

--- a/features/filter/filter_validation_legacy.feature
+++ b/features/filter/filter_validation_legacy.feature
@@ -1,0 +1,171 @@
+@query_parameter_validator
+Feature: Validate filters based upon filter description
+
+  Background:
+    Given I add "Accept" header equal to "application/json"
+
+  @createSchema
+  Scenario: Required filter should not throw an error if set
+    When I am on "/filter_validators?required=foo&required-allow-empty=&arrayRequired[foo]="
+    Then the response status code should be 200
+
+  Scenario: Required filter that does not allow empty value should throw an error if empty
+    When I am on "/filter_validators?required=&required-allow-empty=&arrayRequired[foo]="
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "required" does not allow empty value'
+
+  Scenario: Required filter should throw an error if not set
+    When I am on "/filter_validators"
+    Then the response status code should be 400
+    And the JSON node "detail" should match '/^Query parameter "required" is required\nQuery parameter "required-allow-empty" is required$/'
+
+  Scenario: Required filter should not throw an error if set
+    When I am on "/array_filter_validators?arrayRequired[]=foo&indexedArrayRequired[foo]=foo"
+    Then the response status code should be 200
+
+  Scenario: Required filter should throw an error if not set
+    When I am on "/array_filter_validators"
+    Then the response status code should be 400
+    And the JSON node "detail" should match '/^Query parameter "arrayRequired\[\]" is required\nQuery parameter "indexedArrayRequired\[foo\]" is required$/'
+
+    When I am on "/array_filter_validators?arrayRequired=foo&indexedArrayRequired[foo]=foo"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "arrayRequired[]" is required'
+
+    When I am on "/array_filter_validators?arrayRequired[foo]=foo"
+    Then the response status code should be 400
+    And the JSON node "detail" should match '/^Query parameter "arrayRequired\[\]" is required\nQuery parameter "indexedArrayRequired\[foo\]" is required$/'
+
+    When I am on "/array_filter_validators?arrayRequired[]=foo"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "indexedArrayRequired[foo]" is required'
+
+    When I am on "/array_filter_validators?arrayRequired[]=foo&indexedArrayRequired[bar]=bar"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "indexedArrayRequired[foo]" is required'
+
+  Scenario: Test filter bounds: maximum
+    When I am on "/filter_validators?required=foo&required-allow-empty&maximum=10"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&maximum=11"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "maximum" must be less than or equal to 10'
+
+  Scenario: Test filter bounds: exclusiveMaximum
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMaximum=9"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMaximum=10"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "exclusiveMaximum" must be less than 10'
+
+  Scenario: Test filter bounds: minimum
+    When I am on "/filter_validators?required=foo&required-allow-empty&minimum=5"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&minimum=0"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "minimum" must be greater than or equal to 5'
+
+  Scenario: Test filter bounds: exclusiveMinimum
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=6"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMinimum=5"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "exclusiveMinimum" must be greater than 5'
+
+  Scenario: Test filter bounds: max length
+    When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3=123"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3=1234"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "max-length-3" length must be lower than or equal to 3'
+
+  Scenario: Do not throw an error if value is not an array
+    When I am on "/filter_validators?required=foo&required-allow-empty&max-length-3[]=12345"
+    Then the response status code should be 200
+
+  Scenario: Test filter bounds: min length
+    When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=123"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&min-length-3=12"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "min-length-3" length must be greater than or equal to 3'
+
+  Scenario: Test filter pattern
+    When I am on "/filter_validators?required=foo&required-allow-empty&pattern=pattern"
+    When I am on "/filter_validators?required=foo&required-allow-empty&pattern=nrettap"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&pattern=not-pattern"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "pattern" must match pattern /^(pattern|nrettap)$/'
+
+  Scenario: Test filter enum
+    When I am on "/filter_validators?required=foo&required-allow-empty&enum=in-enum"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&enum=not-in-enum"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "enum" must be one of "in-enum, mune-ni"'
+
+  Scenario: Test filter multipleOf
+    When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=4"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&multiple-of=3"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "multiple-of" must multiple of 2'
+
+  Scenario: Test filter array items csv format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-min-2=a,b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-min-2=a"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "csv-min-2" must contain more than 2 values'
+
+  Scenario: Test filter array items csv format maxItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-max-3=a,b,c"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-max-3=a,b,c,d"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "csv-max-3" must contain less than 3 values'
+
+  Scenario: Test filter array items tsv format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&tsv-min-2=a\tb"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&tsv-min-2=a,b"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "tsv-min-2" must contain more than 2 values'
+
+  Scenario: Test filter array items pipes format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&pipes-min-2=a|b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&pipes-min-2=a,b"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "pipes-min-2" must contain more than 2 values'
+
+  Scenario: Test filter array items ssv format minItems
+    When I am on "/filter_validators?required=foo&required-allow-empty&ssv-min-2=a b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&ssv-min-2=a,b"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "ssv-min-2" must contain more than 2 values'
+
+  @dropSchema
+  Scenario: Test filter array items unique items
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-uniques=a,b"
+    Then the response status code should be 200
+
+    When I am on "/filter_validators?required=foo&required-allow-empty&csv-uniques=a,a"
+    Then the response status code should be 400
+    And the JSON node "detail" should be equal to 'Query parameter "csv-uniques" must contain unique values'

--- a/src/Doctrine/Common/Filter/OrderFilterTrait.php
+++ b/src/Doctrine/Common/Filter/OrderFilterTrait.php
@@ -54,6 +54,7 @@ trait OrderFilterTrait
                 'required' => false,
                 'schema' => [
                     'type' => 'string',
+                    'default' => strtolower($propertyOptions['default_direction'] ?? OrderFilterInterface::DIRECTION_ASC),
                     'enum' => [
                         strtolower(OrderFilterInterface::DIRECTION_ASC),
                         strtolower(OrderFilterInterface::DIRECTION_DESC),

--- a/src/Doctrine/Odm/Tests/Filter/OrderFilterTest.php
+++ b/src/Doctrine/Odm/Tests/Filter/OrderFilterTest.php
@@ -42,6 +42,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -54,6 +55,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -66,6 +68,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -78,6 +81,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -90,6 +94,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -102,6 +107,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -114,6 +120,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -126,6 +133,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -138,6 +146,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -150,6 +159,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -162,6 +172,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -174,6 +185,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -187,6 +199,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'required' => false,
                 'schema' => [
                     'type' => 'string',
+                    'default' => 'asc',
                     'enum' => [
                         'asc',
                         'desc',
@@ -198,6 +211,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -210,6 +224,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -222,6 +237,7 @@ class OrderFilterTest extends DoctrineMongoDbOdmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',

--- a/src/Doctrine/Odm/Tests/Filter/OrderFilterTestTrait.php
+++ b/src/Doctrine/Odm/Tests/Filter/OrderFilterTestTrait.php
@@ -30,6 +30,7 @@ trait OrderFilterTestTrait
                 'required' => false,
                 'schema' => [
                     'type' => 'string',
+                    'default' => 'asc',
                     'enum' => [
                         'asc',
                         'desc',
@@ -42,6 +43,7 @@ trait OrderFilterTestTrait
                 'required' => false,
                 'schema' => [
                     'type' => 'string',
+                    'default' => 'asc',
                     'enum' => [
                         'asc',
                         'desc',

--- a/src/Doctrine/Orm/Tests/Filter/OrderFilterTest.php
+++ b/src/Doctrine/Orm/Tests/Filter/OrderFilterTest.php
@@ -40,6 +40,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -52,6 +53,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -64,6 +66,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -76,6 +79,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -88,6 +92,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -100,6 +105,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -112,6 +118,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -124,6 +131,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -136,6 +144,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -148,6 +157,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -160,6 +170,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -172,6 +183,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -187,6 +199,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -199,6 +212,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -211,6 +225,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -223,6 +238,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -235,6 +251,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -247,6 +264,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -259,6 +277,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -271,6 +290,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -283,6 +303,7 @@ class OrderFilterTest extends DoctrineOrmFilterTestCase
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',

--- a/src/Doctrine/Orm/Tests/Filter/OrderFilterTestTrait.php
+++ b/src/Doctrine/Orm/Tests/Filter/OrderFilterTestTrait.php
@@ -29,6 +29,7 @@ trait OrderFilterTestTrait
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',
@@ -41,6 +42,7 @@ trait OrderFilterTestTrait
                 'type' => 'string',
                 'required' => false,
                 'schema' => [
+                    'default' => 'asc',
                     'type' => 'string',
                     'enum' => [
                         'asc',

--- a/src/Hydra/Serializer/CollectionFiltersNormalizer.php
+++ b/src/Hydra/Serializer/CollectionFiltersNormalizer.php
@@ -163,7 +163,7 @@ final class CollectionFiltersNormalizer implements NormalizerInterface, Normaliz
 
         foreach ($parameters ?? [] as $key => $parameter) {
             // Each IriTemplateMapping maps a variable used in the template to a property
-            if (!$parameter instanceof QueryParameterInterface) {
+            if (!$parameter instanceof QueryParameterInterface || false === $parameter->getHydra()) {
                 continue;
             }
 

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -24,11 +24,11 @@ use Symfony\Component\Validator\Constraint;
 abstract class Parameter
 {
     /**
-     * @param array{type?: string}|null                       $schema
-     * @param array<string, mixed>                            $extraProperties
-     * @param ParameterProviderInterface|callable|string|null $provider
-     * @param FilterInterface|string|null                     $filter
-     * @param Constraint|Constraint[]|null                    $constraints
+     * @param (array<string, mixed>&array{type?: string, default?: string})|null $schema
+     * @param array<string, mixed>                                               $extraProperties
+     * @param ParameterProviderInterface|callable|string|null                    $provider
+     * @param FilterInterface|string|null                                        $filter
+     * @param Constraint|Constraint[]|null                                       $constraints
      */
     public function __construct(
         protected ?string $key = null,
@@ -40,6 +40,7 @@ abstract class Parameter
         protected ?string $description = null,
         protected ?bool $required = null,
         protected ?int $priority = null,
+        protected ?bool $hydra = null,
         protected Constraint|array|null $constraints = null,
         protected string|\Stringable|null $security = null,
         protected ?string $securityMessage = null,
@@ -93,6 +94,11 @@ abstract class Parameter
     public function getPriority(): ?int
     {
         return $this->priority;
+    }
+
+    public function getHydra(): ?bool
+    {
+        return $this->hydra;
     }
 
     /**
@@ -208,6 +214,14 @@ abstract class Parameter
     {
         $self = clone $this;
         $self->required = $required;
+
+        return $self;
+    }
+
+    public function withHydra(bool $hydra): static
+    {
+        $self = clone $this;
+        $self->hydra = $hydra;
 
         return $self;
     }

--- a/src/Metadata/Resource/Factory/DeprecationResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/DeprecationResourceMetadataCollectionFactory.php
@@ -46,6 +46,10 @@ class DeprecationResourceMetadataCollectionFactory implements ResourceMetadataCo
                     $this->triggerDeprecationOnce($operation, 'extraProperties["standard_put"]', 'In API Platform 4 PUT will always replace the data, use extraProperties["standard_put"] to "true" on every operation to avoid breaking PUT\'s behavior. Use PATCH to use the old behavior.');
                 }
 
+                if (true === ($extraProperties['use_legacy_parameter_validator'] ?? null)) {
+                    $this->triggerDeprecationOnce($operation, 'extraProperties["use_legacy_parameter_validator"]', 'In API Platform 4 the query_parameter_validator will be removed in favor of Parameter constraints, set "use_legacy_parameter_validator" to false.');
+                }
+
                 $newOperations[$operationName] = $operation;
             }
 

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -15,8 +15,10 @@ namespace ApiPlatform\Metadata\Resource\Factory;
 
 use ApiPlatform\Metadata\FilterInterface;
 use ApiPlatform\Metadata\HeaderParameterInterface;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Parameter;
 use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use ApiPlatform\Serializer\Filter\FilterInterface as SerializerFilterInterface;
@@ -32,6 +34,7 @@ use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\Unique;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -63,13 +66,19 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
                     $parameters->add($key, $parameter->withPriority($priority));
                 }
 
-                $operations->add($operationName, $operation->withParameters($parameters));
+                // As we deprecate the parameter validator, we declare a parameter for each filter transfering validation to the new system
+                if ($operation->getFilters() && 0 === $parameters->count() && false === ($operation->getExtraProperties()['use_legacy_parameter_validator'] ?? true)) {
+                    $parameters = $this->addFilterValidation($operation);
+                }
+
+                if (\count($parameters) > 0) {
+                    $operations->add($operationName, $operation->withParameters($parameters));
+                }
             }
 
             $resourceMetadataCollection[$i] = $resource->withOperations($operations->sort());
 
-            $graphQlOperations = $resource->getGraphQlOperations();
-            if (!$graphQlOperations) {
+            if (!$graphQlOperations = $resource->getGraphQlOperations()) {
                 continue;
             }
 
@@ -125,8 +134,7 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
             if ($openApi instanceof OpenApiParameter) {
                 $parameter = $parameter->withOpenApi($openApi);
             } elseif (\is_array($openApi)) {
-                // @phpstan-ignore-next-line
-                $schema = $schema ?? $openapi['schema'] ?? [];
+                $schema = $schema ?? $openApi['schema'] ?? [];
                 $parameter = $parameter->withOpenApi(new OpenApiParameter(
                     $key,
                     $parameter instanceof HeaderParameterInterface ? 'header' : 'query',
@@ -208,6 +216,10 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
             $assertions[] = new Choice(choices: $schema['enum']);
         }
 
+        if (isset($schema['type']) && 'array' === $schema['type']) {
+            $assertions[] = new Type(type: 'array');
+        }
+
         if (!$assertions) {
             return $parameter;
         }
@@ -217,5 +229,71 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         }
 
         return $parameter->withConstraints($assertions);
+    }
+
+    private function addFilterValidation(HttpOperation $operation): Parameters
+    {
+        $parameters = new Parameters();
+        $internalPriority = -1;
+
+        foreach ($operation->getFilters() as $filter) {
+            if (!$this->filterLocator->has($filter)) {
+                continue;
+            }
+
+            $filter = $this->filterLocator->get($filter);
+            foreach ($filter->getDescription($operation->getClass()) as $parameterName => $definition) {
+                $key = $parameterName;
+                $required = $definition['required'] ?? false;
+                $schema = $definition['schema'] ?? null;
+
+                if (isset($definition['swagger'])) {
+                    trigger_deprecation('api-platform/core', '3.4', 'The key "swagger" in a filter description is deprecated, use "schema" or "openapi" instead.');
+                    $schema = $schema ?? $definition['swagger'];
+                }
+
+                $openApi = null;
+                if (isset($definition['openapi'])) {
+                    trigger_deprecation('api-platform/core', '3.4', sprintf('The key "openapi" in a filter description should be a "%s" class or use "schema" to specify the JSON Schema.', OpenApiParameter::class));
+                    if ($definition['openapi'] instanceof OpenApiParameter) {
+                        $openApi = $definition['openapi'];
+                    } else {
+                        $schema = $schema ?? $openApi;
+                    }
+                }
+
+                if (isset($schema['allowEmptyValue']) && !$openApi) {
+                    trigger_deprecation('api-platform/core', '3.4', 'The "allowEmptyValue" option should be declared using an "openapi" parameter.');
+                    $openApi = new OpenApiParameter(name: $key, in: 'query', allowEmptyValue: $schema['allowEmptyValue']);
+                }
+
+                // The query parameter validator forced this, lets maintain BC on filters
+                if (true === $required && !$openApi) {
+                    $openApi = new OpenApiParameter(name: $key, in: 'query', allowEmptyValue: false);
+                }
+
+                if (\is_bool($schema['exclusiveMinimum'] ?? null)) {
+                    trigger_deprecation('api-platform/core', '3.4', 'The "exclusiveMinimum" schema value should be a number not a boolean.');
+                    $schema['exclusiveMinimum'] = $schema['minimum'];
+                    unset($schema['minimum']);
+                }
+
+                if (\is_bool($schema['exclusiveMaximum'] ?? null)) {
+                    trigger_deprecation('api-platform/core', '3.4', 'The "exclusiveMaximum" schema value should be a number not a boolean.');
+                    $schema['exclusiveMaximum'] = $schema['maximum'];
+                    unset($schema['maximum']);
+                }
+
+                $parameters->add($key, $this->addSchemaValidation(
+                    // we disable openapi and hydra on purpose as their docs comes from filters see the condition for addFilterValidation above
+                    new QueryParameter(key: $key, property: $definition['property'] ?? null, priority: $internalPriority--, schema: $schema, openApi: false, hydra: false),
+                    $schema,
+                    $required,
+                    $openApi
+                ));
+            }
+        }
+
+        return $parameters;
     }
 }

--- a/src/State/Provider/ParameterProvider.php
+++ b/src/State/Provider/ParameterProvider.php
@@ -55,7 +55,7 @@ final class ParameterProvider implements ProviderInterface
             $values = $this->getParameterValues($parameter, $request, $context);
             $value = $this->extractParameterValues($parameter, $values);
 
-            if ((!$value || $value instanceof ParameterNotFound) && ($default = $parameter->getSchema()['default'] ?? false)) {
+            if (($default = $parameter->getSchema()['default'] ?? false) && ($value instanceof ParameterNotFound || !$value)) {
                 $value = $default;
             }
 

--- a/src/Symfony/EventListener/QueryParameterValidateListener.php
+++ b/src/Symfony/EventListener/QueryParameterValidateListener.php
@@ -67,6 +67,10 @@ final class QueryParameterValidateListener
             return;
         }
 
+        if (!($operation->getExtraProperties()['use_legacy_parameter_validator'] ?? true)) {
+            return;
+        }
+
         if (!($operation?->getQueryParameterValidationEnabled() ?? true) || !$operation instanceof HttpOperation) {
             return;
         }

--- a/src/Symfony/Validator/State/QueryParameterValidateProvider.php
+++ b/src/Symfony/Validator/State/QueryParameterValidateProvider.php
@@ -38,6 +38,10 @@ final class QueryParameterValidateProvider implements ProviderInterface
             return $this->decorated?->provide($operation, $uriVariables, $context);
         }
 
+        if (!($operation->getExtraProperties()['use_legacy_parameter_validator'] ?? true)) {
+            return $this->decorated?->provide($operation, $uriVariables, $context);
+        }
+
         if (!($operation->getQueryParameterValidationEnabled() ?? true) || !$operation instanceof CollectionOperationInterface) {
             return $this->decorated?->provide($operation, $uriVariables, $context);
         }

--- a/tests/.ignored-deprecations
+++ b/tests/.ignored-deprecations
@@ -16,3 +16,11 @@
 %Since symfony/validator 7.1: Not passing a value for the "requireTld" option to the Url constraint is deprecated. Its default value will change to "true".%
 
 %$fieldsBuilder argument of SchemaBuilder implementing "ApiPlatform\\GraphQl\\Type\\FieldsBuilderInterface" is deprecated since API Platform 3.1. It has to implement "ApiPlatform\\GraphQl\\Type\\FieldsBuilderEnumInterface" instead.%
+
+# old test filters will be removed in 4.0
+%Since api-platform/core 3.4: The key "swagger" in a filter description is deprecated, use "schema" or "openapi" instead.%
+%Since api-platform/core 3.4: The key "openapi" in a filter description should be a "ApiPlatform\\OpenApi\\Model\\Parameter" class or use "schema" to specify the JSON Schema.%
+%Since api-platform/core 3.4: The "exclusiveMaximum" schema value should be a number not a boolean.%
+%Since api-platform/core 3.4: The "exclusiveMinimum" schema value should be a number not a boolean.%
+%Since api-platform/core 3.4: The "allowEmptyValue" option should be declared using an "openapi" parameter.%
+

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -234,6 +234,7 @@ class AppKernel extends Kernel
         $metadataBackwardCompatibilityLayer = (bool) ($_SERVER['EVENT_LISTENERS_BACKWARD_COMPATIBILITY_LAYER'] ?? false);
         $useSymfonyListeners = (bool) ($_SERVER['USE_SYMFONY_LISTENERS'] ?? false);
         $rfc7807CompliantErrors = (bool) ($_SERVER['RFC_7807_COMPLIANT_ERRORS'] ?? true);
+        $useQueryParameterValidator = (bool) ($_SERVER['QUERY_PARAMETER_VALIDATOR'] ?? false);
 
         $legacyConfig = [];
         if ($metadataBackwardCompatibilityLayer) {
@@ -263,6 +264,7 @@ class AppKernel extends Kernel
                 'extra_properties' => [
                     'rfc_7807_compliant_errors' => $rfc7807CompliantErrors,
                     'standard_put' => true,
+                    'use_legacy_parameter_validator' => $useQueryParameterValidator,
                 ],
             ],
         ]);


### PR DESCRIPTION
The idea here is that we deprecate the QueryParameterValidator in 3.4 in favor of using the new parameter attributes (QueryParameter and HeaderParameter). By doing so, we introduce a backward compatibility flag: 

```
defaults: 
    extra_properties:
        use_legacy_parameter_validator: true
```

This flag is `true` by default in 3.4 and gets removed in 4.0. When using `false` we add parameters for each declared filter and validation will still be effective (according to `$queryParameterValidationEnabled`). A few changes occur though (hence the flag): 

- status code is 422 instead of 400
- there's no more `collectionFormat` support from swagger, indeed this completely changed in OpenAPI 3.1 and we did not yet add the support of `style` validation on parameters (https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values) 
- violation messages are now the ones from Symfony but basically the same validation occurs 

Left tbd: 

- [x] add the `queryParameterValidationEnabled` everywhere (as it also applies to graphql `args`)
- [x] add a deprecation when the `use_legacy_parameter_validator` is not `false`
- [ ] fix tests