### PR TITLE
feat(symfony): skip error handler

### DIFF
--- a/src/Symfony/EventListener/ErrorListener.php
+++ b/src/Symfony/EventListener/ErrorListener.php
@@ -81,7 +81,7 @@ final class ErrorListener extends SymfonyErrorListener
         //   - use api platform to handle errors (the default behavior we handle firewall errors for example but they're out of our scope)
 
         // Let the error handler take this we don't handle HTML nor non-api platform requests
-        if ('html' === $format) {
+        if (false === ($apiOperation?->getExtraProperties()['_api_error_handler'] ?? true) || 'html' === $format) {
             $this->controller = 'error_controller';
 
             return parent::duplicateRequest($exception, $request);

--- a/tests/Fixtures/TestBundle/ApiResource/Issue5921/ExceptionResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue5921/ExceptionResource.php
@@ -17,7 +17,12 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Tests\Fixtures\TestBundle\Exception\TestException;
 
-#[Get(uriTemplate: 'issue5921{._format}', read: true, provider: [ExceptionResource::class, 'provide'], extraProperties: ['rfc_7807_compliant_errors' => false])]
+#[Get(
+    uriTemplate: 'issue5921{._format}',
+    read: true,
+    provider: [ExceptionResource::class, 'provide'],
+    extraProperties: ['_api_error_handler' => false]
+)]
 class ExceptionResource
 {
     public static function provide(Operation $operation, array $uriVariables = [], array $context = []): void

--- a/tests/Fixtures/TestBundle/Serializer/ErrorNormalizer.php
+++ b/tests/Fixtures/TestBundle/Serializer/ErrorNormalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Serializer;
 
-use ApiPlatform\Tests\Fixtures\TestBundle\Exception\TestException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class ErrorNormalizer implements NormalizerInterface
@@ -32,20 +32,17 @@ final class ErrorNormalizer implements NormalizerInterface
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        if (\is_object($data) && $data instanceof TestException) {
-            return true;
-        }
-
-        return $this->decorated->supportsNormalization($data, $format, $context);
-    }
-
-    public function hasCacheableSupportsMethod(): bool
-    {
-        return false;
+        return 'json' === $format;
     }
 
     public function getSupportedTypes(?string $format): array
     {
-        return $this->decorated->getSupportedTypes($format);
+        if ('json' === $format) {
+            return [
+                FlattenException::class => true,
+            ];
+        }
+
+        return [];
     }
 }

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -448,8 +448,9 @@ services:
             $decorated: '@.inner'
 
     ApiPlatform\Tests\Fixtures\TestBundle\Serializer\ErrorNormalizer:
-        decorates: 'api_platform.problem.normalizer.error'
-        arguments: [ '@.inner' ]
+        arguments: [ '@serializer.normalizer.problem' ]
+        tags:
+            - name: 'serializer.normalizer'
 
     api_platform.http_cache.tag_collector:
         class: ApiPlatform\Tests\Fixtures\TestBundle\HttpCache\TagCollectorDefault


### PR DESCRIPTION
Allow to skip the error handler with `extraProperties: ['_api_error_handler' => false]`