### PR TITLE
feat(jsonschema): make JSON-LD specific properties required only in the schema for output

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -153,7 +153,7 @@ Feature: Documentation support
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 6 elements
 
     # Subcollection - check schema
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany.output"
 
     # Deprecations
     And the JSON node "paths./dummies.get.deprecated" should be false
@@ -165,8 +165,8 @@ Feature: Documentation support
     And the JSON node "paths./deprecated_resources/{id}.patch.deprecated" should be true
 
     # Formats
-    And the OpenAPI class "Dummy.jsonld" exists
-    And the "@id" property exists for the OpenAPI class "Dummy.jsonld"
+    And the OpenAPI class "Dummy.jsonld.output" exists
+    And the "@id" property exists for the OpenAPI class "Dummy.jsonld.output"
     And the JSON node "paths./dummies.get.responses.200.content.application/ld+json" should be equal to:
     """
     {
@@ -176,7 +176,7 @@ Feature: Documentation support
                 "hydra:member": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/components/schemas/Dummy.jsonld"
+                        "$ref": "#/components/schemas/Dummy.jsonld.output"
                     }
                 },
                 "hydra:totalItems": {

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -27,7 +27,6 @@ use ApiPlatform\Metadata\Operation;
 final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     private const BASE_PROP = [
-        'readOnly' => true,
         'type' => 'string',
     ];
     private const BASE_PROPS = [
@@ -36,7 +35,6 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
     ];
     private const BASE_ROOT_PROPS = [
         '@context' => [
-            'readOnly' => true,
             'oneOf' => [
                 ['type' => 'string'],
                 [
@@ -74,18 +72,43 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             return $schema;
         }
 
-        if ('input' === $type) {
-            return $schema;
+        if (($key = $schema->getRootDefinitionKey() ?? $schema->getItemsDefinitionKey()) !== null) {
+            $postfix = '.'.$type;
+            $definitions = $schema->getDefinitions();
+            $definitions[$key.$postfix] = $definitions[$key];
+            unset($definitions[$key]);
+
+            if (($schema['type'] ?? '') === 'array') {
+                $schema['items']['$ref'] .= $postfix;
+            } else {
+                $schema['$ref'] .= $postfix;
+            }
         }
 
         $definitions = $schema->getDefinitions();
         if ($key = $schema->getRootDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);
+            if (Schema::TYPE_OUTPUT === $type) {
+                foreach (array_keys(self::BASE_ROOT_PROPS) as $property) {
+                    $definitions[$key]['required'] ??= [];
+                    if (!\in_array($property, $definitions[$key]['required'], true)) {
+                        $definitions[$key]['required'][] = $property;
+                    }
+                }
+            }
 
             return $schema;
         }
         if ($key = $schema->getItemsDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
+            if (Schema::TYPE_OUTPUT === $type) {
+                foreach (array_keys(self::BASE_PROPS) as $property) {
+                    $definitions[$key]['required'] ??= [];
+                    if (!\in_array($property, $definitions[$key]['required'], true)) {
+                        $definitions[$key]['required'][] = $property;
+                    }
+                }
+            }
         }
 
         if (($schema['type'] ?? '') === 'array') {

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -88,27 +88,13 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         $definitions = $schema->getDefinitions();
         if ($key = $schema->getRootDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);
-            if (Schema::TYPE_OUTPUT === $type) {
-                foreach (array_keys(self::BASE_ROOT_PROPS) as $property) {
-                    $definitions[$key]['required'] ??= [];
-                    if (!\in_array($property, $definitions[$key]['required'], true)) {
-                        $definitions[$key]['required'][] = $property;
-                    }
-                }
-            }
+            $this->makeJsonLdKeywordPropertiesRequired($definitions, $key, $type, true, null === $operation);
 
             return $schema;
         }
         if ($key = $schema->getItemsDefinitionKey()) {
             $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
-            if (Schema::TYPE_OUTPUT === $type) {
-                foreach (array_keys(self::BASE_PROPS) as $property) {
-                    $definitions[$key]['required'] ??= [];
-                    if (!\in_array($property, $definitions[$key]['required'], true)) {
-                        $definitions[$key]['required'][] = $property;
-                    }
-                }
-            }
+            $this->makeJsonLdKeywordPropertiesRequired($definitions, $key, $type, false, null === $operation);
         }
 
         if (($schema['type'] ?? '') === 'array') {
@@ -209,6 +195,27 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
     {
         if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
             $this->schemaFactory->setSchemaFactory($schemaFactory);
+        }
+    }
+
+    private function makeJsonLdKeywordPropertiesRequired(\ArrayObject $definitions, string $key, string $type, bool $isRoot, bool $isSubSchema): void
+    {
+        if (Schema::TYPE_INPUT === $type) {
+            return;
+        }
+
+        $definitions[$key]['required'] ??= [];
+
+        $requiredProperties = match (true) {
+            $isSubSchema => ['@type'],
+            $isRoot => ['@context', '@id', '@type'],
+            default => ['@id', '@type'],
+        };
+
+        foreach ($requiredProperties as $property) {
+            if (!\in_array($property, $definitions[$key]['required'], true)) {
+                $definitions[$key]['required'][] = $property;
+            }
         }
     }
 }

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -190,8 +190,8 @@ class SchemaFactoryTest extends TestCase
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
         $this->assertTrue(isset($definitions[$rootDefinitionKey]['required']));
         $requiredProperties = $resultSchema['definitions'][$rootDefinitionKey]['required'];
-        $this->assertContains('@context', $requiredProperties);
-        $this->assertContains('@id', $requiredProperties);
+        $this->assertNotContains('@context', $requiredProperties);
+        $this->assertNotContains('@id', $requiredProperties);
         $this->assertContains('@type', $requiredProperties);
 
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection());

--- a/tests/Hydra/JsonSchema/SchemaFactoryTest.php
+++ b/tests/Hydra/JsonSchema/SchemaFactoryTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\JsonSchema\SchemaFactory as BaseSchemaFactory;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
@@ -49,6 +50,7 @@ class SchemaFactoryTest extends TestCase
 
         $propertyNameCollectionFactory = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactory->create(Dummy::class, ['enable_getter_setter_extraction' => true, 'schema_type' => Schema::TYPE_OUTPUT])->willReturn(new PropertyNameCollection());
+        $propertyNameCollectionFactory->create(Dummy::class, ['enable_getter_setter_extraction' => true, 'schema_type' => Schema::TYPE_INPUT])->willReturn(new PropertyNameCollection());
         $propertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
 
         $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
@@ -69,7 +71,12 @@ class SchemaFactoryTest extends TestCase
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class);
 
         $this->assertTrue($resultSchema->isDefined());
-        $this->assertSame('Dummy.jsonld', $resultSchema->getRootDefinitionKey());
+        $this->assertSame('Dummy.jsonld.output', $resultSchema->getRootDefinitionKey());
+
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_INPUT, new Post());
+
+        $this->assertTrue($resultSchema->isDefined());
+        $this->assertSame('Dummy.jsonld.input', $resultSchema->getRootDefinitionKey());
     }
 
     public function testCustomFormatBuildSchema(): void
@@ -94,7 +101,6 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('@context', $properties);
         $this->assertEquals(
             [
-                'readOnly' => true,
                 'oneOf' => [
                     ['type' => 'string'],
                     [
@@ -122,7 +128,7 @@ class SchemaFactoryTest extends TestCase
     public function testSchemaTypeBuildSchema(): void
     {
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection());
-        $definitionName = 'Dummy.jsonld';
+        $definitionName = 'Dummy.jsonld.output';
 
         $this->assertNull($resultSchema->getRootDefinitionKey());
         // @noRector
@@ -151,6 +157,12 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayNotHasKey('@context', $properties);
         $this->assertArrayHasKey('@type', $properties);
         $this->assertArrayHasKey('@id', $properties);
+
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_INPUT, new Post());
+        $definitionName = 'Dummy.jsonld.input';
+
+        $this->assertSame($definitionName, $resultSchema->getRootDefinitionKey());
+        $this->assertFalse(isset($resultSchema['properties']));
     }
 
     public function testHasHydraViewNavigationBuildSchema(): void
@@ -167,5 +179,37 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('hydra:last', $resultSchema['properties']['hydra:view']['properties']);
         $this->assertArrayHasKey('hydra:previous', $resultSchema['properties']['hydra:view']['properties']);
         $this->assertArrayHasKey('hydra:next', $resultSchema['properties']['hydra:view']['properties']);
+    }
+
+    public function testRequiredBasePropertiesBuildSchema(): void
+    {
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class);
+        $definitions = $resultSchema->getDefinitions();
+        $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
+
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]));
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]['required']));
+        $requiredProperties = $resultSchema['definitions'][$rootDefinitionKey]['required'];
+        $this->assertContains('@context', $requiredProperties);
+        $this->assertContains('@id', $requiredProperties);
+        $this->assertContains('@type', $requiredProperties);
+
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection());
+        $definitions = $resultSchema->getDefinitions();
+        $itemsDefinitionKey = array_key_first($definitions->getArrayCopy());
+
+        $this->assertTrue(isset($definitions[$itemsDefinitionKey]));
+        $this->assertTrue(isset($definitions[$itemsDefinitionKey]['required']));
+        $requiredProperties = $resultSchema['definitions'][$itemsDefinitionKey]['required'];
+        $this->assertNotContains('@context', $requiredProperties);
+        $this->assertContains('@id', $requiredProperties);
+        $this->assertContains('@type', $requiredProperties);
+
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_INPUT, new Post());
+        $definitions = $resultSchema->getDefinitions();
+        $itemsDefinitionKey = array_key_first($definitions->getArrayCopy());
+
+        $this->assertTrue(isset($definitions[$itemsDefinitionKey]));
+        $this->assertFalse(isset($definitions[$itemsDefinitionKey]['required']));
     }
 }

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -76,9 +76,9 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => $this->entityClass, '--operation' => '_api_/dummies{._format}_post', '--format' => 'jsonld', '--type' => 'input']);
         $result = $this->tester->getDisplay();
 
-        $this->assertStringNotContainsString('@id', $result);
-        $this->assertStringNotContainsString('@context', $result);
-        $this->assertStringNotContainsString('@type', $result);
+        $this->assertStringContainsString('@id', $result);
+        $this->assertStringContainsString('@context', $result);
+        $this->assertStringContainsString('@type', $result);
     }
 
     /**
@@ -103,24 +103,24 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['tests'], [
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['tests'], [
             'type' => 'string',
             'foo' => 'bar',
         ]);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['nonResourceTests'], [
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['nonResourceTests'], [
             'type' => 'array',
             'items' => [
-                '$ref' => '#/definitions/NonResourceTestEntity.jsonld-write',
+                '$ref' => '#/definitions/NonResourceTestEntity.jsonld-write.input',
             ],
         ]);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['description'], [
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['description'], [
             'maxLength' => 255,
         ]);
 
-        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write']['properties']['type'], [
-            '$ref' => '#/definitions/TestEntity.jsonld-write',
+        $this->assertEquals($json['definitions']['BagOfTests.jsonld-write.input']['properties']['type'], [
+            '$ref' => '#/definitions/TestEntity.jsonld-write.input',
         ]);
     }
 
@@ -130,14 +130,14 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['Nest.jsonld']['properties']['owner']['anyOf'], [
-            ['$ref' => '#/definitions/Wren.jsonld'],
-            ['$ref' => '#/definitions/Robin.jsonld'],
+        $this->assertEquals($json['definitions']['Nest.jsonld.output']['properties']['owner']['anyOf'], [
+            ['$ref' => '#/definitions/Wren.jsonld.output'],
+            ['$ref' => '#/definitions/Robin.jsonld.output'],
             ['type' => 'null'],
         ]);
 
-        $this->assertArrayHasKey('Wren.jsonld', $json['definitions']);
-        $this->assertArrayHasKey('Robin.jsonld', $json['definitions']);
+        $this->assertArrayHasKey('Wren.jsonld.output', $json['definitions']);
+        $this->assertArrayHasKey('Robin.jsonld.output', $json['definitions']);
     }
 
     public function testArraySchemaWithMultipleUnionTypesJsonApi(): void
@@ -185,7 +185,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['Foo.jsonld']['properties']['expiration'], ['type' => 'string', 'format' => 'date']);
+        $this->assertEquals($json['definitions']['Foo.jsonld.output']['properties']['expiration'], ['type' => 'string', 'format' => 'date']);
     }
 
     /**
@@ -197,7 +197,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals($json['definitions']['SaveProduct.jsonld']['properties']['codes']['items']['$ref'], '#/definitions/ProductCode.jsonld');
+        $this->assertEquals($json['definitions']['SaveProduct.jsonld.input']['properties']['codes']['items']['$ref'], '#/definitions/ProductCode.jsonld.input');
     }
 
     /**
@@ -209,8 +209,8 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertEquals('#/definitions/DummyFriend', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld']['properties']['itemDto']['$ref']);
-        $this->assertEquals('#/definitions/DummyDate', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld']['properties']['collectionDto']['items']['$ref']);
+        $this->assertEquals('#/definitions/DummyFriend', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld.output']['properties']['itemDto']['$ref']);
+        $this->assertEquals('#/definitions/DummyDate', $json['definitions']['Issue6299.Issue6299OutputDto.jsonld.output']['properties']['collectionDto']['items']['$ref']);
     }
 
     /**
@@ -222,7 +222,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
 
-        $this->assertArrayHasKey('@id', $json['definitions']['ThirdLevel.jsonld-friends']['properties']);
+        $this->assertArrayHasKey('@id', $json['definitions']['ThirdLevel.jsonld-friends.output']['properties']);
     }
 
     public function testJsonApiIncludesSchema(): void
@@ -280,7 +280,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6317\Issue6317', '--type' => 'output', '--format' => 'jsonld']);
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
-        $properties = $json['definitions']['Issue6317.jsonld']['properties'];
+        $properties = $json['definitions']['Issue6317.jsonld.output']['properties'];
 
         $this->assertArrayHasKey('example', $properties['id']);
         $this->assertArrayHasKey('example', $properties['name']);
@@ -295,7 +295,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ResourceWithEnumProperty', '--type' => 'output', '--format' => 'jsonld']);
         $result = $this->tester->getDisplay();
         $json = json_decode($result, associative: true);
-        $properties = $json['definitions']['ResourceWithEnumProperty.jsonld']['properties'];
+        $properties = $json['definitions']['ResourceWithEnumProperty.jsonld.output']['properties'];
 
         $this->assertSame(
             [

--- a/tests/Symfony/Bundle/Command/OpenApiCommandTest.php
+++ b/tests/Symfony/Bundle/Command/OpenApiCommandTest.php
@@ -134,7 +134,7 @@ YAML;
         };
 
         $assertExample($json['components']['schemas']['Issue6317']['properties'], 'id');
-        $assertExample($json['components']['schemas']['Issue6317.jsonld']['properties'], 'id');
+        $assertExample($json['components']['schemas']['Issue6317.jsonld.output']['properties'], 'id');
         $assertExample($json['components']['schemas']['Issue6317.jsonapi']['properties']['data']['properties']['attributes']['properties'], '_id');
         $assertExample($json['components']['schemas']['Issue6317.jsonhal']['properties'], 'id');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | #6484
| License       | MIT
| Doc PR        | N/A

In JSON Schema for JSON-LD, following things are the truth:

* JSON-LD specific properties such as `@context` `@id` `@type` can be included in the request body. (See #6451)
* JSON-LD specific properties such as `@context` `@id` `@type` always have a value in the response body. (In other words, they are required.)

Therefore, this PR will make the following fixes:

* Make JSON-LD specific properties such as `@context` `@id` `@type` non-readOnly.
* Separate the JSON-LD schema for input and output.
* Only in the schema for output, make JSON-LD specific properties such as `@context` `@id` `@type` required.

Below is a simple example.

```php
#[ORM\Entity(repositoryClass: TodoRepository::class)]
#[ApiResource]
class Todo
{
    #[ORM\Id]
    #[ORM\GeneratedValue]
    #[ORM\Column]
    private ?int $id = null;

    #[ORM\Column(length: 255)]
    #[Assert\NotBlank]
    #[Assert\Length(max: 255)]
    private ?string $title = null;

    #[ORM\Column(type: Types::TEXT, nullable: true)]
    private ?string $description = null;

    #[ORM\Column]
    #[Assert\NotNull]
    private ?bool $done = null;
```

Currently, the following schema is generated for the above API resource.

![image](https://github.com/api-platform/core/assets/4360663/c4a5b129-11c1-4d48-9fdb-787bd05824b4)

This schema is clearly incorrect because:

* JSON-LD specific properties such as `@context` `@id` `@type` can be included in the request body. (See #6451) **So the must not be readOnly.**
* JSON-LD specific properties such as `@context` `@id` `@type` always have a value in the response body. (**In other words, they are required in the output context.**)

JSON-LD specific properties such as `@context` `@id` `@type` **should be output as required in the OpenAPI document**. However, since the above schema is **shared by both the request body and response body**, if we set these properties to required, they will also be required in the request body.

The fundamental problem is that the above schema is **shared by both the request body and response body**. In the first place, in the current implementation, even though [`ApiPlatform\Hydra\JsonSchema\SchemaFactory` does not add JSON-LD specific properties in the `input` context](https://github.com/api-platform/core/blob/953ec19ed2249cc4a0f67f14174f7fcc9302db39/src/Hydra/JsonSchema/SchemaFactory.php#L77-L79), the schemas for input and output are **generated with the same key**, so the same schema is shared between the input and output contexts. This is clearly a bug.

> See:
> * https://github.com/api-platform/core/blob/953ec19ed2249cc4a0f67f14174f7fcc9302db39/src/OpenApi/Factory/OpenApiFactory.php#L265-L267
> * https://github.com/api-platform/core/blob/953ec19ed2249cc4a0f67f14174f7fcc9302db39/src/OpenApi/Factory/OpenApiFactory.php#L415-L417

Therefore, in this PR, I first modified the schemas for input and output to be generated with different keys.

And I also made JSON-LD specific properties such as `@context` `@id` `@type` non-readOnly (because they can be included in the request body) and made those properties required only in the schema for output (if those properties exist).

This ensures that JSON-LD specific properties are not required in the request body, and those properties are marked as required in the response body.

![image](https://github.com/user-attachments/assets/9128529b-6ca5-4c36-9dde-8f8255207c25)

This has the advantage that the type information of API clients automatically generated by [OpenAPI TypeScript](https://openapi-ts.pages.dev/) etc. will be more precise.

```diff
  export interface operations {
      api_todos_post: {
          requestBody: {
-             "application/ld+json": components["schemas"]["Todo.jsonld"];
+             "application/ld+json": components["schemas"]["Todo.jsonld.input"];
          };
          responses: {
              201: {
                  content: {
-                     "application/ld+json": compoennts["schemas"]["Todo.jsonld"];
+                     "application/ld+json": compoennts["schemas"]["Todo.jsonld.output"];
                  };
              };
          };
      };
  };
  
  export interface components {
      schemas: {
+         "Todo.jsonld.input": {
+             "@context"?: string | {
+                 "@vocab": string;
+                 /** @enum {string} */
+                 hydra: "http://www.w3.org/ns/hydra/core#";
+                 [key: string]: unknown;
+             };
+             "@id"?: string;
+             "@type"?: string;
+             readonly id?: number;
+             title: string;
+             description?: string | null;
+             done: boolean;
+         };
-         "Todo.jsonld": {
+         "Todo.jsonld.output": {
-             readonly "@context"?: string | {
+             "@context": string | {
                  "@vocab": string;
                  /** @enum {string} */
                  hydra: "http://www.w3.org/ns/hydra/core#";
                  [key: string]: unknown;
              };
-             readonly "@id"?: string;
+             "@id": string;
-             readonly "@type"?: string;
+             "@type": string;
              readonly id?: number;
              title: string;
              description?: string | null;
              done: boolean;
          };
      };
  };
```
