### PR TITLE
RespondProcessor: pass operation and context when generating IRI

### DIFF
--- a/src/State/Processor/RespondProcessor.php
+++ b/src/State/Processor/RespondProcessor.php
@@ -112,7 +112,7 @@ final class RespondProcessor implements ProcessorInterface
         $status ??= self::METHOD_TO_CODE[$method] ?? 200;
 
         if ($hasData && $this->iriConverter && !isset($headers['Content-Location'])) {
-            $iri = $this->iriConverter->getIriFromResource($originalData);
+            $iri = $this->iriConverter->getIriFromResource($originalData, UrlGeneratorInterface::ABS_PATH, $operation, $context);
             $headers['Content-Location'] = $iri;
 
             if ((201 === $status || (300 <= $status && $status < 400)) && 'POST' === $method && !isset($headers['Location'])) {


### PR DESCRIPTION
RespondProcessor: pass operation and context when generating IRI for Content-Location header, similar to the JsonLd Serializer

| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see below -->
| Tickets       | Closes #6494
| License       | MIT
| Doc PR        | 


