### PR TITLE
fix(symfony): fix debug:api-resource command for class with multiple resources with same uriTemplate

### DIFF
--- a/src/Symfony/Bundle/Command/DebugResourceCommand.php
+++ b/src/Symfony/Bundle/Command/DebugResourceCommand.php
@@ -62,13 +62,13 @@ final class DebugResourceCommand extends Command
         $resources = [];
         foreach ($resourceCollection as $resource) {
             if ($resource->getUriTemplate()) {
-                $resources[] = $resource->getUriTemplate();
+                $resources[] = ($resource->getRoutePrefix() ?? '').$resource->getUriTemplate();
                 continue;
             }
 
             foreach ($resource->getOperations() as $operation) {
                 if ($operation->getUriTemplate()) {
-                    $resources[] = $operation->getUriTemplate();
+                    $resources[] = ($resource->getRoutePrefix() ?? '').$operation->getUriTemplate();
                     break;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | Closes n/a
| License       | MIT
| Doc PR        |n/a

Currently when you run command `debug:api-resource` for class, which has multiple resources with same `uriTemplate` (but different `routePrefix`) - you see:
```
There are 2 resources declared on the class Book, which one do you want to debug ? 

  [0] /books/{id}{._format}
  [1] /books/{id}{._format}
```
but result for `[0]` record is always displayed regardless of your selection, because `$answerResource = $helper->ask($input, $output, $questionResource);` return choice label, not value.

<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
