### PR TITLE
Fix(graphql)(mercure): Use public URL for subscription URI creation if it is available

### DIFF
--- a/src/GraphQl/Subscription/MercureSubscriptionIriGenerator.php
+++ b/src/GraphQl/Subscription/MercureSubscriptionIriGenerator.php
@@ -41,6 +41,6 @@ final class MercureSubscriptionIriGenerator implements MercureSubscriptionIriGen
 
     public function generateMercureUrl(string $subscriptionId, ?string $hub = null): string
     {
-        return \sprintf('%s?topic=%s', $this->registry->getHub($hub)->getUrl(), $this->generateTopicIri($subscriptionId));
+        return \sprintf('%s?topic=%s', $this->registry->getHub($hub)->getPublicUrl(), $this->generateTopicIri($subscriptionId));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | Didn't find any, came up with a solution instead of making an issue :)
| License       | MIT
| Doc PR        | 

This is required when publishing and reading host names are not the same, ex: docker environment ("mercure" vs "localhost:port" between server side and client side), having different publishing URL and public access url's, etc. Mercure itself and Mercure bundle have been supporting this for a while.