### PR TITLE
feat(dx): additional log to help locate a potential missing provider

### DIFF
--- a/src/Symfony/Bundle/Resources/config/symfony/events.xml
+++ b/src/Symfony/Bundle/Resources/config/symfony/events.xml
@@ -21,6 +21,7 @@
         <service id="api_platform.state_provider.read" class="ApiPlatform\State\Provider\ReadProvider">
             <argument type="service" id="api_platform.state_provider.locator" />
             <argument type="service" id="api_platform.serializer.context_builder" />
+            <argument key="$logger" type="service" id="logger" on-invalid="null" />
         </service>
 
         <!-- kernel.request priority must be < 8 to be executed after the Firewall -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | Closes #6335
| License       | MIT

Just adding a simple log to avoid completely hiding the fact that there was a ProviderNotFoundException behind a NotFoundHttpException. 
It could help save time for devs who simply forgot to implement the provider. 