### PR TITLE
fix(symfony): allow schema restriction for collection like property from choice constraint

### DIFF
--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
@@ -78,9 +78,17 @@ final class PropertySchemaChoiceRestriction implements PropertySchemaRestriction
      */
     public function supports(Constraint $constraint, ApiProperty $propertyMetadata): bool
     {
-        $types = array_map(fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (Type $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [Type::BUILTIN_TYPE_STRING];
+        }
+
+        if (
+            null !== ($builtinType = $propertyMetadata->getBuiltinTypes()[0] ?? null)
+            && $builtinType->isCollection()
+            && \count($builtinType->getCollectionValueTypes())
+        ) {
+            $types = array_unique(array_merge($types, array_map(static fn (Type $type) => $type->getBuiltinType(), $builtinType->getCollectionValueTypes())));
         }
 
         return $constraint instanceof Choice && \count($types) && array_intersect($types, [Type::BUILTIN_TYPE_STRING, Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT]);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
Add support for automatic schema restriction for collection-like properties:
```
    /**
     * @var string[] $features
     */
    #[ApiProperty]
    #[Assert\Choice(callback: [Feature::class, 'getCaseValues'], multiple: true)]
    private array $features;
```