### PR TITLE
fix(laravel): snake case props

### DIFF
--- a/src/JsonApi/Tests/Fixtures/CustomConverter.php
+++ b/src/JsonApi/Tests/Fixtures/CustomConverter.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\JsonApi\Tests\Fixtures;
 
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
-use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Custom converter that will only convert a property named "nameConverted"
@@ -23,7 +22,7 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  */
 class CustomConverter implements AdvancedNameConverterInterface
 {
-    private NameConverterInterface $nameConverter;
+    private CamelCaseToSnakeCaseNameConverter $nameConverter;
 
     public function __construct()
     {

--- a/src/JsonApi/Tests/Fixtures/CustomConverter.php
+++ b/src/JsonApi/Tests/Fixtures/CustomConverter.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\JsonApi\Tests\Fixtures;
 
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Custom converter that will only convert a property named "nameConverted"
@@ -22,7 +23,7 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
  */
 class CustomConverter implements AdvancedNameConverterInterface
 {
-    private CamelCaseToSnakeCaseNameConverter $nameConverter;
+    private NameConverterInterface $nameConverter;
 
     public function __construct()
     {

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -50,6 +50,7 @@ use ApiPlatform\Laravel\Eloquent\Metadata\ModelMetadata;
 use ApiPlatform\Laravel\Eloquent\Metadata\ResourceClassResolver as EloquentResourceClassResolver;
 use ApiPlatform\Laravel\Eloquent\PropertyAccess\PropertyAccessor as EloquentPropertyAccessor;
 use ApiPlatform\Laravel\Eloquent\Serializer\SerializerContextBuilder as EloquentSerializerContextBuilder;
+use ApiPlatform\Laravel\Eloquent\Serializer\SnakeCaseToCamelCaseNameConverter;
 use ApiPlatform\Laravel\Eloquent\State\CollectionProvider;
 use ApiPlatform\Laravel\Eloquent\State\ItemProvider;
 use ApiPlatform\Laravel\Eloquent\State\LinksHandler;
@@ -286,7 +287,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->bind(NameConverterInterface::class, function (Application $app) {
-            return new MetadataAwareNameConverter($app->make(ClassMetadataFactoryInterface::class));
+            return new MetadataAwareNameConverter($app->make(ClassMetadataFactoryInterface::class), $app->make(SnakeCaseToCamelCaseNameConverter::class));
         });
 
         $this->app->bind(OperationMetadataFactoryInterface::class, OperationMetadataFactory::class);

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -131,7 +131,6 @@ use Illuminate\Support\ServiceProvider;
 use Negotiation\Negotiator;
 use phpDocumentor\Reflection\DocBlockFactory;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -142,7 +141,6 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter as NameConverterCamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
@@ -284,11 +282,11 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->bind(PropertyAccessorInterface::class, function () {
-            return new EloquentPropertyAccessor(PropertyAccess::createPropertyAccessor());
+            return new EloquentPropertyAccessor();
         });
 
         $this->app->bind(NameConverterInterface::class, function (Application $app) {
-            return new MetadataAwareNameConverter($app->make(ClassMetadataFactoryInterface::class), new NameConverterCamelCaseToSnakeCaseNameConverter());
+            return new MetadataAwareNameConverter($app->make(ClassMetadataFactoryInterface::class));
         });
 
         $this->app->bind(OperationMetadataFactoryInterface::class, OperationMetadataFactory::class);

--- a/src/Laravel/Eloquent/PropertyAccess/PropertyAccessor.php
+++ b/src/Laravel/Eloquent/PropertyAccess/PropertyAccessor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Laravel\Eloquent\PropertyAccess;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
 
@@ -22,9 +23,12 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  */
 final class PropertyAccessor implements PropertyAccessorInterface
 {
+    private readonly PropertyAccessorInterface $inner;
+
     public function __construct(
-        private readonly PropertyAccessorInterface $inner,
+        ?PropertyAccessorInterface $inner = null,
     ) {
+        $this->inner = $inner ?? PropertyAccess::createPropertyAccessor();
     }
 
     /**

--- a/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
+++ b/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
@@ -11,8 +11,11 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @internal
  *
+ * @see Adapted from https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php.
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
+ * @copyright Fabien Potencier <fabien@symfony.com>
  */
 final class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
 {

--- a/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
+++ b/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
@@ -29,7 +29,7 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 final class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
 {
     /**
-     * @param array|null $attributes The list of attributes to rename or null for all attributes
+     * @param string[]|null $attributes The list of attributes to rename or null for all attributes
      */
     public function __construct(
         private readonly ?array $attributes = null,

--- a/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
+++ b/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Eloquent\Serializer;
+
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+/**
+ * Underscore to cameCase name converter.
+ *
+ * @internal
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
+ */
+final class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
+{
+    /**
+     * @param array|null $attributes The list of attributes to rename or null for all attributes
+     */
+    public function __construct(
+        private readonly ?array $attributes = null,
+    ) {
+    }
+
+    /**
+     * @param class-string|null $class
+     * @param string|null $format
+     * @param array<string, mixed> $context
+     */
+    public function normalize(
+        string $propertyName, ?string $class = null, ?string $format = null, array $context = []
+    ): string
+    {
+        if (null === $this->attributes || \in_array($propertyName, $this->attributes, true)) {
+            return lcfirst(preg_replace_callback(
+                '/(^|_|\.)+(.)/',
+                fn($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]),
+                $propertyName
+            ));
+        }
+
+        return $propertyName;
+    }
+
+    /**
+     * @param class-string|null $class
+     * @param string|null $format
+     * @param array<string, mixed> $context
+     */
+    public function denormalize(
+        string $propertyName, ?string $class = null, ?string $format = null, array $context = []
+    ): string
+    {
+        $snakeCased = strtolower(preg_replace('/[A-Z]/', '_\\0', lcfirst($propertyName)));
+        if (null === $this->attributes || \in_array($snakeCased, $this->attributes, true)) {
+            return $snakeCased;
+        }
+
+        return $propertyName;
+    }
+}

--- a/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
+++ b/src/Laravel/Eloquent/Serializer/SnakeCaseToCamelCaseNameConverter.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace ApiPlatform\Laravel\Eloquent\Serializer;
@@ -28,18 +37,16 @@ final class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
     }
 
     /**
-     * @param class-string|null $class
-     * @param string|null $format
+     * @param class-string|null    $class
      * @param array<string, mixed> $context
      */
     public function normalize(
         string $propertyName, ?string $class = null, ?string $format = null, array $context = []
-    ): string
-    {
+    ): string {
         if (null === $this->attributes || \in_array($propertyName, $this->attributes, true)) {
             return lcfirst(preg_replace_callback(
                 '/(^|_|\.)+(.)/',
-                fn($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]),
+                fn ($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]),
                 $propertyName
             ));
         }
@@ -48,14 +55,12 @@ final class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
     }
 
     /**
-     * @param class-string|null $class
-     * @param string|null $format
+     * @param class-string|null    $class
      * @param array<string, mixed> $context
      */
     public function denormalize(
         string $propertyName, ?string $class = null, ?string $format = null, array $context = []
-    ): string
-    {
+    ): string {
         $snakeCased = strtolower(preg_replace('/[A-Z]/', '_\\0', lcfirst($propertyName)));
         if (null === $this->attributes || \in_array($snakeCased, $this->attributes, true)) {
             return $snakeCased;

--- a/src/Laravel/Tests/JsonApiTest.php
+++ b/src/Laravel/Tests/JsonApiTest.php
@@ -69,7 +69,7 @@ class JsonApiTest extends TestCase
             '/api/books',
             [
                 'data' => [
-                    'attributes' => ['name' => 'Don Quichotte', 'isbn' => fake()->isbn13()],
+                    'attributes' => ['name' => 'Don Quichotte', 'isbn' => fake()->isbn13(), 'publicationDate' => fake()->date()],
                     'relationships' => ['author' => ['data' => ['id' => $this->getIriFromResource($author), 'type' => 'Author']]],
                 ],
             ],

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -63,6 +63,7 @@ class JsonLdTest extends TestCase
                 'name' => 'Don Quichotte',
                 'author' => $this->getIriFromResource($author),
                 'isbn' => fake()->isbn13(),
+                'publicationDate' => fake()->date(),
             ],
             [
                 'accept' => 'application/ld+json',

--- a/src/Laravel/workbench/app/Models/Book.php
+++ b/src/Laravel/workbench/app/Models/Book.php
@@ -30,7 +30,7 @@ class Book extends Model
     use HasFactory;
     use HasUlids;
 
-    protected $visible = ['name', 'author', 'isbn'];
+    protected $visible = ['name', 'author', 'isbn', 'publication_date'];
     protected $fillable = ['name'];
 
     public function author(): BelongsTo

--- a/src/Laravel/workbench/database/factories/BookFactory.php
+++ b/src/Laravel/workbench/database/factories/BookFactory.php
@@ -36,6 +36,7 @@ class BookFactory extends Factory
             'id' => (string) new Ulid(),
             'author_id' => AuthorFactory::new(),
             'isbn' => fake()->isbn13(),
+            'publication_date' => fake()->date(),
         ];
     }
 }

--- a/src/Laravel/workbench/database/migrations/2023_07_15_231244_create_book_table.php
+++ b/src/Laravel/workbench/database/migrations/2023_07_15_231244_create_book_table.php
@@ -31,6 +31,7 @@ return new class extends Migration {
             $table->ulid('id')->primary();
             $table->string('name');
             $table->string('isbn');
+            $table->date('publication_date');
             $table->integer('author_id')->unsigned();
             $table->foreign('author_id')->references('id')->on('authors');
             $table->timestamps();

--- a/src/Metadata/Util/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Metadata/Util/CamelCaseToSnakeCaseNameConverter.php
@@ -31,17 +31,14 @@ namespace ApiPlatform\Metadata\Util;
  */
 class CamelCaseToSnakeCaseNameConverter
 {
-    private $attributes;
-    private $lowerCamelCase;
-
     /**
      * @param array|null $attributes     The list of attributes to rename or null for all attributes
      * @param bool       $lowerCamelCase Use lowerCamelCase style
      */
-    public function __construct(?array $attributes = null, bool $lowerCamelCase = true)
-    {
-        $this->attributes = $attributes;
-        $this->lowerCamelCase = $lowerCamelCase;
+    public function __construct(
+        private readonly ?array $attributes = null,
+        private readonly bool $lowerCamelCase = true,
+    ) {
     }
 
     public function normalize(string $propertyName): string
@@ -55,9 +52,11 @@ class CamelCaseToSnakeCaseNameConverter
 
     public function denormalize(string $propertyName): string
     {
-        $camelCasedName = preg_replace_callback('/(^|_|\.)+(.)/', function ($match) {
-            return ('.' === $match[1] ? '_' : '').strtoupper($match[2]);
-        }, $propertyName);
+        $camelCasedName = preg_replace_callback(
+            '/(^|_|\.)+(.)/',
+            fn ($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]),
+            $propertyName
+        );
 
         if ($this->lowerCamelCase) {
             $camelCasedName = lcfirst($camelCasedName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Currently, model properties containing an underscore aren't written or read because an unneeded case conversion occurs. This patch fixes the issue.

~~A better fix could be to always convert internal snake_case model props to public camelCase API resources props.~~
Now implemented in this PR.
