### PR TITLE
fix(laravel): Eloquent PropertyAccessor

### DIFF
--- a/src/Laravel/Eloquent/PropertyAccess/PropertyAccessor.php
+++ b/src/Laravel/Eloquent/PropertyAccess/PropertyAccessor.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Laravel\Eloquent\PropertyAccess;
 
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Model;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
@@ -36,6 +36,12 @@ final class PropertyAccessor implements PropertyAccessorInterface
      */
     public function setValue(object|array &$objectOrArray, string|PropertyPathInterface $propertyPath, mixed $value): void
     {
+        if ($objectOrArray instanceof Model) {
+            $objectOrArray->{$propertyPath} = $value;
+
+            return;
+        }
+
         $this->inner->setValue($objectOrArray, $propertyPath, $value);
     }
 
@@ -44,13 +50,11 @@ final class PropertyAccessor implements PropertyAccessorInterface
      */
     public function getValue(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): mixed
     {
-        $value = $this->inner->getValue($objectOrArray, $propertyPath);
-
-        if ($value instanceof HasMany) {
+        if ($objectOrArray instanceof Model) {
             return $objectOrArray->{$propertyPath};
         }
 
-        return $value;
+        return $this->inner->getValue($objectOrArray, $propertyPath);
     }
 
     /**
@@ -58,6 +62,10 @@ final class PropertyAccessor implements PropertyAccessorInterface
      */
     public function isWritable(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): bool
     {
+        if ($objectOrArray instanceof Model) {
+            return true;
+        }
+
         return $this->inner->isWritable($objectOrArray, $propertyPath);
     }
 
@@ -66,6 +74,10 @@ final class PropertyAccessor implements PropertyAccessorInterface
      */
     public function isReadable(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): bool
     {
+        if ($objectOrArray instanceof Model) {
+            return true;
+        }
+
         return $this->inner->isReadable($objectOrArray, $propertyPath);
     }
 }

--- a/src/Laravel/Tests/JsonApiTest.php
+++ b/src/Laravel/Tests/JsonApiTest.php
@@ -69,8 +69,19 @@ class JsonApiTest extends TestCase
             '/api/books',
             [
                 'data' => [
-                    'attributes' => ['name' => 'Don Quichotte', 'isbn' => fake()->isbn13(), 'publicationDate' => fake()->date()],
-                    'relationships' => ['author' => ['data' => ['id' => $this->getIriFromResource($author), 'type' => 'Author']]],
+                    'attributes' => [
+                        'name' => 'Don Quichotte',
+                        'isbn' => fake()->isbn13(),
+                        'publicationDate' => fake()->optional()->date(),
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
+                                'id' => $this->getIriFromResource($author),
+                                'type' => 'Author',
+                            ],
+                        ],
+                    ],
                 ],
             ],
             [

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -63,7 +63,7 @@ class JsonLdTest extends TestCase
                 'name' => 'Don Quichotte',
                 'author' => $this->getIriFromResource($author),
                 'isbn' => fake()->isbn13(),
-                'publicationDate' => fake()->date(),
+                'publicationDate' => fake()->optional()->date(),
             ],
             [
                 'accept' => 'application/ld+json',

--- a/src/Laravel/workbench/database/factories/BookFactory.php
+++ b/src/Laravel/workbench/database/factories/BookFactory.php
@@ -36,7 +36,7 @@ class BookFactory extends Factory
             'id' => (string) new Ulid(),
             'author_id' => AuthorFactory::new(),
             'isbn' => fake()->isbn13(),
-            'publication_date' => fake()->date(),
+            'publication_date' => fake()->optional()->date(),
         ];
     }
 }

--- a/src/Laravel/workbench/database/migrations/2023_07_15_231244_create_book_table.php
+++ b/src/Laravel/workbench/database/migrations/2023_07_15_231244_create_book_table.php
@@ -31,7 +31,7 @@ return new class extends Migration {
             $table->ulid('id')->primary();
             $table->string('name');
             $table->string('isbn');
-            $table->date('publication_date');
+            $table->date('publication_date')->nullable();
             $table->integer('author_id')->unsigned();
             $table->foreign('author_id')->references('id')->on('authors');
             $table->timestamps();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes n/a
| License       | MIT
| Doc PR        | n/a

The current implementation fails to access properties containing the `null` value and likely has other issues.

This patch fixes this issue, simplifies the approach, and increases performance. 