### PR TITLE
fix(laravel): visible and hidden fields support

### DIFF
--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -264,12 +264,12 @@ final class ModelMetadata
      */
     private function attributeIsHidden(string $attribute, Model $model): bool
     {
-        if (\count($model->getHidden()) > 0) {
-            return \in_array($attribute, $model->getHidden(), true);
+        if ($visible = $model->getVisible()) {
+            return !\in_array($attribute, $visible, true);
         }
 
-        if (\count($model->getVisible()) > 0) {
-            return !\in_array($attribute, $model->getVisible(), true);
+        if ($hidden = $model->getHidden()) {
+            return \in_array($attribute, $hidden, true);
         }
 
         return false;

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -286,9 +286,10 @@ class JsonLdTest extends TestCase
 
     public function testVisible(): void
     {
-        $response = $this->get('/api/posts/1', ['accept' => 'application/ld+json']);
+        $response = $this->get('/api/posts', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
         $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        dump($response->json());
         $response->assertJsonMissingPath('internalNote');
     }
 }

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -275,4 +275,20 @@ class JsonLdTest extends TestCase
         $response = $this->get('/api/notexists', ['accept' => 'application/ld+json']);
         $response->assertNotFound();
     }
+
+    public function testHidden(): void
+    {
+        $response = $this->get('/api/posts/1/comments/1', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertJsonMissingPath('internalNote');
+    }
+
+    public function testVisible(): void
+    {
+        $response = $this->get('/api/posts/1', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertJsonMissingPath('internalNote');
+    }
 }

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -286,10 +286,9 @@ class JsonLdTest extends TestCase
 
     public function testVisible(): void
     {
-        $response = $this->get('/api/posts', ['accept' => 'application/ld+json']);
+        $response = $this->get('/api/books', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
         $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
-        dump($response->json());
-        $response->assertJsonMissingPath('internalNote');
+        $this->assertStringNotContainsString('internalNote', $response->getContent());
     }
 }

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -289,6 +289,6 @@ class JsonLdTest extends TestCase
         $response = $this->get('/api/books', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
         $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
-        $this->assertStringNotContainsString('internalNote', $response->getContent());
+        $this->assertStringNotContainsString('internalNote', (string) $response->getContent());
     }
 }

--- a/src/Laravel/workbench/app/Models/Book.php
+++ b/src/Laravel/workbench/app/Models/Book.php
@@ -33,7 +33,7 @@ class Book extends Model
     use HasFactory;
     use HasUlids;
 
-    //protected $visible = ['name', 'author', 'isbn', 'publication_date'];
+    protected $visible = ['name', 'author', 'isbn', 'publication_date'];
     protected $fillable = ['name'];
 
     public function author(): BelongsTo

--- a/src/Laravel/workbench/app/Models/Book.php
+++ b/src/Laravel/workbench/app/Models/Book.php
@@ -33,7 +33,7 @@ class Book extends Model
     use HasFactory;
     use HasUlids;
 
-    protected $visible = ['name', 'author', 'isbn', 'publication_date'];
+    //protected $visible = ['name', 'author', 'isbn', 'publication_date'];
     protected $fillable = ['name'];
 
     public function author(): BelongsTo

--- a/src/Laravel/workbench/app/Models/Comment.php
+++ b/src/Laravel/workbench/app/Models/Comment.php
@@ -50,7 +50,7 @@ class Comment extends Model
 {
     use HasFactory;
 
-    protected $visible = ['text', 'post'];
+    protected $hidden = ['internal_note'];
 
     public function post(): BelongsTo
     {

--- a/src/Laravel/workbench/database/factories/BookFactory.php
+++ b/src/Laravel/workbench/database/factories/BookFactory.php
@@ -37,7 +37,7 @@ class BookFactory extends Factory
             'author_id' => AuthorFactory::new(),
             'isbn' => fake()->isbn13(),
             'publication_date' => fake()->optional()->date(),
-            'internal_note' => fake()->optional()->text(),
+            'internal_note' => fake()->text(),
         ];
     }
 }

--- a/src/Laravel/workbench/database/factories/BookFactory.php
+++ b/src/Laravel/workbench/database/factories/BookFactory.php
@@ -37,6 +37,7 @@ class BookFactory extends Factory
             'author_id' => AuthorFactory::new(),
             'isbn' => fake()->isbn13(),
             'publication_date' => fake()->optional()->date(),
+            'internal_note' => fake()->optional()->text(),
         ];
     }
 }

--- a/src/Laravel/workbench/database/factories/CommentFactory.php
+++ b/src/Laravel/workbench/database/factories/CommentFactory.php
@@ -40,6 +40,7 @@ class CommentFactory extends Factory
         return [
             'post_id' => PostFactory::new(),
             'text' => fake()->text(),
+            'internal_note' => fake()->optional()->text(),
         ];
     }
 }

--- a/src/Laravel/workbench/database/migrations/2023_07_15_231244_create_book_table.php
+++ b/src/Laravel/workbench/database/migrations/2023_07_15_231244_create_book_table.php
@@ -32,6 +32,7 @@ return new class extends Migration {
             $table->string('name');
             $table->string('isbn');
             $table->date('publication_date')->nullable();
+            $table->text('internal_note')->nullable();
             $table->integer('author_id')->unsigned();
             $table->foreign('author_id')->references('id')->on('authors');
             $table->timestamps();
@@ -53,6 +54,7 @@ return new class extends Migration {
         Schema::create('comments', function (Blueprint $table): void {
             $table->id();
             $table->text('text');
+            $table->text('internal_note')->nullable();
             $table->integer('post_id')->unsigned();
             $table->foreign('post_id')->references('id')->on('posts');
             $table->timestamps();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

`Model::$visible` is an allow list. If it is defined, only fields explicitly listed in the array must be visible.
This patch fixes the issue and adds some tests for the feature.

According to [the docs](https://laravel.com/docs/11.x/eloquent-serialization#temporarily-modifying-attribute-visibility), it's also possible to hide the field for an instance by using `makeVisible()` and `makeHidden()`. 
I may be wrong, but this feature doesn't seem to be currently supported. This should be fixed in a follow-up PR.

