### PR TITLE
fix(laravel): api_doc route regex

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -827,6 +827,7 @@ class ApiPlatformProvider extends ServiceProvider
 
             return $entrypointAction->__invoke($request);
         });
+        $route->where('index', 'index');
         $route->name('api_entrypoint')->middleware(ApiPlatformMiddleware::class);
         $routeCollection->add($route);
         $route = new Route(['GET'], $prefix.'/.well-known/genid/{id}', function (): void {

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -269,4 +269,10 @@ class JsonLdTest extends TestCase
         $response = $this->get($iri, ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
     }
+
+    public function testApiDocsRegex(): void
+    {
+        $response = $this->get('/api/notexists', ['accept' => 'application/ld+json']);
+        $response->assertNotFound();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Prevents URLs such as `/api/foobar` to match.