### PR TITLE
fix(Symfony): canWrite guessing in WriteListener

### DIFF
--- a/src/Symfony/EventListener/WriteListener.php
+++ b/src/Symfony/EventListener/WriteListener.php
@@ -90,6 +90,16 @@ final class WriteListener
             return;
         }
 
+        $canWrite = $operation->canWrite();
+
+        if (null === $canWrite) {
+            $canWrite = !$request->isMethodSafe();
+        }
+
+        if (!$canWrite) {
+            return;
+        }
+
         if ($operation && (!$this->processor instanceof CallableProcessor && !$this->iriConverter)) {
             if (null === $operation->canWrite()) {
                 $operation = $operation->withWrite(!$request->isMethodSafe());

--- a/src/Symfony/EventListener/WriteListener.php
+++ b/src/Symfony/EventListener/WriteListener.php
@@ -90,7 +90,7 @@ final class WriteListener
             return;
         }
 
-        $canWrite = $operation->canWrite();
+        $canWrite = $operation?->canWrite();
 
         if (null === $canWrite) {
             $canWrite = !$request->isMethodSafe();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | Closes #6501 

As explained in the issue, in version 3.3 : a `Get` operation using a Controller is always calling the `WriteProcessor` after the Controller is called, which causes an "Invalid identifier or value configuration" if you are using another identifier.

Example : 

```php
new Get(
    output: SomethingOutput::class,
    provider: SomethingProvider::class,
)
```

A simple operation like this calls the `WriteProcessor`.
