### PR TITLE
fix(doctrine): use parameter.property as filter value key

### DIFF
--- a/src/Doctrine/Common/ParameterValueExtractorTrait.php
+++ b/src/Doctrine/Common/ParameterValueExtractorTrait.php
@@ -22,7 +22,7 @@ trait ParameterValueExtractorTrait
      */
     private function extractParameterValue(Parameter $parameter, mixed $value): array
     {
-        $key = $parameter->getKey();
+        $key = $parameter->getProperty() ?? $parameter->getKey();
         if (!str_contains($key, ':property')) {
             return [$key => $value];
         }

--- a/tests/Fixtures/TestBundle/Entity/SearchFilterParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/SearchFilterParameter.php
@@ -25,6 +25,7 @@ use Doctrine\ORM\Mapping as ORM;
     uriTemplate: 'search_filter_parameter{._format}',
     parameters: [
         'foo' => new QueryParameter(filter: 'app_search_filter_via_parameter'),
+        'fooAlias' => new QueryParameter(filter: 'app_search_filter_via_parameter', property: 'foo'),
         'order[:property]' => new QueryParameter(filter: 'app_search_filter_via_parameter.order_filter'),
 
         'searchPartial[:property]' => new QueryParameter(filter: 'app_search_filter_partial'),

--- a/tests/Functional/Parameters/DoctrineTest.php
+++ b/tests/Functional/Parameters/DoctrineTest.php
@@ -33,11 +33,16 @@ final class DoctrineTest extends ApiTestCase
         $this->assertEquals('bar', $a['hydra:member'][1]['foo']);
 
         $this->assertArraySubset(['hydra:search' => [
-            'hydra:template' => \sprintf('/%s{?foo,order[order[id]],order[order[foo]],searchPartial[foo],searchExact[foo],searchOnTextAndDate[foo],searchOnTextAndDate[createdAt][before],searchOnTextAndDate[createdAt][strictly_before],searchOnTextAndDate[createdAt][after],searchOnTextAndDate[createdAt][strictly_after],q}', $route),
+            'hydra:template' => \sprintf('/%s{?foo,fooAlias,order[order[id]],order[order[foo]],searchPartial[foo],searchExact[foo],searchOnTextAndDate[foo],searchOnTextAndDate[createdAt][before],searchOnTextAndDate[createdAt][strictly_before],searchOnTextAndDate[createdAt][after],searchOnTextAndDate[createdAt][strictly_after],q}', $route),
             'hydra:mapping' => [
                 ['@type' => 'IriTemplateMapping', 'variable' => 'foo', 'property' => 'foo'],
             ],
         ]], $a);
+
+        $response = self::createClient()->request('GET', $route.'?fooAlias=baz');
+        $a = $response->toArray();
+        $this->assertCount(1, $a['hydra:member']);
+        $this->assertEquals('baz', $a['hydra:member'][0]['foo']);
 
         $response = self::createClient()->request('GET', $route.'?order[foo]=asc');
         $this->assertEquals($response->toArray()['hydra:member'][0]['foo'], 'bar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| License       | MIT

This small change uses `Parameter::$property` instead of `Parameter::$key` in filters.
This would allow for "alias" parameters to work out of the box.

Given this api resource:
```php
#[GetCollection(
    parameters: [
        'fooAlias' => new QueryParameter(filter: 'some_filter', property: 'foo'),
    ]
)]
class MyClass
{
    #[ORM\Column()]
    public string $foo = '';
}
```
such calls would search on `foo` property: `/my-classs?fooAlias=bar`
