### PR TITLE
fix(doctrine): move event listeners to doctrine/common

### DIFF
--- a/src/Doctrine/Common/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Doctrine/Common/EventListener/PublishMercureUpdatesListener.php
@@ -11,10 +11,11 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Doctrine\EventListener;
+namespace ApiPlatform\Doctrine\Common\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface as LegacyResourceClassResolverInterface;
+use ApiPlatform\Doctrine\Common\Messenger\DispatchTrait;
 use ApiPlatform\Exception\InvalidArgumentException;
 use ApiPlatform\Exception\OperationNotFoundException;
 use ApiPlatform\Exception\RuntimeException;
@@ -27,7 +28,6 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\Metadata\Util\ResourceClassInfoTrait;
-use ApiPlatform\Symfony\Messenger\DispatchTrait;
 use Doctrine\Common\EventArgs;
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs as MongoDbOdmOnFlushEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs as OrmOnFlushEventArgs;
@@ -43,8 +43,6 @@ use Symfony\Component\Serializer\SerializerInterface;
  * Publishes resources updates to the Mercure hub.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @deprecated moved to \ApiPlatform\Doctrine\Common\EventListener\PublishMercureUpdatesListener
  */
 final class PublishMercureUpdatesListener
 {

--- a/src/Doctrine/Common/EventListener/PurgeHttpCacheListener.php
+++ b/src/Doctrine/Common/EventListener/PurgeHttpCacheListener.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Doctrine\EventListener;
+namespace ApiPlatform\Doctrine\Common\EventListener;
 
 use ApiPlatform\Api\IriConverterInterface as LegacyIriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface as LegacyResourceClassResolverInterface;
-use ApiPlatform\Exception\InvalidArgumentException;
-use ApiPlatform\Exception\OperationNotFoundException;
-use ApiPlatform\Exception\RuntimeException;
 use ApiPlatform\HttpCache\PurgerInterface;
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
+use ApiPlatform\Metadata\Exception\OperationNotFoundException;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
@@ -36,8 +36,6 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  * Purges responses containing modified entities from the proxy cache.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @deprecated moved to \ApiPlatform\Doctrine\Common\EventListener\PurgeHttpCacheListener
  */
 final class PurgeHttpCacheListener
 {

--- a/src/Doctrine/Common/Messenger/DispatchTrait.php
+++ b/src/Doctrine/Common/Messenger/DispatchTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @internal
+ */
+trait DispatchTrait
+{
+    private ?MessageBusInterface $messageBus;
+
+    /**
+     * @param object|Envelope $message
+     */
+    private function dispatch(object $message): Envelope
+    {
+        if (!$this->messageBus instanceof MessageBusInterface) {
+            throw new \InvalidArgumentException('The message bus is not set.');
+        }
+
+        if (!class_exists(HandlerFailedException::class)) {
+            return $this->messageBus->dispatch($message);
+        }
+
+        try {
+            return $this->messageBus->dispatch($message);
+        } catch (HandlerFailedException $e) {
+            // unwrap the exception thrown in handler for Symfony Messenger >= 4.3
+            while ($e instanceof HandlerFailedException) {
+                /** @var \Throwable $e */
+                $e = $e->getPrevious();
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/Doctrine/Common/Tests/EventListener/PublishMercureUpdatesListenerTest.php
+++ b/src/Doctrine/Common/Tests/EventListener/PublishMercureUpdatesListenerTest.php
@@ -11,9 +11,16 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Tests\Doctrine\EventListener;
+namespace ApiPlatform\Doctrine\Common\Tests\EventListener;
 
-use ApiPlatform\Doctrine\EventListener\PublishMercureUpdatesListener;
+use ApiPlatform\Doctrine\Common\EventListener\PublishMercureUpdatesListener;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\NotAResource;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\DummyCar;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\DummyFriend;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\DummyMercure;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\DummyOffer;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\MercureWithTopicsAndGetOperation;
 use ApiPlatform\GraphQl\Subscription\MercureSubscriptionIriGeneratorInterface as GraphQlMercureSubscriptionIriGeneratorInterface;
 use ApiPlatform\GraphQl\Subscription\SubscriptionManagerInterface as GraphQlSubscriptionManagerInterface;
 use ApiPlatform\Metadata\ApiResource;
@@ -25,13 +32,6 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
-use ApiPlatform\Tests\Fixtures\NotAResource;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyCar;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyFriend;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyMercure;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyOffer;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MercureWithTopicsAndGetOperation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\UnitOfWork;

--- a/src/Doctrine/Common/Tests/EventListener/PurgeHttpCacheListenerTest.php
+++ b/src/Doctrine/Common/Tests/EventListener/PurgeHttpCacheListenerTest.php
@@ -11,21 +11,21 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Tests\Doctrine\EventListener;
+namespace ApiPlatform\Doctrine\Common\Tests\EventListener;
 
-use ApiPlatform\Doctrine\EventListener\PurgeHttpCacheListener;
-use ApiPlatform\Exception\InvalidArgumentException;
-use ApiPlatform\Exception\ItemNotFoundException;
+use ApiPlatform\Doctrine\Common\EventListener\PurgeHttpCacheListener;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\NotAResource;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\ContainNonResource;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\DummyNoGetOperation;
+use ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\HttpCache\PurgerInterface;
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
+use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
-use ApiPlatform\Tests\Fixtures\NotAResource;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ContainNonResource;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyNoGetOperation;
-use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;

--- a/src/Doctrine/Common/Tests/Fixtures/NotAResource.php
+++ b/src/Doctrine/Common/Tests/Fixtures/NotAResource.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * This class is not mapped as an API resource.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class NotAResource
+{
+    public function __construct(
+        #[Groups('contain_non_resource')]
+        private $foo,
+        #[Groups('contain_non_resource')]
+        private $bar,
+    ) {
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/ContainNonResource.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/ContainNonResource.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\NotAResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * Resource linked to a standard object.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+#[ApiResource(filters: ['my_dummy.property'], normalizationContext: ['groups' => ['contain_non_resource']])]
+#[ORM\Entity]
+class ContainNonResource
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[Groups('contain_non_resource')]
+    public $id;
+    /**
+     * @var ContainNonResource
+     */
+    #[Groups('contain_non_resource')]
+    public $nested;
+    /**
+     * @var NotAResource
+     */
+    #[Groups('contain_non_resource')]
+    public $notAResource;
+}

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyCar.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyCar.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\Serializer\Filter\GroupFilter;
+use ApiPlatform\Serializer\Filter\PropertyFilter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiFilter(DateFilter::class, strategy: DateFilter::EXCLUDE_NULL)]
+#[ApiFilter(BooleanFilter::class)]
+#[ApiFilter(PropertyFilter::class, arguments: ['parameterName' => 'foobar'])]
+#[ApiFilter(GroupFilter::class, arguments: ['parameterName' => 'foobargroups'])]
+#[ApiFilter(GroupFilter::class, arguments: ['parameterName' => 'foobargroups_override'], id: 'override')]
+#[ApiResource(operations: [new Get(openapi: new OpenApiOperation(tags: [])), new Put(), new Delete(), new Post(), new GetCollection()], sunset: '2050-01-01', normalizationContext: ['groups' => ['colors']])]
+#[ORM\Entity]
+class DummyCar
+{
+    #[ORM\Id]
+    public int $id;
+
+    #[ApiFilter(SearchFilter::class, strategy: 'exact')]
+
+    #[ApiFilter(SearchFilter::class, strategy: 'partial')]
+    #[ORM\Column(type: 'string')]
+    private string $name;
+    #[ORM\Column(type: 'boolean')]
+    private bool $canSell;
+    #[ORM\Column(type: 'datetime')]
+    private \DateTime $availableAt;
+    #[ORM\Column]
+    private string $brand = 'DummyBrand';
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * Get name.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getCanSell(): bool
+    {
+        return $this->canSell;
+    }
+
+    public function setCanSell(bool $canSell): void
+    {
+        $this->canSell = $canSell;
+    }
+
+    public function getAvailableAt(): \DateTime
+    {
+        return $this->availableAt;
+    }
+
+    public function setAvailableAt(\DateTime $availableAt): void
+    {
+        $this->availableAt = $availableAt;
+    }
+
+    public function getBrand(): string
+    {
+        return $this->brand;
+    }
+
+    public function setBrand(string $brand): void
+    {
+        $this->brand = $brand;
+    }
+}

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyCarInfo.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyCarInfo.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Sergey Balasov <sbalasov@gmail.com>
+ */
+#[ORM\Embeddable]
+class DummyCarInfo
+{
+    /**
+     * @var string
+     */
+    #[ORM\Column(nullable: true)]
+    public $name;
+}

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyMercure.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyMercure.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+#[ApiResource(mercure: true, extraProperties: ['standard_put' => false])]
+#[ORM\Entity]
+class DummyMercure
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public $id;
+    #[ORM\Column]
+    public $name;
+    #[ORM\Column]
+    public $description;
+    #[ORM\ManyToOne(targetEntity: RelatedDummy::class)]
+    public $relatedDummy;
+}

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyNoGetOperation.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyNoGetOperation.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * DummyNoGetOperation.
+ *
+ * @author Grégoire Hébert gregoire@les-tilleuls.coop
+ */
+#[ApiResource(operations: [new Put(), new Post()])]
+#[ORM\Entity]
+class DummyNoGetOperation
+{
+    /**
+     * @var int The id
+     */
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public $id;
+
+    /**
+     * @var string
+     */
+    #[ORM\Column]
+    public $lorem;
+
+    public function setId($id): void
+    {
+        $this->id = $id;
+    }
+}

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyOffer.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/DummyOffer.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Dummy Offer.
+ *
+ * https://github.com/api-platform/core/issues/1107.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+#[ApiResource]
+#[ORM\Entity]
+class DummyOffer
+{
+    /**
+     * @var int The id
+     */
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+    /**
+     * @var int The dummy aggregate offer value
+     */
+    #[ORM\Column(type: 'integer')]
+    private int $value;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    public function setValue(int $value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/MercureWithTopicsAndGetOperation.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/MercureWithTopicsAndGetOperation.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(
+    operations: [
+        new Get(uriTemplate: '/mercure_with_topics_and_get_operations/{id}{._format}'),
+        new Post(uriTemplate: '/mercure_with_topics_and_get_operations{._format}'),
+        new Get(uriTemplate: '/custom_resource/mercure_with_topics_and_get_operations/{id}{._format}'),
+    ],
+    mercure: [
+        'topics' => [
+            '@=iri(object)',
+            '@=iri(object, '.UrlGeneratorInterface::ABS_URL.', get_operation(object, "/custom_resource/mercure_with_topics_and_get_operations/{id}{._format}"))',
+        ],
+    ]
+)]
+#[ORM\Entity]
+class MercureWithTopicsAndGetOperation
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public $id;
+    #[ORM\Column]
+    public $name;
+}

--- a/src/Doctrine/Common/composer.json
+++ b/src/Doctrine/Common/composer.json
@@ -23,14 +23,23 @@
     ],
     "require": {
         "php": ">=8.1",
-        "api-platform/metadata": "@dev",
-        "api-platform/state": "@dev",
+        "api-platform/metadata": "^3.4",
+        "api-platform/state": "^3.4",
         "doctrine/collections": "^2.1",
         "doctrine/common": "^3.2.2",
-        "doctrine/persistence": "^3.2"
+        "doctrine/persistence": "^3.2",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/messenger": "^6.4 || ^7.0"
     },
     "require-dev": {
         "doctrine/mongodb-odm": "^2.6",
+        "symfony/expression-language": "^6.4 || 7.0",
+        "api-platform/http-cache": "^3.4",
+        "api-platform/graphql": "^3.4",
+        "api-platform/validator": "^3.4",
+        "api-platform/serializer": "^3.4",
+        "symfony/mercure-bundle": "*",
         "doctrine/orm": "^2.17 || ^3.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^10.0",
@@ -42,7 +51,10 @@
     "suggest": {
         "phpstan/phpdoc-parser": "For PHP documentation support.",
         "symfony/yaml": "For YAML resource configuration.",
-        "symfony/config": "For XML resource configuration."
+        "symfony/config": "For XML resource configuration.",
+        "api-platform/http-cache": "For HTTP cache invalidation.",
+        "api-platform/graphql": "For GraphQl mercure subscriptions.",
+        "symfony/mercure-bundle": "For mercure updates publisher."
     },
     "autoload": {
         "psr-4": {

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -545,11 +545,11 @@ final class FieldsBuilder implements FieldsBuilderInterface, FieldsBuilderEnumIn
 
             $entityClass = $resourceClass;
             if ($options = $resourceOperation->getStateOptions()) {
-                if ($options instanceof Options && $options->getEntityClass()) {
+                if (class_exists(Options::class) && $options instanceof Options && $options->getEntityClass()) {
                     $entityClass = $options->getEntityClass();
                 }
 
-                if ($options instanceof ODMOptions && $options->getDocumentClass()) {
+                if (class_exists(ODMOptions::class) && $options instanceof ODMOptions && $options->getDocumentClass()) {
                     $entityClass = $options->getDocumentClass();
                 }
             }

--- a/src/GraphQl/composer.json
+++ b/src/GraphQl/composer.json
@@ -21,10 +21,10 @@
     ],
     "require": {
         "php": ">=8.1",
-        "api-platform/metadata": "^3.1",
-        "api-platform/serializer": "^3.1",
-        "api-platform/state": "^3.1",
-        "api-platform/validator": "^3.1",
+        "api-platform/metadata": "^3.4",
+        "api-platform/state": "^3.4",
+        "api-platform/serializer": "^3.4",
+        "api-platform/validator": "^3.4",
         "symfony/property-info": "^6.4 || ^7.1",
         "symfony/serializer": "^6.4 || ^7.1",
         "webonyx/graphql-php": "^14.0 || ^15.0",
@@ -38,10 +38,7 @@
         "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "symfony/routing": "^6.4 || ^7.0",
         "symfony/validator": "^6.4 || ^7.0",
-        "sebastian/comparator": "<5.0",
-        "api-platform/doctrine-common": "^3.2",
-        "api-platform/doctrine-odm": "^3.2",
-        "api-platform/doctrine-orm": "^3.2"
+        "sebastian/comparator": "<5.0"
     },
     "autoload": {
         "psr-4": {
@@ -50,6 +47,10 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
+    },
+    "suggest": {
+        "api-platform/doctrine-odm": "To support doctrine ODM state options.",
+        "api-platform/doctrine-orm": "To support doctrine ORM state options."
     },
     "config": {
         "preferred-install": {

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -81,7 +81,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
             }
         }
 
-        if (null === $context['output'] && ($options = $operation?->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
+        if (null === $context['output'] && ($options = $operation?->getStateOptions()) && class_exists(Options::class) && $options instanceof Options && $options->getEntityClass()) {
             $context['force_resource_class'] = $operation->getClass();
         }
 

--- a/src/Serializer/composer.json
+++ b/src/Serializer/composer.json
@@ -35,10 +35,10 @@
         "symfony/mercure-bundle": "*",
         "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "symfony/var-dumper": "^6.4 || ^7.0",
-        "symfony/yaml": "^6.4 || ^7.0",
-        "api-platform/doctrine-odm": "^3.2",
-        "api-platform/doctrine-orm": "^3.2",
-        "api-platform/doctrine-common": "^3.2"
+        "symfony/yaml": "^6.4 || ^7.0"
+    },
+    "suggest": {
+        "api-platform/doctrine-orm": "To support doctrine ORM state options."
     },
     "autoload": {
         "psr-4": {

--- a/src/deprecation.php
+++ b/src/deprecation.php
@@ -49,6 +49,8 @@ $movedClasses = [
     ApiPlatform\Util\ClientTrait::class => ApiPlatform\Symfony\Bundle\Test\ClientTrait::class,
     ApiPlatform\Util\RequestAttributesExtractor::class => ApiPlatform\State\Util\RequestAttributesExtractor::class,
     ApiPlatform\Symfony\Util\RequestAttributesExtractor::class => ApiPlatform\State\Util\RequestAttributesExtractor::class,
+    ApiPlatform\Doctrine\EventListener\PublishMercureUpdatesListener::class => ApiPlatform\Doctrine\Common\EventListener\PublishMercureUpdatesListener::class,
+    ApiPlatform\Doctrine\EventListener\PurgeHttpCacheListener::class => ApiPlatform\Doctrine\Common\EventListener\PurgeHttpCacheListener::class,
 ];
 
 $removedClasses = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| License       | MIT

Moves the PurgerListener and the CacheListener to the `api-platform/doctrine-common` package to be installed as part of the subtree split. 