### PR TITLE
feat(processor): add missing context when generating iri for content …

### DIFF
--- a/src/State/Processor/RespondProcessor.php
+++ b/src/State/Processor/RespondProcessor.php
@@ -103,7 +103,7 @@ final class RespondProcessor implements ProcessorInterface
         $status ??= self::METHOD_TO_CODE[$method] ?? 200;
 
         if ($hasData && $this->iriConverter) {
-            $iri = $this->iriConverter->getIriFromResource($originalData);
+            $iri = $this->iriConverter->getIriFromResource($originalData, context: $context);
             $headers['Content-Location'] = $iri;
 
             if ((201 === $status || (300 <= $status && $status < 400)) && 'POST' === $method) {


### PR DESCRIPTION
…location header

| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Tickets       | 
| License       | MIT
| Doc PR        | 

When it generate the iri, it misses the context, so if we need some uri variables from the context to generate the route it will not work (like a object_id not available in the resource)

Without this, it will throw an error that it cannot generate an iri item for this resource
