### PR TITLE
feat: better path sorting for openapi UIs

### DIFF
--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -20,8 +20,33 @@ final class Paths
     public function addPath(string $path, PathItem $pathItem): void
     {
         $this->paths[$path] = $pathItem;
+    }
 
-        ksort($this->paths);
+    private function comparePathsByKey($keyA, $keyB): int
+    {
+        $a = $this->paths[$keyA];
+        $b = $this->paths[$keyB];
+
+        $tagsA = [
+            ...($a->getGet()?->getTags() ?? []),
+            ...($a->getPost()?->getTags() ?? []),
+            ...($a->getPut()?->getTags() ?? []),
+            ...($a->getDelete()?->getTags() ?? []),
+        ];
+        sort($tagsA);
+
+        $tagsB = [
+            ...($b->getGet()?->getTags() ?? []),
+            ...($b->getPost()?->getTags() ?? []),
+            ...($b->getPut()?->getTags() ?? []),
+            ...($b->getDelete()?->getTags() ?? []),
+        ];
+        sort($tagsB);
+
+        return match(true) {
+            current($tagsA) === current($tagsB) => $keyA <=> $keyB,
+            default => current($tagsA) <=> current($tagsB),
+        };
     }
 
     public function getPath(string $path): ?PathItem
@@ -31,6 +56,9 @@ final class Paths
 
     public function getPaths(): array
     {
+        // sort paths by tags, then by path for each tag
+        uksort($this->paths, $this->comparePathsByKey(...));
+
         return $this->paths;
     }
 }

--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -22,33 +22,6 @@ final class Paths
         $this->paths[$path] = $pathItem;
     }
 
-    private function comparePathsByKey($keyA, $keyB): int
-    {
-        $a = $this->paths[$keyA];
-        $b = $this->paths[$keyB];
-
-        $tagsA = [
-            ...($a->getGet()?->getTags() ?? []),
-            ...($a->getPost()?->getTags() ?? []),
-            ...($a->getPut()?->getTags() ?? []),
-            ...($a->getDelete()?->getTags() ?? []),
-        ];
-        sort($tagsA);
-
-        $tagsB = [
-            ...($b->getGet()?->getTags() ?? []),
-            ...($b->getPost()?->getTags() ?? []),
-            ...($b->getPut()?->getTags() ?? []),
-            ...($b->getDelete()?->getTags() ?? []),
-        ];
-        sort($tagsB);
-
-        return match (true) {
-            current($tagsA) === current($tagsB) => $keyA <=> $keyB,
-            default => current($tagsA) <=> current($tagsB),
-        };
-    }
-
     public function getPath(string $path): ?PathItem
     {
         return $this->paths[$path] ?? null;
@@ -56,9 +29,6 @@ final class Paths
 
     public function getPaths(): array
     {
-        // sort paths by tags, then by path for each tag
-        uksort($this->paths, $this->comparePathsByKey(...));
-
         return $this->paths;
     }
 }

--- a/src/OpenApi/Model/Paths.php
+++ b/src/OpenApi/Model/Paths.php
@@ -43,7 +43,7 @@ final class Paths
         ];
         sort($tagsB);
 
-        return match(true) {
+        return match (true) {
             current($tagsA) === current($tagsB) => $keyA <=> $keyB,
             default => current($tagsA) <=> current($tagsB),
         };

--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -39,42 +39,7 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
      */
     public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
-        $pathsCallback = static function ($decoratedObject): array {
-            if ($decoratedObject instanceof Paths) {
-                $paths = $decoratedObject->getPaths();
-
-                // sort paths by tags, then by path for each tag
-                uksort($paths, function ($keyA, $keyB) use ($paths) {
-                    $a = $paths[$keyA];
-                    $b = $paths[$keyB];
-
-                    $tagsA = [
-                        ...($a->getGet()?->getTags() ?? []),
-                        ...($a->getPost()?->getTags() ?? []),
-                        ...($a->getPut()?->getTags() ?? []),
-                        ...($a->getDelete()?->getTags() ?? []),
-                    ];
-                    sort($tagsA);
-
-                    $tagsB = [
-                        ...($b->getGet()?->getTags() ?? []),
-                        ...($b->getPost()?->getTags() ?? []),
-                        ...($b->getPut()?->getTags() ?? []),
-                        ...($b->getDelete()?->getTags() ?? []),
-                    ];
-                    sort($tagsB);
-
-                    return match (true) {
-                        current($tagsA) === current($tagsB) => $keyA <=> $keyB,
-                        default => current($tagsA) <=> current($tagsB),
-                    };
-                });
-
-                return $paths;
-            }
-
-            return [];
-        };
+        $pathsCallback = $this->getPathsCallBack();
         $context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] = true;
         $context[AbstractObjectNormalizer::SKIP_NULL_VALUES] = true;
         $context[AbstractNormalizer::CALLBACKS] = [
@@ -129,5 +94,45 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
         }
 
         return true;
+    }
+
+    private function getPathsCallBack(): \Closure
+    {
+        return static function ($decoratedObject): array {
+            if ($decoratedObject instanceof Paths) {
+                $paths = $decoratedObject->getPaths();
+
+                // sort paths by tags, then by path for each tag
+                uksort($paths, function ($keyA, $keyB) use ($paths) {
+                    $a = $paths[$keyA];
+                    $b = $paths[$keyB];
+
+                    $tagsA = [
+                        ...($a->getGet()?->getTags() ?? []),
+                        ...($a->getPost()?->getTags() ?? []),
+                        ...($a->getPut()?->getTags() ?? []),
+                        ...($a->getDelete()?->getTags() ?? []),
+                    ];
+                    sort($tagsA);
+
+                    $tagsB = [
+                        ...($b->getGet()?->getTags() ?? []),
+                        ...($b->getPost()?->getTags() ?? []),
+                        ...($b->getPut()?->getTags() ?? []),
+                        ...($b->getDelete()?->getTags() ?? []),
+                    ];
+                    sort($tagsB);
+
+                    return match (true) {
+                        current($tagsA) === current($tagsB) => $keyA <=> $keyB,
+                        default => current($tagsA) <=> current($tagsB),
+                    };
+                });
+
+                return $paths;
+            }
+
+            return [];
+        };
     }
 }

--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -39,7 +39,42 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
      */
     public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
-        $pathsCallback = static fn ($decoratedObject): array => $decoratedObject instanceof Paths ? $decoratedObject->getPaths() : [];
+        $pathsCallback = static function ($decoratedObject): array {
+            if($decoratedObject instanceof Paths) {
+                $paths = $decoratedObject->getPaths();
+
+                // sort paths by tags, then by path for each tag
+                uksort($paths, function ($keyA, $keyB) use ($paths) {
+                    $a = $paths[$keyA];
+                    $b = $paths[$keyB];
+
+                    $tagsA = [
+                        ...($a->getGet()?->getTags() ?? []),
+                        ...($a->getPost()?->getTags() ?? []),
+                        ...($a->getPut()?->getTags() ?? []),
+                        ...($a->getDelete()?->getTags() ?? []),
+                    ];
+                    sort($tagsA);
+
+                    $tagsB = [
+                        ...($b->getGet()?->getTags() ?? []),
+                        ...($b->getPost()?->getTags() ?? []),
+                        ...($b->getPut()?->getTags() ?? []),
+                        ...($b->getDelete()?->getTags() ?? []),
+                    ];
+                    sort($tagsB);
+
+                    return match (true) {
+                        current($tagsA) === current($tagsB) => $keyA <=> $keyB,
+                        default => current($tagsA) <=> current($tagsB),
+                    };
+                });
+
+                return $paths;
+            }
+
+            return [];
+        };
         $context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] = true;
         $context[AbstractObjectNormalizer::SKIP_NULL_VALUES] = true;
         $context[AbstractNormalizer::CALLBACKS] = [

--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -40,7 +40,7 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
     public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         $pathsCallback = static function ($decoratedObject): array {
-            if($decoratedObject instanceof Paths) {
+            if ($decoratedObject instanceof Paths) {
                 $paths = $decoratedObject->getPaths();
 
                 // sort paths by tags, then by path for each tag

--- a/src/OpenApi/Serializer/OpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/OpenApiNormalizer.php
@@ -110,6 +110,7 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
                     $tagsA = [
                         ...($a->getGet()?->getTags() ?? []),
                         ...($a->getPost()?->getTags() ?? []),
+                        ...($a->getPatch()?->getTags() ?? []),
                         ...($a->getPut()?->getTags() ?? []),
                         ...($a->getDelete()?->getTags() ?? []),
                     ];
@@ -118,6 +119,7 @@ final class OpenApiNormalizer implements NormalizerInterface, CacheableSupportsM
                     $tagsB = [
                         ...($b->getGet()?->getTags() ?? []),
                         ...($b->getPost()?->getTags() ?? []),
+                        ...($b->getPatch()?->getTags() ?? []),
                         ...($b->getPut()?->getTags() ?? []),
                         ...($b->getDelete()?->getTags() ?? []),
                     ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| License       | MIT

I've noticed for a while that operations sorting as displayed by tools like swagger-ui or scalar could be confusing at first - they are sorted by path, but displayed by tags first.

This PR sorts them by tags, then by path. As a very small optimization (assuming there are more writes than reads) it also triggers the sorting only when the paths are actually used instead of sorting each time a new path is added.