### PR TITLE
fix(laravel): remove json api provider

### DIFF
--- a/src/Laravel/ApiPlatformMiddleware.php
+++ b/src/Laravel/ApiPlatformMiddleware.php
@@ -30,6 +30,7 @@ class ApiPlatformMiddleware
      */
     public function handle(Request $request, \Closure $next, ?string $operationName = null): Response
     {
+        $operation = null;
         if ($operationName) {
             $request->attributes->set('_api_operation', $operation = $this->operationMetadataFactory->create($operationName));
         }
@@ -41,9 +42,7 @@ class ApiPlatformMiddleware
             }
         }
 
-        if ($format) {
-            $request->attributes->set('_format', substr($format, 1, \strlen($format) - 1));
-        }
+        $request->attributes->set('_format', $format ? substr($format, 1, \strlen($format) - 1) : '');
 
         return $next($request);
     }

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -57,7 +57,6 @@ use ApiPlatform\JsonApi\Serializer\EntrypointNormalizer as JsonApiEntrypointNorm
 use ApiPlatform\JsonApi\Serializer\ItemNormalizer as JsonApiItemNormalizer;
 use ApiPlatform\JsonApi\Serializer\ObjectNormalizer as JsonApiObjectNormalizer;
 use ApiPlatform\JsonApi\Serializer\ReservedAttributeNameConverter;
-use ApiPlatform\JsonApi\State\JsonApiProvider;
 use ApiPlatform\JsonLd\Action\ContextAction;
 use ApiPlatform\JsonLd\AnonymousContextBuilderInterface;
 use ApiPlatform\JsonLd\ContextBuilder as JsonLdContextBuilder;
@@ -433,16 +432,8 @@ class ApiPlatformProvider extends ServiceProvider
             return new ValidateProvider($app->make(SwaggerUiProvider::class), $app);
         });
 
-        $this->app->singleton(JsonApiProvider::class, function (Application $app) {
-            /** @var ConfigRepository */
-            $config = $app['config'];
-
-            // TODO: improve the JsonApiProvider and check the operation parameters for an OrderFilter
-            return new JsonApiProvider($app->make(ValidateProvider::class), 'sort');
-        });
-
         $this->app->singleton(DeserializeProvider::class, function (Application $app) {
-            return new DeserializeProvider($app->make(JsonApiProvider::class), $app->make(SerializerInterface::class), $app->make(SerializerContextBuilderInterface::class));
+            return new DeserializeProvider($app->make(ValidateProvider::class), $app->make(SerializerInterface::class), $app->make(SerializerContextBuilderInterface::class));
         });
 
         $this->app->tag([PropertyFilter::class], SerializerFilterInterface::class);

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -443,6 +443,7 @@ class ApiPlatformProvider extends ServiceProvider
 
             return new SerializerFilterParameterProvider(new ServiceLocator($tagged));
         });
+        $this->app->alias(SerializerFilterParameterProvider::class, 'api_platform.serializer.filter_parameter_provider');
 
         $this->app->tag([SerializerFilterParameterProvider::class], ParameterProviderInterface::class);
 
@@ -455,6 +456,7 @@ class ApiPlatformProvider extends ServiceProvider
 
         $this->app->singleton(ParameterProvider::class, function (Application $app) {
             $tagged = iterator_to_array($app->tagged(ParameterProviderInterface::class));
+            $tagged['api_platform.serializer.filter_parameter_provider'] = $app->make(SerializerFilterParameterProvider::class);
 
             return new ParameterProvider(
                 new ParameterValidatorProvider(

--- a/src/Laravel/Controller/ApiPlatformController.php
+++ b/src/Laravel/Controller/ApiPlatformController.php
@@ -104,7 +104,12 @@ class ApiPlatformController extends Controller
     {
         $uriVariables = [];
         foreach ($operation->getUriVariables() ?? [] as $parameterName => $_) {
-            $uriVariables[(string) $parameterName] = $request->route($parameterName);
+            $parameter = $request->route($parameterName);
+            if (\is_string($parameter) && ($format = $request->attributes->get('_format')) && str_contains($parameter, $format)) {
+                $parameter = substr($parameter, 0, \strlen($parameter) - (\strlen($format) + 1));
+            }
+
+            $uriVariables[(string) $parameterName] = $parameter;
         }
 
         return $uriVariables;

--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -193,6 +193,7 @@ final class ModelMetadata
                     'name' => $method->getName(),
                     'type' => $relation::class,
                     'related' => \get_class($relation->getRelated()),
+                    'foreign_key' => method_exists($relation, 'getForeignKeyName') ? $relation->getForeignKeyName() : null,
                 ];
             })
             ->filter()

--- a/src/Laravel/Eloquent/Serializer/SerializerContextBuilder.php
+++ b/src/Laravel/Eloquent/Serializer/SerializerContextBuilder.php
@@ -37,8 +37,10 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
             return $context;
         }
 
-        // isWritable/isReadable is checked later on
-        $context[AbstractNormalizer::ATTRIBUTES] = iterator_to_array($this->propertyNameCollectionFactory->create($context['resource_class'], ['serializer_groups' => $context['groups'] ?? null]));
+        if (!isset($context[AbstractNormalizer::ATTRIBUTES])) {
+            // isWritable/isReadable is checked later on
+            $context[AbstractNormalizer::ATTRIBUTES] = iterator_to_array($this->propertyNameCollectionFactory->create($context['resource_class'], ['serializer_groups' => $context['groups'] ?? null]));
+        }
 
         return $context;
     }

--- a/src/Laravel/State/ParameterValidatorProvider.php
+++ b/src/Laravel/State/ParameterValidatorProvider.php
@@ -64,8 +64,12 @@ final class ParameterValidatorProvider implements ProviderInterface
                 $value = null;
             }
 
-            foreach ($constraints as $c) {
-                $allConstraints[] = $c;
+            foreach ((array) $constraints as $k => $c) {
+                if (!\is_string($k)) {
+                    $k = $key;
+                }
+
+                $allConstraints[$k] = $c;
             }
         }
 

--- a/src/Laravel/Tests/EloquentTest.php
+++ b/src/Laravel/Tests/EloquentTest.php
@@ -33,6 +33,18 @@ class EloquentTest extends TestCase
         $this->assertSame($response->json()['member'][0], $book);
     }
 
+    public function testValidateSearchFilter(): void
+    {
+        $response = $this->get('/api/books?isbn=a', ['accept' => ['application/ld+json']]);
+        $this->assertSame($response->json()['detail'], 'The isbn field must be at least 2 characters.');
+    }
+
+    public function testSearchFilterRelation(): void
+    {
+        $response = $this->get('/api/books?author=1', ['accept' => ['application/ld+json']]);
+        $this->assertSame($response->json()['member'][0]['author'], '/api/authors/1');
+    }
+
     public function testPropertyFilter(): void
     {
         $response = $this->get('/api/books', ['accept' => ['application/ld+json']]);

--- a/src/Laravel/Tests/EloquentTest.php
+++ b/src/Laravel/Tests/EloquentTest.php
@@ -33,6 +33,19 @@ class EloquentTest extends TestCase
         $this->assertSame($response->json()['member'][0], $book);
     }
 
+    public function testPropertyFilter(): void
+    {
+        $response = $this->get('/api/books', ['accept' => ['application/ld+json']]);
+        $book = $response->json()['member'][0];
+
+        $response = $this->get(\sprintf('%s.jsonld?properties[]=author', $book['@id']));
+        $book = $response->json();
+
+        $this->assertArrayHasKey('@id', $book);
+        $this->assertArrayHasKey('author', $book);
+        $this->assertArrayNotHasKey('name', $book);
+    }
+
     public function testPartialSearchFilter(): void
     {
         $response = $this->get('/api/books', ['accept' => ['application/ld+json']]);

--- a/src/Laravel/workbench/app/Models/Book.php
+++ b/src/Laravel/workbench/app/Models/Book.php
@@ -45,8 +45,9 @@ use Workbench\App\Http\Requests\BookFormRequest;
         new GetCollection(),
     ]
 )]
-#[QueryParameter(key: 'isbn', filter: PartialSearchFilter::class)]
+#[QueryParameter(key: 'isbn', filter: PartialSearchFilter::class, constraints: 'min:2')]
 #[QueryParameter(key: 'name', filter: PartialSearchFilter::class)]
+#[QueryParameter(key: 'author', filter: EqualsFilter::class)]
 #[QueryParameter(key: 'publicationDate', filter: DateFilter::class)]
 #[QueryParameter(
     key: 'name2',

--- a/src/Laravel/workbench/app/Models/Book.php
+++ b/src/Laravel/workbench/app/Models/Book.php
@@ -25,6 +25,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Serializer\Filter\PropertyFilter;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -52,6 +53,7 @@ use Workbench\App\Http\Requests\BookFormRequest;
     filter: new OrFilter(new EqualsFilter()),
     property: 'name'
 )]
+#[QueryParameter(key: 'properties', filter: PropertyFilter::class)]
 class Book extends Model
 {
     use HasFactory;

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -28,7 +28,7 @@ abstract class Parameter
      * @param array<string, mixed>                                               $extraProperties
      * @param ParameterProviderInterface|callable|string|null                    $provider
      * @param FilterInterface|string|null                                        $filter
-     * @param Constraint|Constraint[]|null                                       $constraints
+     * @param Constraint|array<string, string>|string|Constraint[]|null          $constraints
      */
     public function __construct(
         protected ?string $key = null,
@@ -41,7 +41,7 @@ abstract class Parameter
         protected ?bool $required = null,
         protected ?int $priority = null,
         protected ?false $hydra = null,
-        protected Constraint|array|null $constraints = null,
+        protected Constraint|array|string|null $constraints = null,
         protected string|\Stringable|null $security = null,
         protected ?string $securityMessage = null,
         protected ?array $extraProperties = [],
@@ -103,9 +103,9 @@ abstract class Parameter
     }
 
     /**
-     * @return Constraint|Constraint[]|null
+     * @return Constraint|string|array<string, string>|Constraint[]|null
      */
-    public function getConstraints(): Constraint|array|null
+    public function getConstraints(): Constraint|string|array|null
     {
         return $this->constraints;
     }
@@ -232,7 +232,10 @@ abstract class Parameter
         return $self;
     }
 
-    public function withConstraints(array|Constraint $constraints): static
+    /**
+     * @param string|array<string, string>|Constraint[]|Constraint $constraints
+     */
+    public function withConstraints(string|array|Constraint $constraints): static
     {
         $self = clone $this;
         $self->constraints = $constraints;

--- a/src/Serializer/Filter/PropertyFilter.php
+++ b/src/Serializer/Filter/PropertyFilter.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Serializer\Filter;
 
+use ApiPlatform\Metadata\HasOpenApiParameterFilterInterface;
+use ApiPlatform\Metadata\Parameter as MetadataParameter;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
@@ -114,7 +117,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
-final class PropertyFilter implements FilterInterface
+final class PropertyFilter implements FilterInterface, HasOpenApiParameterFilterInterface
 {
     private ?array $whitelist;
 
@@ -245,5 +248,10 @@ final class PropertyFilter implements FilterInterface
     private function denormalizePropertyName($property): string
     {
         return null !== $this->nameConverter ? $this->nameConverter->denormalize($property) : $property;
+    }
+
+    public function getOpenApiParameter(MetadataParameter $parameter): Parameter
+    {
+        return new Parameter(name: $parameter->getKey().'[]', in: $parameter instanceof QueryParameter ? 'query' : 'header');
     }
 }

--- a/src/Serializer/Parameter/SerializerFilterParameterProvider.php
+++ b/src/Serializer/Parameter/SerializerFilterParameterProvider.php
@@ -45,7 +45,7 @@ final class SerializerFilterParameterProvider implements ParameterProviderInterf
             return null;
         }
 
-        $context = $operation->getNormalizationContext();
+        $context = $operation->getNormalizationContext() ?? [];
         $request->attributes->set('_api_parameter', $parameter);
         $filter->apply($request, true, RequestAttributesExtractor::extractAttributes($request), $context);
 

--- a/src/State/SerializerContextBuilderInterface.php
+++ b/src/State/SerializerContextBuilderInterface.php
@@ -48,7 +48,8 @@ interface SerializerContextBuilderInterface
      *   deep_object_to_populate?: bool,
      *   collect_denormalization_errors?: bool,
      *   exclude_from_cache_key?: string[],
-     *   api_included?: bool
+     *   api_included?: bool,
+     *   attributes?: string[],
      * }
      */
     public function createFromRequest(Request $request, bool $normalization, ?array $extractedAttributes = null): array;


### PR DESCRIPTION
We don't need this anymore as implementing filters and pagination is done by users using the QueryParameter, and users MAY follow the specification if they want to (as the specification doesn't enforce anything but only recommends)
