### PR TITLE
fix: count TraversablePaginator

### DIFF
--- a/src/State/Pagination/TraversablePaginator.php
+++ b/src/State/Pagination/TraversablePaginator.php
@@ -68,6 +68,10 @@ final class TraversablePaginator implements \IteratorAggregate, PaginatorInterfa
             return (int) ceil($this->totalItems);
         }
 
+        if ($this->totalItems === $this->itemsPerPage) {
+            return (int) ceil($this->totalItems);
+        }
+
         return $this->totalItems % $this->itemsPerPage;
     }
 

--- a/tests/State/Pagination/TraversablePaginatorTest.php
+++ b/tests/State/Pagination/TraversablePaginatorTest.php
@@ -50,6 +50,8 @@ class TraversablePaginatorTest extends TestCase
             'Empty results' => [[], 1, 2, 0, 1, 0],
             '0 items per page' => [[0, 1, 2, 3], 1, 0, 4, 1, 4],
             'Total items less than items per page' => [[0, 1, 2], 1, 4, 3, 1, 3],
+            'Only one result' => [[0], 1, 1, 1, 1, 1],
+            'Same result number than total page' => [[0, 2, 3], 1, 3, 3, 1, 3],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| License       | MIT

Hello,

whenever the `TraversablePaginator` has the same number of items than the `itemsPerPage`, it currently returns `0`, although it should return `totalItems` 

This PR fixes this buggy behavior

It seems strange that nobody has noticed this before :thinking: 