### PR TITLE
fix: remove "hydra:" remaining prefix

### DIFF
--- a/docs/guides/validate-incoming-data.php
+++ b/docs/guides/validate-incoming-data.php
@@ -139,8 +139,8 @@ namespace App\Tests {
             // {
             //   "@context": "/contexts/ConstraintViolationList",
             //   "@type": "ConstraintViolationList",
-            //   "hydra:title": "An error occurred",
-            //   "hydra:description": "properties: The product must have the minimal properties required (\"description\", \"price\")",
+            //   "title": "An error occurred",
+            //   "description": "properties: The product must have the minimal properties required (\"description\", \"price\")",
             //   "violations": [
             //     {
             //       "propertyPath": "properties",
@@ -151,7 +151,7 @@ namespace App\Tests {
             // ```
             $this->assertResponseStatusCodeSame(422);
             $this->assertJsonContains([
-                'hydra:description' => 'properties: The product must have the minimal properties required ("description", "price")',
+                'description' => 'properties: The product must have the minimal properties required ("description", "price")',
                 'title' => 'An error occurred',
                 'violations' => [
                     ['propertyPath' => 'properties', 'message' => 'The product must have the minimal properties required ("description", "price")'],

--- a/features/hydra/error.feature
+++ b/features/hydra/error.feature
@@ -17,9 +17,8 @@ Feature: Error handling
     And the header "Link" should contain '<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"'
     And the JSON node "type" should exist
     And the JSON node "title" should be equal to "An error occurred"
-    And the JSON node "hydra:title" should be equal to "An error occurred"
     And the JSON node "detail" should exist
-    And the JSON node "hydra:description" should exist
+    And the JSON node "description" should exist
     And the JSON node "trace" should exist
     And the JSON node "status" should exist
     And the JSON node "@context" should not exist
@@ -47,10 +46,9 @@ Feature: Error handling
               }
           ],
           "detail": "name: This value should not be blank.",
-          "hydra:title": "An error occurred",
-          "hydra:description": "name: This value should not be blank.",
-          "type": "/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3",
-          "title": "An error occurred"
+          "title": "An error occurred",
+          "description": "name: This value should not be blank.",
+          "type": "/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3"
       }
     """
 
@@ -82,9 +80,8 @@ Feature: Error handling
     And the JSON node "@context" should not exist
     And the JSON node "type" should exist
     And the JSON node "title" should be equal to "An error occurred"
-    And the JSON node "hydra:title" should be equal to "An error occurred"
     And the JSON node "detail" should exist
-    And the JSON node "hydra:description" should exist
+    And the JSON node "description" should exist
 
   Scenario: Get an rfc 7807 bad method error
     When I add "Content-Type" header equal to "application/ld+json"
@@ -100,9 +97,8 @@ Feature: Error handling
     And the JSON node "@context" should not exist
     And the JSON node "type" should exist
     And the JSON node "title" should be equal to "An error occurred"
-    And the JSON node "hydra:title" should be equal to "An error occurred"
     And the JSON node "detail" should exist
-    And the JSON node "hydra:description" should exist
+    And the JSON node "description" should exist
 
   Scenario: Get an rfc 7807 validation error
     When I add "Content-Type" header equal to "application/ld+json"

--- a/features/jsonld/input_output.feature
+++ b/features/jsonld/input_output.feature
@@ -309,7 +309,7 @@ Feature: JSON-LD DTO input and output
     """
     Then the response status code should be 400
     And the response should be in JSON
-    And the JSON node "hydra:description" should be equal to "The input data is misformatted."
+    And the JSON node "description" should be equal to "The input data is misformatted."
 
   @!mongodb
   Scenario: Reset password through an input DTO without DataTransformer

--- a/features/main/attribute_resource.feature
+++ b/features/main/attribute_resource.feature
@@ -100,7 +100,7 @@ Feature: Resource attributes
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
     And the header "Link" should contain '<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"'
-    And the JSON node "hydra:description" should be equal to 'Unable to generate an IRI for the item of type "ApiPlatform\Tests\Fixtures\TestBundle\Entity\IncompleteUriVariableConfigured"'
+    And the JSON node "description" should be equal to 'Unable to generate an IRI for the item of type "ApiPlatform\Tests\Fixtures\TestBundle\Entity\IncompleteUriVariableConfigured"'
 
   Scenario: Uri variables with Post operation
     When I add "Content-Type" header equal to "application/ld+json"

--- a/features/main/not_exposed.feature
+++ b/features/main/not_exposed.feature
@@ -171,12 +171,21 @@ Feature: Expose only a collection of objects
     When I send a "GET" request to "<uri>"
     Then the response status code should be 404
     And the response should be in JSON
-    And the JSON node "hydra:description" should be equal to "<hydra:description>"
+    And the JSON node "hydra:description" should be equal to "<description>"
     Examples:
-      | uri                      | hydra:description                                                                                                          |
-      | /.well-known/genid/12345 | This route is not exposed on purpose. It generates an IRI for a collection resource without identifier nor item operation. |
+      | uri                      | description                                                                                                          |
       | /tables/12345            | This route does not aim to be called.                                                                                      |
       | /forks/12345             | This route does not aim to be called.                                                                                      |
+
+  Scenario Outline: Get a not exposed route returns a 404 with an explanation
+    When I send a "GET" request to "<uri>"
+    Then the response status code should be 404
+    And the response should be in JSON
+    And the JSON node "description" should be equal to "<description>"
+    Examples:
+      | uri                      | description                                                                                                          |
+      | /.well-known/genid/12345 | This route is not exposed on purpose. It generates an IRI for a collection resource without identifier nor item operation. |
+
 
   Scenario: Get a single item still works
     When I send a "GET" request to "/cuillers/12345"

--- a/features/main/relation.feature
+++ b/features/main/relation.feature
@@ -472,7 +472,7 @@ Feature: Relations support
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
-    And the JSON node "hydra:description" should contain 'Invalid IRI "certainly not an IRI".'
+    And the JSON node "description" should contain 'Invalid IRI "certainly not an IRI".'
 
   Scenario: Passing an invalid type to a relation
     When I add "Content-Type" header equal to "application/ld+json"
@@ -493,20 +493,20 @@ Feature: Relations support
       "properties": {
         "@type": {
           "type": "string",
-          "pattern": "^hydra:Error$"
+          "pattern": "^Error$"
         },
-        "hydra:title": {
+        "title": {
           "type": "string",
           "pattern": "^An error occurred$"
         },
-        "hydra:description": {
+        "description": {
           "pattern": "^The type of the \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\RelatedDummy\" resource must be \"array\" \\(nested document\\) or \"string\" \\(IRI\\), \"integer\" given.$"
         }
       },
       "required": [
         "@type",
-        "hydra:title",
-        "hydra:description"
+        "title",
+        "description"
       ]
     }
     """

--- a/features/main/union_intersect_types.feature
+++ b/features/main/union_intersect_types.feature
@@ -118,4 +118,4 @@ Feature: Union/Intersect types
     Then the response status code should be 400
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
-    And the JSON node "hydra:description" should be equal to 'Could not denormalize object of type "ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5452\ActivableInterface", no supporting normalizer found.'
+    And the JSON node "description" should be equal to 'Could not denormalize object of type "ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5452\ActivableInterface", no supporting normalizer found.'

--- a/features/main/validation.feature
+++ b/features/main/validation.feature
@@ -87,7 +87,7 @@ Feature: Using validations groups
     And the JSON node "violations[0].message" should be equal to "This value should not be null."
     And the JSON node "violations[0].propertyPath" should be equal to "test"
     And the JSON node "detail" should be equal to "test: This value should not be null."
-    And the JSON node "hydra:description" should be equal to "test: This value should not be null."
+    And the JSON node "description" should be equal to "test: This value should not be null."
     And the header "Content-Type" should be equal to "application/problem+json; charset=utf-8"
 
   @!mongodb

--- a/features/serializer/vo_relations.feature
+++ b/features/serializer/vo_relations.feature
@@ -148,20 +148,20 @@ Feature: Value object as ApiResource
       "properties": {
         "@type": {
           "type": "string",
-          "pattern": "^hydra:Error$"
+          "pattern": "^Error$"
         },
-        "hydra:title": {
+        "title": {
           "type": "string",
           "pattern": "^An error occurred$"
         },
-        "hydra:description": {
+        "description": {
           "pattern": "^Cannot create an instance of \"ApiPlatform\\\\Tests\\\\Fixtures\\\\TestBundle\\\\(Document|Entity)\\\\VoDummyCar\" from serialized data because its constructor requires the following parameters to be present : \"\\$drivers\".$"
         }
       },
       "required": [
         "@type",
-        "hydra:title",
-        "hydra:description"
+        "title",
+        "description"
       ]
     }
     """

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\JsonLd;
 
 use ApiPlatform\JsonLd\Serializer\HydraPrefixTrait;
+use ApiPlatform\Metadata\Error;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\IriConverterInterface;
@@ -184,7 +185,7 @@ final class ContextBuilder implements AnonymousContextBuilderInterface
             }
         }
 
-        if (false === ($this->defaultContext[self::HYDRA_CONTEXT_HAS_PREFIX] ?? true)) {
+        if (false === ($this->defaultContext[self::HYDRA_CONTEXT_HAS_PREFIX] ?? true) || $operation instanceof Error) {
             return ['http://www.w3.org/ns/hydra/context.jsonld', $context];
         }
 

--- a/src/State/ApiResource/Error.php
+++ b/src/State/ApiResource/Error.php
@@ -25,7 +25,6 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\WebLink\Link;
 
 #[ErrorResource(
-    types: ['hydra:Error'],
     openapi: false,
     uriVariables: ['status'],
     uriTemplate: '/errors/{status}',
@@ -98,21 +97,7 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
     #[Groups(['trace'])]
     public ?array $originalTrace = null;
 
-    #[SerializedName('hydra:title')]
     #[Groups(['jsonld'])]
-    public function getHydraTitle(): ?string
-    {
-        return $this->title;
-    }
-
-    #[SerializedName('hydra:description')]
-    #[Groups(['jsonld'])]
-    public function getHydraDescription(): ?string
-    {
-        return $this->detail;
-    }
-
-    #[SerializedName('description')]
     public function getDescription(): ?string
     {
         return $this->detail;

--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -108,16 +108,8 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
         return $id;
     }
 
-    #[SerializedName('hydra:title')]
     #[Groups(['jsonld'])]
-    public function getHydraTitle(): string
-    {
-        return $this->errorTitle ?? 'An error occurred';
-    }
-
-    #[Groups(['jsonld'])]
-    #[SerializedName('hydra:description')]
-    public function getHydraDescription(): string
+    public function getDescription(): string
     {
         return $this->detail;
     }


### PR DESCRIPTION
Additionally, [api-platform/admin](https://github.com/api-platform/admin) must be updated because of the following error (with `hydra_prefix: false`):

![image](https://github.com/user-attachments/assets/560d292c-1e21-4999-916d-b0ea922ddb6f)
