### PR TITLE
fix(serializer): allow state's SerializerFilterContextBuilderInterface

### DIFF
--- a/src/Serializer/SerializerFilterContextBuilder.php
+++ b/src/Serializer/SerializerFilterContextBuilder.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Util\AttributesExtractor;
 use ApiPlatform\Serializer\Filter\FilterInterface;
+use ApiPlatform\State\SerializerContextBuilderInterface as StateSerializerContextBuilderInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -27,7 +28,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class SerializerFilterContextBuilder implements SerializerContextBuilderInterface
 {
-    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ContainerInterface $filterLocator, private readonly SerializerContextBuilderInterface $decorated)
+    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ContainerInterface $filterLocator, private readonly StateSerializerContextBuilderInterface $decorated)
     {
     }
 

--- a/src/Serializer/SerializerFilterContextBuilder.php
+++ b/src/Serializer/SerializerFilterContextBuilder.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class SerializerFilterContextBuilder implements SerializerContextBuilderInterface
 {
-    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ContainerInterface $filterLocator, private readonly StateSerializerContextBuilderInterface $decorated)
+    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ContainerInterface $filterLocator, private readonly SerializerContextBuilderInterface|StateSerializerContextBuilderInterface $decorated)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->


As `ApiPlatform\Serializer\SerializerContextBuilderInterface` is deprecated in favour of `ApiPlatform\State\SerializerContextBuilderInterface` and:
```php
interface ApiPlatform\Serializer\SerializerContextBuilderInterface extends ApiPlatform\State\SerializerContextBuilderInterface
```

it is not possible to use non-deprecated inteface for a ContextBuilder, as the `ApiPlatform\Serializer\SerializerFilterContextBuilder` is still expecting deprecated interface for `$decorated` parameter.

It looks like this deprecated interface has not been removed also in v4, where I should expect it to be gone.

Hope it makes sense. 
