### PR TITLE
Fix incorrect namespace

### DIFF
--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -85,8 +85,8 @@
         </service>
 
         <!-- Resources Operations path resolver -->
-        <service id="api_platform.path_segment_name_generator.underscore" class="ApiPlatform\Operation\UnderscorePathSegmentNameGenerator" public="false" />
-        <service id="api_platform.path_segment_name_generator.dash" class="ApiPlatform\Operation\DashPathSegmentNameGenerator" public="false" />
+        <service id="api_platform.path_segment_name_generator.underscore" class="ApiPlatform\Metadata\Operation\UnderscorePathSegmentNameGenerator" public="false" />
+        <service id="api_platform.path_segment_name_generator.dash" class="ApiPlatform\Metadata\Operation\DashPathSegmentNameGenerator" public="false" />
 
         <service id="api_platform.metadata.path_segment_name_generator.underscore" class="ApiPlatform\Metadata\Operation\UnderscorePathSegmentNameGenerator" public="false">
             <argument type="service" id="api_platform.inflector" on-invalid="null" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes incorrect namespaces in new release. Attempted to load class "DashPathSegmentNameGenerator" from namespace "ApiPlatform\Operation". Did you forget a "use" statement for "ApiPlatform\Metadata\Operation\DashPathSegmentNameGenerator"?
