### PR TITLE
Laravel: Use `Model::qualifyColumn()` instead of `$table.$column`

### DIFF
--- a/src/Laravel/Eloquent/State/LinksHandler.php
+++ b/src/Laravel/Eloquent/State/LinksHandler.php
@@ -37,19 +37,19 @@ final class LinksHandler implements LinksHandlerInterface
                 $identifier = $uriVariables[$uriVariable];
 
                 if ($to = $link->getToProperty()) {
-                    $builder = $builder->where($builder->getModel()->getTable().'.'.$builder->getModel()->{$to}()->getForeignKeyName(), $identifier);
+                    $builder = $builder->where($builder->getModel()->{$to}()->getQualifiedForeignKeyName(), $identifier);
 
                     continue;
                 }
 
                 if ($from = $link->getFromProperty()) {
                     $relation = $this->application->make($link->getFromClass());
-                    $builder = $builder->getModel()->where($builder->getModel()->getTable().'.'.$relation->{$from}()->getForeignKeyName(), $identifier);
+                    $builder = $builder->getModel()->where($relation->{$from}()->getQualifiedForeignKeyName(), $identifier);
 
                     continue;
                 }
 
-                $builder->where($builder->getModel()->getTable().'.'.$link->getIdentifiers()[0], $identifier);
+                $builder->where($builder->getModel()->qualifyColumn($link->getIdentifiers()[0]), $identifier);
             }
 
             return $builder;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | -
| License       | MIT
| Doc PR        | -

The function [`Model::qualifyColumn()`](https://github.com/laravel/framework/blob/abf86b08b08c5ea5c9247877bc8b6ea259805f80/src/Illuminate/Database/Eloquent/Model.php#L586-L593) does exactly the same as the existing code. But for MongoDB, we had to [override this method](https://github.com/mongodb/laravel-mongodb/blob/716d8e166809502a22017b476979678a57d5d91d/src/Eloquent/DocumentModel.php#L564-L567) as the column name (field name) cannot be prefixed with the table name (collection name). So we need this method to be used instead of having the logic hard coded.

For relations, we use the `getQualifiedForeignKeyName` that has the same mechanism for [`BelongsTo`](https://github.com/laravel/framework/blob/abf86b08b08c5ea5c9247877bc8b6ea259805f80/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php#L314) and [`HasOneOrManyThrough `](https://github.com/laravel/framework/blob/abf86b08b08c5ea5c9247877bc8b6ea259805f80/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php#L811), but nothing for [`HasOneOrMany`](https://github.com/laravel/framework/blob/abf86b08b08c5ea5c9247877bc8b6ea259805f80/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L557) (I don't know why 😞).


<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
