### PR TITLE
fix: overwriting XML ApiResource definition by YAML ApiResource definition

### DIFF
--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
@@ -53,14 +53,14 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
             return $resourceMetadataCollection;
         }
 
-        foreach ($this->buildResources($resources, $resourceClass) as $i => $resource) {
+        foreach ($this->buildResources($resources, $resourceClass) as $resource) {
             foreach ($this->defaults['attributes'] ?? [] as $key => $value) {
                 if (method_exists($resource, 'get'.ucfirst($key)) && !$resource->{'get'.ucfirst($key)}()) {
                     $resource = $resource->{'with'.ucfirst($key)}($value);
                 }
             }
 
-            $resourceMetadataCollection[$i] = $resource;
+            $resourceMetadataCollection[] = $resource;
         }
 
         return $resourceMetadataCollection;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | fixes #6619 
| License       | MIT
| Doc PR        | 

In case the same ApiResource is defined in both XML and YAML, this PR makes the ApiResource defined in YAML add itself as another one instead of overwriting the existing one defined in XML.
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
