### PR TITLE
fix: using parameters in fromClass and toClass uriVariables' options

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -271,10 +271,10 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             if ($toProperty = $this->phpize($data, 'toProperty', 'string')) {
                 $uriVariables[$parameterName]['to_property'] = $toProperty;
             }
-            if ($fromClass = $this->phpize($data, 'fromClass', 'string')) {
+            if ($fromClass = $this->resolve($this->phpize($data, 'fromClass', 'string'))) {
                 $uriVariables[$parameterName]['from_class'] = $fromClass;
             }
-            if ($toClass = $this->phpize($data, 'toClass', 'string')) {
+            if ($toClass = $this->resolve($this->phpize($data, 'toClass', 'string'))) {
                 $uriVariables[$parameterName]['to_class'] = $toClass;
             }
             if (isset($data->identifiers->values)) {

--- a/src/Metadata/Extractor/YamlResourceExtractor.php
+++ b/src/Metadata/Extractor/YamlResourceExtractor.php
@@ -193,13 +193,13 @@ final class YamlResourceExtractor extends AbstractResourceExtractor
                 unset($data[0], $data[1]);
             }
             if (isset($data['fromClass'])) {
-                $uriVariables[$parameterName]['from_class'] = $data['fromClass'];
+                $uriVariables[$parameterName]['from_class'] = $this->resolve($data['fromClass']);
             }
             if (isset($data['fromProperty'])) {
                 $uriVariables[$parameterName]['from_property'] = $data['fromProperty'];
             }
             if (isset($data['toClass'])) {
-                $uriVariables[$parameterName]['to_class'] = $data['toClass'];
+                $uriVariables[$parameterName]['to_class'] = $this->resolve($data['toClass']);
             }
             if (isset($data['toProperty'])) {
                 $uriVariables[$parameterName]['to_property'] = $data['toProperty'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | related to https://github.com/api-platform/core/pull/6659
| License       | MIT
| Doc PR        | 

Currently there is no possibility to pass the class as a parameter in `fromClass` and `toClass` uriVariables' options and this PR adds this missed possibility.
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
