### PR TITLE
Fix: route registration of EntrypointController should be after GraphQL's EntrypointController

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -1293,14 +1293,6 @@ class ApiPlatformProvider extends ServiceProvider
         $route->name('api_doc')->middleware(ApiPlatformMiddleware::class);
         $routeCollection->add($route);
 
-        $route = new Route(['GET'], $prefix.'/{index?}{_format?}', function (Request $request, Application $app) {
-            $entrypointAction = $app->make(EntrypointController::class);
-
-            return $entrypointAction->__invoke($request);
-        });
-        $route->where('index', 'index');
-        $route->name('api_entrypoint')->middleware(ApiPlatformMiddleware::class);
-        $routeCollection->add($route);
         $route = new Route(['GET'], $prefix.'/.well-known/genid/{id}', function (): void {
             throw new NotExposedHttpException('This route is not exposed on purpose. It generates an IRI for a collection resource without identifier nor item operation.');
         });
@@ -1322,6 +1314,15 @@ class ApiPlatformProvider extends ServiceProvider
             });
             $routeCollection->add($route);
         }
+
+        $route = new Route(['GET'], $prefix.'/{index?}{_format?}', function (Request $request, Application $app) {
+            $entrypointAction = $app->make(EntrypointController::class);
+
+            return $entrypointAction->__invoke($request);
+        });
+        $route->where('index', 'index');
+        $route->name('api_entrypoint')->middleware(ApiPlatformMiddleware::class);
+        $routeCollection->add($route);
 
         $router->setRoutes($routeCollection);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | Closes #2767
| License       | MIT

If GraphQL is enabled and API Platform's route prefix is configured to be an empty string instead of the default `/api` then the `/graphql` route is incorrectly handled by `\ApiPlatform\Laravel\Controller\EntrypointController` instead of `ApiPlatform\Laravel\GraphQl\Controller\EntrypointController`.

This is because the routes being handled by the former controller are registered before the GraphQL routes. Instead, they should be registered last.