### PR TITLE
fix(json schema): fixed definition name factory to allow using the same class names in different namespaces

### DIFF
--- a/src/JsonSchema/DefinitionNameFactory.php
+++ b/src/JsonSchema/DefinitionNameFactory.php
@@ -21,6 +21,9 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
 {
     use ResourceClassInfoTrait;
 
+    private const GLUE = '.';
+    private array $prefixCache = [];
+
     public function __construct(private ?array $distinctFormats)
     {
     }
@@ -32,18 +35,18 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
         }
 
         if (!isset($prefix)) {
-            $prefix = (new \ReflectionClass($className))->getShortName();
+            $prefix = $this->createPrefixFromClass($className);
         }
 
         if (null !== $inputOrOutputClass && $className !== $inputOrOutputClass) {
             $parts = explode('\\', $inputOrOutputClass);
             $shortName = end($parts);
-            $prefix .= '.'.$shortName;
+            $prefix .= self::GLUE.$shortName;
         }
 
         if ('json' !== $format && ($this->distinctFormats[$format] ?? false)) {
             // JSON is the default, and so isn't included in the definition name
-            $prefix .= '.'.$format;
+            $prefix .= self::GLUE.$format;
         }
 
         $definitionName = $serializerContext[SchemaFactory::OPENAPI_DEFINITION_NAME] ?? null;
@@ -60,5 +63,23 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
     private function encodeDefinitionName(string $name): string
     {
         return preg_replace('/[^a-zA-Z0-9.\-_]/', '.', $name);
+    }
+
+    private function createPrefixFromClass(string $fullyQualifiedClassName, int $namespaceParts = 1): string
+    {
+        $parts = explode('\\', $fullyQualifiedClassName);
+        $name = implode(self::GLUE, \array_slice($parts, -$namespaceParts));
+
+        if (!isset($this->prefixCache[$name])) {
+            $this->prefixCache[$name] = $fullyQualifiedClassName;
+
+            return $name;
+        }
+
+        if ($this->prefixCache[$name] !== $fullyQualifiedClassName) {
+            $name = $this->createPrefixFromClass($fullyQualifiedClassName, ++$namespaceParts);
+        }
+
+        return $name;
     }
 }

--- a/tests/JsonSchema/DefinitionNameFactoryTest.php
+++ b/tests/JsonSchema/DefinitionNameFactoryTest.php
@@ -69,4 +69,29 @@ final class DefinitionNameFactoryTest extends TestCase
 
         static::assertSame($expected, $definitionNameFactory->create($className, $format, $inputOrOutputClass, $operation, $serializerContext));
     }
+
+    public function testCreateDifferentPrefixesForClassesWithTheSameShortName(): void
+    {
+        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true]);
+
+        self::assertEquals(
+            'DummyClass.jsonapi',
+            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceA\Module\DummyClass::class, 'jsonapi')
+        );
+
+        self::assertEquals(
+            'Module.DummyClass.jsonapi',
+            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceB\Module\DummyClass::class, 'jsonapi')
+        );
+
+        self::assertEquals(
+            'NamespaceC.Module.DummyClass.jsonapi',
+            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceC\Module\DummyClass::class, 'jsonapi')
+        );
+
+        self::assertEquals(
+            'DummyClass.jsonhal',
+            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceA\Module\DummyClass::class, 'jsonhal')
+        );
+    }
 }

--- a/tests/JsonSchema/Dummy/NamespaceA/Module/DummyClass.php
+++ b/tests/JsonSchema/Dummy/NamespaceA/Module/DummyClass.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\JsonSchema\Dummy\NamespaceA\Module;
+
+class DummyClass
+{
+}

--- a/tests/JsonSchema/Dummy/NamespaceB/Module/DummyClass.php
+++ b/tests/JsonSchema/Dummy/NamespaceB/Module/DummyClass.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\JsonSchema\Dummy\NamespaceB\Module;
+
+class DummyClass
+{
+}

--- a/tests/JsonSchema/Dummy/NamespaceC/Module/DummyClass.php
+++ b/tests/JsonSchema/Dummy/NamespaceC/Module/DummyClass.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\JsonSchema\Dummy\NamespaceC\Module;
+
+class DummyClass
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see below -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

It fixes documentation models reference in the case where there are 2 or more classes with the same name but in different namespaces.
Previously the very first class model was created and used in all places in documentation.

Now if the name is the same but namespace is different, a previous one element of a namespace is prepended to the name until the name is unique 
