### PR TITLE
fix(laravel): allow serializer attributes through ApiProperty

### DIFF
--- a/src/JsonLd/Serializer/ErrorNormalizer.php
+++ b/src/JsonLd/Serializer/ErrorNormalizer.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\JsonLd\Serializer;
 
 use ApiPlatform\State\ApiResource\Error;
-use ApiPlatform\Symfony\Validator\Exception\ValidationException as SymfonyValidationException;
 use ApiPlatform\Validator\Exception\ValidationException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -48,7 +47,7 @@ final class ErrorNormalizer implements NormalizerInterface
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $this->inner->supportsNormalization($data, $format, $context)
-            && (is_a($data, Error::class) || is_a($data, ValidationException::class) || is_a($data, SymfonyValidationException::class));
+            && (is_a($data, Error::class) || is_a($data, ValidationException::class));
     }
 
     public function getSupportedTypes(?string $format): array

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -165,6 +165,7 @@ use ApiPlatform\Serializer\Filter\PropertyFilter;
 use ApiPlatform\Serializer\ItemNormalizer;
 use ApiPlatform\Serializer\JsonEncoder;
 use ApiPlatform\Serializer\Mapping\Factory\ClassMetadataFactory as SerializerClassMetadataFactory;
+use ApiPlatform\Serializer\Mapping\Loader\PropertyMetadataLoader;
 use ApiPlatform\Serializer\Parameter\SerializerFilterParameterProvider;
 use ApiPlatform\Serializer\SerializerContextBuilder;
 use ApiPlatform\State\CallableProcessor;
@@ -206,6 +207,7 @@ use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
@@ -244,8 +246,15 @@ class ApiPlatformProvider extends ServiceProvider
 
         $this->app->bind(LoaderInterface::class, AttributeLoader::class);
         $this->app->bind(ClassMetadataFactoryInterface::class, ClassMetadataFactory::class);
-        $this->app->singleton(ClassMetadataFactory::class, function () {
-            return new ClassMetadataFactory(new AttributeLoader());
+        $this->app->singleton(ClassMetadataFactory::class, function (Application $app) {
+            return new ClassMetadataFactory(
+                new LoaderChain([
+                    new PropertyMetadataLoader(
+                        $app->make(PropertyNameCollectionFactoryInterface::class),
+                    ),
+                    new AttributeLoader(),
+                ])
+            );
         });
 
         $this->app->singleton(SerializerClassMetadataFactory::class, function (Application $app) {

--- a/src/Laravel/Eloquent/Metadata/Factory/Property/EloquentPropertyNameCollectionMetadataFactory.php
+++ b/src/Laravel/Eloquent/Metadata/Factory/Property/EloquentPropertyNameCollectionMetadataFactory.php
@@ -39,8 +39,12 @@ final class EloquentPropertyNameCollectionMetadataFactory implements PropertyNam
             return $this->decorated?->create($resourceClass, $options) ?? new PropertyNameCollection();
         }
 
-        $refl = new \ReflectionClass($resourceClass);
         try {
+            $refl = new \ReflectionClass($resourceClass);
+            if ($refl->isAbstract()) {
+                return $this->decorated?->create($resourceClass, $options) ?? new PropertyNameCollection();
+            }
+
             $model = $refl->newInstanceWithoutConstructor();
         } catch (\ReflectionException) {
             return $this->decorated?->create($resourceClass, $options) ?? new PropertyNameCollection();

--- a/src/Laravel/Tests/JsonApiTest.php
+++ b/src/Laravel/Tests/JsonApiTest.php
@@ -23,6 +23,7 @@ use Workbench\App\Models\Author;
 use Workbench\App\Models\Book;
 use Workbench\Database\Factories\AuthorFactory;
 use Workbench\Database\Factories\BookFactory;
+use Workbench\Database\Factories\WithAccessorFactory;
 
 class JsonApiTest extends TestCase
 {
@@ -196,5 +197,16 @@ class JsonApiTest extends TestCase
         $response = $this->delete($iri, headers: ['accept' => 'application/vnd.api+json']);
         $response->assertStatus(204);
         $this->assertNull(Book::find($book->id));
+    }
+
+    public function testRelationWithGroups(): void
+    {
+        WithAccessorFactory::new()->create();
+        $response = $this->get('/api/with_accessors/1', ['accept' => 'application/vnd.api+json']);
+        $content = $response->json();
+        $this->assertArrayHasKey('data', $content);
+        $this->assertArrayHasKey('relationships', $content['data']);
+        $this->assertArrayHasKey('relation', $content['data']['relationships']);
+        $this->assertArrayHasKey('data', $content['data']['relationships']['relation']);
     }
 }

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -26,6 +26,7 @@ use Workbench\Database\Factories\BookFactory;
 use Workbench\Database\Factories\CommentFactory;
 use Workbench\Database\Factories\PostFactory;
 use Workbench\Database\Factories\SluggableFactory;
+use Workbench\Database\Factories\WithAccessorFactory;
 
 class JsonLdTest extends TestCase
 {
@@ -326,5 +327,14 @@ class JsonLdTest extends TestCase
         $response->assertStatus(415);
         $content = $response->json();
         $this->assertArrayHasKey('trace', $content);
+    }
+
+    public function testRelationWithGroups(): void
+    {
+        WithAccessorFactory::new()->create();
+        $response = $this->get('/api/with_accessors/1', ['accept' => 'application/ld+json']);
+        $content = $response->json();
+        $this->assertArrayHasKey('relation', $content);
+        $this->assertArrayHasKey('name', $content['relation']);
     }
 }

--- a/src/Laravel/workbench/app/Models/WithAccessor.php
+++ b/src/Laravel/workbench/app/Models/WithAccessor.php
@@ -13,18 +13,28 @@ declare(strict_types=1);
 
 namespace Workbench\App\Models;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Symfony\Component\Serializer\Attribute\Groups;
 
-#[ApiResource]
+#[ApiResource(normalizationContext: ['groups' => ['read']])]
 class WithAccessor extends Model
 {
     use HasFactory;
 
     protected $hidden = ['created_at', 'updated_at', 'id'];
 
+    #[ApiProperty(serialize: [new Groups(['read'])])]
+    public function relation(): BelongsTo
+    {
+        return $this->belongsTo(WithAccessorRelation::class);
+    }
+
+    #[ApiProperty(serialize: [new Groups(['read'])])]
     protected function name(): Attribute
     {
         return Attribute::make(

--- a/src/Laravel/workbench/app/Models/WithAccessorRelation.php
+++ b/src/Laravel/workbench/app/Models/WithAccessorRelation.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use ApiPlatform\Metadata\ApiResource;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[Groups(['read'])]
+#[ApiResource(operations: [])]
+class WithAccessorRelation extends Model
+{
+    use HasFactory;
+}

--- a/src/Laravel/workbench/database/factories/WithAccessorRelationFactory.php
+++ b/src/Laravel/workbench/database/factories/WithAccessorRelationFactory.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Workbench\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Workbench\App\Models\WithAccessor;
+use Workbench\App\Models\WithAccessorRelation;
 
 /**
- * @template TModel of \Workbench\App\Models\WithAccessor
+ * @template TModel of \Workbench\App\Models\WithAccessorRelation
  *
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
  */
-class WithAccessorFactory extends Factory
+class WithAccessorRelationFactory extends Factory
 {
     /**
      * The name of the factory's corresponding model.
      *
      * @var class-string<TModel>
      */
-    protected $model = WithAccessor::class;
+    protected $model = WithAccessorRelation::class;
 
     /**
      * Define the model's default state.
@@ -39,7 +39,6 @@ class WithAccessorFactory extends Factory
     {
         return [
             'name' => strtolower(fake()->name()),
-            'relation_id' => WithAccessorRelationFactory::new(),
         ];
     }
 }

--- a/src/Laravel/workbench/database/migrations/2024_09_24_065934_create_with_accessors_table.php
+++ b/src/Laravel/workbench/database/migrations/2024_09_24_065934_create_with_accessors_table.php
@@ -21,9 +21,17 @@ return new class extends Migration {
      */
     public function up(): void
     {
+        Schema::create('with_accessor_relations', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
         Schema::create('with_accessors', function (Blueprint $table): void {
             $table->id();
             $table->string('name');
+            $table->integer('relation_id')->unsigned();
+            $table->foreign('relation_id')->references('id')->on('with_accessor_relations');
             $table->timestamps();
         });
     }
@@ -34,5 +42,6 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::dropIfExists('with_accessors');
+        Schema::dropIfExists('with_accessors_relation');
     }
 };

--- a/src/Metadata/ApiProperty.php
+++ b/src/Metadata/ApiProperty.php
@@ -14,6 +14,12 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Serializer\Attribute\Ignore;
+use Symfony\Component\Serializer\Attribute\MaxDepth;
+use Symfony\Component\Serializer\Attribute\SerializedName;
+use Symfony\Component\Serializer\Attribute\SerializedPath;
 
 /**
  * ApiProperty annotation.
@@ -23,24 +29,28 @@ use Symfony\Component\PropertyInfo\Type;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::TARGET_CLASS)]
 final class ApiProperty
 {
+    private ?array $types;
+    private ?array $serialize;
+
     /**
-     * @param bool|null               $readableLink            https://api-platform.com/docs/core/serialization/#force-iri-with-relations-of-the-same-type-parentchilds-relations
-     * @param bool|null               $writableLink            https://api-platform.com/docs/core/serialization/#force-iri-with-relations-of-the-same-type-parentchilds-relations
-     * @param bool|null               $required                https://api-platform.com/docs/admin/validation/#client-side-validation
-     * @param bool|null               $identifier              https://api-platform.com/docs/core/identifiers/
-     * @param mixed                   $example                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
-     * @param string|null             $deprecationReason       https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
-     * @param bool|null               $fetchEager              https://api-platform.com/docs/core/performance/#eager-loading
-     * @param array|null              $jsonldContext           https://api-platform.com/docs/core/extending-jsonld-context/#extending-json-ld-and-hydra-contexts
-     * @param array|null              $openapiContext          https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
-     * @param bool|null               $push                    https://api-platform.com/docs/core/push-relations/
-     * @param string|\Stringable|null $security                https://api-platform.com/docs/core/security
-     * @param string|\Stringable|null $securityPostDenormalize https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
-     * @param string[]                $types                   the RDF types of this property
-     * @param string[]                $iris
-     * @param Type[]                  $builtinTypes
-     * @param string|null             $uriTemplate             (experimental) whether to return the subRessource collection IRI instead of an iterable of IRI
-     * @param string|null             $property                The property name
+     * @param bool|null                                                                                                                                   $readableLink            https://api-platform.com/docs/core/serialization/#force-iri-with-relations-of-the-same-type-parentchilds-relations
+     * @param bool|null                                                                                                                                   $writableLink            https://api-platform.com/docs/core/serialization/#force-iri-with-relations-of-the-same-type-parentchilds-relations
+     * @param bool|null                                                                                                                                   $required                https://api-platform.com/docs/admin/validation/#client-side-validation
+     * @param bool|null                                                                                                                                   $identifier              https://api-platform.com/docs/core/identifiers/
+     * @param mixed                                                                                                                                       $example                 https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param string|null                                                                                                                                 $deprecationReason       https://api-platform.com/docs/core/deprecations/#deprecating-resource-classes-operations-and-properties
+     * @param bool|null                                                                                                                                   $fetchEager              https://api-platform.com/docs/core/performance/#eager-loading
+     * @param array|null                                                                                                                                  $jsonldContext           https://api-platform.com/docs/core/extending-jsonld-context/#extending-json-ld-and-hydra-contexts
+     * @param array|null                                                                                                                                  $openapiContext          https://api-platform.com/docs/core/openapi/#using-the-openapi-and-swagger-contexts
+     * @param bool|null                                                                                                                                   $push                    https://api-platform.com/docs/core/push-relations/
+     * @param string|\Stringable|null                                                                                                                     $security                https://api-platform.com/docs/core/security
+     * @param string|\Stringable|null                                                                                                                     $securityPostDenormalize https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization
+     * @param string[]                                                                                                                                    $types                   the RDF types of this property
+     * @param string[]                                                                                                                                    $iris
+     * @param Type[]                                                                                                                                      $builtinTypes
+     * @param string|null                                                                                                                                 $uriTemplate             (experimental) whether to return the subRessource collection IRI instead of an iterable of IRI
+     * @param string|null                                                                                                                                 $property                The property name
+     * @param Context|Groups|Ignore|SerializedName|SerializedPath|MaxDepth|array<array-key, Context|Groups|Ignore|SerializedName|SerializedPath|MaxDepth> $serialize               Serializer attributes
      */
     public function __construct(
         private ?string $description = null,
@@ -193,7 +203,7 @@ final class ApiProperty
          * </div>
          */
         private string|\Stringable|null $securityPostDenormalize = null,
-        private array|string|null $types = null,
+        array|string|null $types = null,
         /*
          * The related php types.
          */
@@ -205,11 +215,11 @@ final class ApiProperty
         private ?string $uriTemplate = null,
         private ?string $property = null,
         private ?string $policy = null,
+        array|Context|Groups|Ignore|SerializedName|SerializedPath|MaxDepth|null $serialize = null,
         private array $extraProperties = [],
     ) {
-        if (\is_string($types)) {
-            $this->types = (array) $types;
-        }
+        $this->types = \is_string($types) ? (array) $types : $types;
+        $this->serialize = \is_array($serialize) ? $serialize : (array) $serialize;
     }
 
     public function getProperty(): ?string
@@ -597,6 +607,22 @@ final class ApiProperty
     {
         $self = clone $this;
         $self->policy = $policy;
+
+        return $self;
+    }
+
+    public function getSerialize(): ?array
+    {
+        return $this->serialize;
+    }
+
+    /**
+     * @param Context|Groups|Ignore|SerializedName|SerializedPath|MaxDepth|array<array-key, Context|Groups|Ignore|SerializedName|SerializedPath|MaxDepth> $serialize
+     */
+    public function withSerialize(array|Context|Groups|Ignore|SerializedName|SerializedPath|MaxDepth $serialize): static
+    {
+        $self = clone $this;
+        $self->serialize = (array) $serialize;
 
         return $self;
     }

--- a/src/Metadata/Tests/Extractor/Adapter/XmlPropertyAdapter.php
+++ b/src/Metadata/Tests/Extractor/Adapter/XmlPropertyAdapter.php
@@ -47,7 +47,8 @@ final class XmlPropertyAdapter implements PropertyAdapterInterface
         'property',
     ];
 
-    private const EXCLUDE = ['policy'];
+    // TODO: add serialize support for XML (policy is Laravel-only)
+    private const EXCLUDE = ['policy', 'serialize'];
 
     /**
      * {@inheritdoc}

--- a/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
+++ b/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Mapping\Loader;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use Illuminate\Database\Eloquent\Model;
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Serializer\Attribute\Ignore;
+use Symfony\Component\Serializer\Attribute\MaxDepth;
+use Symfony\Component\Serializer\Attribute\SerializedName;
+use Symfony\Component\Serializer\Attribute\SerializedPath;
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
+use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
+use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
+
+/**
+ * Loader for PHP attributes using ApiProperty.
+ */
+final class PropertyMetadataLoader implements LoaderInterface
+{
+    public function __construct(private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory)
+    {
+    }
+
+    public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
+    {
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        // It's very weird to grab Eloquent's properties in that case as they're never serialized
+        // the Serializer makes a call on the abstract class, let's save some unneeded work with a condition
+        if (Model::class === $classMetadata->getName()) {
+            return false;
+        }
+
+        $refl = $classMetadata->getReflectionClass();
+        $attributes = [];
+        $classGroups = [];
+        $classContextAnnotation = null;
+
+        foreach ($refl->getAttributes(ApiProperty::class) as $clAttr) {
+            $this->addAttributeMetadata($clAttr->newInstance(), $attributes);
+        }
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+        foreach ($refl->getAttributes() as $a) {
+            $attribute = $a->newInstance();
+            if ($attribute instanceof DiscriminatorMap) {
+                $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping(
+                    $attribute->getTypeProperty(),
+                    $attribute->getMapping()
+                ));
+                continue;
+            }
+
+            if ($attribute instanceof Groups) {
+                $classGroups = $attribute->getGroups();
+
+                continue;
+            }
+
+            if ($attribute instanceof Context) {
+                $classContextAnnotation = $attribute;
+            }
+        }
+
+        foreach ($refl->getProperties() as $reflProperty) {
+            foreach ($reflProperty->getAttributes(ApiProperty::class) as $propAttr) {
+                $this->addAttributeMetadata($propAttr->newInstance()->withProperty($reflProperty->name), $attributes);
+            }
+        }
+
+        foreach ($refl->getMethods() as $reflMethod) {
+            foreach ($reflMethod->getAttributes(ApiProperty::class) as $methodAttr) {
+                $this->addAttributeMetadata($methodAttr->newInstance()->withProperty($reflMethod->getName()), $attributes);
+            }
+        }
+
+        foreach ($this->propertyNameCollectionFactory->create($classMetadata->getName()) as $propertyName) {
+            if (!isset($attributesMetadata[$propertyName])) {
+                $attributesMetadata[$propertyName] = new AttributeMetadata($propertyName);
+                $classMetadata->addAttributeMetadata($attributesMetadata[$propertyName]);
+            }
+
+            foreach ($classGroups as $group) {
+                $attributesMetadata[$propertyName]->addGroup($group);
+            }
+
+            if ($classContextAnnotation) {
+                $this->setAttributeContextsForGroups($classContextAnnotation, $attributesMetadata[$propertyName]);
+            }
+
+            if (!isset($attributes[$propertyName])) {
+                continue;
+            }
+
+            $attributeMetadata = $attributesMetadata[$propertyName];
+
+            // This code is adapted from Symfony\Component\Serializer\Mapping\Loader\AttributeLoader
+            foreach ($attributes[$propertyName] as $attr) {
+                if ($attr instanceof Groups) {
+                    foreach ($attr->getGroups() as $group) {
+                        $attributeMetadata->addGroup($group);
+                    }
+                    continue;
+                }
+
+                match (true) {
+                    $attr instanceof MaxDepth => $attributeMetadata->setMaxDepth($attr->getMaxDepth()),
+                    $attr instanceof SerializedName => $attributeMetadata->setSerializedName($attr->getSerializedName()),
+                    $attr instanceof SerializedPath => $attributeMetadata->setSerializedPath($attr->getSerializedPath()),
+                    $attr instanceof Ignore => $attributeMetadata->setIgnore(true),
+                    $attr instanceof Context => $this->setAttributeContextsForGroups($attr, $attributeMetadata),
+                    default => null,
+                };
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ApiProperty[] $attributes
+     */
+    private function addAttributeMetadata(ApiProperty $attribute, array &$attributes): void
+    {
+        if (($prop = $attribute->getProperty()) && ($value = $attribute->getSerialize())) {
+            $attributes[$prop] = $value;
+        }
+    }
+
+    private function setAttributeContextsForGroups(Context $annotation, AttributeMetadataInterface $attributeMetadata): void
+    {
+        $context = $annotation->getContext();
+        $groups = $annotation->getGroups();
+        $normalizationContext = $annotation->getNormalizationContext();
+        $denormalizationContext = $annotation->getDenormalizationContext();
+        if ($normalizationContext || $context) {
+            $attributeMetadata->setNormalizationContextForGroups($normalizationContext ?: $context, $groups);
+        }
+
+        if ($denormalizationContext || $context) {
+            $attributeMetadata->setDenormalizationContextForGroups($denormalizationContext ?: $context, $groups);
+        }
+    }
+}

--- a/src/Serializer/Tests/Fixtures/Model/HasRelation.php
+++ b/src/Serializer/Tests/Fixtures/Model/HasRelation.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\Model;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+class HasRelation
+{
+    #[ApiProperty(serialize: [new Groups(['read'])])]
+    public function relation(): Relation
+    {
+        return new Relation();
+    }
+}

--- a/src/Serializer/Tests/Fixtures/Model/Relation.php
+++ b/src/Serializer/Tests/Fixtures/Model/Relation.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\Model;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[Groups(['read'])]
+class Relation
+{
+}

--- a/src/Serializer/Tests/Mapping/Loader/PropertyMetadataLoaderTest.php
+++ b/src/Serializer/Tests/Mapping/Loader/PropertyMetadataLoaderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Mapping\Loader;
+
+use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Serializer\Mapping\Loader\PropertyMetadataLoader;
+use ApiPlatform\Serializer\Tests\Fixtures\Model\HasRelation;
+use ApiPlatform\Serializer\Tests\Fixtures\Model\Relation;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\ClassMetadata;
+
+final class PropertyMetadataLoaderTest extends TestCase
+{
+    public function testCreateMappingForASetOfProperties(): void
+    {
+        $coll = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $coll->method('create')->willReturn(new PropertyNameCollection(['relation']));
+        $loader = new PropertyMetadataLoader($coll);
+        $classMetadata = new ClassMetadata(HasRelation::class);
+        $loader->loadClassMetadata($classMetadata);
+        $this->assertArrayHasKey('relation', $classMetadata->attributesMetadata);
+        $this->assertEquals(['read'], $classMetadata->attributesMetadata['relation']->getGroups());
+    }
+
+    public function testCreateMappingForAClass(): void
+    {
+        $coll = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $coll->method('create')->willReturn(new PropertyNameCollection(['name']));
+        $loader = new PropertyMetadataLoader($coll);
+        $classMetadata = new ClassMetadata(Relation::class);
+        $loader->loadClassMetadata($classMetadata);
+        $this->assertArrayHasKey('name', $classMetadata->attributesMetadata);
+        $this->assertEquals(['read'], $classMetadata->attributesMetadata['name']->getGroups());
+    }
+}

--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -23,6 +23,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolver
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlResolverPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\SerializerMappingLoaderPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -58,5 +59,6 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new TestClientPass());
         $container->addCompilerPass(new TestMercureHubPass());
         $container->addCompilerPass(new AuthenticatorManagerPass());
+        $container->addCompilerPass(new SerializerMappingLoaderPass());
     }
 }

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/SerializerMappingLoaderPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/SerializerMappingLoaderPass.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class SerializerMappingLoaderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $chainLoader = $container->getDefinition('serializer.mapping.chain_loader');
+        $loaders = $chainLoader->getArgument(0);
+        $loaders[] = $container->getDefinition('api_platform.serializer.property_metadata_loader');
+        $container->getDefinition('serializer.mapping.cache_warmer')->replaceArgument(0, $loaders);
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/api.xml
+++ b/src/Symfony/Bundle/Resources/config/api.xml
@@ -175,5 +175,9 @@
 
             <tag name="serializer.normalizer" priority="-780" />
         </service>
+
+        <service id="api_platform.serializer.property_metadata_loader" class="ApiPlatform\Serializer\Mapping\Loader\PropertyMetadataLoader" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+        </service>
     </services>
 </container>

--- a/tests/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -24,6 +24,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlQueryResolver
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlResolverPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\SerializerMappingLoaderPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
 use PHPUnit\Framework\TestCase;
@@ -54,6 +55,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(TestClientPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(TestMercureHubPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(AuthenticatorManagerPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(SerializerMappingLoaderPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
 
         $bundle = new ApiPlatformBundle();
         $bundle->build($containerProphecy->reveal());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0 (new metadata feature but a bug fix for laravel)
| License       | MIT
| Doc PR        | required?

```php
#[ApiResource(normalizationContext: ['groups' => ['read']])]
class Resource
{
    #[ApiProperty(serialize: [new Groups(['read'])])]
    public function relation(): Relation
    {
        return new Relation(id: 1, name: 'test');
    }
}

#[Groups(['read'])]
#[ApiResource(operations: [])]
class Relation
{
    public function __construct(public int $id, public string $name) {}
}
```

```json
{
  "@context": "/api/contexts/SomeClass",
  "@id": "/api/some_classes/1",
  "@type": "SomeClass",
  "relation": {
    "@id": "/api/relations/1",
    "@type": "Relation",
    "id": 1,
    "name": "test"
  }
}
```