### PR TITLE
fix: parameter provider in a long running http worker

### DIFF
--- a/src/State/Provider/ParameterProvider.php
+++ b/src/State/Provider/ParameterProvider.php
@@ -52,6 +52,10 @@ final class ParameterProvider implements ProviderInterface
         $context = ['operation' => $operation] + $context;
         $parameters = $operation->getParameters();
         foreach ($parameters ?? [] as $parameter) {
+            $extraProperties = $parameter->getExtraProperties();
+            unset($extraProperties['_api_values']);
+            $parameters->add($parameter->getKey(), $parameter = $parameter->withExtraProperties($extraProperties));
+
             $values = $this->getParameterValues($parameter, $request, $context);
             $value = $this->extractParameterValues($parameter, $values);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | -
| License       | MIT
| Doc PR        | -

In case of using long running http workers (Roadrunner for example), query parameters and in general parameters functionality tends to persist previous request value due to aggressive [caching of resource metadata ](https://github.com/api-platform/core/blob/main/src/Metadata/Resource/Factory/CachedResourceMetadataCollectionFactory.php)

Fixing by clearing extra data before parsing new one

Targeting 3.4, but the issue reproducible at 4.0 as well