### PR TITLE
fix(elasticsearch): Allow ES 7

### DIFF
--- a/src/Elasticsearch/composer.json
+++ b/src/Elasticsearch/composer.json
@@ -27,7 +27,7 @@
         "api-platform/metadata": "^3.4 || ^4.0",
         "api-platform/serializer": "^3.4 || ^4.0",
         "api-platform/state": "^3.4 || ^4.0",
-        "elasticsearch/elasticsearch": "^8.9",
+        "elasticsearch/elasticsearch": "^7.11 || ^8.9",
         "symfony/cache": "^6.4 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

When installing api-platform/core (3.4) elasticsearch 7 and 8 is supported (https://github.com/api-platform/core/blob/v3.4.1/composer.json#L144) but when installing the same version (3.4) with api-platform/elasticsearch only 8 is supported https://github.com/api-platform/core/blob/v3.4.1/src/Elasticsearch/composer.json#L30.
