### PR TITLE
test(laravel): call factories, debug is now false by default

### DIFF
--- a/src/GraphQl/Type/TypeConverter.php
+++ b/src/GraphQl/Type/TypeConverter.php
@@ -168,10 +168,14 @@ final class TypeConverter implements TypeConverterInterface
         try {
             $operation = $resourceMetadataCollection->getOperation($operationName);
         } catch (OperationNotFoundException) {
-            $operation = $resourceMetadataCollection->getOperation($isCollection ? 'collection_query' : 'item_query');
+            try {
+                $operation = $resourceMetadataCollection->getOperation($isCollection ? 'collection_query' : 'item_query');
+            } catch (OperationNotFoundException) {
+                throw new OperationNotFoundException(\sprintf('A GraphQl operation named "%s" should exist on the type "%s" as we reference this type in another query.', $isCollection ? 'collection_query' : 'item_query', $resourceClass));
+            }
         }
         if (!$operation instanceof Operation) {
-            throw new OperationNotFoundException();
+            throw new OperationNotFoundException(\sprintf('A GraphQl operation named "%s" should exist on the type "%s" as we reference this type in another query.', $operationName, $resourceClass));
         }
 
         return $this->typeBuilder->getResourceObjectType($resourceMetadataCollection, $operation, $propertyMetadata, [

--- a/src/Laravel/Tests/AuthTest.php
+++ b/src/Laravel/Tests/AuthTest.php
@@ -14,15 +14,34 @@ declare(strict_types=1);
 namespace ApiPlatform\Laravel\Tests;
 
 use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Config\Repository;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
+use Workbench\Database\Factories\UserFactory;
 
 class AuthTest extends TestCase
 {
     use ApiTestAssertionsTrait;
     use RefreshDatabase;
     use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], function (Repository $config): void {
+            $config->set('api-platform.graphql.enabled', true);
+            $config->set('app.key', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF');
+        });
+    }
+
+    protected function afterRefreshingDatabase(): void
+    {
+        UserFactory::new()->create();
+    }
 
     public function testGetCollection(): void
     {
@@ -44,7 +63,7 @@ class AuthTest extends TestCase
     {
         $response = $this->post('/tokens/create');
         $token = $response->json()['token'];
-        $response = $this->post('/api/vaults', [], ['accept' => ['application/ld+json'], 'content-type' => ['application/ld+json'], 'authorization' => 'Bearer '.$token]);
+        $response = $this->postJson('/api/vaults', [], ['accept' => ['application/ld+json'], 'content-type' => ['application/ld+json'], 'authorization' => 'Bearer '.$token]);
         $response->assertStatus(403);
     }
 

--- a/src/Laravel/Tests/EloquentTest.php
+++ b/src/Laravel/Tests/EloquentTest.php
@@ -17,6 +17,9 @@ use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
+use Workbench\Database\Factories\WithAccessorFactory;
 
 class EloquentTest extends TestCase
 {
@@ -26,6 +29,8 @@ class EloquentTest extends TestCase
 
     public function testSearchFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $book = $response->json()['member'][0];
 
@@ -35,18 +40,24 @@ class EloquentTest extends TestCase
 
     public function testValidateSearchFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books?isbn=a', ['Accept' => ['application/ld+json']]);
         $this->assertSame($response->json()['detail'], 'The isbn field must be at least 2 characters.');
     }
 
     public function testSearchFilterRelation(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books?author=1', ['Accept' => ['application/ld+json']]);
         $this->assertSame($response->json()['member'][0]['author'], '/api/authors/1');
     }
 
     public function testPropertyFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $book = $response->json()['member'][0];
 
@@ -60,6 +71,8 @@ class EloquentTest extends TestCase
 
     public function testPartialSearchFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $book = $response->json()['member'][0];
 
@@ -76,6 +89,8 @@ class EloquentTest extends TestCase
 
     public function testDateFilterEqual(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $book = $response->json()['member'][0];
         $updated = $this->patchJson(
@@ -93,6 +108,8 @@ class EloquentTest extends TestCase
 
     public function testDateFilterIncludeNull(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $book = $response->json()['member'][0];
         $updated = $this->patchJson(
@@ -110,6 +127,8 @@ class EloquentTest extends TestCase
 
     public function testDateFilterExcludeNull(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $book = $response->json()['member'][0];
         $updated = $this->patchJson(
@@ -127,6 +146,8 @@ class EloquentTest extends TestCase
 
     public function testDateFilterGreaterThan(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $bookBefore = $response->json()['member'][0];
         $updated = $this->patchJson(
@@ -155,9 +176,10 @@ class EloquentTest extends TestCase
 
     public function testDateFilterLowerThanEqual(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $bookBefore = $response->json()['member'][0];
-        $updated = $this->patchJson(
+        $this->patchJson(
             $bookBefore['@id'],
             ['publicationDate' => '0001-02-18 00:00:00'],
             [
@@ -184,6 +206,7 @@ class EloquentTest extends TestCase
 
     public function testDateFilterBetween(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $book = $response->json()['member'][0];
         $updated = $this->patchJson(
@@ -223,6 +246,7 @@ class EloquentTest extends TestCase
 
     public function testSearchFilterWithPropertyPlaceholder(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/authors', ['Accept' => ['application/ld+json']])->json();
         $author = $response['member'][0];
 
@@ -235,12 +259,14 @@ class EloquentTest extends TestCase
 
     public function testOrderFilterWithPropertyPlaceholder(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $res = $this->get('/api/authors?order[id]=desc', ['Accept' => ['application/ld+json']])->json();
         $this->assertSame($res['member'][0]['id'], 10);
     }
 
     public function testOrFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']])->json()['member'];
         $book = $response[0];
         $book2 = $response[1];
@@ -251,6 +277,7 @@ class EloquentTest extends TestCase
 
     public function testRangeLowerThanFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $bookBefore = $response->json()['member'][0];
         $this->patchJson(
@@ -279,6 +306,7 @@ class EloquentTest extends TestCase
 
     public function testRangeLowerThanEqualFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $bookBefore = $response->json()['member'][0];
         $this->patchJson(
@@ -308,6 +336,7 @@ class EloquentTest extends TestCase
 
     public function testRangeGreaterThanFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $bookBefore = $response->json()['member'][0];
         $updated = $this->patchJson(
@@ -336,6 +365,7 @@ class EloquentTest extends TestCase
 
     public function testRangeGreaterThanEqualFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['Accept' => ['application/ld+json']]);
         $bookBefore = $response->json()['member'][0];
         $updated = $this->patchJson(
@@ -365,12 +395,14 @@ class EloquentTest extends TestCase
 
     public function testWrongOrderFilter(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $res = $this->get('/api/authors?order[name]=something', ['Accept' => ['application/ld+json']]);
         $this->assertEquals($res->getStatusCode(), 422);
     }
 
     public function testWithAccessor(): void
     {
+        WithAccessorFactory::new()->create();
         $res = $this->get('/api/with_accessors/1', ['Accept' => ['application/ld+json']]);
         $this->assertArraySubset(['name' => 'test'], $res->json());
     }

--- a/src/Laravel/Tests/GraphQlAuthTest.php
+++ b/src/Laravel/Tests/GraphQlAuthTest.php
@@ -20,12 +20,21 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
+use Workbench\Database\Factories\UserFactory;
+use Workbench\Database\Factories\VaultFactory;
 
 class GraphQlAuthTest extends TestCase
 {
     use ApiTestAssertionsTrait;
     use RefreshDatabase;
     use WithWorkbench;
+
+    protected function afterRefreshingDatabase(): void
+    {
+        UserFactory::new()->create();
+    }
 
     /**
      * @param Application $app
@@ -34,6 +43,7 @@ class GraphQlAuthTest extends TestCase
     {
         tap($app['config'], function (Repository $config): void {
             $config->set('api-platform.routes.middleware', ['auth:sanctum']);
+            $config->set('app.key', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF');
             $config->set('api-platform.graphql.enabled', true);
         });
     }
@@ -46,6 +56,7 @@ class GraphQlAuthTest extends TestCase
 
     public function testAuthenticated(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->post('/tokens/create');
         $token = $response->json()['token'];
         $response = $this->get('/api/graphql', ['accept' => ['text/html'], 'authorization' => 'Bearer '.$token]);
@@ -64,6 +75,7 @@ class GraphQlAuthTest extends TestCase
 
     public function testPolicy(): void
     {
+        VaultFactory::new()->count(10)->create();
         $response = $this->post('/tokens/create');
         $token = $response->json()['token'];
         $response = $this->postJson('/api/graphql', ['query' => 'mutation {
@@ -86,6 +98,7 @@ class GraphQlAuthTest extends TestCase
         tap($app['config'], function (Repository $config): void {
             $config->set('api-platform.routes.middleware', ['auth:sanctum']);
             $config->set('api-platform.graphql.enabled', true);
+            $config->set('app.key', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF');
             $config->set('app.debug', false);
         });
     }
@@ -93,6 +106,7 @@ class GraphQlAuthTest extends TestCase
     #[DefineEnvironment('useProductionMode')]
     public function testProductionError(): void
     {
+        VaultFactory::new()->count(10)->create();
         $response = $this->post('/tokens/create');
         $token = $response->json()['token'];
         $response = $this->postJson('/api/graphql', ['query' => 'mutation {

--- a/src/Laravel/Tests/GraphQlTest.php
+++ b/src/Laravel/Tests/GraphQlTest.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Laravel\Tests;
 
 use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
-use Illuminate\Contracts\Config\Repository;
+use Illuminate\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
 
 class GraphQlTest extends TestCase
 {
@@ -38,6 +40,7 @@ class GraphQlTest extends TestCase
 
     public function testGetBooks(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->postJson('/api/graphql', ['query' => '{books { edges { node {id, name, publicationDate, author {id, name }}}}}'], ['accept' => ['application/json']]);
         $response->assertStatus(200);
         $data = $response->json();

--- a/src/Laravel/Tests/HalTest.php
+++ b/src/Laravel/Tests/HalTest.php
@@ -20,6 +20,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use Workbench\App\Models\Book;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
 
 class HalTest extends TestCase
 {
@@ -35,6 +37,7 @@ class HalTest extends TestCase
         tap($app['config'], function (Repository $config): void {
             $config->set('api-platform.formats', ['jsonhal' => ['application/hal+json']]);
             $config->set('api-platform.docs_formats', ['jsonhal' => ['application/hal+json']]);
+            $config->set('app.debug', true);
         });
     }
 
@@ -61,6 +64,7 @@ class HalTest extends TestCase
 
     public function testGetCollection(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['accept' => 'application/hal+json']);
         $response->assertStatus(200);
         $response->assertHeader('content-type', 'application/hal+json; charset=utf-8');
@@ -79,6 +83,7 @@ class HalTest extends TestCase
 
     public function testGetBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->get($iri, ['accept' => ['application/hal+json']]);
@@ -103,6 +108,7 @@ class HalTest extends TestCase
 
     public function testDeleteBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->delete($iri, headers: ['accept' => 'application/hal+json']);

--- a/src/Laravel/Tests/JsonApiTest.php
+++ b/src/Laravel/Tests/JsonApiTest.php
@@ -21,6 +21,8 @@ use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use Workbench\App\Models\Author;
 use Workbench\App\Models\Book;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
 
 class JsonApiTest extends TestCase
 {
@@ -36,6 +38,7 @@ class JsonApiTest extends TestCase
         tap($app['config'], function (Repository $config): void {
             $config->set('api-platform.formats', ['jsonapi' => ['application/vnd.api+json']]);
             $config->set('api-platform.docs_formats', ['jsonapi' => ['application/vnd.api+json']]);
+            $config->set('app.debug', true);
         });
     }
 
@@ -55,6 +58,7 @@ class JsonApiTest extends TestCase
 
     public function testGetCollection(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['accept' => ['application/vnd.api+json']]);
         $response->assertStatus(200);
         $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
@@ -72,6 +76,7 @@ class JsonApiTest extends TestCase
 
     public function testGetBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->get($iri, ['accept' => ['application/vnd.api+json']]);
@@ -91,6 +96,7 @@ class JsonApiTest extends TestCase
 
     public function testCreateBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $author = Author::find(1);
         $response = $this->postJson(
             '/api/books',
@@ -132,6 +138,7 @@ class JsonApiTest extends TestCase
 
     public function testUpdateBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->putJson(
@@ -157,6 +164,7 @@ class JsonApiTest extends TestCase
 
     public function testPatchBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->patchJson(
@@ -182,6 +190,7 @@ class JsonApiTest extends TestCase
 
     public function testDeleteBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->delete($iri, headers: ['accept' => 'application/vnd.api+json']);

--- a/src/Laravel/Tests/Policy/PolicyAllowTest.php
+++ b/src/Laravel/Tests/Policy/PolicyAllowTest.php
@@ -22,6 +22,8 @@ use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use Workbench\App\Models\Author;
 use Workbench\App\Models\Book;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
 
 class PolicyAllowTest extends TestCase
 {
@@ -43,17 +45,20 @@ class PolicyAllowTest extends TestCase
         tap($app['config'], function (Repository $config): void {
             $config->set('api-platform.formats', ['jsonapi' => ['application/vnd.api+json']]);
             $config->set('api-platform.docs_formats', ['jsonapi' => ['application/vnd.api+json']]);
+            $config->set('app.debug', true);
         });
     }
 
     public function testGetCollection(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['accept' => ['application/vnd.api+json']]);
         $response->assertStatus(200);
     }
 
-    public function testGetEmptyColelction(): void
+    public function testGetEmptyCollection(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books?publicationDate[gt]=9999-12-31', ['accept' => ['application/vnd.api+json']]);
         $response->assertStatus(200);
         $response->assertJsonFragment([
@@ -67,6 +72,7 @@ class PolicyAllowTest extends TestCase
 
     public function testGetBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->get($iri, ['accept' => ['application/vnd.api+json']]);
@@ -75,6 +81,7 @@ class PolicyAllowTest extends TestCase
 
     public function testCreateBook(): void
     {
+        AuthorFactory::new()->create();
         $author = Author::find(1);
         $response = $this->postJson(
             '/api/books',
@@ -106,6 +113,7 @@ class PolicyAllowTest extends TestCase
 
     public function testUpdateBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->putJson(
@@ -123,6 +131,7 @@ class PolicyAllowTest extends TestCase
 
     public function testPatchBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->patchJson(
@@ -140,6 +149,7 @@ class PolicyAllowTest extends TestCase
 
     public function testDeleteBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->delete($iri, headers: ['accept' => 'application/vnd.api+json']);

--- a/src/Laravel/Tests/Policy/PolicyDenyTest.php
+++ b/src/Laravel/Tests/Policy/PolicyDenyTest.php
@@ -22,6 +22,8 @@ use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use Workbench\App\Models\Author;
 use Workbench\App\Models\Book;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
 
 class PolicyDenyTest extends TestCase
 {
@@ -43,6 +45,7 @@ class PolicyDenyTest extends TestCase
         tap($app['config'], function (Repository $config): void {
             $config->set('api-platform.formats', ['jsonapi' => ['application/vnd.api+json']]);
             $config->set('api-platform.docs_formats', ['jsonapi' => ['application/vnd.api+json']]);
+            $config->set('app.debug', true);
         });
     }
 
@@ -54,6 +57,7 @@ class PolicyDenyTest extends TestCase
 
     public function testGetBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->get($iri, ['accept' => ['application/vnd.api+json']]);
@@ -62,6 +66,7 @@ class PolicyDenyTest extends TestCase
 
     public function testCreateBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $author = Author::find(1);
         $response = $this->postJson(
             '/api/books',
@@ -93,6 +98,7 @@ class PolicyDenyTest extends TestCase
 
     public function testUpdateBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->putJson(
@@ -110,6 +116,7 @@ class PolicyDenyTest extends TestCase
 
     public function testPatchBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->patchJson(
@@ -127,6 +134,7 @@ class PolicyDenyTest extends TestCase
 
     public function testDeleteBook(): void
     {
+        BookFactory::new()->has(AuthorFactory::new())->create();
         $book = Book::first();
         $iri = $this->getIriFromResource($book);
         $response = $this->delete($iri, headers: ['accept' => 'application/vnd.api+json']);

--- a/src/Laravel/workbench/app/Models/Vault.php
+++ b/src/Laravel/workbench/app/Models/Vault.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\Post;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -35,7 +36,7 @@ use Workbench\App\Http\Requests\VaultFormRequest;
         ),
         new Delete(middleware: 'auth:sanctum', rules: VaultFormRequest::class, provider: [self::class, 'provide']),
     ],
-    graphQlOperations: [new Mutation(name: 'update', policy: 'update')]
+    graphQlOperations: [new Query(name: 'item_query'), new Mutation(name: 'update', policy: 'update')]
 )]
 class Vault extends Model
 {


### PR DESCRIPTION
Because the `shouldSeed` (https://github.com/orchestral/testbench-core/commit/57954ccc46e9a1824bbce2d3984cf9ec897684cf) is now false by default we didn't executed the DatabaseSeeder every time. I choose to load just what we need for each test to speed up tests. Also, I noted that we may have side effects using the file storage as `app.debug` looks to be `false` by default for testing (not sure what brought this update) and therefore when adding a format inside tests we need to use the MemoryCache, or to clear laravel's cache (couldn't make it work through the workbench command).