### PR TITLE
feat(laravel): adds make:state-provider command

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,6 +15,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude([
         'src/Core/Bridge/Symfony/Maker/Resources/skeleton',
+        'src/Laravel/Console/Maker/Resources/skeleton',
         'src/Laravel/config',
         'tests/Fixtures/app/var',
         'docs/guides',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.0.4
+
+### Features
+
+* [4c0c6348b](https://github.com/api-platform/core/pull/6706/commits/4c0c6348bcbef5e3b942d33b2e0ca318b5cb04f5) feat(laravel): adds make:state-provider command
+
 ## v4.0.3
 
 ### Bug fixes

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -1040,7 +1040,10 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         if ($this->app->runningInConsole()) {
-            $this->commands([Console\InstallCommand::class]);
+            $this->commands([
+                Console\InstallCommand::class,
+                Console\Maker\MakeStateProviderCommand::class,
+            ]);
         }
     }
 

--- a/src/Laravel/Console/Maker/MakeStateProviderCommand.php
+++ b/src/Laravel/Console/Maker/MakeStateProviderCommand.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Laravel\Console\Maker;
 
 use ApiPlatform\Laravel\Console\Maker\Utils\AppServiceProviderTagger;
@@ -22,9 +33,8 @@ final class MakeStateProviderCommand extends Command
         private readonly Filesystem $filesystem,
         private readonly StateProviderGenerator $stateProviderGenerator,
         private readonly AppServiceProviderTagger $appServiceProviderTagger,
-        private readonly StateDirectoryManager $stateDirectoryManager
-    )
-    {
+        private readonly StateDirectoryManager $stateDirectoryManager,
+    ) {
         parent::__construct();
     }
 
@@ -38,19 +48,22 @@ final class MakeStateProviderCommand extends Command
 
         $filePath = $this->stateProviderGenerator->getFilePath($directoryPath, $providerName);
         if ($this->stateProviderGenerator->isFileExists($filePath)) {
-            $this->error(sprintf('[ERROR] The file "%s" can\'t be generated because it already exists.', $filePath));
+            $this->error(\sprintf('[ERROR] The file "%s" can\'t be generated because it already exists.', $filePath));
+
             return self::FAILURE;
         }
 
         $this->stateProviderGenerator->generate($filePath, $providerName);
         if (!$this->filesystem->exists($filePath)) {
-            $this->error(sprintf('[ERROR] The file "%s" could not be created.', $filePath));
+            $this->error(\sprintf('[ERROR] The file "%s" could not be created.', $filePath));
+
             return self::FAILURE;
         }
 
         $this->appServiceProviderTagger->addTagToServiceProvider($providerName);
 
         $this->writeSuccessMessage($filePath);
+
         return self::SUCCESS;
     }
 

--- a/src/Laravel/Console/Maker/MakeStateProviderCommand.php
+++ b/src/Laravel/Console/Maker/MakeStateProviderCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ApiPlatform\Laravel\Console\Maker;
+
+use ApiPlatform\Laravel\Console\Maker\Utils\AppServiceProviderTagger;
+use ApiPlatform\Laravel\Console\Maker\Utils\StateDirectoryManager;
+use ApiPlatform\Laravel\Console\Maker\Utils\StateProviderGenerator;
+use ApiPlatform\Laravel\Console\Maker\Utils\SuccessMessageTrait;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+
+final class MakeStateProviderCommand extends Command
+{
+    use SuccessMessageTrait;
+
+    protected $signature = 'make:state-provider';
+
+    protected $description = 'Creates an API Platform state provider';
+
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        private readonly StateProviderGenerator $stateProviderGenerator,
+        private readonly AppServiceProviderTagger $appServiceProviderTagger,
+        private readonly StateDirectoryManager $stateDirectoryManager
+    )
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    public function handle(): int
+    {
+        $providerName = $this->askForProviderName();
+        $directoryPath = $this->stateDirectoryManager->ensureStateDirectoryExists();
+
+        $filePath = $this->stateProviderGenerator->getFilePath($directoryPath, $providerName);
+        if ($this->stateProviderGenerator->isFileExists($filePath)) {
+            $this->error(sprintf('[ERROR] The file "%s" can\'t be generated because it already exists.', $filePath));
+            return self::FAILURE;
+        }
+
+        $this->stateProviderGenerator->generate($filePath, $providerName);
+        if (!$this->filesystem->exists($filePath)) {
+            $this->error(sprintf('[ERROR] The file "%s" could not be created.', $filePath));
+            return self::FAILURE;
+        }
+
+        $this->appServiceProviderTagger->addTagToServiceProvider($providerName);
+
+        $this->writeSuccessMessage($filePath);
+        return self::SUCCESS;
+    }
+
+    private function askForProviderName(): string
+    {
+        do {
+            $providerName = $this->ask('Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)');
+            if (empty($providerName)) {
+                $this->error('[ERROR] This value cannot be blank.');
+            }
+        } while (empty($providerName));
+
+        return $providerName;
+    }
+}

--- a/src/Laravel/Console/Maker/Resources/skeleton/StateProvider.tpl.php
+++ b/src/Laravel/Console/Maker/Resources/skeleton/StateProvider.tpl.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+final class {{ class_name }} implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        // Retrieve the state from somewhere
+    }
+}

--- a/src/Laravel/Console/Maker/Utils/AppServiceProviderTagger.php
+++ b/src/Laravel/Console/Maker/Utils/AppServiceProviderTagger.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ApiPlatform\Laravel\Console\Maker\Utils;
+
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+
+final readonly class AppServiceProviderTagger
+{
+    /** @var string  */
+    private const SERVICE_PROVIDER_PATH = 'Providers/AppServiceProvider.php';
+
+    /** @var string  */
+    private const ITEM_PROVIDER_USE_STATEMENT = 'use ApiPlatform\Laravel\Eloquent\State\ItemProvider;';
+
+    public function __construct(private Filesystem $filesystem) {}
+
+    /**
+     * @throws FileNotFoundException
+     */
+    public function addTagToServiceProvider(string $providerName): void
+    {
+        $serviceProviderPath = app_path(self::SERVICE_PROVIDER_PATH);
+
+        $this->ensureServiceProviderExists($serviceProviderPath);
+
+        $serviceProviderContent = $this->filesystem->get($serviceProviderPath);
+
+        $this->addUseStatement($serviceProviderContent, self::ITEM_PROVIDER_USE_STATEMENT);
+        $this->addUseStatement($serviceProviderContent, $this->getProviderNamespace($providerName));
+        $this->addTag($serviceProviderContent, $providerName, $serviceProviderPath);
+    }
+
+    private function ensureServiceProviderExists(string $path): void
+    {
+        if (!$this->filesystem->exists($path)) {
+            throw new \RuntimeException("The AppServiceProvider is missing!");
+        }
+    }
+
+    private function addUseStatement(string &$content, string $useStatement): void
+    {
+        if (!str_contains($content, $useStatement)) {
+            $content = preg_replace(
+                '/^(namespace\s[^;]+;\s*)(\n)/m',
+                "$1\n$useStatement$2",
+                $content,
+                1
+            );
+        }
+    }
+
+    private function addTag(string &$content, string $providerName, string $serviceProviderPath): void
+    {
+        $tagStatement = sprintf("\n\n\t\t\$this->app->tag(%s::class, ItemProvider::class);", $providerName);
+        if (!str_contains($content, $tagStatement)) {
+            $content = preg_replace(
+                '/(public function register\(\)[^{]*{)(.*?)(\s*}\s*})/s',
+                "$1$2$tagStatement$3",
+                $content
+            );
+
+            $this->filesystem->put($serviceProviderPath, $content);
+        }
+    }
+
+    public function getProviderNamespace(string $providerName): string
+    {
+        return sprintf('use App\\State\\%s;', $providerName);
+    }
+}

--- a/src/Laravel/Console/Maker/Utils/AppServiceProviderTagger.php
+++ b/src/Laravel/Console/Maker/Utils/AppServiceProviderTagger.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Laravel\Console\Maker\Utils;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -7,13 +18,15 @@ use Illuminate\Filesystem\Filesystem;
 
 final readonly class AppServiceProviderTagger
 {
-    /** @var string  */
+    /** @var string */
     private const SERVICE_PROVIDER_PATH = 'Providers/AppServiceProvider.php';
 
-    /** @var string  */
+    /** @var string */
     private const ITEM_PROVIDER_USE_STATEMENT = 'use ApiPlatform\Laravel\Eloquent\State\ItemProvider;';
 
-    public function __construct(private Filesystem $filesystem) {}
+    public function __construct(private Filesystem $filesystem)
+    {
+    }
 
     /**
      * @throws FileNotFoundException
@@ -34,7 +47,7 @@ final readonly class AppServiceProviderTagger
     private function ensureServiceProviderExists(string $path): void
     {
         if (!$this->filesystem->exists($path)) {
-            throw new \RuntimeException("The AppServiceProvider is missing!");
+            throw new \RuntimeException('The AppServiceProvider is missing!');
         }
     }
 
@@ -52,7 +65,7 @@ final readonly class AppServiceProviderTagger
 
     private function addTag(string &$content, string $providerName, string $serviceProviderPath): void
     {
-        $tagStatement = sprintf("\n\n\t\t\$this->app->tag(%s::class, ItemProvider::class);", $providerName);
+        $tagStatement = \sprintf("\n\n\t\t\$this->app->tag(%s::class, ItemProvider::class);", $providerName);
         if (!str_contains($content, $tagStatement)) {
             $content = preg_replace(
                 '/(public function register\(\)[^{]*{)(.*?)(\s*}\s*})/s',
@@ -66,6 +79,6 @@ final readonly class AppServiceProviderTagger
 
     public function getProviderNamespace(string $providerName): string
     {
-        return sprintf('use App\\State\\%s;', $providerName);
+        return \sprintf('use App\\State\\%s;', $providerName);
     }
 }

--- a/src/Laravel/Console/Maker/Utils/StateDirectoryManager.php
+++ b/src/Laravel/Console/Maker/Utils/StateDirectoryManager.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ApiPlatform\Laravel\Console\Maker\Utils;
+
+use Illuminate\Filesystem\Filesystem;
+
+final readonly class StateDirectoryManager
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function ensureStateDirectoryExists(): string
+    {
+        $directoryPath = base_path('src/State/');
+        $this->filesystem->ensureDirectoryExists($directoryPath);
+
+        return $directoryPath;
+    }
+}

--- a/src/Laravel/Console/Maker/Utils/StateDirectoryManager.php
+++ b/src/Laravel/Console/Maker/Utils/StateDirectoryManager.php
@@ -1,12 +1,25 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Laravel\Console\Maker\Utils;
 
 use Illuminate\Filesystem\Filesystem;
 
 final readonly class StateDirectoryManager
 {
-    public function __construct(private Filesystem $filesystem) {}
+    public function __construct(private Filesystem $filesystem)
+    {
+    }
 
     public function ensureStateDirectoryExists(): string
     {

--- a/src/Laravel/Console/Maker/Utils/StateProviderGenerator.php
+++ b/src/Laravel/Console/Maker/Utils/StateProviderGenerator.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Laravel\Console\Maker\Utils;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -7,11 +18,13 @@ use Illuminate\Filesystem\Filesystem;
 
 final readonly class StateProviderGenerator
 {
-    public function __construct(private Filesystem $filesystem) {}
+    public function __construct(private Filesystem $filesystem)
+    {
+    }
 
     public function getFilePath(string $directoryPath, string $providerName): string
     {
-        return $directoryPath . $providerName . '.php';
+        return $directoryPath.$providerName.'.php';
     }
 
     public function isFileExists(string $filePath): bool
@@ -40,7 +53,7 @@ final readonly class StateProviderGenerator
      */
     private function loadTemplate(): string
     {
-        $templatePath = dirname(__DIR__) . '/Resources/skeleton/StateProvider.tpl.php';
+        $templatePath = \dirname(__DIR__).'/Resources/skeleton/StateProvider.tpl.php';
 
         return $this->filesystem->get($templatePath);
     }

--- a/src/Laravel/Console/Maker/Utils/StateProviderGenerator.php
+++ b/src/Laravel/Console/Maker/Utils/StateProviderGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ApiPlatform\Laravel\Console\Maker\Utils;
+
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+
+final readonly class StateProviderGenerator
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function getFilePath(string $directoryPath, string $providerName): string
+    {
+        return $directoryPath . $providerName . '.php';
+    }
+
+    public function isFileExists(string $filePath): bool
+    {
+        return $this->filesystem->exists($filePath);
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    public function generate(string $pathLink, string $providerName): void
+    {
+        $namespace = 'App\\State';
+        $template = $this->loadTemplate();
+
+        $content = $this->replacePlaceholders($template, [
+            '{{ namespace }}' => $namespace,
+            '{{ class_name }}' => $providerName,
+        ]);
+
+        $this->filesystem->put($pathLink, $content);
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    private function loadTemplate(): string
+    {
+        $templatePath = dirname(__DIR__) . '/Resources/skeleton/StateProvider.tpl.php';
+
+        return $this->filesystem->get($templatePath);
+    }
+
+    private function replacePlaceholders(string $template, array $variables): string
+    {
+        return strtr($template, $variables);
+    }
+}

--- a/src/Laravel/Console/Maker/Utils/SuccessMessageTrait.php
+++ b/src/Laravel/Console/Maker/Utils/SuccessMessageTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ApiPlatform\Laravel\Console\Maker\Utils;
+
+trait SuccessMessageTrait
+{
+    private function writeSuccessMessage(string $filePath): void
+    {
+        $this->newLine();
+        $this->line(' <bg=green;fg=white>          </>');
+        $this->line(' <bg=green;fg=white> Success! </>');
+        $this->line(' <bg=green;fg=white>          </>');
+        $this->newLine();
+        $this->line('<fg=blue>created</>: <fg=white;options=underscore>' . $filePath . '</>');
+        $this->newLine();
+        $this->line('Next: Open your new state provider class and start customizing it.');
+    }
+}

--- a/src/Laravel/Console/Maker/Utils/SuccessMessageTrait.php
+++ b/src/Laravel/Console/Maker/Utils/SuccessMessageTrait.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Laravel\Console\Maker\Utils;
 
 trait SuccessMessageTrait
@@ -11,7 +22,7 @@ trait SuccessMessageTrait
         $this->line(' <bg=green;fg=white> Success! </>');
         $this->line(' <bg=green;fg=white>          </>');
         $this->newLine();
-        $this->line('<fg=blue>created</>: <fg=white;options=underscore>' . $filePath . '</>');
+        $this->line('<fg=blue>created</>: <fg=white;options=underscore>'.$filePath.'</>');
         $this->newLine();
         $this->line('Next: Open your new state provider class and start customizing it.');
     }

--- a/src/Laravel/Tests/Console/Maker/MakeStateProviderCommandTest.php
+++ b/src/Laravel/Tests/Console/Maker/MakeStateProviderCommandTest.php
@@ -20,12 +20,9 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Foundation\Testing\Concerns\InteractsWithConsole;
-
 
 class MakeStateProviderCommandTest extends TestCase
 {
-    use InteractsWithConsole;
     use WithWorkbench;
 
     private ?Filesystem $filesystem;
@@ -78,7 +75,7 @@ class MakeStateProviderCommandTest extends TestCase
         $existingFile = $this->pathResolver->generateStateProviderFilename($providerName);
         $this->filesystem->put($existingFile, '<?php // Existing provider');
 
-        $expectedError = sprintf('[ERROR] The file "%s" can\'t be generated because it already exists.', $existingFile);
+        $expectedError = \sprintf('[ERROR] The file "%s" can\'t be generated because it already exists.', $existingFile);
 
         $this->artisan('make:state-provider')
             ->expectsQuestion('Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)', $providerName)

--- a/src/Laravel/Tests/Console/Maker/MakeStateProviderCommandTest.php
+++ b/src/Laravel/Tests/Console/Maker/MakeStateProviderCommandTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Console\Maker;
+
+use ApiPlatform\Laravel\Tests\Console\Maker\Utils\AppServiceFileGenerator;
+use ApiPlatform\Laravel\Tests\Console\Maker\Utils\PathResolver;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithConsole;
+
+
+class MakeStateProviderCommandTest extends TestCase
+{
+    use InteractsWithConsole;
+    use WithWorkbench;
+
+    private ?Filesystem $filesystem;
+    private PathResolver $pathResolver;
+    private AppServiceFileGenerator $appServiceFileGenerator;
+
+    /**
+     * @throws FileNotFoundException
+     */
+    protected function setup(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+        $this->pathResolver = new PathResolver();
+        $this->appServiceFileGenerator = new AppServiceFileGenerator($this->filesystem);
+
+        $this->appServiceFileGenerator->regenerateProviderFile();
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    public function testMakeStateProviderCommand(): void
+    {
+        $providerName = 'MyStateProvider';
+        $filePath = $this->pathResolver->generateStateProviderFilename($providerName);
+        $appServiceProviderPath = $this->pathResolver->getServiceProviderFilePath();
+
+        $this->artisan('make:state-provider')
+            ->expectsQuestion('Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)', $providerName)
+            ->expectsOutputToContain('Success!')
+            ->expectsOutputToContain("created: $filePath")
+            ->expectsOutputToContain('Next: Open your new state provider class and start customizing it.')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertFileExists($filePath);
+
+        $appServiceProviderContent = $this->filesystem->get($appServiceProviderPath);
+        $this->assertStringContainsString('use ApiPlatform\Laravel\Eloquent\State\ItemProvider;', $appServiceProviderContent);
+        $this->assertStringContainsString("use App\State\\$providerName;", $appServiceProviderContent);
+        $this->assertStringContainsString('$this->app->tag(MyStateProvider::class, ItemProvider::class);', $appServiceProviderContent);
+
+        $this->filesystem->delete($filePath);
+    }
+
+    public function testWhenStateProviderClassAlreadyExists(): void
+    {
+        $providerName = 'ExistingProvider';
+        $existingFile = $this->pathResolver->generateStateProviderFilename($providerName);
+        $this->filesystem->put($existingFile, '<?php // Existing provider');
+
+        $expectedError = sprintf('[ERROR] The file "%s" can\'t be generated because it already exists.', $existingFile);
+
+        $this->artisan('make:state-provider')
+            ->expectsQuestion('Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)', $providerName)
+            ->expectsOutput($expectedError)
+            ->assertExitCode(Command::FAILURE);
+
+        $this->filesystem->delete($existingFile);
+    }
+
+    public function testMakeStateProviderCommandWithoutGivenClassName(): void
+    {
+        $providerName = 'NoEmptyClassName';
+        $filePath = $this->pathResolver->generateStateProviderFilename($providerName);
+
+        $this->artisan('make:state-provider')
+            ->expectsQuestion('Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)', '')
+            ->expectsOutput('[ERROR] This value cannot be blank.')
+            ->expectsQuestion('Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)', $providerName)
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertFileExists($filePath);
+
+        $this->filesystem->delete($filePath);
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->appServiceFileGenerator->regenerateProviderFile();
+    }
+}

--- a/src/Laravel/Tests/Console/Maker/Resources/skeleton/AppServiceProvider.tpl.php
+++ b/src/Laravel/Tests/Console/Maker/Resources/skeleton/AppServiceProvider.tpl.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+    }
+
+    public function register(): void
+    {
+    }
+}

--- a/src/Laravel/Tests/Console/Maker/Resources/skeleton/AppServiceProvider.tpl.php
+++ b/src/Laravel/Tests/Console/Maker/Resources/skeleton/AppServiceProvider.tpl.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;

--- a/src/Laravel/Tests/Console/Maker/Utils/AppServiceFileGenerator.php
+++ b/src/Laravel/Tests/Console/Maker/Utils/AppServiceFileGenerator.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Laravel\Tests\Console\Maker\Utils;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -7,15 +18,16 @@ use Illuminate\Filesystem\Filesystem;
 
 final readonly class AppServiceFileGenerator
 {
-
-    public function __construct(private Filesystem $filesystem) {}
+    public function __construct(private Filesystem $filesystem)
+    {
+    }
 
     /**
      * @throws FileNotFoundException
      */
     public function regenerateProviderFile(): void
     {
-        $templatePath = dirname(__DIR__) . '/Resources/skeleton/AppServiceProvider.tpl.php';
+        $templatePath = \dirname(__DIR__).'/Resources/skeleton/AppServiceProvider.tpl.php';
         $targetPath = base_path('app/Providers/AppServiceProvider.php');
 
         $this->regenerateFileFromTemplate($templatePath, $targetPath);

--- a/src/Laravel/Tests/Console/Maker/Utils/AppServiceFileGenerator.php
+++ b/src/Laravel/Tests/Console/Maker/Utils/AppServiceFileGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ApiPlatform\Laravel\Tests\Console\Maker\Utils;
+
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+
+final readonly class AppServiceFileGenerator
+{
+
+    public function __construct(private Filesystem $filesystem) {}
+
+    /**
+     * @throws FileNotFoundException
+     */
+    public function regenerateProviderFile(): void
+    {
+        $templatePath = dirname(__DIR__) . '/Resources/skeleton/AppServiceProvider.tpl.php';
+        $targetPath = base_path('app/Providers/AppServiceProvider.php');
+
+        $this->regenerateFileFromTemplate($templatePath, $targetPath);
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    private function regenerateFileFromTemplate(string $templatePath, string $targetPath): void
+    {
+        $content = $this->filesystem->get($templatePath);
+
+        $this->filesystem->put($targetPath, $content);
+    }
+}

--- a/src/Laravel/Tests/Console/Maker/Utils/PathResolver.php
+++ b/src/Laravel/Tests/Console/Maker/Utils/PathResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ApiPlatform\Laravel\Tests\Console\Maker\Utils;
+
+final readonly class PathResolver
+{
+    public function getServiceProviderFilePath(): string
+    {
+        return base_path('app/Providers/AppServiceProvider.php');
+    }
+
+    public function generateStateProviderFilename(string $providerName): string
+    {
+        return $this->getStateDirectoryPath() . $providerName . '.php';
+    }
+
+    public function getStateDirectoryPath(): string
+    {
+        return base_path('src/State/');
+    }
+}

--- a/src/Laravel/Tests/Console/Maker/Utils/PathResolver.php
+++ b/src/Laravel/Tests/Console/Maker/Utils/PathResolver.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Laravel\Tests\Console\Maker\Utils;
 
 final readonly class PathResolver
@@ -11,7 +22,7 @@ final readonly class PathResolver
 
     public function generateStateProviderFilename(string $providerName): string
     {
-        return $this->getStateDirectoryPath() . $providerName . '.php';
+        return $this->getStateDirectoryPath().$providerName.'.php';
     }
 
     public function getStateDirectoryPath(): string

--- a/src/Laravel/phpstan.neon.dist
+++ b/src/Laravel/phpstan.neon.dist
@@ -13,8 +13,9 @@ parameters:
 		- State
 		- Test
 		- Tests
-#    ignoreErrors:
-#        - '#PHPDoc tag @var#'
+
+	ignoreErrors:
+	  - '#Cannot call method expectsQuestion#'
 #
 #    excludePaths:
 #        - ./*/*/FileToBeExcluded.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/2018

Introduce the `artisan make:state-provider` command to generate API Platform state providers in Laravel.


