### PR TITLE
fix(symfony): metadata aware name converter has 0 arguments by default

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
@@ -39,14 +39,20 @@ final class MetadataAwareNameConverterPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition('serializer.name_converter.metadata_aware');
-        $num = \count($definition->getArguments());
+        $key = '$fallbackNameConverter';
+        $arguments = $definition->getArguments();
+        if (false === \array_key_exists($key, $arguments)) {
+            $key = 1;
+        }
 
         if ($container->hasAlias('api_platform.name_converter')) {
             $nameConverter = new Reference((string) $container->getAlias('api_platform.name_converter'));
-            if (1 === $num) {
+
+            // old symfony versions
+            if (false === \array_key_exists($key, $arguments)) {
                 $definition->addArgument($nameConverter);
-            } elseif (1 < $num && null === $definition->getArgument(1)) {
-                $definition->setArgument(1, $nameConverter);
+            } elseif (null === $definition->getArgument($key)) {
+                $definition->setArgument($key, $nameConverter);
             }
         }
 

--- a/tests/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPassTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPassTest.php
@@ -101,4 +101,23 @@ class MetadataAwareNameConverterPassTest extends TestCase
 
         $pass->process($containerBuilderProphecy->reveal());
     }
+
+    public function testProcessWithAbstractMetadataAware(): void
+    {
+        $pass = new MetadataAwareNameConverterPass();
+
+        $definition = $this->prophesize(Definition::class);
+        $definition->getArguments()->willReturn(['$metadataFactory' => [], '$fallbackNameConverter' => null])->shouldBeCalled();
+        $definition->getArgument('$fallbackNameConverter')->willReturn(null)->shouldBeCalled();
+        $definition->setArgument('$fallbackNameConverter', new Reference('app.name_converter'))->willReturn($definition)->shouldBeCalled();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(true)->shouldBeCalled();
+        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(true);
+        $containerBuilderProphecy->getAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(new Alias('app.name_converter'));
+        $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldBeCalled();
+        $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn($definition);
+
+        $pass->process($containerBuilderProphecy->reveal());
+    }
 }


### PR DESCRIPTION
Since https://github.com/symfony/symfony/commit/ce228d3a7a6448e5f214033a0cd2710177085f29#diff-f53370286252d2326a377eafd4bba05112518e0c8bf3aedda670fd76a254e9fa the serializer.name_converter.metadata_aware is extending an abstract service. Therefore there are no arguments by default. We relied on the number of arguments to inject API Platform's configured name converter.