### PR TITLE
fix(laravel): openapi Options binding

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -799,7 +799,7 @@ class ApiPlatformProvider extends ServiceProvider
                 $app->make(SchemaFactoryInterface::class),
                 null,
                 $config->get('api-platform.formats'),
-                null, // ?Options $openApiOptions = null,
+                $app->make(Options::class),
                 $app->make(PaginationOptions::class), // ?PaginationOptions $paginationOptions = null,
                 // ?RouterInterface $router = null
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | #6713
| License       | MIT

If the settings are not passed, the UI elements required for login will not appear on the API documentation page.
