### PR TITLE
fix(jsonschema): handle @id when genId is false 

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -232,6 +232,15 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                 continue;
             }
 
+            if (false === $propertyMetadata->getGenId() && !$this->isResourceClass($className)) {
+                $subDefinitionName = $this->definitionNameFactory->create($className, $format, $className,
+                    null, $serializerContext);
+
+                if (isset($subSchema->getDefinitions()[$subDefinitionName])) {
+                    unset($subSchema->getDefinitions()[$subDefinitionName]['properties']['@id']);
+                }
+            }
+
             if ($isCollection) {
                 $propertySchema['items']['$ref'] = $subSchema['$ref'];
                 unset($propertySchema['items']['type']);

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -232,9 +232,8 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                 continue;
             }
 
-            if (false === $propertyMetadata->getGenId() && !$this->isResourceClass($className)) {
-                $subDefinitionName = $this->definitionNameFactory->create($className, $format, $className,
-                    null, $serializerContext);
+            if (false === $propertyMetadata->getGenId()) {
+                $subDefinitionName = $this->definitionNameFactory->create($className, $format, $className, null, $serializerContext);
 
                 if (isset($subSchema->getDefinitions()[$subDefinitionName])) {
                     unset($subSchema->getDefinitions()[$subDefinitionName]['properties']['@id']);

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -334,4 +334,15 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
             $properties['genders']
         );
     }
+
+    /**
+     * Test feature #6716.
+     */
+    public function testGenId(): void
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\Entity\DisableIdGeneration', '--type' => 'output', '--format' => 'jsonld']);
+        $result = $this->tester->getDisplay();
+        $json = json_decode($result, associative: true);
+        $this->assertArrayNotHasKey('@id', $json['definitions']['DisableIdGenerationItem.jsonld']['properties']);
+    }
 }


### PR DESCRIPTION
turn off inserting @id into a schema that is not a resource and has @id autogeneration turned off
