### PR TITLE
Add support for comma separated numeric values in numeric filter

### DIFF
--- a/src/Doctrine/Common/Filter/NumericFilterTrait.php
+++ b/src/Doctrine/Common/Filter/NumericFilterTrait.php
@@ -82,8 +82,8 @@ trait NumericFilterTrait
     protected function normalizeValues($value, string $property): ?array
     {
         // Allow CSV format for multiple values.
-        if (\is_string($value) && \str_contains($value, ',')) {
-            $value = \explode(',', $value);
+        if (\is_string($value) && str_contains($value, ',')) {
+            $value = explode(',', $value);
         }
 
         if (!is_numeric($value) && (!\is_array($value) || !$this->isNumericArray($value))) {

--- a/src/Doctrine/Common/Filter/NumericFilterTrait.php
+++ b/src/Doctrine/Common/Filter/NumericFilterTrait.php
@@ -81,6 +81,11 @@ trait NumericFilterTrait
 
     protected function normalizeValues($value, string $property): ?array
     {
+        // Allow CSV format for multiple values.
+        if (\is_string($value) && \str_contains($value, ',')) {
+            $value = \explode(',', $value);
+        }
+
         if (!is_numeric($value) && (!\is_array($value) || !$this->isNumericArray($value))) {
             $this->getLogger()->notice('Invalid filter ignored', [
                 'exception' => new InvalidArgumentException(\sprintf('Invalid numeric value for "%s" property', $property)),

--- a/src/Doctrine/Orm/Tests/Filter/NumericFilterTestTrait.php
+++ b/src/Doctrine/Orm/Tests/Filter/NumericFilterTestTrait.php
@@ -100,6 +100,16 @@ trait NumericFilterTestTrait
                     'dummyPrice' => '21',
                 ],
             ],
+            'comma-separated numberic string (positive integer)' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                    'dummyPrice' => null,
+                ],
+                [
+                    'dummyPrice' => '21,22',
+                ],
+            ],
             'multiple numeric string (positive integer)' => [
                 [
                     'id' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | api-platform/docs#2037

Currently the NumericFilter allows for searching for `numeric-string` or `numeric-string[]`:
```
/api/entity?numericValue=5
/api/entity?numericValue[]=5&numericValue[]=6
```

This PR adds the support for comma-separated numeric-values:
```
/api/entity?numericValue=5,6
```

Which allows for much shorter urls when searching on multiple numeric values and if I understand the specification correctly this is a valid format. A snipper from the documentation:

> Query parameters can be primitive values, arrays and objects. OpenAPI 3.0 provides several ways to serialize objects and arrays in the query string.
>
> Arrays can be serialized as:
>
>    `form` – /products?color=blue,green,red or /products?color=blue&color=green, depending on the explode keyword

https://swagger.io/docs/specification/v3_0/describing-parameters/#query-parameters
