### PR TITLE
fix(laravel): make command writes to app instead of src

### DIFF
--- a/src/Laravel/Console/Maker/AbstractMakeStateCommand.php
+++ b/src/Laravel/Console/Maker/AbstractMakeStateCommand.php
@@ -40,7 +40,7 @@ abstract class AbstractMakeStateCommand extends Command
     {
         $stateName = $this->askForStateName();
 
-        $directoryPath = base_path('src/State/');
+        $directoryPath = base_path('app/State/');
         $this->filesystem->ensureDirectoryExists($directoryPath);
 
         $filePath = $this->stateTemplateGenerator->getFilePath($directoryPath, $stateName);

--- a/src/Laravel/Tests/Console/Maker/Utils/PathResolver.php
+++ b/src/Laravel/Tests/Console/Maker/Utils/PathResolver.php
@@ -27,6 +27,6 @@ final readonly class PathResolver
 
     public function getStateDirectoryPath(): string
     {
-        return base_path('src/State/');
+        return base_path('app/State/');
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | `4.0` (fix for a feature available since `4.0`)
| License       | MIT

Updates directory paths from 'src/State/' to 'app/State/' in AbstractMakeStateCommand and PathResolver. This aligns with the standard Laravel directory structure conventions.

Before the files were generated in `src/State` instead of `app/State`.