### PR TITLE
Patch 2

### DIFF
--- a/docs/adr/0005-refactor-state-management.md
+++ b/docs/adr/0005-refactor-state-management.md
@@ -30,7 +30,7 @@ For API Platform 3, we refactored the whole metadata susbsytem to be more flexib
 This led to the refactoring of the two main interfaces allowing to plug a data source in API Platform: the state provider and the state processor interfaces.
 
 Leveraging these new interfaces, it should be possible to simplify the code base and to remove most code duplication by transforming most of the code currently
-stored in the kernel event listeners and in the GraphQL resolvers in dedicated state processors and state providers.
+stored in the kernel event listeners and in the GraphQL resolvers in dedicated state processors and state providers. This is quite close to what @alanpoulain proposed in 2019 at https://github.com/api-platform/core/pull/2978 although at that time we needed to refactor the subresource system before tackling this issue. 
 
 ## Decision Outcome
 

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -222,6 +222,14 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                 continue;
             }
 
+            if (false === $propertyMetadata->getGenId()) {
+                $subDefinitionName = $this->definitionNameFactory->create($className, $format, $className, null, $serializerContext);
+
+                if (isset($subSchema->getDefinitions()[$subDefinitionName])) {
+                    unset($subSchema->getDefinitions()[$subDefinitionName]['properties']['@id']);
+                }
+            }
+
             if ($isCollection) {
                 $propertySchema['items']['$ref'] = $subSchema['$ref'];
                 unset($propertySchema['items']['type']);

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -365,4 +365,12 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
             $properties['genders']
         );
     }
+
+    public function testGenId(): void
+    {
+        $this->tester->run(['command' => 'api:json-schema:generate', 'resource' => 'ApiPlatform\Tests\Fixtures\TestBundle\Entity\DisableIdGeneration', '--type' => 'output', '--format' => 'jsonld']);
+        $result = $this->tester->getDisplay();
+        $json = json_decode($result, associative: true);
+        $this->assertArrayNotHasKey('@id', $json['definitions']['DisableIdGenerationItem.jsonld']['properties']);
+    }
 }


### PR DESCRIPTION
turn off inserting @id into a schema that is not a resource and has @id autogeneration turned off

cherry pick from version 3.4 > https://github.com/api-platform/core/pull/6716