### PR TITLE
fix: reintroduce the `show_webby` parameter in Laravel config

### DIFF
--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -8,6 +8,7 @@ return [
     'title' => 'API Platform',
     'description' => 'My awesome API',
     'version' => '1.0.0',
+    'show_webby' => true,
 
     'routes' => [
         // Global middleware applied to every API Platform routes

--- a/src/Laravel/resources/views/swagger-ui.blade.php
+++ b/src/Laravel/resources/views/swagger-ui.blade.php
@@ -14,6 +14,7 @@
         <header>
             <a id="logo" href="https://api-platform.com/"><img src="/vendor/api-platform/logo-header.svg" alt="API Platform"></a>
         </header>
+        @if (config('api-platform.show_webby', true))
         <div class="web calm"><img src="/vendor/api-platform/web.png"></div>
         <svg class="webby_car" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1889.21 582.3">
             <g id="Calque_1">
@@ -209,6 +210,7 @@
                 </g>
             </g>
         </svg>
+        @endif
 
         <div id="swagger-ui" class="api-platform"></div>
         <script src="/vendor/api-platform/swagger-ui/swagger-ui-bundle.js"></script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Fixes https://github.com/api-platform/api-platform/discussions/2781
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/2044

Symfony users are not the only people subjects to arachnophobia. Despite spiders being much more classy in their Lambo, Laravel users still might suffer from fear of them.

Let's fix this issue and re-introduce the `show_webby` parameter!

To remove Webby, add the following to the `config/api-platform.php` file:

```php
return [
    // ...
   'show_webby' => false,
   // ...
];
```
