### PR TITLE
perf(laravel): Caching tables and indexes to avoid multiple queries

### DIFF
--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -70,7 +70,7 @@ final class ModelMetadata
         $columns = Cache::flexible('api-platform.tables.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getColumns($table);
         });
-        /** @var array<string, mixed> $indexes */
+        /** @var array<int, mixed> $indexes */
         $indexes = Cache::flexible('api-platform.indexes.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getIndexes($table);
         });

--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Laravel\Eloquent\Metadata;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 
@@ -65,8 +66,12 @@ final class ModelMetadata
         $connection = $model->getConnection();
         $schema = $connection->getSchemaBuilder();
         $table = $model->getTable();
-        $columns = $schema->getColumns($table);
-        $indexes = $schema->getIndexes($table);
+        $columns = Cache::flexible('api-platform.tables.'.$table, [5, 10], function () use ($schema, $table) {
+            return $schema->getColumns($table);
+        });
+        $indexes = Cache::flexible('api-platform.indexes.'.$table, [5, 10], function () use ($schema, $table) {
+            return $schema->getIndexes($table);
+        });
 
         return collect($columns)
             ->map(fn ($column) => [

--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -66,11 +66,11 @@ final class ModelMetadata
         $connection = $model->getConnection();
         $schema = $connection->getSchemaBuilder();
         $table = $model->getTable();
-        /** @var array $columns */
+        /** @var array<int, mixed> $columns */
         $columns = Cache::flexible('api-platform.tables.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getColumns($table);
         });
-        /** @var array $indexes */
+        /** @var array<int, mixed> $indexes */
         $indexes = Cache::flexible('api-platform.indexes.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getIndexes($table);
         });

--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -66,9 +66,11 @@ final class ModelMetadata
         $connection = $model->getConnection();
         $schema = $connection->getSchemaBuilder();
         $table = $model->getTable();
+        /** @var array $columns */
         $columns = Cache::flexible('api-platform.tables.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getColumns($table);
         });
+        /** @var array $indexes */
         $indexes = Cache::flexible('api-platform.indexes.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getIndexes($table);
         });

--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -66,11 +66,11 @@ final class ModelMetadata
         $connection = $model->getConnection();
         $schema = $connection->getSchemaBuilder();
         $table = $model->getTable();
-        /** @var array<int, mixed> $columns */
+        /** @var array<string, mixed> $columns */
         $columns = Cache::flexible('api-platform.tables.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getColumns($table);
         });
-        /** @var array<int, mixed> $indexes */
+        /** @var array<string, mixed> $indexes */
         $indexes = Cache::flexible('api-platform.indexes.'.$table, [5, 10], function () use ($schema, $table) {
             return $schema->getIndexes($table);
         });

--- a/src/Laravel/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/src/Laravel/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -32,6 +32,7 @@ class WorkbenchServiceProvider extends ServiceProvider
     {
         $config = $this->app['config'];
         $config->set('api-platform.resources', [app_path('Models'), app_path('ApiResource')]);
+        $config->set('cache.default', 'null');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR uses `Cache::flexible`  from Laravel to improve performance so that same table data is not requested multiple times and the request happens in the background
