### PR TITLE
feat(doctrine): boolean filter like laravel filters

### DIFF
--- a/src/Doctrine/Common/Filter/BooleanFilterTrait.php
+++ b/src/Doctrine/Common/Filter/BooleanFilterTrait.php
@@ -61,7 +61,7 @@ trait BooleanFilterTrait
         return $description;
     }
 
-    abstract protected function getProperties(): ?array;
+    abstract public function getProperties(): ?array;
 
     abstract protected function getLogger(): LoggerInterface;
 

--- a/src/Doctrine/Common/Filter/ManagerRegistryAwareInterface.php
+++ b/src/Doctrine/Common/Filter/ManagerRegistryAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Filter;
+
+use Doctrine\Persistence\ManagerRegistry;
+
+interface ManagerRegistryAwareInterface
+{
+    public function hasManagerRegistry(): bool;
+
+    public function getManagerRegistry(): ManagerRegistry;
+
+    public function setManagerRegistry(?ManagerRegistry $managerRegistry): void;
+}

--- a/src/Doctrine/Odm/Filter/AbstractFilter.php
+++ b/src/Doctrine/Odm/Filter/AbstractFilter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Doctrine\Odm\Filter;
 
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
 use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
 use ApiPlatform\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Doctrine\Odm\PropertyHelperTrait as MongoDbOdmPropertyHelperTrait;
@@ -30,14 +31,18 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInterface
+abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInterface, ManagerRegistryAwareInterface
 {
     use MongoDbOdmPropertyHelperTrait;
     use PropertyHelperTrait;
     protected LoggerInterface $logger;
 
-    public function __construct(protected ManagerRegistry $managerRegistry, ?LoggerInterface $logger = null, protected ?array $properties = null, protected ?NameConverterInterface $nameConverter = null)
-    {
+    public function __construct(
+        protected ?ManagerRegistry $managerRegistry = null,
+        ?LoggerInterface $logger = null,
+        protected ?array $properties = null,
+        protected ?NameConverterInterface $nameConverter = null,
+    ) {
         $this->logger = $logger ?? new NullLogger();
     }
 
@@ -56,18 +61,35 @@ abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInt
      */
     abstract protected function filterProperty(string $property, $value, Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void;
 
-    protected function getManagerRegistry(): ManagerRegistry
+    public function hasManagerRegistry(): bool
     {
+        return $this->managerRegistry instanceof ManagerRegistry;
+    }
+
+    public function getManagerRegistry(): ManagerRegistry
+    {
+        if (!$this->hasManagerRegistry()) {
+            throw new \RuntimeException('ManagerRegistry must be initialized before accessing it.');
+        }
+
         return $this->managerRegistry;
     }
 
-    protected function getProperties(): ?array
+    public function setManagerRegistry(?ManagerRegistry $managerRegistry): void
+    {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getProperties(): ?array
     {
         return $this->properties;
     }
 
     /**
-     * @param string[] $properties
+     * @param array<string, mixed> $properties
      */
     public function setProperties(array $properties): void
     {

--- a/src/Doctrine/Odm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Odm/Filter/BooleanFilter.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Doctrine\Odm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\BooleanFilterTrait;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
 
@@ -104,7 +106,7 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-final class BooleanFilter extends AbstractFilter
+final class BooleanFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {
     use BooleanFilterTrait;
 
@@ -138,5 +140,13 @@ final class BooleanFilter extends AbstractFilter
         }
 
         $aggregationBuilder->match()->field($matchField)->equals($value);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSchema(Parameter $parameter): array
+    {
+        return $parameter->getSchema() ?? ['type' => 'boolean'];
     }
 }

--- a/src/Doctrine/Odm/PropertyHelperTrait.php
+++ b/src/Doctrine/Odm/PropertyHelperTrait.php
@@ -27,7 +27,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  */
 trait PropertyHelperTrait
 {
-    abstract protected function getManagerRegistry(): ManagerRegistry;
+    abstract protected function getManagerRegistry(): ?ManagerRegistry;
 
     /**
      * Splits the given property into parts.
@@ -39,9 +39,9 @@ trait PropertyHelperTrait
      */
     protected function getClassMetadata(string $resourceClass): ClassMetadata
     {
-        $manager = $this
-            ->getManagerRegistry()
-            ->getManagerForClass($resourceClass);
+        /** @var ?ManagerRegistry $managerRegistry */
+        $managerRegistry = $this->getManagerRegistry();
+        $manager = $managerRegistry?->getManagerForClass($resourceClass);
 
         if ($manager) {
             return $manager->getClassMetadata($resourceClass);

--- a/src/Doctrine/Orm/Filter/AbstractFilter.php
+++ b/src/Doctrine/Orm/Filter/AbstractFilter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Doctrine\Orm\Filter;
 
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
 use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
 use ApiPlatform\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Doctrine\Orm\PropertyHelperTrait as OrmPropertyHelperTrait;
@@ -24,14 +25,18 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
-abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInterface
+abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInterface, ManagerRegistryAwareInterface
 {
     use OrmPropertyHelperTrait;
     use PropertyHelperTrait;
     protected LoggerInterface $logger;
 
-    public function __construct(protected ManagerRegistry $managerRegistry, ?LoggerInterface $logger = null, protected ?array $properties = null, protected ?NameConverterInterface $nameConverter = null)
-    {
+    public function __construct(
+        protected ?ManagerRegistry $managerRegistry = null,
+        ?LoggerInterface $logger = null,
+        protected ?array $properties = null,
+        protected ?NameConverterInterface $nameConverter = null,
+    ) {
         $this->logger = $logger ?? new NullLogger();
     }
 
@@ -53,27 +58,41 @@ abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInt
      */
     abstract protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void;
 
-    protected function getManagerRegistry(): ManagerRegistry
+    public function hasManagerRegistry(): bool
     {
+        return $this->managerRegistry instanceof ManagerRegistry;
+    }
+
+    public function getManagerRegistry(): ManagerRegistry
+    {
+        if (!$this->hasManagerRegistry()) {
+            throw new \RuntimeException('ManagerRegistry must be initialized before accessing it.');
+        }
+
         return $this->managerRegistry;
     }
 
-    protected function getProperties(): ?array
+    public function setManagerRegistry(?ManagerRegistry $managerRegistry): void
+    {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    public function getProperties(): ?array
     {
         return $this->properties;
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    public function setProperties(array $properties): void
+    {
+        $this->properties = $properties;
     }
 
     protected function getLogger(): LoggerInterface
     {
         return $this->logger;
-    }
-
-    /**
-     * @param string[] $properties
-     */
-    public function setProperties(array $properties): void
-    {
-        $this->properties = $properties;
     }
 
     /**

--- a/src/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Orm/Filter/BooleanFilter.php
@@ -15,7 +15,9 @@ namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\BooleanFilterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
@@ -106,7 +108,7 @@ use Doctrine\ORM\QueryBuilder;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class BooleanFilter extends AbstractFilter
+final class BooleanFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {
     use BooleanFilterTrait;
 
@@ -144,5 +146,13 @@ final class BooleanFilter extends AbstractFilter
         $queryBuilder
             ->andWhere(\sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
             ->setParameter($valueParameter, $value);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSchema(Parameter $parameter): array
+    {
+        return $parameter->getSchema() ?? ['type' => 'boolean'];
     }
 }

--- a/src/Doctrine/Orm/PropertyHelperTrait.php
+++ b/src/Doctrine/Orm/PropertyHelperTrait.php
@@ -29,7 +29,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  */
 trait PropertyHelperTrait
 {
-    abstract protected function getManagerRegistry(): ManagerRegistry;
+    abstract protected function getManagerRegistry(): ?ManagerRegistry;
 
     /**
      * Splits the given property into parts.

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -360,6 +360,7 @@ class ApiPlatformProvider extends ServiceProvider
                         new ParameterResourceMetadataCollectionFactory(
                             $this->app->make(PropertyNameCollectionFactoryInterface::class),
                             $this->app->make(PropertyMetadataFactoryInterface::class),
+                            $this->app->make(LoggerInterface::class),
                             new AlternateUriResourceMetadataCollectionFactory(
                                 new FiltersResourceMetadataCollectionFactory(
                                     new FormatsResourceMetadataCollectionFactory(

--- a/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTests.php
+++ b/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTests.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Tests\Resource\Factory;
 
+use ApiPlatform\Metadata\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Metadata\FilterInterface;
 use ApiPlatform\Metadata\Parameters;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
@@ -22,16 +23,23 @@ use ApiPlatform\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFa
 use ApiPlatform\Metadata\Resource\Factory\ParameterResourceMetadataCollectionFactory;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\WithParameter;
 use ApiPlatform\OpenApi\Model\Parameter;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class ParameterResourceMetadataCollectionFactoryTests extends TestCase
 {
+    /**
+     * @throws Exception
+     * @throws ResourceClassNotFoundException
+     */
     public function testParameterFactory(): void
     {
         $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
         $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
         $filterLocator = $this->createStub(ContainerInterface::class);
+        $logger = $this->createStub(LoggerInterface::class);
         $filterLocator->method('has')->willReturn(true);
         $filterLocator->method('get')->willReturn(new class implements FilterInterface {
             public function getDescription(string $resourceClass): array
@@ -55,6 +63,7 @@ class ParameterResourceMetadataCollectionFactoryTests extends TestCase
         $parameter = new ParameterResourceMetadataCollectionFactory(
             $nameCollection,
             $propertyMetadata,
+            $logger,
             new AttributesResourceMetadataCollectionFactory(),
             $filterLocator
         );

--- a/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
@@ -137,7 +137,7 @@
 
         <service id="api_platform.doctrine_mongodb.odm.extension.parameter_extension" class="ApiPlatform\Doctrine\Odm\Extension\ParameterExtension" public="false">
             <argument type="service" id="api_platform.filter_locator" />
-
+            <argument type="service" id="doctrine_mongodb" on-invalid="null"/>
             <tag name="api_platform.doctrine_mongodb.odm.aggregation_extension.collection" priority="32" />
             <tag name="api_platform.doctrine_mongodb.odm.aggregation_extension.item"/>
         </service>

--- a/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -150,6 +150,7 @@
 
         <service id="api_platform.doctrine.orm.extension.parameter_extension" class="ApiPlatform\Doctrine\Orm\Extension\ParameterExtension" public="false">
             <argument type="service" id="api_platform.filter_locator" />
+            <argument type="service" id="doctrine" on-invalid="null"/>
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="-16" />
             <tag name="api_platform.doctrine.orm.query_extension.item" priority="-9" />
         </service>

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -82,6 +82,7 @@
         <service id="api_platform.metadata.resource.metadata_collection_factory.parameter" class="ApiPlatform\Metadata\Resource\Factory\ParameterResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" public="false" decoration-priority="1000">
             <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="logger" />
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.parameter.inner" />
             <argument type="service" id="api_platform.filter_locator" />
         </service>

--- a/tests/Fixtures/TestBundle/Document/FilteredBooleanParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredBooleanParameter.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Odm\Filter\BooleanFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[GetCollection(
+    parameters: [
+        'active' => new QueryParameter(
+            filter: new BooleanFilter(),
+        ),
+        'enabled' => new QueryParameter(
+            filter: new BooleanFilter(),
+            property: 'active',
+        ),
+    ],
+)]
+#[ODM\Document]
+class FilteredBooleanParameter
+{
+    public function __construct(
+        #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+        public ?int $id = null,
+
+        #[ODM\Field(type: 'bool', nullable: true)]
+        public ?bool $active = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(?bool $active): void
+    {
+        $this->active = $active;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FilteredBooleanParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredBooleanParameter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[GetCollection(
+    parameters: [
+        'active' => new QueryParameter(
+            filter: new BooleanFilter(),
+        ),
+        'enabled' => new QueryParameter(
+            filter: new BooleanFilter(),
+            property: 'active',
+        ),
+    ],
+)]
+#[ORM\Entity]
+class FilteredBooleanParameter
+{
+    public function __construct(
+        #[ORM\Column]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        public ?int $id = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?bool $active = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(?bool $isActive): void
+    {
+        $this->active = $isActive;
+    }
+}

--- a/tests/Functional/Parameters/BooleanFilterTest.php
+++ b/tests/Functional/Parameters/BooleanFilterTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredBooleanParameter as FilteredBooleanParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredBooleanParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class BooleanFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FilteredBooleanParameter::class];
+    }
+
+    /**
+     * @throws MongoDBException
+     * @throws \Throwable
+     */
+    protected function setUp(): void
+    {
+        $resource = $this->isMongoDB() ? FilteredBooleanParameterDocument::class : FilteredBooleanParameter::class;
+
+        $this->recreateSchema([$resource]);
+        $this->loadFixtures($resource);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('booleanFilterTrueFalseValuesProvider')]
+    public function testBooleanFilter(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray();
+        $entities = $data['hydra:member'];
+
+        $this->assertCount($expectedCount, $entities, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+
+        $expectedValue = str_contains($url, '=true') || str_contains($url, '=1');
+        foreach ($entities as $entity) {
+            $errorMessage = \sprintf("Expected 'active' to be %s", $expectedValue ? 'true' : 'false');
+            $this->assertSame($expectedValue, $entity['active'], $errorMessage);
+        }
+    }
+
+    public static function booleanFilterTrueFalseValuesProvider(): \Generator
+    {
+        yield 'active_true' => ['/filtered_boolean_parameters?active=true', 2];
+        yield 'active_false' => ['/filtered_boolean_parameters?active=false', 1];
+        yield 'active_1' => ['/filtered_boolean_parameters?active=1', 2];
+        yield 'active_0' => ['/filtered_boolean_parameters?active=0', 1];
+        yield 'enabled_true' => ['/filtered_boolean_parameters?enabled=true', 2];
+        yield 'enabled_false' => ['/filtered_boolean_parameters?enabled=false', 1];
+        yield 'enabled_1' => ['/filtered_boolean_parameters?enabled=1', 2];
+        yield 'enabled_0' => ['/filtered_boolean_parameters?enabled=0', 1];
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    #[DataProvider('nullableAndEmptyBooleanFilterProvider')]
+    public function testBooleanFilterWithNullAndEmptyValues(string $url): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray();
+        $entities = $data['hydra:member'];
+
+        $expectedCount = 3;
+        $this->assertCount($expectedCount, $entities, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function nullableAndEmptyBooleanFilterProvider(): \Generator
+    {
+        yield 'null_value' => ['/filtered_boolean_parameters?active=null'];
+        yield 'null_value_alias' => ['/filtered_boolean_parameters?enabled=null'];
+        yield 'active_empty' => ['/filtered_boolean_parameters?active=', 3];
+        yield 'enabled_empty' => ['/filtered_boolean_parameters?enabled=', 3];
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws MongoDBException
+     */
+    private function loadFixtures(string $resource): void
+    {
+        $manager = $this->getManager();
+
+        $entitiesData = [true, true, false, null];
+        foreach ($entitiesData as $activeValue) {
+            $entity = new $resource(active: $activeValue);
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `main`
| License       | MIT
| Doc PR        | _Coming soon_

Goal:

Using filters as we use Laravel filters. Example with Symfony:
```php
#[ApiResource]
#[GetCollection(
    parameters: [
        'active' => new QueryParameter(
            filter: new BooleanFilter(),
        ),

        // support also for filter aliasing
        'enabled' => new QueryParameter(
            filter: new BooleanFilter(),
            property: 'active',
        ),
    ],
)]
#[ORM\Entity]
class FilteredBooleanParameter {
    // ...
}
```

TODO:
- [x] Check swagger UI to see what it's like
- [x] Do the job for Doctrine ODM (MongoDM)
- [x] Fix PHPStan
- [x] Fix MongoDM tests