### PR TITLE
feat(laravel): use laravel cache setting

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -297,7 +297,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->extend(PropertyMetadataFactoryInterface::class, function (PropertyInfoPropertyMetadataFactory $inner, Application $app) {
-            /** @var ConfigRepository */
+            /** @var ConfigRepository $config */
             $config = $app['config'];
 
             return new CachePropertyMetadataFactory(
@@ -313,12 +313,12 @@ class ApiPlatformProvider extends ServiceProvider
                         $app->make(ResourceClassResolverInterface::class)
                     ),
                 ),
-                true === $config->get('app.debug') ? 'array' : 'file'
+                true === $config->get('app.debug') ? 'array' : $config->get('cache.default', 'file')
             );
         });
 
         $this->app->singleton(PropertyNameCollectionFactoryInterface::class, function (Application $app) {
-            /** @var ConfigRepository */
+            /** @var ConfigRepository $config */
             $config = $app['config'];
 
             return new CachePropertyNameCollectionMetadataFactory(
@@ -331,7 +331,7 @@ class ApiPlatformProvider extends ServiceProvider
                         )
                     )
                 ),
-                true === $config->get('app.debug') ? 'array' : 'file'
+                true === $config->get('app.debug') ? 'array' : $config->get('cache.default', 'file')
             );
         });
 
@@ -345,7 +345,7 @@ class ApiPlatformProvider extends ServiceProvider
 
         // TODO: add cached metadata factories
         $this->app->singleton(ResourceMetadataCollectionFactoryInterface::class, function (Application $app) {
-            /** @var ConfigRepository */
+            /** @var ConfigRepository $config */
             $config = $app['config'];
             $formats = $config->get('api-platform.formats');
 
@@ -401,7 +401,7 @@ class ApiPlatformProvider extends ServiceProvider
                         $app->make('filters')
                     )
                 ),
-                true === $config->get('app.debug') ? 'array' : 'file'
+                true === $config->get('app.debug') ? 'array' : $config->get('cache.default', 'file')
             );
         });
 

--- a/src/Laravel/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/src/Laravel/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -32,6 +32,7 @@ class WorkbenchServiceProvider extends ServiceProvider
     {
         $config = $this->app['config'];
         $config->set('api-platform.resources', [app_path('Models'), app_path('ApiResource')]);
+        $config->set('cache.default', 'null');
     }
 
     /**


### PR DESCRIPTION
Make use of the default laravel cache setting, makes it possible for developers to configure where data should be cached

Closes: #6735

| Q             | A
| ------------- | ---
| Branch?       | main?
| Tickets       | Closes #6735 
| License       | MIT
| Doc PR        | [#2048](https://github.com/api-platform/docs/pull/2048)

Not sure if you consider this a feature or a bugfix, let me know if you want this to be merged against the 4.x branch instead.
