### PR TITLE
fix(metadata): providing parameter constraints skips automatic ones

### DIFF
--- a/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
+++ b/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
@@ -91,6 +91,12 @@ final class ParameterValidationResourceMetadataCollectionFactory implements Reso
 
     private function addSchemaValidation(Parameter $parameter, ?array $schema = null, ?bool $required = null, ?OpenApiParameter $openApi = null): Parameter
     {
+        $constraints = $parameter->getConstraints();
+
+        if (\is_array($constraints) && \count($constraints) > 0) {
+            return $parameter;
+        }
+
         $schema ??= $parameter->getSchema();
         $required ??= $parameter->getRequired() ?? false;
         $openApi ??= $parameter->getOpenApi();

--- a/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
+++ b/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
@@ -91,9 +91,7 @@ final class ParameterValidationResourceMetadataCollectionFactory implements Reso
 
     private function addSchemaValidation(Parameter $parameter, ?array $schema = null, ?bool $required = null, ?OpenApiParameter $openApi = null): Parameter
     {
-        $constraints = $parameter->getConstraints();
-
-        if (\is_array($constraints) && \count($constraints) > 0) {
+        if (null !== $parameter->getConstraints()) {
             return $parameter;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | -
| License       | MIT
| Doc PR        | -

Hello,

According to the documentation https://api-platform.com/docs/core/filters/#parameter-validation, we can read:

```
You can also use your own constraint by setting the constraints option on a Parameter. In that case we won’t setup the automatic validation for you and it’ll replace our defaults.
```

Then, given the following simplified resource definition:

```
#[Api\ApiResource(
    // ...
    parameters: [
        'channel' => new QueryParameter(required: true, constraints: [new ChannelConstraint()]),
    ],
)]
```

I would expect that the `NotNull` constraint automatically provided by the `required` parameter is not provided anymore as I define custom constraint.

If you mind why the required parameter is defined here, it's for forcing the required flag in the Open API documentation.

Here, a PR proposing a fix on the 4.0 branch, not sure if the bug is present on the 3.x branch or the main branch as my project use the 4.x branch currently and the class modified in this PR seems not existing on these branches.

If you agree about this fix, I can take some time to add tests about it.