### PR TITLE
chore(symfony): conflict with symfony/framework-bundle 7.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "doctrine/orm": "<2.14.0",
         "doctrine/mongodb-odm": "<2.4",
         "doctrine/persistence": "<1.3",
-        "symfony/framework-bundle": "6.4.6 || 7.1.6",
+        "symfony/framework-bundle": "6.4.6 || 7.0.6",
         "symfony/var-exporter": "<6.1.1",
         "phpunit/phpunit": "<9.5",
         "phpspec/prophecy": "<1.15",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | 
| License       | MIT
| Doc PR        |


Hi, in the PR #6468, which was updating minimum dependencies from Symfony 7.0 to 7.1, the line for symfony/framework-bundle in conflict section was mistakenly updated too.

Since Symfony 7.0 as be re-allowed in #6628, I've only revert the change made in previous PR to keep the conflict on v7.0.6 and allow v7.1.6.