### PR TITLE
fix(validator): allow to pass both a ConstraintViolationList and a previous exception

### DIFF
--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -75,7 +75,7 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
 
         if ($message instanceof ConstraintViolationListInterface) {
             $this->constraintViolationList = $message;
-            parent::__construct($code ?? $this->__toString(), $previous ?? 0, $errorTitle instanceof \Throwable ? $errorTitle : null);
+            parent::__construct($this->__toString(), $code ?? 0, $previous);
 
             return;
         }

--- a/src/Validator/Tests/Exception/ValidationExceptionTest.php
+++ b/src/Validator/Tests/Exception/ValidationExceptionTest.php
@@ -39,4 +39,19 @@ foo: message 2
 TXT
         ), $e->__toString());
     }
+
+    public function testWithPrevious(): void
+    {
+        $previous = new \Exception();
+        $e = new ValidationException(new ConstraintViolationList([
+            new ConstraintViolation('message 1', '', [], '', '', 'invalid'),
+        ]), null, $previous);
+        $this->assertInstanceOf(\RuntimeException::class, $e);
+
+        $this->assertSame(str_replace(\PHP_EOL, "\n", <<<TXT
+message 1
+TXT
+        ), $e->__toString());
+        $this->assertSame($previous, $e->getPrevious());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       |  
| License       | MIT
| Doc PR        | 

When a `ApiPlatform\Validator\Exception\ValidationException` is created with a `ConstraintViolationList` and a `$previous` exception, the current constructor breaks on https://github.com/api-platform/core/blob/67fbe51c570abe1ece6651ae6a037662e9012881/src/Validator/Exception/ValidationException.php#L76

with the following error:

```
TypeError: Exception::__construct(): Argument #2 ($code) must be of type int, Exception given
```
