### PR TITLE
fix(doctrine): throw an exception when a filter is not found in a parameter

### DIFF
--- a/src/Doctrine/Orm/Extension/ParameterExtension.php
+++ b/src/Doctrine/Orm/Extension/ParameterExtension.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Doctrine\Orm\Extension;
 use ApiPlatform\Doctrine\Common\ParameterValueExtractorTrait;
 use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ParameterNotFound;
 use Doctrine\ORM\QueryBuilder;
@@ -50,9 +51,11 @@ final class ParameterExtension implements QueryCollectionExtensionInterface, Que
             }
 
             $filter = $this->filterLocator->has($filterId) ? $this->filterLocator->get($filterId) : null;
-            if ($filter instanceof FilterInterface) {
-                $filter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, ['filters' => $values, 'parameter' => $parameter] + $context);
+            if (!$filter instanceof FilterInterface) {
+                throw new InvalidArgumentException(\sprintf('Could not find filter "%s" for parameter "%s" in operation "%s" for resource "%s".', $filterId, $parameter->getKey(), $operation?->getShortName(), $resourceClass));
             }
+
+            $filter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, ['filters' => $values, 'parameter' => $parameter] + $context);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       |
| License       | MIT
| Doc PR        |

I noticed there are many places where APIP fails silently. This make our code harder to debug.

I don't know if this is a feature, or just a mistake. If it's a mistake, I'll try to send more PR.
