### PR TITLE
fix(laravel): remove link header when jsonld is not enabled

### DIFF
--- a/src/Laravel/Tests/LinkHeaderTest.php
+++ b/src/Laravel/Tests/LinkHeaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class LinkHeaderTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use RefreshDatabase;
+    use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], function (Repository $config): void {
+            $config->set('app.debug', true);
+            $config->set('api-platform.formats', ['jsonld' => ['application/ld+json']]);
+            $config->set('api-platform.docs_formats', ['jsonld' => ['application/ld+json']]);
+        });
+    }
+
+    public function testLinkHeader(): void
+    {
+        $response = $this->get('/api/', ['accept' => ['application/ld+json']]);
+        $response->assertStatus(200);
+        $response->assertHeader('link', '<http://localhost/api/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"');
+    }
+}

--- a/src/Laravel/Tests/LinkHeaderWithoutJsonldTest.php
+++ b/src/Laravel/Tests/LinkHeaderWithoutJsonldTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class LinkHeaderWithoutJsonldTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use RefreshDatabase;
+    use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], function (Repository $config): void {
+            $config->set('app.debug', true);
+            $config->set('api-platform.formats', ['jsonapi' => ['application/vnd.api+json']]);
+            $config->set('api-platform.docs_formats', ['jsonapi' => ['application/vnd.api+json']]);
+        });
+    }
+
+    public function testLinkHeader(): void
+    {
+        $response = $this->get('/api/', ['accept' => ['application/vnd.api+json']]);
+        $response->assertStatus(200);
+        $response->assertHeaderMissing('link');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 4.0
| Tickets       | https://github.com/api-platform/core/issues/6738 (second part)
| License       | MIT
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
Do not inject HydraLinkProcessor if the jsonld format is not activated in the config.