### PR TITLE
 feat(doctrine): doctrine filters like laravel eloquent filters 

### DIFF
--- a/src/Doctrine/Common/Filter/ManagerRegistryAwareInterface.php
+++ b/src/Doctrine/Common/Filter/ManagerRegistryAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Filter;
+
+use Doctrine\Persistence\ManagerRegistry;
+
+interface ManagerRegistryAwareInterface
+{
+    public function hasManagerRegistry(): bool;
+
+    public function getManagerRegistry(): ManagerRegistry;
+
+    public function setManagerRegistry(ManagerRegistry $managerRegistry): void;
+}

--- a/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php
+++ b/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Filter;
+
+use ApiPlatform\Metadata\Parameter;
+use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
+
+trait PropertyPlaceholderOpenApiParameterTrait
+{
+    /**
+     * @return array<OpenApiParameter>|null
+     */
+    public function getOpenApiParameters(Parameter $parameter): ?array
+    {
+        if (str_contains($parameter->getKey(), ':property')) {
+            $parameters = [];
+            $key = str_replace('[:property]', '', $parameter->getKey());
+            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
+                $parameters[] = new OpenApiParameter(name: \sprintf('%s[%s]', $key, $property), in: 'query');
+            }
+
+            return $parameters;
+        }
+
+        return null;
+    }
+}

--- a/src/Doctrine/Odm/Extension/ParameterExtension.php
+++ b/src/Doctrine/Odm/Extension/ParameterExtension.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Doctrine\Odm\Extension;
 
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
 use ApiPlatform\Doctrine\Common\ParameterValueExtractorTrait;
+use ApiPlatform\Doctrine\Odm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Odm\Filter\FilterInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ParameterNotFound;
+use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Psr\Container\ContainerInterface;
 
@@ -29,14 +32,20 @@ final class ParameterExtension implements AggregationCollectionExtensionInterfac
 {
     use ParameterValueExtractorTrait;
 
-    public function __construct(private readonly ContainerInterface $filterLocator)
-    {
+    public function __construct(
+        private readonly ContainerInterface $filterLocator,
+        private readonly ?ManagerRegistry $managerRegistry = null,
+    ) {
     }
 
+    /**
+     * @param array<string, mixed> $context
+     */
     private function applyFilter(Builder $aggregationBuilder, ?string $resourceClass = null, ?Operation $operation = null, array &$context = []): void
     {
         foreach ($operation->getParameters() ?? [] as $parameter) {
-            if (!($v = $parameter->getValue()) || $v instanceof ParameterNotFound) {
+            // TODO: remove the null equality as a parameter can have a null value
+            if (null === ($v = $parameter->getValue()) || $v instanceof ParameterNotFound) {
                 continue;
             }
 
@@ -45,14 +54,40 @@ final class ParameterExtension implements AggregationCollectionExtensionInterfac
                 continue;
             }
 
-            $filter = $this->filterLocator->has($filterId) ? $this->filterLocator->get($filterId) : null;
-            if ($filter instanceof FilterInterface) {
-                $filterContext = ['filters' => $values, 'parameter' => $parameter];
-                $filter->apply($aggregationBuilder, $resourceClass, $operation, $filterContext);
-                // update by reference
-                if (isset($filterContext['mongodb_odm_sort_fields'])) {
-                    $context['mongodb_odm_sort_fields'] = $filterContext['mongodb_odm_sort_fields'];
+            $filter = match (true) {
+                $filterId instanceof FilterInterface => $filterId,
+                \is_string($filterId) && $this->filterLocator->has($filterId) => $this->filterLocator->get($filterId),
+                default => null,
+            };
+
+            if (!$filter instanceof FilterInterface) {
+                continue;
+            }
+
+            if ($this->managerRegistry && $filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
+                $filter->setManagerRegistry($this->managerRegistry);
+            }
+
+            if ($filter instanceof AbstractFilter && !$filter->getProperties()) {
+                $propertyKey = $parameter->getProperty() ?? $parameter->getKey();
+
+                if (str_contains($propertyKey, ':property')) {
+                    $extraProperties = $parameter->getExtraProperties()['_properties'] ?? [];
+                    foreach (array_keys($extraProperties) as $property) {
+                        $properties[$property] = $parameter->getFilterContext();
+                    }
+                } else {
+                    $properties = [$propertyKey => $parameter->getFilterContext()];
                 }
+
+                $filter->setProperties($properties ?? []);
+            }
+
+            $filterContext = ['filters' => $values, 'parameter' => $parameter];
+            $filter->apply($aggregationBuilder, $resourceClass, $operation, $filterContext);
+            // update by reference
+            if (isset($filterContext['mongodb_odm_sort_fields'])) {
+                $context['mongodb_odm_sort_fields'] = $filterContext['mongodb_odm_sort_fields'];
             }
         }
     }

--- a/src/Doctrine/Odm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Odm/Filter/BooleanFilter.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Doctrine\Odm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\BooleanFilterTrait;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
 
@@ -104,7 +106,7 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-final class BooleanFilter extends AbstractFilter
+final class BooleanFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {
     use BooleanFilterTrait;
 
@@ -138,5 +140,13 @@ final class BooleanFilter extends AbstractFilter
         }
 
         $aggregationBuilder->match()->field($matchField)->equals($value);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSchema(Parameter $parameter): array
+    {
+        return ['type' => 'boolean'];
     }
 }

--- a/src/Doctrine/Odm/Filter/NumericFilter.php
+++ b/src/Doctrine/Odm/Filter/NumericFilter.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Doctrine\Odm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\NumericFilterTrait;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
 
@@ -104,7 +106,7 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-final class NumericFilter extends AbstractFilter
+final class NumericFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {
     use NumericFilterTrait;
 
@@ -162,5 +164,10 @@ final class NumericFilter extends AbstractFilter
         }
 
         return 'int';
+    }
+
+    public function getSchema(Parameter $parameter): array
+    {
+        return ['type' => 'numeric'];
     }
 }

--- a/src/Doctrine/Odm/Filter/OrderFilter.php
+++ b/src/Doctrine/Odm/Filter/OrderFilter.php
@@ -278,15 +278,6 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface, 
      */
     public function getSchema(Parameter $parameter): array
     {
-        if (str_contains($parameter->getKey(), ':property')) {
-            $properties = [];
-            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
-                $properties[] = [$property => ['type' => 'string', 'enum' => ['asc', 'desc']]];
-            }
-
-            return ['type' => 'object', 'properties' => $properties];
-        }
-
         return ['type' => 'string', 'enum' => ['asc', 'desc']];
     }
 }

--- a/src/Doctrine/Odm/Filter/OrderFilter.php
+++ b/src/Doctrine/Odm/Filter/OrderFilter.php
@@ -230,9 +230,11 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface, 
      */
     public function apply(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {
-        if (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName])) {
-            parent::apply($aggregationBuilder, $resourceClass, $operation, $context);
-
+        if (
+            isset($context['filters'])
+            && (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName]))
+            && !isset($context['parameter'])
+        ) {
             return;
         }
 

--- a/src/Doctrine/Odm/Filter/OrderFilter.php
+++ b/src/Doctrine/Odm/Filter/OrderFilter.php
@@ -15,7 +15,11 @@ namespace ApiPlatform\Doctrine\Odm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\OrderFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\OrderFilterTrait;
+use ApiPlatform\Doctrine\Common\Filter\PropertyPlaceholderOpenApiParameterTrait;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
+use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
@@ -196,11 +200,12 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-final class OrderFilter extends AbstractFilter implements OrderFilterInterface
+final class OrderFilter extends AbstractFilter implements OrderFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {
     use OrderFilterTrait;
+    use PropertyPlaceholderOpenApiParameterTrait;
 
-    public function __construct(ManagerRegistry $managerRegistry, string $orderParameterName = 'order', ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null)
+    public function __construct(?ManagerRegistry $managerRegistry = null, string $orderParameterName = 'order', ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null)
     {
         if (null !== $properties) {
             $properties = array_map(static function ($propertyOptions) {
@@ -225,12 +230,15 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface
      */
     public function apply(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {
-        if (isset($context['filters']) && !isset($context['filters'][$this->orderParameterName])) {
+        if (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName])) {
+            parent::apply($aggregationBuilder, $resourceClass, $operation, $context);
+
             return;
         }
 
-        if (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName])) {
-            parent::apply($aggregationBuilder, $resourceClass, $operation, $context);
+        $parameter = $context['parameter'] ?? null;
+        if (null !== ($value = $context['filters'][$parameter?->getProperty()] ?? null)) {
+            $this->filterProperty($this->denormalizePropertyName($parameter->getProperty()), $value, $aggregationBuilder, $resourceClass, $operation, $context);
 
             return;
         }
@@ -243,13 +251,13 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $direction, Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
+    protected function filterProperty(string $property, $value, Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {
         if (!$this->isPropertyEnabled($property, $resourceClass) || !$this->isPropertyMapped($property, $resourceClass)) {
             return;
         }
 
-        $direction = $this->normalizeValue($direction, $property);
+        $direction = $this->normalizeValue($value, $property);
         if (null === $direction) {
             return;
         }
@@ -263,5 +271,22 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface
         $aggregationBuilder->sort(
             $context['mongodb_odm_sort_fields'] = ($context['mongodb_odm_sort_fields'] ?? []) + [$matchField => $direction]
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSchema(Parameter $parameter): array
+    {
+        if (str_contains($parameter->getKey(), ':property')) {
+            $properties = [];
+            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
+                $properties[] = [$property => ['type' => 'string', 'enum' => ['asc', 'desc']]];
+            }
+
+            return ['type' => 'object', 'properties' => $properties];
+        }
+
+        return ['type' => 'string', 'enum' => ['asc', 'desc']];
     }
 }

--- a/src/Doctrine/Odm/Filter/RangeFilter.php
+++ b/src/Doctrine/Odm/Filter/RangeFilter.php
@@ -15,7 +15,11 @@ namespace ApiPlatform\Doctrine\Odm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\RangeFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\RangeFilterTrait;
+use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 
 /**
@@ -104,7 +108,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
  * @author Lee Siong Chan <ahlee2326@me.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
-final class RangeFilter extends AbstractFilter implements RangeFilterInterface
+final class RangeFilter extends AbstractFilter implements RangeFilterInterface, OpenApiParameterFilterInterface
 {
     use RangeFilterTrait;
 
@@ -203,5 +207,18 @@ final class RangeFilter extends AbstractFilter implements RangeFilterInterface
 
                 break;
         }
+    }
+
+    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
+    {
+        $in = $parameter instanceof QueryParameter ? 'query' : 'header';
+        $key = $parameter->getKey();
+
+        return [
+            new OpenApiParameter(name: $key.'[gt]', in: $in),
+            new OpenApiParameter(name: $key.'[lt]', in: $in),
+            new OpenApiParameter(name: $key.'[gte]', in: $in),
+            new OpenApiParameter(name: $key.'[lte]', in: $in),
+        ];
     }
 }

--- a/src/Doctrine/Odm/PropertyHelperTrait.php
+++ b/src/Doctrine/Odm/PropertyHelperTrait.php
@@ -27,7 +27,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  */
 trait PropertyHelperTrait
 {
-    abstract protected function getManagerRegistry(): ManagerRegistry;
+    abstract protected function getManagerRegistry(): ?ManagerRegistry;
 
     /**
      * Splits the given property into parts.
@@ -39,9 +39,9 @@ trait PropertyHelperTrait
      */
     protected function getClassMetadata(string $resourceClass): ClassMetadata
     {
-        $manager = $this
-            ->getManagerRegistry()
-            ->getManagerForClass($resourceClass);
+        /** @var ?ManagerRegistry $managerRegistry */
+        $managerRegistry = $this->getManagerRegistry();
+        $manager = $managerRegistry?->getManagerForClass($resourceClass);
 
         if ($manager) {
             return $manager->getClassMetadata($resourceClass);

--- a/src/Doctrine/Orm/Extension/ParameterExtension.php
+++ b/src/Doctrine/Orm/Extension/ParameterExtension.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Doctrine\Orm\Extension;
 
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
 use ApiPlatform\Doctrine\Common\ParameterValueExtractorTrait;
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
@@ -21,6 +23,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ParameterNotFound;
 use Doctrine\ORM\QueryBuilder;
 use Psr\Container\ContainerInterface;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
 
 /**
  * Reads operation parameters and execute its filter.
@@ -31,8 +34,10 @@ final class ParameterExtension implements QueryCollectionExtensionInterface, Que
 {
     use ParameterValueExtractorTrait;
 
-    public function __construct(private readonly ContainerInterface $filterLocator)
-    {
+    public function __construct(
+        private readonly ContainerInterface $filterLocator,
+        private readonly ?ManagerRegistry $managerRegistry = null,
+    ) {
     }
 
     /**
@@ -41,7 +46,8 @@ final class ParameterExtension implements QueryCollectionExtensionInterface, Que
     private function applyFilter(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
         foreach ($operation?->getParameters() ?? [] as $parameter) {
-            if (!($v = $parameter->getValue()) || $v instanceof ParameterNotFound) {
+            // TODO: remove the null equality as a parameter can have a null value
+            if (null === ($v = $parameter->getValue()) || $v instanceof ParameterNotFound) {
                 continue;
             }
 
@@ -50,12 +56,38 @@ final class ParameterExtension implements QueryCollectionExtensionInterface, Que
                 continue;
             }
 
-            $filter = $this->filterLocator->has($filterId) ? $this->filterLocator->get($filterId) : null;
+            $filter = match (true) {
+                $filterId instanceof FilterInterface => $filterId,
+                \is_string($filterId) && $this->filterLocator->has($filterId) => $this->filterLocator->get($filterId),
+                default => null,
+            };
+
             if (!$filter instanceof FilterInterface) {
                 throw new InvalidArgumentException(\sprintf('Could not find filter "%s" for parameter "%s" in operation "%s" for resource "%s".', $filterId, $parameter->getKey(), $operation?->getShortName(), $resourceClass));
             }
 
-            $filter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, ['filters' => $values, 'parameter' => $parameter] + $context);
+            if ($this->managerRegistry && $filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
+                $filter->setManagerRegistry($this->managerRegistry);
+            }
+
+            if ($filter instanceof AbstractFilter && !$filter->getProperties()) {
+                $propertyKey = $parameter->getProperty() ?? $parameter->getKey();
+
+                if (str_contains($propertyKey, ':property')) {
+                    $extraProperties = $parameter->getExtraProperties()['_properties'] ?? [];
+                    foreach (array_keys($extraProperties) as $property) {
+                        $properties[$property] = $parameter->getFilterContext();
+                    }
+                } else {
+                    $properties = [$propertyKey => $parameter->getFilterContext()];
+                }
+
+                $filter->setProperties($properties ?? []);
+            }
+
+            $filter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation,
+                ['filters' => $values, 'parameter' => $parameter] + $context
+            );
         }
     }
 

--- a/src/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Orm/Filter/BooleanFilter.php
@@ -15,7 +15,9 @@ namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\BooleanFilterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
@@ -106,7 +108,7 @@ use Doctrine\ORM\QueryBuilder;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class BooleanFilter extends AbstractFilter
+final class BooleanFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {
     use BooleanFilterTrait;
 
@@ -144,5 +146,13 @@ final class BooleanFilter extends AbstractFilter
         $queryBuilder
             ->andWhere(\sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
             ->setParameter($valueParameter, $value);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSchema(Parameter $parameter): array
+    {
+        return ['type' => 'boolean'];
     }
 }

--- a/src/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Doctrine/Orm/Filter/DateFilter.php
@@ -158,7 +158,7 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
         $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
-        if ($this->isPropertyNested($property, $resourceClass) && \count($values) > 0) {
+        if ($this->isPropertyNested($property, $resourceClass) && \count($value) > 0) {
             [$alias, $field] = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $resourceClass, Join::INNER_JOIN);
         }
 

--- a/src/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Doctrine/Orm/Filter/DateFilter.php
@@ -17,7 +17,12 @@ use ApiPlatform\Doctrine\Common\Filter\DateFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\DateFilterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
+use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query\Expr\Join;
@@ -120,7 +125,7 @@ use Doctrine\ORM\QueryBuilder;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
-final class DateFilter extends AbstractFilter implements DateFilterInterface
+final class DateFilter extends AbstractFilter implements DateFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {
     use DateFilterTrait;
 
@@ -138,11 +143,11 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
-        // Expect $values to be an array having the period as keys and the date value as values
+        // Expect $value to be an array having the period as keys and the date value as values
         if (
-            !\is_array($values)
+            !\is_array($value)
             || !$this->isPropertyEnabled($property, $resourceClass)
             || !$this->isPropertyMapped($property, $resourceClass)
             || !$this->isDateField($property, $resourceClass)
@@ -164,53 +169,53 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface
             $queryBuilder->andWhere($queryBuilder->expr()->isNotNull(\sprintf('%s.%s', $alias, $field)));
         }
 
-        if (isset($values[self::PARAMETER_BEFORE])) {
+        if (isset($value[self::PARAMETER_BEFORE])) {
             $this->addWhere(
                 $queryBuilder,
                 $queryNameGenerator,
                 $alias,
                 $field,
                 self::PARAMETER_BEFORE,
-                $values[self::PARAMETER_BEFORE],
+                $value[self::PARAMETER_BEFORE],
                 $nullManagement,
                 $type
             );
         }
 
-        if (isset($values[self::PARAMETER_STRICTLY_BEFORE])) {
+        if (isset($value[self::PARAMETER_STRICTLY_BEFORE])) {
             $this->addWhere(
                 $queryBuilder,
                 $queryNameGenerator,
                 $alias,
                 $field,
                 self::PARAMETER_STRICTLY_BEFORE,
-                $values[self::PARAMETER_STRICTLY_BEFORE],
+                $value[self::PARAMETER_STRICTLY_BEFORE],
                 $nullManagement,
                 $type
             );
         }
 
-        if (isset($values[self::PARAMETER_AFTER])) {
+        if (isset($value[self::PARAMETER_AFTER])) {
             $this->addWhere(
                 $queryBuilder,
                 $queryNameGenerator,
                 $alias,
                 $field,
                 self::PARAMETER_AFTER,
-                $values[self::PARAMETER_AFTER],
+                $value[self::PARAMETER_AFTER],
                 $nullManagement,
                 $type
             );
         }
 
-        if (isset($values[self::PARAMETER_STRICTLY_AFTER])) {
+        if (isset($value[self::PARAMETER_STRICTLY_AFTER])) {
             $this->addWhere(
                 $queryBuilder,
                 $queryNameGenerator,
                 $alias,
                 $field,
                 self::PARAMETER_STRICTLY_AFTER,
-                $values[self::PARAMETER_STRICTLY_AFTER],
+                $value[self::PARAMETER_STRICTLY_AFTER],
                 $nullManagement,
                 $type
             );
@@ -268,5 +273,26 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface
         }
 
         $queryBuilder->setParameter($valueParameter, $value, $type);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSchema(Parameter $parameter): array
+    {
+        return ['type' => 'date'];
+    }
+
+    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
+    {
+        $in = $parameter instanceof QueryParameter ? 'query' : 'header';
+        $key = $parameter->getKey();
+
+        return [
+            new OpenApiParameter(name: $key.'[after]', in: $in),
+            new OpenApiParameter(name: $key.'[before]', in: $in),
+            new OpenApiParameter(name: $key.'[strictly_after]', in: $in),
+            new OpenApiParameter(name: $key.'[strictly_before]', in: $in),
+        ];
     }
 }

--- a/src/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Doctrine/Orm/Filter/NumericFilter.php
@@ -15,7 +15,9 @@ namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\NumericFilterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
@@ -106,7 +108,7 @@ use Doctrine\ORM\QueryBuilder;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  */
-final class NumericFilter extends AbstractFilter
+final class NumericFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {
     use NumericFilterTrait;
 
@@ -175,5 +177,10 @@ final class NumericFilter extends AbstractFilter
         }
 
         return 'int';
+    }
+
+    public function getSchema(Parameter $parameter): array
+    {
+        return ['type' => 'numeric'];
     }
 }

--- a/src/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Doctrine/Orm/Filter/OrderFilter.php
@@ -244,13 +244,6 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface, 
             return;
         }
 
-        $parameter = $context['parameter'] ?? null;
-        if (null !== ($value = $context['filters'][$parameter?->getProperty()] ?? null)) {
-            $this->filterProperty($this->denormalizePropertyName($parameter->getProperty()), $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
-
-            return;
-        }
-
         foreach ($context['filters'][$this->orderParameterName] as $property => $value) {
             $this->filterProperty($this->denormalizePropertyName($property), $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
         }

--- a/src/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Doctrine/Orm/Filter/OrderFilter.php
@@ -285,15 +285,6 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface, 
      */
     public function getSchema(Parameter $parameter): array
     {
-        if (str_contains($parameter->getKey(), ':property')) {
-            $properties = [];
-            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
-                $properties[] = [$property => ['type' => 'string', 'enum' => ['asc', 'desc']]];
-            }
-
-            return ['type' => 'object', 'properties' => $properties];
-        }
-
         return ['type' => 'string', 'enum' => ['asc', 'desc']];
     }
 }

--- a/src/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Doctrine/Orm/Filter/OrderFilter.php
@@ -15,8 +15,12 @@ namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\OrderFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\OrderFilterTrait;
+use ApiPlatform\Doctrine\Common\Filter\PropertyPlaceholderOpenApiParameterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
+use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -195,11 +199,12 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
-final class OrderFilter extends AbstractFilter implements OrderFilterInterface
+final class OrderFilter extends AbstractFilter implements OrderFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {
     use OrderFilterTrait;
+    use PropertyPlaceholderOpenApiParameterTrait;
 
-    public function __construct(ManagerRegistry $managerRegistry, string $orderParameterName = 'order', ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null, private readonly ?string $orderNullsComparison = null)
+    public function __construct(?ManagerRegistry $managerRegistry = null, string $orderParameterName = 'order', ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null, private readonly ?string $orderNullsComparison = null)
     {
         if (null !== $properties) {
             $properties = array_map(static function ($propertyOptions) {
@@ -224,12 +229,15 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface
      */
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
-        if (isset($context['filters']) && !isset($context['filters'][$this->orderParameterName])) {
+        if (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName])) {
+            parent::apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
+
             return;
         }
 
-        if (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName])) {
-            parent::apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
+        $parameter = $context['parameter'] ?? null;
+        if (null !== ($value = $context['filters'][$parameter?->getProperty()] ?? null)) {
+            $this->filterProperty($this->denormalizePropertyName($parameter->getProperty()), $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
 
             return;
         }
@@ -242,13 +250,13 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $direction, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
         if (!$this->isPropertyEnabled($property, $resourceClass) || !$this->isPropertyMapped($property, $resourceClass)) {
             return;
         }
 
-        $direction = $this->normalizeValue($direction, $property);
+        $direction = $this->normalizeValue($value, $property);
         if (null === $direction) {
             return;
         }
@@ -270,5 +278,22 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface
         }
 
         $queryBuilder->addOrderBy(\sprintf('%s.%s', $alias, $field), $direction);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSchema(Parameter $parameter): array
+    {
+        if (str_contains($parameter->getKey(), ':property')) {
+            $properties = [];
+            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
+                $properties[] = [$property => ['type' => 'string', 'enum' => ['asc', 'desc']]];
+            }
+
+            return ['type' => 'object', 'properties' => $properties];
+        }
+
+        return ['type' => 'string', 'enum' => ['asc', 'desc']];
     }
 }

--- a/src/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Doctrine/Orm/Filter/OrderFilter.php
@@ -229,8 +229,17 @@ final class OrderFilter extends AbstractFilter implements OrderFilterInterface, 
      */
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
-        if (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName])) {
-            parent::apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
+        if (
+            isset($context['filters'])
+            && (!isset($context['filters'][$this->orderParameterName]) || !\is_array($context['filters'][$this->orderParameterName]))
+            && !isset($context['parameter'])
+        ) {
+            return;
+        }
+
+        $parameter = $context['parameter'] ?? null;
+        if (null !== ($value = $context['filters'][$parameter?->getProperty()] ?? null)) {
+            $this->filterProperty($this->denormalizePropertyName($parameter->getProperty()), $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
 
             return;
         }

--- a/src/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Doctrine/Orm/Filter/RangeFilter.php
@@ -16,7 +16,11 @@ namespace ApiPlatform\Doctrine\Orm\Filter;
 use ApiPlatform\Doctrine\Common\Filter\RangeFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\RangeFilterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 
@@ -105,7 +109,7 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
  */
-final class RangeFilter extends AbstractFilter implements RangeFilterInterface
+final class RangeFilter extends AbstractFilter implements RangeFilterInterface, OpenApiParameterFilterInterface
 {
     use RangeFilterTrait;
 
@@ -221,5 +225,18 @@ final class RangeFilter extends AbstractFilter implements RangeFilterInterface
 
                 break;
         }
+    }
+
+    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
+    {
+        $in = $parameter instanceof QueryParameter ? 'query' : 'header';
+        $key = $parameter->getKey();
+
+        return [
+            new OpenApiParameter(name: $key.'[gt]', in: $in),
+            new OpenApiParameter(name: $key.'[lt]', in: $in),
+            new OpenApiParameter(name: $key.'[gte]', in: $in),
+            new OpenApiParameter(name: $key.'[lte]', in: $in),
+        ];
     }
 }

--- a/src/Doctrine/Orm/PropertyHelperTrait.php
+++ b/src/Doctrine/Orm/PropertyHelperTrait.php
@@ -29,7 +29,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  */
 trait PropertyHelperTrait
 {
-    abstract protected function getManagerRegistry(): ManagerRegistry;
+    abstract protected function getManagerRegistry(): ?ManagerRegistry;
 
     /**
      * Splits the given property into parts.

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -397,7 +397,8 @@ class ApiPlatformProvider extends ServiceProvider
                                 )
                             ),
                             $app->make('filters'),
-                            $app->make(CamelCaseToSnakeCaseNameConverter::class)
+                            $app->make(CamelCaseToSnakeCaseNameConverter::class),
+                            $this->app->make(LoggerInterface::class)
                         ),
                         $app->make('filters')
                     )

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -44,7 +44,7 @@ abstract class Parameter
         protected string|\Stringable|null $security = null,
         protected ?string $securityMessage = null,
         protected ?array $extraProperties = [],
-        protected ?array $filterContext = null,
+        protected array|string|null $filterContext = null,
     ) {
     }
 
@@ -137,7 +137,7 @@ abstract class Parameter
         return $this->extraProperties;
     }
 
-    public function getFilterContext(): ?array
+    public function getFilterContext(): array|string|null
     {
         return $this->filterContext;
     }
@@ -198,6 +198,14 @@ abstract class Parameter
     {
         $self = clone $this;
         $self->filter = $filter;
+
+        return $self;
+    }
+
+    public function withFilterContext(array|string $filterContext): static
+    {
+        $self = clone $this;
+        $self->filterContext = $filterContext;
 
         return $self;
     }

--- a/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_mongodb_odm.xml
@@ -137,7 +137,7 @@
 
         <service id="api_platform.doctrine_mongodb.odm.extension.parameter_extension" class="ApiPlatform\Doctrine\Odm\Extension\ParameterExtension" public="false">
             <argument type="service" id="api_platform.filter_locator" />
-
+            <argument type="service" id="doctrine_mongodb" on-invalid="null"/>
             <tag name="api_platform.doctrine_mongodb.odm.aggregation_extension.collection" priority="32" />
             <tag name="api_platform.doctrine_mongodb.odm.aggregation_extension.item"/>
         </service>

--- a/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
+++ b/src/Symfony/Bundle/Resources/config/doctrine_orm.xml
@@ -150,6 +150,7 @@
 
         <service id="api_platform.doctrine.orm.extension.parameter_extension" class="ApiPlatform\Doctrine\Orm\Extension\ParameterExtension" public="false">
             <argument type="service" id="api_platform.filter_locator" />
+            <argument type="service" id="doctrine" on-invalid="null"/>
             <tag name="api_platform.doctrine.orm.query_extension.collection" priority="-16" />
             <tag name="api_platform.doctrine.orm.query_extension.item" priority="-9" />
         </service>

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -85,6 +85,7 @@
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.parameter.inner" />
             <argument type="service" id="api_platform.filter_locator" on-invalid="ignore" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
         <service id="api_platform.metadata.resource.metadata_collection_factory.cached" class="ApiPlatform\Metadata\Resource\Factory\CachedResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="-10" public="false">

--- a/src/Symfony/Validator/State/ParameterValidatorProvider.php
+++ b/src/Symfony/Validator/State/ParameterValidatorProvider.php
@@ -61,7 +61,15 @@ final class ParameterValidatorProvider implements ProviderInterface
                 $value = null;
             }
 
-            $violations = $this->validator->validate($value, $constraints);
+            $violations = [];
+            if (\is_array($value) && $properties = $parameter->getExtraProperties()['_properties'] ?? []) {
+                foreach ($properties as $property) {
+                    $violations = [...$violations, ...$this->validator->validate($value[$property] ?? null, $constraints)];
+                }
+            } else {
+                $violations = $this->validator->validate($value, $constraints);
+            }
+
             foreach ($violations as $violation) {
                 $constraintViolationList->add(new ConstraintViolation(
                     $violation->getMessage(),

--- a/tests/Fixtures/TestBundle/Document/FilteredBooleanParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredBooleanParameter.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Odm\Filter\BooleanFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[GetCollection(
+    parameters: [
+        'active' => new QueryParameter(
+            filter: new BooleanFilter(),
+        ),
+        'enabled' => new QueryParameter(
+            filter: new BooleanFilter(),
+            property: 'active',
+        ),
+    ],
+)]
+#[ODM\Document]
+class FilteredBooleanParameter
+{
+    public function __construct(
+        #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+        public ?int $id = null,
+
+        #[ODM\Field(type: 'bool', nullable: true)]
+        public ?bool $active = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(?bool $active): void
+    {
+        $this->active = $active;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/FilteredDateParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredDateParameter.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Common\Filter\DateFilterInterface;
+use ApiPlatform\Doctrine\Odm\Filter\DateFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'createdAt' => new QueryParameter(
+            filter: new DateFilter(),
+        ),
+        'date' => new QueryParameter(
+            filter: new DateFilter(),
+            property: 'createdAt',
+        ),
+        'date_include_null_always' => new QueryParameter(
+            filter: new DateFilter(),
+            property: 'createdAt',
+            filterContext: DateFilterInterface::INCLUDE_NULL_BEFORE_AND_AFTER,
+        ),
+        'date_old_way' => new QueryParameter(
+            filter: new DateFilter(properties: ['createdAt' => DateFilterInterface::INCLUDE_NULL_BEFORE_AND_AFTER]),
+            property: 'createdAt',
+        ),
+    ],
+)]
+#[ODM\Document]
+class FilteredDateParameter
+{
+    public function __construct(
+        #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+        public ?int $id = null,
+
+        #[ODM\Field(type: 'date_immutable', nullable: true)]
+        public ?\DateTimeImmutable $createdAt = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/FilteredExistsParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredExistsParameter.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Odm\Filter\ExistsFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'createdAt' => new QueryParameter(
+            filter: new ExistsFilter(),
+        ),
+        'hasCreationDate' => new QueryParameter(
+            filter: new ExistsFilter(),
+            property: 'createdAt',
+        ),
+        'exists[:property]' => new QueryParameter(
+            filter: new ExistsFilter(),
+        ),
+    ],
+)]
+#[ODM\Document]
+class FilteredExistsParameter
+{
+    public function __construct(
+        #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+        public ?int $id = null,
+
+        #[ODM\Field(type: 'date_immutable', nullable: true)]
+        public ?\DateTimeImmutable $createdAt = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/FilteredNumericParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredNumericParameter.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Odm\Filter\NumericFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'quantity' => new QueryParameter(
+            filter: new NumericFilter(),
+        ),
+        'amount' => new QueryParameter(
+            filter: new NumericFilter(),
+            property: 'quantity',
+        ),
+        'ratio' => new QueryParameter(
+            filter: new NumericFilter(),
+        ),
+    ],
+)]
+#[ODM\Document]
+class FilteredNumericParameter
+{
+    public function __construct(
+        #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+        public ?int $id = null,
+
+        #[ODM\Field(type: 'int', nullable: true)]
+        public ?int $quantity = null,
+
+        #[ODM\Field(type: 'float', nullable: true)]
+        public ?float $ratio = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getQuantity(): ?int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(?int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+
+    public function getRatio(): ?float
+    {
+        return $this->ratio;
+    }
+
+    public function setRatio(?float $ratio): void
+    {
+        $this->ratio = $ratio;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/FilteredOrderParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredOrderParameter.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Common\Filter\OrderFilterInterface;
+use ApiPlatform\Doctrine\Odm\Filter\OrderFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'createdAt' => new QueryParameter(
+            filter: new OrderFilter(),
+        ),
+        'date' => new QueryParameter(
+            filter: new OrderFilter(),
+            property: 'createdAt',
+        ),
+        'date_null_always_first' => new QueryParameter(
+            filter: new OrderFilter(),
+            property: 'createdAt',
+            filterContext: OrderFilterInterface::NULLS_ALWAYS_FIRST,
+        ),
+        'date_null_always_first_old_way' => new QueryParameter(
+            filter: new OrderFilter(properties: ['createdAt' => OrderFilterInterface::NULLS_ALWAYS_FIRST]),
+            property: 'createdAt',
+        ),
+        'order[:property]' => new QueryParameter(
+            filter: new OrderFilter(),
+            filterContext: OrderFilterInterface::NULLS_ALWAYS_FIRST,
+        ),
+    ],
+)]
+#[ODM\Document]
+class FilteredOrderParameter
+{
+    public function __construct(
+        #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+        public ?int $id = null,
+
+        #[ODM\Field(type: 'date_immutable', nullable: true)]
+        public ?\DateTimeImmutable $createdAt = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/FilteredRangeParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredRangeParameter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Odm\Filter\RangeFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'quantity' => new QueryParameter(
+            filter: new RangeFilter(),
+        ),
+        'amount' => new QueryParameter(
+            filter: new RangeFilter(),
+            property: 'quantity',
+        ),
+    ],
+)]
+#[ODM\Document]
+class FilteredRangeParameter
+{
+    public function __construct(
+        #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+        public ?int $id = null,
+
+        #[ODM\Field(type: 'int', nullable: true)]
+        public ?int $quantity = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getQuantity(): ?int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(?int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FilteredBooleanParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredBooleanParameter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[GetCollection(
+    parameters: [
+        'active' => new QueryParameter(
+            filter: new BooleanFilter(),
+        ),
+        'enabled' => new QueryParameter(
+            filter: new BooleanFilter(),
+            property: 'active',
+        ),
+    ],
+)]
+#[ORM\Entity]
+class FilteredBooleanParameter
+{
+    public function __construct(
+        #[ORM\Column]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        public ?int $id = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?bool $active = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(?bool $isActive): void
+    {
+        $this->active = $isActive;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FilteredDateParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredDateParameter.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Common\Filter\DateFilterInterface;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'createdAt' => new QueryParameter(
+            filter: new DateFilter(),
+        ),
+        'date' => new QueryParameter(
+            filter: new DateFilter(),
+            property: 'createdAt',
+        ),
+        'date_include_null_always' => new QueryParameter(
+            filter: new DateFilter(),
+            property: 'createdAt',
+            filterContext: DateFilterInterface::INCLUDE_NULL_BEFORE_AND_AFTER,
+        ),
+        'date_old_way' => new QueryParameter(
+            filter: new DateFilter(properties: ['createdAt' => DateFilterInterface::INCLUDE_NULL_BEFORE_AND_AFTER]),
+            property: 'createdAt',
+        ),
+    ],
+)]
+#[ORM\Entity]
+class FilteredDateParameter
+{
+    public function __construct(
+        #[ORM\Column]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        public ?int $id = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?\DateTimeImmutable $createdAt = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FilteredExistsParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredExistsParameter.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\ExistsFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'createdAt' => new QueryParameter(
+            filter: new ExistsFilter(),
+        ),
+        'hasCreationDate' => new QueryParameter(
+            filter: new ExistsFilter(),
+            property: 'createdAt',
+        ),
+        'exists[:property]' => new QueryParameter(
+            filter: new ExistsFilter(),
+        ),
+    ],
+)]
+#[ORM\Entity]
+class FilteredExistsParameter
+{
+    public function __construct(
+        #[ORM\Column]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        public ?int $id = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?\DateTimeImmutable $createdAt = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FilteredNumericParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredNumericParameter.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\NumericFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'quantity' => new QueryParameter(
+            filter: new NumericFilter(),
+        ),
+        'amount' => new QueryParameter(
+            filter: new NumericFilter(),
+            property: 'quantity',
+        ),
+        'ratio' => new QueryParameter(
+            filter: new NumericFilter(),
+        ),
+    ],
+)]
+#[ORM\Entity]
+class FilteredNumericParameter
+{
+    public function __construct(
+        #[ORM\Column]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        public ?int $id = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?int $quantity = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?float $ratio = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getQuantity(): ?int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(?int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+
+    public function getRatio(): ?float
+    {
+        return $this->ratio;
+    }
+
+    public function setRatio(?float $ratio): void
+    {
+        $this->ratio = $ratio;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FilteredOrderParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredOrderParameter.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Common\Filter\OrderFilterInterface;
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'createdAt' => new QueryParameter(
+            filter: new OrderFilter(),
+        ),
+        'date' => new QueryParameter(
+            filter: new OrderFilter(),
+            property: 'createdAt',
+        ),
+        'date_null_always_first' => new QueryParameter(
+            filter: new OrderFilter(),
+            property: 'createdAt',
+            filterContext: OrderFilterInterface::NULLS_ALWAYS_FIRST,
+        ),
+        'date_null_always_first_old_way' => new QueryParameter(
+            filter: new OrderFilter(properties: ['createdAt' => OrderFilterInterface::NULLS_ALWAYS_FIRST]),
+            property: 'createdAt',
+        ),
+        'order[:property]' => new QueryParameter(
+            filter: new OrderFilter(),
+            filterContext: OrderFilterInterface::NULLS_ALWAYS_FIRST,
+        ),
+    ],
+)]
+#[ORM\Entity]
+class FilteredOrderParameter
+{
+    public function __construct(
+        #[ORM\Column]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        public ?int $id = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?\DateTimeImmutable $createdAt = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FilteredRangeParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredRangeParameter.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\RangeFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[GetCollection(
+    paginationItemsPerPage: 5,
+    parameters: [
+        'quantity' => new QueryParameter(
+            filter: new RangeFilter(),
+        ),
+        'amount' => new QueryParameter(
+            filter: new RangeFilter(),
+            property: 'quantity',
+        ),
+    ],
+)]
+#[ORM\Entity]
+class FilteredRangeParameter
+{
+    public function __construct(
+        #[ORM\Column]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        public ?int $id = null,
+
+        #[ORM\Column(nullable: true)]
+        public ?int $quantity = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getQuantity(): ?int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(?int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+}

--- a/tests/Functional/Parameters/BooleanFilterTest.php
+++ b/tests/Functional/Parameters/BooleanFilterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredBooleanParameter as FilteredBooleanParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredBooleanParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class BooleanFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FilteredBooleanParameter::class];
+    }
+
+    /**
+     * @throws MongoDBException
+     * @throws \Throwable
+     */
+    protected function setUp(): void
+    {
+        $entityClass = $this->isMongoDB() ? FilteredBooleanParameterDocument::class : FilteredBooleanParameter::class;
+
+        $this->recreateSchema([$entityClass]);
+        $this->loadFixtures($entityClass);
+    }
+
+    /**
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    #[DataProvider('booleanFilterScenariosProvider')]
+    public function testBooleanFilterResponses(string $url, int $expectedActiveItemCount, bool $expectedActiveStatus): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedActiveItemCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedActiveItemCount, $url));
+
+        foreach ($filteredItems as $item) {
+            $this->assertSame($expectedActiveStatus, $item['active'], \sprintf("Expected 'active' to be %s", $expectedActiveStatus));
+        }
+    }
+
+    public static function booleanFilterScenariosProvider(): \Generator
+    {
+        yield 'active_true' => ['/filtered_boolean_parameters?active=true', 2, true];
+        yield 'active_false' => ['/filtered_boolean_parameters?active=false', 1, false];
+        yield 'active_numeric_1' => ['/filtered_boolean_parameters?active=1', 2, true];
+        yield 'active_numeric_0' => ['/filtered_boolean_parameters?active=0', 1, false];
+        yield 'enabled_alias_true' => ['/filtered_boolean_parameters?enabled=true', 2, true];
+        yield 'enabled_alias_false' => ['/filtered_boolean_parameters?enabled=false', 1, false];
+        yield 'enabled_alias_numeric_1' => ['/filtered_boolean_parameters?enabled=1', 2, true];
+        yield 'enabled_alias_numeric_0' => ['/filtered_boolean_parameters?enabled=0', 1, false];
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    #[DataProvider('booleanFilterNullAndEmptyScenariosProvider')]
+    public function testBooleanFilterWithNullAndEmptyValues(string $url): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $expectedItemCount = 3;
+        $this->assertCount($expectedItemCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedItemCount, $url));
+    }
+
+    public static function booleanFilterNullAndEmptyScenariosProvider(): \Generator
+    {
+        yield 'active_null_value' => ['/filtered_boolean_parameters?active=null'];
+        yield 'active_empty_value' => ['/filtered_boolean_parameters?active=', 3];
+        yield 'enabled_alias_null_value' => ['/filtered_boolean_parameters?enabled=null'];
+        yield 'enabled_alias_empty_value' => ['/filtered_boolean_parameters?enabled=', 3];
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws MongoDBException
+     */
+    private function loadFixtures(string $entityClass): void
+    {
+        $manager = $this->getManager();
+
+        $booleanStates = [true, true, false, null];
+        foreach ($booleanStates as $activeValue) {
+            $entity = new $entityClass(active: $activeValue);
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}

--- a/tests/Functional/Parameters/DateFilterTest.php
+++ b/tests/Functional/Parameters/DateFilterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredDateParameter as FilteredDateParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredDateParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class DateFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FilteredDateParameter::class];
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    protected function setUp(): void
+    {
+        $entityClass = $this->isMongoDB() ? FilteredDateParameterDocument::class : FilteredDateParameter::class;
+
+        $this->recreateSchema([$entityClass]);
+        $this->loadFixtures($entityClass);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('dateFilterScenariosProvider')]
+    public function testDateFilterResponses(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function dateFilterScenariosProvider(): \Generator
+    {
+        yield 'created_at_after' => ['/filtered_date_parameters?createdAt[after]=2024-01-01', 3];
+        yield 'created_at_before' => ['/filtered_date_parameters?createdAt[before]=2024-12-31', 3];
+        yield 'created_at_before_single_result' => ['/filtered_date_parameters?createdAt[before]=2024-01-02', 1];
+        yield 'created_at_strictly_after' => ['/filtered_date_parameters?createdAt[strictly_after]=2024-01-01', 2];
+        yield 'created_at_strictly_before' => ['/filtered_date_parameters?createdAt[strictly_before]=2024-12-31T23:59:59Z', 3];
+        yield 'date_alias_after' => ['/filtered_date_parameters?date[after]=2024-01-01', 3];
+        yield 'date_alias_before' => ['/filtered_date_parameters?date[before]=2024-12-31', 3];
+        yield 'date_alias_before_first' => ['/filtered_date_parameters?date[before]=2024-01-02', 1];
+        yield 'date_alias_strictly_after' => ['/filtered_date_parameters?date[strictly_after]=2024-01-01', 2];
+        yield 'date_alias_strictly_before' => ['/filtered_date_parameters?date[strictly_before]=2024-12-31T23:59:59Z', 3];
+        yield 'date_alias_include_null_always_after_date' => ['/filtered_date_parameters?date_include_null_always[after]=2024-06-15', 3];
+        yield 'date_alias_include_null_always_before_date' => ['/filtered_date_parameters?date_include_null_always[before]=2024-06-14', 2];
+        yield 'date_alias_include_null_always_before_all_date' => ['/filtered_date_parameters?date_include_null_always[before]=2024-12-31', 4];
+        yield 'date_alias_old_way' => ['/filtered_date_parameters?date_old_way[before]=2024-06-14', 2];
+        yield 'date_alias_old_way_after_last_one' => ['/filtered_date_parameters?date_old_way[after]=2024-12-31', 1];
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    #[DataProvider('dateFilterNullAndEmptyScenariosProvider')]
+    public function testDateFilterWithNullAndEmptyValues(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function dateFilterNullAndEmptyScenariosProvider(): \Generator
+    {
+        yield 'created_at_null_value' => ['/filtered_date_parameters?createdAt=null', 4];
+        yield 'created_at_empty_value' => ['/filtered_date_parameters?createdAt=', 4];
+        yield 'date_null_value_alias' => ['/filtered_date_parameters?date=null', 4];
+        yield 'date_empty_value_alias' => ['/filtered_date_parameters?date=', 4];
+        yield 'date_alias__include_null_always_with_null_alias' => ['/filtered_date_parameters?date_include_null_always=null', 4];
+        yield 'date__alias_include_null_always_with_empty_alias' => ['/filtered_date_parameters?date_include_null_always=', 4];
+        yield 'date_alias_old_way_with_null_alias' => ['/filtered_date_parameters?date_old_way=null', 4];
+        yield 'date__alias_old_way_with_empty_alias' => ['/filtered_date_parameters?date_old_way=', 4];
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws MongoDBException
+     */
+    private function loadFixtures(string $entityClass): void
+    {
+        $manager = $this->getManager();
+
+        $dates = [
+            new \DateTimeImmutable('2024-01-01'),
+            new \DateTimeImmutable('2024-06-15'),
+            new \DateTimeImmutable('2024-12-25'),
+            null,
+        ];
+
+        foreach ($dates as $createdAtValue) {
+            $entity = new $entityClass(createdAt: $createdAtValue);
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}

--- a/tests/Functional/Parameters/ExistsFilterTest.php
+++ b/tests/Functional/Parameters/ExistsFilterTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredExistsParameter as FilteredExistsParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredExistsParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class ExistsFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FilteredExistsParameter::class];
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    protected function setUp(): void
+    {
+        $entityClass = $this->isMongoDB() ? FilteredExistsParameterDocument::class : FilteredExistsParameter::class;
+
+        $this->recreateSchema([$entityClass]);
+        $this->loadFixtures($entityClass);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('existsFilterScenariosProvider')]
+    public function testExistsFilterResponses(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function existsFilterScenariosProvider(): \Generator
+    {
+        yield 'created_at_exists_entities' => ['/filtered_exists_parameters?createdAt=true', 2];
+        yield 'created_at_not_exists' => ['/filtered_exists_parameters?createdAt=false', 1];
+        yield 'has_creation_date_alias_exists_entities' => ['/filtered_exists_parameters?hasCreationDate=true', 2];
+        yield 'has_creation_date_alias__not_exists_entities' => ['/filtered_exists_parameters?hasCreationDate=false', 1];
+        yield 'exists_property_created_at_entities' => ['/filtered_exists_parameters?exists[createdAt]=true', 2];
+        yield 'exists_property_created_at_not_exists' => ['/filtered_exists_parameters?exists[createdAt]=false', 1];
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws MongoDBException
+     */
+    private function loadFixtures(string $entityClass): void
+    {
+        $manager = $this->getManager();
+
+        foreach ([new \DateTimeImmutable(), null, new \DateTimeImmutable()] as $createdAt) {
+            $entity = new $entityClass(createdAt: $createdAt);
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}

--- a/tests/Functional/Parameters/NumericFilterTest.php
+++ b/tests/Functional/Parameters/NumericFilterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredNumericParameter as FilteredNumericParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredNumericParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class NumericFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FilteredNumericParameter::class];
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    protected function setUp(): void
+    {
+        $entityClass = $this->isMongoDB() ? FilteredNumericParameterDocument::class : FilteredNumericParameter::class;
+
+        $this->recreateSchema([$entityClass]);
+        $this->loadFixtures($entityClass);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('rangeFilterScenariosProvider')]
+    public function testRangeFilterResponses(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function rangeFilterScenariosProvider(): \Generator
+    {
+        yield 'quantity_int_equal' => ['/filtered_numeric_parameters?quantity=10', 1];
+        yield 'ratio_float_equal' => ['/filtered_numeric_parameters?ratio=1.0', 2];
+        yield 'amount_alias_int_equal' => ['/filtered_numeric_parameters?amount=20', 2];
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('nullAndEmptyScenariosProvider')]
+    public function testRangeFilterWithNullAndEmptyValues(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function nullAndEmptyScenariosProvider(): \Generator
+    {
+        yield 'quantity_int_null_value' => ['/filtered_numeric_parameters?quantity=null', 4];
+        yield 'quantity_int_empty_value' => ['/filtered_numeric_parameters?quantity=', 4];
+        yield 'ratio_float_null_value' => ['/filtered_numeric_parameters?ratio=null', 4];
+        yield 'ratio_float_empty_value' => ['/filtered_numeric_parameters?ratio=', 4];
+        yield 'amount_alias_int_null_value' => ['/filtered_numeric_parameters?amount=null', 4];
+        yield 'amount_alias_int_empty_value' => ['/filtered_numeric_parameters?amount=', 4];
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws MongoDBException
+     */
+    private function loadFixtures(string $entityClass): void
+    {
+        $manager = $this->getManager();
+
+        foreach ([[10, 1.0], [20, 2.0], [30, 3.0], [20, 1.0]] as [$quantity, $ratio]) {
+            $entity = new $entityClass(quantity: $quantity, ratio: $ratio);
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}

--- a/tests/Functional/Parameters/OrderFilterTest.php
+++ b/tests/Functional/Parameters/OrderFilterTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredOrderParameter as FilteredOrderParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredOrderParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class OrderFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FilteredOrderParameter::class];
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    protected function setUp(): void
+    {
+        $entityClass = $this->isMongoDB() ? FilteredOrderParameterDocument::class : FilteredOrderParameter::class;
+
+        $this->recreateSchema([$entityClass]);
+        $this->loadFixtures($entityClass);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('orderFilterScenariosProvider')]
+    public function testOrderFilterResponses(string $url, array $expectedOrder): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $orderedItems = $responseData['hydra:member'];
+
+        $actualOrder = array_map(fn ($item) => $item['createdAt'] ?? null, $orderedItems);
+
+        $this->assertSame($expectedOrder, $actualOrder, \sprintf('Expected order does not match for URL %s', $url));
+    }
+
+    public static function orderFilterScenariosProvider(): \Generator
+    {
+        yield 'created_at_ordered_asc' => [
+            '/filtered_order_parameters?createdAt=asc',
+            [null, '2024-01-01T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-12-25T00:00:00+00:00'],
+        ];
+        yield 'created_at_ordered_desc' => [
+            '/filtered_order_parameters?createdAt=desc',
+            ['2024-12-25T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-01-01T00:00:00+00:00', null],
+        ];
+        yield 'date_alias_ordered_asc' => [
+            '/filtered_order_parameters?date=asc',
+            [null, '2024-01-01T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-12-25T00:00:00+00:00'],
+        ];
+        yield 'date_alias_ordered_desc' => [
+            '/filtered_order_parameters?date=desc',
+            ['2024-12-25T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-01-01T00:00:00+00:00', null],
+        ];
+        yield 'date_null_always_first_alias_nulls_first' => [
+            '/filtered_order_parameters?date_null_always_first=asc',
+            [null, '2024-01-01T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-12-25T00:00:00+00:00'],
+        ];
+        yield 'date_null_always_first_alias_nulls_last' => [
+            '/filtered_order_parameters?date_null_always_first=desc',
+            ['2024-12-25T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-01-01T00:00:00+00:00', null],
+        ];
+        yield 'date_null_always_first_old_way_alias_nulls_first' => [
+            '/filtered_order_parameters?date_null_always_first_old_way=asc',
+            [null, '2024-01-01T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-12-25T00:00:00+00:00'],
+        ];
+        yield 'date_null_always_first_old_way_alias_nulls_last' => [
+            '/filtered_order_parameters?date_null_always_first_old_way=desc',
+            ['2024-12-25T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-01-01T00:00:00+00:00', null],
+        ];
+        yield 'order_property_created_at_nulls_first' => [
+            '/filtered_order_parameters?order[createdAt]=asc',
+            [null, '2024-01-01T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-12-25T00:00:00+00:00'],
+        ];
+        yield 'order_property_created_at_nulls_last' => [
+            '/filtered_order_parameters?order[createdAt]=desc',
+            ['2024-12-25T00:00:00+00:00', '2024-06-15T00:00:00+00:00', '2024-01-01T00:00:00+00:00', null],
+        ];
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws MongoDBException
+     */
+    private function loadFixtures(string $entityClass): void
+    {
+        $manager = $this->getManager();
+
+        $dates = [
+            new \DateTimeImmutable('2024-01-01'),
+            new \DateTimeImmutable('2024-12-25'),
+            null,
+            new \DateTimeImmutable('2024-06-15'),
+        ];
+
+        foreach ($dates as $createdAtValue) {
+            $entity = new $entityClass(createdAt: $createdAtValue);
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}

--- a/tests/Functional/Parameters/RangeFilterTest.php
+++ b/tests/Functional/Parameters/RangeFilterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredRangeParameter as FilteredRangeParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredRangeParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class RangeFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FilteredRangeParameter::class];
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    protected function setUp(): void
+    {
+        $entityClass = $this->isMongoDB() ? FilteredRangeParameterDocument::class : FilteredRangeParameter::class;
+
+        $this->recreateSchema([$entityClass]);
+        $this->loadFixtures($entityClass);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('rangeFilterScenariosProvider')]
+    public function testRangeFilterResponses(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function rangeFilterScenariosProvider(): \Generator
+    {
+        yield 'quantity_greater_than' => ['/filtered_range_parameters?quantity[gt]=10', 3];
+        yield 'quantity_less_than' => ['/filtered_range_parameters?quantity[lt]=50', 3];
+        yield 'quantity_between' => ['/filtered_range_parameters?quantity[between]=15..40', 2];
+        yield 'quantity_gte' => ['/filtered_range_parameters?quantity[gte]=20', 3];
+        yield 'quantity_lte' => ['/filtered_range_parameters?quantity[lte]=30', 3];
+        yield 'quantity_greater_than_and_less_than' => ['/filtered_range_parameters?quantity[gt]=10&quantity[lt]=50', 2];
+        yield 'quantity_gte_and_lte' => ['/filtered_range_parameters?quantity[gte]=20&quantity[lte]=30', 2];
+        yield 'quantity_gte_and_less_than' => ['/filtered_range_parameters?quantity[gte]=15&quantity[lt]=50', 2];
+        yield 'quantity_between_and_lte' => ['/filtered_range_parameters?quantity[between]=15..40&quantity[lte]=30', 2];
+        yield 'amount_alias_greater_than' => ['/filtered_range_parameters?amount[gt]=10', 3];
+        yield 'amount_alias_less_than' => ['/filtered_range_parameters?amount[lt]=50', 3];
+        yield 'amount_alias_between' => ['/filtered_range_parameters?amount[between]=15..40', 2];
+        yield 'amount_alias_gte' => ['/filtered_range_parameters?amount[gte]=20', 3];
+        yield 'amount_alias_lte' => ['/filtered_range_parameters?amount[lte]=30', 3];
+        yield 'amount_alias_gte_and_lte' => ['/filtered_range_parameters?amount[gte]=20&amount[lte]=30', 2];
+        yield 'amount_alias_greater_than_and_less_than' => ['/filtered_range_parameters?amount[gt]=10&amount[lt]=50', 2];
+        yield 'amount_alias_between_and_gte' => ['/filtered_range_parameters?amount[between]=15..40&amount[gte]=20', 2];
+        yield 'amount_alias_lte_and_between' => ['/filtered_range_parameters?amount[lte]=30&amount[between]=15..40', 2];
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    #[DataProvider('nullAndEmptyScenariosProvider')]
+    public function testRangeFilterWithNullAndEmptyValues(string $url, int $expectedCount): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredItems = $responseData['hydra:member'];
+
+        $this->assertCount($expectedCount, $filteredItems, \sprintf('Expected %d items for URL %s', $expectedCount, $url));
+    }
+
+    public static function nullAndEmptyScenariosProvider(): \Generator
+    {
+        yield 'quantity_null_value' => ['/filtered_range_parameters?quantity=null', 4];
+        yield 'quantity_empty_value' => ['/filtered_range_parameters?quantity=', 4];
+        yield 'amont_alias_null_value' => ['/filtered_range_parameters?amount=null', 4];
+        yield 'amount_alias_empty_value' => ['/filtered_range_parameters?amount=', 4];
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws MongoDBException
+     */
+    private function loadFixtures(string $entityClass): void
+    {
+        $manager = $this->getManager();
+
+        foreach ([10, 20, 30, 50] as $quantity) {
+            $entity = new $entityClass(quantity: $quantity);
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | `main`
| Tickets        | Closes #6844 
| License       | MIT
| Doc PR        | _Coming soon_

**Completes #6749.**

Goal:

Using  Dotrine filters as we use Laravel Eloquent filters. Example using  a `BooleanFilter` with Symfony and Doctrine:
```php
#[ApiResource]
#[GetCollection(
    parameters: [
        'active' => new QueryParameter(
            filter: new BooleanFilter(),
        ),

        // support also for filter aliasing
        'enabled' => new QueryParameter(
            filter: new BooleanFilter(),
            property: 'active',
        ),
    ],
)]
#[ORM\Entity]
class FilteredBooleanParameter {
    // ...
}
```

TODO:
- [x] BooleanFilter
- [x] DateFilter
- [x] RangeFilter
- [x] Numeric
- [x] Exists
- [x] OrderFilter

**Will be done in another PR**:
- SearchFilter
