### PR TITLE
doc: use newly registered YAML media type

### DIFF
--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -106,7 +106,7 @@ class ApiResource extends Metadata
          *       'jsonapi' => ['application/vnd.api+json'],
          *       'json' =>    ['application/json'],
          *       'xml' =>     ['application/xml', 'text/xml'],
-         *       'yaml' =>    ['application/x-yaml'],
+         *       'yaml' =>    ['application/yaml],
          *       'csv' =>     ['text/csv'],
          *       'html' =>    ['text/html'],
          *       'myformat' =>['application/vnd.myformat'],

--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -106,7 +106,7 @@ class ApiResource extends Metadata
          *       'jsonapi' => ['application/vnd.api+json'],
          *       'json' =>    ['application/json'],
          *       'xml' =>     ['application/xml', 'text/xml'],
-         *       'yaml' =>    ['application/yaml],
+         *       'yaml' =>    ['application/yaml'],
          *       'csv' =>     ['text/csv'],
          *       'html' =>    ['text/html'],
          *       'myformat' =>['application/vnd.myformat'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | n/a
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/2054

YAML is now a RFC and has an official media type: https://www.rfc-editor.org/rfc/rfc9512.html#name-media-type-application-yaml