### PR TITLE
Make StateProcessor.tpl.php compatible with 3.4

### DIFF
--- a/src/Symfony/Maker/Resources/skeleton/StateProcessor.tpl.php
+++ b/src/Symfony/Maker/Resources/skeleton/StateProcessor.tpl.php
@@ -8,8 +8,8 @@ use ApiPlatform\State\ProcessorInterface;
 
 class <?php echo $class_name; ?> implements ProcessorInterface
 {
-    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
-        // Handle the state
+        // Handle the state and return the inner processor
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | stable
| Tickets       | Might prevent issues as in #6771
| License       | MIT
| Doc PR        | -

API Platform 3.4+ needs to return the processor

Should now target the proper branch too