### PR TITLE
fix(state): empty result when the array paginator is out of bound

### DIFF
--- a/src/State/Pagination/ArrayPaginator.php
+++ b/src/State/Pagination/ArrayPaginator.php
@@ -27,14 +27,15 @@ final class ArrayPaginator implements \IteratorAggregate, PaginatorInterface, Ha
 
     public function __construct(array $results, int $firstResult, int $maxResults)
     {
-        if ($maxResults > 0) {
+        $this->firstResult = $firstResult;
+        $this->maxResults = $maxResults;
+        $this->totalItems = \count($results);
+
+        if ($maxResults > 0 && $firstResult < $this->totalItems) {
             $this->iterator = new \LimitIterator(new \ArrayIterator($results), $firstResult, $maxResults);
         } else {
             $this->iterator = new \EmptyIterator();
         }
-        $this->firstResult = $firstResult;
-        $this->maxResults = $maxResults;
-        $this->totalItems = \count($results);
     }
 
     /**

--- a/tests/State/Pagination/ArrayPaginatorTest.php
+++ b/tests/State/Pagination/ArrayPaginatorTest.php
@@ -43,6 +43,7 @@ class ArrayPaginatorTest extends TestCase
             'Second of two pages of 3 items for the first page and 2 for the second' => [[0, 1, 2, 3, 4], 3, 3, 2, 5, 2, 2, false],
             'Empty results' => [[], 0, 2, 0, 0, 1, 1, false],
             '0 for max results' => [[0, 1, 2, 3], 2, 0, 0, 4, 1, 1, false],
+            'First result greater than total items' => [[0, 1], 2, 1, 0, 2, 3, 2, false],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | -
| License       | MIT
| Doc PR        | -

Hello,

When using Doctrine or Elastic paginator, it behaves by giving an empty array when the page is out of bounds but when using the Array paginator, it throws an `OutOfBoundsException`.

This PR align this behavior accross all paginators.