### PR TITLE
fix(elasticsearch): return $currentProperty when $nestedPath is null

### DIFF
--- a/src/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -74,7 +74,7 @@ trait FieldDatatypeTrait
             ) {
                 $nestedPath = $this->getNestedFieldPath($nextResourceClass, implode('.', $properties));
 
-                return null === $nestedPath ? $nestedPath : "$currentProperty.$nestedPath";
+                return null === $nestedPath ? $currentProperty : "$currentProperty.$nestedPath";
             }
 
             if (


### PR DESCRIPTION
return `$currentProperty` when `$nestedPath` is `null`

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        |  

This brings [Filtering on Nested Properties (Elastic)](https://api-platform.com/docs/core/filters/#filtering-on-nested-properties-elastic) to work