### PR TITLE
feat(symfony): object mapper with state options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -180,6 +180,7 @@
         "symfony/maker-bundle": "^1.24",
         "symfony/mercure-bundle": "*",
         "symfony/messenger": "^6.4 || ^7.0",
+        "symfony/object-mapper": "^7.3",
         "symfony/routing": "^6.4 || ^7.0",
         "symfony/security-bundle": "^6.4 || ^7.0",
         "symfony/security-core": "^6.4 || ^7.0",

--- a/src/State/Processor/ObjectMapperProcessor.php
+++ b/src/State/Processor/ObjectMapperProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Processor;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+
+/**
+ * @implements ProcessorInterface<mixed,mixed>
+ */
+final class ObjectMapperProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<mixed,mixed> $decorated
+     */
+    public function __construct(
+        private readonly ?ObjectMapperInterface $objectMapper,
+        private readonly ProcessorInterface $decorated,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if (!$this->objectMapper || !$operation->canWrite()) {
+            return $this->decorated->process($data, $operation, $uriVariables, $context);
+        }
+
+        if (!(new \ReflectionClass($operation->getClass()))->getAttributes(Map::class)) {
+            return $this->decorated->process($data, $operation, $uriVariables, $context);
+        }
+
+        return $this->objectMapper->map($this->decorated->process($this->objectMapper->map($data), $operation, $uriVariables, $context));
+    }
+}

--- a/src/State/Provider/ObjectMapperProvider.php
+++ b/src/State/Provider/ObjectMapperProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Provider;
+
+use ApiPlatform\Doctrine\Odm\State\Options as OdmOptions;
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Util\CloneTrait;
+use ApiPlatform\State\Pagination\ArrayPaginator;
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use ApiPlatform\State\ProviderInterface;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+
+/**
+ * @implements ProviderInterface<object>
+ */
+final class ObjectMapperProvider implements ProviderInterface
+{
+    use CloneTrait;
+
+    /**
+     * @param ProviderInterface<object> $decorated
+     */
+    public function __construct(
+        private readonly ?ObjectMapperInterface $objectMapper,
+        private readonly ProviderInterface $decorated,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        $data = $this->decorated->provide($operation, $uriVariables, $context);
+
+        if (!$this->objectMapper || !\is_object($data)) {
+            return $data;
+        }
+
+        $request = $context['request'] ?? null;
+        $entityClass = null;
+        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
+            $entityClass = $options->getEntityClass();
+        }
+
+        if (($options = $operation->getStateOptions()) && $options instanceof OdmOptions && $options->getDocumentClass()) {
+            $entityClass = $options->getDocumentClass();
+        }
+
+        $entityClass ??= $data::class;
+
+        if (!(new \ReflectionClass($entityClass))->getAttributes(Map::class)) {
+            return $data;
+        }
+
+        if ($data instanceof PaginatorInterface) {
+            $data = new ArrayPaginator(array_map(fn ($v) => $this->objectMapper->map($v), iterator_to_array($data)), 0, \count($data));
+        } else {
+            $data = $this->objectMapper->map($data);
+        }
+
+        $request?->attributes->set('data', $data);
+        $request?->attributes->set('previous_data', $this->clone($data));
+
+        return $data;
+    }
+}

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -59,6 +59,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -169,6 +170,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerArgumentResolverConfiguration($loader);
         $this->registerLinkSecurityConfiguration($loader, $config);
 
+        if (class_exists(ObjectMapper::class)) {
+            $loader->load('state/object_mapper.xml');
+        }
         $container->registerForAutoconfiguration(FilterInterface::class)
             ->addTag('api_platform.filter');
         $container->registerForAutoconfiguration(ProviderInterface::class)

--- a/src/Symfony/Bundle/Resources/config/state/object_mapper.xml
+++ b/src/Symfony/Bundle/Resources/config/state/object_mapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="api_platform.state_provider.object_mapper" class="ApiPlatform\State\Provider\ObjectMapperProvider" decorates="api_platform.state_provider.read">
+            <argument type="service" id="object_mapper" on-invalid="null" />
+            <argument type="service" id="api_platform.state_provider.object_mapper.inner" />
+        </service>
+
+        <service id="api_platform.state_processor.object_mapper" class="ApiPlatform\State\Processor\ObjectMapperProcessor" decorates="api_platform.state_processor.locator">
+            <argument type="service" id="object_mapper" on-invalid="null" />
+            <argument type="service" id="api_platform.state_processor.object_mapper.inner" />
+        </service>
+    </services>
+</container>

--- a/tests/Fixtures/TestBundle/ApiResource/MappedResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResource.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\JsonLd\ContextBuilder;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MappedEntity;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    stateOptions: new Options(entityClass: MappedEntity::class),
+    normalizationContext: [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false],
+)]
+#[Map(target: MappedEntity::class)]
+final class MappedResource
+{
+    #[Map(if: false)]
+    public ?string $id = null;
+
+    #[Map(target: 'firstName', transform: [self::class, 'toFirstName'])]
+    #[Map(target: 'lastName', transform: [self::class, 'toLastName'])]
+    public string $username;
+
+    public static function toFirstName(string $v): string
+    {
+        return explode(' ', $v)[0];
+    }
+
+    public static function toLastName(string $v): string
+    {
+        return explode(' ', $v)[1];
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/MappedResourceOdm.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResourceOdm.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Odm\State\Options;
+use ApiPlatform\JsonLd\ContextBuilder;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\MappedDocument;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    stateOptions: new Options(documentClass: MappedDocument::class),
+    normalizationContext: [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false],
+)]
+#[Map(target: MappedDocument::class)]
+final class MappedResourceOdm
+{
+    #[Map(if: false)]
+    public ?string $id = null;
+
+    #[Map(target: 'firstName', transform: [self::class, 'toFirstName'])]
+    #[Map(target: 'lastName', transform: [self::class, 'toLastName'])]
+    public string $username;
+
+    public static function toFirstName(string $v): string
+    {
+        return explode(' ', $v)[0];
+    }
+
+    public static function toLastName(string $v): string
+    {
+        return explode(' ', $v)[1];
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/MappedDocument.php
+++ b/tests/Fixtures/TestBundle/Document/MappedDocument.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResourceOdm;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * MappedEntity to MappedResource.
+ */
+#[ODM\Document]
+#[Map(target: MappedResourceOdm::class)]
+class MappedDocument
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\Field(type: 'string')]
+    #[Map(if: false)]
+    private string $firstName;
+
+    #[Map(target: 'username', transform: [self::class, 'toUsername'])]
+    #[ODM\Field(type: 'string')]
+    private string $lastName;
+
+    public static function toUsername($value, $object): string
+    {
+        return $object->getFirstName().' '.$object->getLastName();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setLastName(string $name): void
+    {
+        $this->lastName = $name;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function setFirstName(string $name): void
+    {
+        $this->firstName = $name;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/MappedEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/MappedEntity.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * MappedEntity to MappedResource.
+ */
+#[ORM\Entity]
+#[Map(target: MappedResource::class)]
+class MappedEntity
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    #[Map(if: false)]
+    private string $firstName;
+
+    #[Map(target: 'username', transform: [self::class, 'toUsername'])]
+    #[ORM\Column]
+    private string $lastName;
+
+    public static function toUsername($value, $object): string
+    {
+        return $object->getFirstName().' '.$object->getLastName();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setLastName(string $name): void
+    {
+        $this->lastName = $name;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function setFirstName(string $name): void
+    {
+        $this->firstName = $name;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+}

--- a/tests/Functional/MappingTest.php
+++ b/tests/Functional/MappingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResourceOdm;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\MappedDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MappedEntity;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Doctrine\ODM\MongoDB\DocumentManager;
+
+final class MappingTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [MappedResource::class, MappedResourceOdm::class];
+    }
+
+    public function testShouldMapBetweenResourceAndEntity(): void
+    {
+        if (!$this->getContainer()->has('object_mapper')) {
+            $this->markTestSkipped('ObjectMapper not installed');
+        }
+
+        $this->recreateSchema([MappedEntity::class]);
+        $this->loadFixtures();
+        $r = self::createClient()->request('GET', $this->isMongoDB() ? 'mapped_resource_odms' : 'mapped_resources');
+        $this->assertJsonContains(['member' => [
+            ['username' => 'B0 A0'],
+            ['username' => 'B1 A1'],
+            ['username' => 'B2 A2'],
+        ]]);
+
+        $r = self::createClient()->request('POST', $this->isMongoDB() ? 'mapped_resource_odms' : 'mapped_resources', ['json' => ['username' => 'so yuka']]);
+        $this->assertJsonContains(['username' => 'so yuka']);
+
+        $manager = $this->getManager();
+        $repo = $manager->getRepository($this->isMongoDB() ? MappedDocument::class : MappedEntity::class);
+        $persisted = $repo->findOneBy(['id' => $r->toArray()['id']]);
+        $this->assertSame('so', $persisted->getFirstName());
+        $this->assertSame('yuka', $persisted->getLastName());
+
+        $uri = $r->toArray()['@id'];
+        self::createClient()->request('GET', $uri);
+        $this->assertJsonContains(['username' => 'so yuka']);
+
+        $r = self::createClient()->request('PATCH', $uri, ['json' => ['username' => 'ba zar'], 'headers' => ['content-type' => 'application/merge-patch+json']]);
+        $this->assertJsonContains(['username' => 'ba zar']);
+    }
+
+    private function loadFixtures(): void
+    {
+        $manager = $this->getManager();
+
+        for ($i = 0; $i < 10; ++$i) {
+            $e = $manager instanceof DocumentManager ? new MappedDocument() : new MappedEntity();
+            $e->setLastName('A'.$i);
+            $e->setFirstName('B'.$i);
+            $manager->persist($e);
+        }
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Still a few things left to be done but this is a first approach. This makes API Platform compatible with the Object Mapper component: https://github.com/symfony/symfony/pull/51741

Demo: 

```
composer create-project symfony/skeleton test-objectmapper2
cd test-objectmapper2
composer req debug api-platform/symfony api-platform/doctrine-orm make orm symfony/asset 
nvim .env # uncomment sqlite
nvim composer.json # change extra.symfony to 7.3.*
composer config minimum-stability RC
composer req symfony/object-mapper:^7.3.0-RC1 symfony/type-info:v7.3.0-RC1 symfony/framework-bundle:v7.3.0-RC1 -W 
# clone my pr https://github.com/api-platform/core/pull/6801 to a parent directory:
# example with gh in a api-platform/core clone: `gh pr checkout 6801`
composer link ../core-6801 # if link is not available `composer global require soyuka/pmu`
bin/console make:entity # create an entity Book with id/title
bin/console d:s:u --force 
frankenphp php-server --listen :8080 -r public
```

Example:

```php
<?php

namespace App\Entity;

use App\ApiResource\Book as AppBook;
use App\Repository\BookRepository;
use Doctrine\ORM\Mapping as ORM;
use Symfony\Component\ObjectMapper\Attribute\Map;

#[ORM\Entity(repositoryClass: BookRepository::class)]
#[Map(target: AppBook::class)]
class Book
{
    #[ORM\Id]
    #[ORM\GeneratedValue]
    #[ORM\Column]
    private ?int $id = null;

    #[ORM\Column(length: 255)]
    #[Map(transform: 'ucfirst')] // example of transformation to the dto
    private ?string $title = null;

    public function getId(): ?int
    {
        return $this->id;
    }

    public function getTitle(): ?string
    {
        return $this->title;
    }

    public function setTitle(string $title): static
    {
        $this->title = $title;

        return $this;
    }
}
```

```php
<?php

namespace App\ApiResource;

use ApiPlatform\Doctrine\Orm\State\Options;
use ApiPlatform\Metadata\ApiResource;
use App\Entity\Book as BookEntity;
use Symfony\Component\ObjectMapper\Attribute\Map;

#[ApiResource(stateOptions: new Options(entityClass: BookEntity::class))]
#[Map(target: BookEntity::class)]
class Book
{
    #[Map(if: false)] // do not map the id from the dto to the entity
    public string $id;
    #[Map(transform: 'strtolower')] // example of transformation
    public string $title;
}
```