### PR TITLE
fix(symfony): unset item_uri_template when serializing an error

### DIFF
--- a/src/Symfony/EventListener/ErrorListener.php
+++ b/src/Symfony/EventListener/ErrorListener.php
@@ -115,6 +115,10 @@ final class ErrorListener extends SymfonyErrorListener
             $normalizationContext += ['api_error_resource' => true];
         }
 
+        if (isset($normalizationContext['item_uri_template'])) {
+            unset($normalizationContext['item_uri_template']);
+        }
+
         if (!isset($normalizationContext[AbstractObjectNormalizer::IGNORED_ATTRIBUTES])) {
             $normalizationContext[AbstractObjectNormalizer::IGNORED_ATTRIBUTES] = ['trace', 'file', 'line', 'code', 'message', 'traceAsString'];
         }

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6718/Organization.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6718/Organization.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6718;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+
+#[ApiResource(
+    shortName: 'OrganisationIssue6718',
+    extraProperties: ['rfc_7807_compliant_errors' => true],
+    operations: [
+        new Get(
+            uriTemplate: '/6718_organisations/{id}',
+            provider: [self::class, 'itemProvider'],
+        ),
+        new Get(
+            uriTemplate: '/6718_users/{userId}/organisation',
+            uriVariables: [
+                'userId',
+            ],
+            normalizationContext: [
+                'item_uri_template' => '/6718_organisations/{id}',
+                'hydra_prefix' => false,
+            ],
+            provider: [self::class, 'userOrganizationItemProvider']
+        ),
+    ],
+)]
+class Organization
+{
+    public function __construct(public readonly string $id)
+    {
+    }
+
+    public static function itemProvider(Operation $operation, array $uriVariables = []): ?self
+    {
+        return new self($uriVariables['id']);
+    }
+
+    public static function userOrganizationItemProvider(): ?self
+    {
+        return null;
+    }
+}

--- a/tests/Functional/ItemUriTemplateTest.php
+++ b/tests/Functional/ItemUriTemplateTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+
+class ItemUriTemplateTest extends ApiTestCase
+{
+    public function testIssue6718(): void
+    {
+        self::createClient()->request('GET', '/6718_users/1/organisation', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+        $this->assertJsonContains(['description' => 'Not Found']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | fixes #6718
| License       | MIT
