### PR TITLE
fix(symfony): object typed property schema collection restriction

### DIFF
--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestriction.php
@@ -40,7 +40,7 @@ final class PropertySchemaCollectionRestriction implements PropertySchemaRestric
     {
         $restriction = [
             'type' => 'object',
-            'properties' => [],
+            'properties' => new \ArrayObject(),
             'additionalProperties' => $constraint->allowExtraFields,
         ];
         $required = [];

--- a/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
@@ -79,7 +79,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
 
     public static function createProvider(): \Generator
     {
-        yield 'empty' => [new Collection([]), new ApiProperty(), ['type' => 'object', 'properties' => [], 'additionalProperties' => false]];
+        yield 'empty' => [new Collection([]), new ApiProperty(), ['type' => 'object', 'properties' => new \ArrayObject(), 'additionalProperties' => false]];
 
         $fields = [
             'name' => new Required([
@@ -104,13 +104,13 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
                 ],
             ]),
         ];
-        $properties = [
+        $properties = new \ArrayObject([
             'name' => new \ArrayObject(),
             'email' => ['minLength' => 2, 'maxLength' => 255, 'format' => 'email'],
             'phone' => ['pattern' => '^([+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
             'age' => ['exclusiveMinimum' => 0],
-            'social' => ['type' => 'object', 'properties' => ['githubUsername' => new \ArrayObject()], 'additionalProperties' => false, 'required' => ['githubUsername']],
-        ];
+            'social' => ['type' => 'object', 'properties' => new \ArrayObject(['githubUsername' => new \ArrayObject()]), 'additionalProperties' => false, 'required' => ['githubUsername']],
+        ]);
         $required = ['name', 'email', 'social'];
 
         yield 'with fields' => [

--- a/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -630,7 +630,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
 
         $this->assertEquals([
             'type' => 'object',
-            'properties' => [
+            'properties' => new \ArrayObject([
                 'name' => new \ArrayObject(),
                 'email' => ['format' => 'email', 'minLength' => 2, 'maxLength' => 255],
                 'phone' => ['pattern' => '^([+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
@@ -639,13 +639,13 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
                 ],
                 'social' => [
                     'type' => 'object',
-                    'properties' => [
+                    'properties' => new \ArrayObject([
                         'githubUsername' => new \ArrayObject(),
-                    ],
+                    ]),
                     'additionalProperties' => false,
                     'required' => ['githubUsername'],
                 ],
-            ],
+            ]),
             'additionalProperties' => true,
             'required' => ['name', 'email', 'social'],
         ], $schema);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

in case of `Collection` constraint with empty `fields` key (this is valid value for it):
```
    /**
     * @var array<string, mixed>
     */
    #[Assert\Collection(fields: [])]
    public array $options = [];
```
`properties` field is generated as plain array, which is incorrect (must be always object):
```
        options:
          type: object
          properties: [] <--------
          additionalProperties: false
```