### PR TITLE
fix(jsonschema): hashmaps produces invalid openapi schema

### DIFF
--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -21,7 +21,6 @@ use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\Util\ResourceClassInfoTrait;
 use Doctrine\Common\Collections\ArrayCollection;
 use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
@@ -38,7 +37,6 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
     public function __construct(
         ResourceClassResolverInterface $resourceClassResolver,
         private readonly ?PropertyMetadataFactoryInterface $decorated = null,
-        private readonly ?PropertyInfoExtractorInterface $propertyInfo = null,
     ) {
         $this->resourceClassResolver = $resourceClassResolver;
     }
@@ -270,17 +268,7 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             ];
         }
 
-        if (!$this->propertyInfo) {
-            return ['type' => 'object'];
-        }
-
-        $properties = $this->propertyInfo->getProperties($className, ['serializer_groups' => null]);
-        $propertiesSchema = [];
-        foreach ($properties as $property) {
-            $propertiesSchema[$property] = $this->create($className, $property)->getSchema();
-        }
-
-        return ['type' => 'object', 'properties' => $propertiesSchema];
+        return ['type' => Schema::UNKNOWN_TYPE];
     }
 
     /**

--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -21,6 +21,7 @@ use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\Util\ResourceClassInfoTrait;
 use Doctrine\Common\Collections\ArrayCollection;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
@@ -34,8 +35,11 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
 
     public const JSON_SCHEMA_USER_DEFINED = 'user_defined_schema';
 
-    public function __construct(ResourceClassResolverInterface $resourceClassResolver, private readonly ?PropertyMetadataFactoryInterface $decorated = null)
-    {
+    public function __construct(
+        ResourceClassResolverInterface $resourceClassResolver,
+        private readonly ?PropertyMetadataFactoryInterface $decorated = null,
+        private readonly ?PropertyInfoExtractorInterface $propertyInfo = null,
+    ) {
         $this->resourceClassResolver = $resourceClassResolver;
     }
 
@@ -198,6 +202,8 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
      * Gets the JSON Schema document which specifies the data type corresponding to the given PHP class, and recursively adds needed new schema to the current schema if provided.
      *
      * Note: if the class is not part of exceptions listed above, any class is considered as a resource.
+     *
+     * @throws PropertyNotFoundException
      */
     private function getClassType(?string $className, bool $nullable, ?bool $readableLink): array
     {
@@ -240,7 +246,8 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             ];
         }
 
-        if (!$this->isResourceClass($className) && is_a($className, \BackedEnum::class, true)) {
+        $isResourceClass = $this->isResourceClass($className);
+        if (!$isResourceClass && is_a($className, \BackedEnum::class, true)) {
             $enumCases = array_map(static fn (\BackedEnum $enum): string|int => $enum->value, $className::cases());
 
             $type = \is_string($enumCases[0] ?? '') ? 'string' : 'integer';
@@ -255,7 +262,7 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             ];
         }
 
-        if (true !== $readableLink && $this->isResourceClass($className)) {
+        if (true !== $readableLink && $isResourceClass) {
             return [
                 'type' => 'string',
                 'format' => 'iri-reference',
@@ -263,8 +270,17 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             ];
         }
 
-        // TODO: add propertyNameCollectionFactory and recurse to find the underlying schema? Right now SchemaFactory does the job so we don't compute anything here.
-        return ['type' => Schema::UNKNOWN_TYPE];
+        if (!$this->propertyInfo) {
+            return ['type' => 'object'];
+        }
+
+        $properties = $this->propertyInfo->getProperties($className, ['serializer_groups' => null]);
+        $propertiesSchema = [];
+        foreach ($properties as $property) {
+            $propertiesSchema[$property] = $this->create($className, $property)->getSchema();
+        }
+
+        return ['type' => 'object', 'properties' => $propertiesSchema];
     }
 
     /**

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -183,7 +183,8 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         $propertySchemaType = $propertySchema['type'] ?? false;
 
         $isUnknown = Schema::UNKNOWN_TYPE === $propertySchemaType
-            || ('array' === $propertySchemaType && Schema::UNKNOWN_TYPE === ($propertySchema['items']['type'] ?? null));
+            || ('array' === $propertySchemaType && Schema::UNKNOWN_TYPE === ($propertySchema['items']['type'] ?? null))
+            || ('object' === $propertySchemaType && Schema::UNKNOWN_TYPE === ($propertySchema['additionalProperties']['type'] ?? null));
 
         if (
             !$isUnknown && (
@@ -241,8 +242,9 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             }
 
             if ($isCollection) {
-                $propertySchema['items']['$ref'] = $subSchema['$ref'];
-                unset($propertySchema['items']['type']);
+                $key = ($propertySchema['type'] ?? null) === 'object' ? 'additionalProperties' : 'items';
+                $propertySchema[$key]['$ref'] = $subSchema['$ref'];
+                unset($propertySchema[$key]['type']);
                 break;
             }
 

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -33,7 +33,6 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\OpenApi\Attributes\Webhook;
-use ApiPlatform\OpenApi\Model;
 use ApiPlatform\OpenApi\Model\Components;
 use ApiPlatform\OpenApi\Model\Contact;
 use ApiPlatform\OpenApi\Model\ExternalDocumentation;
@@ -512,11 +511,11 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     }
 
     /**
-     * @return \ArrayObject<Model\MediaType>
+     * @return \ArrayObject<MediaType>
      */
     private function buildContent(array $responseMimeTypes, array $operationSchemas): \ArrayObject
     {
-        /** @var \ArrayObject<Model\MediaType> $content */
+        /** @var \ArrayObject<MediaType> $content */
         $content = new \ArrayObject();
 
         foreach ($responseMimeTypes as $mimeType => $format) {
@@ -603,11 +602,11 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     /**
      * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#linkObject.
      *
-     * @return \ArrayObject<Model\Link>
+     * @return \ArrayObject<Link>
      */
     private function getLinks(ResourceMetadataCollection $resourceMetadataCollection, HttpOperation $currentOperation): \ArrayObject
     {
-        /** @var \ArrayObject<Model\Link> $links */
+        /** @var \ArrayObject<Link> $links */
         $links = new \ArrayObject();
 
         // Only compute get links for now

--- a/src/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Symfony/Bundle/Resources/config/json_schema.xml
@@ -36,6 +36,7 @@
         <service id="api_platform.json_schema.metadata.property.metadata_factory.schema" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="10" class="ApiPlatform\JsonSchema\Metadata\Property\Factory\SchemaPropertyMetadataFactory" public="false">
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.json_schema.metadata.property.metadata_factory.schema.inner" />
+            <argument type="service" id="api_platform.property_info" on-invalid="null" />
         </service>
 
         <service id="api_platform.json_schema.backward_compatible_schema_factory" decorates="api_platform.json_schema.schema_factory" decoration-priority="-2" class="ApiPlatform\JsonSchema\BackwardCompatibleSchemaFactory">

--- a/src/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Symfony/Bundle/Resources/config/json_schema.xml
@@ -36,7 +36,6 @@
         <service id="api_platform.json_schema.metadata.property.metadata_factory.schema" decorates="api_platform.metadata.property.metadata_factory" decoration-priority="10" class="ApiPlatform\JsonSchema\Metadata\Property\Factory\SchemaPropertyMetadataFactory" public="false">
             <argument type="service" id="api_platform.resource_class_resolver" />
             <argument type="service" id="api_platform.json_schema.metadata.property.metadata_factory.schema.inner" />
-            <argument type="service" id="api_platform.property_info" on-invalid="null" />
         </service>
 
         <service id="api_platform.json_schema.backward_compatible_schema_factory" decorates="api_platform.json_schema.schema_factory" decoration-priority="-2" class="ApiPlatform\JsonSchema\BackwardCompatibleSchemaFactory">

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6800/Foo.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6800/Foo.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6800;
+
+class Foo
+{
+    public string $bar;
+    public int $baz;
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6800/TestApiDocHashmapArrayObjectIssue.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6800/TestApiDocHashmapArrayObjectIssue.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6800;
+
+use ApiPlatform\Metadata\Get;
+
+#[Get]
+class TestApiDocHashmapArrayObjectIssue
+{
+    /** @var array<Foo> */
+    public array $foos;
+
+    /** @var Foo[] */
+    public array $fooOtherSyntax;
+
+    /** @var array<string, Foo> */
+    public array $fooHashmaps;
+}

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -377,15 +377,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
             [
                 'type' => 'array',
                 'items' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'bar' => [
-                            'type' => 'string',
-                        ],
-                        'baz' => [
-                            'type' => 'integer',
-                        ],
-                    ],
+                    '$ref' => '#/definitions/Foo.jsonld',
                 ],
             ],
         ];
@@ -394,15 +386,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
             [
                 'type' => 'array',
                 'items' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'bar' => [
-                            'type' => 'string',
-                        ],
-                        'baz' => [
-                            'type' => 'integer',
-                        ],
-                    ],
+                    '$ref' => '#/definitions/Foo.jsonld',
                 ],
             ],
         ];
@@ -411,15 +395,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
             [
                 'type' => 'object',
                 'additionalProperties' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'bar' => [
-                            'type' => 'string',
-                        ],
-                        'baz' => [
-                            'type' => 'integer',
-                        ],
-                    ],
+                    '$ref' => '#/definitions/Foo.jsonld',
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `3.4`
| Tickets       | Closes #6800 
| License       | MIT

Key changes:
- Fix OpenAPI schema generation for hashmap properties
- Add tests to verify the correct schema generation for hashmap properties and different syntax for arrays of objects
