### PR TITLE
fix(symfony): retain existing associations of formats to MIME types when adding new MIME types

### DIFF
--- a/src/State/Provider/ContentNegotiationProvider.php
+++ b/src/State/Provider/ContentNegotiationProvider.php
@@ -67,7 +67,9 @@ final class ContentNegotiationProvider implements ProviderInterface
     private function addRequestFormats(Request $request, array $formats): void
     {
         foreach ($formats as $format => $mimeTypes) {
-            $request->setFormat($format, (array) $mimeTypes);
+            $existingMimeTypes = $request->getMimeTypes($format);
+            $newMimeTypes = array_unique(array_merge($existingMimeTypes, (array) $mimeTypes));
+            $request->setFormat($format, $newMimeTypes);
         }
     }
 

--- a/src/State/Provider/ContentNegotiationProvider.php
+++ b/src/State/Provider/ContentNegotiationProvider.php
@@ -68,7 +68,7 @@ final class ContentNegotiationProvider implements ProviderInterface
     {
         foreach ($formats as $format => $mimeTypes) {
             $existingMimeTypes = $request->getMimeTypes($format);
-            $newMimeTypes = array_unique(array_merge($existingMimeTypes, (array) $mimeTypes));
+            $newMimeTypes = array_unique(array_merge((array) $mimeTypes, $existingMimeTypes));
             $request->setFormat($format, $newMimeTypes);
         }
     }

--- a/tests/State/Provider/ContentNegotiationProviderTest.php
+++ b/tests/State/Provider/ContentNegotiationProviderTest.php
@@ -27,6 +27,23 @@ class ContentNegotiationProviderTest extends TestCase
 {
     use ProphecyTrait;
 
+    public function testAddRequestFormatsAddsMimeTypesToFormat(): void
+    {
+        $provider = new ContentNegotiationProvider();
+        $request = new Request();
+        $formats = ['json' => ['application/problem+json']];
+
+        $operation = new Post(outputFormats: $formats);
+        $context = ['request' => $request];
+
+        $provider->provide($operation, [], $context);
+
+        $mimeTypes = $request->getMimeTypes('json');
+
+        $this->assertContains('application/problem+json', $mimeTypes);
+        $this->assertContains('application/json', $mimeTypes);
+    }
+
     public function testRequestWithEmptyContentType(): void
     {
         $expectedResult = new \stdClass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | Closes #6831 
| License       | MIT
| Doc PR        | n/a

Proposed fix for bug where in long-running worker processes e.g. FrankenPHP, the `Request` formats are overwritten and can lose their default associations such as `json` --> `application/json`.