### PR TITLE
ci(php-cs-fixer): add parallel execution

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,6 +29,7 @@ $finder = PhpCsFixer\Finder::create()
     ]);
 
 return (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([
         '@DoctrineAnnotation' => true,


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | `4.0`
| License       | MIT

Enable parallel execution by configuring PHP-CS-Fixer with automatic detection of optimal parallel settings using the `ParallelConfigFactory::detect` method. This improves performance in environments that support parallel processing.
