### PR TITLE
fix(doctrine): Fixed ORM DateFilter applying inner join when no filtering values have been provided

### DIFF
--- a/src/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Doctrine/Orm/Filter/DateFilter.php
@@ -153,7 +153,7 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface
         $alias = $queryBuilder->getRootAliases()[0];
         $field = $property;
 
-        if ($this->isPropertyNested($property, $resourceClass)) {
+        if ($this->isPropertyNested($property, $resourceClass) && \count($values) > 0) {
             [$alias, $field] = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $resourceClass, Join::INNER_JOIN);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | None
| License       | MIT
| Doc PR        | 

DateFilter applies an inner join on nested property relations even when no values to filter on are provided. This update adds a check ensuring the values array is not empty before applying the join.

Without this fix, simply defining a DateFilter on nullable relations in GraphQL excludes all records lacking related entities, due to the nature of INNER JOIN.