### PR TITLE
Fix/missing error normalizer trait

### DIFF
--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\JsonApi\Serializer;
 
-use ApiPlatform\Problem\Serializer\ErrorNormalizerTrait;
 use ApiPlatform\Serializer\CacheableSupportsMethodInterface;
 use ApiPlatform\Symfony\Validator\Exception\ConstraintViolationListAwareExceptionInterface as LegacyConstraintViolationListAwareExceptionInterface;
 use ApiPlatform\Validator\Exception\ConstraintViolationListAwareExceptionInterface;

--- a/src/JsonApi/Serializer/ErrorNormalizerTrait.php
+++ b/src/JsonApi/Serializer/ErrorNormalizerTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\JsonApi\Serializer;
+
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\Response;
+
+trait ErrorNormalizerTrait
+{
+    private function getErrorMessage($object, array $context, bool $debug = false): string
+    {
+        $message = $object->getMessage();
+
+        if ($debug) {
+            return $message;
+        }
+
+        if ($object instanceof FlattenException) {
+            $statusCode = $context['statusCode'] ?? $object->getStatusCode();
+            if ($statusCode >= 500 && $statusCode < 600) {
+                $message = Response::$statusTexts[$statusCode] ?? Response::$statusTexts[Response::HTTP_INTERNAL_SERVER_ERROR];
+            }
+        }
+
+        return $message;
+    }
+
+    private function getErrorCode(object $object): ?string
+    {
+        if ($object instanceof FlattenException) {
+            return (string)$object->getStatusCode();
+        }
+
+        if ($object instanceof \Exception) {
+            $code = $object->getCode();
+            return $code !== 0 ? (string)$code : null;
+        }
+
+        return null;
+    }
+}
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->


This PR:

- Adds missing jsonapi error normalizer trait
- Removes usage of deprecated ErrorCodeSerializableInterface from ErrorNormalizerTrait

Without this fix, it is not possible to install api-platform/json-api as a standalone composer package due to the missing trait dependency.

**Note:** This issue only affects the **api-platform/json-api** sub-split repository. The main **api-platform/core** repository contains the correct code.

