### PR TITLE
fix(doctrine): fixed backed enum filter to use case name as value to filter by

### DIFF
--- a/src/Doctrine/Common/Filter/BackedEnumFilterTrait.php
+++ b/src/Doctrine/Common/Filter/BackedEnumFilterTrait.php
@@ -59,7 +59,7 @@ trait BackedEnumFilterTrait
                 'required' => false,
                 'schema' => [
                     'type' => 'string',
-                    'enum' => array_map(fn (\BackedEnum $case) => $case->value, $this->enumTypes[$property]::cases()),
+                    'enum' => array_map(fn (\BackedEnum $case) => $case->name, $this->enumTypes[$property]::cases()),
                 ],
             ];
         }
@@ -80,7 +80,7 @@ trait BackedEnumFilterTrait
 
     private function normalizeValue($value, string $property): mixed
     {
-        $values = array_map(fn (\BackedEnum $case) => $case->value, $this->enumTypes[$property]::cases());
+        $values = array_map(fn (\BackedEnum $case) => $case->name, $this->enumTypes[$property]::cases());
 
         if (\in_array($value, $values, true)) {
             return $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | #6298 
| License       | MIT
| Doc PR        | 

In GraphQL enums are serialized using the case name, not the value of the enum in the responses. Backed Enum Filter users value as enum values, which is also hard coded to "string" type, which creates issues with backed enums of any other type than string (I run into this issue using a int backed enum).

This straightforward fix puts the expected filter values inline with the serialization of enums, so now you can use the GraphQL schema to populate your enum filter (schema defined enums as ENUM_NAME: ENUM_NAME and not ENUM_MANE: ENUM_VALUE )

One problem I do have is I can't make the schema to define the filter as Enum so it shows up as one in GraphQL schema, I'm probably missing something here. 