### PR TITLE
fix(metadata): various parameter improvements

### DIFF
--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -25,15 +25,15 @@ Feature: Validate filters based upon filter description
   Scenario: Required filter should throw an error if not set
     When I am on "/array_filter_validators"
     Then the response status code should be 422
-    And the JSON node "detail" should be equal to 'arrayRequired: This value should not be blank.\nindexedArrayRequired: This value should not be blank.'
+    And the JSON node "detail" should be equal to 'arrayRequired[]: This value should not be blank.\nindexedArrayRequired[foo]: This value should not be blank.'
 
     When I am on "/array_filter_validators?arrayRequired[foo]=foo"
     Then the response status code should be 422
-    And the JSON node "detail" should be equal to 'indexedArrayRequired: This value should not be blank.'
+    And the JSON node "detail" should be equal to 'indexedArrayRequired[foo]: This value should not be blank.'
 
     When I am on "/array_filter_validators?arrayRequired[]=foo"
     Then the response status code should be 422
-    And the JSON node "detail" should be equal to 'indexedArrayRequired: This value should not be blank.'
+    And the JSON node "detail" should be equal to 'indexedArrayRequired[foo]: This value should not be blank.'
 
   Scenario: Test filter bounds: maximum
     When I am on "/filter_validators?required=foo&required-allow-empty&maximum=10"

--- a/features/filter/filter_validation.feature
+++ b/features/filter/filter_validation.feature
@@ -49,7 +49,7 @@ Feature: Validate filters based upon filter description
 
     When I am on "/filter_validators?required=foo&required-allow-empty&exclusiveMaximum=10"
     Then the response status code should be 422
-    And the JSON node "detail" should be equal to 'maximum: This value should be less than 10.'
+    And the JSON node "detail" should be equal to 'exclusiveMaximum: This value should be less than 10.'
 
   Scenario: Test filter bounds: minimum
     When I am on "/filter_validators?required=foo&required-allow-empty&minimum=5"

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -124,9 +124,9 @@ abstract class Parameter
      *
      * @readonly
      */
-    public function getValue(): mixed
+    public function getValue(mixed $default = new ParameterNotFound()): mixed
     {
-        return $this->extraProperties['_api_values'] ?? new ParameterNotFound();
+        return $this->extraProperties['_api_values'] ?? $default;
     }
 
     /**

--- a/src/Metadata/Parameters.php
+++ b/src/Metadata/Parameters.php
@@ -70,7 +70,7 @@ final class Parameters implements \IteratorAggregate, \Countable
     /**
      * @param class-string $parameterClass
      */
-    public function remove(string $key, string $parameterClass): self
+    public function remove(string $key, string $parameterClass = QueryParameter::class): self
     {
         foreach ($this->parameters as $i => [$parameterName, $parameter]) {
             if ($parameterName === $key && $parameterClass === $parameter::class) {
@@ -86,7 +86,7 @@ final class Parameters implements \IteratorAggregate, \Countable
     /**
      * @param class-string $parameterClass
      */
-    public function get(string $key, string $parameterClass): ?Parameter
+    public function get(string $key, string $parameterClass = QueryParameter::class): ?Parameter
     {
         foreach ($this->parameters as [$parameterName, $parameter]) {
             if ($parameterName === $key && $parameterClass === $parameter::class) {
@@ -100,7 +100,7 @@ final class Parameters implements \IteratorAggregate, \Countable
     /**
      * @param class-string $parameterClass
      */
-    public function has(string $key, string $parameterClass): bool
+    public function has(string $key, string $parameterClass = QueryParameter::class): bool
     {
         foreach ($this->parameters as [$parameterName, $parameter]) {
             if ($parameterName === $key && $parameterClass === $parameter::class) {

--- a/src/Metadata/Tests/ParameterTest.php
+++ b/src/Metadata/Tests/ParameterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests;
+
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\State\ParameterNotFound;
+use PHPUnit\Framework\TestCase;
+
+class ParameterTest extends TestCase
+{
+    public function testDefaultValue(): void
+    {
+        $parameter = new QueryParameter();
+        $this->assertSame('test', $parameter->getValue('test'));
+        $this->assertSame(new ParameterNotFound(), $parameter->getValue('test'));
+    }
+}

--- a/src/Metadata/Tests/ParameterTest.php
+++ b/src/Metadata/Tests/ParameterTest.php
@@ -23,6 +23,6 @@ class ParameterTest extends TestCase
     {
         $parameter = new QueryParameter();
         $this->assertSame('test', $parameter->getValue('test'));
-        $this->assertSame(new ParameterNotFound(), $parameter->getValue('test'));
+        $this->assertSame(new ParameterNotFound(), $parameter->getValue());
     }
 }

--- a/src/Metadata/Tests/ParameterTest.php
+++ b/src/Metadata/Tests/ParameterTest.php
@@ -23,6 +23,6 @@ class ParameterTest extends TestCase
     {
         $parameter = new QueryParameter();
         $this->assertSame('test', $parameter->getValue('test'));
-        $this->assertSame(new ParameterNotFound(), $parameter->getValue());
+        $this->assertInstanceOf(ParameterNotFound::class, $parameter->getValue());
     }
 }

--- a/src/Metadata/Tests/ParametersTest.php
+++ b/src/Metadata/Tests/ParametersTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests;
+
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PHPUnit\Framework\TestCase;
+
+class ParametersTest extends TestCase
+{
+    public function testDefaultValue(): void
+    {
+        $r = new QueryParameter();
+        $parameters = new Parameters(['a' => $r]);
+        $this->assertSame($r, $parameters->get('a'));
+    }
+}

--- a/src/Symfony/Validator/State/ParameterValidatorProvider.php
+++ b/src/Symfony/Validator/State/ParameterValidatorProvider.php
@@ -21,6 +21,7 @@ use ApiPlatform\State\Util\ParameterParserTrait;
 use ApiPlatform\Validator\Exception\ValidationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -56,7 +57,6 @@ final class ParameterValidatorProvider implements ProviderInterface
                 continue;
             }
 
-            $key = $parameter->getKey();
             $value = $parameter->getValue();
             if ($value instanceof ParameterNotFound) {
                 $value = null;
@@ -87,7 +87,7 @@ final class ParameterValidatorProvider implements ProviderInterface
     }
 
     // There's a `property` inside Parameter but it's used for hydra:search only as here we want the parameter name instead
-    private function getProperty(Parameter $parameter, ConstraintViolation $violation)
+    private function getProperty(Parameter $parameter, ConstraintViolationInterface $violation): string
     {
         $key = $parameter->getKey();
 

--- a/src/Symfony/Validator/State/ParameterValidatorProvider.php
+++ b/src/Symfony/Validator/State/ParameterValidatorProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\Validator\State;
 
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 use ApiPlatform\State\ParameterNotFound;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\Util\ParameterParserTrait;
@@ -68,9 +69,7 @@ final class ParameterValidatorProvider implements ProviderInterface
                     $violation->getMessageTemplate(),
                     $violation->getParameters(),
                     $violation->getRoot(),
-                    $parameter->getProperty() ?? (
-                        str_contains($key, ':property') ? str_replace('[:property]', $violation->getPropertyPath(), $key) : $key.$violation->getPropertyPath()
-                    ),
+                    $this->getProperty($parameter, $violation),
                     $violation->getInvalidValue(),
                     $violation->getPlural(),
                     $violation->getCode(),
@@ -85,5 +84,25 @@ final class ParameterValidatorProvider implements ProviderInterface
         }
 
         return $this->decorated->provide($operation, $uriVariables, $context);
+    }
+
+    // There's a `property` inside Parameter but it's used for hydra:search only as here we want the parameter name instead
+    private function getProperty(Parameter $parameter, ConstraintViolation $violation)
+    {
+        $key = $parameter->getKey();
+
+        if (str_contains($key, '[:property]')) {
+            return str_replace('[:property]', $violation->getPropertyPath(), $key);
+        }
+
+        if (str_contains($key, ':property')) {
+            return str_replace(':property', $violation->getPropertyPath(), $key);
+        }
+
+        if ($p = $violation->getPropertyPath()) {
+            return $p;
+        }
+
+        return $key;
     }
 }

--- a/tests/Fixtures/TestBundle/ApiResource/WithParameter.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WithParameter.php
@@ -27,6 +27,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Parameter\CustomGroupParameterProvider
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[Get(
     uriTemplate: 'with_parameters/{id}{._format}',
@@ -63,6 +64,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
         'array' => new QueryParameter(schema: ['minItems' => 2, 'maxItems' => 3]),
         'multipleOf' => new QueryParameter(schema: ['multipleOf' => 2]),
         'pattern' => new QueryParameter(schema: ['pattern' => '/\d/']),
+        'int' => new QueryParameter(property: 'a', constraints: [new Assert\Type('integer')], provider: [self::class, 'toInt']),
     ],
     provider: [self::class, 'collectionProvider']
 )]
@@ -131,5 +133,25 @@ class WithParameter
         $values = [$parameters->get('q', HeaderParameter::class)->getValue(), $parameters->get('q', QueryParameter::class)->getValue()];
 
         return new JsonResponse($values);
+    }
+
+    public static function toInt(Parameter $parameter, array $parameters = [], array $context = []): ?Operation
+    {
+        if (null === ($operation = $context['operation'] ?? null)) {
+            return null;
+        }
+
+        $value = $parameter->getValue();
+
+        if (is_numeric($value)) {
+            $value = (int) $value;
+        }
+
+        $parameters = $operation->getParameters();
+        $parameters->add($parameter->getKey(), $parameter = $parameter->withExtraProperties(
+            $parameter->getExtraProperties() + ['_api_values' => $value]
+        ));
+
+        return $operation->withParameters($parameters);
     }
 }

--- a/tests/Functional/Parameters/ValidationTest.php
+++ b/tests/Functional/Parameters/ValidationTest.php
@@ -20,7 +20,7 @@ final class ValidationTest extends ApiTestCase
     public function testWithGroupFilter(): void
     {
         $response = self::createClient()->request('GET', 'with_parameters_collection');
-        $this->assertArraySubset(['violations' => [['propertyPath' => 'a', 'message' => 'The parameter "hydra" is required.']]], $response->toArray(false));
+        $this->assertArraySubset(['violations' => [['message' => 'The parameter "hydra" is required.']]], $response->toArray(false));
         $response = self::createClient()->request('GET', 'with_parameters_collection?hydra');
         $this->assertResponseIsSuccessful();
     }
@@ -132,6 +132,14 @@ final class ValidationTest extends ApiTestCase
                     'message' => 'The value you selected is not a valid choice.',
                 ],
             ],
+        ], $response->toArray(false));
+    }
+
+    public function testValidateMessage(): void
+    {
+        $response = self::createClient()->request('GET', 'validate_parameters?int=test');
+        $this->assertArraySubset([
+            'detail' => 'int: This value should be of type integer.',
         ], $response->toArray(false));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4

- `Parameter::getValue()` now takes a default value as argument `getValue(mixed $default = new ParameterNotFound()): mixed`
- `Parametes::get(string $key, string $parameterClass = QueryParameter::class)` (but also `has` and `remove`) now has a default value as second argument to `QueryParameter::class`
- Constraint violation had the wrong message when using `property`, fixed by using the `key` instead: 

```
#[QueryParameter(property: 'id', key: 'int', constraints: [new Assert\Type('integer')], provider: [self::class, 'toInt']))]
```

```diff
-id: This value should be of type integer.
+int: This value should be of type integer.
```

<details>
<summary>See the `toInt` provider.</summary>

```php
    public static function toInt(Parameter $parameter, array $parameters = [], array $context = []): ?Operation
    {
        if (null === ($operation = $context['operation'] ?? null)) {
            return null;
        }

        $value = $parameter->getValue();

        if (is_numeric($value)) {
            $value = (int) $value;
        }

        $parameters = $operation->getParameters();
        $parameters->add($parameter->getKey(), $parameter = $parameter->withExtraProperties(
            $parameter->getExtraProperties() + ['_api_values' => $value]
        ));

        return $operation->withParameters($parameters);
    }
```

</details>

Note that in the future I'd like to introduce "parameter transformers" to do some parameter value transformation. Stay tuned!