### PR TITLE
fix(laravel): restore accidentally removed BooleanFilter

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -429,6 +429,7 @@ class ApiPlatformProvider extends ServiceProvider
         $this->app->bind(OperationMetadataFactoryInterface::class, OperationMetadataFactory::class);
 
         $this->app->tag([
+            BooleanFilter::class,
             EqualsFilter::class,
             PartialSearchFilter::class,
             DateFilter::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `main`
| Tickets       | -
| License       | MIT

The `BooleanFilter` was most certainly deleted by mistake in `Laravel/ApiPlatformProvider.php`, in this [merge commit](https://github.com/api-platform/core/commit/716a43b825f9c569971ac57a889338134959f2e1#diff-1f34d8685c9bbcc2037ef47c41cb6dac916a0fe6fc06e2047b9635e35fa13527L426-R440). 

This is why the CI is failing in the `main` branch:
![image](https://github.com/user-attachments/assets/d9f0d4e1-46d2-4b77-9904-ea1fb606cba7)


I propose a patch to reintroduce it.
