### PR TITLE
feat(doctrine): Added 'exactly' condition to DateFilter

### DIFF
--- a/src/Doctrine/Common/Filter/DateFilterInterface.php
+++ b/src/Doctrine/Common/Filter/DateFilterInterface.php
@@ -24,6 +24,7 @@ interface DateFilterInterface
 {
     public const PARAMETER_BEFORE = 'before';
     public const PARAMETER_STRICTLY_BEFORE = 'strictly_before';
+    public const PARAMETER_EXACTLY = 'exactly';
     public const PARAMETER_AFTER = 'after';
     public const PARAMETER_STRICTLY_AFTER = 'strictly_after';
     public const EXCLUDE_NULL = 'exclude_null';

--- a/src/Doctrine/Common/Filter/DateFilterTrait.php
+++ b/src/Doctrine/Common/Filter/DateFilterTrait.php
@@ -44,8 +44,9 @@ trait DateFilterTrait
                 continue;
             }
 
-            $description += $this->getFilterDescription($property, self::PARAMETER_BEFORE);
             $description += $this->getFilterDescription($property, self::PARAMETER_STRICTLY_BEFORE);
+            $description += $this->getFilterDescription($property, self::PARAMETER_BEFORE);
+            $description += $this->getFilterDescription($property, self::PARAMETER_EXACTLY);
             $description += $this->getFilterDescription($property, self::PARAMETER_AFTER);
             $description += $this->getFilterDescription($property, self::PARAMETER_STRICTLY_AFTER);
         }

--- a/src/Doctrine/Odm/Filter/DateFilter.php
+++ b/src/Doctrine/Odm/Filter/DateFilter.php
@@ -28,7 +28,7 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
 /**
  * The date filter allows to filter a collection by date intervals.
  *
- * Syntax: `?property[<after|before|strictly_after|strictly_before>]=value`.
+ * Syntax: `?property[<strictly_before|before|exactly|after|strictly_after>]=value`.
  *
  * The value can take any date format supported by the [`\DateTime` constructor](https://www.php.net/manual/en/datetime.construct.php).
  *
@@ -158,6 +158,16 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
             $aggregationBuilder->match()->field($matchField)->notEqual(null);
         }
 
+        if (isset($value[self::PARAMETER_STRICTLY_BEFORE])) {
+            $this->addMatch(
+                $aggregationBuilder,
+                $matchField,
+                self::PARAMETER_STRICTLY_BEFORE,
+                $value[self::PARAMETER_STRICTLY_BEFORE],
+                $nullManagement
+            );
+        }
+
         if (isset($value[self::PARAMETER_BEFORE])) {
             $this->addMatch(
                 $aggregationBuilder,
@@ -168,12 +178,12 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
             );
         }
 
-        if (isset($value[self::PARAMETER_STRICTLY_BEFORE])) {
+        if (isset($value[self::PARAMETER_EXACTLY])) {
             $this->addMatch(
                 $aggregationBuilder,
                 $matchField,
-                self::PARAMETER_STRICTLY_BEFORE,
-                $value[self::PARAMETER_STRICTLY_BEFORE],
+                self::PARAMETER_EXACTLY,
+                $value[self::PARAMETER_EXACTLY],
                 $nullManagement
             );
         }
@@ -222,8 +232,9 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
         }
 
         $operatorValue = [
-            self::PARAMETER_BEFORE => '$lte',
             self::PARAMETER_STRICTLY_BEFORE => '$lt',
+            self::PARAMETER_BEFORE => '$lte',
+            self::PARAMETER_EXACTLY => '$eq',
             self::PARAMETER_AFTER => '$gte',
             self::PARAMETER_STRICTLY_AFTER => '$gt',
         ];
@@ -257,10 +268,11 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
         $key = $parameter->getKey();
 
         return [
-            new OpenApiParameter(name: $key.'[after]', in: $in),
-            new OpenApiParameter(name: $key.'[before]', in: $in),
-            new OpenApiParameter(name: $key.'[strictly_after]', in: $in),
             new OpenApiParameter(name: $key.'[strictly_before]', in: $in),
+            new OpenApiParameter(name: $key.'[before]', in: $in),
+            new OpenApiParameter(name: $key.'[exactly]', in: $in),
+            new OpenApiParameter(name: $key.'[after]', in: $in),
+            new OpenApiParameter(name: $key.'[strictly_after]', in: $in),
         ];
     }
 }

--- a/src/Doctrine/Odm/Tests/Filter/DateFilterTestTrait.php
+++ b/src/Doctrine/Odm/Tests/Filter/DateFilterTestTrait.php
@@ -24,12 +24,17 @@ trait DateFilterTestTrait
         $filter = $this->buildFilter();
 
         $this->assertEquals([
+            'dummyDate[strictly_before]' => [
+                'property' => 'dummyDate',
+                'type' => \DateTimeInterface::class,
+                'required' => false,
+            ],
             'dummyDate[before]' => [
                 'property' => 'dummyDate',
                 'type' => \DateTimeInterface::class,
                 'required' => false,
             ],
-            'dummyDate[strictly_before]' => [
+            'dummyDate[exactly]' => [
                 'property' => 'dummyDate',
                 'type' => \DateTimeInterface::class,
                 'required' => false,

--- a/src/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Doctrine/Orm/Filter/DateFilter.php
@@ -31,7 +31,7 @@ use Doctrine\ORM\QueryBuilder;
 /**
  * The date filter allows to filter a collection by date intervals.
  *
- * Syntax: `?property[<after|before|strictly_after|strictly_before>]=value`.
+ * Syntax: `?property[<strictly_before|before|exactly|after|strictly_after|>]=value`.
  *
  * The value can take any date format supported by the [`\DateTime` constructor](https://www.php.net/manual/en/datetime.construct.php).
  *
@@ -169,6 +169,19 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
             $queryBuilder->andWhere($queryBuilder->expr()->isNotNull(\sprintf('%s.%s', $alias, $field)));
         }
 
+        if (isset($value[self::PARAMETER_STRICTLY_BEFORE])) {
+            $this->addWhere(
+                $queryBuilder,
+                $queryNameGenerator,
+                $alias,
+                $field,
+                self::PARAMETER_STRICTLY_BEFORE,
+                $value[self::PARAMETER_STRICTLY_BEFORE],
+                $nullManagement,
+                $type
+            );
+        }
+
         if (isset($value[self::PARAMETER_BEFORE])) {
             $this->addWhere(
                 $queryBuilder,
@@ -182,14 +195,14 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
             );
         }
 
-        if (isset($value[self::PARAMETER_STRICTLY_BEFORE])) {
+        if (isset($value[self::PARAMETER_EXACTLY])) {
             $this->addWhere(
                 $queryBuilder,
                 $queryNameGenerator,
                 $alias,
                 $field,
-                self::PARAMETER_STRICTLY_BEFORE,
-                $value[self::PARAMETER_STRICTLY_BEFORE],
+                self::PARAMETER_EXACTLY,
+                $value[self::PARAMETER_EXACTLY],
                 $nullManagement,
                 $type
             );
@@ -247,8 +260,9 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
 
         $valueParameter = $queryNameGenerator->generateParameterName($field);
         $operatorValue = [
-            self::PARAMETER_BEFORE => '<=',
             self::PARAMETER_STRICTLY_BEFORE => '<',
+            self::PARAMETER_BEFORE => '<=',
+            self::PARAMETER_EXACTLY => '=',
             self::PARAMETER_AFTER => '>=',
             self::PARAMETER_STRICTLY_AFTER => '>',
         ];
@@ -289,10 +303,11 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
         $key = $parameter->getKey();
 
         return [
-            new OpenApiParameter(name: $key.'[after]', in: $in),
-            new OpenApiParameter(name: $key.'[before]', in: $in),
-            new OpenApiParameter(name: $key.'[strictly_after]', in: $in),
             new OpenApiParameter(name: $key.'[strictly_before]', in: $in),
+            new OpenApiParameter(name: $key.'[before]', in: $in),
+            new OpenApiParameter(name: $key.'[exactly]', in: $in),
+            new OpenApiParameter(name: $key.'[after]', in: $in),
+            new OpenApiParameter(name: $key.'[strictly_after]', in: $in),
         ];
     }
 }

--- a/src/Doctrine/Orm/Tests/Filter/DateFilterTestTrait.php
+++ b/src/Doctrine/Orm/Tests/Filter/DateFilterTestTrait.php
@@ -24,12 +24,17 @@ trait DateFilterTestTrait
         $filter = $this->buildFilter();
 
         $this->assertEquals([
+            'dummyDate[strictly_before]' => [
+                'property' => 'dummyDate',
+                'type' => \DateTimeInterface::class,
+                'required' => false,
+            ],
             'dummyDate[before]' => [
                 'property' => 'dummyDate',
                 'type' => \DateTimeInterface::class,
                 'required' => false,
             ],
-            'dummyDate[strictly_before]' => [
+            'dummyDate[exactly]' => [
                 'property' => 'dummyDate',
                 'type' => \DateTimeInterface::class,
                 'required' => false,

--- a/tests/Functional/Parameters/DoctrineTest.php
+++ b/tests/Functional/Parameters/DoctrineTest.php
@@ -47,7 +47,7 @@ final class DoctrineTest extends ApiTestCase
         $this->assertEquals('bar', $a['hydra:member'][1]['foo']);
 
         $this->assertArraySubset(['hydra:search' => [
-            'hydra:template' => \sprintf('/%s{?foo,fooAlias,order[order[id]],order[order[foo]],searchPartial[foo],searchExact[foo],searchOnTextAndDate[foo],searchOnTextAndDate[createdAt][before],searchOnTextAndDate[createdAt][strictly_before],searchOnTextAndDate[createdAt][after],searchOnTextAndDate[createdAt][strictly_after],q,id,createdAt}', $route),
+            'hydra:template' => \sprintf('/%s{?foo,fooAlias,order[order[id]],order[order[foo]],searchPartial[foo],searchExact[foo],searchOnTextAndDate[foo],searchOnTextAndDate[createdAt][strictly_before],searchOnTextAndDate[createdAt][before],searchOnTextAndDate[createdAt][exactly],searchOnTextAndDate[createdAt][after],searchOnTextAndDate[createdAt][strictly_after],q,id,createdAt}', $route),
         ]], $a);
 
         $this->assertArraySubset(['@type' => 'IriTemplateMapping', 'variable' => 'fooAlias', 'property' => 'foo'], $a['hydra:search']['hydra:mapping'][1]);
@@ -71,6 +71,11 @@ final class DoctrineTest extends ApiTestCase
         $members = $response->toArray()['hydra:member'];
         $this->assertCount(1, $members);
         $this->assertArraySubset(['foo' => 'bar', 'createdAt' => '2024-01-21T00:00:00+00:00'], $members[0]);
+
+        $response = self::createClient()->request('GET', $route.'?searchOnTextAndDate[createdAt][exactly]=2024-01-22');
+        $members = $response->toArray()['hydra:member'];
+        $this->assertCount(1, $members);
+        $this->assertArraySubset(['foo' => 'bar', 'createdAt' => '2024-01-22T00:00:00+00:00'], $members[0]);
     }
 
     public function testGraphQl(): void
@@ -134,7 +139,7 @@ final class DoctrineTest extends ApiTestCase
         $manager->flush();
         $response = self::createClient()->request('GET', 'filter_with_state_options?date[before]='.$d->format('Y-m-d'));
         $a = $response->toArray();
-        $this->assertEquals('/filter_with_state_options{?date[before],date[strictly_before],date[after],date[strictly_after]}', $a['hydra:search']['hydra:template']);
+        $this->assertEquals('/filter_with_state_options{?date[strictly_before],date[before],date[exactly],date[after],date[strictly_after]}', $a['hydra:search']['hydra:template']);
         $this->assertCount(1, $a['hydra:member']);
         $this->assertEquals('current', $a['hydra:member'][0]['name']);
         $response = self::createClient()->request('GET', 'filter_with_state_options?date[strictly_after]='.$d->format('Y-m-d'));


### PR DESCRIPTION
fixes: #6114

| Q             | A
| ------------- | ---
| Branch       | main
| Tickets       | Closes #6114
| License       | MIT
| Doc PR        | N/A

- added an `exacly` condition to `DateFilter`. I had a doubt between `exact` and `exactly`, but I find the second more pertinent.
- reordered conditions in chronological order : `strictly_before`, `before`, `exactly`, `after`, `strictly_after`.

