### PR TITLE
fix(symfony): suggest `DocumentationAction` as replacement for deprecated `SwaggerUiAction`

### DIFF
--- a/src/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
+++ b/src/Symfony/Bundle/SwaggerUi/SwaggerUiAction.php
@@ -26,7 +26,7 @@ use Twig\Environment as TwigEnvironment;
 /**
  * Displays the swaggerui interface.
  *
- * @deprecated use ApiPlatform\Symfony\Bundle\SwaggerUi\Processor instead
+ * @deprecated use ApiPlatform\Symfony\Action\DocumentationAction instead
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The original deprecation was introduced at [#5657](https://github.com/api-platform/core/commit/afb739b392d337159f6475f7c3144cbac74b1067#diff-10997c2eea998f54ae8b684cf439f54183156dd825abc92dfd68cb37cc63e399R30) and initially released under the [v3.2.0-alpha.1
](https://github.com/api-platform/core/releases/tag/v3.2.0-alpha.1) tag.
Then, the release [3.3.0](https://github.com/api-platform/core/blob/3b8a0068beb23acbf7a9a0da19e4b9638bf883e4/src/Symfony/Action/DocumentationAction.php#L37) introduced the `DocumentationAction` class, which IMO is a much natural replacement for the deprecated class.

Additionally, the referenced class (`ApiPlatform\Symfony\Bundle\SwaggerUi\Processor`) in the deprecation message does not exist. Maybe the intention was to reference `ApiPlatform\Symfony\Bundle\SwaggerUi\SwaggerUiProcessor`.

<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
