### PR TITLE
fix: Missing interface in `Handle doctrine links` guide

### DIFF
--- a/docs/guides/handle-links.php
+++ b/docs/guides/handle-links.php
@@ -19,6 +19,8 @@ namespace App\Entity {
     use ApiPlatform\Metadata\Link;
     use Doctrine\ORM\Mapping as ORM;
     use Doctrine\ORM\QueryBuilder;
+    // Change the namespace depending on whether you're using Doctrine ORM, Doctrine ODM or Eloquent.
+    use ApiPlatform\Doctrine\Orm\State\LinksHandlerInterface;
 
     // To get around that, you can hook into the link management with an [ORM StateOption](/docs/reference/Doctrine/Orm/State/Options/)
     #[GetCollection(
@@ -29,7 +31,7 @@ namespace App\Entity {
     )]
     #[Get('/company/{companyId}/employees/{id}')]
     #[ORM\Entity]
-    class Employee
+    class Employee implements LinksHandlerInterface
     {
         #[ORM\Id, ORM\Column, ORM\GeneratedValue]
         public ?int $id;

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -429,6 +429,7 @@ class ApiPlatformProvider extends ServiceProvider
         $this->app->bind(OperationMetadataFactoryInterface::class, OperationMetadataFactory::class);
 
         $this->app->tag([
+            BooleanFilter::class,
             EqualsFilter::class,
             PartialSearchFilter::class,
             DateFilter::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Closes https://github.com/api-platform/docs/issues/2121
| License       | MIT
| Doc PR        | 

In the documentation it's written:

> The handleLinks option takes a service name implementing the [LinksHandlerInterface](https://api-platform.com/docs/guides/handle-links/) or a callable.

I don't know if it's intended but the `Employee` entity does not implement this interface. I saw that the interface namespace was not the same depending on if we're using Doctrine ODM, Doctrine ORM or Eloquent but I think it must be written somewhere. Otherwise developers will not be notified if the interface change over time.