### PR TITLE
Allow phpstan/phpdoc-parser 2 (which in turns allow PHPstan 2, Larastan 3) for api-platform/laravel

### DIFF
--- a/src/Laravel/Eloquent/Filter/DateFilter.php
+++ b/src/Laravel/Eloquent/Filter/DateFilter.php
@@ -84,7 +84,10 @@ final class DateFilter implements FilterInterface, JsonSchemaFilterInterface, Op
         return ['type' => 'date'];
     }
 
-    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
+    /**
+     * @return OpenApiParameter[]
+     */
+    public function getOpenApiParameters(Parameter $parameter): array
     {
         $in = $parameter instanceof QueryParameter ? 'query' : 'header';
         $key = $parameter->getKey();

--- a/src/Laravel/Eloquent/Filter/OrFilter.php
+++ b/src/Laravel/Eloquent/Filter/OrFilter.php
@@ -49,7 +49,7 @@ final readonly class OrFilter implements FilterInterface, JsonSchemaFilterInterf
         return ['type' => 'array', 'items' => $schema];
     }
 
-    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
+    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter
     {
         return new OpenApiParameter(name: $parameter->getKey().'[]', in: 'query', style: 'deepObject', explode: true);
     }

--- a/src/Laravel/Eloquent/Filter/OrderFilter.php
+++ b/src/Laravel/Eloquent/Filter/OrderFilter.php
@@ -54,7 +54,10 @@ final class OrderFilter implements FilterInterface, JsonSchemaFilterInterface, O
         return ['type' => 'string', 'enum' => ['asc', 'desc']];
     }
 
-    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
+    /**
+     * @return OpenApiParameter[]|null
+     */
+    public function getOpenApiParameters(Parameter $parameter): ?array
     {
         if (str_contains($parameter->getKey(), ':property')) {
             $parameters = [];

--- a/src/Laravel/Eloquent/Filter/RangeFilter.php
+++ b/src/Laravel/Eloquent/Filter/RangeFilter.php
@@ -52,7 +52,10 @@ final class RangeFilter implements FilterInterface, JsonSchemaFilterInterface, O
         return ['type' => 'number'];
     }
 
-    public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
+    /**
+     * @return OpenApiParameter[]
+     */
+    public function getOpenApiParameters(Parameter $parameter): array
     {
         $in = $parameter instanceof QueryParameter ? 'query' : 'header';
         $key = $parameter->getKey();

--- a/src/Laravel/Eloquent/Paginator.php
+++ b/src/Laravel/Eloquent/Paginator.php
@@ -34,7 +34,7 @@ final class Paginator implements PaginatorInterface, HasNextPagePaginatorInterfa
 
     public function count(): int
     {
-        return $this->paginator->count();
+        return $this->paginator->count(); // @phpstan-ignore-line
     }
 
     public function getLastPage(): float

--- a/src/Laravel/Eloquent/PartialPaginator.php
+++ b/src/Laravel/Eloquent/PartialPaginator.php
@@ -33,7 +33,7 @@ final class PartialPaginator implements PartialPaginatorInterface, \IteratorAggr
 
     public function count(): int
     {
-        return $this->paginator->count();
+        return $this->paginator->count(); // @phpstan-ignore-line
     }
 
     public function getCurrentPage(): float

--- a/src/Laravel/Routing/IriConverter.php
+++ b/src/Laravel/Routing/IriConverter.php
@@ -159,7 +159,7 @@ class IriConverter implements IriConverterInterface
         if (\is_object($resource)) {
             try {
                 $identifiers = $this->identifiersExtractor->getIdentifiersFromItem($resource, $identifiersExtractorOperation, $context);
-            } catch (InvalidArgumentException|RuntimeException $e) {
+            } catch (RuntimeException $e) {
                 // We can try using context uri variables if any
                 if (!$identifiers) {
                     throw new InvalidArgumentException(\sprintf('Unable to generate an IRI for the item of type "%s"', $operation->getClass()), $e->getCode(), $e);

--- a/src/Laravel/Routing/SkolemIriConverter.php
+++ b/src/Laravel/Routing/SkolemIriConverter.php
@@ -53,7 +53,7 @@ final class SkolemIriConverter implements IriConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function getIriFromResource(object|string $resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): ?string
+    public function getIriFromResource(object|string $resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): string
     {
         $referenceType = $operation ? ($operation->getUrlGenerationStrategy() ?? $referenceType) : $referenceType;
         if (($isObject = \is_object($resource)) && $this->objectHashMap->contains($resource)) {

--- a/src/Laravel/Tests/Console/Maker/MakeStateProcessorCommandTest.php
+++ b/src/Laravel/Tests/Console/Maker/MakeStateProcessorCommandTest.php
@@ -30,7 +30,7 @@ class MakeStateProcessorCommandTest extends TestCase
     /** @var string */
     private const CHOSEN_CLASS_NAME = 'Choose a class name for your state processor (e.g. <fg=yellow>AwesomeStateProcessor</>)';
 
-    private ?Filesystem $filesystem;
+    private Filesystem $filesystem;
     private PathResolver $pathResolver;
     private AppServiceFileGenerator $appServiceFileGenerator;
 

--- a/src/Laravel/Tests/Console/Maker/MakeStateProviderCommandTest.php
+++ b/src/Laravel/Tests/Console/Maker/MakeStateProviderCommandTest.php
@@ -30,7 +30,7 @@ class MakeStateProviderCommandTest extends TestCase
     /** @var string */
     private const STATE_PROVIDER_CLASS_NAME = 'Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)';
 
-    private ?Filesystem $filesystem;
+    private Filesystem $filesystem;
     private PathResolver $pathResolver;
     private AppServiceFileGenerator $appServiceFileGenerator;
 

--- a/src/Laravel/composer.json
+++ b/src/Laravel/composer.json
@@ -49,12 +49,12 @@
         "illuminate/container": "^11.0",
         "symfony/web-link": "^6.4 || ^7.1",
         "willdurand/negotiation": "^3.1",
-        "phpstan/phpdoc-parser": "^1.29",
+        "phpstan/phpdoc-parser": "^1.29 || ^2.0",
         "phpdocumentor/reflection-docblock": "^5.1"
     },
     "require-dev": {
         "doctrine/dbal": "^4.0",
-        "larastan/larastan": "^2.0",
+        "larastan/larastan": "^2.0 || ^3.0",
         "orchestra/testbench": "^9.1",
         "phpunit/phpunit": "^11.2",
         "api-platform/graphql": "^4.0",


### PR DESCRIPTION
Hi,

I'm trying to install `api-platform/laravel` on a codebase with larastan 3 which failed as it throw error saying phpstan/phpdoc-parser must be at least 2.0. So I edited composer.json to allow 2.0 too

Then i also allow larastan 3.0 since phpstan/phpdoc-parser 2.0 require phpstan 2.0 (larastan 3.x use phpstan 2.x, larastan 3.x use phpstan 1.x)