### PR TITLE
fix(state): skip Content-Location header for GET requests

### DIFF
--- a/features/hydra/collection.feature
+++ b/features/hydra/collection.feature
@@ -77,7 +77,6 @@ Feature: Collections support
     When I send a "GET" request to "/dummies?page=7"
     Then the response status code should be 200
     And the response should be in JSON
-    And the header "Content-Location" should be equal to "/dummies.jsonld?page=7"
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON should be valid according to this schema:
     """

--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -60,6 +60,7 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {

--- a/features/main/crud.feature
+++ b/features/main/crud.feature
@@ -101,13 +101,14 @@ Feature: Create-Retrieve-Update-Delete
   Scenario: Get a not found exception
     When I send a "GET" request to "/dummies/42"
     Then the response status code should be 404
+    And the header "Content-Location" should not exist
 
   Scenario: Get a collection
     When I send a "GET" request to "/dummies"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
-    And the header "Content-Location" should be equal to "/dummies.jsonld"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -617,6 +618,7 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
       {
@@ -641,6 +643,7 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
       {
@@ -658,6 +661,7 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -677,6 +681,7 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -719,6 +724,7 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -738,6 +744,7 @@ Feature: Create-Retrieve-Update-Delete
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {

--- a/features/main/crud_abstract.feature
+++ b/features/main/crud_abstract.feature
@@ -35,6 +35,7 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -52,6 +53,7 @@ Feature: Create-Retrieve-Update-Delete on abstract resource
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be valid according to this schema:
     """
     {

--- a/features/main/crud_uri_variables.feature
+++ b/features/main/crud_uri_variables.feature
@@ -96,6 +96,7 @@ Feature: Uri Variables
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -164,6 +165,7 @@ Feature: Uri Variables
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -183,6 +185,7 @@ Feature: Uri Variables
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
+    And the header "Content-Location" should not exist
     And the JSON should be equal to:
     """
     {
@@ -200,3 +203,4 @@ Feature: Uri Variables
     When I add "Content-Type" header equal to "application/ld+json"
     And I send a "GET" request to "/companies/1/employees/2"
     Then the response status code should be 404
+    And the header "Content-Location" should not exist

--- a/src/State/Processor/RespondProcessor.php
+++ b/src/State/Processor/RespondProcessor.php
@@ -129,7 +129,7 @@ final class RespondProcessor implements ProcessorInterface
                     $iri = $this->iriConverter->getIriFromResource($operation->getClass(), UrlGeneratorInterface::ABS_PATH, $operation);
                 }
 
-                if ($iri) {
+                if ($iri && 'GET' !== $method) {
                     $location = \sprintf('%s.%s', $iri, $request->getRequestFormat());
                     if (isset($requestParts['query'])) {
                         $location .= '?'.$requestParts['query'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `4.0`
| Tickets       | Closes #6750
| License       | MIT

Eliminates the unnecessary `Content-Location` header from GET responses to prevent potential issues, such as with temporary or preview resources lacking an ID. 

While compliant with RFC 9110, this header is redundant and not required. For more details, refer to #6750.