### PR TITLE
fix(symfony): fix property restrictions for root resource with dynamic validation groups

### DIFF
--- a/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
+++ b/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
@@ -151,7 +151,10 @@ final class ValidatorPropertyMetadataFactory implements PropertyMetadataFactoryI
      */
     private function getValidationGroups(ValidatorClassMetadataInterface $classMetadata, array $options): array
     {
-        if (isset($options['validation_groups'])) {
+        if (
+            isset($options['validation_groups'])
+            || !is_callable($options['validation_groups'])
+        ) {
             return $options['validation_groups'];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

```php
#[ApiResource(
    validationContext: [
        'groups' => [self::class, 'getValidationGroups'],
    ],
)]
class Foo
```
If root resource has dynamic validation groups - validation groups for it in `ValidatorPropertyMetadataFactory` are evaluated as plain array `['\App\Entity\Fee', 'getValidationGroups']` and as a result no constraint is found for these validation groups.