### PR TITLE
fix(symfony): fix property restrictions for root resource with dynamic validation groups

### DIFF
--- a/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
+++ b/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
@@ -151,7 +151,10 @@ final class ValidatorPropertyMetadataFactory implements PropertyMetadataFactoryI
      */
     private function getValidationGroups(ValidatorClassMetadataInterface $classMetadata, array $options): array
     {
-        if (isset($options['validation_groups'])) {
+        if (
+            isset($options['validation_groups'])
+            && !\is_callable($options['validation_groups'])
+        ) {
             return $options['validation_groups'];
         }
 

--- a/tests/Fixtures/DummyValidatedEntity.php
+++ b/tests/Fixtures/DummyValidatedEntity.php
@@ -77,4 +77,12 @@ class DummyValidatedEntity
      */
     #[Assert\Url]
     public $dummyUrl;
+
+    /**
+     * @return string[]
+     */
+    public static function getValidationGroups(): array
+    {
+        return ['dummy'];
+    }
 }

--- a/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/tests/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -272,8 +272,8 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
 
         $validatorMetadataFactory = $this->prophesize(MetadataFactoryInterface::class);
         $validatorMetadataFactory->getMetadataFor(DummyValidatedEntity::class)
-                                 ->willReturn($validatorClassMetadata)
-                                 ->shouldBeCalled();
+            ->willReturn($validatorClassMetadata)
+            ->shouldBeCalled();
 
         $decoratedPropertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $property = 'dummy';
@@ -283,7 +283,9 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
 
         $lengthRestrictions = new PropertySchemaLengthRestriction();
         $validatorPropertyMetadataFactory = new ValidatorPropertyMetadataFactory(
-            $validatorMetadataFactory->reveal(), $decoratedPropertyMetadataFactory->reveal(), [$lengthRestrictions]
+            $validatorMetadataFactory->reveal(),
+            $decoratedPropertyMetadataFactory->reveal(),
+            [$lengthRestrictions]
         );
 
         $schema = $validatorPropertyMetadataFactory->create(DummyValidatedEntity::class, $property)->getSchema();
@@ -299,8 +301,8 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
 
         $validatorMetadataFactory = $this->prophesize(MetadataFactoryInterface::class);
         $validatorMetadataFactory->getMetadataFor(DummyValidatedEntity::class)
-                                 ->willReturn($validatorClassMetadata)
-                                 ->shouldBeCalled();
+            ->willReturn($validatorClassMetadata)
+            ->shouldBeCalled();
 
         $decoratedPropertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $decoratedPropertyMetadataFactory->create(DummyValidatedEntity::class, 'dummy', [])->willReturn(
@@ -308,7 +310,8 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         )->shouldBeCalled();
 
         $validationPropertyMetadataFactory = new ValidatorPropertyMetadataFactory(
-            $validatorMetadataFactory->reveal(), $decoratedPropertyMetadataFactory->reveal(),
+            $validatorMetadataFactory->reveal(),
+            $decoratedPropertyMetadataFactory->reveal(),
             [new PropertySchemaRegexRestriction()]
         );
 
@@ -326,8 +329,8 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
 
         $validatorMetadataFactory = $this->prophesize(MetadataFactoryInterface::class);
         $validatorMetadataFactory->getMetadataFor($class)
-                                 ->willReturn($validatorClassMetadata)
-                                 ->shouldBeCalled();
+            ->willReturn($validatorClassMetadata)
+            ->shouldBeCalled();
 
         $decoratedPropertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $decoratedPropertyMetadataFactory->create($class, $property, [])->willReturn(
@@ -521,7 +524,8 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         )->shouldBeCalled();
 
         $validationPropertyMetadataFactory = new ValidatorPropertyMetadataFactory(
-            $validatorMetadataFactory->reveal(), $decoratedPropertyMetadataFactory->reveal(),
+            $validatorMetadataFactory->reveal(),
+            $decoratedPropertyMetadataFactory->reveal(),
             [new PropertySchemaChoiceRestriction()]
         );
 
@@ -558,7 +562,8 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         )->shouldBeCalled();
 
         $validationPropertyMetadataFactory = new ValidatorPropertyMetadataFactory(
-            $validatorMetadataFactory->reveal(), $decoratedPropertyMetadataFactory->reveal(),
+            $validatorMetadataFactory->reveal(),
+            $decoratedPropertyMetadataFactory->reveal(),
             [new PropertySchemaCountRestriction()]
         );
 
@@ -660,7 +665,8 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         )->shouldBeCalled();
 
         $validationPropertyMetadataFactory = new ValidatorPropertyMetadataFactory(
-            $validatorMetadataFactory->reveal(), $decoratedPropertyMetadataFactory->reveal(),
+            $validatorMetadataFactory->reveal(),
+            $decoratedPropertyMetadataFactory->reveal(),
             [
                 new PropertySchemaGreaterThanOrEqualRestriction(),
                 new PropertySchemaGreaterThanRestriction(),
@@ -723,5 +729,23 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
             'property' => 'negativeOrZero',
             'expectedSchema' => ['maximum' => 0],
         ];
+    }
+
+    public function testCallableGroup(): void
+    {
+        $propertyMetadata = (new ApiProperty())->withDescription('A dummy group')->withReadable(true)->withWritable(true);
+
+        $decoratedPropertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $decoratedPropertyMetadataFactory->create(DummyValidatedEntity::class, 'dummyGroup', ['validation_groups' => [DummyValidatedEntity::class, 'getValidationGroups']])->willReturn($propertyMetadata)->shouldBeCalled();
+
+        $validatorMetadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $validatorMetadataFactory->getMetadataFor(DummyValidatedEntity::class)->willReturn($this->validatorClassMetadata)->shouldBeCalled();
+
+        $validatorPropertyMetadataFactory = new ValidatorPropertyMetadataFactory(
+            $validatorMetadataFactory->reveal(),
+            $decoratedPropertyMetadataFactory->reveal(),
+            []
+        );
+        $validatorPropertyMetadataFactory->create(DummyValidatedEntity::class, 'dummyGroup', ['validation_groups' => [DummyValidatedEntity::class, 'getValidationGroups']]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0 <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
```php
#[ApiResource(
    validationContext: [
        'groups' => [self::class, 'getValidationGroups'],
    ],
)]
class Foo
```
If root resource has dynamic validation groups - validation groups for it in `ValidatorPropertyMetadataFactory` are evaluated as plain array `['\App\Entity\Fee', 'getValidationGroups']` and as a result no constraint is found for these validation groups.