### PR TITLE
fix(openapi): typing issue with `openapiContext` in `#[ApiProperty]`

### DIFF
--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -106,7 +106,7 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
         // never override the following keys if at least one is already set or if there's a custom openapi context
         if ([] === $types
             || ($propertySchema['type'] ?? $propertySchema['$ref'] ?? $propertySchema['anyOf'] ?? $propertySchema['allOf'] ?? $propertySchema['oneOf'] ?? false)
-            || (array_key_exists('type', $propertyMetadata->getOpenapiContext() ?? []))
+            || \array_key_exists('type', $propertyMetadata->getOpenapiContext() ?? [])
         ) {
             return $propertyMetadata->withSchema($propertySchema);
         }

--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -106,7 +106,7 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
         // never override the following keys if at least one is already set or if there's a custom openapi context
         if ([] === $types
             || ($propertySchema['type'] ?? $propertySchema['$ref'] ?? $propertySchema['anyOf'] ?? $propertySchema['allOf'] ?? $propertySchema['oneOf'] ?? false)
-            || ($propertyMetadata->getOpenapiContext() ?? false)
+            || (array_key_exists('type', $propertyMetadata->getOpenapiContext() ?? []))
         ) {
             return $propertyMetadata->withSchema($propertySchema);
         }

--- a/src/JsonSchema/Tests/Fixtures/DummyWithCustomOpenApiContext.php
+++ b/src/JsonSchema/Tests/Fixtures/DummyWithCustomOpenApiContext.php
@@ -30,4 +30,10 @@ class DummyWithCustomOpenApiContext
 {
     #[ApiProperty(openapiContext: ['type' => 'object', 'properties' => ['alpha' => ['type' => 'integer']]])]
     public $acme;
+
+    #[ApiProperty(openapiContext: ['description' => 'My description'])]
+    public bool $foo;
+
+    #[ApiProperty(openapiContext: ['iris' => 'https://schema.org/Date'])]
+    public \DateTimeImmutable $bar;
 }


### PR DESCRIPTION
When specify an `openapiContext` in #`[ApiProperty]`, the typing of the same property is no longer used, and force to explicitly specify it within the `openapiContext` array.

| Q             | A
| ------------- | ---
| Branch       | 3.4
| Tickets       | Closes https://github.com/api-platform/core/issues/6893 
| License       | MIT