### PR TITLE
fix(openapi): document error outputs using json-schemas

### DIFF
--- a/src/JsonSchema/ResourceMetadataTrait.php
+++ b/src/JsonSchema/ResourceMetadataTrait.php
@@ -36,7 +36,7 @@ trait ResourceMetadataTrait
         return $forceSubschema ? ($inputOrOutput['class'] ?? $inputOrOutput->class ?? $operation->getClass()) : ($inputOrOutput['class'] ?? $inputOrOutput->class ?? null);
     }
 
-    private function findOperation(string $className, string $type, ?Operation $operation, ?array $serializerContext): Operation
+    private function findOperation(string $className, string $type, ?Operation $operation, ?array $serializerContext, ?string $format = null): Operation
     {
         if (null === $operation) {
             if (null === $this->resourceMetadataFactory) {
@@ -54,7 +54,7 @@ trait ResourceMetadataTrait
                 $operation = new HttpOperation();
             }
 
-            return $this->findOperationForType($resourceMetadataCollection, $type, $operation);
+            return $this->findOperationForType($resourceMetadataCollection, $type, $operation, $format);
         }
 
         // The best here is to use an Operation when calling `buildSchema`, we try to do a smart guess otherwise
@@ -65,13 +65,13 @@ trait ResourceMetadataTrait
                 return $resourceMetadataCollection->getOperation($operation->getName());
             }
 
-            return $this->findOperationForType($resourceMetadataCollection, $type, $operation);
+            return $this->findOperationForType($resourceMetadataCollection, $type, $operation, $format);
         }
 
         return $operation;
     }
 
-    private function findOperationForType(ResourceMetadataCollection $resourceMetadataCollection, string $type, Operation $operation): Operation
+    private function findOperationForType(ResourceMetadataCollection $resourceMetadataCollection, string $type, Operation $operation, ?string $format = null): Operation
     {
         // Find the operation and use the first one that matches criterias
         foreach ($resourceMetadataCollection as $resourceMetadata) {
@@ -82,6 +82,11 @@ trait ResourceMetadataTrait
                 }
 
                 if (Schema::TYPE_INPUT === $type && \in_array($op->getMethod(), ['POST', 'PATCH', 'PUT'], true)) {
+                    $operation = $op;
+                    break 2;
+                }
+
+                if ($format && Schema::TYPE_OUTPUT === $type && \array_key_exists($format, $op->getOutputFormats() ?? [])) {
                     $operation = $op;
                     break 2;
                 }

--- a/src/Laravel/Eloquent/Metadata/Factory/Property/EloquentPropertyMetadataFactory.php
+++ b/src/Laravel/Eloquent/Metadata/Factory/Property/EloquentPropertyMetadataFactory.php
@@ -46,6 +46,10 @@ final class EloquentPropertyMetadataFactory implements PropertyMetadataFactoryIn
      */
     public function create(string $resourceClass, string $property, array $options = []): ApiProperty
     {
+        if (!is_a($resourceClass, Model::class, true)) {
+            return $this->decorated?->create($resourceClass, $property, $options) ?? new ApiProperty();
+        }
+
         try {
             $refl = new \ReflectionClass($resourceClass);
             $model = $refl->newInstanceWithoutConstructor();

--- a/src/Metadata/ApiProperty.php
+++ b/src/Metadata/ApiProperty.php
@@ -231,7 +231,7 @@ final class ApiProperty
         return $this->property;
     }
 
-    public function withProperty(string $property): self
+    public function withProperty(string $property): static
     {
         $self = clone $this;
         $self->property = $property;
@@ -244,7 +244,7 @@ final class ApiProperty
         return $this->description;
     }
 
-    public function withDescription(string $description): self
+    public function withDescription(string $description): static
     {
         $self = clone $this;
         $self->description = $description;
@@ -257,7 +257,7 @@ final class ApiProperty
         return $this->readable;
     }
 
-    public function withReadable(bool $readable): self
+    public function withReadable(bool $readable): static
     {
         $self = clone $this;
         $self->readable = $readable;
@@ -270,7 +270,7 @@ final class ApiProperty
         return $this->writable;
     }
 
-    public function withWritable(bool $writable): self
+    public function withWritable(bool $writable): static
     {
         $self = clone $this;
         $self->writable = $writable;
@@ -283,7 +283,7 @@ final class ApiProperty
         return $this->readableLink;
     }
 
-    public function withReadableLink(bool $readableLink): self
+    public function withReadableLink(bool $readableLink): static
     {
         $self = clone $this;
         $self->readableLink = $readableLink;
@@ -296,7 +296,7 @@ final class ApiProperty
         return $this->writableLink;
     }
 
-    public function withWritableLink(bool $writableLink): self
+    public function withWritableLink(bool $writableLink): static
     {
         $self = clone $this;
         $self->writableLink = $writableLink;
@@ -309,7 +309,7 @@ final class ApiProperty
         return $this->required;
     }
 
-    public function withRequired(bool $required): self
+    public function withRequired(bool $required): static
     {
         $self = clone $this;
         $self->required = $required;
@@ -322,7 +322,7 @@ final class ApiProperty
         return $this->identifier;
     }
 
-    public function withIdentifier(bool $identifier): self
+    public function withIdentifier(bool $identifier): static
     {
         $self = clone $this;
         $self->identifier = $identifier;
@@ -335,7 +335,7 @@ final class ApiProperty
         return $this->default;
     }
 
-    public function withDefault($default): self
+    public function withDefault($default): static
     {
         $self = clone $this;
         $self->default = $default;
@@ -348,7 +348,7 @@ final class ApiProperty
         return $this->example;
     }
 
-    public function withExample(mixed $example): self
+    public function withExample(mixed $example): static
     {
         $self = clone $this;
         $self->example = $example;
@@ -361,7 +361,7 @@ final class ApiProperty
         return $this->deprecationReason;
     }
 
-    public function withDeprecationReason($deprecationReason): self
+    public function withDeprecationReason($deprecationReason): static
     {
         $self = clone $this;
         $self->deprecationReason = $deprecationReason;
@@ -374,7 +374,7 @@ final class ApiProperty
         return $this->fetchable;
     }
 
-    public function withFetchable($fetchable): self
+    public function withFetchable($fetchable): static
     {
         $self = clone $this;
         $self->fetchable = $fetchable;
@@ -387,7 +387,7 @@ final class ApiProperty
         return $this->fetchEager;
     }
 
-    public function withFetchEager($fetchEager): self
+    public function withFetchEager($fetchEager): static
     {
         $self = clone $this;
         $self->fetchEager = $fetchEager;
@@ -400,7 +400,7 @@ final class ApiProperty
         return $this->jsonldContext;
     }
 
-    public function withJsonldContext($jsonldContext): self
+    public function withJsonldContext($jsonldContext): static
     {
         $self = clone $this;
         $self->jsonldContext = $jsonldContext;
@@ -413,7 +413,7 @@ final class ApiProperty
         return $this->openapiContext;
     }
 
-    public function withOpenapiContext($openapiContext): self
+    public function withOpenapiContext($openapiContext): static
     {
         $self = clone $this;
         $self->openapiContext = $openapiContext;
@@ -426,7 +426,7 @@ final class ApiProperty
         return $this->jsonSchemaContext;
     }
 
-    public function withJsonSchemaContext($jsonSchemaContext): self
+    public function withJsonSchemaContext($jsonSchemaContext): static
     {
         $self = clone $this;
         $self->jsonSchemaContext = $jsonSchemaContext;
@@ -439,7 +439,7 @@ final class ApiProperty
         return $this->push;
     }
 
-    public function withPush($push): self
+    public function withPush($push): static
     {
         $self = clone $this;
         $self->push = $push;
@@ -452,7 +452,7 @@ final class ApiProperty
         return $this->security instanceof \Stringable ? (string) $this->security : $this->security;
     }
 
-    public function withSecurity($security): self
+    public function withSecurity($security): static
     {
         $self = clone $this;
         $self->security = $security;
@@ -465,7 +465,7 @@ final class ApiProperty
         return $this->securityPostDenormalize instanceof \Stringable ? (string) $this->securityPostDenormalize : $this->securityPostDenormalize;
     }
 
-    public function withSecurityPostDenormalize($securityPostDenormalize): self
+    public function withSecurityPostDenormalize($securityPostDenormalize): static
     {
         $self = clone $this;
         $self->securityPostDenormalize = $securityPostDenormalize;
@@ -481,7 +481,7 @@ final class ApiProperty
     /**
      * @param string[]|string $types
      */
-    public function withTypes(array|string $types = []): self
+    public function withTypes(array|string $types = []): static
     {
         $self = clone $this;
         $self->types = (array) $types;
@@ -500,7 +500,7 @@ final class ApiProperty
     /**
      * @param Type[] $builtinTypes
      */
-    public function withBuiltinTypes(array $builtinTypes = []): self
+    public function withBuiltinTypes(array $builtinTypes = []): static
     {
         $self = clone $this;
         $self->builtinTypes = $builtinTypes;
@@ -513,7 +513,7 @@ final class ApiProperty
         return $this->schema;
     }
 
-    public function withSchema(array $schema = []): self
+    public function withSchema(array $schema = []): static
     {
         $self = clone $this;
         $self->schema = $schema;
@@ -521,7 +521,7 @@ final class ApiProperty
         return $self;
     }
 
-    public function withInitializable(bool $initializable): self
+    public function withInitializable(?bool $initializable): static
     {
         $self = clone $this;
         $self->initializable = $initializable;
@@ -539,7 +539,7 @@ final class ApiProperty
         return $this->extraProperties;
     }
 
-    public function withExtraProperties(array $extraProperties = []): self
+    public function withExtraProperties(array $extraProperties = []): static
     {
         $self = clone $this;
         $self->extraProperties = $extraProperties;
@@ -560,7 +560,7 @@ final class ApiProperty
      *
      * @param string|string[] $iris
      */
-    public function withIris(string|array $iris): self
+    public function withIris(string|array $iris): static
     {
         $metadata = clone $this;
         $metadata->iris = (array) $iris;
@@ -576,7 +576,7 @@ final class ApiProperty
         return $this->genId;
     }
 
-    public function withGenId(bool $genId): self
+    public function withGenId(bool $genId): static
     {
         $metadata = clone $this;
         $metadata->genId = $genId;
@@ -594,7 +594,7 @@ final class ApiProperty
         return $this->uriTemplate;
     }
 
-    public function withUriTemplate(?string $uriTemplate): self
+    public function withUriTemplate(?string $uriTemplate): static
     {
         $metadata = clone $this;
         $metadata->uriTemplate = $uriTemplate;

--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -1027,7 +1027,7 @@ class ApiResource extends Metadata
         return $this->operations;
     }
 
-    public function withOperations(Operations $operations): self
+    public function withOperations(Operations $operations): static
     {
         $self = clone $this;
         $self->operations = $operations;
@@ -1041,7 +1041,7 @@ class ApiResource extends Metadata
         return $this->uriTemplate;
     }
 
-    public function withUriTemplate(string $uriTemplate): self
+    public function withUriTemplate(string $uriTemplate): static
     {
         $self = clone $this;
         $self->uriTemplate = $uriTemplate;
@@ -1057,7 +1057,7 @@ class ApiResource extends Metadata
     /**
      * @param string[]|string $types
      */
-    public function withTypes(array|string $types): self
+    public function withTypes(array|string $types): static
     {
         $self = clone $this;
         $self->types = (array) $types;
@@ -1073,7 +1073,7 @@ class ApiResource extends Metadata
         return $this->formats;
     }
 
-    public function withFormats(mixed $formats): self
+    public function withFormats(mixed $formats): static
     {
         $self = clone $this;
         $self->formats = $formats;
@@ -1092,7 +1092,7 @@ class ApiResource extends Metadata
     /**
      * @param mixed|null $inputFormats
      */
-    public function withInputFormats($inputFormats): self
+    public function withInputFormats($inputFormats): static
     {
         $self = clone $this;
         $self->inputFormats = $inputFormats;
@@ -1111,7 +1111,7 @@ class ApiResource extends Metadata
     /**
      * @param mixed|null $outputFormats
      */
-    public function withOutputFormats($outputFormats): self
+    public function withOutputFormats($outputFormats): static
     {
         $self = clone $this;
         $self->outputFormats = $outputFormats;
@@ -1130,7 +1130,7 @@ class ApiResource extends Metadata
     /**
      * @param array<string, Link>|array<string, array>|string[]|string|null $uriVariables
      */
-    public function withUriVariables($uriVariables): self
+    public function withUriVariables($uriVariables): static
     {
         $self = clone $this;
         $self->uriVariables = $uriVariables;
@@ -1143,7 +1143,7 @@ class ApiResource extends Metadata
         return $this->routePrefix;
     }
 
-    public function withRoutePrefix(string $routePrefix): self
+    public function withRoutePrefix(string $routePrefix): static
     {
         $self = clone $this;
         $self->routePrefix = $routePrefix;
@@ -1156,7 +1156,7 @@ class ApiResource extends Metadata
         return $this->defaults;
     }
 
-    public function withDefaults(array $defaults): self
+    public function withDefaults(array $defaults): static
     {
         $self = clone $this;
         $self->defaults = $defaults;
@@ -1169,7 +1169,7 @@ class ApiResource extends Metadata
         return $this->requirements;
     }
 
-    public function withRequirements(array $requirements): self
+    public function withRequirements(array $requirements): static
     {
         $self = clone $this;
         $self->requirements = $requirements;
@@ -1182,7 +1182,7 @@ class ApiResource extends Metadata
         return $this->options;
     }
 
-    public function withOptions(array $options): self
+    public function withOptions(array $options): static
     {
         $self = clone $this;
         $self->options = $options;
@@ -1195,7 +1195,7 @@ class ApiResource extends Metadata
         return $this->stateless;
     }
 
-    public function withStateless(bool $stateless): self
+    public function withStateless(bool $stateless): static
     {
         $self = clone $this;
         $self->stateless = $stateless;
@@ -1208,7 +1208,7 @@ class ApiResource extends Metadata
         return $this->sunset;
     }
 
-    public function withSunset(string $sunset): self
+    public function withSunset(string $sunset): static
     {
         $self = clone $this;
         $self->sunset = $sunset;
@@ -1221,7 +1221,7 @@ class ApiResource extends Metadata
         return $this->acceptPatch;
     }
 
-    public function withAcceptPatch(string $acceptPatch): self
+    public function withAcceptPatch(string $acceptPatch): static
     {
         $self = clone $this;
         $self->acceptPatch = $acceptPatch;
@@ -1234,7 +1234,10 @@ class ApiResource extends Metadata
         return $this->status;
     }
 
-    public function withStatus($status): self
+    /**
+     * @param int $status
+     */
+    public function withStatus($status): static
     {
         $self = clone $this;
         $self->status = $status;
@@ -1247,7 +1250,7 @@ class ApiResource extends Metadata
         return $this->host;
     }
 
-    public function withHost(string $host): self
+    public function withHost(string $host): static
     {
         $self = clone $this;
         $self->host = $host;
@@ -1260,7 +1263,7 @@ class ApiResource extends Metadata
         return $this->schemes;
     }
 
-    public function withSchemes(array $schemes): self
+    public function withSchemes(array $schemes): static
     {
         $self = clone $this;
         $self->schemes = $schemes;
@@ -1273,7 +1276,7 @@ class ApiResource extends Metadata
         return $this->condition;
     }
 
-    public function withCondition(string $condition): self
+    public function withCondition(string $condition): static
     {
         $self = clone $this;
         $self->condition = $condition;
@@ -1286,7 +1289,7 @@ class ApiResource extends Metadata
         return $this->controller;
     }
 
-    public function withController(string $controller): self
+    public function withController(string $controller): static
     {
         $self = clone $this;
         $self->controller = $controller;
@@ -1299,7 +1302,7 @@ class ApiResource extends Metadata
         return $this->headers;
     }
 
-    public function withHeaders(array $headers): self
+    public function withHeaders(array $headers): static
     {
         $self = clone $this;
         $self->headers = $headers;
@@ -1312,7 +1315,7 @@ class ApiResource extends Metadata
         return $this->cacheHeaders;
     }
 
-    public function withCacheHeaders(array $cacheHeaders): self
+    public function withCacheHeaders(array $cacheHeaders): static
     {
         $self = clone $this;
         $self->cacheHeaders = $cacheHeaders;
@@ -1328,7 +1331,7 @@ class ApiResource extends Metadata
         return $this->hydraContext;
     }
 
-    public function withHydraContext(array $hydraContext): self
+    public function withHydraContext(array $hydraContext): static
     {
         $self = clone $this;
         $self->hydraContext = $hydraContext;
@@ -1341,7 +1344,7 @@ class ApiResource extends Metadata
         return $this->openapi;
     }
 
-    public function withOpenapi(bool|OpenApiOperation $openapi): self
+    public function withOpenapi(bool|OpenApiOperation $openapi): static
     {
         $self = clone $this;
         $self->openapi = $openapi;
@@ -1354,7 +1357,7 @@ class ApiResource extends Metadata
         return $this->paginationViaCursor;
     }
 
-    public function withPaginationViaCursor(array $paginationViaCursor): self
+    public function withPaginationViaCursor(array $paginationViaCursor): static
     {
         $self = clone $this;
         $self->paginationViaCursor = $paginationViaCursor;
@@ -1367,7 +1370,7 @@ class ApiResource extends Metadata
         return $this->exceptionToStatus;
     }
 
-    public function withExceptionToStatus(array $exceptionToStatus): self
+    public function withExceptionToStatus(array $exceptionToStatus): static
     {
         $self = clone $this;
         $self->exceptionToStatus = $exceptionToStatus;
@@ -1383,7 +1386,7 @@ class ApiResource extends Metadata
         return $this->graphQlOperations;
     }
 
-    public function withGraphQlOperations(array $graphQlOperations): self
+    public function withGraphQlOperations(array $graphQlOperations): static
     {
         $self = clone $this;
         $self->graphQlOperations = $graphQlOperations;
@@ -1399,7 +1402,7 @@ class ApiResource extends Metadata
     /**
      * @param Link[] $links
      */
-    public function withLinks(array $links): self
+    public function withLinks(array $links): static
     {
         $self = clone $this;
         $self->links = $links;

--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -270,7 +270,7 @@ class HttpOperation extends Operation
         return $this->method;
     }
 
-    public function withMethod(string $method): self
+    public function withMethod(string $method): static
     {
         $self = clone $this;
         $self->method = $method;
@@ -299,7 +299,7 @@ class HttpOperation extends Operation
     /**
      * @param string[]|string $types
      */
-    public function withTypes($types): self
+    public function withTypes($types): static
     {
         $self = clone $this;
         $self->types = (array) $types;
@@ -312,7 +312,7 @@ class HttpOperation extends Operation
         return $this->formats;
     }
 
-    public function withFormats($formats = null): self
+    public function withFormats($formats = null): static
     {
         $self = clone $this;
         $self->formats = $formats;
@@ -325,7 +325,7 @@ class HttpOperation extends Operation
         return $this->inputFormats;
     }
 
-    public function withInputFormats($inputFormats = null): self
+    public function withInputFormats($inputFormats = null): static
     {
         $self = clone $this;
         $self->inputFormats = $inputFormats;
@@ -338,7 +338,7 @@ class HttpOperation extends Operation
         return $this->outputFormats;
     }
 
-    public function withOutputFormats($outputFormats = null): self
+    public function withOutputFormats($outputFormats = null): static
     {
         $self = clone $this;
         $self->outputFormats = $outputFormats;
@@ -351,7 +351,7 @@ class HttpOperation extends Operation
         return $this->uriVariables;
     }
 
-    public function withUriVariables($uriVariables): self
+    public function withUriVariables($uriVariables): static
     {
         $self = clone $this;
         $self->uriVariables = $uriVariables;
@@ -364,7 +364,7 @@ class HttpOperation extends Operation
         return $this->routePrefix;
     }
 
-    public function withRoutePrefix(string $routePrefix): self
+    public function withRoutePrefix(string $routePrefix): static
     {
         $self = clone $this;
         $self->routePrefix = $routePrefix;
@@ -377,7 +377,7 @@ class HttpOperation extends Operation
         return $this->routeName;
     }
 
-    public function withRouteName(?string $routeName): self
+    public function withRouteName(?string $routeName): static
     {
         $self = clone $this;
         $self->routeName = $routeName;
@@ -390,7 +390,7 @@ class HttpOperation extends Operation
         return $this->defaults;
     }
 
-    public function withDefaults(array $defaults): self
+    public function withDefaults(array $defaults): static
     {
         $self = clone $this;
         $self->defaults = $defaults;
@@ -403,7 +403,7 @@ class HttpOperation extends Operation
         return $this->requirements;
     }
 
-    public function withRequirements(array $requirements): self
+    public function withRequirements(array $requirements): static
     {
         $self = clone $this;
         $self->requirements = $requirements;
@@ -416,7 +416,7 @@ class HttpOperation extends Operation
         return $this->options;
     }
 
-    public function withOptions(array $options): self
+    public function withOptions(array $options): static
     {
         $self = clone $this;
         $self->options = $options;
@@ -429,7 +429,7 @@ class HttpOperation extends Operation
         return $this->stateless;
     }
 
-    public function withStateless($stateless): self
+    public function withStateless($stateless): static
     {
         $self = clone $this;
         $self->stateless = $stateless;
@@ -442,7 +442,7 @@ class HttpOperation extends Operation
         return $this->sunset;
     }
 
-    public function withSunset(string $sunset): self
+    public function withSunset(string $sunset): static
     {
         $self = clone $this;
         $self->sunset = $sunset;
@@ -455,7 +455,7 @@ class HttpOperation extends Operation
         return $this->acceptPatch;
     }
 
-    public function withAcceptPatch(string $acceptPatch): self
+    public function withAcceptPatch(string $acceptPatch): static
     {
         $self = clone $this;
         $self->acceptPatch = $acceptPatch;
@@ -468,7 +468,7 @@ class HttpOperation extends Operation
         return $this->status;
     }
 
-    public function withStatus(int $status): self
+    public function withStatus(int $status): static
     {
         $self = clone $this;
         $self->status = $status;
@@ -481,7 +481,7 @@ class HttpOperation extends Operation
         return $this->host;
     }
 
-    public function withHost(string $host): self
+    public function withHost(string $host): static
     {
         $self = clone $this;
         $self->host = $host;
@@ -494,7 +494,7 @@ class HttpOperation extends Operation
         return $this->schemes;
     }
 
-    public function withSchemes(array $schemes): self
+    public function withSchemes(array $schemes): static
     {
         $self = clone $this;
         $self->schemes = $schemes;
@@ -507,7 +507,7 @@ class HttpOperation extends Operation
         return $this->condition;
     }
 
-    public function withCondition(string $condition): self
+    public function withCondition(string $condition): static
     {
         $self = clone $this;
         $self->condition = $condition;
@@ -520,7 +520,7 @@ class HttpOperation extends Operation
         return $this->controller;
     }
 
-    public function withController(string $controller): self
+    public function withController(string $controller): static
     {
         $self = clone $this;
         $self->controller = $controller;
@@ -533,7 +533,7 @@ class HttpOperation extends Operation
         return $this->headers;
     }
 
-    public function withHeaders(array $headers): self
+    public function withHeaders(array $headers): static
     {
         $self = clone $this;
         $self->headers = $headers;
@@ -546,7 +546,7 @@ class HttpOperation extends Operation
         return $this->cacheHeaders;
     }
 
-    public function withCacheHeaders(array $cacheHeaders): self
+    public function withCacheHeaders(array $cacheHeaders): static
     {
         $self = clone $this;
         $self->cacheHeaders = $cacheHeaders;
@@ -559,7 +559,7 @@ class HttpOperation extends Operation
         return $this->paginationViaCursor;
     }
 
-    public function withPaginationViaCursor(array $paginationViaCursor): self
+    public function withPaginationViaCursor(array $paginationViaCursor): static
     {
         $self = clone $this;
         $self->paginationViaCursor = $paginationViaCursor;
@@ -572,7 +572,7 @@ class HttpOperation extends Operation
         return $this->hydraContext;
     }
 
-    public function withHydraContext(array $hydraContext): self
+    public function withHydraContext(array $hydraContext): static
     {
         $self = clone $this;
         $self->hydraContext = $hydraContext;
@@ -585,7 +585,7 @@ class HttpOperation extends Operation
         return $this->openapi;
     }
 
-    public function withOpenapi(bool|OpenApiOperation|Webhook $openapi): self
+    public function withOpenapi(bool|OpenApiOperation|Webhook $openapi): static
     {
         $self = clone $this;
         $self->openapi = $openapi;
@@ -598,7 +598,7 @@ class HttpOperation extends Operation
         return $this->exceptionToStatus;
     }
 
-    public function withExceptionToStatus(array $exceptionToStatus): self
+    public function withExceptionToStatus(array $exceptionToStatus): static
     {
         $self = clone $this;
         $self->exceptionToStatus = $exceptionToStatus;
@@ -614,7 +614,7 @@ class HttpOperation extends Operation
     /**
      * @param WebLink[] $links
      */
-    public function withLinks(array $links): self
+    public function withLinks(array $links): static
     {
         $self = clone $this;
         $self->links = $links;
@@ -630,7 +630,7 @@ class HttpOperation extends Operation
     /**
      * @param class-string<ProblemExceptionInterface>[] $errors
      */
-    public function withErrors(array $errors): self
+    public function withErrors(array $errors): static
     {
         $self = clone $this;
         $self->errors = $errors;

--- a/src/Metadata/Operation.php
+++ b/src/Metadata/Operation.php
@@ -874,7 +874,7 @@ abstract class Operation extends Metadata
         return $this->read;
     }
 
-    public function withRead(bool $read = true): self
+    public function withRead(bool $read = true): static
     {
         $self = clone $this;
         $self->read = $read;
@@ -887,7 +887,7 @@ abstract class Operation extends Metadata
         return $this->deserialize;
     }
 
-    public function withDeserialize(bool $deserialize = true): self
+    public function withDeserialize(bool $deserialize = true): static
     {
         $self = clone $this;
         $self->deserialize = $deserialize;
@@ -900,7 +900,7 @@ abstract class Operation extends Metadata
         return $this->validate;
     }
 
-    public function withValidate(bool $validate = true): self
+    public function withValidate(bool $validate = true): static
     {
         $self = clone $this;
         $self->validate = $validate;
@@ -913,7 +913,7 @@ abstract class Operation extends Metadata
         return $this->write;
     }
 
-    public function withWrite(bool $write = true): self
+    public function withWrite(bool $write = true): static
     {
         $self = clone $this;
         $self->write = $write;
@@ -926,7 +926,7 @@ abstract class Operation extends Metadata
         return $this->serialize;
     }
 
-    public function withSerialize(bool $serialize = true): self
+    public function withSerialize(bool $serialize = true): static
     {
         $self = clone $this;
         $self->serialize = $serialize;
@@ -939,7 +939,7 @@ abstract class Operation extends Metadata
         return $this->priority;
     }
 
-    public function withPriority(int $priority = 0): self
+    public function withPriority(int $priority = 0): static
     {
         $self = clone $this;
         $self->priority = $priority;
@@ -952,7 +952,7 @@ abstract class Operation extends Metadata
         return $this->name;
     }
 
-    public function withName(string $name = ''): self
+    public function withName(string $name = ''): static
     {
         $self = clone $this;
         $self->name = $name;

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -248,7 +248,7 @@ abstract class Parameter
         return $self;
     }
 
-    public function withSecurity(string|\Stringable|null $security): self
+    public function withSecurity(string|\Stringable|null $security): static
     {
         $self = clone $this;
         $self->security = $security;
@@ -256,7 +256,7 @@ abstract class Parameter
         return $self;
     }
 
-    public function withSecurityMessage(?string $securityMessage): self
+    public function withSecurityMessage(?string $securityMessage): static
     {
         $self = clone $this;
         $self->securityMessage = $securityMessage;

--- a/src/OpenApi/Tests/Serializer/OpenApiNormalizerTest.php
+++ b/src/OpenApi/Tests/Serializer/OpenApiNormalizerTest.php
@@ -43,7 +43,9 @@ use ApiPlatform\OpenApi\OpenApi;
 use ApiPlatform\OpenApi\Options;
 use ApiPlatform\OpenApi\Serializer\OpenApiNormalizer;
 use ApiPlatform\OpenApi\Tests\Fixtures\Dummy;
+use ApiPlatform\State\ApiResource\Error;
 use ApiPlatform\State\Pagination\PaginationOptions;
+use ApiPlatform\Validator\Exception\ValidationException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -100,6 +102,7 @@ class OpenApiNormalizerTest extends TestCase
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactoryProphecy->create(Dummy::class, Argument::any())->shouldBeCalled()->willReturn(new PropertyNameCollection(['id', 'name', 'description', 'dummyDate']));
         $propertyNameCollectionFactoryProphecy->create('Zorro', Argument::any())->shouldBeCalled()->willReturn(new PropertyNameCollection(['id']));
+        $propertyNameCollectionFactoryProphecy->create(Error::class, Argument::any())->shouldBeCalled()->willReturn(new PropertyNameCollection([]));
 
         $baseOperation = (new HttpOperation())->withTypes(['http://schema.example.com/Dummy'])
                                               ->withInputFormats(self::OPERATION_FORMATS['input_formats'])->withOutputFormats(self::OPERATION_FORMATS['output_formats'])
@@ -141,6 +144,8 @@ class OpenApiNormalizerTest extends TestCase
         $resourceCollectionMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $resourceCollectionMetadataFactoryProphecy->create(Dummy::class)->shouldBeCalled()->willReturn($dummyMetadata);
         $resourceCollectionMetadataFactoryProphecy->create('Zorro')->shouldBeCalled()->willReturn($zorroMetadata);
+        $resourceCollectionMetadataFactoryProphecy->create(Error::class)->shouldBeCalled()->willReturn(new ResourceMetadataCollection(Error::class, []));
+        $resourceCollectionMetadataFactoryProphecy->create(ValidationException::class)->shouldBeCalled()->willReturn(new ResourceMetadataCollection(ValidationException::class, []));
 
         $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
         $propertyMetadataFactoryProphecy->create(Dummy::class, 'id', Argument::any())->shouldBeCalled()->willReturn(

--- a/src/State/ApiResource/Error.php
+++ b/src/State/ApiResource/Error.php
@@ -25,7 +25,6 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\WebLink\Link;
 
 #[ErrorResource(
-    openapi: false,
     uriVariables: ['status'],
     uriTemplate: '/errors/{status}',
     operations: [
@@ -37,15 +36,17 @@ use Symfony\Component\WebLink\Link;
             normalizationContext: [
                 'groups' => ['jsonproblem'],
                 'skip_null_values' => true,
+                'ignored_attributes' => ['trace', 'file', 'line', 'code', 'message', 'traceAsString', 'previous'],
             ],
         ),
         new Operation(
             name: '_api_errors_hydra',
             routeName: 'api_errors',
-            outputFormats: ['jsonld' => ['application/problem+json']],
+            outputFormats: ['jsonld' => ['application/problem+json', 'application/ld+json']],
             normalizationContext: [
                 'groups' => ['jsonld'],
                 'skip_null_values' => true,
+                'ignored_attributes' => ['trace', 'file', 'line', 'code', 'message', 'traceAsString', 'previous'],
             ],
             links: [new Link(rel: 'http://www.w3.org/ns/json-ld#error', href: 'http://www.w3.org/ns/hydra/error')],
         ),
@@ -55,32 +56,46 @@ use Symfony\Component\WebLink\Link;
             hideHydraOperation: true,
             outputFormats: ['jsonapi' => ['application/vnd.api+json']],
             normalizationContext: [
+                'disable_json_schema_serializer_groups' => false,
                 'groups' => ['jsonapi'],
                 'skip_null_values' => true,
+                'ignored_attributes' => ['trace', 'file', 'line', 'code', 'message', 'traceAsString', 'previous'],
             ],
         ),
         new Operation(
             name: '_api_errors',
             routeName: 'api_errors',
             hideHydraOperation: true,
+            openapi: false
         ),
     ],
     provider: 'api_platform.state.error_provider',
-    graphQlOperations: []
+    graphQlOperations: [],
+    description: 'A representation of common errors.'
 )]
 #[ApiProperty(property: 'traceAsString', hydra: false)]
 #[ApiProperty(property: 'string', hydra: false)]
 class Error extends \Exception implements ProblemExceptionInterface, HttpExceptionInterface
 {
+    private ?string $id = null;
+
     public function __construct(
         private string $title,
         private string $detail,
-        #[ApiProperty(identifier: true, writable: false, initializable: false)] private int $status,
+        #[ApiProperty(
+            description: 'The HTTP status code applicable to this problem.',
+            identifier: true,
+            writable: false,
+            initializable: false,
+            schema: ['type' => 'number', 'example' => 404, 'default' => 400]
+        )] private int $status,
         ?array $originalTrace = null,
         private ?string $instance = null,
         private string $type = 'about:blank',
         private array $headers = [],
         ?\Throwable $previous = null,
+        private ?array $meta = null,
+        private ?array $source = null,
     ) {
         parent::__construct($title, $status, $previous);
 
@@ -98,7 +113,28 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
     #[Groups(['jsonapi'])]
     public function getId(): string
     {
-        return (string) $this->status;
+        return $this->id ?? ((string) $this->status);
+    }
+
+    #[Groups(['jsonapi'])]
+    #[ApiProperty(schema: ['type' => 'object'])]
+    public function getMeta(): ?array
+    {
+        return $this->meta;
+    }
+
+    #[Groups(['jsonapi'])]
+    #[ApiProperty(schema: [
+        'type' => 'object',
+        'properties' => [
+            'pointer' => ['type' => 'string'],
+            'parameter' => ['type' => 'string'],
+            'header' => ['type' => 'string'],
+        ],
+    ])]
+    public function getSource(): ?array
+    {
+        return $this->source;
     }
 
     #[SerializedName('trace')]
@@ -142,7 +178,7 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
     }
 
     #[Groups(['jsonld', 'jsonproblem', 'jsonapi'])]
-    #[ApiProperty(writable: false, initializable: false)]
+    #[ApiProperty(writable: false, initializable: false, description: 'A URI reference that identifies the problem type')]
     public function getType(): string
     {
         return $this->type;
@@ -154,7 +190,7 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
     }
 
     #[Groups(['jsonld', 'jsonproblem', 'jsonapi'])]
-    #[ApiProperty(writable: false, initializable: false)]
+    #[ApiProperty(writable: false, initializable: false, description: 'A short, human-readable summary of the problem.')]
     public function getTitle(): ?string
     {
         return $this->title;
@@ -177,7 +213,7 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
     }
 
     #[Groups(['jsonld', 'jsonproblem', 'jsonapi'])]
-    #[ApiProperty(writable: false, initializable: false)]
+    #[ApiProperty(writable: false, initializable: false, description: 'A human-readable explanation specific to this occurrence of the problem.')]
     public function getDetail(): ?string
     {
         return $this->detail;
@@ -188,8 +224,8 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
         $this->detail = $detail;
     }
 
-    #[Groups(['jsonld', 'jsonproblem'])]
-    #[ApiProperty(writable: false, initializable: false)]
+    #[Groups(['jsonld', 'jsonproblem', 'jsonapi'])]
+    #[ApiProperty(writable: false, initializable: false, description: 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.')]
     public function getInstance(): ?string
     {
         return $this->instance;
@@ -198,5 +234,20 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
     public function setInstance(?string $instance = null): void
     {
         $this->instance = $instance;
+    }
+
+    public function setId(?string $id = null): void
+    {
+        $this->id = $id;
+    }
+
+    public function setMeta(?array $meta = null): void
+    {
+        $this->meta = $meta;
+    }
+
+    public function setSource(?array $source = null): void
+    {
+        $this->source = $source;
     }
 }

--- a/tests/Fixtures/TestBundle/ApiResource/Crud.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Crud.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource]
+class Crud
+{
+    public string $id;
+}

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Crud;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+class OpenApiTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [Crud::class];
+    }
+
+    public function testErrorsAreDocumented(): void
+    {
+        $container = static::getContainer();
+        $response = self::createClient()->request('GET', '/docs', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+
+        $res = $response->toArray();
+        $this->assertTrue(isset($res['paths']['/cruds/{id}']['patch']['responses']));
+        $responses = $res['paths']['/cruds/{id}']['patch']['responses'];
+
+        foreach ($responses as $status => $response) {
+            if ($status < 400) {
+                continue;
+            }
+
+            $this->assertArrayHasKey('application/problem+json', $response['content']);
+            $this->assertArrayHasKey('application/ld+json', $response['content']);
+            $this->assertArrayHasKey('application/vnd.api+json', $response['content']);
+
+            match ($status) {
+                422 => $this->assertStringStartsWith('#/components/schemas/ConstraintViolation', $response['content']['application/problem+json']['schema']['$ref']),
+                default => $this->assertStringStartsWith('#/components/schemas/Error', $response['content']['application/problem+json']['schema']['$ref']),
+            };
+        }
+
+        // problem detail https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+        foreach (['title', 'detail', 'instance', 'type', 'status'] as $key) {
+            $this->assertArrayHasKey($key, $res['components']['schemas']['Error.jsonld-jsonproblem']['properties']);
+        }
+
+        foreach (['title', 'detail', 'instance', 'type', 'status', '@id', '@type', '@context'] as $key) {
+            $this->assertArrayHasKey($key, $res['components']['schemas']['Error.jsonld-jsonld']['properties']);
+        }
+        foreach (['id', 'title', 'detail', 'instance', 'type', 'status', 'meta', 'source'] as $key) {
+            $this->assertArrayHasKey($key, $res['components']['schemas']['Error.jsonapi-jsonapi']['properties']['errors']['properties']);
+        }
+    }
+}

--- a/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
+++ b/tests/JsonSchema/Command/JsonSchemaGenerateCommandTest.php
@@ -34,6 +34,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6212\Nest;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Question;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -378,9 +379,7 @@ class JsonSchemaGenerateCommandTest extends KernelTestCase
         $this->assertArrayNotHasKey('@id', $json['definitions']['DisableIdGenerationItem.jsonld']['properties']);
     }
 
-    /**
-     * @dataProvider arrayPropertyTypeSyntaxProvider
-     */
+    #[DataProvider('arrayPropertyTypeSyntaxProvider')]
     public function testOpenApiSchemaGenerationForArrayProperty(string $propertyName, array $expectedProperties): void
     {
         $this->tester->run([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | not sure yet
| Tickets       | Closes #6918
| License       | MIT
| Doc PR        | n/a

This fixes many issues related to how errors and constraint violations are documented, it was reported in #6918 and is a follow up of #6748 (therefore I'd be up to add this on 4.1 instead of 4.0 as without the patch there are still inconsistencies).

A few screenshots:

![20250120_16h42m54s_grim](https://github.com/user-attachments/assets/b0282367-35a4-4790-906c-4792a5c1d830)
![20250120_16h42m48s_grim](https://github.com/user-attachments/assets/a87be3b7-df4c-484f-a052-ec1087fee378)
![20250120_16h42m36s_grim](https://github.com/user-attachments/assets/51dd7131-601c-437e-93ca-02c32c9fef30)

I still need to add a few tests as this was hard to implement we need to cover regressions...