### PR TITLE
feat(mongodb): Replace usage of deprecated method `AggregationBuilder::execute()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
         "doctrine/common": "^3.2.2",
         "doctrine/dbal": "^4.0",
         "doctrine/doctrine-bundle": "^2.11",
-        "doctrine/mongodb-odm": "^2.9.2",
+        "doctrine/mongodb-odm": "^2.10",
         "doctrine/mongodb-odm-bundle": "^4.0 || ^5.0",
         "doctrine/orm": "^2.17 || ^3.0",
         "elasticsearch/elasticsearch": "^8.4",

--- a/src/Doctrine/Odm/Extension/PaginationExtension.php
+++ b/src/Doctrine/Odm/Extension/PaginationExtension.php
@@ -111,7 +111,7 @@ final class PaginationExtension implements AggregationResultCollectionExtensionI
         $attribute = $operation?->getExtraProperties()['doctrine_mongodb'] ?? [];
         $executeOptions = $attribute['execute_options'] ?? [];
 
-        return new Paginator($aggregationBuilder->execute($executeOptions), $manager->getUnitOfWork(), $resourceClass);
+        return new Paginator($aggregationBuilder->getAggregation($executeOptions)->getIterator(), $manager->getUnitOfWork(), $resourceClass);
     }
 
     private function addCountToContext(Builder $aggregationBuilder, array $context): array

--- a/src/Doctrine/Odm/State/CollectionProvider.php
+++ b/src/Doctrine/Odm/State/CollectionProvider.php
@@ -77,6 +77,6 @@ final class CollectionProvider implements ProviderInterface
         $attribute = $operation->getExtraProperties()['doctrine_mongodb'] ?? [];
         $executeOptions = $attribute['execute_options'] ?? [];
 
-        return $aggregationBuilder->hydrate($documentClass)->execute($executeOptions);
+        return $aggregationBuilder->hydrate($documentClass)->getAggregation($executeOptions)->getIterator();
     }
 }

--- a/src/Doctrine/Odm/State/ItemProvider.php
+++ b/src/Doctrine/Odm/State/ItemProvider.php
@@ -84,6 +84,6 @@ final class ItemProvider implements ProviderInterface
 
         $executeOptions = $operation->getExtraProperties()['doctrine_mongodb']['execute_options'] ?? [];
 
-        return $aggregationBuilder->hydrate($documentClass)->execute($executeOptions)->current() ?: null;
+        return $aggregationBuilder->hydrate($documentClass)->getAggregation($executeOptions)->getIterator()->current() ?: null;
     }
 }

--- a/src/Doctrine/Odm/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Odm/State/LinksHandlerTrait.php
@@ -128,7 +128,7 @@ trait LinksHandlerTrait
             return $aggregation;
         }
 
-        $results = $aggregation->execute($executeOptions)->toArray();
+        $results = $aggregation->getAggregation($executeOptions)->getIterator()->toArray();
         $in = [];
         foreach ($results as $result) {
             foreach ($result[$lookupPropertyAlias] ?? [] as $lookupResult) {

--- a/src/Doctrine/Odm/Tests/Extension/PaginationExtensionTest.php
+++ b/src/Doctrine/Odm/Tests/Extension/PaginationExtensionTest.php
@@ -21,13 +21,13 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\Pagination\PaginatorInterface;
 use ApiPlatform\State\Pagination\PartialPaginatorInterface;
-use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\AddFields;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Count;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Facet;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Skip;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -334,7 +334,7 @@ class PaginationExtensionTest extends TestCase
             ],
         ]);
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iteratorProphecy->reveal());
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
@@ -394,7 +394,7 @@ class PaginationExtensionTest extends TestCase
             ],
         ]);
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iteratorProphecy->reveal());
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);

--- a/src/Doctrine/Odm/Tests/Extension/PaginationExtensionTest.php
+++ b/src/Doctrine/Odm/Tests/Extension/PaginationExtensionTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\Pagination\PaginatorInterface;
 use ApiPlatform\State\Pagination\PartialPaginatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\AddFields;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Count;
@@ -333,8 +334,11 @@ class PaginationExtensionTest extends TestCase
             ],
         ]);
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iteratorProphecy->reveal());
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
-        $aggregationBuilderProphecy->execute([])->willReturn($iteratorProphecy->reveal());
+        $aggregationBuilderProphecy->getAggregation([])->willReturn($aggregationProphecy->reveal());
         $aggregationBuilderProphecy->getPipeline()->willReturn([
             [
                 '$facet' => [
@@ -390,8 +394,11 @@ class PaginationExtensionTest extends TestCase
             ],
         ]);
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iteratorProphecy->reveal());
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
-        $aggregationBuilderProphecy->execute(['allowDiskUse' => true])->willReturn($iteratorProphecy->reveal());
+        $aggregationBuilderProphecy->getAggregation(['allowDiskUse' => true])->willReturn($aggregationProphecy->reveal());
         $aggregationBuilderProphecy->getPipeline()->willReturn([
             [
                 '$facet' => [

--- a/src/Doctrine/Odm/Tests/State/CollectionProviderTest.php
+++ b/src/Doctrine/Odm/Tests/State/CollectionProviderTest.php
@@ -20,6 +20,7 @@ use ApiPlatform\Doctrine\Odm\Tests\Fixtures\Document\ProviderDocument;
 use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
@@ -50,9 +51,12 @@ class CollectionProviderTest extends TestCase
     {
         $iterator = $this->prophesize(Iterator::class)->reveal();
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iterator);
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
         $aggregationBuilderProphecy->hydrate(ProviderDocument::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
-        $aggregationBuilderProphecy->execute([])->willReturn($iterator)->shouldBeCalled();
+        $aggregationBuilderProphecy->getAggregation([])->willReturn($aggregationProphecy)->shouldBeCalled();
         $aggregationBuilder = $aggregationBuilderProphecy->reveal();
 
         $repositoryProphecy = $this->prophesize(DocumentRepository::class);
@@ -76,9 +80,12 @@ class CollectionProviderTest extends TestCase
     {
         $iterator = $this->prophesize(Iterator::class)->reveal();
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iterator);
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
         $aggregationBuilderProphecy->hydrate(ProviderDocument::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
-        $aggregationBuilderProphecy->execute(['allowDiskUse' => true])->willReturn($iterator)->shouldBeCalled();
+        $aggregationBuilderProphecy->getAggregation(['allowDiskUse' => true])->willReturn($aggregationProphecy)->shouldBeCalled();
         $aggregationBuilder = $aggregationBuilderProphecy->reveal();
 
         $repositoryProphecy = $this->prophesize(DocumentRepository::class);
@@ -143,9 +150,12 @@ class CollectionProviderTest extends TestCase
     {
         $iterator = $this->prophesize(Iterator::class)->reveal();
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iterator);
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
         $aggregationBuilderProphecy->hydrate(ProviderDocument::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
-        $aggregationBuilderProphecy->execute([])->willReturn($iterator)->shouldBeCalled();
+        $aggregationBuilderProphecy->getAggregation([])->willReturn($aggregationProphecy)->shouldBeCalled();
         $aggregationBuilder = $aggregationBuilderProphecy->reveal();
 
         $repositoryProphecy = $this->prophesize(DocumentRepository::class);

--- a/src/Doctrine/Odm/Tests/State/CollectionProviderTest.php
+++ b/src/Doctrine/Odm/Tests/State/CollectionProviderTest.php
@@ -20,9 +20,9 @@ use ApiPlatform\Doctrine\Odm\Tests\Fixtures\Document\ProviderDocument;
 use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
-use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -51,7 +51,7 @@ class CollectionProviderTest extends TestCase
     {
         $iterator = $this->prophesize(Iterator::class)->reveal();
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iterator);
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
@@ -80,7 +80,7 @@ class CollectionProviderTest extends TestCase
     {
         $iterator = $this->prophesize(Iterator::class)->reveal();
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iterator);
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
@@ -150,7 +150,7 @@ class CollectionProviderTest extends TestCase
     {
         $iterator = $this->prophesize(Iterator::class)->reveal();
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iterator);
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);

--- a/src/Doctrine/Odm/Tests/State/ItemProviderTest.php
+++ b/src/Doctrine/Odm/Tests/State/ItemProviderTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\MatchStage as AggregationMatch;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -49,10 +50,13 @@ class ItemProviderTest extends TestCase
         $result = new \stdClass();
         $iterator->current()->willReturn($result)->shouldBeCalled();
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iterator);
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
         $aggregationBuilderProphecy->match()->willReturn($matchProphecy->reveal())->shouldBeCalled();
         $aggregationBuilderProphecy->hydrate(ProviderDocument::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
-        $aggregationBuilderProphecy->execute([])->willReturn($iterator->reveal())->shouldBeCalled();
+        $aggregationBuilderProphecy->getAggregation([])->willReturn($aggregationProphecy->reveal())->shouldBeCalled();
         $aggregationBuilder = $aggregationBuilderProphecy->reveal();
 
         $managerRegistry = $this->getManagerRegistry(ProviderDocument::class, $aggregationBuilder);
@@ -82,10 +86,13 @@ class ItemProviderTest extends TestCase
         $result = new \stdClass();
         $iterator->current()->willReturn($result)->shouldBeCalled();
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iterator);
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
         $aggregationBuilderProphecy->match()->willReturn($matchProphecy->reveal())->shouldBeCalled();
         $aggregationBuilderProphecy->hydrate(ProviderDocument::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
-        $aggregationBuilderProphecy->execute(['allowDiskUse' => true])->willReturn($iterator->reveal())->shouldBeCalled();
+        $aggregationBuilderProphecy->getAggregation(['allowDiskUse' => true])->willReturn($aggregationProphecy->reveal())->shouldBeCalled();
         $aggregationBuilder = $aggregationBuilderProphecy->reveal();
 
         $managerRegistry = $this->getManagerRegistry(ProviderDocument::class, $aggregationBuilder);
@@ -116,10 +123,13 @@ class ItemProviderTest extends TestCase
         $result = new \stdClass();
         $iterator->current()->willReturn($result)->shouldBeCalled();
 
+        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy->getIterator()->willReturn($iterator);
+
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
         $aggregationBuilderProphecy->match()->willReturn($matchProphecy->reveal())->shouldBeCalled();
         $aggregationBuilderProphecy->hydrate(ProviderDocument::class)->willReturn($aggregationBuilderProphecy)->shouldBeCalled();
-        $aggregationBuilderProphecy->execute([])->willReturn($iterator->reveal())->shouldBeCalled();
+        $aggregationBuilderProphecy->getAggregation([])->willReturn($aggregationProphecy->reveal())->shouldBeCalled();
         $aggregationBuilder = $aggregationBuilderProphecy->reveal();
 
         $managerRegistry = $this->getManagerRegistry(ProviderDocument::class, $aggregationBuilder);

--- a/src/Doctrine/Odm/Tests/State/ItemProviderTest.php
+++ b/src/Doctrine/Odm/Tests/State/ItemProviderTest.php
@@ -21,10 +21,10 @@ use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
-use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\MatchStage as AggregationMatch;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -50,7 +50,7 @@ class ItemProviderTest extends TestCase
         $result = new \stdClass();
         $iterator->current()->willReturn($result)->shouldBeCalled();
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iterator);
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
@@ -86,7 +86,7 @@ class ItemProviderTest extends TestCase
         $result = new \stdClass();
         $iterator->current()->willReturn($result)->shouldBeCalled();
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iterator);
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
@@ -123,7 +123,7 @@ class ItemProviderTest extends TestCase
         $result = new \stdClass();
         $iterator->current()->willReturn($result)->shouldBeCalled();
 
-        $aggregationProphecy = $this->prophesize(Aggregation::class);
+        $aggregationProphecy = $this->prophesize(IterableResult::class);
         $aggregationProphecy->getIterator()->willReturn($iterator);
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The method `AggregationBuilder::execute()` is [deprecated](https://github.com/doctrine/mongodb-odm/blob/2.10.0/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php#L176).

This requires updating the minimum version of MongoDB ODM for testing, as the new result class have been added in v2.10.0 by https://github.com/doctrine/mongodb-odm/pull/2702, so we can mock it.