### PR TITLE
fix: Fix cross-package version dependencies

### DIFF
--- a/src/Doctrine/Odm/composer.json
+++ b/src/Doctrine/Odm/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "api-platform/doctrine-common": "^3.4 || ^4.0",
+        "api-platform/doctrine-common": "^4.1",
         "api-platform/metadata": "^3.4 || ^4.0",
         "api-platform/state": "^3.4 || ^4.0",
         "doctrine/mongodb-odm": "^2.2",

--- a/src/Doctrine/Orm/composer.json
+++ b/src/Doctrine/Orm/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "api-platform/doctrine-common": "^3.4 || ^4.0",
+        "api-platform/doctrine-common": "^4.1",
         "api-platform/metadata": "^3.4 || ^4.0",
         "api-platform/state": "^3.4 || ^4.0",
         "doctrine/orm": "^2.17 || ^3.0",

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -38,7 +38,7 @@
         "api-platform/serializer": "^3.4 || ^4.0",
         "api-platform/state": "^3.4 || ^4.0",
         "api-platform/validator": "^3.4 || ^4.0",
-        "api-platform/openapi": "^3.4 || ^4.0",
+        "api-platform/openapi": "^4.1",
         "symfony/property-info": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
         "symfony/serializer": "^6.4 || ^7.0",

--- a/src/Validator/composer.json
+++ b/src/Validator/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "api-platform/metadata": "^3.4 || ^4.0",
+        "api-platform/metadata": "^4.1",
         "symfony/web-link": "^6.4 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | -
| License       | MIT
| Doc PR        | -

#### Doctrine

https://github.com/api-platform/core/pull/6775 introduced a new interface `ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface` that is implemented by `ApiPlatform\Doctrine\{Orm,Odm}\Filter\AbstractFilter`, making `api-platform/doctrine-{orm,odm}: 4.1` require `api-platform/doctrine-common: 4.1`.

I hit this error while requiring only the dev version of `api-platform/doctrine-odm`.

```
!!    Invalid service "api_platform.doctrine_mongodb.odm.search_filter": class "A  
!!    piPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface" not found   
!!    while loading "ApiPlatform\Doctrine\Odm\Filter\SearchFilter".       
```

#### Symfony Bundle

https://github.com/api-platform/core/pull/6877 added `OpenApi::hasPersistAuthorization()` used by `SwaggerUiAction`.

#### Validator

https://github.com/api-platform/core/pull/6748 made attribute `ApiProperty` repeatable, used multiple times by `ValidationException`.



