### PR TITLE
let search filters define their default strategy

### DIFF
--- a/src/Doctrine/Common/Filter/SearchFilterTrait.php
+++ b/src/Doctrine/Common/Filter/SearchFilterTrait.php
@@ -32,6 +32,7 @@ trait SearchFilterTrait
 {
     use PropertyHelperTrait;
 
+    protected string $defaultStrategy = self::STRATEGY_EXACT;
     protected IriConverterInterface|LegacyIriConverterInterface $iriConverter;
     protected PropertyAccessorInterface $propertyAccessor;
     protected IdentifiersExtractorInterface|LegacyIdentifiersExtractorInterface|null $identifiersExtractor = null;
@@ -65,7 +66,7 @@ trait SearchFilterTrait
             $propertyName = $this->normalizePropertyName($property);
             if ($metadata->hasField($field)) {
                 $typeOfField = $this->getType($metadata->getTypeOfField($field));
-                $strategy = $this->getProperties()[$property] ?? self::STRATEGY_EXACT;
+                $strategy = $this->getProperties()[$property] ?? $this->defaultStrategy;
                 $filterParameterNames = [$propertyName];
 
                 if (\in_array($strategy, [self::STRATEGY_EXACT, self::STRATEGY_IEXACT], true)) {

--- a/src/Doctrine/Odm/Filter/SearchFilter.php
+++ b/src/Doctrine/Odm/Filter/SearchFilter.php
@@ -142,13 +142,14 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 
     public const DOCTRINE_INTEGER_TYPE = [MongoDbType::INTEGER, MongoDbType::INT];
 
-    public function __construct(ManagerRegistry $managerRegistry, IriConverterInterface|LegacyIriConverterInterface $iriConverter, IdentifiersExtractorInterface|LegacyIdentifiersExtractorInterface|null $identifiersExtractor, ?PropertyAccessorInterface $propertyAccessor = null, ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null)
+    public function __construct(ManagerRegistry $managerRegistry, IriConverterInterface|LegacyIriConverterInterface $iriConverter, IdentifiersExtractorInterface|LegacyIdentifiersExtractorInterface|null $identifiersExtractor, ?PropertyAccessorInterface $propertyAccessor = null, ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null, ?string $defaultStrategy = null)
     {
         parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
 
         $this->iriConverter = $iriConverter;
         $this->identifiersExtractor = $identifiersExtractor;
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+        $this->defaultStrategy = $defaultStrategy ?? self::STRATEGY_EXACT;
     }
 
     protected function getIriConverter(): LegacyIriConverterInterface|IriConverterInterface
@@ -187,7 +188,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         }
 
         $caseSensitive = true;
-        $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
+        $strategy = $this->properties[$property] ?? $this->defaultStrategy;
 
         // prefixing the strategy with i makes it case insensitive
         if (str_starts_with($strategy, 'i')) {

--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -141,13 +141,14 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 
     public const DOCTRINE_INTEGER_TYPE = Types::INTEGER;
 
-    public function __construct(ManagerRegistry $managerRegistry, IriConverterInterface|LegacyIriConverterInterface $iriConverter, ?PropertyAccessorInterface $propertyAccessor = null, ?LoggerInterface $logger = null, ?array $properties = null, IdentifiersExtractorInterface|LegacyIdentifiersExtractorInterface|null $identifiersExtractor = null, ?NameConverterInterface $nameConverter = null)
+    public function __construct(ManagerRegistry $managerRegistry, IriConverterInterface|LegacyIriConverterInterface $iriConverter, ?PropertyAccessorInterface $propertyAccessor = null, ?LoggerInterface $logger = null, ?array $properties = null, IdentifiersExtractorInterface|LegacyIdentifiersExtractorInterface|null $identifiersExtractor = null, ?NameConverterInterface $nameConverter = null, ?string $defaultStrategy = null)
     {
         parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
 
         $this->iriConverter = $iriConverter;
         $this->identifiersExtractor = $identifiersExtractor;
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+        $this->defaultStrategy = $defaultStrategy ?? self::STRATEGY_EXACT;
     }
 
     protected function getIriConverter(): IriConverterInterface|LegacyIriConverterInterface
@@ -187,7 +188,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         }
 
         $caseSensitive = true;
-        $strategy = $this->properties[$property] ?? self::STRATEGY_EXACT;
+        $strategy = $this->properties[$property] ?? $this->defaultStrategy;
 
         // prefixing the strategy with i makes it case insensitive
         if (str_starts_with($strategy, 'i')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Tickets       | none
| License       | MIT
| Doc PR        | none

This would allow placeholder filters to work with postgres without having to define all properties