### PR TITLE
fix(laravel): Prevent overwriting existing routes on the router

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -235,8 +235,8 @@ class ApiPlatformProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/config/api-platform.php', 'api-platform');
 
         $this->app->singleton(PropertyInfoExtractorInterface::class, function () {
-            $phpDocExtractor = class_exists(DocBlockFactory::class) ? new PhpDocExtractor : null;
-            $reflectionExtractor = new ReflectionExtractor;
+            $phpDocExtractor = class_exists(DocBlockFactory::class) ? new PhpDocExtractor() : null;
+            $reflectionExtractor = new ReflectionExtractor();
 
             return new PropertyInfoExtractor(
                 [$reflectionExtractor],
@@ -255,7 +255,7 @@ class ApiPlatformProvider extends ServiceProvider
                     new PropertyMetadataLoader(
                         $app->make(PropertyNameCollectionFactoryInterface::class),
                     ),
-                    new AttributeLoader,
+                    new AttributeLoader(),
                 ])
             );
         });
@@ -276,7 +276,7 @@ class ApiPlatformProvider extends ServiceProvider
             $logger = $app->make(LoggerInterface::class);
 
             foreach ($paths as $i => $path) {
-                if (! file_exists($path)) {
+                if (!file_exists($path)) {
                     $logger->warning(\sprintf('We skipped reading resources in "%s" as the path does not exist. Please check the configuration at "api-platform.resources".', $path));
                     unset($paths[$i]);
                 }
@@ -316,7 +316,7 @@ class ApiPlatformProvider extends ServiceProvider
                         $app->make(ResourceClassResolverInterface::class)
                     ),
                 ),
-                $config->get('app.debug') === true ? 'array' : $config->get('cache.default', 'file')
+                true === $config->get('app.debug') ? 'array' : $config->get('cache.default', 'file')
             );
         });
 
@@ -334,7 +334,7 @@ class ApiPlatformProvider extends ServiceProvider
                         )
                     )
                 ),
-                $config->get('app.debug') === true ? 'array' : $config->get('cache.default', 'file')
+                true === $config->get('app.debug') ? 'array' : $config->get('cache.default', 'file')
             );
         });
 
@@ -352,7 +352,7 @@ class ApiPlatformProvider extends ServiceProvider
             $config = $app['config'];
             $formats = $config->get('api-platform.formats');
 
-            if ($config->get('api-platform.swagger_ui.enabled', false) && ! isset($formats['html'])) {
+            if ($config->get('api-platform.swagger_ui.enabled', false) && !isset($formats['html'])) {
                 $formats['html'] = ['text/html'];
             }
 
@@ -404,12 +404,12 @@ class ApiPlatformProvider extends ServiceProvider
                         $app->make('filters')
                     )
                 ),
-                $config->get('app.debug') === true ? 'array' : $config->get('cache.default', 'file')
+                true === $config->get('app.debug') ? 'array' : $config->get('cache.default', 'file')
             );
         });
 
         $this->app->bind(PropertyAccessorInterface::class, function () {
-            return new EloquentPropertyAccessor;
+            return new EloquentPropertyAccessor();
         });
 
         $this->app->bind(NameConverterInterface::class, function (Application $app) {
@@ -492,7 +492,7 @@ class ApiPlatformProvider extends ServiceProvider
         $this->app->alias(SerializerFilterParameterProvider::class, 'api_platform.serializer.filter_parameter_provider');
 
         $this->app->singleton(SortFilterParameterProvider::class, function (Application $app) {
-            return new SortFilterParameterProvider;
+            return new SortFilterParameterProvider();
         });
         $this->app->tag([SerializerFilterParameterProvider::class, SortFilterParameterProvider::class, SparseFieldsetParameterProvider::class], ParameterProviderInterface::class);
 
@@ -523,7 +523,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton(Negotiator::class, function (Application $app) {
-            return new Negotiator;
+            return new Negotiator();
         });
         $this->app->singleton(ContentNegotiationProvider::class, function (Application $app) {
             /** @var ConfigRepository */
@@ -549,7 +549,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton(RespondProcessor::class, function () {
-            return new AddLinkHeaderProcessor(new RespondProcessor, new HttpHeaderSerializer);
+            return new AddLinkHeaderProcessor(new RespondProcessor(), new HttpHeaderSerializer());
         });
 
         $this->app->singleton(SerializeProcessor::class, function (Application $app) {
@@ -602,7 +602,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton(DateTimeZoneNormalizer::class, function () {
-            return new DateTimeZoneNormalizer;
+            return new DateTimeZoneNormalizer();
         });
 
         $this->app->singleton(DateIntervalNormalizer::class, function (Application $app) {
@@ -650,7 +650,7 @@ class ApiPlatformProvider extends ServiceProvider
             );
 
             $urlGenerator = new UrlGeneratorRouter($app->make(Router::class));
-            $urlGenerator->setContext((new RequestContext)->fromRequest($trimmedRequest));
+            $urlGenerator->setContext((new RequestContext())->fromRequest($trimmedRequest));
 
             return $urlGenerator;
         });
@@ -677,7 +677,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton(ResourceAccessCheckerInterface::class, function () {
-            return new ResourceAccessChecker;
+            return new ResourceAccessChecker();
         });
 
         $this->app->singleton(ItemNormalizer::class, function (Application $app) {
@@ -998,7 +998,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton('api_platform_normalizer_list', function (Application $app) {
-            $list = new \SplPriorityQueue;
+            $list = new \SplPriorityQueue();
             $list->insert($app->make(HydraEntrypointNormalizer::class), -800);
             $list->insert($app->make(HydraPartialCollectionViewNormalizer::class), -800);
             $list->insert($app->make(HalCollectionNormalizer::class), -800);
@@ -1052,7 +1052,7 @@ class ApiPlatformProvider extends ServiceProvider
                     new JsonEncoder('jsonopenapi'),
                     new JsonEncoder('jsonapi'),
                     new JsonEncoder('jsonhal'),
-                    new CsvEncoder,
+                    new CsvEncoder(),
                 ]
             );
         });
@@ -1096,7 +1096,7 @@ class ApiPlatformProvider extends ServiceProvider
         );
 
         $this->app->singleton(InflectorInterface::class, function (Application $app) {
-            return new Inflector;
+            return new Inflector();
         });
 
         if ($this->app->runningInConsole()) {
@@ -1135,7 +1135,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton(GraphQlErrorNormalizer::class, function () {
-            return new GraphQlErrorNormalizer;
+            return new GraphQlErrorNormalizer();
         });
 
         $this->app->singleton(GraphQlValidationExceptionNormalizer::class, function (Application $app) {
@@ -1146,11 +1146,11 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton(GraphQlHttpExceptionNormalizer::class, function () {
-            return new GraphQlHttpExceptionNormalizer;
+            return new GraphQlHttpExceptionNormalizer();
         });
 
         $this->app->singleton(GraphQlRuntimeExceptionNormalizer::class, function () {
-            return new GraphQlHttpExceptionNormalizer;
+            return new GraphQlHttpExceptionNormalizer();
         });
 
         $app->singleton('api_platform.graphql.type_locator', function (Application $app) {
@@ -1169,7 +1169,7 @@ class ApiPlatformProvider extends ServiceProvider
             return new TypesFactory($app->make('api_platform.graphql.type_locator'), array_column($tagged, 'name'));
         });
         $app->singleton(TypesContainerInterface::class, function () {
-            return new TypesContainer;
+            return new TypesContainer();
         });
 
         $app->singleton(ResourceFieldResolver::class, function (Application $app) {
@@ -1302,7 +1302,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $app->singleton(ErrorHandlerInterface::class, function () {
-            return new GraphQlErrorHandler;
+            return new GraphQlErrorHandler();
         });
 
         $app->singleton(ExecutorInterface::class, function (Application $app) {

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -194,6 +194,7 @@ use ApiPlatform\State\Provider\SecurityParameterProvider;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\SerializerContextBuilderInterface;
 use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerInterface;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Foundation\CachesRoutes;
@@ -1346,7 +1347,7 @@ class ApiPlatformProvider extends ServiceProvider
     /**
      * Bootstrap services.
      */
-    public function boot(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory, Router $router): void
+    public function boot(ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory, Router $router, Container $container): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -1447,7 +1448,9 @@ class ApiPlatformProvider extends ServiceProvider
         $route->middleware($globalMiddlewares);
         $routeCollection->add($route);
 
-        $router->setRoutes($routeCollection);
+        foreach ($routeCollection->getRoutes() as $route) {
+            $router->getRoutes()->add($route->setRouter($router)->setContainer($container));
+        }
     }
 
     private function shouldRegisterRoutes(): bool

--- a/src/Laravel/Tests/ApiTest.php
+++ b/src/Laravel/Tests/ApiTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class ApiTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use RefreshDatabase;
+    use WithWorkbench;
+
+    /**
+     * @param  Application  $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], function (Repository $config): void {
+            $config->set('api-platform.routes.domain', 'http://test.com');
+            $config->set('app.debug', true);
+            $config->set('api-platform.formats', ['jsonld' => ['application/ld+json']]);
+            $config->set('api-platform.docs_formats', ['jsonld' => ['application/ld+json']]);
+        });
+    }
+
+    public function test_domain_can_be_set()
+    {
+        $response = $this->get('http://test.com/api/', ['accept' => ['application/ld+json']]);
+        $response->assertSuccessful();
+    }
+}

--- a/src/Laravel/Tests/ApiTest.php
+++ b/src/Laravel/Tests/ApiTest.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
@@ -14,7 +25,7 @@ class ApiTest extends TestCase
     use WithWorkbench;
 
     /**
-     * @param  Application  $app
+     * @param Application $app
      */
     protected function defineEnvironment($app): void
     {
@@ -26,8 +37,11 @@ class ApiTest extends TestCase
         });
     }
 
-    public function test_domain_can_be_set()
+    public function testDomainCanBeSet(): void
     {
+        $response = $this->get('http://foobar.com/api/', ['accept' => ['application/ld+json']]);
+        $response->assertNotFound();
+
         $response = $this->get('http://test.com/api/', ['accept' => ['application/ld+json']]);
         $response->assertSuccessful();
     }

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -21,8 +21,8 @@ return [
 
     'formats' => [
         'jsonld' => ['application/ld+json'],
-        // 'jsonapi' => ['application/vnd.api+json'],
-        // 'csv' => ['text/csv'],
+        //'jsonapi' => ['application/vnd.api+json'],
+        //'csv' => ['text/csv'],
     ],
 
     'patch_formats' => [
@@ -31,7 +31,7 @@ return [
 
     'docs_formats' => [
         'jsonld' => ['application/ld+json'],
-        // 'jsonapi' => ['application/vnd.api+json'],
+        //'jsonapi' => ['application/vnd.api+json'],
         'jsonopenapi' => ['application/vnd.openapi+json'],
         'html' => ['text/html'],
     ],
@@ -62,24 +62,24 @@ return [
     'graphql' => [
         'enabled' => false,
         'nesting_separator' => '__',
-        'introspection' => ['enabled' => true],
+        'introspection' => ['enabled' => true]
     ],
 
     'exception_to_status' => [
         AuthenticationException::class => 401,
-        AuthorizationException::class => 403,
+        AuthorizationException::class => 403
     ],
 
     'swagger_ui' => [
         'enabled' => true,
-        // 'apiKeys' => [
+        //'apiKeys' => [
         //    'api' => [
         //        'type' => 'Bearer',
         //        'name' => 'Authentication Token',
         //        'in' => 'header'
         //    ]
-        // ],
-        // 'oauth' => [
+        //],
+        //'oauth' => [
         //    'enabled' => true,
         //    'type' => 'oauth2',
         //    'flow' => 'authorizationCode',
@@ -88,16 +88,16 @@ return [
         //    'refreshUrl' => '',
         //    'scopes' => ['scope1' => 'Description scope 1'],
         //    'pkce' => true
-        // ],
-        // 'license' => [
+        //],
+        //'license' => [
         //    'name' => 'Apache 2.0',
         //    'url' => 'https://www.apache.org/licenses/LICENSE-2.0.html',
-        // ],
-        // 'contact' => [
+        //],
+        //'contact' => [
         //    'name' => 'API Support',
         //    'url' => 'https://www.example.com/support',
         //    'email' => 'support@example.com',
-        // ],
+        //],
     ],
 
     'url_generation_strategy' => UrlGeneratorInterface::ABS_PATH,
@@ -105,5 +105,5 @@ return [
     'serializer' => [
         'hydra_prefix' => false,
         // 'datetime_format' => \DateTimeInterface::RFC3339
-    ],
+    ]
 ];

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -10,6 +10,7 @@ return [
     'version' => '1.0.0',
 
     'routes' => [
+        'domain' => null,
         // Global middleware applied to every API Platform routes
         // 'middleware' => []
     ],
@@ -20,8 +21,8 @@ return [
 
     'formats' => [
         'jsonld' => ['application/ld+json'],
-        //'jsonapi' => ['application/vnd.api+json'],
-        //'csv' => ['text/csv'],
+        // 'jsonapi' => ['application/vnd.api+json'],
+        // 'csv' => ['text/csv'],
     ],
 
     'patch_formats' => [
@@ -30,7 +31,7 @@ return [
 
     'docs_formats' => [
         'jsonld' => ['application/ld+json'],
-        //'jsonapi' => ['application/vnd.api+json'],
+        // 'jsonapi' => ['application/vnd.api+json'],
         'jsonopenapi' => ['application/vnd.openapi+json'],
         'html' => ['text/html'],
     ],
@@ -43,42 +44,42 @@ return [
         'pagination_enabled' => true,
         'pagination_partial' => false,
         'pagination_client_enabled' => false,
-		'pagination_client_items_per_page' => false,
-		'pagination_client_partial' => false,
-		'pagination_items_per_page' => 30,
-		'pagination_maximum_items_per_page' => 30,
+        'pagination_client_items_per_page' => false,
+        'pagination_client_partial' => false,
+        'pagination_items_per_page' => 30,
+        'pagination_maximum_items_per_page' => 30,
         'route_prefix' => '/api',
         'middleware' => [],
     ],
 
-	'pagination' => [
-		'page_parameter_name' => 'page',
-		'enabled_parameter_name' => 'pagination',
-		'items_per_page_parameter_name' => 'itemsPerPage',
-		'partial_parameter_name' => 'partial',
-	],
+    'pagination' => [
+        'page_parameter_name' => 'page',
+        'enabled_parameter_name' => 'pagination',
+        'items_per_page_parameter_name' => 'itemsPerPage',
+        'partial_parameter_name' => 'partial',
+    ],
 
     'graphql' => [
         'enabled' => false,
         'nesting_separator' => '__',
-        'introspection' => ['enabled' => true]
+        'introspection' => ['enabled' => true],
     ],
 
     'exception_to_status' => [
         AuthenticationException::class => 401,
-        AuthorizationException::class => 403
+        AuthorizationException::class => 403,
     ],
 
     'swagger_ui' => [
         'enabled' => true,
-        //'apiKeys' => [
+        // 'apiKeys' => [
         //    'api' => [
         //        'type' => 'Bearer',
         //        'name' => 'Authentication Token',
         //        'in' => 'header'
         //    ]
-        //],
-        //'oauth' => [
+        // ],
+        // 'oauth' => [
         //    'enabled' => true,
         //    'type' => 'oauth2',
         //    'flow' => 'authorizationCode',
@@ -87,16 +88,16 @@ return [
         //    'refreshUrl' => '',
         //    'scopes' => ['scope1' => 'Description scope 1'],
         //    'pkce' => true
-        //],
-        //'license' => [
+        // ],
+        // 'license' => [
         //    'name' => 'Apache 2.0',
         //    'url' => 'https://www.apache.org/licenses/LICENSE-2.0.html',
-        //],
-        //'contact' => [
+        // ],
+        // 'contact' => [
         //    'name' => 'API Support',
         //    'url' => 'https://www.example.com/support',
         //    'email' => 'support@example.com',
-        //],
+        // ],
     ],
 
     'url_generation_strategy' => UrlGeneratorInterface::ABS_PATH,
@@ -104,5 +105,5 @@ return [
     'serializer' => [
         'hydra_prefix' => false,
         // 'datetime_format' => \DateTimeInterface::RFC3339
-    ]
+    ],
 ];

--- a/src/Laravel/routes/api.php
+++ b/src/Laravel/routes/api.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 use ApiPlatform\JsonLd\Action\ContextAction;
 use ApiPlatform\Laravel\ApiPlatformMiddleware;
 use ApiPlatform\Laravel\Controller\ApiPlatformController;
@@ -17,14 +28,14 @@ use Illuminate\Support\Str;
 $globalMiddlewares = config()->get('api-platform.routes.middleware', []);
 $domain = config()->get('api-platform.routes.domain');
 
-Route::domain($domain)->middleware($globalMiddlewares)->group(function () {
+Route::domain($domain)->middleware($globalMiddlewares)->group(function (): void {
     $resourceNameCollectionFactory = app()->make(ResourceNameCollectionFactoryInterface::class);
     $resourceMetadataFactory = app()->make(ResourceMetadataCollectionFactoryInterface::class);
 
     foreach ($resourceNameCollectionFactory->create() as $resourceClass) {
         foreach ($resourceMetadataFactory->create($resourceClass) as $resourceMetadata) {
             foreach ($resourceMetadata->getOperations() as $operation) {
-                /** @var HttpOperation $operation */
+                /* @var HttpOperation $operation */
                 Route::addRoute($operation->getMethod(), Str::replace('{._format}', '{_format?}', $operation->getUriTemplate()), ApiPlatformController::class)
                     ->prefix($operation->getRoutePrefix())
                     ->middleware(ApiPlatformMiddleware::class.':'.$operation->getName())
@@ -38,8 +49,8 @@ Route::domain($domain)->middleware($globalMiddlewares)->group(function () {
 
     $prefix = config()->get('api-platform.defaults.route_prefix') ?? '';
 
-    Route::group(['prefix' => $prefix], function () {
-        Route::group(['middleware' => ApiPlatformMiddleware::class], function () {
+    Route::group(['prefix' => $prefix], function (): void {
+        Route::group(['middleware' => ApiPlatformMiddleware::class], function (): void {
             Route::get('/contexts/{shortName?}{_format?}', ContextAction::class)
                 ->middleware(ApiPlatformMiddleware::class)
                 ->name('api_jsonld_context');
@@ -53,6 +64,7 @@ Route::domain($domain)->middleware($globalMiddlewares)->group(function () {
                 ->name('api_genid');
 
             Route::get('/{index?}{_format?}', EntrypointController::class)
+                ->where('index', 'index')
                 ->middleware(ApiPlatformMiddleware::class)
                 ->name('api_entrypoint');
         });

--- a/src/Laravel/routes/api.php
+++ b/src/Laravel/routes/api.php
@@ -1,0 +1,68 @@
+<?php
+
+use ApiPlatform\JsonLd\Action\ContextAction;
+use ApiPlatform\Laravel\ApiPlatformMiddleware;
+use ApiPlatform\Laravel\Controller\ApiPlatformController;
+use ApiPlatform\Laravel\Controller\DocumentationController;
+use ApiPlatform\Laravel\Controller\EntrypointController;
+use ApiPlatform\Laravel\GraphQl\Controller\EntrypointController as GraphQlEntrypointController;
+use ApiPlatform\Laravel\GraphQl\Controller\GraphiQlController;
+use ApiPlatform\Metadata\Exception\NotExposedHttpException;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+
+$globalMiddlewares = config()->get('api-platform.routes.middleware', []);
+$domain = config()->get('api-platform.routes.domain');
+
+Route::domain($domain)->middleware($globalMiddlewares)->group(function () {
+    $resourceNameCollectionFactory = app()->make(ResourceNameCollectionFactoryInterface::class);
+    $resourceMetadataFactory = app()->make(ResourceMetadataCollectionFactoryInterface::class);
+
+    foreach ($resourceNameCollectionFactory->create() as $resourceClass) {
+        foreach ($resourceMetadataFactory->create($resourceClass) as $resourceMetadata) {
+            foreach ($resourceMetadata->getOperations() as $operation) {
+                /** @var HttpOperation $operation */
+                Route::addRoute($operation->getMethod(), Str::replace('{._format}', '{_format?}', $operation->getUriTemplate()), ApiPlatformController::class)
+                    ->prefix($operation->getRoutePrefix())
+                    ->middleware(ApiPlatformMiddleware::class.':'.$operation->getName())
+                    ->middleware($operation->getMiddleware())
+                    ->where('_format', '^\.[a-zA-Z]+')
+                    ->name($operation->getName())
+                    ->setDefaults(['_api_operation_name' => $operation->getName(), '_api_resource_class' => $operation->getClass()]);
+            }
+        }
+    }
+
+    $prefix = config()->get('api-platform.defaults.route_prefix') ?? '';
+
+    Route::group(['prefix' => $prefix], function () {
+        Route::group(['middleware' => ApiPlatformMiddleware::class], function () {
+            Route::get('/contexts/{shortName?}{_format?}', ContextAction::class)
+                ->middleware(ApiPlatformMiddleware::class)
+                ->name('api_jsonld_context');
+
+            Route::get('/docs{_format?}', DocumentationController::class)
+                ->middleware(ApiPlatformMiddleware::class)
+                ->name('api_doc');
+
+            Route::get('/.well-known/genid/{id}', fn () => throw new NotExposedHttpException('This route is not exposed on purpose. It generates an IRI for a collection resource without identifier nor item operation.'))
+                ->middleware(ApiPlatformMiddleware::class)
+                ->name('api_genid');
+
+            Route::get('/{index?}{_format?}', EntrypointController::class)
+                ->middleware(ApiPlatformMiddleware::class)
+                ->name('api_entrypoint');
+        });
+
+        if (config()->get('api-platform.graphql.enabled')) {
+            Route::addRoute(['POST', 'GET'], '/graphql', GraphQlEntrypointController::class)
+                ->name('api_graphql');
+
+            Route::get('/graphiql', GraphiQlController::class)
+                ->name('api_graphiql');
+        }
+    });
+});


### PR DESCRIPTION
**Problem**

When the API Platform service provider is not auto-discovered, and manually added as a provider, the SP would overwrite any route that had been registered up until that point. 

Because of the Eloquent ORM introspection that happens when discovering metadata, a DB service is required to perform the introspection. This happens whenever composer `php artisan package:discover` is run. This is not optimal for CI/CD environments where you often don't have those services running to perform chores like linting and static analysis. 

**Solution**

By allowing the developer to add API Platforms SP to composer's `dont-discover` array and manually registering the SP at a later time, we can prevent the needs of the DB specifically when `php artisan package:discover` is run. We then register API Platform's SP in our providers array and let Laravel do the rest. Because the SP is now being registered AFTER the default `RouteServiceProvider`, this PR will no longer overwrite the existing routes as it did before.