### PR TITLE
fix: ApiProperty::$serialize array conversion and make ApiProperty repeatable

### DIFF
--- a/src/Metadata/ApiProperty.php
+++ b/src/Metadata/ApiProperty.php
@@ -26,7 +26,7 @@ use Symfony\Component\Serializer\Attribute\SerializedPath;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ApiProperty
 {
     private ?array $types;
@@ -219,7 +219,7 @@ final class ApiProperty
         private array $extraProperties = [],
     ) {
         $this->types = \is_string($types) ? (array) $types : $types;
-        $this->serialize = \is_array($serialize) ? $serialize : (array) $serialize;
+        $this->serialize = \is_array($serialize) ? $serialize : [$serialize];
     }
 
     public function getProperty(): ?string

--- a/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
+++ b/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
@@ -40,7 +40,6 @@ final class PropertyMetadataLoader implements LoaderInterface
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
     {
-        $attributesMetadata = $classMetadata->getAttributesMetadata();
         // It's very weird to grab Eloquent's properties in that case as they're never serialized
         // the Serializer makes a call on the abstract class, let's save some unneeded work with a condition
         if (Model::class === $classMetadata->getName()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | Closes https://github.com/api-platform/core/issues/6929
| License       | MIT
| Doc PR        | n/a

The array cast is faulty (it converts the properties of the object) in an array and the attribute must be repeatable when used on a class.

This fixes https://github.com/api-platform/core/issues/6929