### PR TITLE
perf: various optimizations for Laravel/Symfony

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -247,6 +247,7 @@ class ApiPlatformProvider extends ServiceProvider
             );
         });
 
+        $this->app->singleton(ModelMetadata::class);
         $this->app->bind(LoaderInterface::class, AttributeLoader::class);
         $this->app->bind(ClassMetadataFactoryInterface::class, ClassMetadataFactory::class);
         $this->app->singleton(ClassMetadataFactory::class, function (Application $app) {

--- a/src/Metadata/Resource/Factory/ConcernsResourceNameCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ConcernsResourceNameCollectionFactory.php
@@ -47,10 +47,14 @@ final class ConcernsResourceNameCollectionFactory implements ResourceNameCollect
         }
 
         foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories($this->paths) as $className => $reflectionClass) {
+            if (!$reflectionClass->hasMethod('apiResource')) {
+                continue;
+            }
+
+            $m = $reflectionClass->getMethod('apiResource');
+
             if (
-                $reflectionClass->hasMethod('apiResource')
-                && ($m = $reflectionClass->getMethod('apiResource'))
-                && $m->isPublic()
+                $m->isPublic()
                 && $m->isStatic()
             ) {
                 $classes[$className] = true;


### PR DESCRIPTION
Few changes:

  - ModelMetadata was not a singleton in Laravel and we had 2 different instances
  - ModelMetadata clean up (some methods were dead code) + added memory cache for better speed in dev mode
  - defining uriVariables (for example: `uriVariables: ['id']`) is always faster then letting us compute them as we go through every property, added a local memory cache for that too
  -  ReflectionClassRecursiveIterator is now used in 3 classes (compared to only one in API Platform 3.4), 2 of them are used with Symfony and 3 with Laravel, I added a simple local memory cache for that too as it loops over all declared classes in the project. 

https://github.com/api-platform/core/pull/6943 is a great start to remove that ReflectionClassRecursiveIterator but we need time to do it properly, and it also probably means proposing patches to Symfony + Doctrine-Bridge.

Blackfire: https://blackfire.io/profiles/compare/a1369434-ce45-4f88-88df-97049aa83f03/graph


![20250207_16h07m25s_grim](https://github.com/user-attachments/assets/b0b1c2c6-bfac-47d3-a36d-caa5344fc667)
