### PR TITLE
feat(json-schema): mutualize json schema between formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1298,7 +1298,7 @@ jobs:
           tests/Fixtures/app/console api:openapi:export --yaml -o build/out/openapi/openapi_v3.yaml
       - name: Validate OpenAPI documents
         run: |
-          npx @quobix/vacuum lint -r tests/Fixtures/app/ruleset.yaml build/out/openapi/openapi_v3.yaml -d
+          npx @quobix/vacuum lint -r tests/Fixtures/app/ruleset.yaml build/out/openapi/openapi_v3.yaml -d --ignore-array-circle-ref --ignore-polymorph-circle-ref -b --no-clip
 
   laravel:
     name: Laravel (PHP ${{ matrix.php }})

--- a/features/jsonapi/related-resouces-inclusion.feature
+++ b/features/jsonapi/related-resouces-inclusion.feature
@@ -54,7 +54,9 @@ Feature: JSON API Inclusion of Related Resources
     }
   """
 
+  @createSchema
   Scenario: Request inclusion of a non existing related resource
+    Given there are 3 dummy property objects
     When I send a "GET" request to "/dummy_properties/1?include=foo"
     Then the response status code should be 200
     And the response should be in JSON
@@ -87,7 +89,9 @@ Feature: JSON API Inclusion of Related Resources
     }
   """
 
+  @createSchema
   Scenario: Request inclusion of a related resource keeping main object properties unfiltered
+    Given there are 3 dummy property objects
     When I send a "GET" request to "/dummy_properties/1?include=group&fields[group]=id,foo&fields[DummyProperty]=bar,baz"
     Then the response status code should be 200
     And the response should be in JSON

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -153,10 +153,9 @@ Feature: Documentation support
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 6 elements
 
     # Subcollection - check schema
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.allOf[1].properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany"
 
     # Deprecations
-    And the JSON node "paths./dummies.get.deprecated" should be false
     And the JSON node "paths./deprecated_resources.get.deprecated" should be true
     And the JSON node "paths./deprecated_resources.post.deprecated" should be true
     And the JSON node "paths./deprecated_resources/{id}.get.deprecated" should be true
@@ -166,111 +165,6 @@ Feature: Documentation support
 
     # Formats
     And the OpenAPI class "Dummy.jsonld" exists
-    And the "@id" property exists for the OpenAPI class "Dummy.jsonld"
-    And the JSON node "paths./dummies.get.responses.200.content.application/ld+json" should be equal to:
-    """
-    {
-        "schema": {
-            "type": "object",
-            "properties": {
-                "hydra:member": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/components/schemas/Dummy.jsonld"
-                    }
-                },
-                "hydra:totalItems": {
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "hydra:view": {
-                    "type": "object",
-                    "properties": {
-                        "@id": {
-                            "type": "string",
-                            "format": "iri-reference"
-                        },
-                        "@type": {
-                            "type": "string"
-                        },
-                        "hydra:first": {
-                            "type": "string",
-                            "format": "iri-reference"
-                        },
-                        "hydra:last": {
-                            "type": "string",
-                            "format": "iri-reference"
-                        },
-                        "hydra:previous": {
-                            "type": "string",
-                            "format": "iri-reference"
-                        },
-                        "hydra:next": {
-                            "type": "string",
-                            "format": "iri-reference"
-                        }
-                    },
-                    "example": {
-                        "@id": "string",
-                        "type": "string",
-                        "hydra:first": "string",
-                        "hydra:last": "string",
-                        "hydra:previous": "string",
-                        "hydra:next": "string"
-                    }
-                },
-                "hydra:search": {
-                    "type": "object",
-                    "properties": {
-                        "@type": {
-                            "type": "string"
-                        },
-                        "hydra:template": {
-                            "type": "string"
-                        },
-                        "hydra:variableRepresentation": {
-                            "type": "string"
-                        },
-                        "hydra:mapping": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "@type": {
-                                        "type": "string"
-                                    },
-                                    "variable": {
-                                        "type": "string"
-                                    },
-                                    "property": {
-                                        "type": ["string", "null"]
-                                    },
-                                    "required": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "required": [
-                "hydra:member"
-            ]
-        }
-    }
-    """
-    And the JSON node "paths./dummies.get.responses.200.content.application/json" should be equal to:
-    """
-    {
-        "schema": {
-            "type": "array",
-            "items": {
-                "$ref": "#/components/schemas/Dummy"
-            }
-        }
-    }
-    """
     And the JSON node "paths./override_open_api_responses.post.responses" should be equal to:
     """
     {
@@ -322,7 +216,6 @@ Feature: Documentation support
     And the "resourceRelated" property for the OpenAPI class "Resource" should be equal to:
     """
     {
-      "readOnly": true,
       "anyOf": [
         {
           "$ref": "#/components/schemas/ResourceRelated"

--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -80,13 +80,12 @@ Feature: Documentation support
     And the JSON node "paths./api/custom-call/{id}.put" should exist
     # Properties
     And the "id" property exists for the OpenAPI class "Dummy"
-    And the "name" property is required for the OpenAPI class "Dummy"
+    And the "name" property is required for the OpenAPI class "Dummy.jsonld"
     And the "genderType" property exists for the OpenAPI class "Person"
     And the "genderType" property for the OpenAPI class "Person" should be equal to:
     """
     {
       "default": "male",
-      "example": "male",
       "type": ["string", "null"],
       "enum": [
           "male",
@@ -216,6 +215,7 @@ Feature: Documentation support
     And the "resourceRelated" property for the OpenAPI class "Resource" should be equal to:
     """
     {
+      "readOnly": true,
       "anyOf": [
         {
           "$ref": "#/components/schemas/ResourceRelated"

--- a/src/Hal/JsonSchema/SchemaFactory.php
+++ b/src/Hal/JsonSchema/SchemaFactory.php
@@ -13,10 +13,15 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Hal\JsonSchema;
 
+use ApiPlatform\JsonSchema\DefinitionNameFactory;
+use ApiPlatform\JsonSchema\DefinitionNameFactoryInterface;
+use ApiPlatform\JsonSchema\ResourceMetadataTrait;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\JsonSchema\SchemaUriPrefixTrait;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 
 /**
  * Decorator factory which adds HAL properties to the JSON Schema document.
@@ -26,6 +31,11 @@ use ApiPlatform\Metadata\Operation;
  */
 final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
+    use ResourceMetadataTrait;
+    use SchemaUriPrefixTrait;
+
+    private const COLLECTION_BASE_SCHEMA_NAME = 'HalCollectionBaseSchema';
+
     private const HREF_PROP = [
         'href' => [
             'type' => 'string',
@@ -44,8 +54,12 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         ],
     ];
 
-    public function __construct(private readonly SchemaFactoryInterface $schemaFactory)
+    public function __construct(private readonly SchemaFactoryInterface $schemaFactory, private ?DefinitionNameFactoryInterface $definitionNameFactory = null, ?ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null)
     {
+        if (!$definitionNameFactory) {
+            $this->definitionNameFactory = new DefinitionNameFactory();
+        }
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
         if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
             $this->schemaFactory->setSchemaFactory($this);
         }
@@ -56,78 +70,130 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
      */
     public function buildSchema(string $className, string $format = 'jsonhal', string $type = Schema::TYPE_OUTPUT, ?Operation $operation = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
     {
-        $schema = $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
         if ('jsonhal' !== $format) {
-            return $schema;
+            return $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
         }
 
+        if (!$this->isResourceClass($className)) {
+            $operation = null;
+            $inputOrOutputClass = null;
+            $serializerContext ??= [];
+        } else {
+            $operation = $this->findOperation($className, $type, $operation, $serializerContext, $format);
+            $inputOrOutputClass = $this->findOutputClass($className, $type, $operation, $serializerContext);
+            $serializerContext ??= $this->getSerializerContext($operation, $type);
+        }
+
+        if (null === $inputOrOutputClass) {
+            // input or output disabled
+            return $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
+        }
+
+        $schema = $this->schemaFactory->buildSchema($className, 'json', $type, $operation, $schema, $serializerContext, $forceCollection);
         $definitions = $schema->getDefinitions();
-        if ($key = $schema->getRootDefinitionKey()) {
-            $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
+        $definitionName = $this->definitionNameFactory->create($className, $format, $className, $operation, $serializerContext);
+        $prefix = $this->getSchemaUriPrefix($schema->getVersion());
+        $collectionKey = $schema->getItemsDefinitionKey();
+
+        // Already computed
+        if (!$collectionKey && isset($definitions[$definitionName])) {
+            $schema['$ref'] = $prefix.$definitionName;
 
             return $schema;
         }
-        if ($key = $schema->getItemsDefinitionKey()) {
-            $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
+
+        $key = $schema->getRootDefinitionKey() ?? $collectionKey;
+
+        $definitions[$definitionName] = [
+            'allOf' => [
+                ['type' => 'object', 'properties' => self::BASE_PROPS],
+                ['$ref' => $prefix.$key],
+            ],
+        ];
+
+        if (isset($definitions[$key]['description'])) {
+            $definitions[$definitionName]['description'] = $definitions[$key]['description'];
+        }
+
+        if (!$collectionKey) {
+            $schema['$ref'] = $prefix.$definitionName;
+
+            return $schema;
         }
 
         if (($schema['type'] ?? '') === 'array') {
-            $items = $schema['items'];
-            unset($schema['items']);
-
-            $schema['type'] = 'object';
-            $schema['properties'] = [
-                '_embedded' => [
-                    'anyOf' => [
-                        [
+            if (!isset($definitions[self::COLLECTION_BASE_SCHEMA_NAME])) {
+                $definitions[self::COLLECTION_BASE_SCHEMA_NAME] = [
+                    'type' => 'object',
+                    'properties' => [
+                        '_embedded' => [
+                            'anyOf' => [
+                                [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'item' => [
+                                            'type' => 'array',
+                                        ],
+                                    ],
+                                ],
+                                ['type' => 'object'],
+                            ],
+                        ],
+                        'totalItems' => [
+                            'type' => 'integer',
+                            'minimum' => 0,
+                        ],
+                        'itemsPerPage' => [
+                            'type' => 'integer',
+                            'minimum' => 0,
+                        ],
+                        '_links' => [
                             'type' => 'object',
                             'properties' => [
-                                'item' => [
-                                    'type' => 'array',
-                                    'items' => $items,
+                                'self' => [
+                                    'type' => 'object',
+                                    'properties' => self::HREF_PROP,
+                                ],
+                                'first' => [
+                                    'type' => 'object',
+                                    'properties' => self::HREF_PROP,
+                                ],
+                                'last' => [
+                                    'type' => 'object',
+                                    'properties' => self::HREF_PROP,
+                                ],
+                                'next' => [
+                                    'type' => 'object',
+                                    'properties' => self::HREF_PROP,
+                                ],
+                                'previous' => [
+                                    'type' => 'object',
+                                    'properties' => self::HREF_PROP,
                                 ],
                             ],
                         ],
-                        ['type' => 'object'],
                     ],
-                ],
-                'totalItems' => [
-                    'type' => 'integer',
-                    'minimum' => 0,
-                ],
-                'itemsPerPage' => [
-                    'type' => 'integer',
-                    'minimum' => 0,
-                ],
-                '_links' => [
+                    'required' => ['_links', '_embedded'],
+                ];
+            }
+
+            unset($schema['items']);
+            unset($schema['type']);
+
+            $schema['description'] = "$definitionName collection.";
+            $schema['allOf'] = [
+                ['$ref' => $prefix.self::COLLECTION_BASE_SCHEMA_NAME],
+                [
                     'type' => 'object',
                     'properties' => [
-                        'self' => [
-                            'type' => 'object',
-                            'properties' => self::HREF_PROP,
-                        ],
-                        'first' => [
-                            'type' => 'object',
-                            'properties' => self::HREF_PROP,
-                        ],
-                        'last' => [
-                            'type' => 'object',
-                            'properties' => self::HREF_PROP,
-                        ],
-                        'next' => [
-                            'type' => 'object',
-                            'properties' => self::HREF_PROP,
-                        ],
-                        'previous' => [
-                            'type' => 'object',
-                            'properties' => self::HREF_PROP,
+                        '_embedded' => [
+                            'additionalProperties' => [
+                                'type' => 'array',
+                                'items' => ['$ref' => $prefix.$definitionName],
+                            ],
                         ],
                     ],
                 ],
-            ];
-            $schema['required'] = [
-                '_links',
-                '_embedded',
             ];
 
             return $schema;

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -15,10 +15,15 @@ namespace ApiPlatform\Hydra\JsonSchema;
 
 use ApiPlatform\JsonLd\ContextBuilder;
 use ApiPlatform\JsonLd\Serializer\HydraPrefixTrait;
+use ApiPlatform\JsonSchema\DefinitionNameFactory;
+use ApiPlatform\JsonSchema\DefinitionNameFactoryInterface;
+use ApiPlatform\JsonSchema\ResourceMetadataTrait;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\JsonSchema\SchemaUriPrefixTrait;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 
 /**
  * Decorator factory which adds Hydra properties to the JSON Schema document.
@@ -28,39 +33,67 @@ use ApiPlatform\Metadata\Operation;
 final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     use HydraPrefixTrait;
+    use ResourceMetadataTrait;
+    use SchemaUriPrefixTrait;
+
+    private const ITEM_BASE_SCHEMA_NAME = 'HydraItemBaseSchema';
+    private const ITEM_BASE_SCHEMA_OUTPUT_NAME = 'HydraOutputBaseSchema';
+    private const COLLECTION_BASE_SCHEMA_NAME = 'HydraCollectionBaseSchema';
     private const BASE_PROP = [
-        'readOnly' => true,
         'type' => 'string',
     ];
     private const BASE_PROPS = [
         '@id' => self::BASE_PROP,
         '@type' => self::BASE_PROP,
     ];
-    private const BASE_ROOT_PROPS = [
-        '@context' => [
-            'readOnly' => true,
-            'oneOf' => [
-                ['type' => 'string'],
-                [
-                    'type' => 'object',
-                    'properties' => [
-                        '@vocab' => [
-                            'type' => 'string',
+    private const ITEM_BASE_SCHEMA = [
+        'type' => 'object',
+        'properties' => [
+            '@context' => [
+                'oneOf' => [
+                    ['type' => 'string'],
+                    [
+                        'type' => 'object',
+                        'properties' => [
+                            '@vocab' => [
+                                'type' => 'string',
+                            ],
+                            'hydra' => [
+                                'type' => 'string',
+                                'enum' => [ContextBuilder::HYDRA_NS],
+                            ],
                         ],
-                        'hydra' => [
-                            'type' => 'string',
-                            'enum' => [ContextBuilder::HYDRA_NS],
-                        ],
+                        'required' => ['@vocab', 'hydra'],
+                        'additionalProperties' => true,
                     ],
-                    'required' => ['@vocab', 'hydra'],
-                    'additionalProperties' => true,
                 ],
             ],
-        ],
-    ] + self::BASE_PROPS;
+        ] + self::BASE_PROPS,
+    ];
 
-    public function __construct(private readonly SchemaFactoryInterface $schemaFactory, private readonly array $defaultContext = [])
-    {
+    private const ITEM_BASE_SCHEMA_OUTPUT = [
+        'required' => ['@id', '@type'],
+    ] + self::ITEM_BASE_SCHEMA;
+
+    /**
+     * @var array<string, true>
+     */
+    private array $transformed = [];
+
+    /**
+     * @param array<string, mixed> $defaultContext
+     */
+    public function __construct(
+        private readonly SchemaFactoryInterface $schemaFactory,
+        private readonly array $defaultContext = [],
+        private ?DefinitionNameFactoryInterface $definitionNameFactory = null,
+        ?ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null,
+    ) {
+        if (!$definitionNameFactory) {
+            $this->definitionNameFactory = new DefinitionNameFactory();
+        }
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+
         if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
             $this->schemaFactory->setSchemaFactory($this);
         }
@@ -71,30 +104,76 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
      */
     public function buildSchema(string $className, string $format = 'jsonld', string $type = Schema::TYPE_OUTPUT, ?Operation $operation = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
     {
-        $schema = $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
-        if ('jsonld' !== $format) {
-            return $schema;
+        if ('jsonld' !== $format || 'input' === $type) {
+            return $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
+        }
+        if (!$this->isResourceClass($className)) {
+            $operation = null;
+            $inputOrOutputClass = null;
+            $serializerContext ??= [];
+        } else {
+            $operation = $this->findOperation($className, $type, $operation, $serializerContext, $format);
+            $inputOrOutputClass = $this->findOutputClass($className, $type, $operation, $serializerContext);
+            $serializerContext ??= $this->getSerializerContext($operation, $type);
         }
 
-        if ('input' === $type) {
-            return $schema;
+        if (null === $inputOrOutputClass) {
+            // input or output disabled
+            return $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
         }
 
+        $definitionName = $this->definitionNameFactory->create($className, $format, $inputOrOutputClass, $operation, $serializerContext);
+
+        // JSON-LD is slightly different then JSON:API or HAL
+        // All the references that are resources must also be in JSON-LD therefore combining
+        // the HydraItemBaseSchema and the JSON schema is harder (unless we loop again through all relationship)
+        // The less intensive path is to compute the jsonld schemas, then to combine in an allOf
+        $schema = $this->schemaFactory->buildSchema($className, 'jsonld', $type, $operation, $schema, $serializerContext, $forceCollection);
         $definitions = $schema->getDefinitions();
-        if ($key = $schema->getRootDefinitionKey()) {
-            $definitions[$key]['properties'] = self::BASE_ROOT_PROPS + ($definitions[$key]['properties'] ?? []);
+
+        $prefix = $this->getSchemaUriPrefix($schema->getVersion());
+        $collectionKey = $schema->getItemsDefinitionKey();
+        $key = $schema->getRootDefinitionKey() ?? $collectionKey;
+
+        if (!$collectionKey) {
+            if ($this->transformed[$definitionName] ?? false) {
+                return $schema;
+            }
+
+            $baseName = Schema::TYPE_OUTPUT === $type ? self::ITEM_BASE_SCHEMA_NAME : self::ITEM_BASE_SCHEMA_OUTPUT_NAME;
+
+            if ($this->isResourceClass($inputOrOutputClass)) {
+                if (!isset($definitions[$baseName])) {
+                    $definitions[$baseName] = Schema::TYPE_OUTPUT === $type ? self::ITEM_BASE_SCHEMA_OUTPUT : self::ITEM_BASE_SCHEMA;
+                }
+            }
+
+            $allOf = new \ArrayObject(['allOf' => [
+                ['$ref' => $prefix.$baseName],
+                $definitions[$key],
+            ]]);
+
+            if (isset($definitions[$key]['description'])) {
+                $allOf['description'] = $definitions[$key]['description'];
+            }
+
+            $definitions[$definitionName] = $allOf;
+            unset($definitions[$definitionName]['allOf'][1]['description']);
+
+            $schema['$ref'] = $prefix.$definitionName;
+
+            $this->transformed[$definitionName] = true;
 
             return $schema;
         }
-        if ($key = $schema->getItemsDefinitionKey()) {
-            $definitions[$key]['properties'] = self::BASE_PROPS + ($definitions[$key]['properties'] ?? []);
+
+        if (($schema['type'] ?? '') !== 'array') {
+            return $schema;
         }
 
-        if (($schema['type'] ?? '') === 'array') {
-            // hydra:collection
-            $items = $schema['items'];
-            unset($schema['items']);
+        $hydraPrefix = $this->getHydraPrefix($serializerContext + $this->defaultContext);
 
+        if (!isset($definitions[self::COLLECTION_BASE_SCHEMA_NAME])) {
             switch ($schema->getVersion()) {
                 // JSON Schema + OpenAPI 3.1
                 case Schema::VERSION_OPENAPI:
@@ -107,80 +186,95 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                     break;
             }
 
-            $hydraPrefix = $this->getHydraPrefix(($serializerContext ?? []) + $this->defaultContext);
-            $schema['type'] = 'object';
-            $schema['properties'] = [
-                $hydraPrefix.'member' => [
-                    'type' => 'array',
-                    'items' => $items,
+            $definitions[self::COLLECTION_BASE_SCHEMA_NAME] = [
+                'type' => 'object',
+                'required' => [
+                    $hydraPrefix.'member',
                 ],
-                $hydraPrefix.'totalItems' => [
-                    'type' => 'integer',
-                    'minimum' => 0,
-                ],
-                $hydraPrefix.'view' => [
-                    'type' => 'object',
-                    'properties' => [
-                        '@id' => [
-                            'type' => 'string',
-                            'format' => 'iri-reference',
+                'properties' => [
+                    $hydraPrefix.'member' => [
+                        'type' => 'array',
+                    ],
+                    $hydraPrefix.'totalItems' => [
+                        'type' => 'integer',
+                        'minimum' => 0,
+                    ],
+                    $hydraPrefix.'view' => [
+                        'type' => 'object',
+                        'properties' => [
+                            '@id' => [
+                                'type' => 'string',
+                                'format' => 'iri-reference',
+                            ],
+                            '@type' => [
+                                'type' => 'string',
+                            ],
+                            $hydraPrefix.'first' => [
+                                'type' => 'string',
+                                'format' => 'iri-reference',
+                            ],
+                            $hydraPrefix.'last' => [
+                                'type' => 'string',
+                                'format' => 'iri-reference',
+                            ],
+                            $hydraPrefix.'previous' => [
+                                'type' => 'string',
+                                'format' => 'iri-reference',
+                            ],
+                            $hydraPrefix.'next' => [
+                                'type' => 'string',
+                                'format' => 'iri-reference',
+                            ],
                         ],
-                        '@type' => [
+                        'example' => [
+                            '@id' => 'string',
                             'type' => 'string',
-                        ],
-                        $hydraPrefix.'first' => [
-                            'type' => 'string',
-                            'format' => 'iri-reference',
-                        ],
-                        $hydraPrefix.'last' => [
-                            'type' => 'string',
-                            'format' => 'iri-reference',
-                        ],
-                        $hydraPrefix.'previous' => [
-                            'type' => 'string',
-                            'format' => 'iri-reference',
-                        ],
-                        $hydraPrefix.'next' => [
-                            'type' => 'string',
-                            'format' => 'iri-reference',
+                            $hydraPrefix.'first' => 'string',
+                            $hydraPrefix.'last' => 'string',
+                            $hydraPrefix.'previous' => 'string',
+                            $hydraPrefix.'next' => 'string',
                         ],
                     ],
-                    'example' => [
-                        '@id' => 'string',
-                        'type' => 'string',
-                        $hydraPrefix.'first' => 'string',
-                        $hydraPrefix.'last' => 'string',
-                        $hydraPrefix.'previous' => 'string',
-                        $hydraPrefix.'next' => 'string',
-                    ],
-                ],
-                $hydraPrefix.'search' => [
-                    'type' => 'object',
-                    'properties' => [
-                        '@type' => ['type' => 'string'],
-                        $hydraPrefix.'template' => ['type' => 'string'],
-                        $hydraPrefix.'variableRepresentation' => ['type' => 'string'],
-                        $hydraPrefix.'mapping' => [
-                            'type' => 'array',
-                            'items' => [
-                                'type' => 'object',
-                                'properties' => [
-                                    '@type' => ['type' => 'string'],
-                                    'variable' => ['type' => 'string'],
-                                    'property' => $nullableStringDefinition,
-                                    'required' => ['type' => 'boolean'],
+                    $hydraPrefix.'search' => [
+                        'type' => 'object',
+                        'properties' => [
+                            '@type' => ['type' => 'string'],
+                            $hydraPrefix.'template' => ['type' => 'string'],
+                            $hydraPrefix.'variableRepresentation' => ['type' => 'string'],
+                            $hydraPrefix.'mapping' => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        '@type' => ['type' => 'string'],
+                                        'variable' => ['type' => 'string'],
+                                        'property' => $nullableStringDefinition,
+                                        'required' => ['type' => 'boolean'],
+                                    ],
                                 ],
                             ],
                         ],
                     ],
                 ],
             ];
-            $schema['required'] = [
-                $hydraPrefix.'member',
-            ];
-
-            return $schema;
         }
+
+        $schema['type'] = 'object';
+        $schema['description'] = "$definitionName collection.";
+        $schema['allOf'] = [
+            ['$ref' => $prefix.self::COLLECTION_BASE_SCHEMA_NAME],
+            [
+                'type' => 'object',
+                'properties' => [
+                    $hydraPrefix.'member' => [
+                        'type' => 'array',
+                        'items' => $schema['items'],
+                    ],
+                ],
+            ],
+        ];
+
+        unset($schema['items']);
 
         return $schema;
     }

--- a/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\JsonLd\ContextBuilder;
 use ApiPlatform\JsonSchema\DefinitionNameFactory;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactory as BaseSchemaFactory;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -28,6 +29,7 @@ use ApiPlatform\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 class SchemaFactoryTest extends TestCase
@@ -48,10 +50,12 @@ class SchemaFactoryTest extends TestCase
         );
 
         $propertyNameCollectionFactory = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
-        $propertyNameCollectionFactory->create(Dummy::class, ['enable_getter_setter_extraction' => true, 'schema_type' => Schema::TYPE_OUTPUT])->willReturn(new PropertyNameCollection());
+        $propertyNameCollectionFactory->create(Dummy::class, ['enable_getter_setter_extraction' => true, 'schema_type' => Schema::TYPE_OUTPUT])->willReturn(new PropertyNameCollection(['id', 'name']));
         $propertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->create(Dummy::class, 'id', Argument::type('array'))->willReturn(new ApiProperty(identifier: true));
+        $propertyMetadataFactory->create(Dummy::class, 'name', Argument::type('array'))->willReturn(new ApiProperty());
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $baseSchemaFactory = new BaseSchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryCollection->reveal(),
@@ -60,7 +64,12 @@ class SchemaFactoryTest extends TestCase
             definitionNameFactory: $definitionNameFactory,
         );
 
-        $this->schemaFactory = new SchemaFactory($baseSchemaFactory);
+        $this->schemaFactory = new SchemaFactory(
+            $baseSchemaFactory,
+            [],
+            $definitionNameFactory,
+            $resourceMetadataFactoryCollection->reveal(),
+        );
     }
 
     public function testBuildSchema(): void
@@ -86,12 +95,13 @@ class SchemaFactoryTest extends TestCase
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
         $this->assertTrue(isset($definitions[$rootDefinitionKey]));
-        $this->assertTrue(isset($definitions[$rootDefinitionKey]['properties']));
-        $properties = $resultSchema['definitions'][$rootDefinitionKey]['properties'];
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]['allOf'][1]['properties']));
+        $this->assertEquals($definitions[$rootDefinitionKey]['allOf'][0], ['$ref' => '#/definitions/HydraItemBaseSchema']);
+
+        $properties = $definitions['HydraItemBaseSchema']['properties'];
         $this->assertArrayHasKey('@context', $properties);
         $this->assertEquals(
             [
-                'readOnly' => true,
                 'oneOf' => [
                     ['type' => 'string'],
                     [
@@ -119,55 +129,34 @@ class SchemaFactoryTest extends TestCase
     public function testSchemaTypeBuildSchema(): void
     {
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection());
-        $definitionName = 'Dummy.jsonld';
-
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        $this->assertTrue(isset($resultSchema['properties']));
-        $this->assertTrue(isset($resultSchema['properties']['hydra:member']));
-        $this->assertArrayHasKey('hydra:totalItems', $resultSchema['properties']);
-        $this->assertArrayHasKey('hydra:view', $resultSchema['properties']);
-        $this->assertArrayHasKey('hydra:search', $resultSchema['properties']);
-        $properties = $resultSchema['definitions'][$definitionName]['properties'];
+        $hydraCollectionSchema = $resultSchema['definitions']['HydraCollectionBaseSchema'];
+        $properties = $hydraCollectionSchema['properties'];
+        $this->assertTrue(isset($properties['hydra:member']));
+        $this->assertArrayHasKey('hydra:totalItems', $properties);
+        $this->assertArrayHasKey('hydra:view', $properties);
+        $this->assertArrayHasKey('hydra:search', $properties);
         $this->assertArrayNotHasKey('@context', $properties);
-        $this->assertArrayHasKey('@type', $properties);
-        $this->assertArrayHasKey('@id', $properties);
 
-        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, null, null, true);
+        $this->assertTrue(isset($properties['hydra:view']));
+        $this->assertArrayHasKey('properties', $properties['hydra:view']);
+        $this->assertArrayHasKey('hydra:first', $properties['hydra:view']['properties']);
+        $this->assertArrayHasKey('hydra:last', $properties['hydra:view']['properties']);
+        $this->assertArrayHasKey('hydra:previous', $properties['hydra:view']['properties']);
+        $this->assertArrayHasKey('hydra:next', $properties['hydra:view']['properties']);
 
-        $this->assertNull($resultSchema->getRootDefinitionKey());
-        $this->assertTrue(isset($resultSchema['properties']));
-        $this->assertTrue(isset($resultSchema['properties']['hydra:member']));
-        $this->assertArrayHasKey('hydra:totalItems', $resultSchema['properties']);
-        $this->assertArrayHasKey('hydra:view', $resultSchema['properties']);
-        $this->assertArrayHasKey('hydra:search', $resultSchema['properties']);
-        $properties = $resultSchema['definitions'][$definitionName]['properties'];
-        $this->assertArrayNotHasKey('@context', $properties);
-        $this->assertArrayHasKey('@type', $properties);
-        $this->assertArrayHasKey('@id', $properties);
-    }
-
-    public function testHasHydraViewNavigationBuildSchema(): void
-    {
-        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection());
-
-        $this->assertNull($resultSchema->getRootDefinitionKey());
-        $this->assertTrue(isset($resultSchema['properties']));
-        $this->assertTrue(isset($resultSchema['properties']['hydra:view']));
-        $this->assertArrayHasKey('properties', $resultSchema['properties']['hydra:view']);
-        $this->assertArrayHasKey('hydra:first', $resultSchema['properties']['hydra:view']['properties']);
-        $this->assertArrayHasKey('hydra:last', $resultSchema['properties']['hydra:view']['properties']);
-        $this->assertArrayHasKey('hydra:previous', $resultSchema['properties']['hydra:view']['properties']);
-        $this->assertArrayHasKey('hydra:next', $resultSchema['properties']['hydra:view']['properties']);
+        $forcedCollection = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, null, null, true);
+        $this->assertEquals($resultSchema['allOf'][0]['$ref'], $forcedCollection['allOf'][0]['$ref']);
     }
 
     public function testSchemaTypeBuildSchemaWithoutPrefix(): void
     {
         $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new GetCollection(), null, [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false]);
         $this->assertNull($resultSchema->getRootDefinitionKey());
-        $this->assertTrue(isset($resultSchema['properties']));
-        $this->assertTrue(isset($resultSchema['properties']['member']));
-        $this->assertArrayHasKey('totalItems', $resultSchema['properties']);
-        $this->assertArrayHasKey('view', $resultSchema['properties']);
-        $this->assertArrayHasKey('search', $resultSchema['properties']);
+        $hydraCollectionSchema = $resultSchema['definitions']['HydraCollectionBaseSchema'];
+        $properties = $hydraCollectionSchema['properties'];
+        $this->assertArrayHasKey('totalItems', $properties);
+        $this->assertArrayHasKey('view', $properties);
+        $this->assertArrayHasKey('search', $properties);
     }
 }

--- a/src/JsonApi/JsonSchema/SchemaFactory.php
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace ApiPlatform\JsonApi\JsonSchema;
 
+use ApiPlatform\JsonSchema\DefinitionNameFactory;
 use ApiPlatform\JsonSchema\DefinitionNameFactoryInterface;
 use ApiPlatform\JsonSchema\ResourceMetadataTrait;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\JsonSchema\SchemaUriPrefixTrait;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -37,6 +39,7 @@ use Symfony\Component\TypeInfo\Type\ObjectType;
 final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareInterface
 {
     use ResourceMetadataTrait;
+    use SchemaUriPrefixTrait;
 
     /**
      * As JSON:API recommends using [includes](https://jsonapi.org/format/#fetching-includes) instead of groups
@@ -44,6 +47,8 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
      * a serializer context.
      */
     public const DISABLE_JSON_SCHEMA_SERIALIZER_GROUPS = 'disable_json_schema_serializer_groups';
+
+    private const COLLECTION_BASE_SCHEMA_NAME = 'JsonApiCollectionBaseSchema';
 
     private const LINKS_PROPS = [
         'type' => 'object',
@@ -119,8 +124,16 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         ],
     ];
 
-    public function __construct(private readonly SchemaFactoryInterface $schemaFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, ?ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null, private readonly ?DefinitionNameFactoryInterface $definitionNameFactory = null)
+    /**
+     * @var array<string, bool>
+     */
+    private $builtSchema = [];
+
+    public function __construct(private readonly SchemaFactoryInterface $schemaFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, ResourceClassResolverInterface $resourceClassResolver, ?ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory = null, private ?DefinitionNameFactoryInterface $definitionNameFactory = null)
     {
+        if (!$definitionNameFactory) {
+            $this->definitionNameFactory = new DefinitionNameFactory();
+        }
         if ($this->schemaFactory instanceof SchemaFactoryAwareInterface) {
             $this->schemaFactory->setSchemaFactory($this);
         }
@@ -136,59 +149,104 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         if ('jsonapi' !== $format) {
             return $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
         }
-        // We don't use the serializer context here as JSON:API doesn't leverage serializer groups for related resources.
-        // That is done by query parameter. @see https://jsonapi.org/format/#fetching-includes
-        $serializerContext ??= $this->getSerializerContext($operation ?? $this->findOperation($className, $type, $operation, $serializerContext, $format), $type);
-        $jsonApiSerializerContext = !($serializerContext[self::DISABLE_JSON_SCHEMA_SERIALIZER_GROUPS] ?? true) ? $serializerContext : [];
-        $schema = $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $jsonApiSerializerContext, $forceCollection);
 
-        if (($key = $schema->getRootDefinitionKey()) || ($key = $schema->getItemsDefinitionKey())) {
-            $definitions = $schema->getDefinitions();
-            $properties = $definitions[$key]['properties'] ?? [];
-
-            if (Error::class === $className && !isset($properties['errors'])) {
-                $definitions[$key]['properties'] = [
-                    'errors' => [
-                        'type' => 'object',
-                        'properties' => $properties,
-                    ],
-                ];
-
-                return $schema;
-            }
-
-            // Prevent reapplying
-            if (isset($properties['id'], $properties['type']) || isset($properties['data']) || isset($properties['errors'])) {
-                return $schema;
-            }
-
-            $definitions[$key]['properties'] = $this->buildDefinitionPropertiesSchema($key, $className, $format, $type, $operation, $schema, []);
-
-            if ($schema->getRootDefinitionKey()) {
-                return $schema;
-            }
+        if (!$this->isResourceClass($className)) {
+            $operation = null;
+            $inputOrOutputClass = null;
+            $serializerContext ??= [];
+        } else {
+            $operation = $this->findOperation($className, $type, $operation, $serializerContext, $format);
+            $inputOrOutputClass = $this->findOutputClass($className, $type, $operation, $serializerContext);
+            $serializerContext ??= $this->getSerializerContext($operation, $type);
         }
 
-        if (($schema['type'] ?? '') === 'array') {
-            // data
-            $items = $schema['items'];
-            unset($schema['items']);
+        if (null === $inputOrOutputClass) {
+            // input or output disabled
+            return $this->schemaFactory->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
+        }
 
-            $schema['type'] = 'object';
-            $schema['properties'] = [
-                'links' => self::LINKS_PROPS,
-                'meta' => self::META_PROPS,
-                'data' => [
-                    'type' => 'array',
-                    'items' => $items,
-                ],
-            ];
-            $schema['required'] = [
-                'data',
-            ];
+        // We don't use the serializer context here as JSON:API doesn't leverage serializer groups for related resources.
+        // That is done by query parameter. @see https://jsonapi.org/format/#fetching-includes
+        $jsonApiSerializerContext = $serializerContext;
+        if (true === ($serializerContext[self::DISABLE_JSON_SCHEMA_SERIALIZER_GROUPS] ?? true) && $inputOrOutputClass === $className) {
+            unset($jsonApiSerializerContext['groups']);
+        }
+
+        $schema = $this->schemaFactory->buildSchema($className, 'json', $type, $operation, $schema, $jsonApiSerializerContext, $forceCollection);
+        $definitionName = $this->definitionNameFactory->create($inputOrOutputClass, $format, $className, $operation, $jsonApiSerializerContext);
+        $prefix = $this->getSchemaUriPrefix($schema->getVersion());
+        $definitions = $schema->getDefinitions();
+        $collectionKey = $schema->getItemsDefinitionKey();
+
+        // Already computed
+        if (!$collectionKey && isset($definitions[$definitionName])) {
+            $schema['$ref'] = $prefix.$definitionName;
 
             return $schema;
         }
+
+        $key = $schema->getRootDefinitionKey() ?? $collectionKey;
+        $properties = $definitions[$definitionName]['properties'] ?? [];
+
+        if (Error::class === $className && !isset($properties['errors'])) {
+            $definitions[$definitionName]['properties'] = [
+                'errors' => [
+                    'type' => 'array',
+                    'items' => [
+                        'allOf' => [
+                            ['$ref' => $prefix.$key],
+                            ['type' => 'object', 'properties' => ['source' => ['type' => 'object'], 'status' => ['type' => 'string']]],
+                        ],
+                    ],
+                ],
+            ];
+
+            $schema['$ref'] = $prefix.$definitionName;
+
+            return $schema;
+        }
+
+        if (!$collectionKey) {
+            $definitions[$definitionName]['properties'] = $this->buildDefinitionPropertiesSchema($key, $className, $format, $type, $operation, $schema, []);
+            $schema['$ref'] = $prefix.$definitionName;
+
+            return $schema;
+        }
+
+        if (($schema['type'] ?? '') !== 'array') {
+            return $schema;
+        }
+
+        if (!isset($definitions[self::COLLECTION_BASE_SCHEMA_NAME])) {
+            $definitions[self::COLLECTION_BASE_SCHEMA_NAME] = [
+                'type' => 'object',
+                'properties' => [
+                    'links' => self::LINKS_PROPS,
+                    'meta' => self::META_PROPS,
+                    'data' => [
+                        'type' => 'array',
+                    ],
+                ],
+                'required' => ['data'],
+            ];
+        }
+
+        unset($schema['items']);
+        unset($schema['type']);
+
+        $properties = $this->buildDefinitionPropertiesSchema($key, $className, $format, $type, $operation, $schema, []);
+        $properties['data']['properties']['attributes']['$ref'] = $prefix.$key;
+
+        $schema['description'] = "$definitionName collection.";
+        $schema['allOf'] = [
+            ['$ref' => $prefix.self::COLLECTION_BASE_SCHEMA_NAME],
+            ['type' => 'object', 'properties' => [
+                'data' => [
+                    'type' => 'array',
+                    'items' => $properties['data'],
+                ],
+            ]],
+        ];
 
         return $schema;
     }
@@ -217,12 +275,27 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                         continue;
                     }
 
-                    $operation = $this->findOperation($relatedClassName, $type, $operation, $serializerContext);
+                    $operation = $this->findOperation($relatedClassName, $type, null, $serializerContext);
                     $inputOrOutputClass = $this->findOutputClass($relatedClassName, $type, $operation, $serializerContext);
                     $serializerContext ??= $this->getSerializerContext($operation, $type);
                     $definitionName = $this->definitionNameFactory->create($relatedClassName, $format, $inputOrOutputClass, $operation, $serializerContext);
-                    $ref = Schema::VERSION_OPENAPI === $schema->getVersion() ? '#/components/schemas/'.$definitionName : '#/definitions/'.$definitionName;
-                    $refs[$ref] = '$ref';
+
+                    // to avoid recursion
+                    if ($this->builtSchema[$definitionName] ?? false) {
+                        $refs[$this->getSchemaUriPrefix($schema->getVersion()).$definitionName] = '$ref';
+                        continue;
+                    }
+
+                    if (!isset($definitions[$definitionName])) {
+                        $this->builtSchema[$definitionName] = true;
+                        $subSchema = new Schema($schema->getVersion());
+                        $subSchema->setDefinitions($schema->getDefinitions());
+                        $subSchema = $this->buildSchema($relatedClassName, $format, $type, $operation, $subSchema, $serializerContext + [self::FORCE_SUBSCHEMA => true], false);
+                        $schema->setDefinitions($subSchema->getDefinitions());
+                        $definitions = $schema->getDefinitions();
+                    }
+
+                    $refs[$this->getSchemaUriPrefix($schema->getVersion()).$definitionName] = '$ref';
                 }
                 $relatedDefinitions[$propertyName] = array_flip($refs);
                 if ($isOne) {
@@ -235,15 +308,18 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                 ];
                 continue;
             }
+
             if ('id' === $propertyName) {
+                // should probably be renamed "lid" and moved to the above node
                 $attributes['_id'] = $property;
                 continue;
             }
             $attributes[$propertyName] = $property;
         }
 
+        $currentRef = $this->getSchemaUriPrefix($schema->getVersion()).$schema->getRootDefinitionKey();
         $replacement = self::PROPERTY_PROPS;
-        $replacement['attributes']['properties'] = $attributes;
+        $replacement['attributes'] = ['$ref' => $currentRef];
 
         $included = [];
         if (\count($relationships) > 0) {
@@ -264,19 +340,6 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                     ],
                 ],
             ];
-        }
-
-        if ($required = $definitions[$key]['required'] ?? null) {
-            foreach ($required as $require) {
-                if (isset($replacement['attributes']['properties'][$require])) {
-                    $replacement['attributes']['required'][] = $require;
-                    continue;
-                }
-                if (isset($relationships[$require])) {
-                    $replacement['relationships']['required'][] = $require;
-                }
-            }
-            unset($definitions[$key]['required']);
         }
 
         return [

--- a/src/JsonSchema/DefinitionNameFactory.php
+++ b/src/JsonSchema/DefinitionNameFactory.php
@@ -24,8 +24,11 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
     private const GLUE = '.';
     private array $prefixCache = [];
 
-    public function __construct(private ?array $distinctFormats)
+    public function __construct(private ?array $distinctFormats = null)
     {
+        if ($distinctFormats) {
+            trigger_deprecation('api-platform/json-schema', '4.2', 'The distinctFormats argument is deprecated and will be removed in 5.0.');
+        }
     }
 
     public function create(string $className, string $format = 'json', ?string $inputOrOutputClass = null, ?Operation $operation = null, array $serializerContext = []): string
@@ -44,7 +47,10 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
             $prefix .= self::GLUE.$shortName;
         }
 
-        if ('json' !== $format && ($this->distinctFormats[$format] ?? false)) {
+        // TODO: remove in 5.0
+        $v = $this->distinctFormats ? ($this->distinctFormats[$format] ?? false) : true;
+
+        if ('json' !== $format && $v) {
             // JSON is the default, and so isn't included in the definition name
             $prefix .= self::GLUE.$format;
         }

--- a/src/JsonSchema/ResourceMetadataTrait.php
+++ b/src/JsonSchema/ResourceMetadataTrait.php
@@ -73,12 +73,12 @@ trait ResourceMetadataTrait
 
     private function findOperationForType(ResourceMetadataCollection $resourceMetadataCollection, string $type, Operation $operation, ?string $format = null): Operation
     {
+        $lookForCollection = $operation instanceof CollectionOperationInterface;
         // Find the operation and use the first one that matches criterias
         foreach ($resourceMetadataCollection as $resourceMetadata) {
             foreach ($resourceMetadata->getOperations() ?? [] as $op) {
-                if ($operation instanceof CollectionOperationInterface && $op instanceof CollectionOperationInterface) {
-                    $operation = $op;
-                    break 2;
+                if (!$lookForCollection && $op instanceof CollectionOperationInterface) {
+                    continue;
                 }
 
                 if (Schema::TYPE_INPUT === $type && \in_array($op->getMethod(), ['POST', 'PATCH', 'PUT'], true)) {

--- a/src/JsonSchema/Schema.php
+++ b/src/JsonSchema/Schema.php
@@ -123,7 +123,10 @@ final class Schema extends \ArrayObject
     {
         // strlen('#/definitions/') = 14
         // strlen('#/components/schemas/') = 21
-        $prefix = self::VERSION_OPENAPI === $this->version ? 21 : 14;
+        $prefix = match ($this->version) {
+            self::VERSION_OPENAPI => 21,
+            default => 14,
+        };
 
         return substr($definitionKey, $prefix);
     }

--- a/src/JsonSchema/SchemaFactoryInterface.php
+++ b/src/JsonSchema/SchemaFactoryInterface.php
@@ -22,6 +22,8 @@ use ApiPlatform\Metadata\Operation;
  */
 interface SchemaFactoryInterface
 {
+    public const FORCE_SUBSCHEMA = '_api_subschema_force_readable_link';
+
     /**
      * Builds the JSON Schema document corresponding to the given PHP class.
      */

--- a/src/JsonSchema/SchemaUriPrefixTrait.php
+++ b/src/JsonSchema/SchemaUriPrefixTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\JsonSchema;
+
+/**
+ * @internal
+ */
+trait SchemaUriPrefixTrait
+{
+    public function getSchemaUriPrefix(string $version): string
+    {
+        return match ($version) {
+            Schema::VERSION_OPENAPI => '#/components/schemas/',
+            default => '#/definitions/',
+        };
+    }
+}

--- a/src/JsonSchema/Tests/DefinitionNameFactoryTest.php
+++ b/src/JsonSchema/Tests/DefinitionNameFactoryTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Tests\JsonSchema;
+namespace ApiPlatform\JsonSchema\Tests;
 
 use ApiPlatform\JsonSchema\DefinitionNameFactory;
 use ApiPlatform\JsonSchema\SchemaFactory;
@@ -65,33 +65,33 @@ final class DefinitionNameFactoryTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('providerDefinitions')]
     public function testCreate(string $expected, string $className, string $format = 'json', ?string $inputOrOutputClass = null, ?Operation $operation = null, array $serializerContext = []): void
     {
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         static::assertSame($expected, $definitionNameFactory->create($className, $format, $inputOrOutputClass, $operation, $serializerContext));
     }
 
     public function testCreateDifferentPrefixesForClassesWithTheSameShortName(): void
     {
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         self::assertEquals(
             'DummyClass.jsonapi',
-            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceA\Module\DummyClass::class, 'jsonapi')
+            $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceA\Module\DummyClass::class, 'jsonapi')
         );
 
         self::assertEquals(
             'Module.DummyClass.jsonapi',
-            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceB\Module\DummyClass::class, 'jsonapi')
+            $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceB\Module\DummyClass::class, 'jsonapi')
         );
 
         self::assertEquals(
             'NamespaceC.Module.DummyClass.jsonapi',
-            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceC\Module\DummyClass::class, 'jsonapi')
+            $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceC\Module\DummyClass::class, 'jsonapi')
         );
 
         self::assertEquals(
             'DummyClass.jsonhal',
-            $definitionNameFactory->create(\ApiPlatform\Tests\JsonSchema\Dummy\NamespaceA\Module\DummyClass::class, 'jsonhal')
+            $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceA\Module\DummyClass::class, 'jsonhal')
         );
     }
 }

--- a/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/NamespaceA/Module/DummyClass.php
+++ b/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/NamespaceA/Module/DummyClass.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Tests\JsonSchema\Dummy\NamespaceC\Module;
+namespace ApiPlatform\JsonSchema\Tests\Fixtures\DefinitionNameFactory\NamespaceA\Module;
 
 class DummyClass
 {

--- a/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/NamespaceB/Module/DummyClass.php
+++ b/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/NamespaceB/Module/DummyClass.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Tests\JsonSchema\Dummy\NamespaceA\Module;
+namespace ApiPlatform\JsonSchema\Tests\Fixtures\DefinitionNameFactory\NamespaceB\Module;
 
 class DummyClass
 {

--- a/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/NamespaceC/Module/DummyClass.php
+++ b/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/NamespaceC/Module/DummyClass.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ApiPlatform\Tests\JsonSchema\Dummy\NamespaceB\Module;
+namespace ApiPlatform\JsonSchema\Tests\Fixtures\DefinitionNameFactory\NamespaceC\Module;
 
 class DummyClass
 {

--- a/src/JsonSchema/Tests/SchemaFactoryTest.php
+++ b/src/JsonSchema/Tests/SchemaFactoryTest.php
@@ -79,7 +79,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),
@@ -154,7 +154,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),
@@ -231,7 +231,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(NotAResourceWithUnionIntersectTypes::class)->willReturn(false);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),
@@ -255,7 +255,6 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayHasKey('ignoredProperty', $definitions[$rootDefinitionKey]['properties']);
         $this->assertArrayHasKey('type', $definitions[$rootDefinitionKey]['properties']['ignoredProperty']);
         $this->assertSame(['string', 'null'], $definitions[$rootDefinitionKey]['properties']['ignoredProperty']['type']);
-
         $this->assertArrayHasKey('unionType', $definitions[$rootDefinitionKey]['properties']);
         $this->assertArrayHasKey('oneOf', $definitions[$rootDefinitionKey]['properties']['unionType']);
         $this->assertCount(2, $definitions[$rootDefinitionKey]['properties']['unionType']['oneOf']);
@@ -301,7 +300,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(NotAResourceWithUnionIntersectTypes::class)->willReturn(false);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),
@@ -385,7 +384,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(OverriddenOperationDummy::class)->willReturn(true);
         $resourceClassResolverProphecy->isResourceClass(GenderTypeEnum::class)->willReturn(true);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),
@@ -462,7 +461,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy->isResourceClass(OverriddenOperationDummy::class)->willReturn(true);
         $resourceClassResolverProphecy->isResourceClass(GenderTypeEnum::class)->willReturn(true);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),
@@ -521,7 +520,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),
@@ -573,7 +572,7 @@ class SchemaFactoryTest extends TestCase
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false);
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactoryProphecy->reveal(),

--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -103,8 +103,8 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
         }
 
         $serializerAttributeMetadata = $this->getSerializerAttributeMetadata($resourceClass, $propertyName);
-        $groups = $serializerAttributeMetadata ? $serializerAttributeMetadata->getGroups() : [];
-        $ignored = $serializerAttributeMetadata && $serializerAttributeMetadata->isIgnored();
+        $groups = $serializerAttributeMetadata?->getGroups() ?? [];
+        $ignored = $serializerAttributeMetadata?->isIgnored() ?? false;
 
         if (false !== $propertyMetadata->isReadable()) {
             $propertyMetadata = $propertyMetadata->withReadable(!$ignored && (null === $normalizationGroups || array_intersect($normalizationGroups, $groups)));

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -560,7 +560,6 @@ class OpenApiFactoryTest extends TestCase
             'type' => 'object',
             'description' => 'This is a dummy',
             'externalDocs' => ['url' => 'http://schema.example.com/Dummy'],
-            'deprecated' => false,
             'properties' => [
                 'id' => new \ArrayObject([
                     'type' => 'integer',
@@ -595,7 +594,6 @@ class OpenApiFactoryTest extends TestCase
         $dummyErrorSchema->setDefinitions(new \ArrayObject([
             'type' => 'object',
             'description' => 'nice one!',
-            'deprecated' => false,
             'properties' => [
                 'type' => new \ArrayObject([
                     'type' => 'string',
@@ -621,7 +619,7 @@ class OpenApiFactoryTest extends TestCase
             ],
         ]));
         $errorSchema = clone $dummyErrorSchema->getDefinitions();
-        $errorSchema['description'] = '';
+        unset($errorSchema['description']);
 
         $openApi = $factory(['base_url' => '/app_dev.php/']);
 
@@ -646,7 +644,9 @@ class OpenApiFactoryTest extends TestCase
         $this->assertEquals($components->getSchemas(), new \ArrayObject([
             'Dummy' => $dummySchema->getDefinitions(),
             'Dummy.OutputDto' => $dummySchema->getDefinitions(),
-            'Parameter' => $parameterSchema,
+            'Dummy.jsonld' => $dummySchema->getDefinitions(),
+            'Dummy.OutputDto.jsonld' => $dummySchema->getDefinitions(),
+            'Parameter.jsonld' => $parameterSchema,
             'DummyErrorResource' => $dummyErrorSchema->getDefinitions(),
             'Error' => $errorSchema,
         ]));
@@ -681,7 +681,7 @@ class OpenApiFactoryTest extends TestCase
                 '200' => new Response('Dummy collection', new \ArrayObject([
                     'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject([
                         'type' => 'array',
-                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto'],
+                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld'],
                     ]))),
                 ])),
             ],
@@ -711,7 +711,7 @@ class OpenApiFactoryTest extends TestCase
                 '201' => new Response(
                     'Dummy resource created',
                     new \ArrayObject([
-                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld']))),
                     ]),
                     null,
                     new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
@@ -734,7 +734,7 @@ class OpenApiFactoryTest extends TestCase
             new RequestBody(
                 'The new Dummy resource',
                 new \ArrayObject([
-                    'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy']))),
+                    'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.jsonld']))),
                 ]),
                 true
             )
@@ -753,7 +753,7 @@ class OpenApiFactoryTest extends TestCase
                 '200' => new Response(
                     'Dummy resource',
                     new \ArrayObject([
-                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld']))),
                     ])
                 ),
                 '404' => new Response(
@@ -775,7 +775,7 @@ class OpenApiFactoryTest extends TestCase
                 '200' => new Response(
                     'Dummy resource updated',
                     new \ArrayObject([
-                        'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto'])),
+                        'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld'])),
                     ]),
                     null,
                     new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$request.path.id']), null, 'This is a dummy')])
@@ -803,7 +803,7 @@ class OpenApiFactoryTest extends TestCase
             new RequestBody(
                 'The updated Dummy resource',
                 new \ArrayObject([
-                    'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy'])),
+                    'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.jsonld'])),
                 ]),
                 true
             )
@@ -883,7 +883,7 @@ class OpenApiFactoryTest extends TestCase
                     'Dummy resource updated',
                     new \ArrayObject([
                         'application/json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto'])),
-                        'text/csv' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto'])),
+                        'text/csv' => new \ArrayObject(),
                     ]),
                     null,
                     new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$request.path.id']), null, 'This is a dummy')])
@@ -912,7 +912,7 @@ class OpenApiFactoryTest extends TestCase
                 'The updated Dummy resource',
                 new \ArrayObject([
                     'application/json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy'])),
-                    'text/csv' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy'])),
+                    'text/csv' => new \ArrayObject(),
                 ]),
                 true
             )
@@ -926,7 +926,7 @@ class OpenApiFactoryTest extends TestCase
                 '200' => new Response('Dummy collection', new \ArrayObject([
                     'application/ld+json' => new MediaType(new \ArrayObject([
                         'type' => 'array',
-                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto'],
+                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld'],
                     ])),
                 ])),
             ],
@@ -961,7 +961,6 @@ class OpenApiFactoryTest extends TestCase
                     'enum' => ['asc', 'desc'],
                 ]),
             ],
-            deprecated: false
         ), $filteredPath->getGet());
 
         $paginatedPath = $paths->getPath('/paginated');
@@ -972,7 +971,7 @@ class OpenApiFactoryTest extends TestCase
                 '200' => new Response('Dummy collection', new \ArrayObject([
                     'application/ld+json' => new MediaType(new \ArrayObject([
                         'type' => 'array',
-                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto'],
+                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld'],
                     ])),
                 ])),
             ],
@@ -1004,7 +1003,7 @@ class OpenApiFactoryTest extends TestCase
                 '201' => new Response(
                     'Dummy resource created',
                     new \ArrayObject([
-                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld']))),
                     ]),
                     null,
                     new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
@@ -1045,7 +1044,6 @@ class OpenApiFactoryTest extends TestCase
                 ]),
                 false
             ),
-            deprecated: false,
         ), $requestBodyPath->getPost());
 
         $requestBodyPath = $paths->getPath('/dummiesRequestBodyWithoutContent');
@@ -1056,7 +1054,7 @@ class OpenApiFactoryTest extends TestCase
                 '201' => new Response(
                     'Dummy resource created',
                     new \ArrayObject([
-                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld']))),
                     ]),
                     null,
                     new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
@@ -1079,11 +1077,10 @@ class OpenApiFactoryTest extends TestCase
             new RequestBody(
                 'Extended description for the new Dummy resource',
                 new \ArrayObject([
-                    'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy']))),
+                    'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.jsonld']))),
                 ]),
                 false
             ),
-            deprecated: false,
         ), $requestBodyPath->getPost());
 
         $dummyItemPath = $paths->getPath('/dummyitems/{id}');
@@ -1124,11 +1121,10 @@ class OpenApiFactoryTest extends TestCase
             new RequestBody(
                 'The updated Dummy resource',
                 new \ArrayObject([
-                    'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy'])),
+                    'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.jsonld'])),
                 ]),
                 true
             ),
-            deprecated: false
         ), $dummyItemPath->getPut());
 
         $dummyItemPath = $paths->getPath('/dummyitems');
@@ -1164,11 +1160,10 @@ class OpenApiFactoryTest extends TestCase
             new RequestBody(
                 'The new Dummy resource',
                 new \ArrayObject([
-                    'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy'])),
+                    'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.jsonld'])),
                 ]),
                 true
             ),
-            deprecated: false
         ), $dummyItemPath->getPost());
 
         $dummyItemPath = $paths->getPath('/dummyitems/{id}/images');
@@ -1208,7 +1203,7 @@ class OpenApiFactoryTest extends TestCase
                 '201' => new Response(
                     'Dummy resource created',
                     new \ArrayObject([
-                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto']))),
+                        'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld']))),
                     ]),
                     null,
                     new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
@@ -1246,7 +1241,7 @@ class OpenApiFactoryTest extends TestCase
                 '200' => new Response('Dummy collection', new \ArrayObject([
                     'application/ld+json' => new MediaType(new \ArrayObject(new \ArrayObject([
                         'type' => 'array',
-                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto'],
+                        'items' => ['$ref' => '#/components/schemas/Dummy.OutputDto.jsonld'],
                     ]))),
                 ])),
                 '418' => new Response(
@@ -1276,7 +1271,6 @@ class OpenApiFactoryTest extends TestCase
                     'type' => 'boolean',
                 ]),
             ],
-            deprecated: false
         ), $paths->getPath('/erroredDummies')->getGet());
 
         $diamondsGetPath = $paths->getPath('/diamonds');

--- a/src/OpenApi/Tests/Serializer/OpenApiNormalizerTest.php
+++ b/src/OpenApi/Tests/Serializer/OpenApiNormalizerTest.php
@@ -208,7 +208,7 @@ class OpenApiNormalizerTest extends TestCase
         $propertyNameCollectionFactory = $propertyNameCollectionFactoryProphecy->reveal();
         $propertyMetadataFactory = $propertyMetadataFactoryProphecy->reveal();
 
-        $definitionNameFactory = new DefinitionNameFactory(['jsonapi' => true, 'jsonhal' => true, 'jsonld' => true]);
+        $definitionNameFactory = new DefinitionNameFactory();
 
         $schemaFactory = new SchemaFactory(
             resourceMetadataFactory: $resourceMetadataFactory,

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -113,6 +113,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $patchFormats = $this->getFormats($config['patch_formats']);
         $errorFormats = $this->getFormats($config['error_formats']);
         $docsFormats = $this->getFormats($config['docs_formats']);
+
         if (!$config['enable_docs']) {
             // JSON-LD documentation format is mandatory, even if documentation is disabled.
             $docsFormats = isset($formats['jsonld']) ? ['jsonld' => ['application/ld+json']] : [];
@@ -144,7 +145,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $patchFormats['jsonapi'] = ['application/vnd.api+json'];
         }
 
-        $this->registerCommonConfiguration($container, $config, $loader, $formats, $patchFormats, $errorFormats, $docsFormats, $jsonSchemaFormats);
+        $this->registerCommonConfiguration($container, $config, $loader, $formats, $patchFormats, $errorFormats, $docsFormats);
         $this->registerMetadataConfiguration($container, $config, $loader);
         $this->registerOAuthConfiguration($container, $config);
         $this->registerOpenApiConfiguration($container, $config, $loader);
@@ -189,7 +190,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
     }
 
-    private function registerCommonConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader, array $formats, array $patchFormats, array $errorFormats, array $docsFormats, array $jsonSchemaFormats): void
+    private function registerCommonConfiguration(ContainerBuilder $container, array $config, XmlFileLoader $loader, array $formats, array $patchFormats, array $errorFormats, array $docsFormats): void
     {
         $loader->load('state/state.xml');
         $loader->load('symfony/symfony.xml');
@@ -230,7 +231,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.patch_formats', $patchFormats);
         $container->setParameter('api_platform.error_formats', $errorFormats);
         $container->setParameter('api_platform.docs_formats', $docsFormats);
-        $container->setParameter('api_platform.jsonschema_formats', $jsonSchemaFormats);
+        $container->setParameter('api_platform.jsonschema_formats', []);
         $container->setParameter('api_platform.eager_loading.enabled', $this->isConfigEnabled($container, $config['eager_loading']));
         $container->setParameter('api_platform.eager_loading.max_joins', $config['eager_loading']['max_joins']);
         $container->setParameter('api_platform.eager_loading.fetch_partial', $config['eager_loading']['fetch_partial']);

--- a/src/Symfony/Bundle/Resources/config/hal.xml
+++ b/src/Symfony/Bundle/Resources/config/hal.xml
@@ -9,6 +9,8 @@
 
         <service id="api_platform.hal.json_schema.schema_factory" class="ApiPlatform\Hal\JsonSchema\SchemaFactory" decorates="api_platform.json_schema.schema_factory">
             <argument type="service" id="api_platform.hal.json_schema.schema_factory.inner" />
+            <argument type="service" id="api_platform.json_schema.definition_name_factory" on-invalid="ignore"/>
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" on-invalid="ignore" />
         </service>
 
         <service id="api_platform.hal.encoder" class="ApiPlatform\Serializer\JsonEncoder" public="false">

--- a/src/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Symfony/Bundle/Resources/config/hydra.xml
@@ -8,6 +8,8 @@
         <service id="api_platform.hydra.json_schema.schema_factory" class="ApiPlatform\Hydra\JsonSchema\SchemaFactory" decorates="api_platform.json_schema.schema_factory">
             <argument type="service" id="api_platform.hydra.json_schema.schema_factory.inner" />
             <argument>%api_platform.serializer.default_context%</argument>
+            <argument type="service" id="api_platform.json_schema.definition_name_factory" on-invalid="ignore"/>
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" on-invalid="ignore" />
         </service>
         <service id="api_platform.hydra.normalizer.documentation" class="ApiPlatform\Hydra\Serializer\DocumentationNormalizer" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />

--- a/src/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Symfony/Bundle/Resources/config/json_schema.xml
@@ -13,7 +13,7 @@
             <argument type="service" id="api_platform.metadata.property.metadata_factory" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
             <argument type="service" id="api_platform.resource_class_resolver" />
-            <argument on-invalid="ignore">%api_platform.jsonschema_formats%</argument>
+            <argument on-invalid="ignore" type="collection"></argument>
             <argument type="service" id="api_platform.json_schema.definition_name_factory" on-invalid="ignore"/>
         </service>
         <service id="ApiPlatform\JsonSchema\SchemaFactoryInterface" alias="api_platform.json_schema.schema_factory" />
@@ -33,9 +33,7 @@
             <argument type="service" id="api_platform.json_schema.backward_compatible_schema_factory.inner" />
         </service>
 
-        <service id="api_platform.json_schema.definition_name_factory" class="ApiPlatform\JsonSchema\DefinitionNameFactory">
-            <argument on-invalid="ignore">%api_platform.jsonschema_formats%</argument>
-        </service>
+        <service id="api_platform.json_schema.definition_name_factory" class="ApiPlatform\JsonSchema\DefinitionNameFactory"></service>
 
     </services>
 

--- a/src/Symfony/Tests/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
+++ b/src/Symfony/Tests/Validator/Metadata/Property/Restriction/PropertySchemaCollectionRestrictionTest.php
@@ -104,7 +104,7 @@ final class PropertySchemaCollectionRestrictionTest extends TestCase
             'name' => new \ArrayObject(),
             'email' => ['minLength' => 2, 'maxLength' => 255, 'format' => 'email'],
             'phone' => ['pattern' => '^([+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
-            'age' => ['exclusiveMinimum' => 0],
+            'age' => ['exclusiveMinimum' => 0, 'minimum' => 0],
             'social' => ['type' => 'object', 'properties' => new \ArrayObject(['githubUsername' => new \ArrayObject()]), 'additionalProperties' => false, 'required' => ['githubUsername']],
         ]);
         $required = ['name', 'email', 'social'];

--- a/src/Symfony/Tests/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestrictionTest.php
+++ b/src/Symfony/Tests/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestrictionTest.php
@@ -79,6 +79,7 @@ final class PropertySchemaGreaterThanRestrictionTest extends TestCase
     {
         self::assertEquals([
             'exclusiveMinimum' => 10,
+            'minimum' => 10,
         ], $this->propertySchemaGreaterThanRestriction->create(new GreaterThan(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new LegacyType(LegacyType::BUILTIN_TYPE_INT)])));
     }
 
@@ -86,14 +87,17 @@ final class PropertySchemaGreaterThanRestrictionTest extends TestCase
     {
         self::assertEquals([
             'exclusiveMinimum' => 10,
+            'minimum' => 10,
         ], $this->propertySchemaGreaterThanRestriction->create(new GreaterThan(['value' => 10]), (new ApiProperty())->withNativeType(Type::int())));
 
         self::assertEquals([
             'exclusiveMinimum' => 0,
+            'minimum' => 0,
         ], $this->propertySchemaGreaterThanRestriction->create(new Positive(), (new ApiProperty())->withNativeType(Type::int())));
 
         self::assertEquals([
             'exclusiveMinimum' => 10.99,
+            'minimum' => 10.99,
         ], $this->propertySchemaGreaterThanRestriction->create(new GreaterThan(['value' => 10.99]), (new ApiProperty())->withNativeType(Type::float())));
     }
 }

--- a/src/Symfony/Tests/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestrictionTest.php
+++ b/src/Symfony/Tests/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestrictionTest.php
@@ -79,6 +79,7 @@ final class PropertySchemaLessThanRestrictionTest extends TestCase
     {
         self::assertEquals([
             'exclusiveMaximum' => 10,
+            'maximum' => 10,
         ], $this->propertySchemaLessThanRestriction->create(new LessThan(['value' => 10]), (new ApiProperty())->withBuiltinTypes([new LegacyType(LegacyType::BUILTIN_TYPE_INT)])));
     }
 
@@ -86,14 +87,17 @@ final class PropertySchemaLessThanRestrictionTest extends TestCase
     {
         self::assertEquals([
             'exclusiveMaximum' => 10,
+            'maximum' => 10,
         ], $this->propertySchemaLessThanRestriction->create(new LessThan(['value' => 10]), (new ApiProperty())->withNativeType(Type::int())));
 
         self::assertEquals([
             'exclusiveMaximum' => 0,
+            'maximum' => 0,
         ], $this->propertySchemaLessThanRestriction->create(new Negative(), (new ApiProperty())->withNativeType(Type::int())));
 
         self::assertEquals([
             'exclusiveMaximum' => 10.99,
+            'maximum' => 10.99,
         ], $this->propertySchemaLessThanRestriction->create(new LessThan(['value' => 10.99]), (new ApiProperty())->withNativeType(Type::float())));
     }
 }

--- a/src/Symfony/Tests/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/src/Symfony/Tests/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -712,6 +712,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
                 'phone' => ['pattern' => '^([+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*)$'],
                 'age' => [
                     'exclusiveMinimum' => 0,
+                    'minimum' => 0,
                 ],
                 'social' => [
                     'type' => 'object',
@@ -766,7 +767,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new LegacyType(LegacyType::BUILTIN_TYPE_INT)]),
             'property' => 'greaterThanMe',
-            'expectedSchema' => ['exclusiveMinimum' => 10],
+            'expectedSchema' => ['exclusiveMinimum' => 10, 'minimum' => 10],
         ];
 
         yield [
@@ -778,7 +779,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new LegacyType(LegacyType::BUILTIN_TYPE_INT)]),
             'property' => 'lessThanMe',
-            'expectedSchema' => ['exclusiveMaximum' => 99],
+            'expectedSchema' => ['exclusiveMaximum' => 99, 'maximum' => 99],
         ];
 
         yield [
@@ -790,7 +791,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new LegacyType(LegacyType::BUILTIN_TYPE_INT)]),
             'property' => 'positive',
-            'expectedSchema' => ['exclusiveMinimum' => 0],
+            'expectedSchema' => ['exclusiveMinimum' => 0, 'minimum' => 0],
         ];
 
         yield [
@@ -802,7 +803,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withBuiltinTypes([new LegacyType(LegacyType::BUILTIN_TYPE_INT)]),
             'property' => 'negative',
-            'expectedSchema' => ['exclusiveMaximum' => 0],
+            'expectedSchema' => ['exclusiveMaximum' => 0, 'maximum' => 0],
         ];
 
         yield [
@@ -849,7 +850,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withNativeType(Type::int()),
             'property' => 'greaterThanMe',
-            'expectedSchema' => ['exclusiveMinimum' => 10],
+            'expectedSchema' => ['exclusiveMinimum' => 10, 'minimum' => 10],
         ];
 
         yield [
@@ -861,7 +862,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withNativeType(Type::int()),
             'property' => 'lessThanMe',
-            'expectedSchema' => ['exclusiveMaximum' => 99],
+            'expectedSchema' => ['exclusiveMaximum' => 99, 'maximum' => 99],
         ];
 
         yield [
@@ -873,7 +874,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withNativeType(Type::int()),
             'property' => 'positive',
-            'expectedSchema' => ['exclusiveMinimum' => 0],
+            'expectedSchema' => ['exclusiveMinimum' => 0, 'minimum' => 0],
         ];
 
         yield [
@@ -885,7 +886,7 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         yield [
             'propertyMetadata' => (new ApiProperty())->withNativeType(Type::int()),
             'property' => 'negative',
-            'expectedSchema' => ['exclusiveMaximum' => 0],
+            'expectedSchema' => ['exclusiveMaximum' => 0, 'maximum' => 0],
         ];
 
         yield [

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
@@ -34,6 +34,7 @@ final class PropertySchemaGreaterThanRestriction implements PropertySchemaRestri
     public function create(Constraint $constraint, ApiProperty $propertyMetadata): array
     {
         return [
+            'minimum' => $constraint->value,
             'exclusiveMinimum' => $constraint->value,
         ];
     }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
@@ -34,6 +34,7 @@ final class PropertySchemaLessThanRestriction implements PropertySchemaRestricti
     public function create(Constraint $constraint, ApiProperty $propertyMetadata): array
     {
         return [
+            'maximum' => $constraint->value,
             'exclusiveMaximum' => $constraint->value,
         ];
     }

--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Validator\Exception;
 
+use ApiPlatform\JsonSchema\SchemaFactory;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Error as ErrorOperation;
 use ApiPlatform\Metadata\ErrorResource;
@@ -46,6 +47,7 @@ use Symfony\Component\WebLink\Link;
             name: '_api_validation_errors_problem',
             outputFormats: ['json' => ['application/problem+json']],
             normalizationContext: [
+                SchemaFactory::OPENAPI_DEFINITION_NAME => '',
                 'groups' => ['json'],
                 'ignored_attributes' => ['trace', 'file', 'line', 'code', 'message', 'traceAsString', 'previous'],
                 'skip_null_values' => true,
@@ -56,6 +58,7 @@ use Symfony\Component\WebLink\Link;
             outputFormats: ['jsonld' => ['application/problem+json', 'application/ld+json']],
             links: [new Link(rel: 'http://www.w3.org/ns/json-ld#error', href: 'http://www.w3.org/ns/hydra/error')],
             normalizationContext: [
+                SchemaFactory::OPENAPI_DEFINITION_NAME => '',
                 'groups' => ['jsonld'],
                 'ignored_attributes' => ['trace', 'file', 'line', 'code', 'message', 'traceAsString', 'previous'],
                 'skip_null_values' => true,
@@ -65,6 +68,7 @@ use Symfony\Component\WebLink\Link;
             name: '_api_validation_errors_jsonapi',
             outputFormats: ['jsonapi' => ['application/vnd.api+json']],
             normalizationContext: [
+                SchemaFactory::OPENAPI_DEFINITION_NAME => '',
                 'disable_json_schema_serializer_groups' => false,
                 'groups' => ['jsonapi'],
                 'skip_null_values' => true,

--- a/tests/Behat/OpenApiContext.php
+++ b/tests/Behat/OpenApiContext.php
@@ -97,7 +97,18 @@ final class OpenApiContext implements Context
      */
     public function assertThePropertyIsRequiredForTheOpenAPIClass(string $propertyName, string $className): void
     {
-        if (!\in_array($propertyName, $this->getClassInfo($className)->required, true)) {
+        $ok = false;
+        $schema = $this->getClassInfo($className);
+        if (isset($schema->allOf)) {
+            foreach ($schema->allOf as $schema) {
+                if (isset($schema->required) && \in_array($propertyName, $schema->required, true)) {
+                    $ok = true;
+                    break;
+                }
+            }
+        }
+
+        if (!$ok) {
             throw new ExpectationFailedException(\sprintf('Property "%s" of class "%s" should be required', $propertyName, $className));
         }
     }

--- a/tests/Fixtures/TestBundle/ApiResource/ErrorWithOverridenStatus.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ErrorWithOverridenStatus.php
@@ -23,7 +23,8 @@ use Symfony\Component\Validator\ConstraintViolationList;
     // To make it work with 3.1, remove in 4
     uriVariables: ['id'],
     provider: [ErrorWithOverridenStatus::class, 'throw'],
-    exceptionToStatus: [ValidationException::class => 403]
+    exceptionToStatus: [ValidationException::class => 403],
+    output: false
 )]
 class ErrorWithOverridenStatus
 {

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6317/Issue6317.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6317/Issue6317.php
@@ -22,7 +22,7 @@ enum Issue6317: int
     case First = 1;
     case Second = 2;
 
-    #[ApiProperty(identifier: true, example: 'An example of an ID')]
+    #[ApiProperty(identifier: true, example: 1)]
     public function getId(): int
     {
         return $this->value;
@@ -40,7 +40,7 @@ enum Issue6317: int
         return 1 === $this->value ? '1st' : '2nd';
     }
 
-    #[ApiProperty(openapiContext: ['example' => '42'])]
+    #[ApiProperty(openapiContext: ['example' => 42])]
     public function getCardinal(): int
     {
         return $this->value;

--- a/tests/Fixtures/TestBundle/ApiResource/ResourceWithEnumProperty.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ResourceWithEnumProperty.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -30,6 +31,7 @@ class ResourceWithEnumProperty
 {
     public int $id = 1;
 
+    #[ApiProperty(readableLink: true)]
     public ?BackedEnumIntegerResource $intEnum = null;
 
     /** @var BackedEnumStringResource[] */

--- a/tests/Fixtures/TestBundle/Document/User.php
+++ b/tests/Fixtures/TestBundle/Document/User.php
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-#[ApiResource(operations: [new Get(), new Put(), new Delete(), new Put(input: RecoverPasswordInput::class, output: RecoverPasswordOutput::class, uriTemplate: 'users/recover/{id}'), new Post(), new GetCollection(), new Post(uriTemplate: '/users/password_reset_request', messenger: 'input', input: PasswordResetRequest::class, output: PasswordResetRequestResult::class, normalizationContext: ['groups' => ['user_password_reset_request']], denormalizationContext: ['groups' => ['user_password_reset_request']])], normalizationContext: ['groups' => ['user', 'user-read']], denormalizationContext: ['groups' => ['user', 'user-write']])]
+#[ApiResource(openapi: false, operations: [new Get(), new Put(), new Delete(), new Put(input: RecoverPasswordInput::class, output: RecoverPasswordOutput::class, uriTemplate: 'users/recover/{id}'), new Post(), new GetCollection(), new Post(uriTemplate: '/users/password_reset_request', messenger: 'input', input: PasswordResetRequest::class, output: PasswordResetRequestResult::class, normalizationContext: ['groups' => ['user_password_reset_request']], denormalizationContext: ['groups' => ['user_password_reset_request']])], normalizationContext: ['groups' => ['user', 'user-read']], denormalizationContext: ['groups' => ['user', 'user-write']])]
 #[ODM\Document(collection: 'user_test')]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {

--- a/tests/Fixtures/TestBundle/Document/User.php
+++ b/tests/Fixtures/TestBundle/Document/User.php
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-#[ApiResource(openapi: false, operations: [new Get(), new Put(), new Delete(), new Put(input: RecoverPasswordInput::class, output: RecoverPasswordOutput::class, uriTemplate: 'users/recover/{id}'), new Post(), new GetCollection(), new Post(uriTemplate: '/users/password_reset_request', messenger: 'input', input: PasswordResetRequest::class, output: PasswordResetRequestResult::class, normalizationContext: ['groups' => ['user_password_reset_request']], denormalizationContext: ['groups' => ['user_password_reset_request']])], normalizationContext: ['groups' => ['user', 'user-read']], denormalizationContext: ['groups' => ['user', 'user-write']])]
+#[ApiResource(operations: [new Get(), new Put(), new Delete(), new Put(input: RecoverPasswordInput::class, output: RecoverPasswordOutput::class, uriTemplate: 'users/recover/{id}'), new Post(), new GetCollection(), new Post(uriTemplate: '/users/password_reset_request', messenger: 'input', input: PasswordResetRequest::class, output: PasswordResetRequestResult::class, normalizationContext: ['groups' => ['user_password_reset_request']], denormalizationContext: ['groups' => ['user_password_reset_request']])], normalizationContext: ['groups' => ['user', 'user-read']], denormalizationContext: ['groups' => ['user', 'user-write']])]
 #[ODM\Document(collection: 'user_test')]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {

--- a/tests/Fixtures/TestBundle/Entity/Issue5793/BagOfTests.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue5793/BagOfTests.php
@@ -49,7 +49,7 @@ class BagOfTests
     #[Groups(['read', 'write'])]
     private Collection $nonResourceTests;
 
-    #[ORM\ManyToOne(targetEntity: TestEntity::class)]
+    #[ORM\ManyToOne(targetEntity: TestEntity::class, cascade: ['persist'])]
     #[ORM\JoinColumn(name: 'type', referencedColumnName: 'id', nullable: false)]
     #[Groups(['read', 'write'])]
     protected ?TestEntity $type = null;

--- a/tests/Functional/JsonSchema/JsonApiJsonSchemaTest.php
+++ b/tests/Functional/JsonSchema/JsonApiJsonSchemaTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\JsonSchema;
+
+use ApiPlatform\JsonSchema\Schema;
+use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Animal;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\AnimalObservation;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6317\Issue6317;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Species;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Answer;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Question;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+class JsonApiJsonSchemaTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected SchemaFactoryInterface $schemaFactory;
+    protected OperationMetadataFactoryInterface $operationMetadataFactory;
+    protected static ?bool $alwaysBootKernel = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->schemaFactory = self::getContainer()->get('api_platform.json_schema.schema_factory');
+        $this->operationMetadataFactory = self::getContainer()->get('api_platform.metadata.operation.metadata_factory');
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [
+            AnimalObservation::class,
+            Animal::class,
+            Species::class,
+            Question::class,
+            Answer::class,
+            Issue6317::class,
+        ];
+    }
+
+    public function testJsonApi(): void
+    {
+        $speciesSchema = $this->schemaFactory->buildSchema(Issue6317::class, 'jsonapi', Schema::TYPE_OUTPUT);
+        $this->assertEquals('#/definitions/Issue6317.jsonapi', $speciesSchema['$ref']);
+        $this->assertEquals([
+            'properties' => [
+                'data' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => [
+                            'type' => 'string',
+                        ],
+                        'type' => [
+                            'type' => 'string',
+                        ],
+                        'attributes' => [
+                            '$ref' => '#/definitions/Issue6317',
+                        ],
+                    ],
+                    'required' => [
+                        'type',
+                        'id',
+                    ],
+                ],
+            ],
+        ], $speciesSchema['definitions']['Issue6317.jsonapi']);
+    }
+
+    public function testJsonApiIncludesSchemaForQuestion(): void
+    {
+        if ('mongodb' === self::getContainer()->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $questionSchema = $this->schemaFactory->buildSchema(Question::class, 'jsonapi', Schema::TYPE_OUTPUT);
+        $json = $questionSchema->getDefinitions();
+        $properties = $json['Question.jsonapi']['properties']['data']['properties'];
+        $included = $json['Question.jsonapi']['properties']['included'];
+
+        $this->assertArrayHasKey('answer', $properties['relationships']['properties']);
+        $this->assertArrayHasKey('anyOf', $included['items']);
+        $this->assertCount(1, $included['items']['anyOf']);
+        $this->assertArrayHasKey('$ref', $included['items']['anyOf'][0]);
+        $this->assertSame('#/definitions/Answer.jsonapi', $included['items']['anyOf'][0]['$ref']);
+    }
+
+    public function testJsonApiIncludesSchemaForAnimalObservation(): void
+    {
+        $animalObservationSchema = $this->schemaFactory->buildSchema(AnimalObservation::class, 'jsonapi', Schema::TYPE_OUTPUT);
+        $json = $animalObservationSchema->getDefinitions();
+        $properties = $json['AnimalObservation.jsonapi']['properties']['data']['properties'];
+        $included = $json['AnimalObservation.jsonapi']['properties']['included'];
+
+        $this->assertArrayHasKey('individuals', $properties['relationships']['properties']);
+        $this->assertArrayHasKey('anyOf', $included['items']);
+        $this->assertCount(1, $included['items']['anyOf']);
+        $this->assertSame('#/definitions/Animal.jsonapi', $included['items']['anyOf'][0]['$ref']);
+    }
+
+    public function testJsonApiIncludesSchemaForAnimal(): void
+    {
+        $animalSchema = $this->schemaFactory->buildSchema(Animal::class, 'jsonapi', Schema::TYPE_OUTPUT);
+        $json = $animalSchema->getDefinitions();
+        $properties = $json['Animal.jsonapi']['properties']['data']['properties'];
+        $included = $json['Animal.jsonapi']['properties']['included'];
+
+        $this->assertArrayHasKey('species', $properties['relationships']['properties']);
+        $this->assertArrayHasKey('anyOf', $included['items']);
+        $this->assertCount(1, $included['items']['anyOf']);
+        $this->assertSame('#/definitions/Species.jsonapi', $included['items']['anyOf'][0]['$ref']);
+    }
+
+    public function testJsonApiIncludesSchemaForSpecies(): void
+    {
+        $speciesSchema = $this->schemaFactory->buildSchema(Species::class, 'jsonapi', Schema::TYPE_OUTPUT, forceCollection: true);
+        $this->assertArraySubset(
+            [
+                'description' => 'Species.jsonapi collection.',
+                'allOf' => [
+                    ['$ref' => '#/definitions/JsonApiCollectionBaseSchema'],
+                    [
+                        'type' => 'object',
+                        'properties' => [
+                            'data' => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'id' => [
+                                            'type' => 'string',
+                                        ],
+                                        'type' => [
+                                            'type' => 'string',
+                                        ],
+                                        'attributes' => [
+                                            '$ref' => '#/definitions/Species',
+                                        ],
+                                    ],
+                                    'required' => [
+                                        'type',
+                                        'id',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $speciesSchema->getArrayCopy()
+        );
+    }
+}

--- a/tests/Functional/JsonSchema/JsonLdJsonSchemaTest.php
+++ b/tests/Functional/JsonSchema/JsonLdJsonSchemaTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\JsonSchema;
+
+use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5793\BagOfTests;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6212\Nest;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedToDummyFriend;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ThirdLevel;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class JsonLdJsonSchemaTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected SchemaFactoryInterface $schemaFactory;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [RelatedDummy::class, ThirdLevel::class, RelatedToDummyFriend::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->schemaFactory = self::getContainer()->get('api_platform.json_schema.schema_factory');
+    }
+
+    public function testSubSchemaJsonLd(): void
+    {
+        $schema = $this->schemaFactory->buildSchema(BagOfTests::class, 'jsonld');
+
+        $expectedBagOfTestsSchema = new \ArrayObject([
+            'allOf' => [
+                [
+                    '$ref' => '#/definitions/HydraItemBaseSchema',
+                ],
+                new \ArrayObject([
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => new \ArrayObject([
+                            'type' => 'integer',
+                            'readOnly' => true,
+                        ]),
+                        'description' => new \ArrayObject([
+                            'maxLength' => 255,
+                        ]),
+                        'tests' => new \ArrayObject([
+                            'type' => 'string',
+                            'foo' => 'bar',
+                        ]),
+                        'nonResourceTests' => new \ArrayObject([
+                            'type' => 'array',
+                            'items' => [
+                                '$ref' => '#/definitions/NonResourceTestEntity.jsonld-read',
+                            ],
+                        ]),
+                        'type' => new \ArrayObject([
+                            '$ref' => '#/definitions/TestEntity.jsonld-read',
+                        ]),
+                    ],
+                ]),
+            ],
+        ]);
+
+        $expectedNonResourceTestEntitySchema = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'id' => new \ArrayObject([
+                    'type' => 'integer',
+                    'readOnly' => true,
+                ]),
+                'nullableString' => new \ArrayObject([
+                    'type' => [
+                        'string',
+                        'null',
+                    ],
+                ]),
+                'nullableInt' => new \ArrayObject([
+                    'type' => [
+                        'integer',
+                        'null',
+                    ],
+                ]),
+            ],
+        ]);
+
+        $expectedTestEntitySchema = new \ArrayObject([
+            'allOf' => [
+                [
+                    '$ref' => '#/definitions/HydraItemBaseSchema',
+                ],
+                new \ArrayObject([
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => new \ArrayObject([
+                            'type' => 'integer',
+                            'readOnly' => true,
+                        ]),
+                        'nullableString' => new \ArrayObject([
+                            'type' => [
+                                'string',
+                                'null',
+                            ],
+                        ]),
+                        'nullableInt' => new \ArrayObject([
+                            'type' => [
+                                'integer',
+                                'null',
+                            ],
+                        ]),
+                    ],
+                ]),
+            ],
+        ]);
+
+        $this->assertArrayHasKey('definitions', $schema);
+        $this->assertArrayHasKey('BagOfTests.jsonld-read', $schema['definitions']);
+        $this->assertArrayHasKey('NonResourceTestEntity.jsonld-read', $schema['definitions']);
+        $this->assertArrayHasKey('TestEntity.jsonld-read', $schema['definitions']);
+
+        $this->assertEquals($expectedBagOfTestsSchema, $schema['definitions']['BagOfTests.jsonld-read']);
+        $this->assertEquals($expectedNonResourceTestEntitySchema, $schema['definitions']['NonResourceTestEntity.jsonld-read']);
+        $this->assertEquals($expectedTestEntitySchema, $schema['definitions']['TestEntity.jsonld-read']);
+
+        $this->assertEquals('#/definitions/BagOfTests.jsonld-read', $schema['$ref']);
+    }
+
+    public function testSchemaJsonLdCollection(): void
+    {
+        $schema = $this->schemaFactory->buildSchema(BagOfTests::class, 'jsonld', forceCollection: true);
+
+        $this->assertArrayHasKey('definitions', $schema);
+        $this->assertArrayHasKey('BagOfTests.jsonld-read', $schema['definitions']);
+        $this->assertArrayHasKey('NonResourceTestEntity.jsonld-read', $schema['definitions']);
+        $this->assertArrayHasKey('TestEntity.jsonld-read', $schema['definitions']);
+        $this->assertArrayHasKey('HydraItemBaseSchema', $schema['definitions']);
+        $this->assertArrayHasKey('HydraCollectionBaseSchema', $schema['definitions']);
+
+        $this->assertEquals(['$ref' => '#/definitions/HydraCollectionBaseSchema'], $schema['allOf'][0]);
+        $this->assertEquals(['$ref' => '#/definitions/BagOfTests.jsonld-read'], $schema['allOf'][1]['properties']['hydra:member']['items']);
+    }
+
+    public function testArraySchemaWithMultipleUnionTypes(): void
+    {
+        $schema = $this->schemaFactory->buildSchema(Nest::class, 'jsonld', 'output');
+
+        $this->assertContains(['$ref' => '#/definitions/Robin.jsonld'], $schema['definitions']['Nest.jsonld']['allOf'][1]['properties']['owner']['anyOf']);
+        $this->assertContains(['$ref' => '#/definitions/Wren.jsonld'], $schema['definitions']['Nest.jsonld']['allOf'][1]['properties']['owner']['anyOf']);
+        $this->assertContains(['type' => 'null'], $schema['definitions']['Nest.jsonld']['allOf'][1]['properties']['owner']['anyOf']);
+
+        $this->assertArrayHasKey('Nest.jsonld', $schema['definitions']);
+    }
+}

--- a/tests/Functional/JsonSchema/JsonSchemaTest.php
+++ b/tests/Functional/JsonSchema/JsonSchemaTest.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\JsonSchema;
+
+use ApiPlatform\JsonSchema\Schema;
+use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5452\Book;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5501\BrokenDocs;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue5501\Related;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ResourceWithEnumProperty;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5793\BagOfTests;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5793\TestEntity;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6212\Nest;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\JsonSchemaResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\JsonSchemaResourceRelated;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use JsonSchema\Validator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class JsonSchemaTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected SchemaFactoryInterface $schemaFactory;
+    protected OperationMetadataFactoryInterface $operationMetadataFactory;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->schemaFactory = self::getContainer()->get('api_platform.json_schema.schema_factory');
+        $this->operationMetadataFactory = self::getContainer()->get('api_platform.metadata.operation.metadata_factory');
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [
+            BagOfTests::class,
+            TestEntity::class,
+            BrokenDocs::class,
+            Related::class,
+            Nest::class,
+            ResourceWithEnumProperty::class,
+            Book::class,
+            JsonSchemaResource::class,
+            JsonSchemaResourceRelated::class,
+        ];
+    }
+
+    #[DataProvider('getInvalidSchemas')]
+    public function testSchemaIsNotValid(string $json, array $args): void
+    {
+        $schema = $this->schemaFactory->buildSchema(...$args);
+        $validator = new Validator();
+        $json = json_decode($json, null, 512, \JSON_THROW_ON_ERROR);
+        $validator->validate($json, $schema->getArrayCopy());
+        $this->assertFalse($validator->isValid());
+    }
+
+    /**
+     * @return array<string, array{string, array}>
+     */
+    public static function getInvalidSchemas(): array
+    {
+        return [
+            'json-ld' => [
+                '{"@context":"/contexts/BagOfTests","@id":"/bag_of_tests/1","@type":"BagOfTests","id":1,"description":"string","tests":"a string","nonResourceTests":[{"id":1,"nullableString":"string","nullableInt":0}],"type":{"@type":"TestEntity","id":1,"nullableString":"string","nullableInt":0}}',
+                [BagOfTests::class, 'jsonld'],
+            ],
+        ];
+    }
+
+    #[DataProvider('getSchemas')]
+    public function testSchemaIsValid(string $json, array $args): void
+    {
+        $schema = $this->schemaFactory->buildSchema(...$args);
+        $validator = new Validator();
+        $json = json_decode($json, null, 512, \JSON_THROW_ON_ERROR);
+        $validator->validate($json, $schema->getArrayCopy());
+        $this->assertTrue($validator->isValid());
+    }
+
+    /**
+     * @return array<string, array{string, array}>
+     */
+    public static function getSchemas(): array
+    {
+        return [
+            'json-ld' => [
+                '{"@context":"/contexts/BagOfTests","@id":"/bag_of_tests/1","@type":"BagOfTests","id":1,"description":"string","tests":"a string","nonResourceTests":[{"id":1,"nullableString":"string","nullableInt":0}],"type":{"@id":"/test_entities/1","@type":"TestEntity","id":1,"nullableString":"string","nullableInt":0}}',
+                [BagOfTests::class, 'jsonld'],
+            ],
+            'json-ld Collection' => [
+                '{"@context":"/contexts/BagOfTests","@id":"/bag_of_tests","@type":"hydra:Collection","hydra:totalItems":1,"hydra:member":[{"@id":"/bag_of_tests/1","@type":"BagOfTests","id":1,"description":"string","nonResourceTests":[],"type":{"@id":"/test_entities/1","@type":"TestEntity","id":1,"nullableString":"string","nullableInt":0}}]}',
+                [BagOfTests::class, 'jsonld', 'forceCollection' => true],
+            ],
+        ];
+    }
+
+    /**
+     * Test issue #5501, the locations relation inside BrokenDocs is a Resource (named Related) but its only operation is a NotExposed.
+     * Still, serializer groups are set, and therefore it is a "readableLink" so we actually want to compute the schema, even if it's not accessible
+     * directly, it is accessible through that relation.
+     */
+    public function testExecuteWithNotExposedResourceAndReadableLink(): void
+    {
+        $schema = $this->schemaFactory->buildSchema(BrokenDocs::class, 'jsonld');
+
+        $this->assertArrayHasKey('Related.jsonld-location.read_collection', $schema['definitions']);
+    }
+
+    public function testArraySchemaWithReference(): void
+    {
+        if ('mongodb' === self::getContainer()->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $schema = $this->schemaFactory->buildSchema(BagOfTests::class, 'jsonld', Schema::TYPE_INPUT);
+
+        $this->assertEquals($schema['definitions']['BagOfTests.jsonld-write']['properties']['tests'], new \ArrayObject([
+            'type' => 'string',
+            'foo' => 'bar',
+        ]));
+
+        $this->assertEquals($schema['definitions']['BagOfTests.jsonld-write']['properties']['nonResourceTests'], new \ArrayObject([
+            'type' => 'array',
+            'items' => [
+                '$ref' => '#/definitions/NonResourceTestEntity.jsonld-write',
+            ],
+        ]));
+
+        $this->assertEquals($schema['definitions']['BagOfTests.jsonld-write']['properties']['description'], new \ArrayObject([
+            'maxLength' => 255,
+        ]));
+
+        $this->assertEquals($schema['definitions']['BagOfTests.jsonld-write']['properties']['type'], new \ArrayObject([
+            '$ref' => '#/definitions/TestEntity.jsonld-write',
+        ]));
+    }
+
+    public function testResourceWithEnumPropertiesSchema(): void
+    {
+        $json = $this->schemaFactory->buildSchema(ResourceWithEnumProperty::class, 'jsonld', Schema::TYPE_OUTPUT);
+        $properties = $json['definitions']['ResourceWithEnumProperty.jsonld']['allOf'][1]['properties'];
+
+        $this->assertEquals(
+            new \ArrayObject([
+                'type' => ['integer', 'null'],
+                'enum' => [1, 2, 3, null],
+            ]),
+            $properties['intEnum']
+        );
+        $this->assertEquals(
+            new \ArrayObject([
+                'type' => 'array',
+                'items' => [
+                    'enum' => ['yes', 'no', 'maybe'],
+                    'type' => 'string',
+                ],
+            ]),
+            $properties['stringEnum']
+        );
+        $this->assertEquals(
+            new \ArrayObject([
+                'type' => ['string', 'null'],
+                'enum' => ['male', 'female', null],
+            ]),
+            $properties['gender']
+        );
+        $this->assertEquals(
+            new \ArrayObject([
+                'type' => 'array',
+                'items' => [
+                    'enum' => ['male', 'female'],
+                    'type' => 'string',
+                ],
+            ]),
+            $properties['genders']
+        );
+    }
+
+    public function testSchemaWithUnknownType(): void
+    {
+        $schema = $this->schemaFactory->buildSchema(Book::class, 'json', Schema::TYPE_OUTPUT, $this->operationMetadataFactory->create('_api_/issue-5452/books{._format}_get_collection'));
+        $this->assertContains(['$ref' => '#/definitions/ActivableInterface'], $schema['definitions']['Book']['properties']['library']['anyOf']);
+        $this->assertContains(['$ref' => '#/definitions/TimestampableInterface'], $schema['definitions']['Book']['properties']['library']['anyOf']);
+    }
+
+    public function testReadOnlySchema(): void
+    {
+        if ('mongodb' === self::getContainer()->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $schema = $this->schemaFactory->buildSchema(JsonSchemaResource::class, 'json', Schema::TYPE_OUTPUT);
+        $this->assertTrue($schema['definitions']['Resource']['properties']['resourceRelated']['readOnly'] ?? false);
+    }
+}

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -63,10 +63,71 @@ class OpenApiTest extends ApiTestCase
         }
 
         foreach (['title', 'detail', 'instance', 'type', 'status', '@id', '@type', '@context'] as $key) {
-            $this->assertArrayHasKey($key, $res['components']['schemas']['Error.jsonld']['properties']);
+            $this->assertSame(['allOf' => [
+                ['$ref' => '#/components/schemas/HydraItemBaseSchema'],
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'title' => [
+                            'readOnly' => true,
+                            'description' => 'A short, human-readable summary of the problem.',
+                            'type' => [
+                                0 => 'string',
+                                1 => 'null',
+                            ],
+                        ],
+                        'detail' => [
+                            'readOnly' => true,
+                            'description' => 'A human-readable explanation specific to this occurrence of the problem.',
+                            'type' => [
+                                0 => 'string',
+                                1 => 'null',
+                            ],
+                        ],
+                        'status' => [
+                            'type' => 'number',
+                            'examples' => [
+                                0 => 404,
+                            ],
+                            'default' => 400,
+                        ],
+                        'instance' => [
+                            'readOnly' => true,
+                            'description' => 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.',
+                            'type' => [
+                                0 => 'string',
+                                1 => 'null',
+                            ],
+                        ],
+                        'type' => [
+                            'readOnly' => true,
+                            'description' => 'A URI reference that identifies the problem type',
+                            'type' => 'string',
+                        ],
+                        'description' => [
+                            'readOnly' => true,
+                            'type' => [
+                                0 => 'string',
+                                1 => 'null',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 'description' => 'A representation of common errors.'], $res['components']['schemas']['Error.jsonld']);
         }
+
         foreach (['id', 'title', 'detail', 'instance', 'type', 'status', 'meta', 'source'] as $key) {
-            $this->assertArrayHasKey($key, $res['components']['schemas']['Error.jsonapi']['properties']['errors']['properties']);
+            $this->assertSame(['allOf' => [
+                ['$ref' => '#/components/schemas/Error'],
+                ['type' => 'object', 'properties' => [
+                    'source' => [
+                        'type' => 'object',
+                    ],
+                    'status' => [
+                        'type' => 'string',
+                    ],
+                ]],
+            ]], $res['components']['schemas']['Error.jsonapi']['properties']['errors']['items']);
         }
     }
 
@@ -97,5 +158,26 @@ class OpenApiTest extends ApiTestCase
         $this->assertArrayHasKey('get', $res['paths']['/cruds']);
         $this->assertArrayHasKey('/crud_open_api_api_platform_tags/{id}', $res['paths']);
         $this->assertEquals([['name' => 'Crud', 'description' => 'A resource used for OpenAPI tests.'], ['name' => 'CrudOpenApiApiPlatformTag', 'description' => 'Something nice']], $res['tags']);
+    }
+
+    public function testHasSchemasForMultipleFormats(): void
+    {
+        $response = self::createClient()->request('GET', '/docs?filter_tags[]=internal', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+
+        $res = $response->toArray();
+        $this->assertArrayHasKey('Crud.jsonld', $res['components']['schemas']);
+        $this->assertSame(['allOf' => [
+            ['$ref' => '#/components/schemas/HydraItemBaseSchema'],
+            [
+                'type' => 'object',
+                'properties' => [
+                    'id' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ], 'description' => 'A resource used for OpenAPI tests.'], $res['components']['schemas']['Crud.jsonld']);
     }
 }

--- a/tests/OpenApi/Command/OpenApiCommandTest.php
+++ b/tests/OpenApi/Command/OpenApiCommandTest.php
@@ -147,9 +147,8 @@ YAML;
         };
 
         $assertExample($json['components']['schemas']['Issue6317']['properties'], 'id');
-        $assertExample($json['components']['schemas']['Issue6317.jsonld']['properties'], 'id');
-        $assertExample($json['components']['schemas']['Issue6317.jsonapi']['properties']['data']['properties']['attributes']['properties'], '_id');
-        $assertExample($json['components']['schemas']['Issue6317.jsonhal']['properties'], 'id');
+        $assertExample($json['components']['schemas']['Issue6317.jsonld']['allOf'][1]['properties'], 'id');
+        $this->assertEquals($json['components']['schemas']['Issue6317.jsonhal']['allOf'][1]['$ref'], '#/components/schemas/Issue6317');
     }
 
     private function assertYaml(string $data): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | starts fixing https://github.com/api-platform/core/pull/6485
| License       | MIT

Instead of generating twice a definition for 2 different formats, we generate the `json` one and reference the `json` format inside the `jsonld` format:

https://gist.github.com/soyuka/20d0d216c3fce1b68165dbbf58381e02

When generating a single resource on our TestBundle we lower the OpenAPI file size quite a bit:

  - 12K on 4.1
  - 8.0K with this patch

Left to be done:
- [x] check if serialization groups work
- [ ] fix https://github.com/api-platform/core/pull/6485 
- [ ] tests