### PR TITLE
fix(symfony): detach objects from store to prevent infinite loop duri…

### DIFF
--- a/src/Symfony/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Symfony/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -238,6 +238,11 @@ final class PublishMercureUpdatesListener
 
         $updates = array_merge([$this->buildUpdate($iri, $data, $options)], $this->getGraphQlSubscriptionUpdates($object, $options, $type));
 
+        // Detach objects to prevent infinite loops in case a flush occurs before all updates are published and the store is reset
+        $this->updatedObjects->detach($object);
+        $this->createdObjects->detach($object);
+        $this->deletedObjects->detach($object);
+
         foreach ($updates as $update) {
             if ($options['enable_async_update'] && $this->messageBus) {
                 $this->dispatch($update);


### PR DESCRIPTION
…ng premature flush before all objects updates are published and stores are reset (#6936)

| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Tickets       | Closes #6936
| License       | MIT

