### PR TITLE
fix(symfony): detach objects from store to prevent infinite loop duri…

### DIFF
--- a/src/Symfony/Doctrine/EventListener/PublishMercureUpdatesListener.php
+++ b/src/Symfony/Doctrine/EventListener/PublishMercureUpdatesListener.php
@@ -131,16 +131,29 @@ final class PublishMercureUpdatesListener
     public function postFlush(): void
     {
         try {
-            foreach ($this->createdObjects as $object) {
-                $this->publishUpdate($object, $this->createdObjects[$object], 'create');
+            $creatingObjects = clone $this->createdObjects;
+            foreach ($creatingObjects as $object) {
+                if ($this->createdObjects->contains($object)) {
+                    $this->createdObjects->detach($object);
+                }
+                $this->publishUpdate($object, $creatingObjects[$object], 'create');
             }
 
-            foreach ($this->updatedObjects as $object) {
-                $this->publishUpdate($object, $this->updatedObjects[$object], 'update');
+            $updatingObjects = clone $this->updatedObjects;
+            foreach ($updatingObjects as $object) {
+                if ($this->updatedObjects->contains($object)) {
+                    $this->updatedObjects->detach($object);
+                }
+                $this->publishUpdate($object, $updatingObjects[$object], 'update');
             }
 
-            foreach ($this->deletedObjects as $object) {
-                $this->publishUpdate($object, $this->deletedObjects[$object], 'delete');
+            $deletingObjects = clone $this->deletedObjects;
+            foreach ($deletingObjects as $object) {
+                $options = $this->deletedObjects[$object];
+                if ($this->deletedObjects->contains($object)) {
+                    $this->deletedObjects->detach($object);
+                }
+                $this->publishUpdate($object, $deletingObjects[$object], 'delete');
             }
         } finally {
             $this->reset();
@@ -237,7 +250,6 @@ final class PublishMercureUpdatesListener
         }
 
         $updates = array_merge([$this->buildUpdate($iri, $data, $options)], $this->getGraphQlSubscriptionUpdates($object, $options, $type));
-
         foreach ($updates as $update) {
             if ($options['enable_async_update'] && $this->messageBus) {
                 $this->dispatch($update);


### PR DESCRIPTION
…ng premature flush before all objects updates are published and stores are reset (#6936)

| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #6936  closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
