### PR TITLE
feat(jsonschema): Add `checkMode` parameter to control json schema validation in tests

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -113,7 +113,7 @@ trait ApiTestAssertionsTrait
         static::assertThat(self::getHttpResponse()->toArray(false), $constraint, $message);
     }
 
-    public static function assertMatchesResourceCollectionJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld', ?array $serializationContext = null): void
+    public static function assertMatchesResourceCollectionJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld', ?array $serializationContext = null, ?int $checkMode = null): void
     {
         $schemaFactory = self::getSchemaFactory();
 
@@ -127,10 +127,10 @@ trait ApiTestAssertionsTrait
 
         $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null, ($serializationContext ?? []) + [BackwardCompatibleSchemaFactory::SCHEMA_DRAFT4_VERSION => true]);
 
-        static::assertMatchesJsonSchema($schema->getArrayCopy());
+        static::assertMatchesJsonSchema($schema->getArrayCopy(), $checkMode);
     }
 
-    public static function assertMatchesResourceItemJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld', ?array $serializationContext = null): void
+    public static function assertMatchesResourceItemJsonSchema(string $resourceClass, ?string $operationName = null, string $format = 'jsonld', ?array $serializationContext = null, ?int $checkMode = null): void
     {
         $schemaFactory = self::getSchemaFactory();
 
@@ -144,7 +144,7 @@ trait ApiTestAssertionsTrait
 
         $schema = $schemaFactory->buildSchema($resourceClass, $format, Schema::TYPE_OUTPUT, $operation, null, ($serializationContext ?? []) + [BackwardCompatibleSchemaFactory::SCHEMA_DRAFT4_VERSION => true]);
 
-        static::assertMatchesJsonSchema($schema->getArrayCopy());
+        static::assertMatchesJsonSchema($schema->getArrayCopy(), $checkMode);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       |
| License       | MIT
| Doc PR        | Tell me if it's necessary and I'll create it.

By default, the json schema format is validated when the use the `assertMatchesResourceCollectionJsonSchema` and the `assertMatchesResourceItemJsonSchema`. This is a problem when we change the default DateTime format because we MUST no longer use the format Json Schema validation. We should rely on the 'pattern' attribute instead.

```php
    #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s'])]
    #[ApiProperty(
        // As the format of date-time is not standard, we need to change the
        // JsonSchema accordingly.
        jsonSchemaContext: [
            'type' => 'string',
            // Unfortunately, there is no built-in way here to remove the `format` attribute, so we must disable the format validation if we want the tests to pass 
            'pattern' => '^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])T([01]\\d|2[0-3]):([0-5]\\d):([0-5]\\d)$',
        ],
    )]
    public function getCreatedAt(): ?\DateTimeImmutable
```

There is an existing `$checkMode` parameter but it was not possible to use it using `assertMatchesResource*JsonSchema`.

With my PR it's now possible to do:

```php
use JsonSchema\Constraints\Constraint;

self::assertMatchesResourceCollectionJsonSchema(FooBarWithDateTimeProperty::class, checkMode: Constraint::CHECK_MODE_DISABLE_FORMAT);
```