### PR TITLE
fix: boot kernel only if it's necessary in `createClient()` method

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -36,13 +36,15 @@ abstract class ApiTestCase extends KernelTestCase
      */
     protected static function createClient(array $kernelOptions = [], array $defaultOptions = []): Client
     {
-        $kernel = static::bootKernel($kernelOptions);
+        if (!static::$booted) {
+            static::bootKernel($kernelOptions);
+        }
 
         try {
             /**
              * @var Client
              */
-            $client = $kernel->getContainer()->get('test.api_platform.client');
+            $client = static::$kernel->getContainer()->get('test.api_platform.client');
         } catch (ServiceNotFoundException) {
             if (!class_exists(AbstractBrowser::class) || !trait_exists(HttpClientTrait::class)) {
                 throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit and HttpClient components are not available. Try running "composer require --dev symfony/browser-kit symfony/http-client".');

--- a/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -33,6 +33,7 @@ use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\ExpectationFailedException;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class ApiTestCaseTest extends ApiTestCase
 {
@@ -385,5 +386,21 @@ JSON
     {
         self::createClient([], ['headers' => ['accept' => 'application/json']])->request('DELETE', '/something/that/does/not/exist/ever');
         $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testDoNotRebootKernelOnCreateClient(): void
+    {
+        self::bootKernel();
+
+        $mock = $this->createMock(KernelInterface::class);
+
+        // Client need to be retrieved so we must configure the `getContainer`
+        // method
+        $mock->method('getContainer')->willReturn(self::getContainer());
+        $mock->expects($this->never())->method('boot');
+
+        self::$kernel = $mock;
+
+        self::createClient();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Fix #6971
| License       | MIT
| Doc PR        | 