### PR TITLE
fix(symfony): Update bundle dependency to state package

### DIFF
--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -36,7 +36,7 @@
         "api-platform/hydra": "^3.4 || ^4.0",
         "api-platform/metadata": "^3.4 || ^4.0",
         "api-platform/serializer": "^3.4 || ^4.0",
-        "api-platform/state": "^3.4 || ^4.0",
+        "api-platform/state": "^4.1",
         "api-platform/validator": "^3.4 || ^4.0",
         "api-platform/openapi": "^4.1",
         "symfony/property-info": "^6.4 || ^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | -
| License       | MIT
| Doc PR        | -

In https://github.com/api-platform/core/pull/6952, the class `ApiPlatform\State\ErrorProvider` have been updated, with its DI configuration.

Fixes this error:
> Invalid service "api_platform.state.error_provider": method "ApiPlatform\State\ErrorProvider::__construct()" has no argument named "$resourceMetadataCollectionFactory". Check your service definition.      