### PR TITLE
fix(laravel): addRoute action prefix

### DIFF
--- a/src/Laravel/routes/api.php
+++ b/src/Laravel/routes/api.php
@@ -35,11 +35,11 @@ Route::domain($domain)->middleware($globalMiddlewares)->group(function (): void 
         foreach ($resourceMetadataFactory->create($resourceClass) as $resourceMetadata) {
             foreach ($resourceMetadata->getOperations() as $operation) {
                 $uriTemplate = str_replace('{._format}', '{_format?}', $operation->getUriTemplate());
-                $uriTemplate = rtrim($operation->getRoutePrefix(), '/').'/'.ltrim($uriTemplate, '/');
 
                 /* @var HttpOperation $operation */
-                Route::addRoute($operation->getMethod(), $uriTemplate, ApiPlatformController::class)
-                    ->middleware(ApiPlatformMiddleware::class.':'.$operation->getName())
+                $route = Route::addRoute($operation->getMethod(), $uriTemplate, ['uses' => ApiPlatformController::class, 'prefix' => $operation->getRoutePrefix() ?? '']);
+
+                $route->middleware(ApiPlatformMiddleware::class.':'.$operation->getName())
                     ->middleware($operation->getMiddleware())
                     ->where('_format', '^\.[a-zA-Z]+')
                     ->name($operation->getName())


### PR DESCRIPTION
@jonerickson this is the only way I could make the prefix work, it looks like the laravel router doesn't take the prefix when using `addRoute`, though if I specify this in the `$action` array it works.  