### PR TITLE
fix(validation): deprecate string message for ValidationException con…

### DIFF
--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -82,11 +82,19 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
     protected ?string $errorTitle = null;
     private array|ConstraintViolationListInterface $constraintViolationList = [];
 
-    public function __construct(ConstraintViolationListInterface $message = new ConstraintViolationList(), string|int|null $code = null, int|\Throwable|null $previous = null, \Throwable|string|null $errorTitle = null)
+    public function __construct(string|ConstraintViolationListInterface $message = new ConstraintViolationList(), string|int|null $code = null, int|\Throwable|null $previous = null, \Throwable|string|null $errorTitle = null)
     {
         $this->errorTitle = $errorTitle;
-        $this->constraintViolationList = $message;
-        parent::__construct($this->__toString(), $code ?? 0, $previous);
+
+        if ($message instanceof ConstraintViolationListInterface) {
+            $this->constraintViolationList = $message;
+            parent::__construct($this->__toString(), $code ?? 0, $previous);
+
+            return;
+        }
+
+        trigger_deprecation('api_platform/core', '5.0', \sprintf('The "%s" exception will have a "%s" first argument in 5.x.', self::class, ConstraintViolationListInterface::class));
+        parent::__construct($message ?: $this->__toString(), $code ?? 0, $previous);
     }
 
     /**


### PR DESCRIPTION
…structor

The ValidationException constructor currently accepts a string as the first argument. This is being deprecated in favor of accepting a ConstraintViolationListInterface.

fixes #6997