### PR TITLE
feat(metadata): reduce ApiFilter service id

### DIFF
--- a/src/Metadata/Util/AttributeFilterExtractorTrait.php
+++ b/src/Metadata/Util/AttributeFilterExtractorTrait.php
@@ -133,7 +133,11 @@ trait AttributeFilterExtractorTrait
     private function generateFilterId(\ReflectionClass $reflectionClass, string $filterClass, ?string $filterId = null): string
     {
         $suffix = null !== $filterId ? '_'.$filterId : $filterId;
+        $filterClassName = (new \ReflectionClass($filterClass))->getName();
+        if (null !== $suffix) {
+            $filterClassName = '';
+        }
 
-        return 'annotated_'.(new UnicodeString(str_replace('\\', '', $reflectionClass->getName().(new \ReflectionClass($filterClass))->getName().$suffix)))->snake()->toString();
+        return 'annotated_'.(new UnicodeString(str_replace('\\', '', $reflectionClass->getName().$filterClassName.$suffix)))->snake()->toString();
     }
 }

--- a/tests/Fixtures/TestBundle/ApiResource/Issue5648/DummyResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue5648/DummyResource.php
@@ -30,7 +30,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
     ],
     stateOptions: new Options(entityClass: Dummy::class)
 )]
-#[ApiFilter(CustomFilter::class)]
+#[ApiFilter(CustomFilter::class, id: 'custom_filter')]
 class DummyResource
 {
     #[ApiProperty(identifier: true)]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Reduce the `#[ApiFilter]` service id when an `id` or an `alias` is defined on the attribute.
It can solve the `Filename too long` error when the cache is built.