### PR TITLE
fix(symfony): add a `alwaysBootKernel` property for BC layer

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -29,6 +29,12 @@ abstract class ApiTestCase extends KernelTestCase
     use ApiTestAssertionsTrait;
 
     /**
+     *  If you're using RecreateDatabaseTrait, RefreshDatabaseTrait, ReloadDatabaseTrait from theofidry/AliceBundle, you
+     *  probably need to set this property to false in your test class to avoid recreating the database on each client creation.
+     */
+    protected static bool $alwaysBootKernel = true;
+
+    /**
      * Creates a Client.
      *
      * @param array $kernelOptions  Options to pass to the createKernel method
@@ -36,7 +42,15 @@ abstract class ApiTestCase extends KernelTestCase
      */
     protected static function createClient(array $kernelOptions = [], array $defaultOptions = []): Client
     {
-        if (!static::$booted) {
+        if (static::$alwaysBootKernel) {
+            \trigger_deprecation(
+                'api-platform/core',
+                '4.1.0',
+                'In API Platform 5.0 we will not always boot the kernel when creating a new client (see https://github.com/api-platform/core/issues/6971).',
+            );
+        }
+
+        if (static::$alwaysBootKernel) {
             static::bootKernel($kernelOptions);
         }
 
@@ -44,7 +58,7 @@ abstract class ApiTestCase extends KernelTestCase
             /**
              * @var Client
              */
-            $client = static::$kernel->getContainer()->get('test.api_platform.client');
+            $client = static::getContainer()->get('test.api_platform.client');
         } catch (ServiceNotFoundException) {
             if (!class_exists(AbstractBrowser::class) || !trait_exists(HttpClientTrait::class)) {
                 throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit and HttpClient components are not available. Try running "composer require --dev symfony/browser-kit symfony/http-client".');

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -29,10 +29,14 @@ abstract class ApiTestCase extends KernelTestCase
     use ApiTestAssertionsTrait;
 
     /**
-     *  If you're using RecreateDatabaseTrait, RefreshDatabaseTrait, ReloadDatabaseTrait from theofidry/AliceBundle, you
-     *  probably need to set this property to false in your test class to avoid recreating the database on each client creation.
+     * If you're using RecreateDatabaseTrait, RefreshDatabaseTrait, ReloadDatabaseTrait from theofidry/AliceBundle, you
+     * probably need to set this property to false in your test class to avoid recreating the database on each client creation.
+     *
+     * - `null` triggers a deprecation message and always boots the kernel
+     * - `false` does not boot the kernel if it's already booted
+     * - `true` always boots the kernel without any deprecation message
      */
-    protected static bool $alwaysBootKernel = true;
+    protected static ?bool $alwaysBootKernel = null;
 
     /**
      * Creates a Client.
@@ -42,15 +46,15 @@ abstract class ApiTestCase extends KernelTestCase
      */
     protected static function createClient(array $kernelOptions = [], array $defaultOptions = []): Client
     {
-        if (static::$alwaysBootKernel) {
+        if (null === static::$alwaysBootKernel) {
             trigger_deprecation(
-                'api-platform/core',
+                'api-platform/symfony',
                 '4.1.0',
-                'In API Platform 5.0 we will not always boot the kernel when creating a new client (see https://github.com/api-platform/core/issues/6971).',
+                'In API Platform 5.0, the kernel will not always be booted when a new client is created (see https://github.com/api-platform/core/issues/6971).',
             );
         }
 
-        if (static::$alwaysBootKernel) {
+        if (static::$alwaysBootKernel || null === static::$alwaysBootKernel) {
             static::bootKernel($kernelOptions);
         }
 

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -58,7 +58,7 @@ abstract class ApiTestCase extends KernelTestCase
             /**
              * @var Client
              */
-            $client = static::getContainer()->get('test.api_platform.client');
+            $client = self::getContainer()->get('test.api_platform.client');
         } catch (ServiceNotFoundException) {
             if (!class_exists(AbstractBrowser::class) || !trait_exists(HttpClientTrait::class)) {
                 throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit and HttpClient components are not available. Try running "composer require --dev symfony/browser-kit symfony/http-client".');

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -43,7 +43,7 @@ abstract class ApiTestCase extends KernelTestCase
     protected static function createClient(array $kernelOptions = [], array $defaultOptions = []): Client
     {
         if (static::$alwaysBootKernel) {
-            \trigger_deprecation(
+            trigger_deprecation(
                 'api-platform/core',
                 '4.1.0',
                 'In API Platform 5.0 we will not always boot the kernel when creating a new client (see https://github.com/api-platform/core/issues/6971).',

--- a/tests/Functional/ArrayDtoTest.php
+++ b/tests/Functional/ArrayDtoTest.php
@@ -21,6 +21,8 @@ final class ArrayDtoTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/BackedEnumPropertyTest.php
+++ b/tests/Functional/BackedEnumPropertyTest.php
@@ -28,6 +28,8 @@ final class BackedEnumPropertyTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/BackedEnumResourceTest.php
+++ b/tests/Functional/BackedEnumResourceTest.php
@@ -28,6 +28,8 @@ final class BackedEnumResourceTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/ErrorTest.php
+++ b/tests/Functional/ErrorTest.php
@@ -22,6 +22,8 @@ final class ErrorTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/FormatTest.php
+++ b/tests/Functional/FormatTest.php
@@ -21,6 +21,8 @@ final class FormatTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/HALCircularReference.php
+++ b/tests/Functional/HALCircularReference.php
@@ -19,6 +19,8 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue4358\ResourceB;
 
 class HALCircularReference extends ApiTestCase
 {
+    protected static ?bool $alwaysBootKernel = false;
+
     public function testIssue4358(): void
     {
         $r1 = self::createClient()->request('GET', '/resource_a', ['headers' => ['Accept' => 'application/hal+json']]);

--- a/tests/Functional/HydraTest.php
+++ b/tests/Functional/HydraTest.php
@@ -22,6 +22,8 @@ class HydraTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Issues/Issue6926Test.php
+++ b/tests/Functional/Issues/Issue6926Test.php
@@ -22,6 +22,8 @@ class Issue6926Test extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/ItemUriTemplateTest.php
+++ b/tests/Functional/ItemUriTemplateTest.php
@@ -21,6 +21,8 @@ class ItemUriTemplateTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/JsonLdTest.php
+++ b/tests/Functional/JsonLdTest.php
@@ -25,6 +25,8 @@ class JsonLdTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -22,6 +22,8 @@ class OpenApiTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/BooleanFilterTest.php
+++ b/tests/Functional/Parameters/BooleanFilterTest.php
@@ -31,6 +31,8 @@ final class BooleanFilterTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/DateFilterTest.php
+++ b/tests/Functional/Parameters/DateFilterTest.php
@@ -31,6 +31,8 @@ final class DateFilterTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/DoctrineTest.php
+++ b/tests/Functional/Parameters/DoctrineTest.php
@@ -26,6 +26,8 @@ final class DoctrineTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/ExistsFilterTest.php
+++ b/tests/Functional/Parameters/ExistsFilterTest.php
@@ -31,6 +31,8 @@ final class ExistsFilterTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/HydraTest.php
+++ b/tests/Functional/Parameters/HydraTest.php
@@ -21,6 +21,8 @@ final class HydraTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/NumericFilterTest.php
+++ b/tests/Functional/Parameters/NumericFilterTest.php
@@ -31,6 +31,8 @@ final class NumericFilterTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/OrderFilterTest.php
+++ b/tests/Functional/Parameters/OrderFilterTest.php
@@ -31,6 +31,8 @@ final class OrderFilterTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/ParameterProviderTest.php
+++ b/tests/Functional/Parameters/ParameterProviderTest.php
@@ -21,6 +21,8 @@ final class ParameterProviderTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/ParameterTest.php
+++ b/tests/Functional/Parameters/ParameterTest.php
@@ -21,6 +21,8 @@ final class ParameterTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/QueryParameterStateOptionsTest.php
+++ b/tests/Functional/Parameters/QueryParameterStateOptionsTest.php
@@ -26,6 +26,8 @@ final class QueryParameterStateOptionsTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/RangeFilterTest.php
+++ b/tests/Functional/Parameters/RangeFilterTest.php
@@ -31,6 +31,8 @@ final class RangeFilterTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/SecurityTest.php
+++ b/tests/Functional/Parameters/SecurityTest.php
@@ -23,6 +23,8 @@ final class SecurityTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/StrictParametersTest.php
+++ b/tests/Functional/Parameters/StrictParametersTest.php
@@ -21,6 +21,8 @@ final class StrictParametersTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Functional/Parameters/ValidationTest.php
+++ b/tests/Functional/Parameters/ValidationTest.php
@@ -22,6 +22,8 @@ final class ValidationTest extends ApiTestCase
 {
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -390,6 +390,8 @@ JSON
 
     public function testDoNotRebootKernelOnCreateClient(): void
     {
+        self::$alwaysBootKernel = false;
+
         self::bootKernel();
 
         $mock = $this->createMock(KernelInterface::class);

--- a/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -40,6 +40,8 @@ class ApiTestCaseTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */

--- a/tests/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Symfony/Bundle/Test/ClientTest.php
@@ -29,6 +29,8 @@ class ClientTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     /**
      * @return class-string[]
      */


### PR DESCRIPTION
fix #6991