### PR TITLE
feat(httpcache): add more cache directives to AddHeadersProcessor

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -14,6 +14,7 @@
         "mongodb",
         "jsonld",
         "hydra",
+        "httpcache",
         "jsonapi",
         "graphql",
         "openapi",

--- a/src/HttpCache/Tests/State/AddHeadersProcessorTest.php
+++ b/src/HttpCache/Tests/State/AddHeadersProcessorTest.php
@@ -19,38 +19,54 @@ use ApiPlatform\State\ProcessorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class AddHeadersProcessorTest extends TestCase
 {
-    public function testAddHeaders(): void
+    public function testAddHeadersFromGlobalConfiguration(): void
     {
         $operation = new Get();
-        $response = $this->createMock(Response::class);
-        $response->expects($this->once())->method('setEtag');
-        $response->method('getContent')->willReturn('{}');
-        $response->method('isSuccessful')->willReturn(true);
-        $response->headers = $this->createMock(ResponseHeaderBag::class);
-        $response->headers->method('hasCacheControlDirective')->with($this->logicalOr(
-            $this->identicalTo('public'),
-            $this->identicalTo('s-maxage'),
-            $this->identicalTo('max-age'),
-            $this->identicalTo('stale-while-revalidate'),
-            $this->identicalTo('stale-if-error'),
-        ))->willReturn(false);
-        $response->headers->expects($this->exactly(2))->method('addCacheControlDirective')->with($this->logicalOr(
-            $this->identicalTo('stale-while-revalidate'),
-            $this->identicalTo('stale-if-error'),
-        ), '10');
-        $response->expects($this->once())->method('setPublic');
-        $response->expects($this->once())->method('setMaxAge');
-        $response->expects($this->once())->method('setSharedMaxAge');
-        $request = $this->createMock(Request::class);
-        $request->method('isMethodCacheable')->willReturn(true);
+        $response = new Response('content');
+        $request = new Request();
         $context = ['request' => $request];
         $decorated = $this->createMock(ProcessorInterface::class);
         $decorated->method('process')->willReturn($response);
         $processor = new AddHeadersProcessor($decorated, etag: true, maxAge: 100, sharedMaxAge: 200, vary: ['Accept', 'Accept-Encoding'], public: true, staleWhileRevalidate: 10, staleIfError: 10);
+
         $processor->process($response, $operation, [], $context);
+
+        self::assertSame('max-age=100, public, s-maxage=200, stale-if-error=10, stale-while-revalidate=10', $response->headers->get('cache-control'));
+        self::assertSame('"55f2b31a6acfaa64"', $response->headers->get('etag'));
+        self::assertSame(['Accept', 'Accept-Encoding'], $response->headers->all('vary'));
+    }
+
+    public function testAddHeadersFromOperationConfiguration(): void
+    {
+        $operation = new Get(
+            cacheHeaders: [
+                'public' => false,
+                'max_age' => 250,
+                'shared_max_age' => 500,
+                'stale_while_revalidate' => 30,
+                'stale_if_error' => 15,
+                'vary' => ['Authorization', 'Accept-Language'],
+                'must_revalidate' => true,
+                'proxy_revalidate' => true,
+                'no_cache' => true,
+                'no_store' => true,
+                'no_transform' => true,
+                'immutable' => true,
+            ],
+        );
+        $response = new Response('content');
+        $request = new Request();
+        $context = ['request' => $request];
+        $decorated = $this->createMock(ProcessorInterface::class);
+        $decorated->method('process')->willReturn($response);
+        $processor = new AddHeadersProcessor($decorated);
+
+        $processor->process($response, $operation, [], $context);
+
+        self::assertSame('immutable, max-age=250, must-revalidate, no-store, no-transform, private, proxy-revalidate, stale-if-error=15, stale-while-revalidate=30', $response->headers->get('cache-control'));
+        self::assertSame(['Authorization', 'Accept-Language'], $response->headers->all('vary'));
     }
 }

--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -55,7 +55,13 @@ class HttpOperation extends Operation
      *     public?: bool,
      *     shared_max_age?: int,
      *     stale_while_revalidate?: int,
-     *     stale-if-error?: int,
+     *     stale_if_error?: int,
+     *     must_revalidate?: bool,
+     *     proxy_revalidate?: bool,
+     *     no_cache?: bool,
+     *     no_store?: bool,
+     *     no_transform?: bool,
+     *     immutable?: bool,
      * }|null $cacheHeaders {@see https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers}
      * @param array<string, string>|null $headers
      * @param array{


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Some cache directives were missing from the `AddHeadersProcessor`, like `no-store`, this PR adds them.