### PR TITLE
feat(laravel): add option modelClass in stateOptions

### DIFF
--- a/src/Laravel/Eloquent/State/CollectionProvider.php
+++ b/src/Laravel/Eloquent/State/CollectionProvider.php
@@ -29,6 +29,7 @@ use Psr\Container\ContainerInterface;
 final class CollectionProvider implements ProviderInterface
 {
     use LinksHandlerLocatorTrait;
+    use ModelInstantiationTrait;
 
     /**
      * @param LinksHandlerInterface<Model>      $linksHandler
@@ -45,12 +46,7 @@ final class CollectionProvider implements ProviderInterface
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
-        $modelClass = $operation->getClass();
-        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getModelClass()) {
-            $modelClass = $options->getModelClass();
-        }
-        /** @var Model $model */
-        $model = new ($modelClass)();
+        $model = $this->instantiateModel($operation);
 
         if ($handleLinks = $this->getLinksHandler($operation)) {
             $query = $handleLinks($model->query(), $uriVariables, ['operation' => $operation, 'modelClass' => $operation->getClass()] + $context);

--- a/src/Laravel/Eloquent/State/CollectionProvider.php
+++ b/src/Laravel/Eloquent/State/CollectionProvider.php
@@ -45,8 +45,12 @@ final class CollectionProvider implements ProviderInterface
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
+        $modelClass = $operation->getClass();
+        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getModelClass()) {
+            $modelClass = $options->getModelClass();
+        }
         /** @var Model $model */
-        $model = new ($operation->getClass())();
+        $model = new ($modelClass)();
 
         if ($handleLinks = $this->getLinksHandler($operation)) {
             $query = $handleLinks($model->query(), $uriVariables, ['operation' => $operation, 'modelClass' => $operation->getClass()] + $context);

--- a/src/Laravel/Eloquent/State/ItemProvider.php
+++ b/src/Laravel/Eloquent/State/ItemProvider.php
@@ -24,6 +24,7 @@ use Psr\Container\ContainerInterface;
 final class ItemProvider implements ProviderInterface
 {
     use LinksHandlerLocatorTrait;
+    use ModelInstantiationTrait;
 
     /**
      * @param LinksHandlerInterface<Model> $linksHandler
@@ -37,11 +38,7 @@ final class ItemProvider implements ProviderInterface
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
-        $modelClass = $operation->getClass();
-        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getModelClass()) {
-            $modelClass = $options->getModelClass();
-        }
-        $model = new ($modelClass)();
+        $model = $this->instantiateModel($operation);
 
         if ($handleLinks = $this->getLinksHandler($operation)) {
             $query = $handleLinks($model->query(), $uriVariables, ['operation' => $operation] + $context);

--- a/src/Laravel/Eloquent/State/ItemProvider.php
+++ b/src/Laravel/Eloquent/State/ItemProvider.php
@@ -37,7 +37,11 @@ final class ItemProvider implements ProviderInterface
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
-        $model = new ($operation->getClass())();
+        $modelClass = $operation->getClass();
+        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getModelClass()) {
+            $modelClass = $options->getModelClass();
+        }
+        $model = new ($modelClass)();
 
         if ($handleLinks = $this->getLinksHandler($operation)) {
             $query = $handleLinks($model->query(), $uriVariables, ['operation' => $operation] + $context);

--- a/src/Laravel/Eloquent/State/LinksHandlerLocatorTrait.php
+++ b/src/Laravel/Eloquent/State/LinksHandlerLocatorTrait.php
@@ -26,7 +26,7 @@ trait LinksHandlerLocatorTrait
 
     private function getLinksHandler(Operation $operation): ?callable
     {
-        if (!($options = $operation->getStateOptions()) || !$options instanceof Options) {
+        if (!($options = $operation->getStateOptions()) || !$options instanceof Options || !$options->getHandleLinks()) {
             return null;
         }
 

--- a/src/Laravel/Eloquent/State/ModelInstantiationTrait.php
+++ b/src/Laravel/Eloquent/State/ModelInstantiationTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ApiPlatform\Laravel\Eloquent\State;
+
+use ApiPlatform\Metadata\Operation;
+use Illuminate\Database\Eloquent\Model;
+
+trait ModelInstantiationTrait
+{
+    /**
+     * Instantiates the model from the operation.
+     *
+     * @param Operation $operation
+     * @return Model
+     */
+    protected function instantiateModel(Operation $operation): Model
+    {
+        $modelClass = $operation->getClass();
+
+        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getModelClass()) {
+            $modelClass = $options->getModelClass();
+        }
+
+        return new $modelClass();
+    }
+}

--- a/src/Laravel/Eloquent/State/Options.php
+++ b/src/Laravel/Eloquent/State/Options.php
@@ -23,6 +23,7 @@ class Options implements OptionsInterface
      * @see LinksHandlerInterface
      */
     public function __construct(
+        protected ?string $modelClass = null,
         protected mixed $handleLinks = null,
     ) {
     }
@@ -36,6 +37,19 @@ class Options implements OptionsInterface
     {
         $self = clone $this;
         $self->handleLinks = $handleLinks;
+
+        return $self;
+    }
+
+    public function getModelClass(): ?string
+    {
+        return $this->modelClass;
+    }
+
+    public function withModelClass(?string $modelClass): self
+    {
+        $self = clone $this;
+        $self->modelClass = $modelClass;
 
         return $self;
     }

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -348,4 +348,16 @@ class JsonLdTest extends TestCase
         $response->assertStatus(200);
         $this->assertSame('/api/staff_position_histories', $response->json()['@id']);
     }
+
+    public function testResourceWithOptionModel(): void
+    {
+        $response = $this->get('/api/resource_with_models?page=1', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertJsonFragment([
+            '@context' => '/api/contexts/ResourceWithModel',
+            '@id' => '/api/resource_with_models',
+            '@type' => 'Collection',
+        ]);
+    }
 }

--- a/src/Laravel/workbench/app/ApiResource/ResourceWithModel.php
+++ b/src/Laravel/workbench/app/ApiResource/ResourceWithModel.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\ApiResource;
+
+use ApiPlatform\Laravel\Eloquent\State\CollectionProvider;
+use ApiPlatform\Laravel\Eloquent\State\ItemProvider;
+use ApiPlatform\Laravel\Eloquent\State\Options;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Workbench\App\Models\Book;
+
+#[ApiResource(
+    operations: [
+        new GetCollection(provider: CollectionProvider::class),
+        new Get(provider: ItemProvider::class),
+    ],
+    stateOptions: new Options(modelClass: Book::class),
+)]
+class ResourceWithModel
+{
+    #[ApiProperty(identifier: true)]
+    public ?string $id = null;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch     |  main
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This feature allow you to provide the Model when using the ApiResources folder instead of the Model.
When we use the ApiResources structure we can't use the \ApiPlatform\Laravel\Eloquent\State\ItemProvider class because instead of Symfony there is no getEntityClass, and the resource is used to call the Eloquent logic.

The PR try to implement this.

example:
```php
// \App\ApiResouces\Book

use App\Models\Book as BookModel;

#[ApiResource(
    operations: [
        new GetCollection,
        new Get,
        new Post,
        new Patch,
        new Delete,
    ],
    provider: BookStateProvider::class,
    processor: BookStateProcessor::class,
    stateOptions: new Options(modelClass: BookModel::class)
)]
class Book
{
}
```