### PR TITLE
fix(laravel): json api default parameters

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -810,17 +810,17 @@ class ApiPlatformProvider extends ServiceProvider
             $pagination = $config->get('api-platform.pagination');
 
             return new PaginationOptions(
-                $defaults['pagination_enabled'],
-                $pagination['page_parameter_name'],
-                $defaults['pagination_client_items_per_page'],
-                $pagination['items_per_page_parameter_name'],
-                $defaults['pagination_client_enabled'],
-                $pagination['enabled_parameter_name'],
-                $defaults['pagination_items_per_page'],
-                $defaults['pagination_maximum_items_per_page'],
-                $defaults['pagination_partial'],
-                $defaults['pagination_client_partial'],
-                $pagination['partial_parameter_name'],
+                $defaults['pagination_enabled'] ?? true,
+                $pagination['page_parameter_name'] ?? 'page',
+                $defaults['pagination_client_items_per_page'] ?? false,
+                $pagination['items_per_page_parameter_name'] ?? 'itemsPerPage',
+                $defaults['pagination_client_enabled'] ?? false,
+                $pagination['enabled_parameter_name'] ?? 'pagination',
+                $defaults['pagination_items_per_page'] ?? 30,
+                $defaults['pagination_maximum_items_per_page'] ?? 30,
+                $defaults['pagination_partial'] ?? false,
+                $defaults['pagination_client_partial'] ?? false,
+                $pagination['partial_parameter_name'] ?? 'partial',
             );
         });
 

--- a/src/Laravel/Tests/JsonApiTest.php
+++ b/src/Laravel/Tests/JsonApiTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Laravel\Tests;
 
+use ApiPlatform\JsonApi\Filter\SparseFieldset;
+use ApiPlatform\Laravel\Eloquent\Filter\JsonApi\SortFilter;
 use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use ApiPlatform\Metadata\QueryParameter;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -42,6 +45,13 @@ class JsonApiTest extends TestCase
             $config->set('api-platform.docs_formats', ['jsonapi' => ['application/vnd.api+json']]);
             $config->set('api-platform.resources', [app_path('Models'), app_path('ApiResource')]);
             $config->set('api-platform.pagination.items_per_page_parameter_name', 'limit');
+            $config->set('api-platform.defaults', [
+                'route_prefix' => '/api',
+                'parameters' => [
+                    new QueryParameter(key: 'fields', filter: SparseFieldset::class),
+                    new QueryParameter(key: 'sort', filter: SortFilter::class),
+                ],
+            ]);
 
             $config->set('app.debug', true);
         });

--- a/src/Laravel/workbench/app/Models/Book.php
+++ b/src/Laravel/workbench/app/Models/Book.php
@@ -13,11 +13,9 @@ declare(strict_types=1);
 
 namespace Workbench\App\Models;
 
-use ApiPlatform\JsonApi\Filter\SparseFieldset;
 use ApiPlatform\Laravel\Eloquent\Filter\BooleanFilter;
 use ApiPlatform\Laravel\Eloquent\Filter\DateFilter;
 use ApiPlatform\Laravel\Eloquent\Filter\EqualsFilter;
-use ApiPlatform\Laravel\Eloquent\Filter\JsonApi\SortFilter;
 use ApiPlatform\Laravel\Eloquent\Filter\OrderFilter;
 use ApiPlatform\Laravel\Eloquent\Filter\OrFilter;
 use ApiPlatform\Laravel\Eloquent\Filter\PartialSearchFilter;
@@ -82,8 +80,6 @@ use Workbench\App\Http\Requests\BookFormRequest;
 )]
 #[QueryParameter(key: 'properties', filter: PropertyFilter::class)]
 #[QueryParameter(key: 'published', filter: BooleanFilter::class)]
-#[QueryParameter(key: 'fields', filter: SparseFieldset::class)]
-#[QueryParameter(key: 'sort', filter: SortFilter::class)]
 class Book extends Model
 {
     use HasFactory;


### PR DESCRIPTION
This PR doesn't change much we just moved the parameters to our `defaults` section to test if it works properly. 

We can definitely close #6841 with the documentation commit at https://github.com/api-platform/docs/commit/c7892af178736840d6f93b60192f7c246098ac3e 